### PR TITLE
Phase 2: PlatformDataPlane singleton WS integration

### DIFF
--- a/src/coordinator/bootstrap.rs
+++ b/src/coordinator/bootstrap.rs
@@ -31,7 +31,10 @@ use crate::coordinator::{
 use crate::domain::{OrderStatus, Side};
 use crate::error::Result;
 use crate::exchange::{build_exchange_client, parse_exchange_kind, ExchangeKind};
-use crate::platform::{AgentRiskParams, AgentStatus, Domain, MarketSelector, StrategyDeployment};
+use crate::platform::{
+    AgentRiskParams, AgentStatus, DataPlaneConfig, Domain, MarketSelector, PlatformDataPlane,
+    StrategyDeployment,
+};
 use crate::signing::Wallet;
 use crate::strategy::event_edge::core::EventEdgeCore;
 use crate::strategy::executor::OrderExecutor;
@@ -1517,10 +1520,7 @@ async fn ensure_chainlink_tables(pool: &PgPool) -> Result<()> {
     Ok(())
 }
 
-fn spawn_chainlink_persistence(
-    chainlink_ws: Arc<crate::adapters::ChainlinkRtds>,
-    pool: PgPool,
-) {
+fn spawn_chainlink_persistence(chainlink_ws: Arc<crate::adapters::ChainlinkRtds>, pool: PgPool) {
     tokio::spawn(async move {
         if let Err(e) = ensure_chainlink_tables(&pool).await {
             warn!(
@@ -4854,6 +4854,7 @@ async fn run_managed_strategy_runtime(
     dry_run: bool,
     pm_client: PolymarketClient,
     pm_ws_url: String,
+    data_plane: Option<Arc<PlatformDataPlane>>,
     mut cmd_rx: mpsc::Receiver<CoordinatorCommand>,
     mut shutdown_rx: broadcast::Receiver<()>,
 ) -> Result<()> {
@@ -4906,34 +4907,40 @@ async fn run_managed_strategy_runtime(
     binance_kline_intervals.sort();
     binance_kline_intervals.dedup();
 
-    let mut feed_manager = DataFeedManager::new(manager.clone());
-    if !binance_spot_symbols.is_empty() {
-        feed_manager = feed_manager.with_binance(binance_spot_symbols.clone());
-    }
+    let feed_manager = if let Some(dp) = data_plane {
+        DataFeedManager::from_data_plane(dp, manager.clone()).with_pm_client(pm_client.clone())
+    } else {
+        let mut feed_manager = DataFeedManager::new(manager.clone());
+        if !binance_spot_symbols.is_empty() {
+            feed_manager = feed_manager.with_binance(binance_spot_symbols.clone());
+        }
 
-    if !binance_kline_symbols.is_empty() && !binance_kline_intervals.is_empty() {
-        let backfill_limit = std::env::var("PLOY_BINANCE_KLINE_BACKFILL_LIMIT")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(300);
-        feed_manager = feed_manager.with_binance_klines(
-            binance_kline_symbols.clone(),
-            binance_kline_intervals.clone(),
-            binance_kline_closed_only,
-            backfill_limit,
-        );
-    }
+        if !binance_kline_symbols.is_empty() && !binance_kline_intervals.is_empty() {
+            let backfill_limit = std::env::var("PLOY_BINANCE_KLINE_BACKFILL_LIMIT")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(300);
+            feed_manager = feed_manager.with_binance_klines(
+                binance_kline_symbols.clone(),
+                binance_kline_intervals.clone(),
+                binance_kline_closed_only,
+                backfill_limit,
+            );
+        }
 
-    let has_polymarket_feed = required_feeds.iter().any(|f| {
-        matches!(
-            f,
-            DataFeed::PolymarketEvents { .. } | DataFeed::PolymarketQuotes { .. }
-        )
-    });
-    if has_polymarket_feed {
-        let pm_ws = PolymarketWebSocket::new(&pm_ws_url);
-        feed_manager = feed_manager.with_polymarket(pm_ws, pm_client.clone());
-    }
+        let has_polymarket_feed = required_feeds.iter().any(|f| {
+            matches!(
+                f,
+                DataFeed::PolymarketEvents { .. } | DataFeed::PolymarketQuotes { .. }
+            )
+        });
+        if has_polymarket_feed {
+            let pm_ws = PolymarketWebSocket::new(&pm_ws_url);
+            feed_manager = feed_manager.with_polymarket(pm_ws, pm_client.clone());
+        }
+
+        feed_manager
+    };
 
     manager.start_strategy(strategy, None).await?;
     feed_manager.start().await?;
@@ -5528,6 +5535,7 @@ pub async fn start_platform(
 
     // Shared per-symbol freshness tracker — attached to all WS adapters.
     let freshness = Arc::new(crate::platform::DataPlaneFreshness::new());
+    let use_data_plane = env_bool("PLOY_DATA_PLANE", false);
 
     if config.enable_crypto {
         let crypto_cfg = config.crypto.clone();
@@ -5568,13 +5576,14 @@ pub async fn start_platform(
         // Build a unified coin set across all enabled crypto strategies.
         // Also build a SubscriptionPlan for audit/observability (Phase 1 shadow).
         let mut all_coins: Vec<String> = Vec::new();
-        let mut planner_requirements: Vec<(
-            crate::platform::ConsumerId,
-            Domain,
-            Vec<DataFeed>,
-        )> = Vec::new();
+        let mut planner_requirements: Vec<(crate::platform::ConsumerId, Domain, Vec<DataFeed>)> =
+            Vec::new();
         if momentum_enabled {
-            let symbols: Vec<String> = crypto_cfg.coins.iter().map(|c| format!("{}USDT", c)).collect();
+            let symbols: Vec<String> = crypto_cfg
+                .coins
+                .iter()
+                .map(|c| format!("{}USDT", c))
+                .collect();
             planner_requirements.push((
                 crate::platform::ConsumerId::from(format!("momentum-{}", crypto_cfg.agent_id)),
                 Domain::Crypto,
@@ -5613,6 +5622,42 @@ pub async fn start_platform(
                 }
             }
         }
+        if use_data_plane && pattern_memory_enabled {
+            let mut coins: Vec<String> = if runtime_crypto_targets.pattern_memory_coins.is_empty() {
+                crypto_cfg.coins.clone()
+            } else {
+                runtime_crypto_targets
+                    .pattern_memory_coins
+                    .iter()
+                    .cloned()
+                    .collect()
+            };
+            coins.sort();
+            coins.dedup();
+            for coin in coins {
+                if !all_coins.contains(&coin) {
+                    all_coins.push(coin);
+                }
+            }
+        }
+        if use_data_plane && split_arb_enabled {
+            let mut coins: Vec<String> = if runtime_crypto_targets.split_arb_coins.is_empty() {
+                crypto_cfg.coins.clone()
+            } else {
+                runtime_crypto_targets
+                    .split_arb_coins
+                    .iter()
+                    .cloned()
+                    .collect()
+            };
+            coins.sort();
+            coins.dedup();
+            for coin in coins {
+                if !all_coins.contains(&coin) {
+                    all_coins.push(coin);
+                }
+            }
+        }
         if all_coins.is_empty() {
             warn!("crypto domain enabled but no crypto agents are active (coins set is empty)");
         }
@@ -5629,13 +5674,44 @@ pub async fn start_platform(
 
         // Create WebSocket feeds
         let symbols: Vec<String> = all_coins.iter().map(|c| format!("{}USDT", c)).collect();
-        let binance_ws = Arc::new(BinanceWebSocket::new(symbols));
-        let pm_ws = Arc::new(PolymarketWebSocket::new(&app_config.market.ws_url));
+        let mut data_plane: Option<Arc<PlatformDataPlane>> = None;
+        let (binance_ws, pm_ws) = if use_data_plane {
+            let data_plane_config = DataPlaneConfig {
+                polymarket_ws_url: app_config.market.ws_url.clone(),
+                binance_spot_symbols: symbols.clone(),
+                binance_kline_symbols: symbols.clone(),
+                binance_kline_intervals: vec!["5m".to_string(), "15m".to_string()],
+                binance_kline_closed_only: true,
+                chainlink_symbols: vec![],
+            };
+            let dp = Arc::new(PlatformDataPlane::new(data_plane_config, Arc::clone(&freshness)));
+            dp.start(Vec::new()).await?;
+            info!("PlatformDataPlane started");
 
-        // Attach per-symbol freshness tracker to WS adapters.
-        binance_ws.set_freshness(Arc::clone(&freshness));
-        pm_ws.set_freshness(Arc::clone(&freshness));
-        info!("data plane freshness tracker attached to WS adapters");
+            let binance_ws = dp.binance_ws().ok_or_else(|| {
+                crate::error::PloyError::Validation(
+                    "PLOY_DATA_PLANE=1 but PlatformDataPlane has no Binance WS adapter"
+                        .to_string(),
+                )
+            })?;
+            let pm_ws = dp.polymarket_ws().ok_or_else(|| {
+                crate::error::PloyError::Validation(
+                    "PLOY_DATA_PLANE=1 but PlatformDataPlane has no Polymarket WS adapter"
+                        .to_string(),
+                )
+            })?;
+            data_plane = Some(dp);
+            (binance_ws, pm_ws)
+        } else {
+            let binance_ws = Arc::new(BinanceWebSocket::new(symbols));
+            let pm_ws = Arc::new(PolymarketWebSocket::new(&app_config.market.ws_url));
+
+            // Attach per-symbol freshness tracker to WS adapters.
+            binance_ws.set_freshness(Arc::clone(&freshness));
+            pm_ws.set_freshness(Arc::clone(&freshness));
+            info!("data plane freshness tracker attached to WS adapters");
+            (binance_ws, pm_ws)
+        };
 
         // Seed PM token → side mapping for data collection, so QuoteUpdates carry the correct
         // UP/DOWN side and can be persisted to Postgres.
@@ -5685,12 +5761,24 @@ pub async fn start_platform(
                 );
             }
         }
-        let (_added, _removed, _updated, total) = pm_ws.reconcile_token_sides(&desired).await;
-        info!(
-            agent = %crypto_cfg.agent_id,
-            token_count = total,
-            "seeded PM token mappings for crypto data collection"
-        );
+        if use_data_plane {
+            for (token, side) in desired.iter() {
+                pm_ws.register_token(token, *side).await;
+            }
+            pm_ws.request_resubscribe();
+            info!(
+                agent = %crypto_cfg.agent_id,
+                token_count = desired.len(),
+                "seeded PM token mappings for crypto data collection"
+            );
+        } else {
+            let (_added, _removed, _updated, total) = pm_ws.reconcile_token_sides(&desired).await;
+            info!(
+                agent = %crypto_cfg.agent_id,
+                token_count = total,
+                "seeded PM token mappings for crypto data collection"
+            );
+        }
 
         if let Some(pool) = shared_pool.as_ref() {
             if let Err(e) = crate::collector::ensure_collector_token_targets_table(pool).await {
@@ -5720,11 +5808,18 @@ pub async fn start_platform(
         let coins_collector = all_coins.clone();
         let agent_id_collector = crypto_cfg.agent_id.clone();
         let pool_collector = shared_pool.clone();
+        let use_data_plane_collector = use_data_plane;
+        let initial_last_desired = if use_data_plane_collector {
+            desired.clone()
+        } else {
+            HashMap::new()
+        };
         tokio::spawn(async move {
             let refresh_secs =
                 env_u64("PM_COLLECTOR_REFRESH_SECS", PM_COLLECTOR_REFRESH_SECS).max(10);
             let mut tick = tokio::time::interval(Duration::from_secs(refresh_secs));
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut last_desired = initial_last_desired;
 
             loop {
                 tick.tick().await;
@@ -5779,18 +5874,35 @@ pub async fn start_platform(
                     }
                 }
 
-                let (added, removed, updated, total) =
-                    pm_ws_collector.reconcile_token_sides(&desired).await;
-                if added > 0 || removed > 0 {
-                    pm_ws_collector.request_resubscribe();
-                    info!(
-                        agent = %agent_id_collector,
-                        added,
-                        removed,
-                        updated,
-                        token_count = total,
-                        "pm token collector reconciled token set; resubscribe requested"
-                    );
+                if use_data_plane_collector {
+                    if desired != last_desired {
+                        let previous_token_count = last_desired.len();
+                        for (token, side) in desired.iter() {
+                            pm_ws_collector.register_token(token, *side).await;
+                        }
+                        pm_ws_collector.request_resubscribe();
+                        info!(
+                            agent = %agent_id_collector,
+                            previous_token_count,
+                            token_count = desired.len(),
+                            "pm token collector refreshed token set on shared data-plane ws; resubscribe requested"
+                        );
+                        last_desired = desired;
+                    }
+                } else {
+                    let (added, removed, updated, total) =
+                        pm_ws_collector.reconcile_token_sides(&desired).await;
+                    if added > 0 || removed > 0 {
+                        pm_ws_collector.request_resubscribe();
+                        info!(
+                            agent = %agent_id_collector,
+                            added,
+                            removed,
+                            updated,
+                            token_count = total,
+                            "pm token collector reconciled token set; resubscribe requested"
+                        );
+                    }
                 }
 
                 if let Some(pool) = pool_collector.as_ref() {
@@ -5842,92 +5954,131 @@ pub async fn start_platform(
                 let pipeline_handle =
                     crate::platform::PersistencePipeline::spawn(pool.clone(), pipeline_config);
 
-                // Bridge PM WS quote updates → pipeline
-                let ph = pipeline_handle.clone();
-                let mut quote_rx = pm_ws.subscribe_updates();
-                tokio::spawn(async move {
-                    loop {
-                        match quote_rx.recv().await {
-                            Ok(update) => {
-                                let tick = crate::platform::ClobQuoteTick {
-                                    token_id: update.token_id.clone(),
-                                    side: format!("{:?}", update.side),
-                                    best_bid: update.quote.best_bid,
-                                    best_ask: update.quote.best_ask,
-                                    bid_size: update.quote.bid_size,
-                                    ask_size: update.quote.ask_size,
-                                    domain: Domain::Crypto,
-                                    received_at: Utc::now(),
-                                };
-                                let _ = ph.try_ingest(crate::platform::PersistenceEvent::ClobQuote(tick));
+                // Bridge PM quote updates → pipeline
+                let quote_rx = if use_data_plane {
+                    data_plane.as_ref().and_then(|dp| dp.subscribe_quotes())
+                } else {
+                    Some(pm_ws.subscribe_updates())
+                };
+                if let Some(mut quote_rx) = quote_rx {
+                    let ph = pipeline_handle.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match quote_rx.recv().await {
+                                Ok(update) => {
+                                    let tick = crate::platform::ClobQuoteTick {
+                                        token_id: update.token_id.clone(),
+                                        side: format!("{:?}", update.side),
+                                        best_bid: update.quote.best_bid,
+                                        best_ask: update.quote.best_ask,
+                                        bid_size: update.quote.bid_size,
+                                        ask_size: update.quote.ask_size,
+                                        domain: Domain::Crypto,
+                                        received_at: Utc::now(),
+                                    };
+                                    let _ = ph.try_ingest(
+                                        crate::platform::PersistenceEvent::ClobQuote(tick),
+                                    );
+                                }
+                                Err(broadcast::error::RecvError::Lagged(n)) => {
+                                    warn!(lagged = n, "unified persistence quote bridge lagged");
+                                }
+                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                            Err(broadcast::error::RecvError::Lagged(n)) => {
-                                warn!(lagged = n, "unified persistence quote bridge lagged");
-                            }
-                            Err(broadcast::error::RecvError::Closed) => break,
                         }
-                    }
-                });
+                    });
+                } else {
+                    warn!("unified persistence quote bridge unavailable: no quote receiver");
+                }
 
-                // Bridge Binance WS price updates → pipeline
-                let ph = pipeline_handle.clone();
-                let mut price_rx = binance_ws.subscribe();
-                tokio::spawn(async move {
-                    loop {
-                        match price_rx.recv().await {
-                            Ok(update) => {
-                                let tick = crate::platform::BinancePriceTick {
-                                    symbol: update.symbol.clone(),
-                                    price: Some(update.price),
-                                    quantity: update.quantity,
-                                    trade_time: update.timestamp,
-                                };
-                                let _ = ph.try_ingest(crate::platform::PersistenceEvent::BinancePrice(tick));
+                // Bridge Binance price updates → pipeline
+                let price_rx = if use_data_plane {
+                    data_plane.as_ref().and_then(|dp| dp.subscribe_prices())
+                } else {
+                    Some(binance_ws.subscribe())
+                };
+                if let Some(mut price_rx) = price_rx {
+                    let ph = pipeline_handle.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match price_rx.recv().await {
+                                Ok(update) => {
+                                    let tick = crate::platform::BinancePriceTick {
+                                        symbol: update.symbol.clone(),
+                                        price: Some(update.price),
+                                        quantity: update.quantity,
+                                        trade_time: update.timestamp,
+                                    };
+                                    let _ = ph.try_ingest(
+                                        crate::platform::PersistenceEvent::BinancePrice(tick),
+                                    );
+                                }
+                                Err(broadcast::error::RecvError::Lagged(n)) => {
+                                    warn!(lagged = n, "unified persistence price bridge lagged");
+                                }
+                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                            Err(broadcast::error::RecvError::Lagged(n)) => {
-                                warn!(lagged = n, "unified persistence price bridge lagged");
-                            }
-                            Err(broadcast::error::RecvError::Closed) => break,
                         }
-                    }
-                });
+                    });
+                } else {
+                    warn!("unified persistence price bridge unavailable: no price receiver");
+                }
 
-                // Bridge PM WS orderbook updates → pipeline
-                let ph = pipeline_handle.clone();
-                let mut book_rx = pm_ws.subscribe_books();
-                tokio::spawn(async move {
-                    use sha2::{Digest, Sha256};
-                    loop {
-                        match book_rx.recv().await {
-                            Ok(book_msg) => {
-                                let bids_json = serde_json::to_value(&book_msg.bids).unwrap_or_default();
-                                let asks_json = serde_json::to_value(&book_msg.asks).unwrap_or_default();
-                                let mut hasher = Sha256::new();
-                                hasher.update(bids_json.to_string().as_bytes());
-                                hasher.update(asks_json.to_string().as_bytes());
-                                let hash = format!("{:x}", hasher.finalize());
-                                let snap = crate::platform::ClobOrderbookSnapshot {
-                                    domain: Domain::Crypto,
-                                    token_id: book_msg.asset_id.clone(),
-                                    market: Some(book_msg.market.clone()),
-                                    bids: bids_json,
-                                    asks: asks_json,
-                                    book_timestamp: book_msg.timestamp.as_deref()
-                                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                                        .map(|dt| dt.with_timezone(&Utc)),
-                                    hash,
-                                    source: "polymarket_ws".into(),
-                                    context: None,
-                                };
-                                let _ = ph.try_ingest(crate::platform::PersistenceEvent::ClobOrderbook(snap));
+                // Bridge PM orderbook updates → pipeline
+                let book_rx = if use_data_plane {
+                    data_plane.as_ref().and_then(|dp| dp.subscribe_books())
+                } else {
+                    Some(pm_ws.subscribe_books())
+                };
+                if let Some(mut book_rx) = book_rx {
+                    let ph = pipeline_handle.clone();
+                    tokio::spawn(async move {
+                        use sha2::{Digest, Sha256};
+                        loop {
+                            match book_rx.recv().await {
+                                Ok(book_msg) => {
+                                    let bids_json =
+                                        serde_json::to_value(&book_msg.bids).unwrap_or_default();
+                                    let asks_json =
+                                        serde_json::to_value(&book_msg.asks).unwrap_or_default();
+                                    let mut hasher = Sha256::new();
+                                    hasher.update(bids_json.to_string().as_bytes());
+                                    hasher.update(asks_json.to_string().as_bytes());
+                                    let hash = format!("{:x}", hasher.finalize());
+                                    let snap = crate::platform::ClobOrderbookSnapshot {
+                                        domain: Domain::Crypto,
+                                        token_id: book_msg.asset_id.clone(),
+                                        market: Some(book_msg.market.clone()),
+                                        bids: bids_json,
+                                        asks: asks_json,
+                                        book_timestamp: book_msg
+                                            .timestamp
+                                            .as_deref()
+                                            .and_then(|s| {
+                                                chrono::DateTime::parse_from_rfc3339(s).ok()
+                                            })
+                                            .map(|dt| dt.with_timezone(&Utc)),
+                                        hash,
+                                        source: "polymarket_ws".into(),
+                                        context: None,
+                                    };
+                                    let _ = ph.try_ingest(
+                                        crate::platform::PersistenceEvent::ClobOrderbook(snap),
+                                    );
+                                }
+                                Err(broadcast::error::RecvError::Lagged(n)) => {
+                                    warn!(
+                                        lagged = n,
+                                        "unified persistence orderbook bridge lagged"
+                                    );
+                                }
+                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                            Err(broadcast::error::RecvError::Lagged(n)) => {
-                                warn!(lagged = n, "unified persistence orderbook bridge lagged");
-                            }
-                            Err(broadcast::error::RecvError::Closed) => break,
                         }
-                    }
-                });
+                    });
+                } else {
+                    warn!("unified persistence orderbook bridge unavailable: no book receiver");
+                }
 
                 info!(
                     agent = crypto_cfg.agent_id,
@@ -6021,21 +6172,23 @@ pub async fn start_platform(
             );
         }
 
-        // Spawn Binance WS in background
-        let bws = binance_ws.clone();
-        tokio::spawn(async move {
-            if let Err(e) = bws.run().await {
-                error!(error = %e, "binance websocket error");
-            }
-        });
+        if !use_data_plane {
+            // Spawn Binance WS in background
+            let bws = binance_ws.clone();
+            tokio::spawn(async move {
+                if let Err(e) = bws.run().await {
+                    error!(error = %e, "binance websocket error");
+                }
+            });
 
-        // Spawn PM WS in background
-        let pws = pm_ws.clone();
-        tokio::spawn(async move {
-            if let Err(e) = pws.run(Vec::new()).await {
-                error!(error = %e, "polymarket websocket error");
-            }
-        });
+            // Spawn PM WS in background
+            let pws = pm_ws.clone();
+            tokio::spawn(async move {
+                if let Err(e) = pws.run(Vec::new()).await {
+                    error!(error = %e, "polymarket websocket error");
+                }
+            });
+        }
 
         if momentum_enabled {
             if let Some(cmd_rx) = cmd_rx_opt {
@@ -6104,6 +6257,7 @@ pub async fn start_platform(
                             crypto_cfg.risk_params.clone(),
                         );
                         let strategy_ws_url = app_config.market.ws_url.clone();
+                        let strategy_data_plane = data_plane.clone();
                         let strategy_shutdown_rx = shutdown_tx.subscribe();
                         let strategy_dry_run = config.dry_run;
                         let jh = tokio::spawn(async move {
@@ -6114,6 +6268,7 @@ pub async fn start_platform(
                                 strategy_dry_run,
                                 strategy_pm_client,
                                 strategy_ws_url,
+                                strategy_data_plane,
                                 strategy_cmd_rx,
                                 strategy_shutdown_rx,
                             )
@@ -6194,6 +6349,7 @@ pub async fn start_platform(
                         crypto_cfg.risk_params.clone(),
                     );
                     let strategy_ws_url = app_config.market.ws_url.clone();
+                    let strategy_data_plane = data_plane.clone();
                     let strategy_shutdown_rx = shutdown_tx.subscribe();
                     let strategy_dry_run = config.dry_run;
                     let jh = tokio::spawn(async move {
@@ -6204,6 +6360,7 @@ pub async fn start_platform(
                             strategy_dry_run,
                             strategy_pm_client,
                             strategy_ws_url,
+                            strategy_data_plane,
                             strategy_cmd_rx,
                             strategy_shutdown_rx,
                         )

--- a/src/platform/data_plane.rs
+++ b/src/platform/data_plane.rs
@@ -1,0 +1,318 @@
+//! Platform data plane orchestration for shared market-data adapters.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+use tracing::error;
+
+use super::freshness::DataPlaneFreshness;
+use crate::adapters::polymarket_ws::BookMessage;
+use crate::adapters::{
+    BinanceKlineWebSocket, BinanceWebSocket, ChainlinkRtds, ChainlinkUpdate, KlineUpdate,
+    PolymarketWebSocket, PriceUpdate, QuoteUpdate,
+};
+use crate::error::{PloyError, Result};
+
+/// Runtime configuration for the platform data plane.
+#[derive(Debug, Clone, Default)]
+pub struct DataPlaneConfig {
+    pub polymarket_ws_url: String,
+    pub binance_spot_symbols: Vec<String>,
+    pub binance_kline_symbols: Vec<String>,
+    pub binance_kline_intervals: Vec<String>,
+    pub binance_kline_closed_only: bool,
+    pub chainlink_symbols: Vec<String>,
+}
+
+impl DataPlaneConfig {
+    fn validate(&self, pm_required: bool) -> Result<()> {
+        if pm_required && self.polymarket_ws_url.trim().is_empty() {
+            return Err(PloyError::Validation(
+                "polymarket_ws_url is required when Polymarket is configured".to_string(),
+            ));
+        }
+
+        let has_kline_symbols = !self.binance_kline_symbols.is_empty();
+        let has_kline_intervals = !self.binance_kline_intervals.is_empty();
+        if has_kline_symbols != has_kline_intervals {
+            return Err(PloyError::Validation(
+                "binance_kline_symbols and binance_kline_intervals must both be set or both be empty".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Shared data-plane runtime with optional singleton WS adapters.
+pub struct PlatformDataPlane {
+    binance_ws: Option<Arc<BinanceWebSocket>>,
+    binance_kline_ws: Option<Arc<BinanceKlineWebSocket>>,
+    polymarket_ws: Option<Arc<PolymarketWebSocket>>,
+    chainlink_ws: Option<Arc<ChainlinkRtds>>,
+    freshness: Arc<DataPlaneFreshness>,
+    config: DataPlaneConfig,
+    started: AtomicBool,
+}
+
+impl PlatformDataPlane {
+    pub fn new(config: DataPlaneConfig, freshness: Arc<DataPlaneFreshness>) -> Self {
+        let binance_ws = if config.binance_spot_symbols.is_empty() {
+            None
+        } else {
+            let ws = Arc::new(BinanceWebSocket::new(config.binance_spot_symbols.clone()));
+            ws.set_freshness(Arc::clone(&freshness));
+            Some(ws)
+        };
+
+        let binance_kline_ws = if config.binance_kline_symbols.is_empty()
+            || config.binance_kline_intervals.is_empty()
+        {
+            None
+        } else {
+            let ws = Arc::new(BinanceKlineWebSocket::new(
+                config.binance_kline_symbols.clone(),
+                config.binance_kline_intervals.clone(),
+                config.binance_kline_closed_only,
+            ));
+            ws.set_freshness(Arc::clone(&freshness));
+            Some(ws)
+        };
+
+        let polymarket_ws = if config.polymarket_ws_url.trim().is_empty() {
+            None
+        } else {
+            let ws = Arc::new(PolymarketWebSocket::new(config.polymarket_ws_url.trim()));
+            ws.set_freshness(Arc::clone(&freshness));
+            Some(ws)
+        };
+
+        let chainlink_ws = if config.chainlink_symbols.is_empty() {
+            None
+        } else {
+            let ws = Arc::new(ChainlinkRtds::new(config.chainlink_symbols.clone()));
+            ws.set_freshness(Arc::clone(&freshness));
+            Some(ws)
+        };
+
+        Self {
+            binance_ws,
+            binance_kline_ws,
+            polymarket_ws,
+            chainlink_ws,
+            freshness,
+            config,
+            started: AtomicBool::new(false),
+        }
+    }
+
+    pub async fn start(&self, initial_pm_tokens: Vec<String>) -> Result<()> {
+        self.config.validate(self.polymarket_ws.is_some())?;
+
+        if self
+            .started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(PloyError::Validation(
+                "PlatformDataPlane::start called more than once".to_string(),
+            ));
+        }
+
+        if let Some(ws) = &self.binance_ws {
+            let ws = Arc::clone(ws);
+            tokio::spawn(async move {
+                if let Err(err) = ws.run().await {
+                    error!("binance websocket task exited: {}", err);
+                }
+            });
+        }
+
+        if let Some(ws) = &self.binance_kline_ws {
+            let ws = Arc::clone(ws);
+            tokio::spawn(async move {
+                if let Err(err) = ws.run().await {
+                    error!("binance kline websocket task exited: {}", err);
+                }
+            });
+        }
+
+        if let Some(ws) = &self.polymarket_ws {
+            let ws = Arc::clone(ws);
+            tokio::spawn(async move {
+                if let Err(err) = ws.run(initial_pm_tokens).await {
+                    error!("polymarket websocket task exited: {}", err);
+                }
+            });
+        }
+
+        if let Some(ws) = &self.chainlink_ws {
+            let ws = Arc::clone(ws);
+            tokio::spawn(async move {
+                if let Err(err) = ws.run().await {
+                    error!("chainlink websocket task exited: {}", err);
+                }
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn subscribe_quotes(&self) -> Option<broadcast::Receiver<QuoteUpdate>> {
+        self.polymarket_ws.as_ref().map(|ws| ws.subscribe_updates())
+    }
+
+    pub fn subscribe_prices(&self) -> Option<broadcast::Receiver<PriceUpdate>> {
+        self.binance_ws.as_ref().map(|ws| ws.subscribe())
+    }
+
+    pub fn subscribe_klines(&self) -> Option<broadcast::Receiver<KlineUpdate>> {
+        self.binance_kline_ws.as_ref().map(|ws| ws.subscribe())
+    }
+
+    pub fn subscribe_books(&self) -> Option<broadcast::Receiver<Arc<BookMessage>>> {
+        self.polymarket_ws.as_ref().map(|ws| ws.subscribe_books())
+    }
+
+    pub fn subscribe_chainlink(&self) -> Option<broadcast::Receiver<ChainlinkUpdate>> {
+        self.chainlink_ws.as_ref().map(|ws| ws.subscribe())
+    }
+
+    pub fn binance_ws(&self) -> Option<Arc<BinanceWebSocket>> {
+        self.binance_ws.clone()
+    }
+
+    pub fn polymarket_ws(&self) -> Option<Arc<PolymarketWebSocket>> {
+        self.polymarket_ws.clone()
+    }
+
+    pub fn binance_kline_ws(&self) -> Option<Arc<BinanceKlineWebSocket>> {
+        self.binance_kline_ws.clone()
+    }
+
+    pub fn chainlink_ws(&self) -> Option<Arc<ChainlinkRtds>> {
+        self.chainlink_ws.clone()
+    }
+
+    pub fn freshness(&self) -> Arc<DataPlaneFreshness> {
+        Arc::clone(&self.freshness)
+    }
+
+    pub fn config(&self) -> &DataPlaneConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_requires_polymarket_url_when_pm_is_configured() {
+        let config = DataPlaneConfig::default();
+        let err = config
+            .validate(true)
+            .expect_err("expected PM validation error");
+
+        match err {
+            PloyError::Validation(msg) => {
+                assert!(msg.contains("polymarket_ws_url"));
+            }
+            other => panic!("expected validation error, got {}", other),
+        }
+    }
+
+    #[test]
+    fn validate_kline_symbol_interval_relationship() {
+        let symbols_only = DataPlaneConfig {
+            binance_kline_symbols: vec!["BTCUSDT".to_string()],
+            ..DataPlaneConfig::default()
+        };
+        assert!(symbols_only.validate(false).is_err());
+
+        let intervals_only = DataPlaneConfig {
+            binance_kline_intervals: vec!["5m".to_string()],
+            ..DataPlaneConfig::default()
+        };
+        assert!(intervals_only.validate(false).is_err());
+
+        let valid = DataPlaneConfig {
+            binance_kline_symbols: vec!["BTCUSDT".to_string()],
+            binance_kline_intervals: vec!["5m".to_string()],
+            ..DataPlaneConfig::default()
+        };
+        assert!(valid.validate(false).is_ok());
+    }
+
+    #[test]
+    fn subscription_handles_match_available_adapters() {
+        let freshness = Arc::new(DataPlaneFreshness::new());
+        let no_pm = PlatformDataPlane::new(
+            DataPlaneConfig {
+                binance_spot_symbols: vec!["BTCUSDT".to_string()],
+                binance_kline_symbols: vec!["BTCUSDT".to_string()],
+                binance_kline_intervals: vec!["5m".to_string()],
+                chainlink_symbols: vec!["btc/usd".to_string()],
+                ..DataPlaneConfig::default()
+            },
+            Arc::clone(&freshness),
+        );
+
+        assert!(no_pm.subscribe_prices().is_some());
+        assert!(no_pm.subscribe_klines().is_some());
+        assert!(no_pm.subscribe_chainlink().is_some());
+        assert!(no_pm.subscribe_quotes().is_none());
+        assert!(no_pm.subscribe_books().is_none());
+
+        let pm_only = PlatformDataPlane::new(
+            DataPlaneConfig {
+                polymarket_ws_url: "wss://example.invalid/ws".to_string(),
+                ..DataPlaneConfig::default()
+            },
+            freshness,
+        );
+
+        assert!(pm_only.subscribe_quotes().is_some());
+        assert!(pm_only.subscribe_books().is_some());
+        assert!(pm_only.subscribe_prices().is_none());
+        assert!(pm_only.subscribe_klines().is_none());
+        assert!(pm_only.subscribe_chainlink().is_none());
+    }
+
+    #[tokio::test]
+    async fn start_allows_initial_pm_tokens_when_pm_not_configured() {
+        let plane = PlatformDataPlane::new(
+            DataPlaneConfig::default(),
+            Arc::new(DataPlaneFreshness::new()),
+        );
+        assert!(plane.start(vec!["token-1".to_string()]).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn start_second_call_returns_error() {
+        let plane = PlatformDataPlane::new(
+            DataPlaneConfig::default(),
+            Arc::new(DataPlaneFreshness::new()),
+        );
+        plane
+            .start(Vec::new())
+            .await
+            .expect("first start should work");
+
+        let err = plane
+            .start(Vec::new())
+            .await
+            .expect_err("second start should fail");
+        match err {
+            PloyError::Validation(msg) => {
+                assert!(
+                    msg.contains("start"),
+                    "unexpected validation message: {}",
+                    msg
+                );
+            }
+            other => panic!("expected validation error, got {}", other),
+        }
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod agents;
 mod contracts;
+pub mod data_plane;
 pub mod freshness;
 pub mod persistence_pipeline;
 mod platform;
@@ -21,6 +22,7 @@ pub use contracts::{
     RiskDecisionStatus, StrategyDeployment, StrategyEvaluationEvidence, StrategyEvaluationMetrics,
     StrategyEvaluationStage, StrategyLifecycleStage, StrategyProductType, Timeframe, TradeIntent,
 };
+pub use data_plane::{DataPlaneConfig, PlatformDataPlane};
 pub use freshness::{DataPlaneFreshness, DataSource};
 pub use persistence_pipeline::{
     BinanceLobTick, BinancePriceTick, ChainlinkPriceTick, ClobOrderbookSnapshot, ClobQuoteTick,

--- a/src/strategy/feeds.rs
+++ b/src/strategy/feeds.rs
@@ -187,6 +187,8 @@ fn parse_price_from_question(question: &str) -> Option<rust_decimal::Decimal> {
 pub struct DataFeedManager {
     /// Reference to strategy manager
     manager: Arc<StrategyManager>,
+    /// Optional shared data plane owner for WS lifecycles.
+    data_plane: Option<Arc<crate::platform::PlatformDataPlane>>,
     /// Binance WebSocket (optional)
     binance_ws: Option<Arc<BinanceWebSocket>>,
     /// Binance Kline WebSocket (optional)
@@ -247,6 +249,7 @@ impl DataFeedManager {
             .map(Arc::new);
         Self {
             manager,
+            data_plane: None,
             binance_ws: None,
             binance_kline_ws: None,
             binance_kline_symbols: Vec::new(),
@@ -254,6 +257,51 @@ impl DataFeedManager {
             binance_kline_backfill_limit: 0,
             binance_kline_last_close: Arc::new(RwLock::new(HashMap::new())),
             polymarket_ws: None,
+            pm_client: None,
+            token_events: Arc::new(RwLock::new(HashMap::new())),
+            active_feeds: Arc::new(RwLock::new(Vec::new())),
+            series_events: Arc::new(RwLock::new(HashMap::new())),
+            metadata_pool,
+        }
+    }
+
+    /// Create a DataFeedManager backed by a shared PlatformDataPlane.
+    pub fn from_data_plane(
+        dp: Arc<crate::platform::PlatformDataPlane>,
+        manager: Arc<StrategyManager>,
+    ) -> Self {
+        let metadata_pool = std::env::var("PLOY_DATABASE__URL")
+            .ok()
+            .or_else(|| std::env::var("DATABASE_URL").ok())
+            .and_then(|url| {
+                PgPoolOptions::new()
+                    .max_connections(2)
+                    .connect_lazy(&url)
+                    .ok()
+            })
+            .map(Arc::new);
+
+        let (binance_kline_symbols, binance_kline_intervals) = {
+            let cfg = dp.config();
+            (
+                cfg.binance_kline_symbols.clone(),
+                cfg.binance_kline_intervals.clone(),
+            )
+        };
+
+        Self {
+            manager,
+            data_plane: Some(dp.clone()),
+            binance_ws: dp.binance_ws(),
+            binance_kline_ws: dp.binance_kline_ws(),
+            binance_kline_symbols,
+            binance_kline_intervals,
+            binance_kline_backfill_limit: std::env::var("PLOY_BINANCE_KLINE_BACKFILL_LIMIT")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(300),
+            binance_kline_last_close: Arc::new(RwLock::new(HashMap::new())),
+            polymarket_ws: dp.polymarket_ws(),
             pm_client: None,
             token_events: Arc::new(RwLock::new(HashMap::new())),
             active_feeds: Arc::new(RwLock::new(Vec::new())),
@@ -294,6 +342,12 @@ impl DataFeedManager {
     /// Configure Polymarket feed
     pub fn with_polymarket(mut self, ws: PolymarketWebSocket, client: PolymarketClient) -> Self {
         self.polymarket_ws = Some(Arc::new(ws));
+        self.pm_client = Some(Arc::new(client));
+        self
+    }
+
+    /// Inject a Polymarket REST client without creating another WS instance.
+    pub fn with_pm_client(mut self, client: PolymarketClient) -> Self {
         self.pm_client = Some(Arc::new(client));
         self
     }
@@ -408,24 +462,37 @@ impl DataFeedManager {
 
             tokio::spawn(async move {
                 info!("Binance price feed started");
-                while let Ok(update) = rx.recv().await {
-                    let market_update = MarketUpdate::BinancePrice {
-                        symbol: update.symbol,
-                        price: update.price,
-                        timestamp: Utc::now(),
-                    };
-                    manager.send_market_update(market_update);
+                loop {
+                    match rx.recv().await {
+                        Ok(update) => {
+                            let market_update = MarketUpdate::BinancePrice {
+                                symbol: update.symbol,
+                                price: update.price,
+                                timestamp: Utc::now(),
+                            };
+                            manager.send_market_update(market_update);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("Binance price feed lagged by {} messages", n);
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            warn!("Binance price feed ended");
+                            break;
+                        }
+                    }
                 }
-                warn!("Binance price feed ended");
             });
 
-            // Start the WebSocket connection
-            let ws = binance_ws.clone();
-            tokio::spawn(async move {
-                if let Err(e) = ws.run().await {
-                    error!("Binance WebSocket error: {}", e);
-                }
-            });
+            if self.data_plane.is_none() {
+                // Start the WebSocket connection
+                let ws = binance_ws.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = ws.run().await {
+                        error!("Binance WebSocket error: {}", e);
+                    }
+                });
+            }
         }
 
         // Start Binance kline feed if configured
@@ -441,54 +508,67 @@ impl DataFeedManager {
 
             tokio::spawn(async move {
                 info!("Binance kline feed started");
-                while let Ok(update) = rx.recv().await {
-                    // Skip duplicates from backfill overlap or WS reconnect replay.
-                    let should_skip = {
-                        let map = last_close.read().await;
-                        map.get(&update.symbol)
-                            .and_then(|m| m.get(&update.interval))
-                            .map(|t| update.kline.close_time <= *t)
-                            .unwrap_or(false)
-                    };
-                    if should_skip {
-                        continue;
+                loop {
+                    match rx.recv().await {
+                        Ok(update) => {
+                            // Skip duplicates from backfill overlap or WS reconnect replay.
+                            let should_skip = {
+                                let map = last_close.read().await;
+                                map.get(&update.symbol)
+                                    .and_then(|m| m.get(&update.interval))
+                                    .map(|t| update.kline.close_time <= *t)
+                                    .unwrap_or(false)
+                            };
+                            if should_skip {
+                                continue;
+                            }
+
+                            {
+                                let mut map = last_close.write().await;
+                                map.entry(update.symbol.clone())
+                                    .or_default()
+                                    .insert(update.interval.clone(), update.kline.close_time);
+                            }
+
+                            let bar = KlineBar {
+                                open_time: update.kline.open_time,
+                                close_time: update.kline.close_time,
+                                open: update.kline.open,
+                                high: update.kline.high,
+                                low: update.kline.low,
+                                close: update.kline.close,
+                                volume: update.kline.volume,
+                                is_closed: update.kline.is_closed,
+                            };
+
+                            let market_update = MarketUpdate::BinanceKline {
+                                symbol: update.symbol,
+                                interval: update.interval,
+                                kline: bar,
+                                timestamp: update.event_time,
+                            };
+                            manager.send_market_update(market_update);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("Binance kline feed lagged by {} messages", n);
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            warn!("Binance kline feed ended");
+                            break;
+                        }
                     }
-
-                    {
-                        let mut map = last_close.write().await;
-                        map.entry(update.symbol.clone())
-                            .or_default()
-                            .insert(update.interval.clone(), update.kline.close_time);
-                    }
-
-                    let bar = KlineBar {
-                        open_time: update.kline.open_time,
-                        close_time: update.kline.close_time,
-                        open: update.kline.open,
-                        high: update.kline.high,
-                        low: update.kline.low,
-                        close: update.kline.close,
-                        volume: update.kline.volume,
-                        is_closed: update.kline.is_closed,
-                    };
-
-                    let market_update = MarketUpdate::BinanceKline {
-                        symbol: update.symbol,
-                        interval: update.interval,
-                        kline: bar,
-                        timestamp: update.event_time,
-                    };
-                    manager.send_market_update(market_update);
                 }
-                warn!("Binance kline feed ended");
             });
 
-            let ws = binance_ws.clone();
-            tokio::spawn(async move {
-                if let Err(e) = ws.run().await {
-                    error!("Binance kline WebSocket error: {}", e);
-                }
-            });
+            if self.data_plane.is_none() {
+                let ws = binance_ws.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = ws.run().await {
+                        error!("Binance kline WebSocket error: {}", e);
+                    }
+                });
+            }
         }
 
         // Start Polymarket feed if configured
@@ -550,6 +630,14 @@ impl DataFeedManager {
     pub async fn subscribe_tokens(&self, token_ids: Vec<String>) -> Result<()> {
         if let Some(ref pm_ws) = self.polymarket_ws {
             info!("Subscribing to {} Polymarket tokens", token_ids.len());
+
+            if self.data_plane.is_some() {
+                debug!(
+                    "Polymarket WS run is managed by PlatformDataPlane; skipping local ws.run()"
+                );
+                pm_ws.request_resubscribe();
+                return Ok(());
+            }
 
             // Start WebSocket with tokens
             let ws = pm_ws.clone();
@@ -864,11 +952,13 @@ impl DataFeedManager {
         let manager = self.manager.clone();
         let series_events = self.series_events.clone();
         let metadata_pool = self.metadata_pool.clone();
+        let use_data_plane = self.data_plane.is_some();
 
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(POLYMARKET_REFRESH_SECS));
             loop {
                 ticker.tick().await;
+                let mut refresh_changed = false;
 
                 for series_id in &series_ids {
                     // Fetch active events and keep only the nearest ones.
@@ -1031,6 +1121,9 @@ impl DataFeedManager {
                             .filter(|id| !discovered.contains_key(*id))
                             .cloned()
                             .collect();
+                        if !removed.is_empty() {
+                            refresh_changed = true;
+                        }
                         for event_id in removed {
                             prev.remove(&event_id);
                             manager.send_market_update(MarketUpdate::EventExpired { event_id });
@@ -1048,6 +1141,7 @@ impl DataFeedManager {
                             };
 
                             if should_send {
+                                refresh_changed = true;
                                 manager.send_market_update(MarketUpdate::EventDiscovered {
                                     event_id: ev.event_id.clone(),
                                     series_id: ev.series_id.clone(),
@@ -1062,6 +1156,13 @@ impl DataFeedManager {
                             prev.insert(event_id, ev);
                         }
                     }
+                }
+
+                if use_data_plane {
+                    if refresh_changed {
+                        pm_ws.request_resubscribe();
+                    }
+                    continue;
                 }
 
                 // Reconcile token subscriptions to keep the set bounded.


### PR DESCRIPTION
## Summary
- add `PlatformDataPlane` + `DataPlaneConfig` as singleton WS owner (`BinanceWebSocket`, `BinanceKlineWebSocket`, `PolymarketWebSocket`, optional `ChainlinkRtds`)
- add `DataFeedManager::from_data_plane(...)` and `with_pm_client(...)` to reuse shared WS handles in strategy runtime
- gate bootstrap wiring behind `PLOY_DATA_PLANE` (default off)
- wire managed strategy runtimes (pattern_memory/split_arb) to receive optional data plane
- in data-plane mode, unified persistence bridges subscribe via data-plane receivers
- avoid duplicate WS run loops when data plane is enabled
- avoid destructive shared PM token clobbering in data-plane mode (non-destructive registration + resubscribe on change)

## Behavior
- `PLOY_DATA_PLANE=0` keeps legacy path
- `PLOY_DATA_PLANE=1` reuses shared WS instances across strategy trait path

## Validation
- `cargo check -q`
- `cargo test -q --lib platform::data_plane::tests`
- `cargo test -q --lib strategy::feeds`
- `cargo test -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Introduced optional unified data-plane for coordinated market data handling across multiple adapters (Binance, Polymarket, Chainlink)
  - Added configurable data-plane integration to strategy runtimes and feed managers

* **Refactor**
  - Enhanced bootstrap and runtime initialization to support optional data-plane path with fallback to legacy behavior
  - Added validation and guard rails for data-plane configuration consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->