### PR TITLE
Phase 3: migrate agent consumers + persistence to data plane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-v2-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-test-v2-
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/src/adapters/binance_ws.rs
+++ b/src/adapters/binance_ws.rs
@@ -948,6 +948,9 @@ mod tests {
         let json = r#"{"e":"aggTrade","E":1700000000000,"s":"BTCUSDT","p":"not_a_number","q":"0.5","T":1700000000000}"#;
         ws.handle_message(json).await;
 
-        assert!(rx.try_recv().is_err(), "invalid price should not produce update");
+        assert!(
+            rx.try_recv().is_err(),
+            "invalid price should not produce update"
+        );
     }
 }

--- a/src/adapters/chainlink_rtds.rs
+++ b/src/adapters/chainlink_rtds.rs
@@ -540,8 +540,9 @@ impl ChainlinkRtds {
                 }],
             };
 
-            let payload = serde_json::to_string(&msg)
-                .map_err(|e| PloyError::Internal(format!("Failed to serialize subscribe: {}", e)))?;
+            let payload = serde_json::to_string(&msg).map_err(|e| {
+                PloyError::Internal(format!("Failed to serialize subscribe: {}", e))
+            })?;
 
             write
                 .send(Message::Text(payload))

--- a/src/adapters/polymarket_ws.rs
+++ b/src/adapters/polymarket_ws.rs
@@ -1457,7 +1457,10 @@ mod tests {
         ws.handle_message(json).await;
 
         // Should NOT receive any update
-        assert!(rx.try_recv().is_err(), "unregistered token should not produce QuoteUpdate");
+        assert!(
+            rx.try_recv().is_err(),
+            "unregistered token should not produce QuoteUpdate"
+        );
     }
 
     /// Empty book (no bids/asks) should still be handled but produce None quotes.
@@ -1478,8 +1481,14 @@ mod tests {
         ws.handle_message(json2).await;
 
         let update = rx.try_recv().expect("should receive update for empty book");
-        assert_eq!(update.quote.best_bid, None, "empty bids should clear best_bid");
-        assert_eq!(update.quote.best_ask, None, "empty asks should clear best_ask");
+        assert_eq!(
+            update.quote.best_bid, None,
+            "empty bids should clear best_bid"
+        );
+        assert_eq!(
+            update.quote.best_ask, None,
+            "empty asks should clear best_ask"
+        );
     }
 
     /// Book broadcast channel should emit Arc<BookMessage> for all tokens (even unregistered).
@@ -1496,7 +1505,9 @@ mod tests {
         let json = r#"[{"asset_id":"0xextra","market":"m","bids":[{"price":"0.30","size":"5"}],"asks":[{"price":"0.70","size":"5"}]}]"#;
         ws.handle_message(json).await;
 
-        let book = book_rx.try_recv().expect("should receive BookMessage broadcast");
+        let book = book_rx
+            .try_recv()
+            .expect("should receive BookMessage broadcast");
         assert_eq!(book.asset_id, "0xextra");
         assert_eq!(book.bids.len(), 1);
         assert_eq!(book.asks.len(), 1);
@@ -1515,7 +1526,13 @@ mod tests {
         ws.handle_message(json).await;
 
         let staleness = freshness.staleness(crate::platform::DataSource::PolymarketWs, "0xfresh");
-        assert!(staleness.is_some(), "freshness should be recorded after book update");
-        assert!(staleness.unwrap() < 1.0, "staleness should be very low (just recorded)");
+        assert!(
+            staleness.is_some(),
+            "freshness should be recorded after book update"
+        );
+        assert!(
+            staleness.unwrap() < 1.0,
+            "staleness should be very low (just recorded)"
+        );
     }
 }

--- a/src/agents/crypto.rs
+++ b/src/agents/crypto.rs
@@ -15,12 +15,14 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
-use crate::adapters::{BinanceWebSocket, PolymarketWebSocket, PriceUpdate, QuoteUpdate};
+use crate::adapters::{PriceUpdate, QuoteUpdate};
 use crate::agents::{AgentContext, TradingAgent};
 use crate::coordinator::CoordinatorCommand;
 use crate::domain::Side;
 use crate::error::Result;
-use crate::platform::{AgentRiskParams, AgentStatus, Domain, OrderIntent, OrderPriority};
+use crate::platform::{
+    AgentRiskParams, AgentStatus, CryptoDataPlaneHandle, Domain, OrderIntent, OrderPriority,
+};
 use crate::strategy::momentum::{EventInfo, EventMatcher};
 
 const TRADED_EVENT_RETENTION_HOURS: i64 = 24;
@@ -461,8 +463,7 @@ struct TrackedPosition {
 /// Pull-based crypto trading agent
 pub struct CryptoTradingAgent {
     config: CryptoTradingConfig,
-    binance_ws: Arc<BinanceWebSocket>,
-    pm_ws: Arc<PolymarketWebSocket>,
+    market_data: CryptoDataPlaneHandle,
     event_matcher: Arc<EventMatcher>,
 }
 
@@ -603,14 +604,12 @@ async fn sync_positions_from_global(
 impl CryptoTradingAgent {
     pub fn new(
         config: CryptoTradingConfig,
-        binance_ws: Arc<BinanceWebSocket>,
-        pm_ws: Arc<PolymarketWebSocket>,
+        market_data: CryptoDataPlaneHandle,
         event_matcher: Arc<EventMatcher>,
     ) -> Self {
         Self {
             config,
-            binance_ws,
-            pm_ws,
+            market_data,
             event_matcher,
         }
     }
@@ -689,8 +688,8 @@ impl TradingAgent for CryptoTradingAgent {
         sync_positions_from_global(&ctx, &self.config.agent_id, &mut positions).await;
 
         // Subscribe to data feeds
-        let mut binance_rx: broadcast::Receiver<PriceUpdate> = self.binance_ws.subscribe();
-        let mut pm_rx: broadcast::Receiver<QuoteUpdate> = self.pm_ws.subscribe_updates();
+        let mut binance_rx: broadcast::Receiver<PriceUpdate> = self.market_data.subscribe_prices();
+        let mut pm_rx: broadcast::Receiver<QuoteUpdate> = self.market_data.subscribe_quotes();
 
         // Periodic refresh of active events
         let refresh_dur = tokio::time::Duration::from_secs(self.config.event_refresh_secs);
@@ -748,13 +747,13 @@ impl TradingAgent for CryptoTradingAgent {
                     if desired_tokens != subscribed_tokens {
                         for events in active_events.values() {
                             for event in events {
-                                self.pm_ws
+                                self.market_data
                                     .register_tokens(&event.up_token_id, &event.down_token_id)
                                     .await;
                             }
                         }
 
-                        self.pm_ws.request_resubscribe();
+                        self.market_data.request_resubscribe();
                         info!(
                             agent = self.config.agent_id,
                             token_count = desired_tokens.len(),
@@ -799,7 +798,7 @@ impl TradingAgent for CryptoTradingAgent {
                     };
 
                     // Spot price + derived signals from the Binance tick cache.
-                    let spot_cache = self.binance_ws.price_cache();
+                    let spot_cache = self.market_data.price_cache();
                     let Some(spot) = spot_cache.get(&update.symbol).await else {
                         continue;
                     };
@@ -852,7 +851,7 @@ impl TradingAgent for CryptoTradingAgent {
                         Some((side, window_move, elapsed_secs, remaining_secs, start_price))
                     };
 
-                    let quote_cache = self.pm_ws.quote_cache();
+                    let quote_cache = self.market_data.quote_cache();
 
                     // Binary options default: exit on signal flip instead of TP/SL.
                     for (slug, pos) in &positions {
@@ -1468,7 +1467,7 @@ impl TradingAgent for CryptoTradingAgent {
                                 &mut positions,
                             )
                             .await;
-                            let quote_cache = self.pm_ws.quote_cache();
+                            let quote_cache = self.market_data.quote_cache();
                             for (slug, pos) in &positions {
                                 let bid = quote_cache
                                     .get(&pos.token_id)

--- a/src/agents/crypto_lob_ml.rs
+++ b/src/agents/crypto_lob_ml.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
-use crate::adapters::{BinanceWebSocket, PolymarketWebSocket, PriceUpdate, QuoteUpdate, SpotPrice};
+use crate::adapters::{PriceUpdate, QuoteUpdate, SpotPrice};
 use crate::agents::{AgentContext, TradingAgent};
 use crate::collector::LobCache;
 use crate::coordinator::CoordinatorCommand;
@@ -27,7 +27,9 @@ use crate::domain::Side;
 use crate::error::{PloyError, Result};
 #[cfg(feature = "onnx")]
 use crate::ml::OnnxModel;
-use crate::platform::{AgentRiskParams, AgentStatus, Domain, OrderIntent, OrderPriority};
+use crate::platform::{
+    AgentRiskParams, AgentStatus, CryptoDataPlaneHandle, Domain, OrderIntent, OrderPriority,
+};
 use crate::strategy::momentum::{EventInfo, EventMatcher};
 
 const TRADED_EVENT_RETENTION_HOURS: i64 = 24;
@@ -471,8 +473,7 @@ fn sequence_len_for_horizon(horizon: &str) -> usize {
 
 pub struct CryptoLobMlAgent {
     config: CryptoLobMlConfig,
-    binance_ws: Arc<BinanceWebSocket>,
-    pm_ws: Arc<PolymarketWebSocket>,
+    market_data: CryptoDataPlaneHandle,
     event_matcher: Arc<EventMatcher>,
     lob_cache: LobCache,
     #[cfg(feature = "onnx")]
@@ -644,8 +645,7 @@ async fn sync_positions_from_global(
 impl CryptoLobMlAgent {
     pub fn new(
         config: CryptoLobMlConfig,
-        binance_ws: Arc<BinanceWebSocket>,
-        pm_ws: Arc<PolymarketWebSocket>,
+        market_data: CryptoDataPlaneHandle,
         event_matcher: Arc<EventMatcher>,
         lob_cache: LobCache,
     ) -> Result<Self> {
@@ -709,8 +709,7 @@ impl CryptoLobMlAgent {
 
             return Ok(Self {
                 config,
-                binance_ws,
-                pm_ws,
+                market_data,
                 event_matcher,
                 lob_cache,
                 onnx_model: Some(m),
@@ -719,7 +718,7 @@ impl CryptoLobMlAgent {
 
         #[cfg(not(feature = "onnx"))]
         {
-            let _ = (binance_ws, pm_ws, event_matcher, lob_cache);
+            let _ = (market_data, event_matcher, lob_cache);
             Err(PloyError::Validation(
                 "crypto_lob_ml requires building with --features onnx".to_string(),
             ))
@@ -1569,8 +1568,8 @@ impl TradingAgent for CryptoLobMlAgent {
         sync_positions_from_global(&ctx, &self.config.agent_id, &mut positions).await;
 
         // Subscribe to data feeds
-        let mut binance_rx: broadcast::Receiver<PriceUpdate> = self.binance_ws.subscribe();
-        let mut pm_rx: broadcast::Receiver<QuoteUpdate> = self.pm_ws.subscribe_updates();
+        let mut binance_rx: broadcast::Receiver<PriceUpdate> = self.market_data.subscribe_prices();
+        let mut pm_rx: broadcast::Receiver<QuoteUpdate> = self.market_data.subscribe_quotes();
 
         let refresh_dur = tokio::time::Duration::from_secs(self.config.event_refresh_secs.max(1));
         let mut refresh_tick = tokio::time::interval(refresh_dur);
@@ -1628,12 +1627,12 @@ impl TradingAgent for CryptoLobMlAgent {
                     if desired_tokens != subscribed_tokens {
                         for events in active_events.values() {
                             for event in events {
-                                self.pm_ws
+                                self.market_data
                                     .register_tokens(&event.up_token_id, &event.down_token_id)
                                     .await;
                             }
                         }
-                        self.pm_ws.request_resubscribe();
+                        self.market_data.request_resubscribe();
                         info!(
                             agent = self.config.agent_id,
                             token_count = desired_tokens.len(),
@@ -1676,7 +1675,7 @@ impl TradingAgent for CryptoLobMlAgent {
                     };
 
                     // Momentum + volatility from trade-tick cache.
-                    let spot_cache = self.binance_ws.price_cache();
+                    let spot_cache = self.market_data.price_cache();
                     let Some(spot) = spot_cache.get(&update.symbol).await else {
                         continue;
                     };
@@ -1713,7 +1712,7 @@ impl TradingAgent for CryptoLobMlAgent {
                     let obi_micro = obi_1 - lob.obi_5;
                     let obi_slope = lob.obi_5 - obi_20;
 
-                    let quote_cache = self.pm_ws.quote_cache();
+                    let quote_cache = self.market_data.quote_cache();
                     for event in events {
                         let timeframe = normalize_timeframe(&event.horizon);
                         let entry_key = format!("{}|{}", update.symbol, &timeframe);
@@ -2431,7 +2430,7 @@ impl TradingAgent for CryptoLobMlAgent {
                                 &mut positions,
                             )
                             .await;
-                            let quote_cache = self.pm_ws.quote_cache();
+                            let quote_cache = self.market_data.quote_cache();
                             for (slug, pos) in &positions {
                                 let bid = quote_cache
                                     .get(&pos.token_id)
@@ -2565,6 +2564,14 @@ impl TradingAgent for CryptoLobMlAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapters::{BinanceWebSocket, PolymarketWebSocket};
+
+    fn sample_market_data() -> CryptoDataPlaneHandle {
+        CryptoDataPlaneHandle::new(
+            Arc::new(BinanceWebSocket::new(vec![])),
+            Arc::new(PolymarketWebSocket::new("wss://example.com")),
+        )
+    }
 
     fn sample_window_context() -> WindowContext {
         WindowContext {
@@ -2746,8 +2753,7 @@ mod tests {
     fn test_estimate_p_up_validates_sequence_input_dim() {
         let agent = CryptoLobMlAgent {
             config: CryptoLobMlConfig::default(),
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2794,8 +2800,7 @@ mod tests {
                 exit_mode,
                 ..CryptoLobMlConfig::default()
             },
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2833,8 +2838,7 @@ mod tests {
 
         let result = CryptoLobMlAgent::new(
             cfg,
-            Arc::new(BinanceWebSocket::new(vec![])),
-            Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            sample_market_data(),
             Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2854,8 +2858,7 @@ mod tests {
 
         let result = CryptoLobMlAgent::new(
             cfg,
-            Arc::new(BinanceWebSocket::new(vec![])),
-            Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            sample_market_data(),
             Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2873,8 +2876,7 @@ mod tests {
     fn test_model_blend_weight_default() {
         let agent = CryptoLobMlAgent {
             config: CryptoLobMlConfig::default(),
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2891,8 +2893,7 @@ mod tests {
     fn test_entry_window_enforces_late_windows_for_5m_and_15m() {
         let agent = CryptoLobMlAgent {
             config: CryptoLobMlConfig::default(),
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2911,8 +2912,7 @@ mod tests {
     fn test_evaluate_entry_signal_uses_lagging_side_default() {
         let agent = CryptoLobMlAgent {
             config: CryptoLobMlConfig::default(),
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2935,8 +2935,7 @@ mod tests {
     fn test_evaluate_entry_signal_rejects_expensive_entry() {
         let agent = CryptoLobMlAgent {
             config: CryptoLobMlConfig::default(),
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),
@@ -2957,8 +2956,7 @@ mod tests {
         cfg.max_entry_price = dec!(0.30);
         let agent = CryptoLobMlAgent {
             config: cfg,
-            binance_ws: Arc::new(BinanceWebSocket::new(vec![])),
-            pm_ws: Arc::new(PolymarketWebSocket::new("wss://example.com")),
+            market_data: sample_market_data(),
             event_matcher: Arc::new(EventMatcher::new(
                 crate::adapters::PolymarketClient::new("https://example.com", true).unwrap(),
             )),

--- a/src/agents/crypto_rl_policy.rs
+++ b/src/agents/crypto_rl_policy.rs
@@ -60,7 +60,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
-use crate::adapters::{BinanceWebSocket, PolymarketWebSocket};
 use crate::agents::{AgentContext, TradingAgent};
 use crate::collector::LobCache;
 #[cfg(feature = "onnx")]
@@ -70,7 +69,9 @@ use crate::domain::Side;
 use crate::error::Result;
 #[cfg(feature = "onnx")]
 use crate::ml::OnnxModel;
-use crate::platform::{AgentRiskParams, AgentStatus, Domain, OrderIntent, OrderPriority};
+use crate::platform::{
+    AgentRiskParams, AgentStatus, CryptoDataPlaneHandle, Domain, OrderIntent, OrderPriority,
+};
 use crate::strategy::momentum::{EventInfo, EventMatcher};
 
 #[cfg(feature = "onnx")]
@@ -291,8 +292,7 @@ fn deployment_id_for_symbol(symbol: &str) -> String {
 
 pub struct CryptoRlPolicyAgent {
     config: CryptoRlPolicyConfig,
-    binance_ws: Arc<BinanceWebSocket>,
-    pm_ws: Arc<PolymarketWebSocket>,
+    market_data: CryptoDataPlaneHandle,
     event_matcher: Arc<EventMatcher>,
     lob_cache: LobCache,
 
@@ -303,8 +303,7 @@ pub struct CryptoRlPolicyAgent {
 impl CryptoRlPolicyAgent {
     pub fn new(
         mut config: CryptoRlPolicyConfig,
-        binance_ws: Arc<BinanceWebSocket>,
-        pm_ws: Arc<PolymarketWebSocket>,
+        market_data: CryptoDataPlaneHandle,
         event_matcher: Arc<EventMatcher>,
         lob_cache: LobCache,
     ) -> Self {
@@ -408,8 +407,7 @@ impl CryptoRlPolicyAgent {
 
         Self {
             config,
-            binance_ws,
-            pm_ws,
+            market_data,
             event_matcher,
             lob_cache,
             #[cfg(feature = "onnx")]
@@ -816,11 +814,11 @@ impl TradingAgent for CryptoRlPolicyAgent {
 
                     if desired_tokens != subscribed_tokens {
                         for event in active_events.values() {
-                            self.pm_ws
+                            self.market_data
                                 .register_tokens(&event.up_token_id, &event.down_token_id)
                                 .await;
                         }
-                        self.pm_ws.request_resubscribe();
+                        self.market_data.request_resubscribe();
                         info!(
                             agent = self.config.agent_id,
                             token_count = desired_tokens.len(),
@@ -837,8 +835,8 @@ impl TradingAgent for CryptoRlPolicyAgent {
                     }
 
                     let now = Utc::now();
-                    let quote_cache = self.pm_ws.quote_cache();
-                    let spot_cache = self.binance_ws.price_cache();
+                    let quote_cache = self.market_data.quote_cache();
+                    let spot_cache = self.market_data.price_cache();
 
                     for coin in &self.config.coins {
                         let symbol = format!("{}USDT", coin.to_uppercase());
@@ -992,7 +990,7 @@ impl TradingAgent for CryptoRlPolicyAgent {
                                     let discrete = action.to_discrete();
                                     let priority = if action.is_aggressive() { OrderPriority::High } else { OrderPriority::Normal };
                                     let policy_version = self.config.policy_model_version.as_deref().unwrap_or("");
-                                    let deployment_id = deployment_id_for_symbol(symbol);
+                                    let deployment_id = deployment_id_for_symbol(&symbol);
 
                                     match discrete {
                                         DiscreteAction::Hold => {}
@@ -1709,7 +1707,7 @@ impl TradingAgent for CryptoRlPolicyAgent {
                         }
                         Some(CoordinatorCommand::ForceClose) => {
                             warn!(agent = self.config.agent_id, "force close — submitting exit orders");
-                            let quote_cache = self.pm_ws.quote_cache();
+                            let quote_cache = self.market_data.quote_cache();
                             for (slug, pos) in &positions {
                                 let deployment_id = deployment_id_for_symbol(&pos.symbol);
                                 for leg in &pos.legs {

--- a/src/agents/openclaw/agent.rs
+++ b/src/agents/openclaw/agent.rs
@@ -7,18 +7,15 @@
 //! 4. Detects and resolves cross-agent position conflicts
 //! 5. Coordinates temporal straddle positions
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use rust_decimal::Decimal;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
-use crate::adapters::binance_ws::BinanceWebSocket;
 use crate::agents::context::AgentContext;
 use crate::agents::traits::TradingAgent;
 use crate::coordinator::CoordinatorCommand;
-use crate::platform::{AgentRiskParams, AgentStatus, Domain};
+use crate::platform::{AgentRiskParams, AgentStatus, BinanceDataPlaneHandle, Domain};
 
 use super::allocator::DynamicAllocator;
 use super::config::OpenClawConfig;
@@ -30,12 +27,15 @@ use super::straddle::StraddleManager;
 /// OpenClaw meta-agent: observes, governs, and allocates — never trades directly.
 pub struct OpenClawAgent {
     config: OpenClawConfig,
-    binance_ws: Arc<BinanceWebSocket>,
+    market_data: BinanceDataPlaneHandle,
 }
 
 impl OpenClawAgent {
-    pub fn new(config: OpenClawConfig, binance_ws: Arc<BinanceWebSocket>) -> Self {
-        Self { config, binance_ws }
+    pub fn new(config: OpenClawConfig, market_data: BinanceDataPlaneHandle) -> Self {
+        Self {
+            config,
+            market_data,
+        }
     }
 }
 
@@ -90,7 +90,7 @@ impl TradingAgent for OpenClawAgent {
         let mut regime_detector = RegimeDetector::new(
             self.config.regime.clone(),
             self.config.btc_symbol.clone(),
-            self.binance_ws.clone(),
+            self.market_data.clone(),
         );
         let mut perf_tracker =
             PerformanceTracker::new(self.config.allocator.clone(), self.config.perf_window_secs);
@@ -181,7 +181,7 @@ impl TradingAgent for OpenClawAgent {
 
                     // Straddle tick (if enabled)
                     if straddle_mgr.is_enabled() {
-                        if let Some(spot) = self.binance_ws.price_cache()
+                        if let Some(spot) = self.market_data.price_cache()
                             .get(&self.config.btc_symbol).await
                         {
                             let _signals = straddle_mgr.tick(spot.price);

--- a/src/agents/openclaw/regime.rs
+++ b/src/agents/openclaw/regime.rs
@@ -6,14 +6,12 @@
 //! - Trending: strong directional consistency in recent price moves
 //! - Ranging: neither trending nor vol-anomalous (mean-reverting)
 
-use std::sync::Arc;
-
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use crate::adapters::binance_ws::BinanceWebSocket;
+use crate::platform::BinanceDataPlaneHandle;
 
 use super::config::RegimeConfig;
 
@@ -63,7 +61,7 @@ pub struct RegimeSnapshot {
 pub struct RegimeDetector {
     config: RegimeConfig,
     btc_symbol: String,
-    binance_ws: Arc<BinanceWebSocket>,
+    market_data: BinanceDataPlaneHandle,
 
     /// Current confirmed regime
     current_regime: MarketRegime,
@@ -77,12 +75,12 @@ impl RegimeDetector {
     pub fn new(
         config: RegimeConfig,
         btc_symbol: String,
-        binance_ws: Arc<BinanceWebSocket>,
+        market_data: BinanceDataPlaneHandle,
     ) -> Self {
         Self {
             config,
             btc_symbol,
-            binance_ws,
+            market_data,
             current_regime: MarketRegime::Ranging,
             candidate_regime: MarketRegime::Ranging,
             candidate_count: 0,
@@ -96,7 +94,7 @@ impl RegimeDetector {
 
     /// Compute regime from latest market data. Returns (snapshot, changed).
     pub async fn tick(&mut self) -> (RegimeSnapshot, bool) {
-        let cache = self.binance_ws.price_cache();
+        let cache = self.market_data.price_cache();
         let vol_short = cache
             .volatility(&self.btc_symbol, self.config.vol_short_secs)
             .await;

--- a/src/cli/strategy.rs
+++ b/src/cli/strategy.rs
@@ -2195,8 +2195,8 @@ async fn backtest_directional_signals_pm_settlement(
     no_refresh: bool,
     database_url: Option<String>,
 ) -> Result<()> {
-    use crate::adapters::PostgresStore;
     use crate::adapters::PolymarketClient;
+    use crate::adapters::PostgresStore;
     use crate::strategy::fee_model::FeeModel;
     use chrono::{DateTime, Utc};
     use rust_decimal::prelude::ToPrimitive;
@@ -2292,13 +2292,17 @@ async fn backtest_directional_signals_pm_settlement(
         let token_id: Option<String> = row.get("token_id");
         let Some(token_id) = token_id else { continue };
         let entry_price: Option<Decimal> = row.get("market_price");
-        let Some(entry_price) = entry_price else { continue };
+        let Some(entry_price) = entry_price else {
+            continue;
+        };
 
         let symbol: Option<String> = row.get("symbol");
         let side: Option<String> = row.get("side");
         let confidence: Option<f64> = row.get("confidence");
         let ev_net: Option<f64> = row.get("edge");
-        let context: serde_json::Value = row.get::<sqlx::types::Json<serde_json::Value>, _>("context").0;
+        let context: serde_json::Value = row
+            .get::<sqlx::types::Json<serde_json::Value>, _>("context")
+            .0;
 
         token_ids.push(token_id.clone());
         signals.push(SignalRow {
@@ -3280,12 +3284,17 @@ async fn run_backtest(
 
     use crate::adapters::PostgresStore;
     use crate::strategy::backtest_feed::HistoricalFeed;
-    use crate::strategy::directional_backtest::{DirectionalBacktestConfig, DirectionalBacktestEngine};
+    use crate::strategy::directional_backtest::{
+        DirectionalBacktestConfig, DirectionalBacktestEngine,
+    };
     use crate::strategy::momentum_backtest::{MomentumBacktestConfig, MomentumBacktestEngine};
 
     match name {
         "momentum" | "directional" => {}
-        other => anyhow::bail!("Unknown backtest strategy: '{}'. Supported: momentum, directional", other),
+        other => anyhow::bail!(
+            "Unknown backtest strategy: '{}'. Supported: momentum, directional",
+            other
+        ),
     }
 
     if mode == StrategyBacktestMode::Settlement {
@@ -3339,7 +3348,8 @@ async fn run_backtest(
     // Unified backtest feed path: database only.
     let store = PostgresStore::new(&db_url, 5).await?;
     info!("Loading historical data from database");
-    let mut feed = HistoricalFeed::from_database(store.pool(), &symbol_list, from_dt, to_dt).await?;
+    let mut feed =
+        HistoricalFeed::from_database(store.pool(), &symbol_list, from_dt, to_dt).await?;
 
     let initial_capital = Decimal::from_f64(capital).unwrap_or_else(|| Decimal::new(10000, 0));
 

--- a/src/collector/sync_collector.rs
+++ b/src/collector/sync_collector.rs
@@ -375,11 +375,9 @@ impl SyncCollector {
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_sync_records_ts ON sync_records(timestamp)")
             .execute(pool)
             .await?;
-        sqlx::query(
-            "CREATE INDEX IF NOT EXISTS idx_sync_records_symbol ON sync_records(symbol)",
-        )
-        .execute(pool)
-        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_sync_records_symbol ON sync_records(symbol)")
+            .execute(pool)
+            .await?;
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_sync_records_symbol_ts ON sync_records(symbol, timestamp)")
             .execute(pool)
             .await?;

--- a/src/coordinator/bootstrap.rs
+++ b/src/coordinator/bootstrap.rs
@@ -3,6 +3,7 @@
 //! Entry point for `ploy platform start`. Creates shared infrastructure,
 //! registers agents based on config flags, and runs the coordinator loop.
 
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
@@ -11,7 +12,6 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::adapters::polymarket_clob::POLYGON_CHAIN_ID;
-use crate::adapters::polymarket_ws::PriceLevel;
 use crate::adapters::{BinanceWebSocket, PolymarketClient, PolymarketWebSocket, PostgresStore};
 use crate::agents::{
     AgentContext, CryptoLobMlAgent, CryptoLobMlConfig, CryptoLobMlEntrySidePolicy,
@@ -32,8 +32,8 @@ use crate::domain::{OrderStatus, Side};
 use crate::error::Result;
 use crate::exchange::{build_exchange_client, parse_exchange_kind, ExchangeKind};
 use crate::platform::{
-    AgentRiskParams, AgentStatus, DataPlaneConfig, Domain, MarketSelector, PlatformDataPlane,
-    StrategyDeployment,
+    AgentRiskParams, AgentStatus, BinanceDataPlaneHandle, CryptoDataPlaneHandle, DataPlaneConfig,
+    Domain, MarketSelector, PlatformDataPlane, StrategyDeployment,
 };
 use crate::signing::Wallet;
 use crate::strategy::event_edge::core::EventEdgeCore;
@@ -1246,336 +1246,6 @@ async fn ensure_clob_trade_alerts_table(pool: &PgPool) -> Result<()> {
     Ok(())
 }
 
-fn spawn_clob_quote_persistence(
-    pm_ws: Arc<PolymarketWebSocket>,
-    pool: PgPool,
-    agent_id: String,
-    domain: Domain,
-) {
-    tokio::spawn(async move {
-        if let Err(e) = ensure_clob_quote_ticks_table(&pool).await {
-            warn!(
-                agent = agent_id,
-                error = %e,
-                "failed to ensure clob_quote_ticks table; quote persistence disabled"
-            );
-            return;
-        }
-
-        let mut rx = pm_ws.subscribe_updates();
-        let mut last_persisted: HashMap<
-            String,
-            (
-                chrono::DateTime<Utc>,
-                Option<rust_decimal::Decimal>,
-                Option<rust_decimal::Decimal>,
-                Option<rust_decimal::Decimal>,
-                Option<rust_decimal::Decimal>,
-            ),
-        > = HashMap::new();
-        let mut persisted_count: u64 = 0;
-
-        loop {
-            match rx.recv().await {
-                Ok(update) => {
-                    if update.quote.best_bid.is_none() && update.quote.best_ask.is_none() {
-                        continue;
-                    }
-
-                    let now = Utc::now();
-                    let should_persist = match last_persisted.get(&update.token_id) {
-                        None => true,
-                        Some((ts, prev_bid, prev_ask, prev_bid_size, prev_ask_size)) => {
-                            let changed = *prev_bid != update.quote.best_bid
-                                || *prev_ask != update.quote.best_ask
-                                || *prev_bid_size != update.quote.bid_size
-                                || *prev_ask_size != update.quote.ask_size;
-                            let elapsed = now.signed_duration_since(*ts).num_seconds()
-                                >= CLOB_PERSIST_MIN_INTERVAL_SECS;
-                            changed && elapsed
-                        }
-                    };
-
-                    if !should_persist {
-                        continue;
-                    }
-
-                    let side = update.side.as_str();
-                    let domain_str = domain.to_string();
-                    if let Err(e) = sqlx::query(
-                        r#"
-                        INSERT INTO clob_quote_ticks
-                            (token_id, side, best_bid, best_ask, bid_size, ask_size, source, domain)
-                        VALUES
-                            ($1, $2, $3, $4, $5, $6, 'polymarket_ws', $7)
-                        "#,
-                    )
-                    .bind(&update.token_id)
-                    .bind(side)
-                    .bind(update.quote.best_bid)
-                    .bind(update.quote.best_ask)
-                    .bind(update.quote.bid_size)
-                    .bind(update.quote.ask_size)
-                    .bind(&domain_str)
-                    .execute(&pool)
-                    .await
-                    {
-                        warn!(
-                            agent = agent_id,
-                            token_id = %update.token_id,
-                            error = %e,
-                            "failed to persist clob quote"
-                        );
-                        continue;
-                    }
-
-                    last_persisted.insert(
-                        update.token_id.clone(),
-                        (
-                            now,
-                            update.quote.best_bid,
-                            update.quote.best_ask,
-                            update.quote.bid_size,
-                            update.quote.ask_size,
-                        ),
-                    );
-                    persisted_count = persisted_count.saturating_add(1);
-
-                    if persisted_count % 1000 == 0 {
-                        info!(
-                            agent = agent_id,
-                            persisted_count, "persisted clob quote ticks"
-                        );
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
-                        agent = agent_id,
-                        lagged = n,
-                        "clob persistence receiver lagged"
-                    );
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    warn!(agent = agent_id, "clob persistence receiver closed");
-                    break;
-                }
-            }
-        }
-    });
-}
-
-fn spawn_binance_price_persistence(
-    binance_ws: Arc<BinanceWebSocket>,
-    pool: PgPool,
-    agent_id: String,
-) {
-    tokio::spawn(async move {
-        if let Err(e) = ensure_binance_price_ticks_table(&pool).await {
-            warn!(
-                agent = agent_id,
-                error = %e,
-                "failed to ensure binance_price_ticks table; Binance persistence disabled"
-            );
-            return;
-        }
-
-        let mut rx = binance_ws.subscribe();
-        let mut last_persisted: HashMap<
-            String,
-            (
-                chrono::DateTime<Utc>,
-                Option<rust_decimal::Decimal>,
-                Option<rust_decimal::Decimal>,
-            ),
-        > = HashMap::new();
-        let mut persisted_count: u64 = 0;
-
-        loop {
-            match rx.recv().await {
-                Ok(update) => {
-                    let now = Utc::now();
-                    let should_persist = match last_persisted.get(&update.symbol) {
-                        None => true,
-                        Some((ts, prev_price, prev_qty)) => {
-                            let changed =
-                                *prev_price != Some(update.price) || *prev_qty != update.quantity;
-                            let elapsed = now.signed_duration_since(*ts).num_seconds()
-                                >= BINANCE_PERSIST_MIN_INTERVAL_SECS;
-                            changed && elapsed
-                        }
-                    };
-
-                    if !should_persist {
-                        continue;
-                    }
-
-                    if let Err(e) = sqlx::query(
-                        r#"
-                        INSERT INTO binance_price_ticks
-                            (symbol, price, quantity, trade_time)
-                        VALUES
-                            ($1, $2, $3, $4)
-                        "#,
-                    )
-                    .bind(&update.symbol)
-                    .bind(update.price)
-                    .bind(update.quantity)
-                    .bind(update.timestamp)
-                    .execute(&pool)
-                    .await
-                    {
-                        warn!(
-                            agent = agent_id,
-                            symbol = %update.symbol,
-                            error = %e,
-                            "failed to persist Binance price tick"
-                        );
-                        continue;
-                    }
-
-                    last_persisted.insert(
-                        update.symbol.clone(),
-                        (now, Some(update.price), update.quantity),
-                    );
-                    persisted_count = persisted_count.saturating_add(1);
-
-                    if persisted_count % 10_000 == 0 {
-                        info!(
-                            agent = agent_id,
-                            persisted_count, "persisted Binance price ticks"
-                        );
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
-                        agent = agent_id,
-                        lagged = n,
-                        "binance persistence receiver lagged"
-                    );
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    warn!(agent = agent_id, "binance persistence receiver closed");
-                    break;
-                }
-            }
-        }
-    });
-}
-
-// ---------------------------------------------------------------------------
-// Chainlink RTDS tick persistence
-// ---------------------------------------------------------------------------
-
-async fn ensure_chainlink_tables(pool: &PgPool) -> Result<()> {
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS chainlink_price_ticks (
-            id BIGSERIAL PRIMARY KEY,
-            symbol TEXT NOT NULL,
-            price NUMERIC NOT NULL,
-            source_timestamp TIMESTAMPTZ NOT NULL,
-            received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        "CREATE INDEX IF NOT EXISTS idx_chainlink_ticks_symbol_time ON chainlink_price_ticks(symbol, source_timestamp DESC)",
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        "CREATE INDEX IF NOT EXISTS idx_chainlink_ticks_time ON chainlink_price_ticks(received_at DESC)",
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS market_window_labels (
-            id BIGSERIAL PRIMARY KEY,
-            symbol TEXT NOT NULL,
-            window_start TIMESTAMPTZ NOT NULL,
-            window_end TIMESTAMPTZ NOT NULL,
-            open_price NUMERIC NOT NULL,
-            close_price NUMERIC,
-            label SMALLINT,
-            condition_id TEXT,
-            UNIQUE(symbol, window_start)
-        )
-        "#,
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        "CREATE INDEX IF NOT EXISTS idx_market_window_labels_symbol ON market_window_labels(symbol, window_start DESC)",
-    )
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
-fn spawn_chainlink_persistence(chainlink_ws: Arc<crate::adapters::ChainlinkRtds>, pool: PgPool) {
-    tokio::spawn(async move {
-        if let Err(e) = ensure_chainlink_tables(&pool).await {
-            warn!(
-                error = %e,
-                "failed to ensure chainlink tables; Chainlink persistence disabled"
-            );
-            return;
-        }
-
-        let mut rx = chainlink_ws.subscribe();
-        let mut persisted_count: u64 = 0;
-
-        loop {
-            match rx.recv().await {
-                Ok(update) => {
-                    if let Err(e) = sqlx::query(
-                        r#"
-                        INSERT INTO chainlink_price_ticks
-                            (symbol, price, source_timestamp)
-                        VALUES
-                            ($1, $2, $3)
-                        "#,
-                    )
-                    .bind(&update.symbol)
-                    .bind(update.price)
-                    .bind(update.timestamp)
-                    .execute(&pool)
-                    .await
-                    {
-                        warn!(
-                            symbol = %update.symbol,
-                            error = %e,
-                            "failed to persist Chainlink price tick"
-                        );
-                        continue;
-                    }
-
-                    persisted_count = persisted_count.saturating_add(1);
-
-                    if persisted_count % 10_000 == 0 {
-                        info!(persisted_count, "persisted Chainlink price ticks");
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(lagged = n, "chainlink persistence receiver lagged");
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    warn!("chainlink persistence receiver closed");
-                    break;
-                }
-            }
-        }
-    });
-}
-
 fn lob_levels_json(
     state: &crate::collector::OrderBookState,
     is_bids: bool,
@@ -1607,138 +1277,6 @@ fn lob_levels_json(
             })
             .collect()
     }
-}
-
-fn spawn_binance_lob_persistence(
-    depth_stream: Arc<crate::collector::BinanceDepthStream>,
-    pool: PgPool,
-    agent_id: String,
-) {
-    tokio::spawn(async move {
-        if let Err(e) = ensure_binance_lob_ticks_table(&pool).await {
-            warn!(
-                agent = agent_id,
-                error = %e,
-                "failed to ensure binance_lob_ticks table; Binance LOB persistence disabled"
-            );
-            return;
-        }
-
-        let snapshot_interval_ms = env_u64("BN_LOB_SNAPSHOT_MS", 1000).max(100);
-        let max_levels = env_usize("BN_LOB_LEVELS", 20).clamp(0, 200);
-
-        let mut rx = depth_stream.subscribe();
-        let mut last_persisted: HashMap<String, chrono::DateTime<Utc>> = HashMap::new();
-        let mut last_update_id: HashMap<String, i64> = HashMap::new();
-        let mut persisted_count: u64 = 0;
-
-        loop {
-            match rx.recv().await {
-                Ok(update) => {
-                    let now = Utc::now();
-                    let symbol = update.symbol.clone();
-
-                    let should_persist =
-                        match (last_persisted.get(&symbol), last_update_id.get(&symbol)) {
-                            (None, _) => true,
-                            (Some(ts), Some(prev_id)) => {
-                                let elapsed_ms =
-                                    now.signed_duration_since(*ts).num_milliseconds().max(0) as u64;
-                                elapsed_ms >= snapshot_interval_ms
-                                    && *prev_id != update.snapshot.update_id
-                            }
-                            (Some(ts), None) => {
-                                let elapsed_ms =
-                                    now.signed_duration_since(*ts).num_milliseconds().max(0) as u64;
-                                elapsed_ms >= snapshot_interval_ms
-                            }
-                        };
-
-                    if !should_persist {
-                        continue;
-                    }
-
-                    let (bids, asks) = if max_levels == 0 {
-                        (Vec::new(), Vec::new())
-                    } else {
-                        (
-                            lob_levels_json(&update.raw_state, true, max_levels),
-                            lob_levels_json(&update.raw_state, false, max_levels),
-                        )
-                    };
-
-                    if let Err(e) = sqlx::query(
-                        r#"
-                        INSERT INTO binance_lob_ticks (
-                            symbol, update_id,
-                            best_bid, best_ask, mid_price, spread_bps,
-                            obi_5, obi_10,
-                            bid_volume_5, ask_volume_5,
-                            bids, asks,
-                            event_time
-                        ) VALUES (
-                            $1, $2,
-                            $3, $4, $5, $6,
-                            $7, $8,
-                            $9, $10,
-                            $11, $12,
-                            $13
-                        )
-                        "#,
-                    )
-                    .bind(&symbol)
-                    .bind(update.snapshot.update_id)
-                    .bind(update.snapshot.best_bid)
-                    .bind(update.snapshot.best_ask)
-                    .bind(update.snapshot.mid_price)
-                    .bind(update.snapshot.spread_bps)
-                    .bind(update.snapshot.obi_5)
-                    .bind(update.snapshot.obi_10)
-                    .bind(update.snapshot.bid_volume_5)
-                    .bind(update.snapshot.ask_volume_5)
-                    .bind(sqlx::types::Json(&bids))
-                    .bind(sqlx::types::Json(&asks))
-                    .bind(update.snapshot.timestamp)
-                    .execute(&pool)
-                    .await
-                    {
-                        warn!(
-                            agent = agent_id,
-                            symbol = %symbol,
-                            error = %e,
-                            "failed to persist Binance LOB tick"
-                        );
-                        continue;
-                    }
-
-                    last_persisted.insert(symbol.clone(), now);
-                    last_update_id.insert(symbol.clone(), update.snapshot.update_id);
-                    persisted_count = persisted_count.saturating_add(1);
-
-                    if persisted_count % 10_000 == 0 {
-                        info!(
-                            agent = agent_id,
-                            persisted_count,
-                            snapshot_interval_ms,
-                            max_levels,
-                            "persisted Binance LOB ticks"
-                        );
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
-                        agent = agent_id,
-                        lagged = n,
-                        "binance lob persistence receiver lagged"
-                    );
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    warn!(agent = agent_id, "binance lob persistence receiver closed");
-                    break;
-                }
-            }
-        }
-    });
 }
 
 type InsertedTradeTickRow = (
@@ -3080,52 +2618,6 @@ fn is_market_resolved(prices: &[rust_decimal::Decimal]) -> bool {
     winners == 1 && losers == prices.len().saturating_sub(1)
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-struct DepthLevelJson {
-    price: String,
-    size: String,
-}
-
-fn parse_depth_levels(
-    levels: &[PriceLevel],
-    is_bid: bool,
-    max_levels: usize,
-) -> Vec<DepthLevelJson> {
-    use rust_decimal::Decimal;
-    let mut parsed: Vec<(Decimal, Decimal)> = Vec::with_capacity(levels.len());
-
-    for lvl in levels {
-        let Ok(price) = lvl.price.parse::<Decimal>() else {
-            continue;
-        };
-        let Ok(size) = lvl.size.parse::<Decimal>() else {
-            continue;
-        };
-        parsed.push((price, size));
-    }
-
-    if is_bid {
-        parsed.sort_by(|a, b| b.0.cmp(&a.0));
-    } else {
-        parsed.sort_by(|a, b| a.0.cmp(&b.0));
-    }
-
-    parsed
-        .into_iter()
-        .take(max_levels)
-        .map(|(price, size)| DepthLevelJson {
-            price: price.to_string(),
-            size: size.to_string(),
-        })
-        .collect()
-}
-
-fn parse_book_timestamp(ts: &Option<String>) -> Option<chrono::DateTime<Utc>> {
-    let raw = ts.as_ref()?;
-    let parsed = chrono::DateTime::parse_from_rfc3339(raw).ok()?;
-    Some(parsed.with_timezone(&Utc))
-}
-
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name)
         .ok()
@@ -3620,133 +3112,6 @@ fn apply_strategy_deployments(
         timeframes = ?tf,
         "applied strategy deployment matrix to platform runtime"
     );
-}
-
-fn spawn_clob_orderbook_persistence(
-    pm_ws: Arc<PolymarketWebSocket>,
-    pool: PgPool,
-    agent_id: String,
-    domain: Domain,
-    max_levels_default: usize,
-    min_interval_secs_default: i64,
-) {
-    tokio::spawn(async move {
-        let agent_label = agent_id.clone();
-        let context_base = json!({
-            "agent_id": agent_id,
-        });
-
-        if let Err(e) = ensure_clob_orderbook_snapshots_table(&pool).await {
-            warn!(
-                agent = agent_label,
-                error = %e,
-                "failed to ensure clob_orderbook_snapshots table; orderbook persistence disabled"
-            );
-            return;
-        }
-
-        let mut rx = pm_ws.subscribe_books();
-        let max_levels = env_usize("PM_ORDERBOOK_LEVELS", max_levels_default).clamp(1, 200);
-        let min_interval_ms = match std::env::var("PM_ORDERBOOK_SNAPSHOT_MS") {
-            Ok(raw) => raw.parse::<u64>().unwrap_or(0),
-            Err(_) => (env_i64("PM_ORDERBOOK_SNAPSHOT_SECS", min_interval_secs_default).max(0)
-                as u64)
-                .saturating_mul(1000),
-        };
-        let require_hash_change = env_bool("PM_ORDERBOOK_REQUIRE_HASH_CHANGE", true);
-
-        let mut last_persisted: HashMap<String, chrono::DateTime<Utc>> = HashMap::new();
-        let mut last_hash: HashMap<String, String> = HashMap::new();
-        let mut persisted_count: u64 = 0;
-
-        loop {
-            match rx.recv().await {
-                Ok(book) => {
-                    let now = Utc::now();
-                    let token_id = book.asset_id.clone();
-
-                    if min_interval_ms > 0 {
-                        let should_persist_by_interval = match last_persisted.get(&token_id) {
-                            None => true,
-                            Some(ts) => {
-                                now.signed_duration_since(*ts).num_milliseconds()
-                                    >= min_interval_ms as i64
-                            }
-                        };
-                        if !should_persist_by_interval {
-                            continue;
-                        }
-                    }
-
-                    if require_hash_change {
-                        if let Some(hash) = book.hash.as_deref() {
-                            if last_hash.get(&token_id).map(|v| v.as_str()) == Some(hash) {
-                                continue;
-                            }
-                        }
-                    }
-
-                    let bids = parse_depth_levels(&book.bids, true, max_levels);
-                    let asks = parse_depth_levels(&book.asks, false, max_levels);
-                    let book_ts = parse_book_timestamp(&book.timestamp);
-
-                    let context = context_base.clone();
-
-                    if let Err(e) = sqlx::query(
-                        r#"
-                        INSERT INTO clob_orderbook_snapshots
-                            (domain, token_id, market, bids, asks, book_timestamp, hash, source, context)
-                        VALUES
-                            ($1, $2, $3, $4, $5, $6, $7, 'polymarket_ws', $8)
-                        "#,
-                    )
-                    .bind(domain.to_string())
-                    .bind(&token_id)
-                    .bind(&book.market)
-                    .bind(sqlx::types::Json(&bids))
-                    .bind(sqlx::types::Json(&asks))
-                    .bind(book_ts)
-                    .bind(&book.hash)
-                    .bind(sqlx::types::Json(context))
-                    .execute(&pool)
-                    .await
-                    {
-                        warn!(
-                            agent = %agent_label,
-                            token_id = %token_id,
-                            error = %e,
-                            "failed to persist clob orderbook snapshot"
-                        );
-                        continue;
-                    }
-
-                    last_persisted.insert(token_id, now);
-                    if let Some(hash) = book.hash.as_ref() {
-                        last_hash.insert(book.asset_id.clone(), hash.clone());
-                    }
-                    persisted_count = persisted_count.saturating_add(1);
-
-                    if persisted_count % 100 == 0 {
-                        info!(
-                            agent = %agent_label,
-                            persisted_count,
-                            max_levels,
-                            min_interval_ms,
-                            require_hash_change,
-                            "persisted clob orderbook snapshots"
-                        );
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(agent = %agent_label, lagged = n, "clob orderbook persistence receiver lagged");
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    warn!(agent = %agent_label, "clob orderbook persistence receiver closed");
-                    break;
-                }
-            }
-        }
-    });
 }
 
 /// Top-level config for the platform bootstrap
@@ -5684,14 +5049,16 @@ pub async fn start_platform(
                 binance_kline_closed_only: true,
                 chainlink_symbols: vec![],
             };
-            let dp = Arc::new(PlatformDataPlane::new(data_plane_config, Arc::clone(&freshness)));
+            let dp = Arc::new(PlatformDataPlane::new(
+                data_plane_config,
+                Arc::clone(&freshness),
+            ));
             dp.start(Vec::new()).await?;
             info!("PlatformDataPlane started");
 
             let binance_ws = dp.binance_ws().ok_or_else(|| {
                 crate::error::PloyError::Validation(
-                    "PLOY_DATA_PLANE=1 but PlatformDataPlane has no Binance WS adapter"
-                        .to_string(),
+                    "PLOY_DATA_PLANE=1 but PlatformDataPlane has no Binance WS adapter".to_string(),
                 )
             })?;
             let pm_ws = dp.polymarket_ws().ok_or_else(|| {
@@ -5712,6 +5079,7 @@ pub async fn start_platform(
             info!("data plane freshness tracker attached to WS adapters");
             (binance_ws, pm_ws)
         };
+        let crypto_market_data = CryptoDataPlaneHandle::new(binance_ws.clone(), pm_ws.clone());
 
         // Seed PM token → side mapping for data collection, so QuoteUpdates carry the correct
         // UP/DOWN side and can be persisted to Postgres.
@@ -5931,187 +5299,229 @@ pub async fn start_platform(
             }
         });
 
-        // Optional persistence pipeline for CLOB quotes (best-effort).
+        let mut crypto_persistence_pipeline: Option<crate::platform::PersistencePipelineHandle> =
+            None;
+        // Optional persistence pipeline for WS-driven market data (best-effort).
         // Do not block agent startup if DB is temporarily unavailable.
         if let Some(pool) = shared_pool.as_ref() {
             let (orderbook_levels_default, orderbook_snapshot_secs_default) = (20usize, 60i64);
+            let orderbook_levels =
+                env_usize("PM_ORDERBOOK_LEVELS", orderbook_levels_default).clamp(1, 200);
+            let orderbook_snapshot_ms = match std::env::var("PM_ORDERBOOK_SNAPSHOT_MS") {
+                Ok(raw) => raw.parse::<u64>().unwrap_or(0),
+                Err(_) => (env_i64(
+                    "PM_ORDERBOOK_SNAPSHOT_SECS",
+                    orderbook_snapshot_secs_default,
+                )
+                .max(0) as u64)
+                    .saturating_mul(1000),
+            };
+            let orderbook_require_hash_change = env_bool("PM_ORDERBOOK_REQUIRE_HASH_CHANGE", true);
 
-            // Phase 1: opt-in unified persistence pipeline.
-            // Set PLOY_UNIFIED_PERSISTENCE=1 to use the new pipeline instead of
-            // individual spawn_*_persistence() calls.
-            let use_unified = std::env::var("PLOY_UNIFIED_PERSISTENCE")
-                .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-                .unwrap_or(false);
+            let quote_table_ready = match ensure_clob_quote_ticks_table(pool).await {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(
+                        agent = crypto_cfg.agent_id,
+                        error = %e,
+                        "failed to ensure clob_quote_ticks table; quote persistence bridge disabled"
+                    );
+                    false
+                }
+            };
+            let price_table_ready = match ensure_binance_price_ticks_table(pool).await {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(
+                        agent = crypto_cfg.agent_id,
+                        error = %e,
+                        "failed to ensure binance_price_ticks table; Binance price persistence bridge disabled"
+                    );
+                    false
+                }
+            };
+            let orderbook_table_ready = match ensure_clob_orderbook_snapshots_table(pool).await {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(
+                        agent = crypto_cfg.agent_id,
+                        error = %e,
+                        "failed to ensure clob_orderbook_snapshots table; orderbook persistence bridge disabled"
+                    );
+                    false
+                }
+            };
 
-            if use_unified {
+            if quote_table_ready || price_table_ready || orderbook_table_ready {
                 let pipeline_config = crate::platform::PersistenceConfig {
                     clob_quote_min_interval_secs: CLOB_PERSIST_MIN_INTERVAL_SECS,
                     binance_price_min_interval_secs: BINANCE_PERSIST_MIN_INTERVAL_SECS,
-                    clob_orderbook_snapshot_interval_ms: orderbook_snapshot_secs_default * 1000,
-                    clob_orderbook_max_levels: orderbook_levels_default,
+                    binance_lob_snapshot_interval_ms: env_u64("BN_LOB_SNAPSHOT_MS", 1000).max(100)
+                        as i64,
+                    binance_lob_max_levels: env_usize("BN_LOB_LEVELS", 20).clamp(0, 200),
+                    clob_orderbook_snapshot_interval_ms: orderbook_snapshot_ms as i64,
+                    clob_orderbook_max_levels: orderbook_levels,
+                    clob_orderbook_require_hash_change: orderbook_require_hash_change,
                     ..Default::default()
                 };
                 let pipeline_handle =
                     crate::platform::PersistencePipeline::spawn(pool.clone(), pipeline_config);
+                crypto_persistence_pipeline = Some(pipeline_handle.clone());
 
-                // Bridge PM quote updates → pipeline
-                let quote_rx = if use_data_plane {
-                    data_plane.as_ref().and_then(|dp| dp.subscribe_quotes())
-                } else {
-                    Some(pm_ws.subscribe_updates())
-                };
-                if let Some(mut quote_rx) = quote_rx {
-                    let ph = pipeline_handle.clone();
-                    tokio::spawn(async move {
-                        loop {
-                            match quote_rx.recv().await {
-                                Ok(update) => {
-                                    let tick = crate::platform::ClobQuoteTick {
-                                        token_id: update.token_id.clone(),
-                                        side: format!("{:?}", update.side),
-                                        best_bid: update.quote.best_bid,
-                                        best_ask: update.quote.best_ask,
-                                        bid_size: update.quote.bid_size,
-                                        ask_size: update.quote.ask_size,
-                                        domain: Domain::Crypto,
-                                        received_at: Utc::now(),
-                                    };
-                                    let _ = ph.try_ingest(
-                                        crate::platform::PersistenceEvent::ClobQuote(tick),
-                                    );
+                if quote_table_ready {
+                    let quote_rx = if use_data_plane {
+                        data_plane.as_ref().and_then(|dp| dp.subscribe_quotes())
+                    } else {
+                        Some(pm_ws.subscribe_updates())
+                    };
+                    if let Some(mut quote_rx) = quote_rx {
+                        let ph = pipeline_handle.clone();
+                        tokio::spawn(async move {
+                            loop {
+                                match quote_rx.recv().await {
+                                    Ok(update) => {
+                                        let tick = crate::platform::ClobQuoteTick {
+                                            token_id: update.token_id.clone(),
+                                            side: update.side.as_str().to_string(),
+                                            best_bid: update.quote.best_bid,
+                                            best_ask: update.quote.best_ask,
+                                            bid_size: update.quote.bid_size,
+                                            ask_size: update.quote.ask_size,
+                                            domain: Domain::Crypto,
+                                            received_at: Utc::now(),
+                                        };
+                                        if ph
+                                            .try_ingest(
+                                                crate::platform::PersistenceEvent::ClobQuote(tick),
+                                            )
+                                            .is_err()
+                                        {
+                                            warn!("persistence quote bridge dropped event");
+                                        }
+                                    }
+                                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                                        warn!(lagged = n, "persistence quote bridge lagged");
+                                    }
+                                    Err(broadcast::error::RecvError::Closed) => break,
                                 }
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!(lagged = n, "unified persistence quote bridge lagged");
-                                }
-                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                        }
-                    });
-                } else {
-                    warn!("unified persistence quote bridge unavailable: no quote receiver");
+                        });
+                    } else {
+                        warn!("persistence quote bridge unavailable: no quote receiver");
+                    }
                 }
 
-                // Bridge Binance price updates → pipeline
-                let price_rx = if use_data_plane {
-                    data_plane.as_ref().and_then(|dp| dp.subscribe_prices())
-                } else {
-                    Some(binance_ws.subscribe())
-                };
-                if let Some(mut price_rx) = price_rx {
-                    let ph = pipeline_handle.clone();
-                    tokio::spawn(async move {
-                        loop {
-                            match price_rx.recv().await {
-                                Ok(update) => {
-                                    let tick = crate::platform::BinancePriceTick {
-                                        symbol: update.symbol.clone(),
-                                        price: Some(update.price),
-                                        quantity: update.quantity,
-                                        trade_time: update.timestamp,
-                                    };
-                                    let _ = ph.try_ingest(
-                                        crate::platform::PersistenceEvent::BinancePrice(tick),
-                                    );
+                if price_table_ready {
+                    let price_rx = if use_data_plane {
+                        data_plane.as_ref().and_then(|dp| dp.subscribe_prices())
+                    } else {
+                        Some(binance_ws.subscribe())
+                    };
+                    if let Some(mut price_rx) = price_rx {
+                        let ph = pipeline_handle.clone();
+                        tokio::spawn(async move {
+                            loop {
+                                match price_rx.recv().await {
+                                    Ok(update) => {
+                                        let tick = crate::platform::BinancePriceTick {
+                                            symbol: update.symbol.clone(),
+                                            price: Some(update.price),
+                                            quantity: update.quantity,
+                                            trade_time: update.timestamp,
+                                        };
+                                        if ph
+                                            .try_ingest(
+                                                crate::platform::PersistenceEvent::BinancePrice(
+                                                    tick,
+                                                ),
+                                            )
+                                            .is_err()
+                                        {
+                                            warn!("persistence price bridge dropped event");
+                                        }
+                                    }
+                                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                                        warn!(lagged = n, "persistence price bridge lagged");
+                                    }
+                                    Err(broadcast::error::RecvError::Closed) => break,
                                 }
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!(lagged = n, "unified persistence price bridge lagged");
-                                }
-                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                        }
-                    });
-                } else {
-                    warn!("unified persistence price bridge unavailable: no price receiver");
+                        });
+                    } else {
+                        warn!("persistence price bridge unavailable: no price receiver");
+                    }
                 }
 
-                // Bridge PM orderbook updates → pipeline
-                let book_rx = if use_data_plane {
-                    data_plane.as_ref().and_then(|dp| dp.subscribe_books())
-                } else {
-                    Some(pm_ws.subscribe_books())
-                };
-                if let Some(mut book_rx) = book_rx {
-                    let ph = pipeline_handle.clone();
-                    tokio::spawn(async move {
-                        use sha2::{Digest, Sha256};
-                        loop {
-                            match book_rx.recv().await {
-                                Ok(book_msg) => {
-                                    let bids_json =
-                                        serde_json::to_value(&book_msg.bids).unwrap_or_default();
-                                    let asks_json =
-                                        serde_json::to_value(&book_msg.asks).unwrap_or_default();
-                                    let mut hasher = Sha256::new();
-                                    hasher.update(bids_json.to_string().as_bytes());
-                                    hasher.update(asks_json.to_string().as_bytes());
-                                    let hash = format!("{:x}", hasher.finalize());
-                                    let snap = crate::platform::ClobOrderbookSnapshot {
-                                        domain: Domain::Crypto,
-                                        token_id: book_msg.asset_id.clone(),
-                                        market: Some(book_msg.market.clone()),
-                                        bids: bids_json,
-                                        asks: asks_json,
-                                        book_timestamp: book_msg
-                                            .timestamp
-                                            .as_deref()
-                                            .and_then(|s| {
-                                                chrono::DateTime::parse_from_rfc3339(s).ok()
-                                            })
-                                            .map(|dt| dt.with_timezone(&Utc)),
-                                        hash,
-                                        source: "polymarket_ws".into(),
-                                        context: None,
-                                    };
-                                    let _ = ph.try_ingest(
-                                        crate::platform::PersistenceEvent::ClobOrderbook(snap),
-                                    );
+                if orderbook_table_ready {
+                    let book_rx = if use_data_plane {
+                        data_plane.as_ref().and_then(|dp| dp.subscribe_books())
+                    } else {
+                        Some(pm_ws.subscribe_books())
+                    };
+                    if let Some(mut book_rx) = book_rx {
+                        let ph = pipeline_handle.clone();
+                        tokio::spawn(async move {
+                            use sha2::{Digest, Sha256};
+                            loop {
+                                match book_rx.recv().await {
+                                    Ok(book_msg) => {
+                                        let bids_json = serde_json::to_value(&book_msg.bids)
+                                            .unwrap_or_default();
+                                        let asks_json = serde_json::to_value(&book_msg.asks)
+                                            .unwrap_or_default();
+                                        let mut hasher = Sha256::new();
+                                        hasher.update(bids_json.to_string().as_bytes());
+                                        hasher.update(asks_json.to_string().as_bytes());
+                                        let hash = format!("{:x}", hasher.finalize());
+                                        let snap = crate::platform::ClobOrderbookSnapshot {
+                                            domain: Domain::Crypto,
+                                            token_id: book_msg.asset_id.clone(),
+                                            market: Some(book_msg.market.clone()),
+                                            bids: bids_json,
+                                            asks: asks_json,
+                                            book_timestamp: book_msg
+                                                .timestamp
+                                                .as_deref()
+                                                .and_then(|s| {
+                                                    chrono::DateTime::parse_from_rfc3339(s).ok()
+                                                })
+                                                .map(|dt| dt.with_timezone(&Utc)),
+                                            hash,
+                                            source: "polymarket_ws".into(),
+                                            context: None,
+                                        };
+                                        if ph
+                                            .try_ingest(
+                                                crate::platform::PersistenceEvent::ClobOrderbook(
+                                                    snap,
+                                                ),
+                                            )
+                                            .is_err()
+                                        {
+                                            warn!("persistence orderbook bridge dropped event");
+                                        }
+                                    }
+                                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                                        warn!(lagged = n, "persistence orderbook bridge lagged");
+                                    }
+                                    Err(broadcast::error::RecvError::Closed) => break,
                                 }
-                                Err(broadcast::error::RecvError::Lagged(n)) => {
-                                    warn!(
-                                        lagged = n,
-                                        "unified persistence orderbook bridge lagged"
-                                    );
-                                }
-                                Err(broadcast::error::RecvError::Closed) => break,
                             }
-                        }
-                    });
-                } else {
-                    warn!("unified persistence orderbook bridge unavailable: no book receiver");
+                        });
+                    } else {
+                        warn!("persistence orderbook bridge unavailable: no book receiver");
+                    }
                 }
 
-                info!(
-                    agent = crypto_cfg.agent_id,
-                    "unified persistence pipeline started (PLOY_UNIFIED_PERSISTENCE=1)"
-                );
+                info!(agent = crypto_cfg.agent_id, "persistence pipeline started");
             } else {
-                // Legacy: individual persistence spawners
-                spawn_clob_quote_persistence(
-                    pm_ws.clone(),
-                    pool.clone(),
-                    crypto_cfg.agent_id.clone(),
-                    Domain::Crypto,
-                );
-                spawn_clob_orderbook_persistence(
-                    pm_ws.clone(),
-                    pool.clone(),
-                    crypto_cfg.agent_id.clone(),
-                    Domain::Crypto,
-                    orderbook_levels_default,
-                    orderbook_snapshot_secs_default,
-                );
-                spawn_binance_price_persistence(
-                    binance_ws.clone(),
-                    pool.clone(),
-                    crypto_cfg.agent_id.clone(),
-                );
-                info!(
+                warn!(
                     agent = crypto_cfg.agent_id,
-                    "legacy persistence tasks started"
+                    "all market-data persistence tables unavailable; WS persistence bridges disabled"
                 );
             }
 
-            // Trade persistence (polling-based) — always uses legacy spawner
+            // Trade persistence (polling-based) — still separate from WS pipeline.
             spawn_polymarket_trade_persistence(
                 event_matcher.clone(),
                 pool.clone(),
@@ -6152,11 +5562,90 @@ pub async fn start_platform(
             lob_cache_opt = Some(lob_cache.clone());
 
             if let Some(pool) = shared_pool.as_ref() {
-                spawn_binance_lob_persistence(
-                    depth_stream.clone(),
-                    pool.clone(),
-                    crypto_cfg.agent_id.clone(),
-                );
+                match ensure_binance_lob_ticks_table(pool).await {
+                    Ok(()) => {
+                        if let Some(ph) = crypto_persistence_pipeline.clone() {
+                            let mut rx = depth_stream.subscribe();
+                            let agent_id = crypto_cfg.agent_id.clone();
+                            let max_levels = env_usize("BN_LOB_LEVELS", 20).clamp(0, 200);
+                            tokio::spawn(async move {
+                                loop {
+                                    match rx.recv().await {
+                                        Ok(update) => {
+                                            let symbol = update.symbol.clone();
+                                            let (bids, asks) = if max_levels == 0 {
+                                                (Vec::new(), Vec::new())
+                                            } else {
+                                                (
+                                                    lob_levels_json(
+                                                        &update.raw_state,
+                                                        true,
+                                                        max_levels,
+                                                    ),
+                                                    lob_levels_json(
+                                                        &update.raw_state,
+                                                        false,
+                                                        max_levels,
+                                                    ),
+                                                )
+                                            };
+                                            let tick = crate::platform::BinanceLobTick {
+                                                symbol,
+                                                update_id: update.snapshot.update_id,
+                                                best_bid: Some(update.snapshot.best_bid),
+                                                best_ask: Some(update.snapshot.best_ask),
+                                                mid_price: Some(update.snapshot.mid_price),
+                                                spread_bps: Some(update.snapshot.spread_bps),
+                                                obi_5: update.snapshot.obi_5.to_f64(),
+                                                obi_10: update.snapshot.obi_10.to_f64(),
+                                                bid_volume_5: Some(update.snapshot.bid_volume_5),
+                                                ask_volume_5: Some(update.snapshot.ask_volume_5),
+                                                bids: serde_json::to_value(&bids)
+                                                    .unwrap_or_default(),
+                                                asks: serde_json::to_value(&asks)
+                                                    .unwrap_or_default(),
+                                                event_time: update.snapshot.timestamp,
+                                            };
+                                            if ph
+                                                .try_ingest(
+                                                    crate::platform::PersistenceEvent::BinanceLob(
+                                                        tick,
+                                                    ),
+                                                )
+                                                .is_err()
+                                            {
+                                                warn!(
+                                                    agent = agent_id,
+                                                    "persistence Binance LOB bridge dropped event"
+                                                );
+                                            }
+                                        }
+                                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                                            warn!(
+                                                agent = agent_id,
+                                                lagged = n,
+                                                "persistence Binance LOB bridge lagged"
+                                            );
+                                        }
+                                        Err(broadcast::error::RecvError::Closed) => break,
+                                    }
+                                }
+                            });
+                        } else {
+                            warn!(
+                                agent = crypto_cfg.agent_id,
+                                "Binance LOB persistence requested but pipeline handle unavailable"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            agent = crypto_cfg.agent_id,
+                            error = %e,
+                            "failed to ensure binance_lob_ticks table; Binance LOB persistence bridge disabled"
+                        );
+                    }
+                }
             }
 
             let ds = depth_stream.clone();
@@ -6194,8 +5683,7 @@ pub async fn start_platform(
             if let Some(cmd_rx) = cmd_rx_opt {
                 let agent = CryptoTradingAgent::new(
                     crypto_cfg.clone(),
-                    binance_ws.clone(),
-                    pm_ws.clone(),
+                    crypto_market_data.clone(),
                     event_matcher.clone(),
                 );
                 let ctx = AgentContext::new(
@@ -6410,8 +5898,7 @@ pub async fn start_platform(
                     let risk_params = lob_cfg.risk_params.clone();
                     let agent = CryptoLobMlAgent::new(
                         lob_cfg.clone(),
-                        binance_ws.clone(),
-                        pm_ws.clone(),
+                        crypto_market_data.clone(),
                         event_matcher.clone(),
                         lob_cache,
                     )?;
@@ -6456,8 +5943,7 @@ pub async fn start_platform(
 
                 let agent = CryptoRlPolicyAgent::new(
                     rl_cfg.clone(),
-                    binance_ws.clone(),
-                    pm_ws.clone(),
+                    crypto_market_data.clone(),
                     event_matcher.clone(),
                     lob_cache,
                 );
@@ -6503,22 +5989,30 @@ pub async fn start_platform(
                         .await?
                 }
             };
-            if let Err(e) = ensure_clob_orderbook_snapshots_table(&pool).await {
-                warn!(agent = sports_cfg.agent_id, error = %e, "failed to ensure clob_orderbook_snapshots table");
-            }
             spawn_polymarket_trade_persistence_from_collector_targets(
                 pool.clone(),
                 sports_cfg.agent_id.clone(),
                 Domain::Sports,
             );
 
-            // Sports L2 data collection: create a dedicated PM WebSocket for NBA token
-            // quote and orderbook snapshot persistence.  Tokens are seeded from
-            // collector_token_targets (domain = SPORTS_NBA) and refreshed every cycle
-            // together with the trade persistence above.
+            // Sports L2 data collection: create a dedicated sports data plane so
+            // PM WS lifecycle stays domain-isolated from crypto.
             {
-                let sports_pm_ws = Arc::new(PolymarketWebSocket::new(&app_config.market.ws_url));
-                sports_pm_ws.set_freshness(Arc::clone(&freshness));
+                let sports_data_plane_config = DataPlaneConfig {
+                    polymarket_ws_url: app_config.market.ws_url.clone(),
+                    ..DataPlaneConfig::default()
+                };
+                let sports_data_plane = Arc::new(PlatformDataPlane::new(
+                    sports_data_plane_config,
+                    Arc::clone(&freshness),
+                ));
+                sports_data_plane.start(Vec::new()).await?;
+                let sports_pm_ws = sports_data_plane.polymarket_ws().ok_or_else(|| {
+                    crate::error::PloyError::Validation(
+                        "sports data plane misconfigured: missing Polymarket WS adapter"
+                            .to_string(),
+                    )
+                })?;
 
                 // Seed initial NBA tokens from collector_token_targets
                 let mut sports_desired: HashMap<String, Side> = HashMap::new();
@@ -6593,29 +6087,158 @@ pub async fn start_platform(
                     }
                 });
 
-                // Persistence: quotes + orderbook snapshots
-                spawn_clob_quote_persistence(
-                    sports_pm_ws.clone(),
-                    pool.clone(),
-                    sports_cfg.agent_id.clone(),
-                    Domain::Sports,
-                );
-                spawn_clob_orderbook_persistence(
-                    sports_pm_ws.clone(),
-                    pool.clone(),
-                    sports_cfg.agent_id.clone(),
-                    Domain::Sports,
-                    20,
-                    60,
-                );
-
-                // Run the sports PM WS
-                let sws = sports_pm_ws.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = sws.run(Vec::new()).await {
-                        error!(error = %e, "sports polymarket websocket error");
+                // Persistence: quotes + orderbook snapshots via unified pipeline.
+                let sports_quote_table_ready = match ensure_clob_quote_ticks_table(&pool).await {
+                    Ok(()) => true,
+                    Err(e) => {
+                        warn!(
+                            agent = sports_cfg.agent_id,
+                            error = %e,
+                            "failed to ensure clob_quote_ticks table; sports quote persistence bridge disabled"
+                        );
+                        false
                     }
-                });
+                };
+                let sports_orderbook_table_ready = match ensure_clob_orderbook_snapshots_table(
+                    &pool,
+                )
+                .await
+                {
+                    Ok(()) => true,
+                    Err(e) => {
+                        warn!(
+                            agent = sports_cfg.agent_id,
+                            error = %e,
+                            "failed to ensure clob_orderbook_snapshots table; sports orderbook persistence bridge disabled"
+                        );
+                        false
+                    }
+                };
+                if sports_quote_table_ready || sports_orderbook_table_ready {
+                    let sports_orderbook_levels =
+                        env_usize("PM_ORDERBOOK_LEVELS", 20).clamp(1, 200);
+                    let sports_orderbook_snapshot_ms =
+                        match std::env::var("PM_ORDERBOOK_SNAPSHOT_MS") {
+                            Ok(raw) => raw.parse::<u64>().unwrap_or(0),
+                            Err(_) => (env_i64("PM_ORDERBOOK_SNAPSHOT_SECS", 60).max(0) as u64)
+                                .saturating_mul(1000),
+                        };
+                    let sports_orderbook_require_hash_change =
+                        env_bool("PM_ORDERBOOK_REQUIRE_HASH_CHANGE", true);
+                    let sports_pipeline_config = crate::platform::PersistenceConfig {
+                        clob_quote_min_interval_secs: CLOB_PERSIST_MIN_INTERVAL_SECS,
+                        clob_orderbook_snapshot_interval_ms: sports_orderbook_snapshot_ms as i64,
+                        clob_orderbook_max_levels: sports_orderbook_levels,
+                        clob_orderbook_require_hash_change: sports_orderbook_require_hash_change,
+                        ..Default::default()
+                    };
+                    let sports_pipeline = crate::platform::PersistencePipeline::spawn(
+                        pool.clone(),
+                        sports_pipeline_config,
+                    );
+
+                    if sports_quote_table_ready {
+                        if let Some(mut quote_rx) = sports_data_plane.subscribe_quotes() {
+                            let ph = sports_pipeline.clone();
+                            tokio::spawn(async move {
+                                loop {
+                                    match quote_rx.recv().await {
+                                        Ok(update) => {
+                                            let tick = crate::platform::ClobQuoteTick {
+                                                token_id: update.token_id.clone(),
+                                                side: update.side.as_str().to_string(),
+                                                best_bid: update.quote.best_bid,
+                                                best_ask: update.quote.best_ask,
+                                                bid_size: update.quote.bid_size,
+                                                ask_size: update.quote.ask_size,
+                                                domain: Domain::Sports,
+                                                received_at: Utc::now(),
+                                            };
+                                            if ph
+                                                .try_ingest(
+                                                    crate::platform::PersistenceEvent::ClobQuote(
+                                                        tick,
+                                                    ),
+                                                )
+                                                .is_err()
+                                            {
+                                                warn!("sports quote bridge dropped event");
+                                            }
+                                        }
+                                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                                            warn!(lagged = n, "sports quote bridge lagged");
+                                        }
+                                        Err(broadcast::error::RecvError::Closed) => break,
+                                    }
+                                }
+                            });
+                        } else {
+                            warn!("sports quote bridge unavailable: no quote receiver");
+                        }
+                    }
+
+                    if sports_orderbook_table_ready {
+                        if let Some(mut book_rx) = sports_data_plane.subscribe_books() {
+                            let ph = sports_pipeline.clone();
+                            tokio::spawn(async move {
+                                use sha2::{Digest, Sha256};
+                                loop {
+                                    match book_rx.recv().await {
+                                        Ok(book_msg) => {
+                                            let bids_json = serde_json::to_value(&book_msg.bids)
+                                                .unwrap_or_default();
+                                            let asks_json = serde_json::to_value(&book_msg.asks)
+                                                .unwrap_or_default();
+                                            let mut hasher = Sha256::new();
+                                            hasher.update(bids_json.to_string().as_bytes());
+                                            hasher.update(asks_json.to_string().as_bytes());
+                                            let hash = format!("{:x}", hasher.finalize());
+                                            let snap = crate::platform::ClobOrderbookSnapshot {
+                                                domain: Domain::Sports,
+                                                token_id: book_msg.asset_id.clone(),
+                                                market: Some(book_msg.market.clone()),
+                                                bids: bids_json,
+                                                asks: asks_json,
+                                                book_timestamp: book_msg
+                                                    .timestamp
+                                                    .as_deref()
+                                                    .and_then(|s| {
+                                                        chrono::DateTime::parse_from_rfc3339(s).ok()
+                                                    })
+                                                    .map(|dt| dt.with_timezone(&Utc)),
+                                                hash,
+                                                source: "polymarket_ws".into(),
+                                                context: None,
+                                            };
+                                            if ph
+                                                .try_ingest(
+                                                    crate::platform::PersistenceEvent::ClobOrderbook(
+                                                        snap,
+                                                    ),
+                                                )
+                                                .is_err()
+                                            {
+                                                warn!("sports orderbook bridge dropped event");
+                                            }
+                                        }
+                                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                                            warn!(lagged = n, "sports orderbook bridge lagged");
+                                        }
+                                        Err(broadcast::error::RecvError::Closed) => break,
+                                    }
+                                }
+                            });
+                        } else {
+                            warn!("sports orderbook bridge unavailable: no book receiver");
+                        }
+                    }
+                } else {
+                    warn!(
+                        agent = sports_cfg.agent_id,
+                        "sports persistence tables unavailable; WS persistence bridges disabled"
+                    );
+                }
+
                 info!(
                     agent = sports_cfg.agent_id,
                     "sports PM WS L2 data collection started"
@@ -6752,7 +6375,8 @@ pub async fn start_platform(
         let cmd_rx =
             coordinator.register_agent(oc_agent_id.clone(), Domain::Custom(0), oc_risk_params);
 
-        let agent = OpenClawAgent::new(config.openclaw.clone(), oc_binance_ws);
+        let oc_market_data = BinanceDataPlaneHandle::new(oc_binance_ws.clone());
+        let agent = OpenClawAgent::new(config.openclaw.clone(), oc_market_data);
         let ctx = AgentContext::new(
             oc_agent_id.clone(),
             Domain::Custom(0),

--- a/src/main_modes/collector_modes.rs
+++ b/src/main_modes/collector_modes.rs
@@ -54,9 +54,7 @@ pub async fn run_collect_mode(symbols: &str, markets: Option<&str>, duration: u6
     let store = PostgresStore::new(&config.database.url, 5).await?;
 
     // Create collector with database, wrapped in Arc for shared access
-    let collector = Arc::new(
-        SyncCollector::new(collector_config).with_pool(store.pool().clone()),
-    );
+    let collector = Arc::new(SyncCollector::new(collector_config).with_pool(store.pool().clone()));
 
     // Subscribe to updates for logging
     let mut rx = collector.subscribe();
@@ -129,9 +127,7 @@ pub async fn run_collect_mode(symbols: &str, markets: Option<&str>, duration: u6
 
 /// Discover active PM tokens for crypto series and spawn a WebSocket bridge
 /// that feeds real-time PM prices into the collector.
-async fn spawn_pm_price_bridge(
-    collector: Arc<ploy::collector::SyncCollector>,
-) {
+async fn spawn_pm_price_bridge(collector: Arc<ploy::collector::SyncCollector>) {
     use ploy::adapters::{PolymarketClient, PolymarketWebSocket};
     use ploy::collector::PolymarketPrice;
     use ploy::domain::market::Side;
@@ -140,7 +136,10 @@ async fn spawn_pm_price_bridge(
     let pm_client = match PolymarketClient::new(PM_REST_URL, true) {
         Ok(c) => c,
         Err(e) => {
-            warn!("Failed to create PM client for collector: {}. PM prices will be unavailable.", e);
+            warn!(
+                "Failed to create PM client for collector: {}. PM prices will be unavailable.",
+                e
+            );
             return;
         }
     };
@@ -166,10 +165,8 @@ async fn spawn_pm_price_bridge(
                                 } else {
                                     Side::Down
                                 };
-                                token_to_market.insert(
-                                    token.token_id.clone(),
-                                    (slug.clone(), side),
-                                );
+                                token_to_market
+                                    .insert(token.token_id.clone(), (slug.clone(), side));
                                 all_token_ids.push(token.token_id.clone());
                             }
                         }

--- a/src/platform/data_plane.rs
+++ b/src/platform/data_plane.rs
@@ -45,6 +45,68 @@ impl DataPlaneConfig {
     }
 }
 
+/// Reusable handle for crypto market data adapters.
+#[derive(Clone)]
+pub struct CryptoDataPlaneHandle {
+    binance_ws: Arc<BinanceWebSocket>,
+    polymarket_ws: Arc<PolymarketWebSocket>,
+}
+
+impl CryptoDataPlaneHandle {
+    pub fn new(binance_ws: Arc<BinanceWebSocket>, polymarket_ws: Arc<PolymarketWebSocket>) -> Self {
+        Self {
+            binance_ws,
+            polymarket_ws,
+        }
+    }
+
+    pub fn subscribe_prices(&self) -> broadcast::Receiver<PriceUpdate> {
+        self.binance_ws.subscribe()
+    }
+
+    pub fn subscribe_quotes(&self) -> broadcast::Receiver<QuoteUpdate> {
+        self.polymarket_ws.subscribe_updates()
+    }
+
+    pub fn price_cache(&self) -> crate::adapters::PriceCache {
+        self.binance_ws.price_cache().clone()
+    }
+
+    pub fn quote_cache(&self) -> crate::adapters::polymarket_ws::QuoteCache {
+        self.polymarket_ws.quote_cache().clone()
+    }
+
+    pub async fn register_tokens(&self, up_token_id: &str, down_token_id: &str) {
+        self.polymarket_ws
+            .register_tokens(up_token_id, down_token_id)
+            .await;
+    }
+
+    pub fn request_resubscribe(&self) {
+        self.polymarket_ws.request_resubscribe();
+    }
+}
+
+/// Reusable handle for Binance market-data adapter access.
+#[derive(Clone)]
+pub struct BinanceDataPlaneHandle {
+    binance_ws: Arc<BinanceWebSocket>,
+}
+
+impl BinanceDataPlaneHandle {
+    pub fn new(binance_ws: Arc<BinanceWebSocket>) -> Self {
+        Self { binance_ws }
+    }
+
+    pub fn subscribe_prices(&self) -> broadcast::Receiver<PriceUpdate> {
+        self.binance_ws.subscribe()
+    }
+
+    pub fn price_cache(&self) -> crate::adapters::PriceCache {
+        self.binance_ws.price_cache().clone()
+    }
+}
+
 /// Shared data-plane runtime with optional singleton WS adapters.
 pub struct PlatformDataPlane {
     binance_ws: Option<Arc<BinanceWebSocket>>,

--- a/src/platform/freshness.rs
+++ b/src/platform/freshness.rs
@@ -257,7 +257,9 @@ impl DataPlaneFreshness {
         ));
 
         // Per-source subscription count
-        out.push_str("\n# HELP ploy_source_subscriptions_total Subscribed tokens/symbols per source\n");
+        out.push_str(
+            "\n# HELP ploy_source_subscriptions_total Subscribed tokens/symbols per source\n",
+        );
         out.push_str("# TYPE ploy_source_subscriptions_total gauge\n");
         for entry in self.source_subscription_count.iter() {
             out.push_str(&format!(
@@ -362,8 +364,14 @@ mod tests {
         f.set_source_connected(DataSource::BinanceSpot, true);
         f.set_source_connected(DataSource::PolymarketWs, false);
 
-        assert_eq!(*f.source_connected.get(&DataSource::BinanceSpot).unwrap(), true);
-        assert_eq!(*f.source_connected.get(&DataSource::PolymarketWs).unwrap(), false);
+        assert_eq!(
+            *f.source_connected.get(&DataSource::BinanceSpot).unwrap(),
+            true
+        );
+        assert_eq!(
+            *f.source_connected.get(&DataSource::PolymarketWs).unwrap(),
+            false
+        );
     }
 
     #[test]
@@ -387,8 +395,10 @@ mod tests {
 
         let output = f.prometheus_metrics();
 
-        assert!(output.contains("ploy_symbol_staleness_seconds{source=\"binance_spot\",symbol=\"BTCUSDT\"}"));
-        assert!(output.contains("ploy_symbol_updates_total{source=\"binance_spot\",symbol=\"BTCUSDT\"} 1"));
+        assert!(output
+            .contains("ploy_symbol_staleness_seconds{source=\"binance_spot\",symbol=\"BTCUSDT\"}"));
+        assert!(output
+            .contains("ploy_symbol_updates_total{source=\"binance_spot\",symbol=\"BTCUSDT\"} 1"));
         assert!(output.contains("ploy_source_connected{source=\"binance_spot\"} 1"));
         assert!(output.contains("ploy_source_messages_total{source=\"binance_spot\"} 1"));
         assert!(output.contains("ploy_source_subscriptions_total{source=\"binance_spot\"} 3"));

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -22,7 +22,9 @@ pub use contracts::{
     RiskDecisionStatus, StrategyDeployment, StrategyEvaluationEvidence, StrategyEvaluationMetrics,
     StrategyEvaluationStage, StrategyLifecycleStage, StrategyProductType, Timeframe, TradeIntent,
 };
-pub use data_plane::{DataPlaneConfig, PlatformDataPlane};
+pub use data_plane::{
+    BinanceDataPlaneHandle, CryptoDataPlaneHandle, DataPlaneConfig, PlatformDataPlane,
+};
 pub use freshness::{DataPlaneFreshness, DataSource};
 pub use persistence_pipeline::{
     BinanceLobTick, BinancePriceTick, ChainlinkPriceTick, ClobOrderbookSnapshot, ClobQuoteTick,

--- a/src/platform/persistence_pipeline.rs
+++ b/src/platform/persistence_pipeline.rs
@@ -176,9 +176,9 @@ struct OrderbookState {
 /// Internal dedup tracker.
 #[derive(Debug, Default)]
 struct DedupState {
-    quotes: HashMap<String, QuoteState>,       // key: token_id
-    prices: HashMap<String, PriceState>,       // key: symbol
-    lobs: HashMap<String, LobState>,           // key: symbol
+    quotes: HashMap<String, QuoteState>,         // key: token_id
+    prices: HashMap<String, PriceState>,         // key: symbol
+    lobs: HashMap<String, LobState>,             // key: symbol
     orderbooks: HashMap<String, OrderbookState>, // key: token_id
 }
 
@@ -251,7 +251,10 @@ impl PersistencePipeline {
         let mut stats = PipelineStats::default();
         let mut log_counter: u64 = 0;
 
-        info!("persistence pipeline started (capacity={})", config.channel_capacity);
+        info!(
+            "persistence pipeline started (capacity={})",
+            config.channel_capacity
+        );
 
         while let Some(event) = rx.recv().await {
             match event {
@@ -279,7 +282,10 @@ impl PersistencePipeline {
                 }
                 PersistenceEvent::BinanceLob(tick) => {
                     if Self::should_persist_lob(&tick, &mut dedup, &config) {
-                        if let Err(e) = Self::write_binance_lob(&pool, &tick, config.binance_lob_max_levels).await {
+                        if let Err(e) =
+                            Self::write_binance_lob(&pool, &tick, config.binance_lob_max_levels)
+                                .await
+                        {
                             warn!(error = %e, symbol = %tick.symbol, "binance lob persist failed");
                         } else {
                             stats.binance_lobs_persisted += 1;
@@ -298,7 +304,13 @@ impl PersistencePipeline {
                 }
                 PersistenceEvent::ClobOrderbook(snap) => {
                     if Self::should_persist_orderbook(&snap, &mut dedup, &config) {
-                        if let Err(e) = Self::write_clob_orderbook(&pool, &snap, config.clob_orderbook_max_levels).await {
+                        if let Err(e) = Self::write_clob_orderbook(
+                            &pool,
+                            &snap,
+                            config.clob_orderbook_max_levels,
+                        )
+                        .await
+                        {
                             warn!(error = %e, token = %snap.token_id, "clob orderbook persist failed");
                         } else {
                             stats.clob_orderbooks_persisted += 1;
@@ -463,7 +475,10 @@ impl PersistencePipeline {
         Ok(())
     }
 
-    async fn write_binance_price(pool: &PgPool, tick: &BinancePriceTick) -> Result<(), sqlx::Error> {
+    async fn write_binance_price(
+        pool: &PgPool,
+        tick: &BinancePriceTick,
+    ) -> Result<(), sqlx::Error> {
         sqlx::query(
             r#"INSERT INTO binance_price_ticks
                (symbol, price, quantity, trade_time)
@@ -558,7 +573,12 @@ mod tests {
         PersistenceConfig::default()
     }
 
-    fn make_quote(token: &str, bid: Option<f64>, ask: Option<f64>, at: DateTime<Utc>) -> ClobQuoteTick {
+    fn make_quote(
+        token: &str,
+        bid: Option<f64>,
+        ask: Option<f64>,
+        at: DateTime<Utc>,
+    ) -> ClobQuoteTick {
         ClobQuoteTick {
             token_id: token.into(),
             side: "UP".into(),
@@ -587,19 +607,27 @@ mod tests {
         let t0 = Utc::now();
 
         let q1 = make_quote("tok-1", Some(0.42), Some(0.45), t0);
-        assert!(PersistencePipeline::should_persist_quote(&q1, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_quote(
+            &q1, &mut dedup, &config
+        ));
 
         // Same values, 1s later (< 2s interval) → skip
         let q2 = make_quote("tok-1", Some(0.42), Some(0.45), t0 + Duration::seconds(1));
-        assert!(!PersistencePipeline::should_persist_quote(&q2, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_quote(
+            &q2, &mut dedup, &config
+        ));
 
         // Same values, 3s later (>= 2s interval) but unchanged → skip
         let q3 = make_quote("tok-1", Some(0.42), Some(0.45), t0 + Duration::seconds(3));
-        assert!(!PersistencePipeline::should_persist_quote(&q3, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_quote(
+            &q3, &mut dedup, &config
+        ));
 
         // Changed values, 3s later → persist
         let q4 = make_quote("tok-1", Some(0.43), Some(0.45), t0 + Duration::seconds(3));
-        assert!(PersistencePipeline::should_persist_quote(&q4, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_quote(
+            &q4, &mut dedup, &config
+        ));
     }
 
     #[test]
@@ -616,7 +644,9 @@ mod tests {
             domain: Domain::Crypto,
             received_at: Utc::now(),
         };
-        assert!(!PersistencePipeline::should_persist_quote(&q, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_quote(
+            &q, &mut dedup, &config
+        ));
     }
 
     #[test]
@@ -626,15 +656,21 @@ mod tests {
         let t0 = Utc::now();
 
         let p1 = make_price("BTCUSDT", 50000.0, t0);
-        assert!(PersistencePipeline::should_persist_price(&p1, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_price(
+            &p1, &mut dedup, &config
+        ));
 
         // Same price, 0.5s later → skip
         let p2 = make_price("BTCUSDT", 50000.0, t0 + Duration::milliseconds(500));
-        assert!(!PersistencePipeline::should_persist_price(&p2, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_price(
+            &p2, &mut dedup, &config
+        ));
 
         // Different price, 2s later → persist
         let p3 = make_price("BTCUSDT", 50001.0, t0 + Duration::seconds(2));
-        assert!(PersistencePipeline::should_persist_price(&p3, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_price(
+            &p3, &mut dedup, &config
+        ));
     }
 
     #[test]
@@ -658,18 +694,24 @@ mod tests {
             asks: serde_json::json!([]),
             event_time: t0,
         };
-        assert!(PersistencePipeline::should_persist_lob(&l1, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_lob(
+            &l1, &mut dedup, &config
+        ));
 
         // Same update_id, 2s later → skip
         let mut l2 = l1.clone();
         l2.event_time = t0 + Duration::seconds(2);
-        assert!(!PersistencePipeline::should_persist_lob(&l2, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_lob(
+            &l2, &mut dedup, &config
+        ));
 
         // New update_id, 2s later → persist
         let mut l3 = l1.clone();
         l3.update_id = 101;
         l3.event_time = t0 + Duration::seconds(2);
-        assert!(PersistencePipeline::should_persist_lob(&l3, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_lob(
+            &l3, &mut dedup, &config
+        ));
     }
 
     #[test]
@@ -688,19 +730,24 @@ mod tests {
             source: "polymarket_ws".into(),
             context: None,
         };
-        assert!(PersistencePipeline::should_persist_orderbook(&s1, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_orderbook(
+            &s1, &mut dedup, &config
+        ));
 
         // Same hash, after interval → skip (require_hash_change=true)
         std::thread::sleep(std::time::Duration::from_millis(10));
         // Force enough time by manipulating dedup state
-        dedup.orderbooks.get_mut("tok-1").unwrap().last_at =
-            Utc::now() - Duration::seconds(10);
-        assert!(!PersistencePipeline::should_persist_orderbook(&s1, &mut dedup, &config));
+        dedup.orderbooks.get_mut("tok-1").unwrap().last_at = Utc::now() - Duration::seconds(10);
+        assert!(!PersistencePipeline::should_persist_orderbook(
+            &s1, &mut dedup, &config
+        ));
 
         // Different hash → persist
         let mut s2 = s1.clone();
         s2.hash = "def456".into();
-        assert!(PersistencePipeline::should_persist_orderbook(&s2, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_orderbook(
+            &s2, &mut dedup, &config
+        ));
     }
 
     #[test]
@@ -712,13 +759,21 @@ mod tests {
         let q1 = make_quote("tok-1", Some(0.42), Some(0.45), t0);
         let q2 = make_quote("tok-2", Some(0.55), Some(0.58), t0);
 
-        assert!(PersistencePipeline::should_persist_quote(&q1, &mut dedup, &config));
-        assert!(PersistencePipeline::should_persist_quote(&q2, &mut dedup, &config));
+        assert!(PersistencePipeline::should_persist_quote(
+            &q1, &mut dedup, &config
+        ));
+        assert!(PersistencePipeline::should_persist_quote(
+            &q2, &mut dedup, &config
+        ));
 
         // tok-1 unchanged within interval → skip; tok-2 changed → still skip (interval)
         let q3 = make_quote("tok-1", Some(0.42), Some(0.45), t0 + Duration::seconds(1));
         let q4 = make_quote("tok-2", Some(0.56), Some(0.58), t0 + Duration::seconds(1));
-        assert!(!PersistencePipeline::should_persist_quote(&q3, &mut dedup, &config));
-        assert!(!PersistencePipeline::should_persist_quote(&q4, &mut dedup, &config));
+        assert!(!PersistencePipeline::should_persist_quote(
+            &q3, &mut dedup, &config
+        ));
+        assert!(!PersistencePipeline::should_persist_quote(
+            &q4, &mut dedup, &config
+        ));
     }
 }

--- a/src/platform/subscription_planner.rs
+++ b/src/platform/subscription_planner.rs
@@ -199,21 +199,19 @@ impl SubscriptionPlanner {
                 .collect(),
             DataFeed::BinanceSpot { symbols } => symbols
                 .iter()
-                .map(|s| SubscriptionKey::BinanceSpot {
-                    symbol: s.clone(),
-                })
+                .map(|s| SubscriptionKey::BinanceSpot { symbol: s.clone() })
                 .collect(),
             DataFeed::BinanceKlines {
-                symbols,
-                intervals,
-                ..
+                symbols, intervals, ..
             } => symbols
                 .iter()
                 .flat_map(|s| {
-                    intervals.iter().map(move |i| SubscriptionKey::BinanceKline {
-                        symbol: s.clone(),
-                        interval: i.clone(),
-                    })
+                    intervals
+                        .iter()
+                        .map(move |i| SubscriptionKey::BinanceKline {
+                            symbol: s.clone(),
+                            interval: i.clone(),
+                        })
                 })
                 .collect(),
             DataFeed::PolymarketEvents { series_ids } => series_ids
@@ -338,10 +336,7 @@ mod tests {
 
     #[test]
     fn build_plan_deduplicates_overlapping_tokens() {
-        let plan = SubscriptionPlanner::build_plan(vec![
-            crypto_consumer(),
-            overlapping_consumer(),
-        ]);
+        let plan = SubscriptionPlanner::build_plan(vec![crypto_consumer(), overlapping_consumer()]);
 
         // BTCUSDT appears in both consumers but should be one key
         let bn_symbols = plan.binance_symbols();
@@ -365,10 +360,7 @@ mod tests {
 
     #[test]
     fn build_plan_isolates_domains() {
-        let plan = SubscriptionPlanner::build_plan(vec![
-            crypto_consumer(),
-            sports_consumer(),
-        ]);
+        let plan = SubscriptionPlanner::build_plan(vec![crypto_consumer(), sports_consumer()]);
 
         assert_eq!(
             plan.consumer_domain(&ConsumerId::from("momentum-btc-15m")),
@@ -423,9 +415,9 @@ mod tests {
             .contains(&SubscriptionKey::PolymarketQuote {
                 token_id: "tok-down-1".into()
             }));
-        assert!(delta.unsubscribe.contains(&SubscriptionKey::Tick {
-            interval_ms: 1000
-        }));
+        assert!(delta
+            .unsubscribe
+            .contains(&SubscriptionKey::Tick { interval_ms: 1000 }));
 
         // Updated keys: BTCUSDT (consumer set changed), tok-up-1 (consumer set changed)
         assert!(delta.updated.contains(&SubscriptionKey::BinanceSpot {
@@ -458,14 +450,13 @@ mod tests {
 
     #[test]
     fn expand_feed_handles_empty_inputs() {
-        assert!(SubscriptionPlanner::expand_feed(&DataFeed::PolymarketQuotes {
-            tokens: vec![]
-        })
-        .is_empty());
-        assert!(SubscriptionPlanner::expand_feed(&DataFeed::BinanceSpot {
-            symbols: vec![]
-        })
-        .is_empty());
+        assert!(
+            SubscriptionPlanner::expand_feed(&DataFeed::PolymarketQuotes { tokens: vec![] })
+                .is_empty()
+        );
+        assert!(
+            SubscriptionPlanner::expand_feed(&DataFeed::BinanceSpot { symbols: vec![] }).is_empty()
+        );
         assert!(SubscriptionPlanner::expand_feed(&DataFeed::BinanceKlines {
             symbols: vec![],
             intervals: vec!["1m".into()],

--- a/src/strategy/adapters.rs
+++ b/src/strategy/adapters.rs
@@ -216,7 +216,8 @@ impl MomentumStrategyAdapter {
             return;
         }
 
-        if let Err(e) = crate::coordinator::bootstrap::ensure_strategy_observability_tables(pool).await
+        if let Err(e) =
+            crate::coordinator::bootstrap::ensure_strategy_observability_tables(pool).await
         {
             warn!(error = %e, "signal recorder: failed to ensure observability tables");
             return;
@@ -657,15 +658,20 @@ impl MomentumStrategyAdapter {
         current_price: &Decimal,
         ts: DateTime<Utc>,
     ) -> Option<StrategyAction> {
-        use crate::strategy::probability;
         use crate::strategy::fee_model::FeeModel;
+        use crate::strategy::probability;
         use rust_decimal::prelude::ToPrimitive;
 
         let events = self.events.read().await;
         let event_list = match events.get(symbol) {
             Some(list) if !list.is_empty() => list,
             _ => {
-                debug!("[{}] DIRECTIONAL: no event for {}, events={:?}", self.id, symbol, events.keys().collect::<Vec<_>>());
+                debug!(
+                    "[{}] DIRECTIONAL: no event for {}, events={:?}",
+                    self.id,
+                    symbol,
+                    events.keys().collect::<Vec<_>>()
+                );
                 return None;
             }
         };
@@ -685,10 +691,13 @@ impl MomentumStrategyAdapter {
             None => {
                 // Log every 30s to avoid spam
                 let minute = ts.timestamp() / 30;
-                static LAST_LOG: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
+                static LAST_LOG: std::sync::atomic::AtomicI64 =
+                    std::sync::atomic::AtomicI64::new(0);
                 let prev = LAST_LOG.swap(minute, std::sync::atomic::Ordering::Relaxed);
                 if prev != minute {
-                    let nearest = event_list.iter().filter(|e| e.end_time > ts)
+                    let nearest = event_list
+                        .iter()
+                        .filter(|e| e.end_time > ts)
                         .min_by_key(|e| e.end_time)
                         .map(|e| (e.end_time - ts).num_seconds())
                         .unwrap_or(-1);
@@ -731,7 +740,13 @@ impl MomentumStrategyAdapter {
                     (Direction::Up, ask)
                 }
                 None => {
-                    debug!("[{}] DIRECTIONAL: {} p={:.1}% but no UP ask (quotes={})", self.id, symbol, p_hat * 100.0, quotes.len());
+                    debug!(
+                        "[{}] DIRECTIONAL: {} p={:.1}% but no UP ask (quotes={})",
+                        self.id,
+                        symbol,
+                        p_hat * 100.0,
+                        quotes.len()
+                    );
                     return None;
                 }
             }
@@ -743,7 +758,13 @@ impl MomentumStrategyAdapter {
                     (Direction::Down, ask)
                 }
                 None => {
-                    debug!("[{}] DIRECTIONAL: {} p={:.1}% but no DOWN ask (token={}..)", self.id, symbol, p_hat * 100.0, &down_token[..8.min(down_token.len())]);
+                    debug!(
+                        "[{}] DIRECTIONAL: {} p={:.1}% but no DOWN ask (token={}..)",
+                        self.id,
+                        symbol,
+                        p_hat * 100.0,
+                        &down_token[..8.min(down_token.len())]
+                    );
                     return None;
                 }
             }
@@ -765,17 +786,23 @@ impl MomentumStrategyAdapter {
         let fee_per_share = market_ask * effective_rate;
         let spread_cost = dec!(0.01); // Conservative 1¢ spread estimate
         let market_ask_f64 = market_ask.to_f64().unwrap_or(0.5);
-        let cost_total_f64 = fee_per_share.to_f64().unwrap_or(0.01)
-            + spread_cost.to_f64().unwrap_or(0.01);
+        let cost_total_f64 =
+            fee_per_share.to_f64().unwrap_or(0.01) + spread_cost.to_f64().unwrap_or(0.01);
 
         // EV_net check (default threshold 0.08 = 8%)
         let ev_net = effective_p - market_ask_f64 - cost_total_f64;
         if ev_net < 0.08 {
             debug!(
                 "[{}] DIRECTIONAL: {} {} p={:.1}% ask={:.0}¢ ev={:.1}% < 8% (σ={:.4} t={:.0}s {}m)",
-                self.id, symbol, if p_hat > 0.5 { "UP" } else { "DOWN" },
-                effective_p * 100.0, market_ask_f64 * 100.0, ev_net * 100.0,
-                sigma, time_remaining, window_secs / 60
+                self.id,
+                symbol,
+                if p_hat > 0.5 { "UP" } else { "DOWN" },
+                effective_p * 100.0,
+                market_ask_f64 * 100.0,
+                ev_net * 100.0,
+                sigma,
+                time_remaining,
+                window_secs / 60
             );
             return None;
         }
@@ -823,7 +850,10 @@ impl MomentumStrategyAdapter {
         let events = self.events.read().await;
         let event_list = events.get(symbol)?;
         let now = Utc::now();
-        let event = event_list.iter().filter(|e| e.end_time > now).min_by_key(|e| e.end_time)?;
+        let event = event_list
+            .iter()
+            .filter(|e| e.end_time > now)
+            .min_by_key(|e| e.end_time)?;
 
         let token_id = match direction {
             Direction::Up => &event.up_token_id,
@@ -845,7 +875,10 @@ impl MomentumStrategyAdapter {
         let events = self.events.read().await;
         let event_list = events.get(symbol)?;
         let now = Utc::now();
-        let event = event_list.iter().filter(|e| e.end_time > now).min_by_key(|e| e.end_time)?;
+        let event = event_list
+            .iter()
+            .filter(|e| e.end_time > now)
+            .min_by_key(|e| e.end_time)?;
 
         let token_id = match direction {
             Direction::Up => event.up_token_id.clone(),
@@ -975,8 +1008,9 @@ impl Strategy for MomentumStrategyAdapter {
 
                 // === DIRECTIONAL MODE: probability model entry ===
                 if self.config.directional_mode {
-                    if let Some(action) =
-                        self.check_directional_entry(symbol, price, *timestamp).await
+                    if let Some(action) = self
+                        .check_directional_entry(symbol, price, *timestamp)
+                        .await
                     {
                         let mut cooldowns = self.cooldowns.write().await;
                         cooldowns.insert(symbol.clone(), Utc::now());
@@ -1030,7 +1064,11 @@ impl Strategy for MomentumStrategyAdapter {
                             let events = self.events.read().await;
                             let quotes = self.pm_quotes.read().await;
                             let now = Utc::now();
-                            if let Some(event) = events.get(symbol).and_then(|list| list.iter().filter(|e| e.end_time > now).min_by_key(|e| e.end_time)) {
+                            if let Some(event) = events.get(symbol).and_then(|list| {
+                                list.iter()
+                                    .filter(|e| e.end_time > now)
+                                    .min_by_key(|e| e.end_time)
+                            }) {
                                 let token_id = match direction {
                                     Direction::Up => &event.up_token_id,
                                     Direction::Down => &event.down_token_id,
@@ -1179,7 +1217,11 @@ impl Strategy for MomentumStrategyAdapter {
 
                 debug!(
                     "[{}] Event discovered: {} for {} ({}m window, ends {})",
-                    self.id, event_id, symbol, window_secs / 60, end_time
+                    self.id,
+                    event_id,
+                    symbol,
+                    window_secs / 60,
+                    end_time
                 );
             }
 

--- a/src/strategy/backtest_feed.rs
+++ b/src/strategy/backtest_feed.rs
@@ -281,7 +281,10 @@ impl HistoricalFeed {
                 });
             }
         }
-        info!("Loaded {} event windows from pm_market_metadata", event_rows.len());
+        info!(
+            "Loaded {} event windows from pm_market_metadata",
+            event_rows.len()
+        );
 
         // Settlement events: one per market_slug where outcome='Up' has settled_price=1
         let settlement_rows: Vec<(
@@ -310,9 +313,7 @@ impl HistoricalFeed {
         // Build slug→symbol lookup
         let slug_to_symbol: HashMap<String, String> = event_rows
             .iter()
-            .filter_map(|(slug, sym, _, _, _)| {
-                sym.as_ref().map(|s| (slug.clone(), s.clone()))
-            })
+            .filter_map(|(slug, sym, _, _, _)| sym.as_ref().map(|s| (slug.clone(), s.clone())))
             .collect();
 
         for (slug, _outcome, settled_price, resolved_at) in &settlement_rows {

--- a/src/strategy/directional_backtest.rs
+++ b/src/strategy/directional_backtest.rs
@@ -464,15 +464,16 @@ impl DirectionalBacktestEngine {
 
         let entry_cost = Decimal::from(sim_result.filled_shares) * sim_result.fill_price;
         // Taker fee at entry: shares × price × feeRate × (p*(1-p))^exponent
-        let entry_fee = self
-            .fee_model
-            .fee_shares(Decimal::from(sim_result.filled_shares), sim_result.fill_price)
-            * sim_result.fill_price;
+        let entry_fee = self.fee_model.fee_shares(
+            Decimal::from(sim_result.filled_shares),
+            sim_result.fill_price,
+        ) * sim_result.fill_price;
         let total_entry_cost = entry_cost + entry_fee;
         if total_entry_cost > self.equity {
             trace!(
                 "Skipping entry: insufficient equity ({} < {})",
-                self.equity, total_entry_cost
+                self.equity,
+                total_entry_cost
             );
             return;
         }
@@ -586,14 +587,16 @@ impl DirectionalBacktestEngine {
             .and_then(|s| {
                 let lookback = self.config.vol_lookback_secs;
                 let floor = self.config.vol_floor;
-                s.volatility(lookback).and_then(|v| v.to_f64()).map(|tick_vol| {
-                    if tick_vol > 0.0 {
-                        let n_ticks = s.history_len().min(5000) as f64;
-                        (tick_vol * n_ticks.sqrt()).max(floor)
-                    } else {
-                        floor
-                    }
-                })
+                s.volatility(lookback)
+                    .and_then(|v| v.to_f64())
+                    .map(|tick_vol| {
+                        if tick_vol > 0.0 {
+                            let n_ticks = s.history_len().min(5000) as f64;
+                            (tick_vol * n_ticks.sqrt()).max(floor)
+                        } else {
+                            floor
+                        }
+                    })
             })
             .unwrap_or(pos.entry_sigma)
             .max(self.config.vol_floor);
@@ -624,13 +627,7 @@ impl DirectionalBacktestEngine {
 
     // ─── Close position ──────────────────────────────────────
 
-    fn close_position(
-        &mut self,
-        idx: usize,
-        exit_price: Decimal,
-        reason: &str,
-        ts: DateTime<Utc>,
-    ) {
+    fn close_position(&mut self, idx: usize, exit_price: Decimal, reason: &str, ts: DateTime<Utc>) {
         let pos = self.positions.remove(idx);
 
         // For settlement ($1 or $0), no need to simulate — it's binary payout.
@@ -641,15 +638,15 @@ impl DirectionalBacktestEngine {
             // At $1.00 or $0.00, the parabolic fee curve = 0 (p*(1-p) = 0)
             (p, p * Decimal::from(pos.shares), Decimal::ZERO)
         } else {
-            let sim_result =
-                self.execution_sim
-                    .simulate_sell(exit_price, ts, pos.shares, 10_000);
+            let sim_result = self
+                .execution_sim
+                .simulate_sell(exit_price, ts, pos.shares, 10_000);
             let raw_proceeds = Decimal::from(sim_result.filled_shares) * sim_result.fill_price;
             // Taker fee on sell: shares × price × feeRate × (p*(1-p))^exponent
-            let sell_fee = self
-                .fee_model
-                .fee_shares(Decimal::from(sim_result.filled_shares), sim_result.fill_price)
-                * sim_result.fill_price;
+            let sell_fee = self.fee_model.fee_shares(
+                Decimal::from(sim_result.filled_shares),
+                sim_result.fill_price,
+            ) * sim_result.fill_price;
             (sim_result.fill_price, raw_proceeds - sell_fee, sell_fee)
         };
 
@@ -918,7 +915,10 @@ impl DirectionalBacktestEngine {
             .count();
 
         println!("\n=== Directional Backtest Summary ===");
-        println!("Settlement rate:  {:.1}% ({}/{})", settlement_rate, settled, total);
+        println!(
+            "Settlement rate:  {:.1}% ({}/{})",
+            settlement_rate, settled, total
+        );
         println!("Exit reasons:");
         for (reason, count) in &exit_counts {
             println!("  {:<16} {}", reason, count);
@@ -964,19 +964,27 @@ impl DirectionalBacktestEngine {
         let min_hold = hold_times.iter().min().copied().unwrap_or(0);
         let max_hold = hold_times.iter().max().copied().unwrap_or(0);
         println!("\nHolding time:");
-        println!("  Avg: {:.0}s  Min: {}s  Max: {}s", avg_hold, min_hold, max_hold);
+        println!(
+            "  Avg: {:.0}s  Min: {}s  Max: {}s",
+            avg_hold, min_hold, max_hold
+        );
 
         // Entry price distribution
-        let entry_prices: Vec<f64> = self.closed_trades.iter().map(|t| t.entry_price.to_f64().unwrap_or(0.0)).collect();
+        let entry_prices: Vec<f64> = self
+            .closed_trades
+            .iter()
+            .map(|t| t.entry_price.to_f64().unwrap_or(0.0))
+            .collect();
         let avg_entry = entry_prices.iter().sum::<f64>() / entry_prices.len().max(1) as f64;
         println!("  Avg entry price: ${:.4}", avg_entry);
 
         // Per-symbol breakdown
         let mut symbol_stats: HashMap<&str, (usize, usize, Decimal, Decimal)> = HashMap::new();
         for t in &self.closed_trades {
-            let entry = symbol_stats
-                .entry(&t.symbol)
-                .or_insert((0, 0, Decimal::ZERO, Decimal::ZERO));
+            let entry =
+                symbol_stats
+                    .entry(&t.symbol)
+                    .or_insert((0, 0, Decimal::ZERO, Decimal::ZERO));
             entry.0 += 1; // total trades
             if t.won {
                 entry.1 += 1; // wins
@@ -1046,11 +1054,7 @@ impl fmt::Display for DirectionalBacktestEngine {
         writeln!(f, "Avg PnL/trade: ${:.4}", results.avg_pnl_per_trade)?;
         writeln!(f, "Sharpe ratio:  {:.2}", results.sharpe_ratio)?;
         writeln!(f, "Profit factor: {:.2}", results.profit_factor)?;
-        writeln!(
-            f,
-            "Max drawdown:  {:.2}%",
-            results.max_drawdown * dec!(100)
-        )?;
+        writeln!(f, "Max drawdown:  {:.2}%", results.max_drawdown * dec!(100))?;
         writeln!(f, "Avg hold time: {:.0}s", results.avg_holding_time_secs)?;
         writeln!(f, "Largest win:   ${:.4}", results.largest_win)?;
         writeln!(f, "Largest loss:  ${:.4}", results.largest_loss)?;

--- a/src/strategy/fee_model.rs
+++ b/src/strategy/fee_model.rs
@@ -252,7 +252,10 @@ mod tests {
     fn test_all_in_cost_components_sum() {
         let model = FeeModel::crypto();
         let cost = model.all_in_cost(dec!(0.50), dec!(0.48), dec!(0.52), dec!(0.3));
-        assert_eq!(cost.total, cost.taker_fee + cost.spread_cost + cost.depth_slippage);
+        assert_eq!(
+            cost.total,
+            cost.taker_fee + cost.spread_cost + cost.depth_slippage
+        );
     }
 
     #[test]

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -58,9 +58,11 @@ pub mod backtest;
 pub mod backtest_feed;
 pub mod calculations;
 pub mod claimer;
+pub mod directional_backtest;
 pub mod dump_hedge;
 pub mod execution;
 pub mod execution_sim;
+pub mod fee_model;
 pub mod integrity;
 pub mod momentum;
 pub mod momentum_backtest;
@@ -70,6 +72,7 @@ pub mod paper_runner;
 #[cfg(feature = "analysis")]
 pub mod parquet_analysis;
 pub mod position_manager;
+pub mod probability;
 pub mod reconciliation;
 pub mod risk_mgmt;
 pub mod signal;
@@ -78,9 +81,6 @@ pub mod trade_logger;
 pub mod trading_costs;
 pub mod volatility;
 pub mod volatility_arb;
-pub mod directional_backtest;
-pub mod fee_model;
-pub mod probability;
 
 // Runtime re-exports
 pub use claimer::{AutoClaimer, ClaimResult, ClaimerConfig, RedeemablePosition};
@@ -131,6 +131,9 @@ pub use backtest::{
     BacktestResults, BacktestTrade, KlineRecord, MarketSnapshot, PMPriceRecord, PaperSignal,
     PaperTrader, PaperTradingStats,
 };
+pub use directional_backtest::{
+    DirectionalBacktestConfig, DirectionalBacktestEngine, DirectionalClosedTrade,
+};
 pub use dump_hedge::{
     DumpHedgeConfig, DumpHedgeEngine, DumpHedgeStats, EnhancedDumpSignal, HedgeResult,
     PendingHedge, ProgressiveHedgeSignal, StopLossReason, StopLossSignal,
@@ -138,6 +141,7 @@ pub use dump_hedge::{
 pub use event_edge::core::{EventEdgeCore, EventEdgeState, TradeDecision};
 pub use event_edge::{run_event_edge, EventEdgeConfig};
 pub use execution_sim::{ExecutionResult, ExecutionSimConfig, ExecutionSimulator};
+pub use fee_model::{AllInCost, FeeModel, FeeRateCache};
 pub use momentum::{
     Direction, EventInfo, EventMatcher, ExitConfig, ExitManager, ExitReason, MomentumConfig,
     MomentumDetector, MomentumEngine, MomentumSignal, Position,
@@ -164,6 +168,7 @@ pub use position_manager::{
     Position as PersistedPosition, PositionManager, PositionStatus as PersistedPositionStatus,
     PositionSummary,
 };
+pub use probability::{estimate_probability, full_estimate, Features, ProbabilityEstimate};
 pub use reconciliation::{
     DiscrepancySeverity, PositionDiscrepancy, ReconciliationConfig, ReconciliationResult,
     ReconciliationService,
@@ -188,9 +193,6 @@ pub use volatility_arb::{
     MarketPricing, VolArbSignal, VolArbStats, VolArbTrade, VolatilityArbConfig,
     VolatilityArbEngine, VolatilityEstimate,
 };
-pub use probability::{estimate_probability, full_estimate, Features, ProbabilityEstimate};
-pub use fee_model::{AllInCost, FeeModel, FeeRateCache};
-pub use directional_backtest::{DirectionalBacktestConfig, DirectionalBacktestEngine, DirectionalClosedTrade};
 
 // New consolidated modules
 pub use calculations::{

--- a/src/strategy/momentum.rs
+++ b/src/strategy/momentum.rs
@@ -25,6 +25,7 @@ use crate::adapters::{
 use crate::config::RiskConfig;
 use crate::domain::{OrderRequest, Side};
 use crate::error::Result;
+use crate::platform::CryptoDataPlaneHandle;
 use crate::strategy::dump_hedge::{DumpHedgeConfig, DumpHedgeEngine};
 use crate::strategy::fee_model::FeeModel;
 use crate::strategy::fund_manager::{FundManager, PositionSizeResult};
@@ -1482,15 +1483,27 @@ impl Position {
 /// Reason for exiting a position
 #[derive(Debug, Clone)]
 pub enum ExitReason {
-    TakeProfit { profit_pct: Decimal },
-    StopLoss { loss_pct: Decimal },
-    TrailingStop { high: Decimal, current: Decimal },
+    TakeProfit {
+        profit_pct: Decimal,
+    },
+    StopLoss {
+        loss_pct: Decimal,
+    },
+    TrailingStop {
+        high: Decimal,
+        current: Decimal,
+    },
     TimeExit,
     Manual,
     /// Probability model thesis invalidated (p_hat dropped below threshold)
-    ProbabilityStop { entry_p_hat: f64, current_p_hat: f64 },
+    ProbabilityStop {
+        entry_p_hat: f64,
+        current_p_hat: f64,
+    },
     /// Hard loss limit per trade
-    HardStop { loss_usd: Decimal },
+    HardStop {
+        loss_usd: Decimal,
+    },
 }
 
 impl std::fmt::Display for ExitReason {
@@ -2209,14 +2222,15 @@ impl MomentumEngine {
     /// Run the momentum strategy
     pub async fn run(
         &self,
-        mut binance_rx: broadcast::Receiver<PriceUpdate>,
-        mut pm_rx: broadcast::Receiver<QuoteUpdate>,
-        binance_cache: &PriceCache,
-        pm_cache: &QuoteCache,
+        market_data: &CryptoDataPlaneHandle,
         mut chainlink_rx: Option<broadcast::Receiver<ChainlinkUpdate>>,
         chainlink_cache: Option<&ChainlinkPriceCache>,
     ) -> Result<()> {
         info!("Starting momentum engine (dry_run={})", self.dry_run);
+        let mut binance_rx = market_data.subscribe_prices();
+        let mut pm_rx = market_data.subscribe_quotes();
+        let binance_cache = market_data.price_cache();
+        let pm_cache = market_data.quote_cache();
 
         // Log mode-specific configuration
         if self.config.hold_to_resolution {
@@ -2278,14 +2292,20 @@ impl MomentumEngine {
             info!("=== DIRECTIONAL PREDICTION MODE ===");
             info!("• Ground truth: Chainlink RTDS (not Binance)");
             info!("• Fee model: parabolic (crypto, fee_rate=0.25, exp=2)");
-            info!("• Entry threshold: EV_net >= {:.1}%", self.entry_threshold * 100.0);
+            info!(
+                "• Entry threshold: EV_net >= {:.1}%",
+                self.entry_threshold * 100.0
+            );
         }
 
         if self.config.directional_mode {
             info!("=== DIRECTIONAL MODE (BINANCE AS ORACLE) ===");
             info!("• Ground truth: Binance spot price (Chainlink proxy)");
             info!("• Fee model: parabolic (crypto, fee_rate=0.25, exp=2)");
-            info!("• Entry threshold: EV_net >= {:.1}%", self.entry_threshold * 100.0);
+            info!(
+                "• Entry threshold: EV_net >= {:.1}%",
+                self.entry_threshold * 100.0
+            );
             info!("• Vol floor: {:.4}", self.config.directional_vol_floor);
             info!("• Symbols: {:?}", self.config.symbols);
         }
@@ -2300,7 +2320,7 @@ impl MomentumEngine {
                     }
                 } => {
                     if let Some(cl_cache) = chainlink_cache {
-                        if let Err(e) = self.on_chainlink_update(&cl_update, cl_cache, binance_cache, pm_cache).await {
+                        if let Err(e) = self.on_chainlink_update(&cl_update, cl_cache, &binance_cache, &pm_cache).await {
                             error!("Error processing Chainlink update: {}", e);
                         }
                     }
@@ -2310,7 +2330,7 @@ impl MomentumEngine {
                 Ok(price_update) = binance_rx.recv() => {
                     // When Chainlink is active, Binance is features-only (no direct entry)
                     if !has_chainlink {
-                        if let Err(e) = self.on_cex_update(&price_update, binance_cache, pm_cache).await {
+                        if let Err(e) = self.on_cex_update(&price_update, &binance_cache, &pm_cache).await {
                             error!("Error processing CEX update: {}", e);
                         }
                     }
@@ -2575,7 +2595,12 @@ impl MomentumEngine {
             return Ok(());
         }
         if market_ask < dec!(0.10) {
-            trace!("Skipping {} {} — ask {:.2}¢ below 10¢ floor", symbol, direction, market_ask * dec!(100));
+            trace!(
+                "Skipping {} {} — ask {:.2}¢ below 10¢ floor",
+                symbol,
+                direction,
+                market_ask * dec!(100)
+            );
             return Ok(());
         }
 
@@ -2585,15 +2610,22 @@ impl MomentumEngine {
         let fee_per_share = market_ask * effective_rate;
         let spread_cost = dec!(0.01); // Conservative 1¢ spread estimate
         let market_ask_f64 = market_ask.to_f64().unwrap_or(0.5);
-        let cost_total_f64 = fee_per_share.to_f64().unwrap_or(0.01)
-            + spread_cost.to_f64().unwrap_or(0.01);
+        let cost_total_f64 =
+            fee_per_share.to_f64().unwrap_or(0.01) + spread_cost.to_f64().unwrap_or(0.01);
 
         // EV_net check
         let ev_net = effective_p - market_ask_f64 - cost_total_f64;
 
         trace!(
             "🎯 {} {} p_hat={:.3} eff_p={:.3} ask={:.3} cost={:.4} ev_net={:.4} σ={:.5}",
-            symbol, direction, p_hat, effective_p, market_ask_f64, cost_total_f64, ev_net, sigma
+            symbol,
+            direction,
+            p_hat,
+            effective_p,
+            market_ask_f64,
+            cost_total_f64,
+            ev_net,
+            sigma
         );
 
         if ev_net < self.entry_threshold {
@@ -2668,10 +2700,11 @@ impl MomentumEngine {
         pm_cache: &QuoteCache,
     ) -> Result<()> {
         // Map Chainlink symbol to Binance symbol for event matching
-        let binance_symbol = match crate::adapters::chainlink_rtds::to_binance_symbol(&update.symbol) {
-            Some(s) => s.to_string(),
-            None => return Ok(()),
-        };
+        let binance_symbol =
+            match crate::adapters::chainlink_rtds::to_binance_symbol(&update.symbol) {
+                Some(s) => s.to_string(),
+                None => return Ok(()),
+            };
 
         if !self.config.symbols.contains(&binance_symbol) {
             return Ok(());
@@ -2747,12 +2780,20 @@ impl MomentumEngine {
 
         // Compute all-in cost
         let best_bid = if direction == Direction::Up {
-            pm_cache.get(&event.up_token_id).and_then(|q| q.best_bid).unwrap_or(market_ask)
+            pm_cache
+                .get(&event.up_token_id)
+                .and_then(|q| q.best_bid)
+                .unwrap_or(market_ask)
         } else {
-            pm_cache.get(&event.down_token_id).and_then(|q| q.best_bid).unwrap_or(market_ask)
+            pm_cache
+                .get(&event.down_token_id)
+                .and_then(|q| q.best_bid)
+                .unwrap_or(market_ask)
         };
         let depth_ratio = dec!(0.3); // conservative default
-        let cost = self.fee_model.all_in_cost(market_ask, best_bid, market_ask, depth_ratio);
+        let cost = self
+            .fee_model
+            .all_in_cost(market_ask, best_bid, market_ask, depth_ratio);
         let cost_total_f64 = cost.total.to_f64().unwrap_or(0.02);
         let market_ask_f64 = market_ask.to_f64().unwrap_or(0.5);
 
@@ -2770,14 +2811,15 @@ impl MomentumEngine {
         }
 
         // Get Binance features for logging (used in future calibration)
-        let (_momentum_10s, _momentum_60s) = if let Some(spot) = binance_cache.get(&binance_symbol).await {
-            (
-                spot.momentum(10).and_then(|m| m.to_f64()).unwrap_or(0.0),
-                spot.momentum(60).and_then(|m| m.to_f64()).unwrap_or(0.0),
-            )
-        } else {
-            (0.0, 0.0)
-        };
+        let (_momentum_10s, _momentum_60s) =
+            if let Some(spot) = binance_cache.get(&binance_symbol).await {
+                (
+                    spot.momentum(10).and_then(|m| m.to_f64()).unwrap_or(0.0),
+                    spot.momentum(60).and_then(|m| m.to_f64()).unwrap_or(0.0),
+                )
+            } else {
+                (0.0, 0.0)
+            };
 
         info!(
             "🔮 DIRECTIONAL ENTRY: {} {} p_hat={:.1}% ev_net={:.1}% ask={:.1}¢ cost={:.2}% σ={:.4}",
@@ -2808,7 +2850,10 @@ impl MomentumEngine {
         // If we entered, update the position with p_hat and S0
         {
             let mut positions = self.positions.write().await;
-            if let Some(pos) = positions.values_mut().find(|p| p.condition_id == event.condition_id) {
+            if let Some(pos) = positions
+                .values_mut()
+                .find(|p| p.condition_id == event.condition_id)
+            {
                 pos.entry_p_hat = Some(p_hat);
                 pos.window_open_price = Some(s0);
             }
@@ -2841,14 +2886,20 @@ impl MomentumEngine {
                     let time_remaining = pos.time_to_resolution().num_seconds() as f64;
 
                     // Map Binance symbol back to Chainlink
-                    if let Some(cl_symbol) = crate::adapters::chainlink_rtds::to_chainlink_symbol(&pos.symbol) {
+                    if let Some(cl_symbol) =
+                        crate::adapters::chainlink_rtds::to_chainlink_symbol(&pos.symbol)
+                    {
                         if let Some(cl_spot) = cl_cache.get(cl_symbol).await {
                             let sigma = cl_spot
                                 .volatility(300)
                                 .and_then(|v| v.to_f64())
                                 .unwrap_or(0.001);
                             let current_p_hat = probability::estimate_probability(
-                                s0, cl_spot.price, sigma, time_remaining, 0.0,
+                                s0,
+                                cl_spot.price,
+                                sigma,
+                                time_remaining,
+                                0.0,
                             );
                             let effective_p = if direction == Direction::Up {
                                 current_p_hat
@@ -2876,12 +2927,16 @@ impl MomentumEngine {
 
                             // Time stop: < 30s remaining AND negative EV
                             if time_remaining < 30.0 {
-                                let ask_f64 = update.quote.best_ask
+                                let ask_f64 = update
+                                    .quote
+                                    .best_ask
                                     .and_then(|a| a.to_f64())
                                     .unwrap_or(0.5);
-                                let cost = self.fee_model.effective_rate(
-                                    update.quote.best_ask.unwrap_or(dec!(0.5))
-                                ).to_f64().unwrap_or(0.015);
+                                let cost = self
+                                    .fee_model
+                                    .effective_rate(update.quote.best_ask.unwrap_or(dec!(0.5)))
+                                    .to_f64()
+                                    .unwrap_or(0.015);
                                 let ev_net = effective_p - ask_f64 - cost;
                                 if ev_net < 0.0 {
                                     if let Some(bid) = update.quote.best_bid {
@@ -2894,7 +2949,8 @@ impl MomentumEngine {
 
                             // Hard stop: unrealized loss > $5
                             if let Some(bid) = update.quote.best_bid {
-                                let unrealized_pnl = (bid - pos.entry_price) * Decimal::from(pos.shares);
+                                let unrealized_pnl =
+                                    (bid - pos.entry_price) * Decimal::from(pos.shares);
                                 if unrealized_pnl < dec!(-5) {
                                     drop(positions);
                                     let reason = ExitReason::HardStop {

--- a/src/strategy/probability.rs
+++ b/src/strategy/probability.rs
@@ -12,21 +12,21 @@ use super::volatility::normal_cdf;
 /// Full probability estimate with features for logging
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProbabilityEstimate {
-    pub p_hat: f64,          // P(Up) estimate [0, 1]
-    pub confidence: f64,     // model confidence [0, 1]
-    pub features: Features,  // for logging/debugging
+    pub p_hat: f64,         // P(Up) estimate [0, 1]
+    pub confidence: f64,    // model confidence [0, 1]
+    pub features: Features, // for logging/debugging
 }
 
 /// Feature vector used in probability estimation
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Features {
-    pub distance_to_beat: f64,  // (St - S0) / S0
-    pub realized_vol: f64,      // σ from Chainlink history
-    pub time_remaining: f64,    // Δt in seconds
-    pub momentum_10s: f64,      // Binance 10s momentum (feature, not truth)
-    pub momentum_60s: f64,      // Binance 60s momentum
-    pub obi: f64,               // Binance L2 orderbook imbalance
-    pub binance_chainlink_spread: f64,  // basis risk indicator
+    pub distance_to_beat: f64,         // (St - S0) / S0
+    pub realized_vol: f64,             // σ from Chainlink history
+    pub time_remaining: f64,           // Δt in seconds
+    pub momentum_10s: f64,             // Binance 10s momentum (feature, not truth)
+    pub momentum_60s: f64,             // Binance 60s momentum
+    pub obi: f64,                      // Binance L2 orderbook imbalance
+    pub binance_chainlink_spread: f64, // basis risk indicator
 }
 
 /// Estimate P(ST >= S0) using log-normal model
@@ -127,18 +127,18 @@ mod tests {
     fn test_price_above_s0_high_probability() {
         // BTC moved up 1% with low vol, 7.5 min remaining
         let p = estimate_probability(dec!(100), dec!(101), 0.001, 450.0, 0.0);
-        assert!(p > 0.7, "p_hat={} should be > 0.7 when price is above S0", p);
+        assert!(
+            p > 0.7,
+            "p_hat={} should be > 0.7 when price is above S0",
+            p
+        );
     }
 
     #[test]
     fn test_price_at_s0_near_half() {
         // Price at S0, should be ~0.5
         let p = estimate_probability(dec!(100), dec!(100), 0.001, 450.0, 0.0);
-        assert!(
-            (p - 0.5).abs() < 0.05,
-            "p_hat={} should be ~0.5 at S0",
-            p
-        );
+        assert!((p - 0.5).abs() < 0.05, "p_hat={} should be ~0.5 at S0", p);
     }
 
     #[test]
@@ -188,10 +188,7 @@ mod tests {
         // Same price move but higher vol should give less extreme probability
         let p_low_vol = estimate_probability(dec!(100), dec!(101), 0.001, 450.0, 0.0);
         let p_high_vol = estimate_probability(dec!(100), dec!(101), 0.01, 450.0, 0.0);
-        assert!(
-            p_low_vol > p_high_vol,
-            "higher vol should reduce certainty"
-        );
+        assert!(p_low_vol > p_high_vol, "higher vol should reduce certainty");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- migrate crypto/openclaw runtime consumers to data-plane handles and remove direct WS ownership from runtime path
- move MomentumEngine runtime input wiring to CryptoDataPlaneHandle (subscribers + caches sourced in engine)
- migrate crypto and sports WS persistence bridges to PersistencePipeline (quote/price/orderbook + Binance LOB bridge)
- remove legacy bootstrap persistence spawner path now superseded by pipeline bridges

## Notes
- sports keeps a domain-isolated dedicated PlatformDataPlane instance
- trade polling persistence remains separate (spawn_polymarket_trade_persistence and spawn_polymarket_trade_persistence_from_collector_targets)

## Verification
- cargo check -q
- cargo check -q --features rl
- cargo check -q --features onnx
- cargo test -q --lib platform::data_plane::tests
- cargo test -q --lib strategy::feeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a unified market-data plane used by trading agents to simplify and standardize data access.

* **New Features**
  * Added strategy modules for directional backtesting, fee modeling, and probability estimation.

* **Bug Fixes & Improvements**
  * Backtest output now includes per-symbol trade stats plus aggregated totals for clearer performance insight.

* **Chores**
  * Widespread formatting, logging, and test-assertion cleanups for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->