### PR TITLE
ops: add ploy platform watchdog

### DIFF
--- a/deployment/ploy-platform-watchdog.service
+++ b/deployment/ploy-platform-watchdog.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 WorkingDirectory=/
-ExecStart=/bin/bash -lc 'for root in /root/ploy /opt/ploy; do if [[ -x "$root/scripts/ploy_platform_watchdog.sh" ]]; then export PLOY_PLATFORM_WATCHDOG_ROOT="$root"; exec "$root/scripts/ploy_platform_watchdog.sh"; fi; done; echo "ploy-platform-watchdog: missing watchdog script under /root/ploy or /opt/ploy" >&2; exit 1'
+ExecStart=/bin/bash -c 'for root in /root/ploy /opt/ploy; do if [[ -x "$root/scripts/ploy_platform_watchdog.sh" ]]; then export PLOY_PLATFORM_WATCHDOG_ROOT="$root"; exec "$root/scripts/ploy_platform_watchdog.sh"; fi; done; echo "ploy-platform-watchdog: missing watchdog script under /root/ploy or /opt/ploy" >&2; exit 1'
 
 NoNewPrivileges=true
 PrivateTmp=true

--- a/deployment/ploy-platform-watchdog.service
+++ b/deployment/ploy-platform-watchdog.service
@@ -11,7 +11,7 @@ ExecStart=/bin/bash -lc 'for root in /root/ploy /opt/ploy; do if [[ -x "$root/sc
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
-ProtectHome=true
+ProtectHome=read-only
 ReadWritePaths=/root/ploy/run /opt/ploy/run
 
 StandardOutput=journal

--- a/deployment/ploy-platform-watchdog.service
+++ b/deployment/ploy-platform-watchdog.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Ploy Platform Watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/ploy
+Environment=PLOY_PLATFORM_WATCHDOG_LOCK_FILE=/opt/ploy/run/allow-platform-stop.lock
+ExecStart=/bin/bash /opt/ploy/scripts/ploy_platform_watchdog.sh
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/ploy/run
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ploy-platform-watchdog
+

--- a/deployment/ploy-platform-watchdog.service
+++ b/deployment/ploy-platform-watchdog.service
@@ -5,17 +5,15 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-WorkingDirectory=/opt/ploy
-Environment=PLOY_PLATFORM_WATCHDOG_LOCK_FILE=/opt/ploy/run/allow-platform-stop.lock
-ExecStart=/bin/bash /opt/ploy/scripts/ploy_platform_watchdog.sh
+WorkingDirectory=/
+ExecStart=/bin/bash -lc 'for root in /root/ploy /opt/ploy; do if [[ -x "$root/scripts/ploy_platform_watchdog.sh" ]]; then export PLOY_PLATFORM_WATCHDOG_ROOT="$root"; exec "$root/scripts/ploy_platform_watchdog.sh"; fi; done; echo "ploy-platform-watchdog: missing watchdog script under /root/ploy or /opt/ploy" >&2; exit 1'
 
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=true
-ReadWritePaths=/opt/ploy/run
+ReadWritePaths=/root/ploy/run /opt/ploy/run
 
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=ploy-platform-watchdog
-

--- a/deployment/ploy-platform-watchdog.timer
+++ b/deployment/ploy-platform-watchdog.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Ploy platform watchdog periodically
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=5m
+Persistent=true
+Unit=ploy-platform-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/plans/2026-03-11-ploy-platform-watchdog-design.md
+++ b/docs/plans/2026-03-11-ploy-platform-watchdog-design.md
@@ -1,0 +1,94 @@
+# Ploy Platform Watchdog Implementation Plan
+
+**Goal:** Add a minimal host-side watchdog that restarts `ploy-platform` when it has been cleanly left inactive, preventing multi-day market-data capture gaps.
+
+**Architecture:** Add a small shell watchdog script plus a oneshot systemd service/timer. The watchdog only checks unit liveness, skips when a maintenance lock file exists or maintenance is running, and starts the configured platform unit if it is unexpectedly inactive. Wire the deployment files and install script so hosts can opt into the timer without touching Rust runtime code.
+
+**Tech Stack:** bash, systemd service/timer units, existing deployment/install-service flow
+
+---
+
+### Task 1: Add a failing shell-level regression harness
+
+**Files:**
+- Create: `scripts/tests/test_ploy_platform_watchdog.sh`
+- Create: `scripts/tests/lib/assert.sh`
+
+**Step 1: Write the failing test**
+
+Add shell tests for:
+- inactive unit -> watchdog calls `systemctl start`
+- inactive unit + lock file -> watchdog does not start
+- inactive unit + active maintenance service -> watchdog does not start
+- active unit -> watchdog does nothing
+
+**Step 2: Run test to verify it fails**
+
+Run: `bash scripts/tests/test_ploy_platform_watchdog.sh`
+Expected: FAIL because watchdog script does not exist yet.
+
+### Task 2: Implement the minimal watchdog script
+
+**Files:**
+- Create: `scripts/ploy_platform_watchdog.sh`
+
+**Step 1: Write minimal implementation**
+
+Implement a bash script that:
+- accepts `PLOY_PLATFORM_WATCHDOG_UNIT`
+- accepts `PLOY_PLATFORM_WATCHDOG_LOCK_FILE`
+- skips when maintenance service is active
+- starts the configured unit when it is inactive and no lock file exists
+
+**Step 2: Run targeted test**
+
+Run: `bash scripts/tests/test_ploy_platform_watchdog.sh`
+Expected: PASS
+
+### Task 3: Add deployment units and installation wiring
+
+**Files:**
+- Create: `deployment/ploy-platform-watchdog.service`
+- Create: `deployment/ploy-platform-watchdog.timer`
+- Modify: `scripts/install-service.sh`
+
+**Step 1: Add systemd units**
+
+Create a oneshot service that runs the watchdog script from `/opt/ploy/scripts`, and a timer that runs every 5 minutes with persistence enabled.
+
+**Step 2: Wire install path**
+
+Install the two new unit files when present and enable the timer during `install-service.sh`.
+
+**Step 3: Run targeted test / lint**
+
+Run: `bash scripts/tests/test_ploy_platform_watchdog.sh`
+Expected: PASS
+
+### Task 4: Verify the deployment diff
+
+**Files:**
+- Modify: `tasks/todo.md`
+
+**Step 1: Record the watchdog plan and validation**
+
+Add a short progress note linking the host outage root cause to the new watchdog.
+
+**Step 2: Run final checks**
+
+Run:
+- `bash scripts/tests/test_ploy_platform_watchdog.sh`
+- `rtk git diff -- deployment/ploy-platform-watchdog.service deployment/ploy-platform-watchdog.timer scripts/ploy_platform_watchdog.sh scripts/install-service.sh tasks/todo.md`
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-03-11-ploy-platform-watchdog-design.md \
+  deployment/ploy-platform-watchdog.service \
+  deployment/ploy-platform-watchdog.timer \
+  scripts/ploy_platform_watchdog.sh \
+  scripts/tests/test_ploy_platform_watchdog.sh \
+  scripts/install-service.sh \
+  tasks/todo.md
+git commit -m "ops: add ploy platform watchdog"
+```

--- a/scripts/aws_ec2_deploy.sh
+++ b/scripts/aws_ec2_deploy.sh
@@ -9,7 +9,7 @@ USER_NAME="ubuntu"
 SSH_KEY=""
 START_AFTER_DEPLOY="true"
 ENABLE_ON_BOOT="true"
-SERVICES="ploy-crypto-collector,ploy-orderbook-history,ploy-maintenance.timer"
+SERVICES="ploy-crypto-collector,ploy-orderbook-history,ploy-maintenance.timer,ploy-platform-watchdog.timer"
 
 usage() {
   cat <<'USAGE'
@@ -23,8 +23,8 @@ Options:
   --start <true|false>     Start services after deploy (default: true)
   --enable <true|false>    Enable services on boot (default: true)
   --services <csv>         Services to enable/start
-                           allowed: ploy,ploy-platform-live,ploy-sports-pm,ploy-crypto-collector,ploy-crypto-dryrun,ploy-crypto-live,ploy-orderbook-history,ploy-maintenance.timer,ploy-strategy-pattern-memory-dryrun,ploy-strategy-momentum-dryrun,ploy-strategy-split-arb-dryrun
-                           default: ploy-crypto-collector,ploy-orderbook-history,ploy-maintenance.timer
+                           allowed: ploy,ploy-platform-live,ploy-sports-pm,ploy-crypto-collector,ploy-crypto-dryrun,ploy-crypto-live,ploy-orderbook-history,ploy-maintenance.timer,ploy-platform-watchdog.timer,ploy-strategy-pattern-memory-dryrun,ploy-strategy-momentum-dryrun,ploy-strategy-split-arb-dryrun
+                           default: ploy-crypto-collector,ploy-orderbook-history,ploy-maintenance.timer,ploy-platform-watchdog.timer
   -h, --help               Show help
 
 Examples:
@@ -45,7 +45,7 @@ USAGE
 
 is_allowed_service() {
   case "$1" in
-    ploy|ploy-platform-live|ploy-sports-pm|ploy-crypto-collector|ploy-crypto-dryrun|ploy-crypto-live|ploy-orderbook-history|ploy-maintenance.timer) return 0 ;;
+    ploy|ploy-platform-live|ploy-sports-pm|ploy-crypto-collector|ploy-crypto-dryrun|ploy-crypto-live|ploy-orderbook-history|ploy-maintenance.timer|ploy-platform-watchdog.timer) return 0 ;;
     ploy-strategy-pattern-memory-dryrun|ploy-strategy-momentum-dryrun|ploy-strategy-split-arb-dryrun) return 0 ;;
     *) return 1 ;;
   esac
@@ -61,7 +61,7 @@ normalize_services_csv() {
     [[ -n "$svc" ]] || continue
     if ! is_allowed_service "$svc"; then
       echo "invalid service in --services: $svc" >&2
-      echo "allowed: ploy, ploy-platform-live, ploy-sports-pm, ploy-crypto-collector, ploy-crypto-dryrun, ploy-crypto-live, ploy-orderbook-history, ploy-maintenance.timer, ploy-strategy-pattern-memory-dryrun, ploy-strategy-momentum-dryrun, ploy-strategy-split-arb-dryrun" >&2
+      echo "allowed: ploy, ploy-platform-live, ploy-sports-pm, ploy-crypto-collector, ploy-crypto-dryrun, ploy-crypto-live, ploy-orderbook-history, ploy-maintenance.timer, ploy-platform-watchdog.timer, ploy-strategy-pattern-memory-dryrun, ploy-strategy-momentum-dryrun, ploy-strategy-split-arb-dryrun" >&2
       exit 2
     fi
     out+=("$svc")
@@ -282,7 +282,9 @@ for unit in \
   "$REMOTE_ROOT/deployment/ploy-strategy-split-arb-dryrun.service" \
   "$REMOTE_ROOT/deployment/ploy-orderbook-history.service" \
   "$REMOTE_ROOT/deployment/ploy-maintenance.service" \
-  "$REMOTE_ROOT/deployment/ploy-maintenance.timer"
+  "$REMOTE_ROOT/deployment/ploy-maintenance.timer" \
+  "$REMOTE_ROOT/deployment/ploy-platform-watchdog.service" \
+  "$REMOTE_ROOT/deployment/ploy-platform-watchdog.timer"
 do
   if [[ -f "$unit" ]]; then
     sudo install -m 0644 "$unit" "/etc/systemd/system/$(basename "$unit")"

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -44,6 +44,12 @@ fi
 if [[ -f /opt/ploy/deployment/ploy-maintenance.timer ]]; then
   sudo install -m 0644 /opt/ploy/deployment/ploy-maintenance.timer /etc/systemd/system/ploy-maintenance.timer
 fi
+if [[ -f /opt/ploy/deployment/ploy-platform-watchdog.service ]]; then
+  sudo install -m 0644 /opt/ploy/deployment/ploy-platform-watchdog.service /etc/systemd/system/ploy-platform-watchdog.service
+fi
+if [[ -f /opt/ploy/deployment/ploy-platform-watchdog.timer ]]; then
+  sudo install -m 0644 /opt/ploy/deployment/ploy-platform-watchdog.timer /etc/systemd/system/ploy-platform-watchdog.timer
+fi
 if [[ -f /opt/ploy/deployment/ploy-strategy-pattern-memory-dryrun.service ]]; then
   sudo install -m 0644 /opt/ploy/deployment/ploy-strategy-pattern-memory-dryrun.service /etc/systemd/system/ploy-strategy-pattern-memory-dryrun.service
 fi
@@ -220,6 +226,9 @@ sudo systemctl daemon-reload
 
 # Enable service to start on boot
 sudo systemctl enable ploy
+if [[ -f /etc/systemd/system/ploy-platform-watchdog.timer ]]; then
+  sudo systemctl enable --now ploy-platform-watchdog.timer
+fi
 
 echo "==> Service installed"
 echo ""
@@ -229,6 +238,7 @@ echo "  sudo systemctl stop ploy    # Stop"
 echo "  sudo systemctl status ploy  # Status"
 echo "  sudo systemctl start ploy-sports-pm       # Start sports PM workload"
 echo "  sudo systemctl start ploy-crypto-dryrun   # Start crypto dry-run workload"
+echo "  sudo systemctl status ploy-platform-watchdog.timer  # Inspect watchdog loop"
 echo "  sudo systemctl start ploy@acc1   # Start account acc1 (multi-account)"
 echo "  sudo systemctl status ploy@acc1  # Status account acc1"
 echo "  journalctl -u ploy -f       # View logs"

--- a/scripts/ploy_platform_watchdog.sh
+++ b/scripts/ploy_platform_watchdog.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOCK_FILE="${PLOY_PLATFORM_WATCHDOG_LOCK_FILE:-/opt/ploy/run/allow-platform-stop.lock}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLOY_PLATFORM_WATCHDOG_ROOT="${PLOY_PLATFORM_WATCHDOG_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+LOCK_FILE="${PLOY_PLATFORM_WATCHDOG_LOCK_FILE:-$PLOY_PLATFORM_WATCHDOG_ROOT/run/allow-platform-stop.lock}"
 MAINTENANCE_UNIT="${PLOY_PLATFORM_WATCHDOG_MAINTENANCE_UNIT:-ploy-maintenance.service}"
 
 log_watchdog() {

--- a/scripts/ploy_platform_watchdog.sh
+++ b/scripts/ploy_platform_watchdog.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCK_FILE="${PLOY_PLATFORM_WATCHDOG_LOCK_FILE:-/opt/ploy/run/allow-platform-stop.lock}"
+MAINTENANCE_UNIT="${PLOY_PLATFORM_WATCHDOG_MAINTENANCE_UNIT:-ploy-maintenance.service}"
+
+log_watchdog() {
+  local message="$1"
+  echo "ploy_platform_watchdog: $message"
+  if command -v logger >/dev/null 2>&1; then
+    logger -t ploy-platform-watchdog "$message" || true
+  fi
+}
+
+resolve_platform_unit() {
+  if [[ -n "${PLOY_PLATFORM_WATCHDOG_UNIT:-}" ]]; then
+    printf '%s\n' "$PLOY_PLATFORM_WATCHDOG_UNIT"
+    return 0
+  fi
+
+  local candidates=(
+    "ploy-platform.service"
+    "ploy-platform-live.service"
+    "ploy-crypto-live.service"
+  )
+
+  local unit
+  for unit in "${candidates[@]}"; do
+    if systemctl cat "$unit" >/dev/null 2>&1; then
+      printf '%s\n' "$unit"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+main() {
+  local platform_unit
+  if ! platform_unit="$(resolve_platform_unit)"; then
+    log_watchdog "no known platform unit installed; skipping"
+    exit 0
+  fi
+
+  if [[ -f "$LOCK_FILE" ]]; then
+    log_watchdog "lock file present at $LOCK_FILE; skipping restart for $platform_unit"
+    exit 0
+  fi
+
+  if systemctl is-active --quiet "$MAINTENANCE_UNIT"; then
+    log_watchdog "maintenance unit $MAINTENANCE_UNIT is active; skipping restart for $platform_unit"
+    exit 0
+  fi
+
+  if systemctl is-active --quiet "$platform_unit"; then
+    exit 0
+  fi
+
+  log_watchdog "unit $platform_unit inactive; starting"
+  systemctl start "$platform_unit"
+}
+
+main "$@"

--- a/scripts/tests/lib/assert.sh
+++ b/scripts/tests/lib/assert.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  if [[ ! -f "$file" ]]; then
+    fail "expected file '$file' to exist"
+  fi
+  if ! grep -Fq "$needle" "$file"; then
+    fail "expected '$file' to contain '$needle'"
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+  if grep -Fq "$needle" "$file"; then
+    fail "expected '$file' not to contain '$needle'"
+  fi
+}

--- a/scripts/tests/test_ploy_platform_watchdog.sh
+++ b/scripts/tests/test_ploy_platform_watchdog.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/tests/lib/assert.sh"
+
+WATCHDOG_SCRIPT="$ROOT_DIR/scripts/ploy_platform_watchdog.sh"
+
+make_stub_systemctl() {
+  local stub_dir="$1"
+  local log_file="$2"
+  cat >"$stub_dir/systemctl" <<'SH'
+#!/bin/bash
+set -euo pipefail
+
+log_file="${SYSTEMCTL_LOG:?}"
+active_unit="${ACTIVE_UNIT:-}"
+maintenance_active="${MAINTENANCE_ACTIVE:-0}"
+
+echo "$*" >> "$log_file"
+
+if [[ "$1" == "is-active" && "$2" == "--quiet" ]]; then
+  unit="$3"
+  if [[ "$unit" == "$active_unit" ]]; then
+    exit 0
+  fi
+  if [[ "${MAINTENANCE_UNIT:-ploy-maintenance.service}" == "$unit" && "$maintenance_active" == "1" ]]; then
+    exit 0
+  fi
+  exit 3
+fi
+
+if [[ "$1" == "start" ]]; then
+  exit 0
+fi
+
+exit 0
+SH
+  chmod +x "$stub_dir/systemctl"
+}
+
+run_watchdog() {
+  local scenario_name="$1"
+  local active_unit="$2"
+  local maintenance_active="$3"
+  local lock_file="$4"
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  local log_file="$tmp_dir/systemctl.log"
+  : > "$log_file"
+  mkdir -p "$tmp_dir/bin"
+  make_stub_systemctl "$tmp_dir/bin" "$log_file"
+
+  PATH="$tmp_dir/bin:$PATH" \
+  SYSTEMCTL_LOG="$log_file" \
+  ACTIVE_UNIT="$active_unit" \
+  MAINTENANCE_ACTIVE="$maintenance_active" \
+  MAINTENANCE_UNIT="ploy-maintenance.service" \
+  PLOY_PLATFORM_WATCHDOG_UNIT="ploy-platform.service" \
+  PLOY_PLATFORM_WATCHDOG_LOCK_FILE="$lock_file" \
+    bash "$WATCHDOG_SCRIPT" >/dev/null
+
+  echo "$log_file"
+}
+
+main() {
+  local tmp_root
+  tmp_root="$(mktemp -d)"
+  trap "rm -rf '$tmp_root'" EXIT
+
+  local log_file
+
+  log_file="$(run_watchdog "inactive" "" "0" "$tmp_root/no-lock")"
+  assert_file_contains "$log_file" "start ploy-platform.service"
+
+  touch "$tmp_root/allow-stop.lock"
+  log_file="$(run_watchdog "locked" "" "0" "$tmp_root/allow-stop.lock")"
+  assert_file_not_contains "$log_file" "start ploy-platform.service"
+
+  log_file="$(run_watchdog "maintenance" "" "1" "$tmp_root/no-lock")"
+  assert_file_not_contains "$log_file" "start ploy-platform.service"
+
+  log_file="$(run_watchdog "active" "ploy-platform.service" "0" "$tmp_root/no-lock")"
+  assert_file_not_contains "$log_file" "start ploy-platform.service"
+
+  echo "ok"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a host-side `ploy-platform` watchdog script plus systemd service/timer
- wire the watchdog into both `install-service.sh` and `aws_ec2_deploy.sh`
- make the watchdog compatible with both legacy `/root/ploy` hosts and current `/opt/ploy` deployments

## Validation
- `bash scripts/tests/test_ploy_platform_watchdog.sh`
- `bash -n scripts/ploy_platform_watchdog.sh scripts/install-service.sh scripts/aws_ec2_deploy.sh`
- verified on `tango-1-1`: `ploy-platform-watchdog.timer` is enabled/active and the lock-file gate skips restart while `ploy-platform.service` stays running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduces a platform watchdog service that automatically restarts the platform when inactive, respecting maintenance mode and lock files
  * Watchdog runs every 5 minutes via systemd timer with security hardening

* **Documentation**
  * Added design documentation for the watchdog implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->