### PR TITLE
Phase 0: characterization replay tests + data-plane observability metrics

### DIFF
--- a/docs/PHASE0_DATA_PLANE_BASELINE_RUNBOOK.md
+++ b/docs/PHASE0_DATA_PLANE_BASELINE_RUNBOOK.md
@@ -1,0 +1,77 @@
+# Phase 0 Data Plane Baseline Runbook
+
+This runbook covers issue #21 baseline tasks that are executed on `tango-1-1`:
+
+- 24h baseline capture for per `(source, symbol)` message rate
+- rollback gate check: drop rate `>5%` sustained `>60s`
+
+## Scripts
+
+- `scripts/collect_data_plane_baseline.py`
+- `scripts/validate_data_plane_drop_rate.py`
+
+## 1) Start 24h Baseline Capture
+
+Run on `tango-1-1` (or any host where `/metrics` is reachable):
+
+```bash
+python3 scripts/collect_data_plane_baseline.py \
+  --metrics-url http://127.0.0.1:9090/metrics \
+  --duration-secs 86400 \
+  --interval-secs 10 \
+  --output-dir data/baseline \
+  --run-id tango-1-1-$(date -u +%Y%m%d-%H%M%S)
+```
+
+Recommended background execution:
+
+```bash
+nohup python3 scripts/collect_data_plane_baseline.py \
+  --metrics-url http://127.0.0.1:9090/metrics \
+  --duration-secs 86400 \
+  --interval-secs 10 \
+  --output-dir data/baseline \
+  --run-id tango-1-1-$(date -u +%Y%m%d-%H%M%S) \
+  > data/baseline/collector.log 2>&1 &
+```
+
+## 2) Output Artifacts
+
+For each run id `<run_id>`, the collector writes:
+
+- `data/baseline/<run_id>.samples.jsonl` (raw counter snapshots and per-interval rates)
+- `data/baseline/<run_id>.summary.json` (aggregated rates, p50/p95, totals)
+- `data/baseline/<run_id>.baseline.json` (baseline reference + rollback rule metadata)
+- `data/baseline/<run_id>.symbol_rates.csv`
+- `data/baseline/<run_id>.source_rates.csv`
+
+## 3) Validate Rollback Gate
+
+Check whether observed run violates rollback rule against baseline:
+
+```bash
+python3 scripts/validate_data_plane_drop_rate.py \
+  --baseline-json data/baseline/<baseline_run>.baseline.json \
+  --samples-jsonl data/baseline/<candidate_run>.samples.jsonl \
+  --scope both \
+  --output-json data/baseline/<candidate_run>.rollback_report.json
+```
+
+Exit code:
+
+- `0` = no sustained breach
+- `1` = rollback condition triggered
+- `2` = invalid input / no usable samples
+
+## 4) Rule Definition
+
+Default rollback rule encoded in baseline file:
+
+- `drop_pct = 0.05`
+- `sustain_secs = 60`
+
+Interpretation:
+
+- For each series (`source|symbol` and source aggregate), trigger if:
+  - observed rate `< baseline_rate * (1 - drop_pct)`
+  - condition remains true for `>= sustain_secs`

--- a/scripts/collect_data_plane_baseline.py
+++ b/scripts/collect_data_plane_baseline.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+Collect a 24h (or custom duration) baseline from Prometheus text metrics.
+
+Focus metrics:
+- ploy_symbol_updates_total{source, symbol}
+- ploy_source_messages_total{source}
+- ploy_source_feed_health{source}
+- ploy_source_subscriptions_total{source}
+- ploy_broadcast_lag_total
+- ploy_broadcast_drop_total
+
+Outputs:
+- <output_dir>/<run_id>.samples.jsonl
+- <output_dir>/<run_id>.summary.json
+- <output_dir>/<run_id>.baseline.json
+- <output_dir>/<run_id>.symbol_rates.csv
+- <output_dir>/<run_id>.source_rates.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+PROM_LINE_RE = re.compile(
+    r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{([^}]*)\})?\s+"
+    r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)$"
+)
+LABEL_RE = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:[^"\\]|\\.)*)"')
+
+SYMBOL_COUNTER = "ploy_symbol_updates_total"
+SOURCE_COUNTER = "ploy_source_messages_total"
+SOURCE_HEALTH = "ploy_source_feed_health"
+SOURCE_SUBS = "ploy_source_subscriptions_total"
+BROADCAST_LAG = "ploy_broadcast_lag_total"
+BROADCAST_DROP = "ploy_broadcast_drop_total"
+
+
+@dataclass
+class Snapshot:
+    symbol_updates_total: Dict[str, float]
+    source_messages_total: Dict[str, float]
+    source_feed_health: Dict[str, float]
+    source_subscriptions_total: Dict[str, float]
+    broadcast_lag_total: float
+    broadcast_drop_total: float
+
+
+def utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_labels(raw: str) -> Dict[str, str]:
+    labels: Dict[str, str] = {}
+    for match in LABEL_RE.finditer(raw):
+        key = match.group(1)
+        val = bytes(match.group(2), "utf-8").decode("unicode_escape")
+        labels[key] = val
+    return labels
+
+
+def parse_prometheus_text(text: str) -> List[Tuple[str, Dict[str, str], float]]:
+    rows: List[Tuple[str, Dict[str, str], float]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = PROM_LINE_RE.match(line)
+        if not match:
+            continue
+        metric = match.group(1)
+        labels_raw = match.group(3) or ""
+        value = float(match.group(4))
+        rows.append((metric, parse_labels(labels_raw), value))
+    return rows
+
+
+def extract_snapshot(rows: Iterable[Tuple[str, Dict[str, str], float]]) -> Snapshot:
+    symbol_updates: Dict[str, float] = {}
+    source_messages: Dict[str, float] = {}
+    source_health: Dict[str, float] = {}
+    source_subs: Dict[str, float] = {}
+    lag_total = 0.0
+    drop_total = 0.0
+
+    for metric, labels, value in rows:
+        if metric == SYMBOL_COUNTER:
+            source = labels.get("source")
+            symbol = labels.get("symbol")
+            if source and symbol:
+                symbol_updates[f"{source}|{symbol}"] = value
+        elif metric == SOURCE_COUNTER:
+            source = labels.get("source")
+            if source:
+                source_messages[source] = value
+        elif metric == SOURCE_HEALTH:
+            source = labels.get("source")
+            if source:
+                source_health[source] = value
+        elif metric == SOURCE_SUBS:
+            source = labels.get("source")
+            if source:
+                source_subs[source] = value
+        elif metric == BROADCAST_LAG:
+            lag_total = value
+        elif metric == BROADCAST_DROP:
+            drop_total = value
+
+    return Snapshot(
+        symbol_updates_total=symbol_updates,
+        source_messages_total=source_messages,
+        source_feed_health=source_health,
+        source_subscriptions_total=source_subs,
+        broadcast_lag_total=lag_total,
+        broadcast_drop_total=drop_total,
+    )
+
+
+def counter_delta(prev: float | None, curr: float) -> float:
+    if prev is None:
+        return 0.0
+    if curr >= prev:
+        return curr - prev
+    # Counter reset.
+    return curr
+
+
+def quantile(values: List[float], q: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    vals = sorted(values)
+    pos = (len(vals) - 1) * q
+    low = int(math.floor(pos))
+    high = int(math.ceil(pos))
+    if low == high:
+        return vals[low]
+    frac = pos - low
+    return vals[low] * (1.0 - frac) + vals[high] * frac
+
+
+def fetch_metrics(url: str, timeout_secs: float) -> str:
+    req = urllib.request.Request(url=url, headers={"User-Agent": "ploy-baseline-collector/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout_secs) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def summarize_rate_series(
+    deltas_by_key: Dict[str, List[float]],
+    interval_secs: float,
+    elapsed_secs: float,
+) -> Dict[str, Dict[str, float]]:
+    out: Dict[str, Dict[str, float]] = {}
+    for key, deltas in deltas_by_key.items():
+        total = float(sum(deltas))
+        rates = [d / interval_secs for d in deltas] if interval_secs > 0 else [0.0 for _ in deltas]
+        avg = total / elapsed_secs if elapsed_secs > 0 else 0.0
+        out[key] = {
+            "total_messages": total,
+            "avg_rps": avg,
+            "min_rps": min(rates) if rates else 0.0,
+            "max_rps": max(rates) if rates else 0.0,
+            "p50_rps": quantile(rates, 0.50),
+            "p95_rps": quantile(rates, 0.95),
+            "samples": float(len(rates)),
+        }
+    return out
+
+
+def write_csv(path: Path, headers: List[str], rows: List[Dict[str, object]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect data-plane baseline from /metrics")
+    parser.add_argument(
+        "--metrics-url",
+        default="http://127.0.0.1:9090/metrics",
+        help="Prometheus text endpoint URL",
+    )
+    parser.add_argument("--duration-secs", type=int, default=24 * 60 * 60)
+    parser.add_argument("--interval-secs", type=int, default=10)
+    parser.add_argument("--timeout-secs", type=float, default=5.0)
+    parser.add_argument("--output-dir", default="data/baseline")
+    parser.add_argument(
+        "--run-id",
+        default=datetime.now(tz=timezone.utc).strftime("baseline-%Y%m%d-%H%M%S"),
+    )
+    parser.add_argument(
+        "--rollback-drop-pct",
+        type=float,
+        default=0.05,
+        help="Drop threshold used to generate baseline min_allowed_rps",
+    )
+    parser.add_argument(
+        "--rollback-sustain-secs",
+        type=int,
+        default=60,
+        help="Sustain window used to generate baseline rollback rule",
+    )
+    args = parser.parse_args()
+
+    if args.interval_secs <= 0:
+        print("--interval-secs must be > 0", file=sys.stderr)
+        return 2
+    if args.duration_secs <= 0:
+        print("--duration-secs must be > 0", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    samples_path = out_dir / f"{args.run_id}.samples.jsonl"
+    summary_path = out_dir / f"{args.run_id}.summary.json"
+    baseline_path = out_dir / f"{args.run_id}.baseline.json"
+    symbol_csv_path = out_dir / f"{args.run_id}.symbol_rates.csv"
+    source_csv_path = out_dir / f"{args.run_id}.source_rates.csv"
+
+    prev_snapshot: Snapshot | None = None
+    symbol_deltas: Dict[str, List[float]] = {}
+    source_deltas: Dict[str, List[float]] = {}
+    lag_deltas: List[float] = []
+    drop_deltas: List[float] = []
+
+    start_epoch = time.time()
+    end_epoch = start_epoch + args.duration_secs
+    sample_count = 0
+    error_count = 0
+
+    print(
+        f"[{utc_now_iso()}] starting baseline collection: "
+        f"url={args.metrics_url} duration={args.duration_secs}s interval={args.interval_secs}s"
+    )
+    print(f"[{utc_now_iso()}] writing samples to: {samples_path}")
+
+    with samples_path.open("w", encoding="utf-8") as out:
+        while time.time() < end_epoch:
+            now_epoch = time.time()
+            now_iso = datetime.fromtimestamp(now_epoch, tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+
+            try:
+                text = fetch_metrics(args.metrics_url, args.timeout_secs)
+                rows = parse_prometheus_text(text)
+                snap = extract_snapshot(rows)
+                sample_count += 1
+            except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+                error_count += 1
+                out.write(
+                    json.dumps(
+                        {
+                            "ts": now_iso,
+                            "epoch_s": now_epoch,
+                            "error": str(exc),
+                        },
+                        ensure_ascii=True,
+                    )
+                    + "\n"
+                )
+                out.flush()
+                time.sleep(args.interval_secs)
+                continue
+
+            symbol_rates: Dict[str, float] = {}
+            source_rates: Dict[str, float] = {}
+            lag_delta = 0.0
+            drop_delta = 0.0
+
+            if prev_snapshot is not None:
+                symbol_keys = set(prev_snapshot.symbol_updates_total.keys()) | set(
+                    snap.symbol_updates_total.keys()
+                )
+                for key in symbol_keys:
+                    d = counter_delta(
+                        prev_snapshot.symbol_updates_total.get(key), snap.symbol_updates_total.get(key, 0.0)
+                    )
+                    symbol_deltas.setdefault(key, []).append(d)
+                    symbol_rates[key] = d / args.interval_secs
+
+                source_keys = set(prev_snapshot.source_messages_total.keys()) | set(
+                    snap.source_messages_total.keys()
+                )
+                for key in source_keys:
+                    d = counter_delta(
+                        prev_snapshot.source_messages_total.get(key), snap.source_messages_total.get(key, 0.0)
+                    )
+                    source_deltas.setdefault(key, []).append(d)
+                    source_rates[key] = d / args.interval_secs
+
+                lag_delta = counter_delta(prev_snapshot.broadcast_lag_total, snap.broadcast_lag_total)
+                drop_delta = counter_delta(prev_snapshot.broadcast_drop_total, snap.broadcast_drop_total)
+                lag_deltas.append(lag_delta)
+                drop_deltas.append(drop_delta)
+
+            prev_snapshot = snap
+
+            out.write(
+                json.dumps(
+                    {
+                        "ts": now_iso,
+                        "epoch_s": now_epoch,
+                        "symbol_updates_total": snap.symbol_updates_total,
+                        "source_messages_total": snap.source_messages_total,
+                        "source_feed_health": snap.source_feed_health,
+                        "source_subscriptions_total": snap.source_subscriptions_total,
+                        "broadcast_lag_total": snap.broadcast_lag_total,
+                        "broadcast_drop_total": snap.broadcast_drop_total,
+                        "symbol_update_rps": symbol_rates,
+                        "source_message_rps": source_rates,
+                        "broadcast_lag_delta": lag_delta,
+                        "broadcast_drop_delta": drop_delta,
+                    },
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+            out.flush()
+
+            # Lightweight progress line every ~1 minute.
+            if sample_count == 1 or sample_count % max(1, int(60 / args.interval_secs)) == 0:
+                print(
+                    f"[{utc_now_iso()}] samples={sample_count} errors={error_count} "
+                    f"symbols={len(snap.symbol_updates_total)} sources={len(snap.source_messages_total)}"
+                )
+
+            sleep_for = max(0.0, args.interval_secs - (time.time() - now_epoch))
+            time.sleep(sleep_for)
+
+    elapsed = max(1.0, time.time() - start_epoch)
+    symbol_summary = summarize_rate_series(symbol_deltas, args.interval_secs, elapsed)
+    source_summary = summarize_rate_series(source_deltas, args.interval_secs, elapsed)
+
+    summary = {
+        "run_id": args.run_id,
+        "generated_at": utc_now_iso(),
+        "metrics_url": args.metrics_url,
+        "duration_secs_requested": args.duration_secs,
+        "duration_secs_observed": elapsed,
+        "interval_secs": args.interval_secs,
+        "sample_count": sample_count,
+        "error_count": error_count,
+        "symbol_rates": symbol_summary,
+        "source_rates": source_summary,
+        "broadcast": {
+            "lag_total": float(sum(lag_deltas)),
+            "drop_total": float(sum(drop_deltas)),
+            "lag_avg_per_interval": (sum(lag_deltas) / len(lag_deltas)) if lag_deltas else 0.0,
+            "drop_avg_per_interval": (sum(drop_deltas) / len(drop_deltas)) if drop_deltas else 0.0,
+        },
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+
+    symbol_rows: List[Dict[str, object]] = []
+    for key, stats in sorted(symbol_summary.items()):
+        source, symbol = key.split("|", 1)
+        symbol_rows.append(
+            {
+                "source": source,
+                "symbol": symbol,
+                **stats,
+            }
+        )
+
+    source_rows: List[Dict[str, object]] = []
+    for source, stats in sorted(source_summary.items()):
+        source_rows.append({"source": source, **stats})
+
+    write_csv(
+        symbol_csv_path,
+        ["source", "symbol", "total_messages", "avg_rps", "min_rps", "max_rps", "p50_rps", "p95_rps", "samples"],
+        symbol_rows,
+    )
+    write_csv(
+        source_csv_path,
+        ["source", "total_messages", "avg_rps", "min_rps", "max_rps", "p50_rps", "p95_rps", "samples"],
+        source_rows,
+    )
+
+    baseline = {
+        "run_id": args.run_id,
+        "generated_at": utc_now_iso(),
+        "interval_secs": args.interval_secs,
+        "rollback_rule": {
+            "drop_pct": args.rollback_drop_pct,
+            "sustain_secs": args.rollback_sustain_secs,
+        },
+        "series": {
+            "symbol_updates": [],
+            "source_messages": [],
+        },
+    }
+
+    for row in symbol_rows:
+        baseline_rps = row["p50_rps"] if row["p50_rps"] > 0 else row["avg_rps"]
+        baseline["series"]["symbol_updates"].append(
+            {
+                "key": f"{row['source']}|{row['symbol']}",
+                "source": row["source"],
+                "symbol": row["symbol"],
+                "baseline_rps": baseline_rps,
+                "min_allowed_rps": baseline_rps * (1.0 - args.rollback_drop_pct),
+            }
+        )
+    for row in source_rows:
+        baseline_rps = row["p50_rps"] if row["p50_rps"] > 0 else row["avg_rps"]
+        baseline["series"]["source_messages"].append(
+            {
+                "key": row["source"],
+                "source": row["source"],
+                "baseline_rps": baseline_rps,
+                "min_allowed_rps": baseline_rps * (1.0 - args.rollback_drop_pct),
+            }
+        )
+
+    baseline_path.write_text(json.dumps(baseline, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(f"[{utc_now_iso()}] done: samples={sample_count} errors={error_count}")
+    print(f"  samples:  {samples_path}")
+    print(f"  summary:  {summary_path}")
+    print(f"  baseline: {baseline_path}")
+    print(f"  csv(sym): {symbol_csv_path}")
+    print(f"  csv(src): {source_csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_data_plane_drop_rate.py
+++ b/scripts/validate_data_plane_drop_rate.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Validate drop-rate rollback criteria against collected baseline samples.
+
+Rollback default rule:
+- observed rate < (baseline_rate * 0.95)
+- sustained for >= 60 seconds
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+def utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_jsonl(path: Path) -> List[dict]:
+    rows: List[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def infer_interval_secs(samples: List[dict], fallback: float) -> float:
+    epochs = [float(s["epoch_s"]) for s in samples if "epoch_s" in s]
+    if len(epochs) < 2:
+        return fallback
+    deltas = [b - a for a, b in zip(epochs, epochs[1:]) if b > a]
+    if not deltas:
+        return fallback
+    return statistics.median(deltas)
+
+
+@dataclass
+class Breach:
+    scope: str
+    key: str
+    baseline_rps: float
+    min_allowed_rps: float
+    max_consecutive_breach_secs: float
+    first_breach_ts: str | None
+
+
+def evaluate_series(
+    samples: List[dict],
+    rates_field: str,
+    baseline_entries: Iterable[dict],
+    interval_secs: float,
+    sustain_secs: float,
+    drop_pct: float,
+    scope: str,
+) -> Tuple[List[Breach], List[dict]]:
+    breaches: List[Breach] = []
+    details: List[dict] = []
+
+    for entry in baseline_entries:
+        key = str(entry["key"])
+        baseline_rps = float(entry.get("baseline_rps", 0.0))
+        if baseline_rps <= 0:
+            continue
+        min_allowed = baseline_rps * (1.0 - drop_pct)
+
+        consecutive = 0.0
+        max_consecutive = 0.0
+        first_breach_ts: str | None = None
+        latest_rate = 0.0
+
+        for sample in samples:
+            rates = sample.get(rates_field)
+            if not isinstance(rates, dict):
+                continue
+            rate = float(rates.get(key, 0.0))
+            latest_rate = rate
+            if rate < min_allowed:
+                consecutive += interval_secs
+                if first_breach_ts is None:
+                    first_breach_ts = sample.get("ts")
+                if consecutive > max_consecutive:
+                    max_consecutive = consecutive
+            else:
+                consecutive = 0.0
+                first_breach_ts = None
+
+        details.append(
+            {
+                "scope": scope,
+                "key": key,
+                "baseline_rps": baseline_rps,
+                "min_allowed_rps": min_allowed,
+                "latest_rps": latest_rate,
+                "max_consecutive_breach_secs": max_consecutive,
+            }
+        )
+
+        if max_consecutive >= sustain_secs:
+            breaches.append(
+                Breach(
+                    scope=scope,
+                    key=key,
+                    baseline_rps=baseline_rps,
+                    min_allowed_rps=min_allowed,
+                    max_consecutive_breach_secs=max_consecutive,
+                    first_breach_ts=first_breach_ts,
+                )
+            )
+
+    return breaches, details
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate rollback drop-rate criteria")
+    parser.add_argument("--baseline-json", required=True)
+    parser.add_argument("--samples-jsonl", required=True)
+    parser.add_argument(
+        "--scope",
+        choices=["symbol", "source", "both"],
+        default="both",
+        help="Validate symbol updates, source messages, or both",
+    )
+    parser.add_argument("--drop-pct", type=float, default=None)
+    parser.add_argument("--sustain-secs", type=float, default=None)
+    parser.add_argument("--output-json", default=None)
+    args = parser.parse_args()
+
+    baseline_path = Path(args.baseline_json)
+    samples_path = Path(args.samples_jsonl)
+
+    baseline = load_json(baseline_path)
+    samples = [s for s in load_jsonl(samples_path) if "error" not in s]
+    if not samples:
+        print("no usable samples (all errored or empty)", file=sys.stderr)
+        return 2
+
+    rule = baseline.get("rollback_rule", {})
+    drop_pct = float(args.drop_pct if args.drop_pct is not None else rule.get("drop_pct", 0.05))
+    sustain_secs = float(
+        args.sustain_secs if args.sustain_secs is not None else rule.get("sustain_secs", 60)
+    )
+    interval_secs = infer_interval_secs(samples, float(baseline.get("interval_secs", 10)))
+
+    all_breaches: List[Breach] = []
+    details: List[dict] = []
+    series = baseline.get("series", {})
+
+    if args.scope in ("symbol", "both"):
+        b, d = evaluate_series(
+            samples=samples,
+            rates_field="symbol_update_rps",
+            baseline_entries=series.get("symbol_updates", []),
+            interval_secs=interval_secs,
+            sustain_secs=sustain_secs,
+            drop_pct=drop_pct,
+            scope="symbol",
+        )
+        all_breaches.extend(b)
+        details.extend(d)
+
+    if args.scope in ("source", "both"):
+        b, d = evaluate_series(
+            samples=samples,
+            rates_field="source_message_rps",
+            baseline_entries=series.get("source_messages", []),
+            interval_secs=interval_secs,
+            sustain_secs=sustain_secs,
+            drop_pct=drop_pct,
+            scope="source",
+        )
+        all_breaches.extend(b)
+        details.extend(d)
+
+    report = {
+        "generated_at": utc_now_iso(),
+        "baseline_json": str(baseline_path),
+        "samples_jsonl": str(samples_path),
+        "drop_pct": drop_pct,
+        "sustain_secs": sustain_secs,
+        "interval_secs": interval_secs,
+        "sample_count": len(samples),
+        "breach_count": len(all_breaches),
+        "breaches": [
+            {
+                "scope": b.scope,
+                "key": b.key,
+                "baseline_rps": b.baseline_rps,
+                "min_allowed_rps": b.min_allowed_rps,
+                "max_consecutive_breach_secs": b.max_consecutive_breach_secs,
+                "first_breach_ts": b.first_breach_ts,
+            }
+            for b in all_breaches
+        ],
+        "series_details": details,
+    }
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+    if all_breaches:
+        print("ROLLBACK_CONDITION_TRIGGERED")
+        for b in all_breaches:
+            print(
+                f"- [{b.scope}] {b.key}: baseline={b.baseline_rps:.4f} "
+                f"min_allowed={b.min_allowed_rps:.4f} "
+                f"max_breach={b.max_consecutive_breach_secs:.1f}s"
+            )
+        return 1
+
+    print(
+        f"OK: no sustained drop-rate breach "
+        f"(drop_pct={drop_pct:.3f}, sustain_secs={sustain_secs:.0f}, samples={len(samples)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/adapters/binance_kline_ws.rs
+++ b/src/adapters/binance_kline_ws.rs
@@ -268,7 +268,13 @@ impl BinanceKlineWebSocket {
 
     /// Attach a shared freshness tracker for the data plane.
     pub fn set_freshness(&self, freshness: Arc<crate::platform::DataPlaneFreshness>) {
-        let _ = self.freshness.set(freshness);
+        if self.freshness.set(Arc::clone(&freshness)).is_ok() {
+            freshness.set_subscription_count(
+                crate::platform::DataSource::BinanceKline,
+                (self.symbols.len() * self.intervals.len()) as u64,
+            );
+            freshness.set_source_connected(crate::platform::DataSource::BinanceKline, false);
+        }
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<KlineUpdate> {
@@ -329,6 +335,16 @@ impl BinanceKlineWebSocket {
     }
 
     async fn connect_and_stream(&self) -> Result<()> {
+        struct ConnectionGuard<'a>(&'a BinanceKlineWebSocket);
+        impl Drop for ConnectionGuard<'_> {
+            fn drop(&mut self) {
+                if let Some(f) = self.0.freshness.get() {
+                    f.set_source_connected(crate::platform::DataSource::BinanceKline, false);
+                }
+            }
+        }
+        let _guard = ConnectionGuard(self);
+
         let url = self.build_url();
         let url = Url::parse(&url)
             .map_err(|e| PloyError::Internal(format!("Invalid WebSocket URL: {}", e)))?;
@@ -337,6 +353,9 @@ impl BinanceKlineWebSocket {
 
         let ws_stream = connect_websocket_with_proxy(&url).await?;
         info!("Connected to Binance kline WS");
+        if let Some(f) = self.freshness.get() {
+            f.set_source_connected(crate::platform::DataSource::BinanceKline, true);
+        }
 
         let (mut write, mut read) = ws_stream.split();
         let mut ping_interval = interval(Duration::from_secs(PING_INTERVAL_SECS));

--- a/src/adapters/binance_kline_ws.rs
+++ b/src/adapters/binance_kline_ws.rs
@@ -472,11 +472,18 @@ impl BinanceKlineWebSocket {
 
         let _ = self.update_tx.send(update);
     }
+
+    /// Test-only hook: inject a raw WebSocket message into the parser/broadcast path.
+    #[cfg(test)]
+    pub async fn ingest_test_message(&self, text: &str) {
+        self.handle_message(text).await;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn parse_combined_stream_closed_kline() {
@@ -512,5 +519,166 @@ mod tests {
         assert_eq!(wrapper.data.symbol, "BTCUSDT");
         assert_eq!(wrapper.data.kline.interval, "5m");
         assert!(wrapper.data.kline.is_closed);
+    }
+
+    #[tokio::test]
+    async fn characterization_closed_kline_emits_update() {
+        let ws = BinanceKlineWebSocket::new(vec!["BTCUSDT".into()], vec!["5m".into()], true);
+        let mut rx = ws.subscribe();
+
+        let msg = r#"{
+            "stream":"btcusdt@kline_5m",
+            "data":{
+                "e":"kline",
+                "E":1700000000000,
+                "s":"BTCUSDT",
+                "k":{
+                    "t":1700000000000,
+                    "T":1700000299999,
+                    "s":"BTCUSDT",
+                    "i":"5m",
+                    "f":0,
+                    "L":0,
+                    "o":"100.0",
+                    "c":"101.0",
+                    "h":"102.0",
+                    "l":"99.0",
+                    "v":"123.4",
+                    "n":0,
+                    "x":true,
+                    "q":"0",
+                    "V":"0",
+                    "Q":"0",
+                    "B":"0"
+                }
+            }
+        }"#;
+
+        ws.ingest_test_message(msg).await;
+        let update = rx.try_recv().expect("closed kline should produce update");
+        assert_eq!(update.symbol, "BTCUSDT");
+        assert_eq!(update.interval, "5m");
+        assert_eq!(update.kline.open, dec!(100.0));
+        assert_eq!(update.kline.close, dec!(101.0));
+        assert!(update.kline.is_closed);
+    }
+
+    #[tokio::test]
+    async fn characterization_open_kline_skipped_when_closed_only() {
+        let ws = BinanceKlineWebSocket::new(vec!["BTCUSDT".into()], vec!["5m".into()], true);
+        let mut rx = ws.subscribe();
+
+        let msg = r#"{
+            "stream":"btcusdt@kline_5m",
+            "data":{
+                "e":"kline",
+                "E":1700000000000,
+                "s":"BTCUSDT",
+                "k":{
+                    "t":1700000000000,
+                    "T":1700000299999,
+                    "s":"BTCUSDT",
+                    "i":"5m",
+                    "f":0,
+                    "L":0,
+                    "o":"100.0",
+                    "c":"101.0",
+                    "h":"102.0",
+                    "l":"99.0",
+                    "v":"123.4",
+                    "n":0,
+                    "x":false,
+                    "q":"0",
+                    "V":"0",
+                    "Q":"0",
+                    "B":"0"
+                }
+            }
+        }"#;
+
+        ws.ingest_test_message(msg).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "open kline should be filtered when closed_only=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn characterization_open_kline_emitted_when_closed_only_disabled() {
+        let ws = BinanceKlineWebSocket::new(vec!["BTCUSDT".into()], vec!["5m".into()], false);
+        let mut rx = ws.subscribe();
+
+        let msg = r#"{
+            "stream":"btcusdt@kline_5m",
+            "data":{
+                "e":"kline",
+                "E":1700000000000,
+                "s":"BTCUSDT",
+                "k":{
+                    "t":1700000000000,
+                    "T":1700000299999,
+                    "s":"BTCUSDT",
+                    "i":"5m",
+                    "f":0,
+                    "L":0,
+                    "o":"100.0",
+                    "c":"100.5",
+                    "h":"101.0",
+                    "l":"99.5",
+                    "v":"45.6",
+                    "n":0,
+                    "x":false,
+                    "q":"0",
+                    "V":"0",
+                    "Q":"0",
+                    "B":"0"
+                }
+            }
+        }"#;
+
+        ws.ingest_test_message(msg).await;
+        let update = rx.try_recv().expect("open kline should be emitted");
+        assert!(!update.kline.is_closed);
+        assert_eq!(update.kline.close, dec!(100.5));
+    }
+
+    #[tokio::test]
+    async fn characterization_freshness_recorded_on_kline() {
+        let ws = BinanceKlineWebSocket::new(vec!["BTCUSDT".into()], vec!["5m".into()], true);
+        let freshness = std::sync::Arc::new(crate::platform::DataPlaneFreshness::new());
+        ws.set_freshness(freshness.clone());
+
+        let msg = r#"{
+            "stream":"btcusdt@kline_5m",
+            "data":{
+                "e":"kline",
+                "E":1700000000000,
+                "s":"BTCUSDT",
+                "k":{
+                    "t":1700000000000,
+                    "T":1700000299999,
+                    "s":"BTCUSDT",
+                    "i":"5m",
+                    "f":0,
+                    "L":0,
+                    "o":"100.0",
+                    "c":"101.0",
+                    "h":"102.0",
+                    "l":"99.0",
+                    "v":"123.4",
+                    "n":0,
+                    "x":true,
+                    "q":"0",
+                    "V":"0",
+                    "Q":"0",
+                    "B":"0"
+                }
+            }
+        }"#;
+
+        ws.ingest_test_message(msg).await;
+        let staleness = freshness.staleness(crate::platform::DataSource::BinanceKline, "BTCUSDT");
+        assert!(staleness.is_some(), "freshness should be recorded");
+        assert!(staleness.unwrap() < 1.0);
     }
 }

--- a/src/adapters/binance_ws.rs
+++ b/src/adapters/binance_ws.rs
@@ -814,6 +814,12 @@ impl BinanceWebSocket {
         // Ignore send errors (no subscribers)
         let _ = self.update_tx.send(update);
     }
+
+    /// Test-only hook: inject a raw WebSocket message into the parser/broadcast path.
+    #[cfg(test)]
+    pub async fn ingest_test_message(&self, text: &str) {
+        self.handle_message(text).await;
+    }
 }
 
 #[cfg(test)]

--- a/src/adapters/binance_ws.rs
+++ b/src/adapters/binance_ws.rs
@@ -623,7 +623,13 @@ impl BinanceWebSocket {
 
     /// Attach a shared freshness tracker for the data plane.
     pub fn set_freshness(&self, freshness: Arc<crate::platform::DataPlaneFreshness>) {
-        let _ = self.freshness.set(freshness);
+        if self.freshness.set(Arc::clone(&freshness)).is_ok() {
+            freshness.set_subscription_count(
+                crate::platform::DataSource::BinanceSpot,
+                self.symbols.len() as u64,
+            );
+            freshness.set_source_connected(crate::platform::DataSource::BinanceSpot, false);
+        }
     }
 
     /// Subscribe to price updates
@@ -686,6 +692,16 @@ impl BinanceWebSocket {
 
     /// Connect and stream price data
     async fn connect_and_stream(&self) -> Result<()> {
+        struct ConnectionGuard<'a>(&'a BinanceWebSocket);
+        impl Drop for ConnectionGuard<'_> {
+            fn drop(&mut self) {
+                if let Some(f) = self.0.freshness.get() {
+                    f.set_source_connected(crate::platform::DataSource::BinanceSpot, false);
+                }
+            }
+        }
+        let _guard = ConnectionGuard(self);
+
         let url = self.build_url();
         let url = Url::parse(&url)
             .map_err(|e| PloyError::Internal(format!("Invalid WebSocket URL: {}", e)))?;
@@ -695,6 +711,9 @@ impl BinanceWebSocket {
         let ws_stream = connect_websocket_with_proxy(&url).await?;
 
         info!("Connected to Binance WebSocket");
+        if let Some(f) = self.freshness.get() {
+            f.set_source_connected(crate::platform::DataSource::BinanceSpot, true);
+        }
 
         let (mut write, mut read) = ws_stream.split();
         let mut ping_interval = interval(Duration::from_secs(PING_INTERVAL_SECS));

--- a/src/adapters/chainlink_rtds.rs
+++ b/src/adapters/chainlink_rtds.rs
@@ -455,7 +455,13 @@ impl ChainlinkRtds {
 
     /// Attach a shared freshness tracker for the data plane.
     pub fn set_freshness(&self, freshness: Arc<crate::platform::DataPlaneFreshness>) {
-        let _ = self.freshness.set(freshness);
+        if self.freshness.set(Arc::clone(&freshness)).is_ok() {
+            freshness.set_subscription_count(
+                crate::platform::DataSource::ChainlinkRtds,
+                self.symbols.len() as u64,
+            );
+            freshness.set_source_connected(crate::platform::DataSource::ChainlinkRtds, false);
+        }
     }
 
     /// Get a reference to the price cache
@@ -516,6 +522,16 @@ impl ChainlinkRtds {
 
     /// Connect, subscribe, and stream price data
     async fn connect_and_stream(&self) -> Result<()> {
+        struct ConnectionGuard<'a>(&'a ChainlinkRtds);
+        impl Drop for ConnectionGuard<'_> {
+            fn drop(&mut self) {
+                if let Some(f) = self.0.freshness.get() {
+                    f.set_source_connected(crate::platform::DataSource::ChainlinkRtds, false);
+                }
+            }
+        }
+        let _guard = ConnectionGuard(self);
+
         let url = Url::parse(CHAINLINK_RTDS_WS_URL)
             .map_err(|e| PloyError::Internal(format!("Invalid RTDS WebSocket URL: {}", e)))?;
 
@@ -524,6 +540,9 @@ impl ChainlinkRtds {
         let ws_stream = connect_websocket_with_proxy(&url).await?;
 
         info!("Connected to Chainlink RTDS WebSocket");
+        if let Some(f) = self.freshness.get() {
+            f.set_source_connected(crate::platform::DataSource::ChainlinkRtds, true);
+        }
 
         let (mut write, mut read) = ws_stream.split();
 

--- a/src/adapters/chainlink_rtds.rs
+++ b/src/adapters/chainlink_rtds.rs
@@ -641,6 +641,12 @@ impl ChainlinkRtds {
         // Ignore send errors (no subscribers)
         let _ = self.update_tx.send(update);
     }
+
+    /// Test-only hook: inject a raw RTDS payload into parser/cache/broadcast path.
+    #[cfg(test)]
+    pub async fn ingest_test_message(&self, text: &str) {
+        self.handle_message(text).await;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -651,6 +657,7 @@ impl ChainlinkRtds {
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+    use std::sync::Arc;
 
     #[test]
     fn test_chainlink_spot_momentum() {
@@ -739,5 +746,43 @@ mod tests {
         // Verify we can subscribe
         let _rx = rtds.subscribe();
         assert!(rtds.symbols.len() == 2);
+    }
+
+    #[tokio::test]
+    async fn characterization_rtds_payload_produces_update() {
+        let rtds = ChainlinkRtds::new(vec!["btc/usd".to_string()]);
+        let mut rx = rtds.subscribe();
+
+        let msg = r#"{"symbol":"btc/usd","timestamp":1700000000000,"value":43250.25}"#;
+        rtds.ingest_test_message(msg).await;
+
+        let update = rx.try_recv().expect("expected Chainlink update");
+        assert_eq!(update.symbol, "btc/usd");
+        assert_eq!(update.price, dec!(43250.25));
+    }
+
+    #[tokio::test]
+    async fn characterization_rtds_payload_updates_cache() {
+        let rtds = ChainlinkRtds::new(vec!["eth/usd".to_string()]);
+        let msg = r#"{"symbol":"eth/usd","timestamp":1700000000000,"value":2150.5}"#;
+        rtds.ingest_test_message(msg).await;
+
+        let cached = rtds.price_cache().get("eth/usd").await;
+        assert!(cached.is_some(), "cache entry should exist");
+        assert_eq!(cached.unwrap().price, dec!(2150.5));
+    }
+
+    #[tokio::test]
+    async fn characterization_rtds_records_freshness() {
+        let rtds = ChainlinkRtds::new(vec!["sol/usd".to_string()]);
+        let freshness = Arc::new(crate::platform::DataPlaneFreshness::new());
+        rtds.set_freshness(freshness.clone());
+
+        let msg = r#"{"symbol":"sol/usd","timestamp":1700000000000,"value":101.01}"#;
+        rtds.ingest_test_message(msg).await;
+
+        let staleness = freshness.staleness(crate::platform::DataSource::ChainlinkRtds, "sol/usd");
+        assert!(staleness.is_some(), "freshness should be recorded");
+        assert!(staleness.unwrap() < 1.0);
     }
 }

--- a/src/adapters/polymarket_ws.rs
+++ b/src/adapters/polymarket_ws.rs
@@ -1097,6 +1097,12 @@ impl PolymarketWebSocket {
         false
     }
 
+    /// Test-only hook: inject a raw WebSocket message into the parser/broadcast path.
+    #[cfg(test)]
+    pub async fn ingest_test_message(&self, text: &str) -> bool {
+        self.handle_message(text).await
+    }
+
     /// Process an order book message
     async fn process_book_message(&self, book: BookMessage) {
         // Avoid borrowing `book` across await points so we can move it into the broadcast channel.

--- a/src/adapters/polymarket_ws.rs
+++ b/src/adapters/polymarket_ws.rs
@@ -716,7 +716,10 @@ impl PolymarketWebSocket {
 
     /// Wire an optional `DataPlaneFreshness` for per-symbol tracking.
     pub fn set_freshness(&self, freshness: Arc<crate::platform::DataPlaneFreshness>) {
-        let _ = self.freshness.set(freshness);
+        if self.freshness.set(Arc::clone(&freshness)).is_ok() {
+            freshness.set_source_connected(crate::platform::DataSource::PolymarketWs, false);
+            freshness.set_subscription_count(crate::platform::DataSource::PolymarketWs, 0);
+        }
     }
 
     /// Get the circuit breaker (for external monitoring)
@@ -961,6 +964,7 @@ impl PolymarketWebSocket {
     /// Connect and subscribe to token updates
     async fn connect_and_subscribe(&self, token_ids: &[String]) -> Result<()> {
         let health = self.health_state.get().cloned();
+        let freshness = self.freshness.get().cloned();
         struct WsHealthGuard(Option<Arc<HealthState>>);
         impl Drop for WsHealthGuard {
             fn drop(&mut self) {
@@ -969,7 +973,16 @@ impl PolymarketWebSocket {
                 }
             }
         }
+        struct WsFreshnessGuard(Option<Arc<crate::platform::DataPlaneFreshness>>);
+        impl Drop for WsFreshnessGuard {
+            fn drop(&mut self) {
+                if let Some(ref f) = self.0 {
+                    f.set_source_connected(crate::platform::DataSource::PolymarketWs, false);
+                }
+            }
+        }
         let _guard = WsHealthGuard(health.clone());
+        let _fresh_guard = WsFreshnessGuard(freshness.clone());
 
         let url = Url::parse(&self.ws_url)
             .map_err(|e| PloyError::Internal(format!("Invalid WebSocket URL: {}", e)))?;
@@ -981,6 +994,9 @@ impl PolymarketWebSocket {
         info!("WebSocket connected");
         if let Some(ref h) = health {
             h.set_ws_connected(true);
+        }
+        if let Some(ref f) = freshness {
+            f.set_source_connected(crate::platform::DataSource::PolymarketWs, true);
         }
 
         let (mut write, mut read) = ws_stream.split();

--- a/src/coordinator/bootstrap.rs
+++ b/src/coordinator/bootstrap.rs
@@ -5364,8 +5364,11 @@ pub async fn start_platform(
                     clob_orderbook_require_hash_change: orderbook_require_hash_change,
                     ..Default::default()
                 };
-                let pipeline_handle =
-                    crate::platform::PersistencePipeline::spawn(pool.clone(), pipeline_config);
+                let pipeline_handle = crate::platform::PersistencePipeline::spawn_with_freshness(
+                    pool.clone(),
+                    pipeline_config,
+                    Some(Arc::clone(&freshness)),
+                );
                 crypto_persistence_pipeline = Some(pipeline_handle.clone());
 
                 if quote_table_ready {
@@ -6058,10 +6061,12 @@ pub async fn start_platform(
                         clob_orderbook_require_hash_change: sports_orderbook_require_hash_change,
                         ..Default::default()
                     };
-                    let sports_pipeline = crate::platform::PersistencePipeline::spawn(
-                        pool.clone(),
-                        sports_pipeline_config,
-                    );
+                    let sports_pipeline =
+                        crate::platform::PersistencePipeline::spawn_with_freshness(
+                            pool.clone(),
+                            sports_pipeline_config,
+                            Some(Arc::clone(&freshness)),
+                        );
 
                     if sports_quote_table_ready {
                         if let Some(quote_rx) = sports_data_plane.subscribe_quotes() {

--- a/src/platform/freshness.rs
+++ b/src/platform/freshness.rs
@@ -113,6 +113,8 @@ pub struct DataPlaneFreshness {
     source_subscription_count: Arc<DashMap<DataSource, AtomicU64>>,
     /// Broadcast channel lag events (dropped messages).
     broadcast_lag_count: Arc<AtomicU64>,
+    /// Broadcast channel drops due to full/closed downstream queues.
+    broadcast_drop_count: Arc<AtomicU64>,
 }
 
 impl DataPlaneFreshness {
@@ -123,6 +125,7 @@ impl DataPlaneFreshness {
             source_message_count: Arc::new(DashMap::new()),
             source_subscription_count: Arc::new(DashMap::new()),
             broadcast_lag_count: Arc::new(AtomicU64::new(0)),
+            broadcast_drop_count: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -152,6 +155,11 @@ impl DataPlaneFreshness {
     /// Record a broadcast channel lag event.
     pub fn record_broadcast_lag(&self, count: u64) {
         self.broadcast_lag_count.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Record a broadcast drop event.
+    pub fn record_broadcast_drop(&self, count: u64) {
+        self.broadcast_drop_count.fetch_add(count, Ordering::Relaxed);
     }
 
     /// Update the subscription count for a source (called when tokens are added/removed).
@@ -214,6 +222,11 @@ impl DataPlaneFreshness {
         self.broadcast_lag_count.load(Ordering::Relaxed)
     }
 
+    /// Total broadcast drops.
+    pub fn total_broadcast_drop(&self) -> u64 {
+        self.broadcast_drop_count.load(Ordering::Relaxed)
+    }
+
     /// Export per-symbol freshness metrics in Prometheus text format.
     pub fn prometheus_metrics(&self) -> String {
         let mut out = String::with_capacity(4096);
@@ -266,6 +279,32 @@ impl DataPlaneFreshness {
             ));
         }
 
+        // Per-source feed health derived from message count + staleness.
+        // 1 = healthy, 0 = degraded, -1 = down (no messages observed yet).
+        out.push_str("\n# HELP ploy_source_feed_health Feed health per source (-1=down, 0=degraded, 1=healthy)\n");
+        out.push_str("# TYPE ploy_source_feed_health gauge\n");
+        for source in [
+            DataSource::PolymarketWs,
+            DataSource::BinanceSpot,
+            DataSource::BinanceKline,
+            DataSource::BinanceLob,
+            DataSource::ChainlinkRtds,
+        ] {
+            let msg_count = self.source_message_count(source);
+            let health = if msg_count == 0 {
+                -1
+            } else if self.stale_symbol_count_for_source(source, 30.0) > 0 {
+                0
+            } else {
+                1
+            };
+            out.push_str(&format!(
+                "ploy_source_feed_health{{source=\"{}\"}} {}\n",
+                source.as_str(),
+                health
+            ));
+        }
+
         // Tracked symbol count
         out.push_str(&format!(
             "\n# HELP ploy_tracked_symbols_total Total unique symbols being tracked\n\
@@ -293,6 +332,13 @@ impl DataPlaneFreshness {
              # TYPE ploy_broadcast_lag_total counter\n\
              ploy_broadcast_lag_total {}\n",
             self.broadcast_lag_count.load(Ordering::Relaxed),
+        ));
+
+        out.push_str(&format!(
+            "\n# HELP ploy_broadcast_drop_total Total dropped events when forwarding broadcast updates\n\
+             # TYPE ploy_broadcast_drop_total counter\n\
+             ploy_broadcast_drop_total {}\n",
+            self.broadcast_drop_count.load(Ordering::Relaxed),
         ));
 
         out
@@ -403,6 +449,16 @@ mod tests {
     }
 
     #[test]
+    fn broadcast_drop_counting() {
+        let f = DataPlaneFreshness::new();
+
+        f.record_broadcast_drop(2);
+        f.record_broadcast_drop(4);
+
+        assert_eq!(f.total_broadcast_drop(), 6);
+    }
+
+    #[test]
     fn prometheus_output_format() {
         let f = DataPlaneFreshness::new();
 
@@ -410,6 +466,7 @@ mod tests {
         f.set_source_connected(DataSource::BinanceSpot, true);
         f.set_subscription_count(DataSource::BinanceSpot, 3);
         f.record_broadcast_lag(2);
+        f.record_broadcast_drop(1);
 
         let output = f.prometheus_metrics();
 
@@ -422,6 +479,8 @@ mod tests {
         assert!(output.contains("ploy_source_subscriptions_total{source=\"binance_spot\"} 3"));
         assert!(output.contains("ploy_tracked_symbols_total 1"));
         assert!(output.contains("ploy_broadcast_lag_total 2"));
+        assert!(output.contains("ploy_broadcast_drop_total 1"));
+        assert!(output.contains("ploy_source_feed_health{source=\"binance_spot\"} 1"));
     }
 
     #[test]

--- a/src/platform/freshness.rs
+++ b/src/platform/freshness.rs
@@ -159,7 +159,8 @@ impl DataPlaneFreshness {
 
     /// Record a broadcast drop event.
     pub fn record_broadcast_drop(&self, count: u64) {
-        self.broadcast_drop_count.fetch_add(count, Ordering::Relaxed);
+        self.broadcast_drop_count
+            .fetch_add(count, Ordering::Relaxed);
     }
 
     /// Update the subscription count for a source (called when tokens are added/removed).

--- a/src/platform/persistence_pipeline.rs
+++ b/src/platform/persistence_pipeline.rs
@@ -9,6 +9,7 @@
 //! - Preserves existing DB schema and SQL
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -19,6 +20,7 @@ use tokio::time::{self, Duration};
 use tracing::{debug, info, warn};
 
 use crate::platform::types::Domain;
+use crate::platform::DataPlaneFreshness;
 
 // ---------------------------------------------------------------------------
 // Pipeline configuration
@@ -219,6 +221,7 @@ impl PendingBuffers {
 #[derive(Clone)]
 pub struct PersistencePipelineHandle {
     tx: mpsc::Sender<PersistenceEvent>,
+    freshness: Option<Arc<DataPlaneFreshness>>,
 }
 
 impl PersistencePipelineHandle {
@@ -248,6 +251,7 @@ impl PersistencePipelineHandle {
         F: FnMut(T) -> Option<PersistenceEvent> + Send + 'static,
     {
         let pipeline = self.clone();
+        let freshness = self.freshness.clone();
         let bridge_name = bridge_name.into();
         tokio::spawn(async move {
             loop {
@@ -258,10 +262,16 @@ impl PersistencePipelineHandle {
                         };
                         if pipeline.try_ingest(event).is_err() {
                             warn!(bridge = %bridge_name, "persistence bridge dropped event");
+                            if let Some(ref f) = freshness {
+                                f.record_broadcast_drop(1);
+                            }
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         warn!(bridge = %bridge_name, lagged = n, "persistence bridge lagged");
+                        if let Some(ref f) = freshness {
+                            f.record_broadcast_lag(n as u64);
+                        }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
@@ -302,9 +312,18 @@ impl PersistencePipeline {
     /// Create the pipeline and spawn the background writer task.
     /// Returns a handle that producers use to send events.
     pub fn spawn(pool: PgPool, config: PersistenceConfig) -> PersistencePipelineHandle {
+        Self::spawn_with_freshness(pool, config, None)
+    }
+
+    /// Create the pipeline with optional shared freshness tracking.
+    pub fn spawn_with_freshness(
+        pool: PgPool,
+        config: PersistenceConfig,
+        freshness: Option<Arc<DataPlaneFreshness>>,
+    ) -> PersistencePipelineHandle {
         let (tx, rx) = mpsc::channel(config.channel_capacity);
         tokio::spawn(Self::run(rx, pool, config));
-        PersistencePipelineHandle { tx }
+        PersistencePipelineHandle { tx, freshness }
     }
 
     async fn run(

--- a/src/strategy/feeds.rs
+++ b/src/strategy/feeds.rs
@@ -458,6 +458,7 @@ impl DataFeedManager {
         // Start Binance feed if configured
         if let Some(ref binance_ws) = self.binance_ws {
             let manager = self.manager.clone();
+            let freshness = self.data_plane.as_ref().map(|dp| dp.freshness());
             let mut rx = binance_ws.subscribe();
 
             tokio::spawn(async move {
@@ -474,6 +475,9 @@ impl DataFeedManager {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                             warn!("Binance price feed lagged by {} messages", n);
+                            if let Some(ref f) = freshness {
+                                f.record_broadcast_lag(n as u64);
+                            }
                             continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -503,6 +507,7 @@ impl DataFeedManager {
             self.backfill_binance_klines().await?;
 
             let manager = self.manager.clone();
+            let freshness = self.data_plane.as_ref().map(|dp| dp.freshness());
             let mut rx = binance_ws.subscribe();
             let last_close = self.binance_kline_last_close.clone();
 
@@ -551,6 +556,9 @@ impl DataFeedManager {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                             warn!("Binance kline feed lagged by {} messages", n);
+                            if let Some(ref f) = freshness {
+                                f.record_broadcast_lag(n as u64);
+                            }
                             continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -574,6 +582,7 @@ impl DataFeedManager {
         // Start Polymarket feed if configured
         if let Some(ref pm_ws) = self.polymarket_ws {
             let manager = self.manager.clone();
+            let freshness = self.data_plane.as_ref().map(|dp| dp.freshness());
             let mut rx = pm_ws.subscribe_updates();
 
             tokio::spawn(async move {
@@ -610,12 +619,16 @@ impl DataFeedManager {
                             };
                             manager.send_market_update(market_update);
                         }
-                        Err(e) => {
-                            warn!("Quote feed recv error: {:?}", e);
-                            // Continue on lagged, break on closed
-                            if matches!(e, tokio::sync::broadcast::error::RecvError::Closed) {
-                                break;
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("Quote feed lagged by {} messages", n);
+                            if let Some(ref f) = freshness {
+                                f.record_broadcast_lag(n as u64);
                             }
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            warn!("Quote feed recv error: channel closed");
+                            break;
                         }
                     }
                 }

--- a/src/strategy/feeds.rs
+++ b/src/strategy/feeds.rs
@@ -1227,6 +1227,127 @@ impl DataFeedBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::{DataPlaneConfig, DataPlaneFreshness, PlatformDataPlane};
+    use crate::strategy::traits::{
+        AlertLevel, DataFeed, MarketUpdate, OrderUpdate, Strategy, StrategyAction,
+        StrategyStateInfo,
+    };
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+    use tokio::time::{timeout, Duration};
+
+    struct FeedCaptureStrategy {
+        id: String,
+    }
+
+    impl FeedCaptureStrategy {
+        fn new(id: &str) -> Self {
+            Self { id: id.to_string() }
+        }
+    }
+
+    #[async_trait]
+    impl Strategy for FeedCaptureStrategy {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn name(&self) -> &str {
+            "feed_capture"
+        }
+
+        fn description(&self) -> &str {
+            "capture market update kinds for tests"
+        }
+
+        fn required_feeds(&self) -> Vec<DataFeed> {
+            vec![]
+        }
+
+        async fn on_market_update(
+            &mut self,
+            update: &MarketUpdate,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            let tag = match update {
+                MarketUpdate::PolymarketQuote { .. } => "polymarket_quote",
+                MarketUpdate::BinancePrice { .. } => "binance_price",
+                MarketUpdate::BinanceKline { .. } => "binance_kline",
+                MarketUpdate::EventDiscovered { .. } => "event_discovered",
+                MarketUpdate::EventExpired { .. } => "event_expired",
+            };
+            Ok(vec![StrategyAction::Alert {
+                level: AlertLevel::Info,
+                message: format!("market:{}", tag),
+            }])
+        }
+
+        async fn on_order_update(
+            &mut self,
+            _update: &OrderUpdate,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(Vec::new())
+        }
+
+        async fn on_tick(
+            &mut self,
+            _now: chrono::DateTime<Utc>,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(Vec::new())
+        }
+
+        fn state(&self) -> StrategyStateInfo {
+            StrategyStateInfo {
+                strategy_id: self.id.clone(),
+                enabled: true,
+                ..StrategyStateInfo::default()
+            }
+        }
+
+        fn positions(&self) -> Vec<crate::strategy::traits::PositionInfo> {
+            Vec::new()
+        }
+
+        fn is_active(&self) -> bool {
+            true
+        }
+
+        async fn shutdown(&mut self) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(Vec::new())
+        }
+
+        fn reset(&mut self) {}
+    }
+
+    async fn setup_manager_with_strategy(
+        strategy_id: &str,
+    ) -> (
+        Arc<StrategyManager>,
+        mpsc::Receiver<(String, StrategyAction)>,
+    ) {
+        let manager = Arc::new(StrategyManager::new(60_000));
+        let action_rx = manager
+            .take_action_receiver()
+            .await
+            .expect("action receiver should be available");
+        manager
+            .start_strategy(Box::new(FeedCaptureStrategy::new(strategy_id)), None)
+            .await
+            .expect("start strategy");
+        (manager, action_rx)
+    }
+
+    async fn recv_market_alert(
+        action_rx: &mut mpsc::Receiver<(String, StrategyAction)>,
+    ) -> (String, String) {
+        let (strategy_id, action) = timeout(Duration::from_secs(1), action_rx.recv())
+            .await
+            .expect("receive timeout")
+            .expect("action channel closed");
+        match action {
+            StrategyAction::Alert { message, .. } => (strategy_id, message),
+            other => panic!("unexpected action: {:?}", other),
+        }
+    }
 
     #[test]
     fn test_feed_builder() {
@@ -1236,5 +1357,148 @@ mod tests {
 
         let binance = builder.build_binance();
         assert!(binance.is_some());
+    }
+
+    #[test]
+    fn test_feed_builder_empty_symbols_returns_none() {
+        let builder = DataFeedBuilder::new();
+        assert!(builder.build_binance().is_none());
+    }
+
+    #[test]
+    fn test_from_data_plane_reuses_singleton_adapters() {
+        let manager = Arc::new(StrategyManager::new(1000));
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                polymarket_ws_url: "wss://example.invalid/ws".to_string(),
+                binance_spot_symbols: vec!["BTCUSDT".to_string()],
+                ..DataPlaneConfig::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+
+        let feed = DataFeedManager::from_data_plane(data_plane.clone(), manager);
+        assert!(feed.data_plane.is_some());
+        assert!(feed.pm_client.is_none());
+
+        let feed_bn = feed.binance_ws.as_ref().expect("feed binance ws");
+        let dp_bn = data_plane.binance_ws().expect("dp binance ws");
+        assert!(Arc::ptr_eq(feed_bn, &dp_bn));
+
+        let feed_pm = feed.polymarket_ws.as_ref().expect("feed pm ws");
+        let dp_pm = data_plane.polymarket_ws().expect("dp pm ws");
+        assert!(Arc::ptr_eq(feed_pm, &dp_pm));
+    }
+
+    #[tokio::test]
+    async fn characterization_replay_binance_price_to_strategy_market_update() {
+        let (manager, mut action_rx) = setup_manager_with_strategy("feed_s1").await;
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                binance_spot_symbols: vec!["BTCUSDT".to_string()],
+                ..DataPlaneConfig::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+
+        let feed = DataFeedManager::from_data_plane(data_plane.clone(), manager);
+        feed.start().await.expect("start feed manager");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let ws = data_plane.binance_ws().expect("binance ws");
+        ws.ingest_test_message(
+            r#"{"e":"aggTrade","E":1700000000000,"s":"BTCUSDT","p":"43250.50","q":"0.123","T":1700000000000}"#,
+        )
+        .await;
+
+        let (sid, message) = recv_market_alert(&mut action_rx).await;
+        assert_eq!(sid, "feed_s1");
+        assert_eq!(message, "market:binance_price");
+    }
+
+    #[tokio::test]
+    async fn characterization_replay_polymarket_quote_to_strategy_market_update() {
+        let (manager, mut action_rx) = setup_manager_with_strategy("feed_s2").await;
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                polymarket_ws_url: "wss://example.invalid/ws".to_string(),
+                ..DataPlaneConfig::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+
+        let pm_ws = data_plane.polymarket_ws().expect("pm ws");
+        pm_ws
+            .register_token("0xabc123", crate::domain::Side::Up)
+            .await;
+
+        let feed = DataFeedManager::from_data_plane(data_plane.clone(), manager);
+        feed.start().await.expect("start feed manager");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let handled = pm_ws.ingest_test_message(
+            r#"[{"asset_id":"0xabc123","market":"0xmarket","bids":[{"price":"0.45","size":"100"}],"asks":[{"price":"0.47","size":"50"}]}]"#,
+        ).await;
+        assert!(handled, "polymarket message should be handled");
+
+        let (sid, message) = recv_market_alert(&mut action_rx).await;
+        assert_eq!(sid, "feed_s2");
+        assert_eq!(message, "market:polymarket_quote");
+    }
+
+    #[tokio::test]
+    async fn characterization_replay_binance_kline_to_strategy_market_update() {
+        let (manager, mut action_rx) = setup_manager_with_strategy("feed_s3").await;
+        let data_plane = Arc::new(PlatformDataPlane::new(
+            DataPlaneConfig {
+                binance_kline_symbols: vec!["BTCUSDT".to_string()],
+                binance_kline_intervals: vec!["5m".to_string()],
+                binance_kline_closed_only: true,
+                ..DataPlaneConfig::default()
+            },
+            Arc::new(DataPlaneFreshness::new()),
+        ));
+
+        let mut feed = DataFeedManager::from_data_plane(data_plane.clone(), manager);
+        // Keep test deterministic/offline: skip REST backfill.
+        feed.binance_kline_backfill_limit = 0;
+        feed.start().await.expect("start feed manager");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        let ws = data_plane.binance_kline_ws().expect("binance kline ws");
+        ws.ingest_test_message(
+            r#"{
+                "stream":"btcusdt@kline_5m",
+                "data":{
+                    "e":"kline",
+                    "E":1700000000000,
+                    "s":"BTCUSDT",
+                    "k":{
+                        "t":1700000000000,
+                        "T":1700000299999,
+                        "s":"BTCUSDT",
+                        "i":"5m",
+                        "f":0,
+                        "L":0,
+                        "o":"100.0",
+                        "c":"101.0",
+                        "h":"102.0",
+                        "l":"99.0",
+                        "v":"123.4",
+                        "n":0,
+                        "x":true,
+                        "q":"0",
+                        "V":"0",
+                        "Q":"0",
+                        "B":"0"
+                    }
+                }
+            }"#,
+        )
+        .await;
+
+        let (sid, message) = recv_market_alert(&mut action_rx).await;
+        assert_eq!(sid, "feed_s3");
+        assert_eq!(message, "market:binance_kline");
     }
 }

--- a/src/strategy/manager.rs
+++ b/src/strategy/manager.rs
@@ -477,6 +477,98 @@ pub struct StrategyInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::strategy::traits::{
+        AlertLevel, DataFeed, MarketUpdate, OrderUpdate, Strategy, StrategyAction,
+        StrategyStateInfo,
+    };
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use rust_decimal_macros::dec;
+    use tokio::time::{timeout, Duration};
+
+    struct TestStrategy {
+        id: String,
+        name: String,
+    }
+
+    impl TestStrategy {
+        fn new(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                name: "test_strategy".to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Strategy for TestStrategy {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "test"
+        }
+
+        fn required_feeds(&self) -> Vec<DataFeed> {
+            vec![DataFeed::BinanceSpot {
+                symbols: vec!["BTCUSDT".to_string()],
+            }]
+        }
+
+        async fn on_market_update(
+            &mut self,
+            _update: &MarketUpdate,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(vec![StrategyAction::Alert {
+                level: AlertLevel::Info,
+                message: "market_update".to_string(),
+            }])
+        }
+
+        async fn on_order_update(
+            &mut self,
+            _update: &OrderUpdate,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(vec![StrategyAction::Alert {
+                level: AlertLevel::Info,
+                message: "order_update".to_string(),
+            }])
+        }
+
+        async fn on_tick(
+            &mut self,
+            _now: chrono::DateTime<Utc>,
+        ) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(Vec::new())
+        }
+
+        fn state(&self) -> StrategyStateInfo {
+            StrategyStateInfo {
+                strategy_id: self.id.clone(),
+                enabled: true,
+                ..StrategyStateInfo::default()
+            }
+        }
+
+        fn positions(&self) -> Vec<crate::strategy::traits::PositionInfo> {
+            Vec::new()
+        }
+
+        fn is_active(&self) -> bool {
+            true
+        }
+
+        async fn shutdown(&mut self) -> crate::error::Result<Vec<StrategyAction>> {
+            Ok(Vec::new())
+        }
+
+        fn reset(&mut self) {}
+    }
 
     #[tokio::test]
     async fn test_strategy_manager_creation() {
@@ -489,5 +581,69 @@ mod tests {
         let strategies = StrategyFactory::available_strategies();
         assert!(!strategies.is_empty());
         assert!(strategies.iter().any(|s| s.name == "momentum"));
+    }
+
+    #[tokio::test]
+    async fn test_market_update_routed_to_running_strategy() {
+        let manager = StrategyManager::new(60_000);
+        let mut action_rx = manager
+            .take_action_receiver()
+            .await
+            .expect("action receiver should be available");
+
+        manager
+            .start_strategy(Box::new(TestStrategy::new("s1")), None)
+            .await
+            .expect("start strategy");
+
+        manager.send_market_update(MarketUpdate::BinancePrice {
+            symbol: "BTCUSDT".to_string(),
+            price: dec!(43210.5),
+            timestamp: Utc::now(),
+        });
+
+        let (strategy_id, action) = timeout(Duration::from_secs(1), action_rx.recv())
+            .await
+            .expect("receive timeout")
+            .expect("channel closed");
+        assert_eq!(strategy_id, "s1");
+        match action {
+            StrategyAction::Alert { message, .. } => assert_eq!(message, "market_update"),
+            other => panic!("unexpected action: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_order_update_routed_to_running_strategy() {
+        let manager = StrategyManager::new(60_000);
+        let mut action_rx = manager
+            .take_action_receiver()
+            .await
+            .expect("action receiver should be available");
+
+        manager
+            .start_strategy(Box::new(TestStrategy::new("s2")), None)
+            .await
+            .expect("start strategy");
+
+        manager.send_order_update(OrderUpdate {
+            order_id: "o1".to_string(),
+            client_order_id: Some("c1".to_string()),
+            status: crate::domain::OrderStatus::Filled,
+            filled_qty: 10,
+            avg_fill_price: Some(dec!(0.42)),
+            timestamp: Utc::now(),
+            error: None,
+        });
+
+        let (strategy_id, action) = timeout(Duration::from_secs(1), action_rx.recv())
+            .await
+            .expect("receive timeout")
+            .expect("channel closed");
+        assert_eq!(strategy_id, "s2");
+        match action {
+            StrategyAction::Alert { message, .. } => assert_eq!(message, "order_update"),
+            other => panic!("unexpected action: {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR advances issue #21 with local, code-level items:

- Adds replay hooks (`ingest_test_message`) for WS adapters under `#[cfg(test)]`
- Expands characterization coverage for Binance kline + Chainlink RTDS
- Adds replay E2E tests for `DataFeedManager`/`StrategyManager` routing
- Wires runtime observability in data-plane path:
  - per-source `source_connected`
  - per-source subscription gauges
  - broadcast lag counter + drop counter
  - per-source feed health gauge (`-1 down, 0 degraded, 1 healthy`)
- Connects persistence bridges to shared freshness tracker so lag/drop is counted from bridge tasks

## Metrics Added/Activated
- `ploy_source_feed_health{source=...}`
- `ploy_source_connected{source=...}`
- `ploy_source_subscriptions_total{source=...}`
- `ploy_broadcast_lag_total`
- `ploy_broadcast_drop_total`
- Existing per-symbol freshness metrics remain enabled via `/metrics`

## Verification
- `cargo test -q strategy::manager::tests::`
- `cargo test -q strategy::feeds::tests::`
- `cargo test -q platform::freshness::tests::`
- `cargo test -q characterization_`

All pass locally.

## Scope Notes
- This PR does **not** complete the 24h baseline run on tango-1-1.
- Issue: #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved data-freshness and connection lifecycle tracking across multiple market-data sources.
  * New observability metrics: total broadcast-drop counter and per-source feed health.
  * Persistence and feed paths now report lag/drop events to freshness tracking.
  * Test hooks added to allow injecting raw messages for end-to-end ingestion tests.

* **Tests**
  * Expanded coverage for parsing, freshness tracking, lag/drop recording, and strategy event routing.

* **Documentation**
  * Added a Phase 0 Data Plane Baseline runbook and CLI utilities for baseline collection and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->