### PR TITLE
Phase 4: cleanup standalone WS creation in entry points

### DIFF
--- a/src/cli/strategy.rs
+++ b/src/cli/strategy.rs
@@ -812,7 +812,7 @@ async fn start_strategy(
 
 /// Run strategy in foreground using StrategyManager
 async fn run_strategy_foreground(name: &str, config_path: &PathBuf, dry_run: bool) -> Result<()> {
-    use crate::adapters::PolymarketWebSocket;
+    use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
     use crate::strategy::DataFeedManager;
 
     // Load config
@@ -928,35 +928,6 @@ async fn run_strategy_foreground(name: &str, config_path: &PathBuf, dry_run: boo
     binance_kline_intervals.sort();
     binance_kline_intervals.dedup();
 
-    // Create data feed manager with required feeds
-    let mut feed_manager = DataFeedManager::new(manager.clone());
-
-    if !binance_spot_symbols.is_empty() {
-        println!(
-            "  \x1b[36mConfiguring Binance spot feed: {:?}\x1b[0m",
-            binance_spot_symbols
-        );
-        feed_manager = feed_manager.with_binance(binance_spot_symbols);
-    }
-
-    if !binance_kline_symbols.is_empty() && !binance_kline_intervals.is_empty() {
-        let backfill_limit = std::env::var("PLOY_BINANCE_KLINE_BACKFILL_LIMIT")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(300);
-
-        println!(
-            "  \x1b[36mConfiguring Binance kline feed: symbols={:?} intervals={:?} closed_only={} backfill_limit={}\x1b[0m",
-            binance_kline_symbols, binance_kline_intervals, binance_kline_closed_only, backfill_limit
-        );
-        feed_manager = feed_manager.with_binance_klines(
-            binance_kline_symbols,
-            binance_kline_intervals,
-            binance_kline_closed_only,
-            backfill_limit,
-        );
-    }
-
     // Configure Polymarket if needed
     let has_polymarket_feed = required_feeds.iter().any(|f| {
         matches!(
@@ -966,12 +937,50 @@ async fn run_strategy_foreground(name: &str, config_path: &PathBuf, dry_run: boo
         )
     });
 
+    if !binance_spot_symbols.is_empty() {
+        println!(
+            "  \x1b[36mConfiguring Binance spot feed: {:?}\x1b[0m",
+            binance_spot_symbols
+        );
+    }
+
+    if !binance_kline_symbols.is_empty() && !binance_kline_intervals.is_empty() {
+        let backfill_limit = std::env::var("PLOY_BINANCE_KLINE_BACKFILL_LIMIT")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(300);
+        println!(
+            "  \x1b[36mConfiguring Binance kline feed: symbols={:?} intervals={:?} closed_only={} backfill_limit={}\x1b[0m",
+            binance_kline_symbols, binance_kline_intervals, binance_kline_closed_only, backfill_limit
+        );
+    }
+
     if has_polymarket_feed {
         println!("  \x1b[36mConfiguring Polymarket feed\x1b[0m");
+    }
+
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: if has_polymarket_feed {
+                "wss://ws-subscriptions-clob.polymarket.com/ws/market".to_string()
+            } else {
+                String::new()
+            },
+            binance_spot_symbols: binance_spot_symbols.clone(),
+            binance_kline_symbols: binance_kline_symbols.clone(),
+            binance_kline_intervals: binance_kline_intervals.clone(),
+            binance_kline_closed_only,
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    data_plane.start(Vec::new()).await?;
+
+    // Create data feed manager backed by the shared data plane.
+    let mut feed_manager = DataFeedManager::from_data_plane(data_plane, manager.clone());
+    if has_polymarket_feed {
         let pm_client = PolymarketClient::new("https://clob.polymarket.com", dry_run)?;
-        let pm_ws =
-            PolymarketWebSocket::new("wss://ws-subscriptions-clob.polymarket.com/ws/market");
-        feed_manager = feed_manager.with_polymarket(pm_ws, pm_client);
+        feed_manager = feed_manager.with_pm_client(pm_client);
     }
 
     // Start the strategy

--- a/src/main_commands/rl/agent.rs
+++ b/src/main_commands/rl/agent.rs
@@ -22,13 +22,13 @@ pub(super) async fn run_agent(
     policy_output: &str,
     policy_version: &Option<String>,
 ) -> Result<()> {
-    use ploy::adapters::{
-        polymarket_clob::POLYGON_CHAIN_ID, BinanceWebSocket, PolymarketClient, PolymarketWebSocket,
-    };
+    use ploy::adapters::{polymarket_clob::POLYGON_CHAIN_ID, PolymarketClient};
     use ploy::domain::Side;
+    use ploy::error::PloyError;
     use ploy::platform::{
-        AgentRiskParams, AgentSubscription, CryptoEvent, Domain, DomainAgent, DomainEvent,
-        EventRouter, OrderPlatform, PlatformConfig, QuoteData, RLCryptoAgent, RLCryptoAgentConfig,
+        AgentRiskParams, AgentSubscription, CryptoEvent, DataPlaneConfig, DataPlaneFreshness,
+        Domain, DomainAgent, DomainEvent, EventRouter, OrderPlatform, PlatformConfig,
+        PlatformDataPlane, QuoteData, RLCryptoAgent, RLCryptoAgentConfig,
     };
     use ploy::rl::config::RLConfig;
     use ploy::signing::Wallet;
@@ -116,35 +116,27 @@ pub(super) async fn run_agent(
         .await;
 
     let symbol_upper = symbol.to_uppercase();
-    let bn_ws = BinanceWebSocket::new(vec![symbol_upper.clone()]);
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market".to_string(),
+            binance_spot_symbols: vec![symbol_upper.clone()],
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    let bn_ws = data_plane.binance_ws().ok_or_else(|| {
+        PloyError::Validation("rl agent data plane missing binance websocket".to_string())
+    })?;
+    let pm_ws = data_plane.polymarket_ws().ok_or_else(|| {
+        PloyError::Validation("rl agent data plane missing polymarket websocket".to_string())
+    })?;
+
     let price_cache = bn_ws.price_cache().clone();
-
-    let bn_ws_handle = tokio::spawn(async move {
-        if let Err(e) = bn_ws.run().await {
-            error!("Binance WS error: {}", e);
-        }
-    });
-
-    let pm_ws_url = "wss://ws-subscriptions-clob.polymarket.com/ws/market";
-    let pm_ws = Arc::new(PolymarketWebSocket::new(pm_ws_url));
     pm_ws.register_token(up_token, Side::Up).await;
     pm_ws.register_token(down_token, Side::Down).await;
+    data_plane.start(Vec::new()).await?;
 
     let quote_cache = pm_ws.quote_cache().clone();
-    let up_token_ws = up_token.to_string();
-    let down_token_ws = down_token.to_string();
-
-    let pm_ws_clone = Arc::clone(&pm_ws);
-    let pm_ws_handle = tokio::spawn(async move {
-        let token_ids = vec![up_token_ws, down_token_ws];
-        info!(
-            "Connecting to Polymarket WebSocket for tokens: {:?}",
-            token_ids
-        );
-        if let Err(e) = pm_ws_clone.run(token_ids).await {
-            error!("Polymarket WS error: {}", e);
-        }
-    });
 
     println!("🚀 Agent started. Listening for market data...\n");
     println!("📡 Binance: {} | Polymarket: UP/DOWN tokens", symbol_upper);
@@ -317,8 +309,6 @@ pub(super) async fn run_agent(
         }
     }
 
-    bn_ws_handle.abort();
-    pm_ws_handle.abort();
     router.stop_all_agents().await?;
     Ok(())
 }

--- a/src/main_modes/collector_modes.rs
+++ b/src/main_modes/collector_modes.rs
@@ -128,9 +128,10 @@ pub async fn run_collect_mode(symbols: &str, markets: Option<&str>, duration: u6
 /// Discover active PM tokens for crypto series and spawn a WebSocket bridge
 /// that feeds real-time PM prices into the collector.
 async fn spawn_pm_price_bridge(collector: Arc<ploy::collector::SyncCollector>) {
-    use ploy::adapters::{PolymarketClient, PolymarketWebSocket};
+    use ploy::adapters::PolymarketClient;
     use ploy::collector::PolymarketPrice;
     use ploy::domain::market::Side;
+    use ploy::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 
     // Create read-only PM client for event discovery
     let pm_client = match PolymarketClient::new(PM_REST_URL, true) {
@@ -196,23 +197,33 @@ async fn spawn_pm_price_bridge(collector: Arc<ploy::collector::SyncCollector>) {
         token_to_market.len() / 2 // UP+DOWN = 1 market
     );
 
-    // Create PM WebSocket and subscribe
-    let pm_ws = Arc::new(PolymarketWebSocket::new(PM_WS_URL));
-    let mut quote_rx = pm_ws.subscribe_updates();
+    // Create PM data plane and subscribe.
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: PM_WS_URL.to_string(),
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    let pm_ws = match data_plane.polymarket_ws() {
+        Some(ws) => ws,
+        None => {
+            warn!("Collector PM data plane missing polymarket websocket; bridge disabled.");
+            return;
+        }
+    };
 
-    // Register token sides for correct quote mapping
+    // Register token sides for correct quote mapping.
     for (token_id, (_slug, side)) in &token_to_market {
         pm_ws.register_token(token_id, *side).await;
     }
 
-    // Spawn PM WebSocket runner
-    let ws_tokens = all_token_ids.clone();
-    let ws = Arc::clone(&pm_ws);
-    tokio::spawn(async move {
-        if let Err(e) = ws.run(ws_tokens).await {
-            error!("Collector PM WebSocket error: {}", e);
-        }
-    });
+    if let Err(e) = data_plane.start(Vec::new()).await {
+        error!("Failed to start collector PM data plane: {}", e);
+        return;
+    }
+
+    let mut quote_rx = pm_ws.subscribe_updates();
 
     // Spawn quote bridge: QuoteUpdate -> PolymarketPrice -> collector
     // Maintains latest (yes, no) per slug and pushes full updates

--- a/src/strategy/crypto/runner.rs
+++ b/src/strategy/crypto/runner.rs
@@ -3,8 +3,10 @@
 //! Main entry point for running split arbitrage on crypto markets.
 
 use super::CryptoMarketDiscovery;
-use crate::adapters::{PolymarketClient, PolymarketWebSocket};
-use crate::error::Result;
+use crate::adapters::PolymarketClient;
+use crate::domain::Side;
+use crate::error::{PloyError, Result};
+use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 use crate::strategy::core::{MarketDiscovery, SplitArbConfig, SplitArbEngine};
 use crate::strategy::OrderExecutor;
 use rust_decimal::Decimal;
@@ -103,10 +105,25 @@ pub async fn run_crypto_split_arb(
         engine.config().min_profit_margin * dec!(100)
     );
 
-    let ws_url = "wss://ws-subscriptions-clob.polymarket.com/ws/market";
-    let ws = PolymarketWebSocket::new(ws_url);
-
-    // Get update receiver
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market".to_string(),
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    let ws = data_plane.polymarket_ws().ok_or_else(|| {
+        PloyError::Validation(
+            "crypto split_arb data plane missing polymarket websocket".to_string(),
+        )
+    })?;
+    for chunk in token_ids.chunks(2) {
+        ws.register_token(&chunk[0], Side::Up).await;
+        if let Some(token_id) = chunk.get(1) {
+            ws.register_token(token_id, Side::Down).await;
+        }
+    }
+    data_plane.start(Vec::new()).await?;
     let mut update_rx = ws.subscribe_updates();
 
     // Stats timer
@@ -116,14 +133,6 @@ pub async fn run_crypto_split_arb(
         loop {
             interval.tick().await;
             engine_clone.print_stats().await;
-        }
-    });
-
-    // Spawn WebSocket runner
-    let token_ids_clone = token_ids.clone();
-    tokio::spawn(async move {
-        if let Err(e) = ws.run(token_ids_clone).await {
-            warn!("WebSocket error: {}", e);
         }
     });
 

--- a/src/strategy/paper_runner.rs
+++ b/src/strategy/paper_runner.rs
@@ -7,16 +7,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::Utc;
 use rust_decimal::prelude::*;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-use crate::adapters::{BinanceWebSocket, PolymarketClient, PolymarketWebSocket};
+use crate::adapters::PolymarketClient;
 use crate::collector::BinanceKlineClient;
+use crate::domain::Side;
+use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 use crate::strategy::core::{BinaryMarket, MarketDiscovery};
 use crate::strategy::{CryptoMarketDiscovery, PaperTrader, PaperTradingStats, VolatilityArbConfig};
 
@@ -166,18 +168,35 @@ impl PaperTradingRunner {
             }
         }
 
-        // Create WebSocket connections
-        let pm_ws =
-            PolymarketWebSocket::new("wss://ws-subscriptions-clob.polymarket.com/ws/market");
-
-        // Binance WS needs lowercase symbols
+        // Build a shared data plane for PM + Binance instead of standalone WS instances.
         let binance_symbols: Vec<String> = self
             .config
             .symbols
             .iter()
             .map(|s| s.to_lowercase())
             .collect();
-        let binance_ws = Arc::new(BinanceWebSocket::new(binance_symbols.clone()));
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+                    .to_string(),
+                binance_spot_symbols: binance_symbols.clone(),
+                ..Default::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+        let pm_ws = data_plane
+            .polymarket_ws()
+            .ok_or_else(|| anyhow!("paper_runner data plane missing polymarket websocket"))?;
+        let binance_ws = data_plane
+            .binance_ws()
+            .ok_or_else(|| anyhow!("paper_runner data plane missing binance websocket"))?;
+
+        // Register yes/no token mappings so QuoteUpdate side routing is active.
+        for market in &markets {
+            pm_ws.register_token(&market.yes_token_id, Side::Up).await;
+            pm_ws.register_token(&market.no_token_id, Side::Down).await;
+        }
+        data_plane.start(Vec::new()).await?;
 
         // Get update channels
         let mut pm_update_rx = pm_ws.subscribe_updates();
@@ -227,22 +246,6 @@ impl PaperTradingRunner {
                 let trader = paper_trader_stats.read().await;
                 let stats = trader.statistics();
                 Self::print_stats(&stats);
-            }
-        });
-
-        // Spawn PM WebSocket runner
-        let token_ids_clone = token_ids.clone();
-        tokio::spawn(async move {
-            if let Err(e) = pm_ws.run(token_ids_clone).await {
-                error!("Polymarket WebSocket error: {}", e);
-            }
-        });
-
-        // Spawn Binance WebSocket runner
-        let binance_ws_runner = Arc::clone(&binance_ws);
-        tokio::spawn(async move {
-            if let Err(e) = binance_ws_runner.run().await {
-                error!("Binance WebSocket error: {}", e);
             }
         });
 

--- a/src/strategy/split_arb.rs
+++ b/src/strategy/split_arb.rs
@@ -9,9 +9,10 @@
 //! Key insight: Don't need to buy both sides simultaneously.
 //! Retail panic creates mispricings at different times.
 
-use crate::adapters::{PolymarketClient, PolymarketWebSocket, QuoteUpdate};
+use crate::adapters::{PolymarketClient, QuoteUpdate};
 use crate::domain::Side;
-use crate::error::Result;
+use crate::error::{PloyError, Result};
+use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 use crate::strategy::OrderExecutor;
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
@@ -823,16 +824,28 @@ pub async fn run_split_arb(
 
     info!("Found {} tokens to monitor", token_ids.len());
 
-    // Connect to WebSocket
-    let pm_ws = PolymarketWebSocket::new("wss://ws-subscriptions-clob.polymarket.com/ws/market");
-    let quote_rx = pm_ws.subscribe_updates();
+    // Build a local data plane instead of creating standalone WS adapters.
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market".to_string(),
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    let pm_ws = data_plane.polymarket_ws().ok_or_else(|| {
+        PloyError::Validation("split_arb data plane missing polymarket websocket".to_string())
+    })?;
 
-    // Spawn WebSocket task
-    let ws_handle = tokio::spawn(async move {
-        if let Err(e) = pm_ws.run(token_ids).await {
-            error!("WebSocket error: {}", e);
+    // Token list is generated as [up, down, up, down, ...].
+    for chunk in token_ids.chunks(2) {
+        pm_ws.register_token(&chunk[0], Side::Up).await;
+        if let Some(token_id) = chunk.get(1) {
+            pm_ws.register_token(token_id, Side::Down).await;
         }
-    });
+    }
+    data_plane.start(Vec::new()).await?;
+
+    let quote_rx = pm_ws.subscribe_updates();
 
     // Spawn status printer
     let engine_clone = engine.stats.clone();
@@ -855,6 +868,5 @@ pub async fn run_split_arb(
     // Run engine
     engine.run(quote_rx).await?;
 
-    ws_handle.abort();
     Ok(())
 }

--- a/src/strategy/sports/runner.rs
+++ b/src/strategy/sports/runner.rs
@@ -3,8 +3,10 @@
 //! Main entry point for running split arbitrage on sports markets.
 
 use super::{SportsLeague, SportsMarketDiscovery};
-use crate::adapters::{PolymarketClient, PolymarketWebSocket};
-use crate::error::Result;
+use crate::adapters::PolymarketClient;
+use crate::domain::Side;
+use crate::error::{PloyError, Result};
+use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 use crate::strategy::core::{MarketDiscovery, SplitArbConfig, SplitArbEngine};
 use crate::strategy::OrderExecutor;
 use rust_decimal_macros::dec;
@@ -99,9 +101,25 @@ pub async fn run_sports_split_arb(
     // Connect to WebSocket
     info!("Sports Split Arbitrage Engine started");
 
-    let ws_url = "wss://ws-subscriptions-clob.polymarket.com/ws/market";
-    let ws = PolymarketWebSocket::new(ws_url);
-
+    let data_plane = Arc::new(PlatformDataPlane::new(
+        DataPlaneConfig {
+            polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market".to_string(),
+            ..Default::default()
+        },
+        Arc::new(DataPlaneFreshness::new()),
+    ));
+    let ws = data_plane.polymarket_ws().ok_or_else(|| {
+        PloyError::Validation(
+            "sports split_arb data plane missing polymarket websocket".to_string(),
+        )
+    })?;
+    for chunk in token_ids.chunks(2) {
+        ws.register_token(&chunk[0], Side::Up).await;
+        if let Some(token_id) = chunk.get(1) {
+            ws.register_token(token_id, Side::Down).await;
+        }
+    }
+    data_plane.start(Vec::new()).await?;
     let mut update_rx = ws.subscribe_updates();
 
     // Stats timer
@@ -111,14 +129,6 @@ pub async fn run_sports_split_arb(
         loop {
             interval.tick().await;
             engine_clone.print_stats().await;
-        }
-    });
-
-    // Spawn WebSocket runner
-    let token_ids_clone = token_ids.clone();
-    tokio::spawn(async move {
-        if let Err(e) = ws.run(token_ids_clone).await {
-            warn!("WebSocket error: {}", e);
         }
     });
 

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -9,13 +9,12 @@ use std::time::Duration;
 use chrono::Utc;
 use rust_decimal::Decimal;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-use crate::adapters::{
-    BinanceWebSocket, PolymarketClient, PolymarketWebSocket, PriceCache, QuoteCache,
-};
+use crate::adapters::{PolymarketClient, PriceCache, QuoteCache};
 use crate::domain::Side;
 use crate::error::Result;
+use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
 use crate::tui::app::TuiApp;
 use crate::tui::data::{DisplayAgent, DisplayRiskState, DisplayTransaction};
 use crate::tui::event::{AppEvent, KeyAction};
@@ -316,20 +315,25 @@ impl DashboardRunner {
     ) {
         info!("Connecting to Binance WebSocket...");
 
-        let binance_ws = BinanceWebSocket::new(symbols);
-        let mut rx = binance_ws.subscribe();
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                binance_spot_symbols: symbols,
+                ..Default::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+        let Some(binance_ws) = data_plane.binance_ws() else {
+            let _ = event_tx.send(AppEvent::Error(
+                "Binance data plane is missing websocket adapter".to_string(),
+            ));
+            return;
+        };
+        if let Err(e) = data_plane.start(Vec::new()).await {
+            let _ = event_tx.send(AppEvent::Error(format!("Binance data plane start: {}", e)));
+            return;
+        }
 
-        // Spawn WebSocket runner
-        let ws_running = Arc::clone(&running);
-        let err_tx = event_tx.clone();
-        tokio::spawn(async move {
-            if let Err(e) = binance_ws.run().await {
-                if ws_running.load(Ordering::SeqCst) {
-                    error!("Binance WebSocket error: {}", e);
-                    let _ = err_tx.send(AppEvent::Error(format!("Binance WS: {}", e)));
-                }
-            }
-        });
+        let mut rx = binance_ws.subscribe();
 
         let mut first_update = true;
 
@@ -366,30 +370,36 @@ impl DashboardRunner {
     ) {
         info!("Connecting to Polymarket WebSocket...");
 
-        let pm_ws = Arc::new(PolymarketWebSocket::new(
-            "wss://ws-subscriptions-clob.polymarket.com/ws/market",
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                polymarket_ws_url: "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+                    .to_string(),
+                ..Default::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
         ));
+        let Some(pm_ws) = data_plane.polymarket_ws() else {
+            let _ = event_tx.send(AppEvent::Error(
+                "Polymarket data plane is missing websocket adapter".to_string(),
+            ));
+            return;
+        };
 
         // Register tokens (alternate UP/DOWN)
         for (i, token_id) in token_ids.iter().enumerate() {
             let side = if i % 2 == 0 { Side::Up } else { Side::Down };
             pm_ws.register_token(token_id, side).await;
         }
+        if let Err(e) = data_plane.start(Vec::new()).await {
+            let _ = event_tx.send(AppEvent::Error(format!(
+                "Polymarket data plane start: {}",
+                e
+            )));
+            return;
+        }
 
         let mut rx = pm_ws.subscribe_updates();
         let _quote_cache = pm_ws.quote_cache().clone();
-
-        // Spawn WebSocket runner
-        let pm_ws_clone = Arc::clone(&pm_ws);
-        let tokens = token_ids.clone();
-        let ws_running = Arc::clone(&running);
-        tokio::spawn(async move {
-            if let Err(e) = pm_ws_clone.run(tokens).await {
-                if ws_running.load(Ordering::SeqCst) {
-                    error!("Polymarket WebSocket error: {}", e);
-                }
-            }
-        });
 
         // Track UP and DOWN quotes separately
         let mut up_quote: Option<crate::domain::Quote> = None;


### PR DESCRIPTION
## Summary
- replace standalone WS creation in Phase 4 entry points with `PlatformDataPlane`-backed adapters
- wire token side registration through `data_plane.polymarket_ws()` where quote side mapping is required
- switch strategy CLI foreground runtime to `DataFeedManager::from_data_plane(...)` + `with_pm_client(...)`

## Files
- `src/strategy/split_arb.rs`
- `src/strategy/paper_runner.rs`
- `src/strategy/sports/runner.rs`
- `src/strategy/crypto/runner.rs`
- `src/tui/runner.rs`
- `src/main_modes/collector_modes.rs`
- `src/main_commands/rl/agent.rs`
- `src/cli/strategy.rs`

## Validation
- `cargo fmt --all`
- `cargo check -q`
- `cargo check -q --features rl`
- `cargo test -q --lib strategy::split_arb`

Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated market data feed management architecture across the platform. The system now uses a unified data plane to centrally manage and initialize Binance and Polymarket market data sources. This enhancement improves data feed consistency, lifecycle management, and overall system reliability for all trading strategies and operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->