### PR TITLE
fix(safety): unify live gate — single enforce_live_gate for all entry points

### DIFF
--- a/src/cli/strategy.rs
+++ b/src/cli/strategy.rs
@@ -548,25 +548,6 @@ async fn list_strategies() -> Result<()> {
     Ok(())
 }
 
-/// Check if the legacy `ploy strategy start` live path is explicitly allowed
-/// via the global `PLOY_ALLOW_LEGACY_LIVE` env var.
-fn legacy_strategy_live_allowed() -> bool {
-    std::env::var("PLOY_ALLOW_LEGACY_LIVE")
-        .map_or(false, |v| v == "true" || v == "1")
-}
-
-/// Start a strategy
-fn enforce_legacy_strategy_live_gate(dry_run: bool) -> Result<()> {
-    if !dry_run && !legacy_strategy_live_allowed() {
-        let msg = "legacy `ploy strategy start` live runtime is disabled by default; use `ploy platform start` (Coordinator/Gateway path)";
-        warn!("{msg}");
-        println!("\x1b[31m✗ {}\x1b[0m", msg);
-        return Err(anyhow::anyhow!(msg));
-    }
-
-    Ok(())
-}
-
 async fn start_strategy(
     name: &str,
     config: Option<PathBuf>,
@@ -575,7 +556,14 @@ async fn start_strategy(
 ) -> Result<()> {
     info!("Starting strategy: {}", name);
 
-    enforce_legacy_strategy_live_gate(dry_run)?;
+    if !dry_run {
+        let result = crate::safety::direct_live::enforce_live_gate("ploy strategy start");
+        if let Err(ref e) = result {
+            warn!("{e}");
+            println!("\x1b[31m✗ {e}\x1b[0m");
+        }
+        result?;
+    }
 
     // Check if already running.
     //
@@ -2639,70 +2627,4 @@ async fn run_nba_comeback(_config: Option<PathBuf>, _dry_run: bool) -> Result<()
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::enforce_legacy_strategy_live_gate;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn set_env(key: &str, value: Option<&str>) {
-        match value {
-            Some(v) => std::env::set_var(key, v),
-            None => std::env::remove_var(key),
-        }
-    }
-
-    #[test]
-    fn strategy_live_gate_blocks_live_without_overrides() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let strategy_key = "PLOY_ALLOW_LEGACY_STRATEGY_LIVE";
-        let global_key = "PLOY_ALLOW_LEGACY_LIVE";
-        let prev_strategy = std::env::var(strategy_key).ok();
-        let prev_global = std::env::var(global_key).ok();
-
-        set_env(strategy_key, None);
-        set_env(global_key, None);
-
-        let err = enforce_legacy_strategy_live_gate(false)
-            .err()
-            .expect("live should be blocked without explicit override");
-        assert!(err.to_string().contains("disabled by default"));
-
-        match prev_strategy.as_deref() {
-            Some(v) => set_env(strategy_key, Some(v)),
-            None => set_env(strategy_key, None),
-        }
-        match prev_global.as_deref() {
-            Some(v) => set_env(global_key, Some(v)),
-            None => set_env(global_key, None),
-        }
-    }
-
-    #[test]
-    fn strategy_live_gate_blocks_even_with_strategy_override() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let strategy_key = "PLOY_ALLOW_LEGACY_STRATEGY_LIVE";
-        let global_key = "PLOY_ALLOW_LEGACY_LIVE";
-        let prev_strategy = std::env::var(strategy_key).ok();
-        let prev_global = std::env::var(global_key).ok();
-
-        set_env(global_key, None);
-        set_env(strategy_key, Some("true"));
-        let err = enforce_legacy_strategy_live_gate(false)
-            .err()
-            .expect("legacy live should still be blocked");
-        assert!(err.to_string().contains("disabled by default"));
-
-        match prev_strategy.as_deref() {
-            Some(v) => set_env(strategy_key, Some(v)),
-            None => set_env(strategy_key, None),
-        }
-        match prev_global.as_deref() {
-            Some(v) => set_env(global_key, Some(v)),
-            None => set_env(global_key, None),
-        }
-    }
 }

--- a/src/safety/direct_live.rs
+++ b/src/safety/direct_live.rs
@@ -14,23 +14,62 @@ pub fn strategy_direct_live_allowed() -> bool {
     false
 }
 
+/// Single enforcement gate for all legacy live entry points.
+///
+/// Returns `Err(PloyError::Validation)` when `direct_live_allowed()` is false
+/// (which is always, by design). Every CLI path that can run live orders
+/// should call this with its command name so the error message is actionable.
+pub fn enforce_live_gate(cmd: &str) -> crate::error::Result<()> {
+    if direct_live_allowed() {
+        return Ok(());
+    }
+    Err(crate::error::PloyError::Validation(format!(
+        "direct `{cmd}` live runtime is disabled; use `ploy platform start` (Coordinator-only live)"
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn direct_live_allowed_is_always_false() {
-        std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true");
+        unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true") };
         assert!(!direct_live_allowed());
-        std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE");
+        unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE") };
     }
 
     #[test]
     fn strategy_direct_live_allowed_is_always_false() {
-        std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true");
-        std::env::set_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE", "true");
+        unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true") };
+        unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE", "true") };
         assert!(!strategy_direct_live_allowed());
-        std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE");
-        std::env::remove_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE");
+        unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE") };
+        unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE") };
+    }
+
+    #[test]
+    fn enforce_live_gate_blocks_all_commands() {
+        for cmd in [
+            "ploy strategy start",
+            "ploy crypto split-arb",
+            "ploy sports split-arb",
+            "ploy agent --enable-trading",
+        ] {
+            let err = enforce_live_gate(cmd).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains(cmd), "error should mention command: {msg}");
+            assert!(
+                msg.contains("ploy platform start"),
+                "error should mention coordinator path: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_live_gate_ignores_env_override() {
+        unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true") };
+        assert!(enforce_live_gate("test-cmd").is_err());
+        unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE") };
     }
 }

--- a/tests/legacy_live_gate.rs
+++ b/tests/legacy_live_gate.rs
@@ -1,0 +1,61 @@
+use ploy::safety::direct_live::{direct_live_allowed, enforce_live_gate, strategy_direct_live_allowed};
+
+/// Every legacy live entry point must be blocked by `enforce_live_gate`.
+#[test]
+fn enforce_live_gate_blocks_all_known_commands() {
+    let commands = [
+        "ploy strategy start",
+        "ploy crypto split-arb",
+        "ploy sports split-arb",
+        "ploy agent --enable-trading",
+    ];
+
+    for cmd in commands {
+        let err = enforce_live_gate(cmd)
+            .expect_err(&format!("enforce_live_gate should block `{cmd}`"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains(cmd),
+            "error for `{cmd}` should include the command name, got: {msg}"
+        );
+        assert!(
+            msg.contains("ploy platform start"),
+            "error for `{cmd}` should mention coordinator path, got: {msg}"
+        );
+    }
+}
+
+/// `direct_live_allowed` must remain false regardless of env-var overrides.
+#[test]
+fn direct_live_allowed_ignores_env_vars() {
+    unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true") };
+    assert!(
+        !direct_live_allowed(),
+        "direct_live_allowed must be hardcoded false"
+    );
+    unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE") };
+}
+
+/// `strategy_direct_live_allowed` must remain false regardless of env-var overrides.
+#[test]
+fn strategy_direct_live_allowed_ignores_env_vars() {
+    unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_LIVE", "true") };
+    unsafe { std::env::set_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE", "true") };
+    assert!(
+        !strategy_direct_live_allowed(),
+        "strategy_direct_live_allowed must be hardcoded false"
+    );
+    unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_LIVE") };
+    unsafe { std::env::remove_var("PLOY_ALLOW_DIRECT_STRATEGY_LIVE") };
+}
+
+/// The gate error should be a `PloyError::Validation` variant.
+#[test]
+fn enforce_live_gate_returns_validation_error() {
+    let err = enforce_live_gate("test-cmd").unwrap_err();
+    let debug = format!("{:?}", err);
+    assert!(
+        debug.contains("Validation"),
+        "expected PloyError::Validation, got: {debug}"
+    );
+}


### PR DESCRIPTION
## Summary
- Replace inline `anyhow::anyhow!` gate in `strategy.rs` with canonical `safety::direct_live::enforce_live_gate()`
- `main_runtime::enforce_coordinator_only_live` now delegates to `enforce_live_gate`, adding only warn/println presentation
- All 5 legacy live entry points route through one function in `safety/direct_live.rs`
- Fix `unsafe` for `set_var`/`remove_var` (required since Rust 1.82)

## Test plan
- [x] `cargo check` — compiles clean (no new warnings)
- [x] `cargo test --test legacy_live_gate` — 4 integration tests pass
- [x] `cargo test safety::direct_live` — 4 unit tests pass
- [x] `cargo test --lib --bins --tests` — 512 tests pass, 0 failures

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized safety gate for direct-live operations: commands that affect live systems are now validated through a unified gate which logs warnings and surfaces clear, colored error messages when denied.

* **Tests**
  * Added comprehensive tests for the safety gate covering command-aware error messages, environment-variable handling, legacy behavior, and validation error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->