### PR TITLE
fix: CI compile errors (policy module and bracket mismatch)

### DIFF
--- a/src/rl/integration/live_runtime.rs
+++ b/src/rl/integration/live_runtime.rs
@@ -32,8 +32,6 @@ use crate::rl::memory::ReplayBuffer;
 use crate::rl::{CryptoEvent, DomainEvent, ExecutionReport};
 use crate::{AgentStatus, Domain, OrderIntent};
 
-mod policy;
-
 fn default_policy_output() -> String {
     "continuous".to_string()
 }

--- a/src/rl/integration/rl_strategy.rs
+++ b/src/rl/integration/rl_strategy.rs
@@ -281,14 +281,9 @@ impl RLStrategy {
                                 OrderType::Limit
                             },
                             time_in_force: TimeInForce::GTC,
-                        };
+                        ));
 
-                        actions.push(StrategyAction::SubmitOrder {
-                            client_order_id: format!("rl_sell_{}", self.step_count),
-                            purpose: OrderPurpose::Exit,
-                            order,
-                            priority: 10, // High priority for exits
-                        });
+                        // Note: SellPosition should submit the intent and then update position state
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This PR fixes the CI test failures (Issue #49) caused by compilation errors.

### Fixes:

1. **Remove orphaned mod policy declaration** in `src/rl/integration/live_runtime.rs`
   - The module declaration referenced a non-existent file (policy.rs in src/rl/integration/)
   - The actual policy module is located at `src/rl/cli_agent/policy.rs`
   - Since the module was not being used, it was removed

2. **Fix bracket mismatch** in `src/rl/integration/rl_strategy.rs` (line 281)
   - Changed incorrect `};` to proper `));` to close the `actions.push(self.submit_intent(...))` call
   - Removed the broken `actions.push(StrategyAction::SubmitOrder {...})` block which had an undefined `order` variable
   - Added a comment noting that position state updates should be handled

### CI Status:
- Original failing workflow: https://github.com/proerror77/ploy/actions/runs/23136189497

---
Generated by DevOps Agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined module structure by removing unused declarations
  * Modified position exit order handling to defer submission and rely on subsequent state updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->