### PR TITLE
harden control-plane metrics, alerts, and auth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ rtk cargo test --test platform_smoke -- --nocapture
 Optional admin auth:
 
 - Set `PLOY_ADMIN_TOKEN` or `PLOY_API_ADMIN_TOKEN` before booting `ployd` to require a bearer token on the control-plane API.
+- Set `PLOY_OPERATOR_TOKEN` or `PLOY_API_OPERATOR_TOKEN` if you want a write-capable operator credential for deployment controls, intent ingress, and order cancel/replace without granting full admin access.
 - Set `PLOY_SIDECAR_AUTH_TOKEN` if you want a read-only agent/sidecar credential for system status, deployment snapshots, trading snapshots, and the SSE event stream.
 - Set `PLOY_API_AUTH_COOKIE_SECRET` as well if you want browser auth cookies to stay valid across daemon restarts or multiple instances.
 - Set `PLOY_REQUEST_RATE_LIMIT_PER_MINUTE` if you need to tighten or relax the daemon HTTP request throttle. `0` disables the limiter.
 - Set `PLOY_LIVE_RECONCILE_BACKOFF_BASE_MS` and `PLOY_LIVE_RECONCILE_BACKOFF_MAX_MS` if you want to tune venue outage retry backoff for live fill reconciliation.
-- `ployctl` will automatically reuse `PLOY_ADMIN_TOKEN`, `PLOY_API_ADMIN_TOKEN`, or `PLOY_API_KEY` for authenticated requests.
+- `ployctl` will automatically reuse `PLOY_ADMIN_TOKEN`, `PLOY_API_ADMIN_TOKEN`, `PLOY_API_KEY`, `PLOY_OPERATOR_TOKEN`, `PLOY_API_OPERATOR_TOKEN`, or `PLOY_SIDECAR_AUTH_TOKEN` for authenticated requests, in that order.
 - Browser operator surfaces authenticate through `/auth/login`, which now sets an `HttpOnly` same-site signed session cookie so the frontend event stream can stay authenticated without storing the raw admin token in browser storage.
 - `ployd` appends authenticated control-plane activity to `run/platform/audit-log.jsonl`, and `ployctl system audit` reads that stream back through the daemon API.
 - `ployctl system status` now surfaces live reconcile failure count, next retry time, and the last reconcile error so venue outages are visible without digging through logs.
+- Current access bands are `public`, `read_only`, `operator`, and `admin`. `sidecar` credentials stop at `read_only`; `operator` credentials can mutate deployments and trading controls; only `admin` can access audit logs and browser-login flows.
 
 Runbooks:
 

--- a/apps/ployctl/src/client.rs
+++ b/apps/ployctl/src/client.rs
@@ -14,6 +14,8 @@ use std::path::{Path, PathBuf};
 pub struct ControlPlaneClient {
     pub control_plane_addr: String,
     pub admin_token: Option<String>,
+    pub operator_token: Option<String>,
+    pub sidecar_token: Option<String>,
     pub runtime_root: PathBuf,
 }
 
@@ -25,6 +27,13 @@ impl ControlPlaneClient {
                 .ok()
                 .or_else(|| std::env::var("PLOY_API_ADMIN_TOKEN").ok())
                 .or_else(|| std::env::var("PLOY_API_KEY").ok())
+                .filter(|token| !token.trim().is_empty()),
+            operator_token: std::env::var("PLOY_OPERATOR_TOKEN")
+                .ok()
+                .or_else(|| std::env::var("PLOY_API_OPERATOR_TOKEN").ok())
+                .filter(|token| !token.trim().is_empty()),
+            sidecar_token: std::env::var("PLOY_SIDECAR_AUTH_TOKEN")
+                .ok()
                 .filter(|token| !token.trim().is_empty()),
             runtime_root: runtime_root.into(),
         }
@@ -352,11 +361,14 @@ impl ControlPlaneClient {
     }
 
     fn authorization_headers(&self) -> String {
-        match &self.admin_token {
-            Some(token) => {
-                format!("Authorization: Bearer {token}\r\nx-ploy-admin-token: {token}\r\n")
-            }
-            None => String::new(),
+        if let Some(token) = &self.admin_token {
+            format!("Authorization: Bearer {token}\r\nx-ploy-admin-token: {token}\r\n")
+        } else if let Some(token) = &self.operator_token {
+            format!("x-ploy-operator-token: {token}\r\n")
+        } else if let Some(token) = &self.sidecar_token {
+            format!("x-ploy-sidecar-token: {token}\r\n")
+        } else {
+            String::new()
         }
     }
 }
@@ -811,6 +823,8 @@ mod tests {
         let client = ControlPlaneClient {
             control_plane_addr: addr.to_string(),
             admin_token: None,
+            operator_token: None,
+            sidecar_token: None,
             runtime_root,
         };
 
@@ -868,6 +882,8 @@ mod tests {
         let client = ControlPlaneClient {
             control_plane_addr: addr.to_string(),
             admin_token: None,
+            operator_token: None,
+            sidecar_token: None,
             runtime_root,
         };
 
@@ -925,10 +941,59 @@ mod tests {
         let client = ControlPlaneClient {
             control_plane_addr: addr.to_string(),
             admin_token: Some("secret-token".to_string()),
+            operator_token: None,
+            sidecar_token: None,
             runtime_root,
         };
 
         let status = client.system_snapshot().expect("status");
         assert_eq!(status.status, "running");
+    }
+
+    #[test]
+    fn client_sends_operator_header_when_configured() {
+        let runtime_root = temp_dir("http-operator-auth");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0_u8; 2048];
+            let bytes = stream.read(&mut request).expect("read request");
+            let request = String::from_utf8_lossy(&request[..bytes]);
+            assert!(!request.contains("Authorization: Bearer"));
+            assert!(request.contains("x-ploy-operator-token: operator-token"));
+
+            let body = serde_json::json!({
+                "deployment_id": "example.paper",
+                "account_id": "acct-paper",
+                "max_gross_exposure": null,
+                "deployment_state": "enabled",
+                "desired_state": "paused",
+                "observed_state": "paused"
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let client = ControlPlaneClient {
+            control_plane_addr: addr.to_string(),
+            admin_token: None,
+            operator_token: Some("operator-token".to_string()),
+            sidecar_token: None,
+            runtime_root,
+        };
+
+        let deployment = client
+            .set_desired_state("example.paper", DesiredState::Paused)
+            .expect("deployment");
+        assert_eq!(deployment.desired_state, DesiredState::Paused);
     }
 }

--- a/apps/ployctl/src/client.rs
+++ b/apps/ployctl/src/client.rs
@@ -1,7 +1,8 @@
 use ploy_operator_contracts::{
-    AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
-    DeploymentState, DeploymentSummary, DesiredState, OperatorEvent, OrderControlResponse,
-    OrderReplaceRequest, SystemStatus, TradingStateSnapshot,
+    ActiveAlert, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
+    DeploymentControlRequest, DeploymentState, DeploymentSummary, DesiredState, OperatorEvent,
+    OrderControlResponse, OrderReplaceRequest, PlatformMetrics, SystemStatus,
+    TradingStateSnapshot,
 };
 use serde::de::DeserializeOwned;
 use std::fs;
@@ -53,6 +54,14 @@ impl ControlPlaneClient {
 
     pub fn audit_logs(&self) -> Result<Vec<AuditLogEntry>, String> {
         self.get_json("/api/audit/logs")
+    }
+
+    pub fn system_metrics(&self) -> Result<PlatformMetrics, String> {
+        self.get_json("/api/system/metrics")
+    }
+
+    pub fn system_alerts(&self) -> Result<Vec<ActiveAlert>, String> {
+        self.get_json("/api/system/alerts")
     }
 
     pub fn deployment_summaries(&self) -> Result<Vec<DeploymentSummary>, String> {

--- a/apps/ployctl/src/client.rs
+++ b/apps/ployctl/src/client.rs
@@ -429,6 +429,9 @@ mod tests {
                 live_reconcile_failures: 0,
                 next_live_reconcile_at: None,
                 last_live_reconcile_error: None,
+                active_alert_count: 0,
+                stale_source_count: 0,
+                last_live_reconcile_success_at: None,
             })
             .expect("status json"),
         )
@@ -640,6 +643,9 @@ mod tests {
                         live_reconcile_failures: 0,
                         next_live_reconcile_at: None,
                         last_live_reconcile_error: None,
+                        active_alert_count: 0,
+                        stale_source_count: 0,
+                        last_live_reconcile_success_at: None,
                     },
                 }))
                 .expect("event1");

--- a/apps/ployctl/src/main.rs
+++ b/apps/ployctl/src/main.rs
@@ -3,6 +3,8 @@ use ployctl::{client::ControlPlaneClient, deployments, system, trading};
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Command {
     SystemStatus,
+    SystemMetrics,
+    SystemAlerts,
     SystemAudit,
     TradingStatus,
     TradingInspect(String),
@@ -30,6 +32,12 @@ impl Command {
         match args {
             [_bin, system, status] if system == "system" && status == "status" => {
                 Ok(Self::SystemStatus)
+            }
+            [_bin, system, metrics] if system == "system" && metrics == "metrics" => {
+                Ok(Self::SystemMetrics)
+            }
+            [_bin, system, alerts] if system == "system" && alerts == "alerts" => {
+                Ok(Self::SystemAlerts)
             }
             [_bin, system, audit] if system == "system" && audit == "audit" => {
                 Ok(Self::SystemAudit)
@@ -120,7 +128,7 @@ impl Command {
             {
                 Ok(Self::DeploymentsArchive(deployment_id.clone()))
             }
-            _ => Err("usage: ployctl system status | ployctl system audit | ployctl trading status | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
+            _ => Err("usage: ployctl system status | ployctl system metrics | ployctl system alerts | ployctl system audit | ployctl trading status | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
         }
     }
 }
@@ -142,6 +150,8 @@ fn main() {
 fn execute(command: Command, client: &ControlPlaneClient) -> Result<String, String> {
     match command {
         Command::SystemStatus => system::render_system_status(client),
+        Command::SystemMetrics => system::render_system_metrics(client),
+        Command::SystemAlerts => system::render_system_alerts(client),
         Command::SystemAudit => system::render_audit_log(client),
         Command::TradingStatus => trading::render_trading_state(client),
         Command::TradingInspect(deployment_id) => {
@@ -226,6 +236,22 @@ mod tests {
         let command =
             Command::parse(&["ployctl", "system", "audit"].map(str::to_string)).expect("command");
         assert_eq!(command, Command::SystemAudit);
+    }
+
+    #[test]
+    fn parses_system_metrics_command() {
+        let command =
+            Command::parse(&["ployctl", "system", "metrics"].map(str::to_string))
+                .expect("command");
+        assert_eq!(command, Command::SystemMetrics);
+    }
+
+    #[test]
+    fn parses_system_alerts_command() {
+        let command =
+            Command::parse(&["ployctl", "system", "alerts"].map(str::to_string))
+                .expect("command");
+        assert_eq!(command, Command::SystemAlerts);
     }
 
     #[test]

--- a/apps/ployctl/src/system.rs
+++ b/apps/ployctl/src/system.rs
@@ -1,15 +1,18 @@
 use crate::client::ControlPlaneClient;
+use ploy_operator_contracts::{AlertKind, AlertSeverity, HeartbeatState};
 
 pub fn render_system_status(client: &ControlPlaneClient) -> Result<String, String> {
     let status = client.system_snapshot()?;
     Ok(format!(
-        "status={} uptime={}s version={} db_connected={} ws_connected={} errors_1h={} last_trade_time={} live_reconcile_failures={} next_live_reconcile_at={} last_live_reconcile_error={}",
+        "status={} uptime={}s version={} db_connected={} ws_connected={} errors_1h={} active_alerts={} stale_sources={} last_trade_time={} live_reconcile_failures={} next_live_reconcile_at={} last_live_reconcile_error={} last_live_reconcile_success_at={}",
         status.status,
         status.uptime_seconds,
         status.version,
         status.database_connected,
         status.websocket_connected,
         status.error_count_1h,
+        status.active_alert_count,
+        status.stale_source_count,
         status
             .last_trade_time
             .map(|value| value.to_rfc3339())
@@ -21,6 +24,10 @@ pub fn render_system_status(client: &ControlPlaneClient) -> Result<String, Strin
             .unwrap_or_else(|| "-".to_string()),
         status
             .last_live_reconcile_error
+            .unwrap_or_else(|| "-".to_string()),
+        status
+            .last_live_reconcile_success_at
+            .map(|value| value.to_rfc3339())
             .unwrap_or_else(|| "-".to_string()),
     ))
 }
@@ -47,11 +54,96 @@ pub fn render_audit_log(client: &ControlPlaneClient) -> Result<String, String> {
         .join("\n"))
 }
 
+pub fn render_system_metrics(client: &ControlPlaneClient) -> Result<String, String> {
+    let metrics = client.system_metrics()?;
+    let heartbeat_summary = if metrics.heartbeats.is_empty() {
+        "-".to_string()
+    } else {
+        metrics
+            .heartbeats
+            .iter()
+            .map(|heartbeat| {
+                format!(
+                    "{}:{}:{}",
+                    heartbeat.source_kind,
+                    heartbeat.source_id,
+                    heartbeat_state_name(heartbeat.state)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+
+    Ok(format!(
+        "deployments_total={} deployments_live={} deployments_degraded={} active_alerts={} stale_sources={} live_reconcile_failures={} last_trade_time={} last_live_reconcile_success_at={} heartbeats={}",
+        metrics.total_deployments,
+        metrics.live_deployments,
+        metrics.degraded_deployments,
+        metrics.active_alerts,
+        metrics.stale_sources,
+        metrics.live_reconcile_failures,
+        metrics
+            .last_trade_time
+            .map(|value| value.to_rfc3339())
+            .unwrap_or_else(|| "-".to_string()),
+        metrics
+            .last_live_reconcile_success_at
+            .map(|value| value.to_rfc3339())
+            .unwrap_or_else(|| "-".to_string()),
+        heartbeat_summary,
+    ))
+}
+
+pub fn render_system_alerts(client: &ControlPlaneClient) -> Result<String, String> {
+    let alerts = client.system_alerts()?;
+    if alerts.is_empty() {
+        return Ok("none".to_string());
+    }
+
+    Ok(alerts
+        .into_iter()
+        .map(|alert| {
+            format!(
+                "{} {} {} {} {}",
+                alert.triggered_at.to_rfc3339(),
+                alert_severity_name(alert.severity),
+                alert_kind_name(alert.kind),
+                alert.source_id,
+                alert.message,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+fn heartbeat_state_name(state: HeartbeatState) -> &'static str {
+    match state {
+        HeartbeatState::Healthy => "healthy",
+        HeartbeatState::Stale => "stale",
+    }
+}
+
+fn alert_severity_name(severity: AlertSeverity) -> &'static str {
+    match severity {
+        AlertSeverity::Warning => "warning",
+        AlertSeverity::Critical => "critical",
+    }
+}
+
+fn alert_kind_name(kind: AlertKind) -> &'static str {
+    match kind {
+        AlertKind::SourceStale => "source_stale",
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{render_audit_log, render_system_status};
+    use super::{
+        render_audit_log, render_system_alerts, render_system_metrics, render_system_status,
+    };
     use crate::client::ControlPlaneClient;
     use chrono::Utc;
+    use ploy_operator_contracts::{ActiveAlert, AlertKind, AlertSeverity};
     use std::fs;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -84,7 +176,10 @@ mod tests {
                 "error_count_1h": 0,
                 "live_reconcile_failures": 0,
                 "next_live_reconcile_at": null,
-                "last_live_reconcile_error": null
+                "last_live_reconcile_error": null,
+                "active_alert_count": 1,
+                "stale_source_count": 2,
+                "last_live_reconcile_success_at": null
             })
             .to_string(),
         )
@@ -94,6 +189,8 @@ mod tests {
         let output = render_system_status(&client).expect("system status");
         assert!(output.contains("running"));
         assert!(output.contains("live_reconcile_failures=0"));
+        assert!(output.contains("active_alerts=1"));
+        assert!(output.contains("stale_sources=2"));
     }
 
     #[test]
@@ -137,5 +234,119 @@ mod tests {
         assert!(output.contains("/api/deployments/example.paper/control"));
         assert!(output.contains("deployment paused"));
         assert!(output.contains("auth=admin"));
+    }
+
+    #[test]
+    fn renders_metrics_from_http() {
+        let runtime_root = temp_dir("metrics");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).expect("read request");
+            let body = serde_json::json!({
+                "total_deployments": 3,
+                "live_deployments": 2,
+                "degraded_deployments": 1,
+                "active_alerts": 2,
+                "stale_sources": 1,
+                "live_reconcile_failures": 4,
+                "last_trade_time": null,
+                "last_live_reconcile_success_at": null,
+                "heartbeats": [{
+                    "source_id": "live_reconcile",
+                    "source_kind": "live_reconcile",
+                    "state": "stale",
+                    "last_seen_at": null,
+                    "stale_after_seconds": 15,
+                    "message": "live reconcile loop exceeded stale threshold"
+                }]
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(&runtime_root);
+        client.control_plane_addr = addr.to_string();
+
+        let output = render_system_metrics(&client).expect("metrics");
+        assert!(output.contains("deployments_total=3"));
+        assert!(output.contains("active_alerts=2"));
+        assert!(output.contains("heartbeats=live_reconcile:live_reconcile:stale"));
+    }
+
+    #[test]
+    fn renders_alerts_from_http() {
+        let runtime_root = temp_dir("alerts");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).expect("read request");
+            let body = serde_json::to_string(&vec![ActiveAlert {
+                alert_id: "source-stale:live_reconcile".to_string(),
+                kind: AlertKind::SourceStale,
+                severity: AlertSeverity::Critical,
+                source_id: "live_reconcile".to_string(),
+                message: "live reconcile loop exceeded stale threshold".to_string(),
+                triggered_at: Utc::now(),
+            }])
+            .expect("body");
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(&runtime_root);
+        client.control_plane_addr = addr.to_string();
+
+        let output = render_system_alerts(&client).expect("alerts");
+        assert!(output.contains("critical"));
+        assert!(output.contains("source_stale"));
+        assert!(output.contains("live_reconcile"));
+    }
+
+    #[test]
+    fn renders_no_alerts_message_when_alert_list_is_empty() {
+        let runtime_root = temp_dir("alerts-empty");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).expect("read request");
+            let body = "[]";
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(&runtime_root);
+        client.control_plane_addr = addr.to_string();
+
+        let output = render_system_alerts(&client).expect("alerts");
+        assert_eq!(output, "none");
     }
 }

--- a/apps/ployctl/src/trading.rs
+++ b/apps/ployctl/src/trading.rs
@@ -185,6 +185,8 @@ mod tests {
         let client = ControlPlaneClient {
             control_plane_addr: addr.to_string(),
             admin_token: None,
+            operator_token: None,
+            sidecar_token: None,
             runtime_root,
         };
         let output = cancel_order(&client, "example.live", "order-1").expect("cancel output");
@@ -229,6 +231,8 @@ mod tests {
         let client = ControlPlaneClient {
             control_plane_addr: addr.to_string(),
             admin_token: None,
+            operator_token: None,
+            sidecar_token: None,
             runtime_root,
         };
         let output = replace_order(

--- a/apps/ployd/src/config.rs
+++ b/apps/ployd/src/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 pub struct PlatformConfig {
     pub listen_addr: String,
     pub admin_token: Option<SecretString>,
+    pub operator_token: Option<SecretString>,
     pub sidecar_token: Option<SecretString>,
     pub auth_cookie_secret: SecretString,
     pub registry_file: PathBuf,
@@ -28,6 +29,7 @@ impl Default for PlatformConfig {
         Self {
             listen_addr: "127.0.0.1:8081".to_string(),
             admin_token: None,
+            operator_token: None,
             sidecar_token: None,
             auth_cookie_secret: generate_cookie_secret(),
             registry_file: PathBuf::from("data/state/deployments.json"),
@@ -61,6 +63,15 @@ impl PlatformConfig {
         } else if let Ok(value) = std::env::var("PLOY_API_ADMIN_TOKEN") {
             if !value.trim().is_empty() {
                 config.admin_token = Some(SecretString::from(value));
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_OPERATOR_TOKEN") {
+            if !value.trim().is_empty() {
+                config.operator_token = Some(SecretString::from(value));
+            }
+        } else if let Ok(value) = std::env::var("PLOY_API_OPERATOR_TOKEN") {
+            if !value.trim().is_empty() {
+                config.operator_token = Some(SecretString::from(value));
             }
         }
         if let Ok(value) = std::env::var("PLOY_SIDECAR_AUTH_TOKEN") {
@@ -167,6 +178,7 @@ mod tests {
     fn default_paths_match_workspace_contract() {
         let config = PlatformConfig::default();
         assert!(config.admin_token.is_none());
+        assert!(config.operator_token.is_none());
         assert!(config.sidecar_token.is_none());
         assert!(!config.auth_cookie_secret.expose_secret().is_empty());
         assert_eq!(

--- a/apps/ployd/src/config.rs
+++ b/apps/ployd/src/config.rs
@@ -17,6 +17,9 @@ pub struct PlatformConfig {
     pub request_rate_limit_per_minute: u32,
     pub live_reconcile_backoff_base_ms: u64,
     pub live_reconcile_backoff_max_ms: u64,
+    pub worker_heartbeat_stale_after_ms: u64,
+    pub live_reconcile_stale_after_ms: u64,
+    pub venue_stale_after_ms: u64,
 }
 
 impl Default for PlatformConfig {
@@ -37,6 +40,9 @@ impl Default for PlatformConfig {
             request_rate_limit_per_minute: 240,
             live_reconcile_backoff_base_ms: 1_000,
             live_reconcile_backoff_max_ms: 30_000,
+            worker_heartbeat_stale_after_ms: 15_000,
+            live_reconcile_stale_after_ms: 15_000,
+            venue_stale_after_ms: 15_000,
         }
     }
 }
@@ -113,6 +119,21 @@ impl PlatformConfig {
                 config.live_reconcile_backoff_max_ms = parsed;
             }
         }
+        if let Ok(value) = std::env::var("PLOY_WORKER_HEARTBEAT_STALE_AFTER_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.worker_heartbeat_stale_after_ms = parsed;
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_LIVE_RECONCILE_STALE_AFTER_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.live_reconcile_stale_after_ms = parsed;
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_VENUE_STALE_AFTER_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.venue_stale_after_ms = parsed;
+            }
+        }
 
         config
     }
@@ -173,5 +194,8 @@ mod tests {
         assert_eq!(config.request_rate_limit_per_minute, 240);
         assert_eq!(config.live_reconcile_backoff_base_ms, 1_000);
         assert_eq!(config.live_reconcile_backoff_max_ms, 30_000);
+        assert_eq!(config.worker_heartbeat_stale_after_ms, 15_000);
+        assert_eq!(config.live_reconcile_stale_after_ms, 15_000);
+        assert_eq!(config.venue_stale_after_ms, 15_000);
     }
 }

--- a/apps/ployd/src/http.rs
+++ b/apps/ployd/src/http.rs
@@ -3,9 +3,10 @@ use crate::runtime::{next_paper_intent_id, PloyDaemon};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use ploy_operator_contracts::{
-    AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
-    DeploymentSnapshotEvent, IntentPurpose, OperatorEvent, OrderReplaceRequest, PaperIntentRequest,
-    StatusUpdate, SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
+    AlertSnapshotEvent, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
+    DeploymentControlRequest, DeploymentSnapshotEvent, IntentPurpose, MetricsSnapshotEvent,
+    OperatorEvent, OrderReplaceRequest, PaperIntentRequest, StatusUpdate, SystemSnapshotEvent,
+    SystemStatus, TradingSnapshotEvent,
 };
 use ploy_trading::{TradeSide, TradingIntent};
 use secrecy::{ExposeSecret, SecretString};
@@ -515,6 +516,8 @@ fn required_access(method: &str, path: &str) -> RequiredAccess {
         | ("POST", "/auth/login")
         | ("POST", "/auth/logout") => RequiredAccess::Public,
         ("GET", "/api/system/status")
+        | ("GET", "/api/system/metrics")
+        | ("GET", "/api/system/alerts")
         | ("GET", "/api/deployments")
         | ("GET", "/api/trading/state")
         | ("GET", "/api/events/stream") => RequiredAccess::ReadOnly,
@@ -862,6 +865,21 @@ fn handle_runtime_request(
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
+        ("GET", "/api/system/metrics") => match state.daemon.lock() {
+            Ok(daemon) => (
+                200,
+                serde_json::to_string(&daemon.platform_metrics())
+                    .unwrap_or_else(|_| "{}".to_string()),
+            ),
+            Err(_) => json_error(503, "daemon_lock_poisoned", None),
+        },
+        ("GET", "/api/system/alerts") => match state.daemon.lock() {
+            Ok(daemon) => (
+                200,
+                serde_json::to_string(&daemon.active_alerts()).unwrap_or_else(|_| "[]".to_string()),
+            ),
+            Err(_) => json_error(503, "daemon_lock_poisoned", None),
+        },
         ("GET", "/api/deployments") => match state.daemon.lock() {
             Ok(daemon) => (
                 200,
@@ -1137,6 +1155,12 @@ pub fn snapshot_events(daemon: &PloyDaemon) -> Vec<OperatorEvent> {
         OperatorEvent::TradingSnapshot(TradingSnapshotEvent {
             trading: daemon.trading_state(),
         }),
+        OperatorEvent::MetricsSnapshot(MetricsSnapshotEvent {
+            metrics: daemon.platform_metrics(),
+        }),
+        OperatorEvent::AlertSnapshot(AlertSnapshotEvent {
+            alerts: daemon.active_alerts(),
+        }),
     ]
 }
 
@@ -1187,7 +1211,7 @@ mod tests {
         ADMIN_SESSION_COOKIE_NAME,
     };
     use crate::events::EventBroker;
-    use chrono::Utc;
+    use chrono::{Duration, Utc};
     use ploy_connectivity::{CancellationOutcome, ReplaceOutcome, StaticExecutionGateway};
     use ploy_operator_contracts::AuditLogEntry;
     use ploy_operator_contracts::{OrderReplaceRequest, PaperIntentRequest};
@@ -1643,6 +1667,86 @@ mod tests {
     }
 
     #[test]
+    fn handle_runtime_request_serves_metrics_and_alert_snapshots() {
+        let root = temp_dir("metrics-alerts");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(runtime_root.clone()).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([
+                {
+                    "deployment_id": "example.live",
+                    "bundle_id": "example",
+                    "runtime_mode": "live",
+                    "desired_state": "running",
+                    "observed_state": "running"
+                }
+            ])
+            .to_string(),
+        )
+        .expect("registry");
+
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+
+        let mut daemon = crate::runtime::PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(StaticExecutionGateway::acknowledged("unused")),
+        )
+        .expect("boot daemon");
+        daemon.control_plane.system.note_source_failure(
+            "live_reconcile",
+            "live_reconcile",
+            Duration::seconds(15),
+            "live reconcile loop exceeded stale threshold".to_string(),
+        );
+        daemon.control_plane.system.note_source_failure(
+            "venue:polymarket",
+            "venue",
+            Duration::seconds(15),
+            "venue heartbeat exceeded stale threshold".to_string(),
+        );
+        daemon.control_plane.system.refresh_source_health();
+
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let (metrics_code, metrics_body) =
+            handle_runtime_request("GET", "/api/system/metrics", None, &state);
+        assert_eq!(metrics_code, 200);
+        let metrics: ploy_operator_contracts::PlatformMetrics =
+            serde_json::from_str(&metrics_body).expect("metrics json");
+        assert!(metrics.active_alerts >= 1);
+        assert!(metrics.stale_sources >= 1);
+
+        let (alerts_code, alerts_body) =
+            handle_runtime_request("GET", "/api/system/alerts", None, &state);
+        assert_eq!(alerts_code, 200);
+        let alerts: Vec<ploy_operator_contracts::ActiveAlert> =
+            serde_json::from_str(&alerts_body).expect("alerts json");
+        assert!(
+            alerts
+                .iter()
+                .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale)
+        );
+        assert!(
+            alerts
+                .iter()
+                .any(|alert| alert.source_id.contains("live_reconcile"))
+        );
+    }
+
+    #[test]
     fn snapshot_events_include_control_plane_and_trading_payloads() {
         let daemon = crate::runtime::PloyDaemon::boot(&crate::config::PlatformConfig::default())
             .expect("boot daemon");
@@ -1658,6 +1762,14 @@ mod tests {
         assert!(events.iter().any(|event| matches!(
             event,
             ploy_operator_contracts::OperatorEvent::TradingSnapshot(_)
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ploy_operator_contracts::OperatorEvent::MetricsSnapshot(_)
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ploy_operator_contracts::OperatorEvent::AlertSnapshot(_)
         )));
     }
 

--- a/apps/ployd/src/http.rs
+++ b/apps/ployd/src/http.rs
@@ -40,6 +40,7 @@ static REQUEST_RATE_LIMITER: OnceLock<Mutex<RateLimiter>> = OnceLock::new();
 enum AuthLevel {
     None,
     Sidecar,
+    Operator,
     Admin,
 }
 
@@ -47,6 +48,7 @@ enum AuthLevel {
 enum RequiredAccess {
     Public,
     ReadOnly,
+    Operator,
     Admin,
 }
 
@@ -304,13 +306,17 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
     let method = request_line.next().unwrap_or("GET");
     let path = request_line.next().unwrap_or("/");
     let client_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
-    let (configured_token, sidecar_token, cookie_secret) = match configured_auth(state) {
+    let (configured_token, operator_token, sidecar_token, cookie_secret) = match configured_auth(state) {
         Ok(auth) => auth,
         Err(response) => return write_json_response(stream, response),
     };
     let auth_level = request_auth_level(
         &request,
         configured_token
+            .as_ref()
+            .map(ExposeSecret::expose_secret)
+            .map(|token| token.as_str()),
+        operator_token
             .as_ref()
             .map(ExposeSecret::expose_secret)
             .map(|token| token.as_str()),
@@ -342,11 +348,13 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
             auth_level,
             required_access,
             configured_token.is_some(),
+            operator_token.is_some(),
             sidecar_token.is_some(),
         ) {
             let response = auth_error_response(
                 required_access,
                 configured_token.is_some(),
+                operator_token.is_some(),
                 sidecar_token.is_some(),
             );
             audit_request(
@@ -385,6 +393,7 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
         body,
         auth_level,
         configured_token.is_some(),
+        operator_token.is_some(),
         sidecar_token.is_some(),
         state,
     );
@@ -444,13 +453,22 @@ fn write_json_response_with_headers(
 
 fn configured_auth(
     state: &Arc<AppState>,
-) -> Result<(Option<SecretString>, Option<SecretString>, SecretString), (u16, String)> {
+) -> Result<
+    (
+        Option<SecretString>,
+        Option<SecretString>,
+        Option<SecretString>,
+        SecretString,
+    ),
+    (u16, String),
+> {
     state
         .daemon
         .lock()
         .map(|daemon| {
             (
                 daemon.config.admin_token.clone(),
+                daemon.config.operator_token.clone(),
                 daemon.config.sidecar_token.clone(),
                 daemon.config.auth_cookie_secret.clone(),
             )
@@ -525,7 +543,7 @@ fn required_access(method: &str, path: &str) -> RequiredAccess {
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             RequiredAccess::ReadOnly
         }
-        _ => RequiredAccess::Admin,
+        _ => RequiredAccess::Operator,
     }
 }
 
@@ -533,6 +551,7 @@ fn auth_level_name(auth_level: AuthLevel) -> &'static str {
     match auth_level {
         AuthLevel::None => "none",
         AuthLevel::Sidecar => "sidecar",
+        AuthLevel::Operator => "operator",
         AuthLevel::Admin => "admin",
     }
 }
@@ -541,6 +560,7 @@ fn required_access_name(required_access: RequiredAccess) -> &'static str {
     match required_access {
         RequiredAccess::Public => "public",
         RequiredAccess::ReadOnly => "read_only",
+        RequiredAccess::Operator => "operator",
         RequiredAccess::Admin => "admin",
     }
 }
@@ -647,6 +667,7 @@ fn extract_cookie<'a>(request: &'a str, name: &str) -> Option<&'a str> {
 fn request_auth_level(
     request: &str,
     admin_token: Option<&str>,
+    operator_token: Option<&str>,
     sidecar_token: Option<&str>,
     cookie_secret: &str,
 ) -> AuthLevel {
@@ -674,6 +695,15 @@ fn request_auth_level(
         }
     }
 
+    if let Some(expected_token) = operator_token {
+        if extract_header(request, "x-ploy-operator-token")
+            .map(|token| token == expected_token)
+            .unwrap_or(false)
+        {
+            return AuthLevel::Operator;
+        }
+    }
+
     if let Some(expected_token) = sidecar_token {
         if extract_header(request, "x-ploy-sidecar-token")
             .map(|token| token == expected_token)
@@ -690,15 +720,20 @@ fn access_allowed(
     auth_level: AuthLevel,
     required_access: RequiredAccess,
     admin_configured: bool,
+    operator_configured: bool,
     sidecar_configured: bool,
 ) -> bool {
-    if !admin_configured && !sidecar_configured {
+    if !admin_configured && !operator_configured && !sidecar_configured {
         return true;
     }
 
     match required_access {
         RequiredAccess::Public => true,
-        RequiredAccess::ReadOnly => matches!(auth_level, AuthLevel::Admin | AuthLevel::Sidecar),
+        RequiredAccess::ReadOnly => matches!(
+            auth_level,
+            AuthLevel::Admin | AuthLevel::Operator | AuthLevel::Sidecar
+        ),
+        RequiredAccess::Operator => matches!(auth_level, AuthLevel::Admin | AuthLevel::Operator),
         RequiredAccess::Admin => auth_level == AuthLevel::Admin,
     }
 }
@@ -706,14 +741,21 @@ fn access_allowed(
 fn auth_error_response(
     required_access: RequiredAccess,
     admin_configured: bool,
+    operator_configured: bool,
     sidecar_configured: bool,
 ) -> (u16, String) {
     let message = match required_access {
         RequiredAccess::Public => return (200, "{}".to_string()),
-        RequiredAccess::ReadOnly if sidecar_configured && !admin_configured => {
-            "control-plane sidecar or admin token is required".to_string()
+        RequiredAccess::ReadOnly if sidecar_configured && !operator_configured && !admin_configured => {
+            "control-plane sidecar, operator, or admin token is required".to_string()
         }
-        RequiredAccess::ReadOnly => "control-plane admin or sidecar token is required".to_string(),
+        RequiredAccess::ReadOnly => {
+            "control-plane admin, operator, or sidecar token is required".to_string()
+        }
+        RequiredAccess::Operator if admin_configured || operator_configured => {
+            "control-plane operator or admin token is required".to_string()
+        }
+        RequiredAccess::Operator => "control-plane operator token is required".to_string(),
         RequiredAccess::Admin => "control-plane admin token is required".to_string(),
     };
     json_error(401, "unauthorized", Some(message))
@@ -784,6 +826,7 @@ fn handle_authenticated_runtime_request(
     body: Option<&str>,
     auth_level: AuthLevel,
     admin_configured: bool,
+    operator_configured: bool,
     sidecar_configured: bool,
     state: &Arc<AppState>,
 ) -> (u16, String) {
@@ -793,7 +836,8 @@ fn handle_authenticated_runtime_request(
             200,
             serde_json::json!({
                 "authenticated": auth_level == AuthLevel::Admin,
-                "auth_required": admin_configured || sidecar_configured,
+                "auth_required": admin_configured || operator_configured || sidecar_configured,
+                "operator_authenticated": auth_level == AuthLevel::Operator,
                 "sidecar_authenticated": auth_level == AuthLevel::Sidecar,
             })
             .to_string(),
@@ -841,10 +885,16 @@ fn handle_authenticated_runtime_request(
             auth_level,
             required_access,
             admin_configured,
+            operator_configured,
             sidecar_configured,
         ) =>
         {
-            auth_error_response(required_access, admin_configured, sidecar_configured)
+            auth_error_response(
+                required_access,
+                admin_configured,
+                operator_configured,
+                sidecar_configured,
+            )
         }
         _ => handle_runtime_request(method, path, body, state),
     }
@@ -1348,6 +1398,7 @@ mod tests {
             AuthLevel::None,
             true,
             false,
+            false,
             &state,
         );
 
@@ -1379,6 +1430,7 @@ mod tests {
             AuthLevel::None,
             true,
             false,
+            false,
             &state,
         );
 
@@ -1409,6 +1461,7 @@ mod tests {
             AuthLevel::None,
             true,
             false,
+            false,
             &state,
         );
 
@@ -1423,7 +1476,7 @@ mod tests {
             "GET /api/events/stream HTTP/1.1\r\nHost: 127.0.0.1:8081\r\nCookie: {cookie}; theme=dark\r\n\r\n"
         );
         assert_eq!(
-            request_auth_level(&request, Some("secret-token"), None, "cookie-secret"),
+            request_auth_level(&request, Some("secret-token"), None, None, "cookie-secret"),
             AuthLevel::Admin
         );
     }
@@ -1462,7 +1515,7 @@ mod tests {
         let cookie = admin_session_cookie("secret-token", "cookie-secret");
         let request = format!("GET / HTTP/1.1\r\nCookie: {cookie}\r\n\r\n");
         assert_eq!(
-            request_auth_level(&request, Some("other-token"), None, "cookie-secret"),
+            request_auth_level(&request, Some("other-token"), None, None, "cookie-secret"),
             AuthLevel::None
         );
     }
@@ -1475,6 +1528,7 @@ mod tests {
             request_auth_level(
                 request,
                 Some("admin-secret"),
+                None,
                 Some("sidecar-secret"),
                 "cookie-secret"
             ),
@@ -1502,6 +1556,7 @@ mod tests {
             None,
             AuthLevel::Sidecar,
             true,
+            false,
             true,
             &state,
         );
@@ -1513,11 +1568,70 @@ mod tests {
             Some("{\"desired_state\":\"paused\",\"deployment_state\":null}"),
             AuthLevel::Sidecar,
             true,
+            false,
             true,
             &state,
         );
         assert_eq!(write_code, 401);
         assert!(write_body.contains("\"error\":\"unauthorized\""));
+    }
+
+    #[test]
+    fn operator_token_grants_write_access_but_not_admin_access() {
+        let request =
+            "POST /api/deployments/example.paper/control HTTP/1.1\r\nx-ploy-operator-token: operator-secret\r\n\r\n";
+        assert_eq!(
+            request_auth_level(
+                request,
+                Some("admin-secret"),
+                Some("operator-secret"),
+                Some("sidecar-secret"),
+                "cookie-secret"
+            ),
+            AuthLevel::Operator
+        );
+
+        let config = crate::config::PlatformConfig {
+            admin_token: Some("admin-secret".to_string().into()),
+            operator_token: Some("operator-secret".to_string().into()),
+            sidecar_token: Some("sidecar-secret".to_string().into()),
+            ..crate::config::PlatformConfig::default()
+        };
+        let daemon = crate::runtime::PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(StaticExecutionGateway::acknowledged("unused")),
+        )
+        .expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let (write_code, write_body) = handle_authenticated_runtime_request(
+            "POST",
+            "/api/deployments/example.paper/control",
+            Some("{\"desired_state\":\"paused\",\"deployment_state\":null}"),
+            AuthLevel::Operator,
+            true,
+            true,
+            true,
+            &state,
+        );
+        assert_eq!(write_code, 404);
+        assert!(write_body.contains("deployment_not_found"));
+
+        let (audit_code, audit_body) = handle_authenticated_runtime_request(
+            "GET",
+            "/api/audit/logs",
+            None,
+            AuthLevel::Operator,
+            true,
+            true,
+            true,
+            &state,
+        );
+        assert_eq!(audit_code, 401);
+        assert!(audit_body.contains("\"error\":\"unauthorized\""));
     }
 
     #[test]

--- a/apps/ployd/src/runtime.rs
+++ b/apps/ployd/src/runtime.rs
@@ -1,17 +1,17 @@
 use crate::config::PlatformConfig;
 use crate::events::EventBroker;
 use crate::http::publish_snapshot_events;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ploy_connectivity::{
     CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome, ExecutionRequest,
     LiveExecutionGateway, PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, TrackedOrder,
 };
 use ploy_deployments::{WorkerLaunchSpec, WorkerSupervisor};
 use ploy_operator_contracts::{
-    DeploymentApplyRequest, DeploymentControlRequest, DeploymentState, DesiredState, FillSnapshot,
-    IntentPurpose, ObservedState, OrderControlResponse, OrderReplaceRequest, OrderSnapshot,
-    PaperIntentResponse, PnlSnapshotResponse, PositionSnapshotResponse, RiskSnapshotResponse,
-    TradingIntentSnapshot, TradingStateSnapshot,
+    ActiveAlert, DeploymentApplyRequest, DeploymentControlRequest, DeploymentState, DesiredState,
+    FillSnapshot, IntentPurpose, ObservedState, OrderControlResponse, OrderReplaceRequest,
+    OrderSnapshot, PaperIntentResponse, PlatformMetrics, PnlSnapshotResponse,
+    PositionSnapshotResponse, RiskSnapshotResponse, TradingIntentSnapshot, TradingStateSnapshot,
 };
 use ploy_platform::{ControlPlane, DeploymentRecord};
 use ploy_trading::{OrderState, TradeSide, TradingIntent, TradingRuntime, TradingRuntimeSnapshot};
@@ -100,6 +100,7 @@ impl PloyDaemon {
             Ok(ReconcileStatus::BackoffActive) => {}
             Err(err) => self.mark_live_runtime_degraded(err),
         }
+        self.refresh_source_health();
         if let Err(err) = self.persist_registry() {
             self.control_plane.system.set_database_connected(false);
             self.control_plane
@@ -128,6 +129,23 @@ impl PloyDaemon {
 
     pub fn inspect_deployment(&self, deployment_id: &str) -> Option<DeploymentRecord> {
         self.control_plane.deployments.get(deployment_id).cloned()
+    }
+
+    pub fn platform_metrics(&self) -> PlatformMetrics {
+        let records = self.control_plane.deployments.records();
+        let total_deployments = records.len();
+        let live_deployments = records.iter().filter(|record| record.runtime_mode == "live").count();
+        let degraded_deployments = records
+            .iter()
+            .filter(|record| record.observed_state == ObservedState::Degraded)
+            .count();
+        self.control_plane
+            .system
+            .metrics(total_deployments, live_deployments, degraded_deployments)
+    }
+
+    pub fn active_alerts(&self) -> Vec<ActiveAlert> {
+        self.control_plane.system.active_alerts()
     }
 
     pub fn trading_state(&self) -> Vec<TradingStateSnapshot> {
@@ -633,6 +651,16 @@ impl PloyDaemon {
 
     fn mark_runtime_healthy(&mut self) {
         self.control_plane.system.note_live_reconcile_healthy();
+        self.control_plane.system.note_source_heartbeat(
+            "live_reconcile",
+            "live_reconcile",
+            ChronoDuration::milliseconds(self.config.live_reconcile_stale_after_ms as i64),
+        );
+        self.control_plane.system.note_source_heartbeat(
+            "venue:polymarket",
+            "venue",
+            ChronoDuration::milliseconds(self.config.venue_stale_after_ms as i64),
+        );
         self.control_plane
             .system
             .note_trade(self.latest_trade_time());
@@ -672,6 +700,18 @@ impl PloyDaemon {
         self.control_plane
             .system
             .mark_degraded(&self.config.listen_addr);
+        self.control_plane.system.note_source_failure(
+            "live_reconcile",
+            "live_reconcile",
+            ChronoDuration::milliseconds(self.config.live_reconcile_stale_after_ms as i64),
+            err.to_string(),
+        );
+        self.control_plane.system.note_source_failure(
+            "venue:polymarket",
+            "venue",
+            ChronoDuration::milliseconds(self.config.venue_stale_after_ms as i64),
+            err.to_string(),
+        );
         self.record_live_reconcile_failure(&err);
 
         for record in self.control_plane.deployments.records() {
@@ -896,9 +936,17 @@ impl PloyDaemon {
                         self.control_plane
                             .deployments
                             .set_observed_state(&record.deployment_id, status.observed_state);
+                        self.control_plane.system.note_source_heartbeat(
+                            format!("worker:{}", record.deployment_id),
+                            "worker",
+                            ChronoDuration::milliseconds(self.config.worker_heartbeat_stale_after_ms as i64),
+                        );
                     }
                 }
                 DesiredState::Paused => {
+                    self.control_plane
+                        .system
+                        .clear_source(&format!("worker:{}", record.deployment_id));
                     if let Some(status) = self.supervisor.pause(&record.deployment_id) {
                         self.control_plane
                             .deployments
@@ -910,6 +958,9 @@ impl PloyDaemon {
                     }
                 }
                 DesiredState::Stopped => {
+                    self.control_plane
+                        .system
+                        .clear_source(&format!("worker:{}", record.deployment_id));
                     if let Some(status) = self.supervisor.stop(&record.deployment_id) {
                         self.control_plane
                             .deployments
@@ -920,6 +971,53 @@ impl PloyDaemon {
                             .set_observed_state(&record.deployment_id, ObservedState::Stopped);
                     }
                 }
+            }
+        }
+    }
+
+    fn refresh_source_health(&mut self) {
+        let stale_sources = self.control_plane.system.refresh_source_health();
+        let records = self.control_plane.deployments.records();
+
+        for record in records {
+            if record.desired_state != DesiredState::Running {
+                continue;
+            }
+            let worker_stale = self
+                .control_plane
+                .system
+                .source_is_stale(&format!("worker:{}", record.deployment_id));
+            let live_source_stale = record.runtime_mode == "live"
+                && (self.control_plane.system.source_is_stale("live_reconcile")
+                    || self.control_plane.system.source_is_stale("venue:polymarket"));
+
+            if worker_stale || live_source_stale {
+                self.control_plane
+                    .deployments
+                    .set_observed_state(&record.deployment_id, ObservedState::Degraded);
+            }
+        }
+
+        if stale_sources > 0 {
+            self.control_plane
+                .system
+                .mark_degraded(&self.config.listen_addr);
+            return;
+        }
+
+        if self.control_plane.system.is_degraded() {
+            self.control_plane
+                .system
+                .mark_recovering(&self.config.listen_addr);
+        }
+
+        for record in self.control_plane.deployments.records() {
+            if record.desired_state == DesiredState::Running
+                && record.observed_state == ObservedState::Degraded
+            {
+                self.control_plane
+                    .deployments
+                    .set_observed_state(&record.deployment_id, ObservedState::Running);
             }
         }
     }
@@ -2448,5 +2546,79 @@ mod tests {
             daemon.reconcile_live_fills().expect("backoff reconcile"),
             ReconcileStatus::BackoffActive
         );
+    }
+
+    #[test]
+    fn daemon_surfaces_live_source_failures_in_metrics_and_alerts() {
+        let root = temp_dir("live-source-alerts");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([
+                {
+                    "deployment_id": "example.live",
+                    "bundle_id": "example",
+                    "runtime_mode": "live",
+                    "desired_state": "running",
+                    "observed_state": "starting"
+                }
+            ])
+            .to_string(),
+        )
+        .expect("write registry");
+
+        let config = PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            tick_interval_ms: 5,
+            live_reconcile_backoff_base_ms: 0,
+            live_reconcile_backoff_max_ms: 0,
+            ..PlatformConfig::default()
+        };
+
+        let mut daemon = PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(FlakyReconcileGateway::default()),
+        )
+        .expect("boot");
+        daemon
+            .submit_intent(TradingIntent {
+                intent_id: "intent-live-metrics".to_string(),
+                deployment_id: "example.live".to_string(),
+                market_id: "market-1".to_string(),
+                token_id: "yes-token".to_string(),
+                side: TradeSide::Buy,
+                quantity: dec!(1),
+                limit_price: Some(dec!(0.41)),
+                purpose: IntentPurpose::Entry,
+                created_at: chrono::Utc::now(),
+            })
+            .expect("submit live intent");
+
+        daemon.write_runtime_snapshots().expect("degraded snapshot");
+
+        let metrics = daemon.platform_metrics();
+        assert_eq!(metrics.stale_sources, 2);
+        assert_eq!(metrics.active_alerts, 2);
+        assert_eq!(metrics.live_reconcile_failures, 1);
+        assert!(metrics
+            .heartbeats
+            .iter()
+            .any(|status| status.source_id == "live_reconcile"));
+        assert!(metrics
+            .heartbeats
+            .iter()
+            .any(|status| status.source_id == "venue:polymarket"));
+
+        let alerts = daemon.active_alerts();
+        assert_eq!(alerts.len(), 2);
+        assert!(alerts.iter().any(|alert| alert.source_id == "live_reconcile"));
+        assert!(alerts.iter().any(|alert| alert.source_id == "venue:polymarket"));
+        assert!(daemon.control_plane.system.status().status.starts_with("degraded@"));
     }
 }

--- a/apps/ploytui/src/lib.rs
+++ b/apps/ploytui/src/lib.rs
@@ -89,6 +89,13 @@ pub fn render_event_line(event: &OperatorEvent) -> String {
         OperatorEvent::TradingSnapshot(event) => {
             format!("trading_snapshot count={}", event.trading.len())
         }
+        OperatorEvent::MetricsSnapshot(event) => format!(
+            "metrics_snapshot alerts={} stale_sources={}",
+            event.metrics.active_alerts, event.metrics.stale_sources
+        ),
+        OperatorEvent::AlertSnapshot(event) => {
+            format!("alert_snapshot count={}", event.alerts.len())
+        }
         OperatorEvent::Status(event) => format!("status {}", event.status),
         OperatorEvent::Log(event) => format!("log {} {}", event.level, event.message),
         OperatorEvent::Trade(event) => format!(
@@ -134,6 +141,9 @@ mod tests {
                 live_reconcile_failures: 0,
                 next_live_reconcile_at: None,
                 last_live_reconcile_error: None,
+                active_alert_count: 0,
+                stale_source_count: 0,
+                last_live_reconcile_success_at: None,
             },
             deployments: vec![DeploymentSummary {
                 deployment_id: "example.paper".to_string(),
@@ -162,6 +172,9 @@ mod tests {
                         live_reconcile_failures: 0,
                         next_live_reconcile_at: None,
                         last_live_reconcile_error: None,
+                        active_alert_count: 0,
+                        stale_source_count: 0,
+                        last_live_reconcile_success_at: None,
                     },
                 }),
                 OperatorEvent::DeploymentSnapshot(DeploymentSnapshotEvent {
@@ -213,6 +226,9 @@ mod tests {
                 live_reconcile_failures: 0,
                 next_live_reconcile_at: None,
                 last_live_reconcile_error: None,
+                active_alert_count: 0,
+                stale_source_count: 0,
+                last_live_reconcile_success_at: None,
             },
         }));
 

--- a/apps/ploytui/src/lib.rs
+++ b/apps/ploytui/src/lib.rs
@@ -1,11 +1,14 @@
 use ploy_operator_contracts::{
-    DeploymentSummary, OperatorEvent, SystemStatus, TradingStateSnapshot,
+    ActiveAlert, DeploymentSummary, OperatorEvent, PlatformMetrics, SystemStatus,
+    TradingStateSnapshot,
 };
 use std::fmt::Write;
 
 #[derive(Debug, Clone)]
 pub struct DashboardSnapshot {
     pub system: SystemStatus,
+    pub metrics: PlatformMetrics,
+    pub alerts: Vec<ActiveAlert>,
     pub deployments: Vec<DeploymentSummary>,
     pub trading: Vec<TradingStateSnapshot>,
     pub recent_events: Vec<OperatorEvent>,
@@ -20,12 +23,65 @@ pub fn render_dashboard(snapshot: &DashboardSnapshot) -> String {
     let _ = writeln!(out, "System");
     let _ = writeln!(
         out,
-        "status={} uptime={}s version={} errors_1h={}",
+        "status={} uptime={}s version={} errors_1h={} active_alerts={} stale_sources={}",
         snapshot.system.status,
         snapshot.system.uptime_seconds,
         snapshot.system.version,
-        snapshot.system.error_count_1h
+        snapshot.system.error_count_1h,
+        snapshot.system.active_alert_count,
+        snapshot.system.stale_source_count,
     );
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "Metrics");
+    let _ = writeln!(
+        out,
+        "deployments_total={} live={} degraded={} live_reconcile_failures={} last_live_reconcile_success_at={}",
+        snapshot.metrics.total_deployments,
+        snapshot.metrics.live_deployments,
+        snapshot.metrics.degraded_deployments,
+        snapshot.metrics.live_reconcile_failures,
+        snapshot
+            .metrics
+            .last_live_reconcile_success_at
+            .map(|value| value.to_rfc3339())
+            .unwrap_or_else(|| "-".to_string())
+    );
+    if snapshot.metrics.heartbeats.is_empty() {
+        let _ = writeln!(out, "  heartbeats=none");
+    } else {
+        for heartbeat in &snapshot.metrics.heartbeats {
+            let _ = writeln!(
+                out,
+                "  {} {} state={} last_seen={} message={}",
+                heartbeat.source_kind,
+                heartbeat.source_id,
+                format!("{:?}", heartbeat.state).to_lowercase(),
+                heartbeat
+                    .last_seen_at
+                    .map(|value| value.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+                heartbeat.message.clone().unwrap_or_else(|| "-".to_string())
+            );
+        }
+    }
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "Active Alerts");
+    if snapshot.alerts.is_empty() {
+        let _ = writeln!(out, "  none");
+    } else {
+        for alert in &snapshot.alerts {
+            let _ = writeln!(
+                out,
+                "  {} {} {} {}",
+                alert.triggered_at.to_rfc3339(),
+                format!("{:?}", alert.severity).to_lowercase(),
+                alert.source_id,
+                alert.message
+            );
+        }
+    }
     let _ = writeln!(out);
 
     let _ = writeln!(out, "Deployments");
@@ -122,8 +178,9 @@ mod tests {
     use super::{render_dashboard, render_event_line, DashboardSnapshot};
     use chrono::Utc;
     use ploy_operator_contracts::{
-        DeploymentSnapshotEvent, DeploymentState, DeploymentSummary, DesiredState, ObservedState,
-        OperatorEvent, SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
+        ActiveAlert, AlertKind, AlertSeverity, DeploymentSnapshotEvent, DeploymentState,
+        DeploymentSummary, DesiredState, HeartbeatState, HeartbeatStatus, ObservedState,
+        OperatorEvent, PlatformMetrics, SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
         TradingStateSnapshot,
     };
 
@@ -145,6 +202,32 @@ mod tests {
                 stale_source_count: 0,
                 last_live_reconcile_success_at: None,
             },
+            metrics: PlatformMetrics {
+                total_deployments: 1,
+                live_deployments: 0,
+                degraded_deployments: 0,
+                active_alerts: 1,
+                stale_sources: 1,
+                live_reconcile_failures: 0,
+                last_trade_time: None,
+                last_live_reconcile_success_at: None,
+                heartbeats: vec![HeartbeatStatus {
+                    source_id: "worker:example.paper".to_string(),
+                    source_kind: "worker".to_string(),
+                    state: HeartbeatState::Healthy,
+                    last_seen_at: Some(Utc::now()),
+                    stale_after_seconds: 15,
+                    message: None,
+                }],
+            },
+            alerts: vec![ActiveAlert {
+                alert_id: "source-stale:live_reconcile".to_string(),
+                kind: AlertKind::SourceStale,
+                severity: AlertSeverity::Critical,
+                source_id: "live_reconcile".to_string(),
+                message: "live reconcile loop exceeded stale threshold".to_string(),
+                triggered_at: Utc::now(),
+            }],
             deployments: vec![DeploymentSummary {
                 deployment_id: "example.paper".to_string(),
                 account_id: "acct-paper".to_string(),
@@ -206,6 +289,8 @@ mod tests {
         assert!(output.contains("System"));
         assert!(output.contains("Deployments"));
         assert!(output.contains("Trading"));
+        assert!(output.contains("Metrics"));
+        assert!(output.contains("Active Alerts"));
         assert!(output.contains("Recent Events"));
         assert!(output.contains("example.paper"));
         assert!(output.contains("running"));

--- a/apps/ploytui/src/main.rs
+++ b/apps/ploytui/src/main.rs
@@ -22,6 +22,9 @@ fn build_snapshot(client: &ControlPlaneClient) -> DashboardSnapshot {
                 live_reconcile_failures: 0,
                 next_live_reconcile_at: None,
                 last_live_reconcile_error: None,
+                active_alert_count: 0,
+                stale_source_count: 0,
+                last_live_reconcile_success_at: None,
             }
         }),
         deployments: client.list_deployments(),

--- a/apps/ploytui/src/main.rs
+++ b/apps/ploytui/src/main.rs
@@ -8,26 +8,45 @@ fn parse_watch_flag(args: &[String]) -> bool {
 }
 
 fn build_snapshot(client: &ControlPlaneClient) -> DashboardSnapshot {
+    let system = client.system_snapshot().unwrap_or_else(|_| {
+        ploy_operator_contracts::SystemStatus {
+            status: "unavailable".to_string(),
+            uptime_seconds: 0,
+            version: "unknown".to_string(),
+            strategy: "platform".to_string(),
+            last_trade_time: None,
+            websocket_connected: false,
+            database_connected: false,
+            error_count_1h: 0,
+            live_reconcile_failures: 0,
+            next_live_reconcile_at: None,
+            last_live_reconcile_error: None,
+            active_alert_count: 0,
+            stale_source_count: 0,
+            last_live_reconcile_success_at: None,
+        }
+    });
+    let deployments = client.list_deployments();
     DashboardSnapshot {
-        system: client.system_snapshot().unwrap_or_else(|_| {
-            ploy_operator_contracts::SystemStatus {
-                status: "unavailable".to_string(),
-                uptime_seconds: 0,
-                version: "unknown".to_string(),
-                strategy: "platform".to_string(),
-                last_trade_time: None,
-                websocket_connected: false,
-                database_connected: false,
-                error_count_1h: 0,
-                live_reconcile_failures: 0,
-                next_live_reconcile_at: None,
-                last_live_reconcile_error: None,
-                active_alert_count: 0,
-                stale_source_count: 0,
-                last_live_reconcile_success_at: None,
-            }
+        metrics: client.system_metrics().unwrap_or_else(|_| ploy_operator_contracts::PlatformMetrics {
+            total_deployments: deployments.len(),
+            live_deployments: 0,
+            degraded_deployments: deployments
+                .iter()
+                .filter(|deployment| {
+                    deployment.observed_state == ploy_operator_contracts::ObservedState::Degraded
+                })
+                .count(),
+            active_alerts: system.active_alert_count,
+            stale_sources: system.stale_source_count,
+            live_reconcile_failures: system.live_reconcile_failures,
+            last_trade_time: system.last_trade_time,
+            last_live_reconcile_success_at: system.last_live_reconcile_success_at,
+            heartbeats: Vec::new(),
         }),
-        deployments: client.list_deployments(),
+        alerts: client.system_alerts().unwrap_or_default(),
+        system,
+        deployments,
         trading: client.trading_state().unwrap_or_default(),
         recent_events: client.recent_events(6).unwrap_or_default(),
     }

--- a/crates/ploy-operator-contracts/src/events.rs
+++ b/crates/ploy-operator-contracts/src/events.rs
@@ -1,5 +1,5 @@
 use crate::deployments::DeploymentSummary;
-use crate::system::SystemStatus;
+use crate::system::{ActiveAlert, PlatformMetrics, SystemStatus};
 use crate::trading::{MarketData, PositionResponse, TradeResponse, TradingStateSnapshot};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -33,6 +33,16 @@ pub struct TradingSnapshotEvent {
     pub trading: Vec<TradingStateSnapshot>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricsSnapshotEvent {
+    pub metrics: PlatformMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AlertSnapshotEvent {
+    pub alerts: Vec<ActiveAlert>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum OperatorEvent {
@@ -52,6 +62,10 @@ pub enum OperatorEvent {
     DeploymentSnapshot(DeploymentSnapshotEvent),
     #[serde(rename = "trading_snapshot")]
     TradingSnapshot(TradingSnapshotEvent),
+    #[serde(rename = "metrics_snapshot")]
+    MetricsSnapshot(MetricsSnapshotEvent),
+    #[serde(rename = "alert_snapshot")]
+    AlertSnapshot(AlertSnapshotEvent),
 }
 
 pub type WsMessage = OperatorEvent;
@@ -59,13 +73,15 @@ pub type WsMessage = OperatorEvent;
 #[cfg(test)]
 mod tests {
     use super::{
-        DeploymentSnapshotEvent, OperatorEvent, StatusUpdate, SystemSnapshotEvent,
-        TradingSnapshotEvent,
+        AlertSnapshotEvent, DeploymentSnapshotEvent, MetricsSnapshotEvent, OperatorEvent,
+        StatusUpdate, SystemSnapshotEvent, TradingSnapshotEvent,
     };
     use crate::{
-        DeploymentState, DeploymentSummary, DesiredState, ObservedState, SystemStatus,
+        ActiveAlert, AlertKind, AlertSeverity, DeploymentState, DeploymentSummary, DesiredState,
+        HeartbeatState, HeartbeatStatus, ObservedState, PlatformMetrics, SystemStatus,
         TradingStateSnapshot,
     };
+    use chrono::Utc;
     use rust_decimal::Decimal;
     use serde_json::json;
 
@@ -135,6 +151,9 @@ mod tests {
                 live_reconcile_failures: 0,
                 next_live_reconcile_at: None,
                 last_live_reconcile_error: None,
+                active_alert_count: 0,
+                stale_source_count: 0,
+                last_live_reconcile_success_at: None,
             },
         }))
         .expect("to_value");
@@ -156,6 +175,9 @@ mod tests {
                         "live_reconcile_failures": 0,
                         "next_live_reconcile_at": null,
                         "last_live_reconcile_error": null,
+                        "active_alert_count": 0,
+                        "stale_source_count": 0,
+                        "last_live_reconcile_success_at": null,
                     }
                 }
             })
@@ -203,5 +225,53 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn metrics_snapshot_event_uses_stable_wire_shape() {
+        let value = serde_json::to_value(OperatorEvent::MetricsSnapshot(MetricsSnapshotEvent {
+            metrics: PlatformMetrics {
+                total_deployments: 2,
+                live_deployments: 1,
+                degraded_deployments: 1,
+                active_alerts: 1,
+                stale_sources: 1,
+                live_reconcile_failures: 2,
+                last_trade_time: None,
+                last_live_reconcile_success_at: None,
+                heartbeats: vec![HeartbeatStatus {
+                    source_id: "venue:polymarket".to_string(),
+                    source_kind: "venue".to_string(),
+                    state: HeartbeatState::Stale,
+                    last_seen_at: Some(Utc::now()),
+                    stale_after_seconds: 15,
+                    message: Some("gateway offline".to_string()),
+                }],
+            },
+        }))
+        .expect("to_value");
+
+        assert_eq!(value["type"], json!("metrics_snapshot"));
+        assert_eq!(value["data"]["metrics"]["total_deployments"], json!(2));
+        assert_eq!(value["data"]["metrics"]["heartbeats"][0]["state"], json!("stale"));
+    }
+
+    #[test]
+    fn alert_snapshot_event_uses_stable_wire_shape() {
+        let value = serde_json::to_value(OperatorEvent::AlertSnapshot(AlertSnapshotEvent {
+            alerts: vec![ActiveAlert {
+                alert_id: "venue:polymarket:stale".to_string(),
+                kind: AlertKind::SourceStale,
+                severity: AlertSeverity::Critical,
+                source_id: "venue:polymarket".to_string(),
+                message: "gateway offline".to_string(),
+                triggered_at: Utc::now(),
+            }],
+        }))
+        .expect("to_value");
+
+        assert_eq!(value["type"], json!("alert_snapshot"));
+        assert_eq!(value["data"]["alerts"][0]["kind"], json!("source_stale"));
+        assert_eq!(value["data"]["alerts"][0]["severity"], json!("critical"));
     }
 }

--- a/crates/ploy-operator-contracts/src/lib.rs
+++ b/crates/ploy-operator-contracts/src/lib.rs
@@ -12,10 +12,13 @@ pub use deployments::{
 };
 pub use errors::ControlPlaneErrorResponse;
 pub use events::{
-    DeploymentSnapshotEvent, LogEntry, OperatorEvent, StatusUpdate, SystemSnapshotEvent,
-    TradingSnapshotEvent, WsMessage,
+    AlertSnapshotEvent, DeploymentSnapshotEvent, LogEntry, MetricsSnapshotEvent, OperatorEvent,
+    StatusUpdate, SystemSnapshotEvent, TradingSnapshotEvent, WsMessage,
 };
-pub use system::{SystemControlResponse, SystemStatus};
+pub use system::{
+    ActiveAlert, AlertKind, AlertSeverity, HeartbeatState, HeartbeatStatus, PlatformMetrics,
+    SystemControlResponse, SystemStatus,
+};
 pub use trading::{
     FillSnapshot, IntentPurpose, MarketData, OrderControlResponse, OrderReplaceRequest,
     OrderSnapshot, PaperIntentRequest, PaperIntentResponse, PnlSnapshotResponse, PositionResponse,

--- a/crates/ploy-operator-contracts/src/system.rs
+++ b/crates/ploy-operator-contracts/src/system.rs
@@ -1,6 +1,59 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeartbeatState {
+    Healthy,
+    Stale,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeartbeatStatus {
+    pub source_id: String,
+    pub source_kind: String,
+    pub state: HeartbeatState,
+    pub last_seen_at: Option<DateTime<Utc>>,
+    pub stale_after_seconds: i64,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertSeverity {
+    Warning,
+    Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertKind {
+    SourceStale,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveAlert {
+    pub alert_id: String,
+    pub kind: AlertKind,
+    pub severity: AlertSeverity,
+    pub source_id: String,
+    pub message: String,
+    pub triggered_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformMetrics {
+    pub total_deployments: usize,
+    pub live_deployments: usize,
+    pub degraded_deployments: usize,
+    pub active_alerts: usize,
+    pub stale_sources: usize,
+    pub live_reconcile_failures: u32,
+    pub last_trade_time: Option<DateTime<Utc>>,
+    pub last_live_reconcile_success_at: Option<DateTime<Utc>>,
+    pub heartbeats: Vec<HeartbeatStatus>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SystemStatus {
     pub status: String,
@@ -17,6 +70,12 @@ pub struct SystemStatus {
     pub next_live_reconcile_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub last_live_reconcile_error: Option<String>,
+    #[serde(default)]
+    pub active_alert_count: usize,
+    #[serde(default)]
+    pub stale_source_count: usize,
+    #[serde(default)]
+    pub last_live_reconcile_success_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ploy-platform/src/system.rs
+++ b/crates/ploy-platform/src/system.rs
@@ -1,5 +1,9 @@
 use chrono::{DateTime, Duration, Utc};
-use ploy_operator_contracts::{SystemControlResponse, SystemStatus};
+use ploy_operator_contracts::{
+    ActiveAlert, AlertKind, AlertSeverity, HeartbeatState, HeartbeatStatus, PlatformMetrics,
+    SystemControlResponse, SystemStatus,
+};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RuntimePhase {
@@ -32,6 +36,18 @@ pub struct SystemService {
     live_reconcile_failures: u32,
     next_live_reconcile_at: Option<DateTime<Utc>>,
     last_live_reconcile_error: Option<String>,
+    last_live_reconcile_success_at: Option<DateTime<Utc>>,
+    sources: BTreeMap<String, SourceStatus>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceStatus {
+    source_kind: String,
+    last_seen_at: Option<DateTime<Utc>>,
+    stale_after: Duration,
+    forced_stale: bool,
+    message: Option<String>,
+    triggered_at: Option<DateTime<Utc>>,
 }
 
 impl Default for SystemService {
@@ -47,6 +63,8 @@ impl Default for SystemService {
             live_reconcile_failures: 0,
             next_live_reconcile_at: None,
             last_live_reconcile_error: None,
+            last_live_reconcile_success_at: None,
+            sources: BTreeMap::new(),
         }
     }
 }
@@ -80,7 +98,9 @@ impl SystemService {
 
     pub fn mark_degraded(&mut self, listen_addr: &str) {
         self.listen_addr = Some(listen_addr.to_string());
-        self.error_timestamps.push(Utc::now());
+        if self.phase != RuntimePhase::Degraded {
+            self.error_timestamps.push(Utc::now());
+        }
         self.phase = RuntimePhase::Degraded;
     }
 
@@ -121,6 +141,160 @@ impl SystemService {
         self.live_reconcile_failures = 0;
         self.next_live_reconcile_at = None;
         self.last_live_reconcile_error = None;
+        self.last_live_reconcile_success_at = Some(Utc::now());
+    }
+
+    pub fn note_source_heartbeat(
+        &mut self,
+        source_id: impl Into<String>,
+        source_kind: impl Into<String>,
+        stale_after: Duration,
+    ) {
+        let now = Utc::now();
+        let source_kind = source_kind.into();
+        let entry = self
+            .sources
+            .entry(source_id.into())
+            .or_insert_with(|| SourceStatus {
+                source_kind: source_kind.clone(),
+                last_seen_at: None,
+                stale_after,
+                forced_stale: false,
+                message: None,
+                triggered_at: None,
+            });
+        entry.source_kind = source_kind;
+        entry.last_seen_at = Some(now);
+        entry.stale_after = stale_after;
+        entry.forced_stale = false;
+        entry.message = None;
+        entry.triggered_at = None;
+    }
+
+    pub fn note_source_failure(
+        &mut self,
+        source_id: impl Into<String>,
+        source_kind: impl Into<String>,
+        stale_after: Duration,
+        message: String,
+    ) {
+        let now = Utc::now();
+        let source_kind = source_kind.into();
+        let entry = self
+            .sources
+            .entry(source_id.into())
+            .or_insert_with(|| SourceStatus {
+                source_kind: source_kind.clone(),
+                last_seen_at: None,
+                stale_after,
+                forced_stale: false,
+                message: None,
+                triggered_at: None,
+            });
+        entry.source_kind = source_kind;
+        entry.last_seen_at = Some(now);
+        entry.stale_after = stale_after;
+        entry.forced_stale = true;
+        entry.message = Some(message);
+        if entry.triggered_at.is_none() {
+            entry.triggered_at = Some(now);
+        }
+    }
+
+    pub fn clear_source(&mut self, source_id: &str) {
+        self.sources.remove(source_id);
+    }
+
+    pub fn refresh_source_health(&mut self) -> usize {
+        let now = Utc::now();
+        let mut stale_count = 0;
+        for source in self.sources.values_mut() {
+            let is_stale = source.forced_stale
+                || source
+                    .last_seen_at
+                    .map(|last_seen_at| now - last_seen_at > source.stale_after)
+                    .unwrap_or(true);
+            if is_stale {
+                stale_count += 1;
+                if source.triggered_at.is_none() {
+                    source.triggered_at = Some(now);
+                }
+            } else {
+                source.triggered_at = None;
+            }
+        }
+        stale_count
+    }
+
+    pub fn stale_source_count(&self) -> usize {
+        self.sources
+            .values()
+            .filter(|source| source.triggered_at.is_some())
+            .count()
+    }
+
+    pub fn heartbeat_statuses(&self) -> Vec<HeartbeatStatus> {
+        self.sources
+            .iter()
+            .map(|(source_id, source)| HeartbeatStatus {
+                source_id: source_id.clone(),
+                source_kind: source.source_kind.clone(),
+                state: if source.triggered_at.is_some() {
+                    HeartbeatState::Stale
+                } else {
+                    HeartbeatState::Healthy
+                },
+                last_seen_at: source.last_seen_at,
+                stale_after_seconds: source.stale_after.num_seconds(),
+                message: source.message.clone(),
+            })
+            .collect()
+    }
+
+    pub fn active_alerts(&self) -> Vec<ActiveAlert> {
+        self.sources
+            .iter()
+            .filter_map(|(source_id, source)| {
+                let triggered_at = source.triggered_at?;
+                Some(ActiveAlert {
+                    alert_id: format!("{source_id}:stale"),
+                    kind: AlertKind::SourceStale,
+                    severity: alert_severity(&source.source_kind),
+                    source_id: source_id.clone(),
+                    message: source
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| format!("{} source is stale", source.source_kind)),
+                    triggered_at,
+                })
+            })
+            .collect()
+    }
+
+    pub fn source_is_stale(&self, source_id: &str) -> bool {
+        self.sources
+            .get(source_id)
+            .map(|source| source.triggered_at.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn metrics(
+        &self,
+        total_deployments: usize,
+        live_deployments: usize,
+        degraded_deployments: usize,
+    ) -> PlatformMetrics {
+        PlatformMetrics {
+            total_deployments,
+            live_deployments,
+            degraded_deployments,
+            active_alerts: self.active_alerts().len(),
+            stale_sources: self.stale_source_count(),
+            live_reconcile_failures: self.live_reconcile_failures,
+            last_trade_time: self.last_trade_time,
+            last_live_reconcile_success_at: self.last_live_reconcile_success_at,
+            heartbeats: self.heartbeat_statuses(),
+        }
     }
 
     pub fn status(&self) -> SystemStatus {
@@ -144,6 +318,9 @@ impl SystemService {
             live_reconcile_failures: self.live_reconcile_failures,
             next_live_reconcile_at: self.next_live_reconcile_at,
             last_live_reconcile_error: self.last_live_reconcile_error.clone(),
+            active_alert_count: self.active_alerts().len(),
+            stale_source_count: self.stale_source_count(),
+            last_live_reconcile_success_at: self.last_live_reconcile_success_at,
         }
     }
 
@@ -152,6 +329,13 @@ impl SystemService {
             success: true,
             message: format!("system {action} accepted"),
         }
+    }
+}
+
+fn alert_severity(source_kind: &str) -> AlertSeverity {
+    match source_kind {
+        "worker" | "live_reconcile" | "venue" => AlertSeverity::Critical,
+        _ => AlertSeverity::Warning,
     }
 }
 
@@ -221,5 +405,33 @@ mod tests {
 
         service.set_status("running");
         assert_eq!(service.status().status, "running");
+    }
+
+    #[test]
+    fn system_service_surfaces_stale_sources_in_metrics_and_alerts() {
+        let mut service = SystemService::default();
+        service.mark_running("127.0.0.1:8081");
+        service.note_source_failure(
+            "venue:polymarket",
+            "venue",
+            Duration::seconds(15),
+            "gateway offline".to_string(),
+        );
+        service.refresh_source_health();
+
+        let status = service.status();
+        assert_eq!(status.active_alert_count, 1);
+        assert_eq!(status.stale_source_count, 1);
+
+        let metrics = service.metrics(2, 1, 1);
+        assert_eq!(metrics.total_deployments, 2);
+        assert_eq!(metrics.stale_sources, 1);
+        assert_eq!(metrics.active_alerts, 1);
+        assert_eq!(metrics.heartbeats.len(), 1);
+        assert_eq!(metrics.heartbeats[0].source_id, "venue:polymarket");
+
+        let alerts = service.active_alerts();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].source_id, "venue:polymarket");
     }
 }

--- a/docs/plans/2026-03-23-platform-hardening-design.md
+++ b/docs/plans/2026-03-23-platform-hardening-design.md
@@ -1,0 +1,170 @@
+# Platform Hardening Design
+
+**Date:** 2026-03-23
+
+**Goal:** Finish the remaining production-hardening work on the workspace-based control-plane runtime so `ployd` can run 24x7 with clear metrics, actionable alerts, stale-source degradation, and tighter operator permissions.
+
+## Scope
+
+This design is for the current workspace/control-plane mainline, not the retired single-binary monolith. The runtime already has:
+
+- `ployd` as the long-running daemon
+- `ployctl` / `ploytui` / frontend on the same control-plane
+- audit logging
+- request rate limiting
+- live reconcile backoff and `degraded / recovering` semantics
+- admin token, browser session cookie, and sidecar read-only token
+
+The missing production-hardening work is:
+
+1. platform-internal metrics and alert state
+2. feed / venue / claim / worker heartbeat tracking with stale-source auto-degrade
+3. finer-grained operator permissions beyond `public / sidecar-readonly / admin`
+
+## Options
+
+### Option 1: Metrics only
+
+Add a few counters to `SystemStatus` and leave stale-source and auth semantics mostly unchanged.
+
+Pros:
+- smallest diff
+
+Cons:
+- still no clear answer to "what is stale?"
+- alerts remain log-shaped instead of operator-shaped
+- auth still cannot distinguish read-only from operator-grade write actions
+
+### Option 2: Platform-internal observability loop
+
+Add first-class metrics and alerts to the daemon, track source heartbeats, project stale/degraded state into system status, expose them over HTTP/SSE/CLI/TUI/frontend, and tighten permissions into capability bands.
+
+Pros:
+- completes the current platform model instead of papering over it
+- gives a usable 24x7 operating surface without external monitoring dependencies
+- keeps the semantics inside the platform before exporting them elsewhere
+
+Cons:
+- touches contracts, daemon state, operator clients, and frontend
+
+### Option 3: External monitoring first
+
+Add Prometheus/Alertmanager or another external system before stabilizing internal alert semantics.
+
+Pros:
+- useful later for real ops integration
+
+Cons:
+- wrong order right now
+- exports unstable semantics and multiplies cleanup work
+
+## Recommendation
+
+Use **Option 2**.
+
+The platform needs one internal truth for health, stale sources, and operator-visible alerts before any external monitoring integration is worth doing.
+
+## Design
+
+### 1. Metrics and alert model
+
+Add new operator contracts for:
+
+- `PlatformMetrics`
+- `ActiveAlert`
+- `AlertSeverity`
+- `AlertKind`
+- `HeartbeatStatus`
+
+The daemon should maintain a small in-memory health projection and publish it to:
+
+- `/api/system/status` for coarse summary
+- `/api/system/metrics` for structured metrics
+- `/api/system/alerts` for current actionable alerts
+- `/api/events/stream` as `metrics_snapshot` and `alert_snapshot`
+
+The first metrics set should stay small and operational:
+
+- total deployment count
+- live deployment count
+- degraded deployment count
+- active alert count by severity
+- live reconcile failure count
+- pending auto-claim accounts
+- stale heartbeat source count
+- last successful live reconcile time
+- last successful claim time
+
+### 2. Heartbeat and stale-source degradation
+
+Track source-level heartbeat instead of only global daemon health.
+
+The first tracked sources should be:
+
+- deployment worker heartbeat
+- live reconcile loop
+- venue connectivity
+- claim loop
+
+The daemon should evaluate source freshness on every tick and:
+
+- raise/update alerts when a source becomes stale
+- mark the system `degraded` while any critical source remains stale
+- move through `recovering` when the source resumes
+
+This should not stop the daemon. It should change health projection and operator visibility.
+
+### 3. Auth scopes
+
+Keep the current tokens and browser sessions, but refine required access into capability bands:
+
+- `public`
+- `read`
+- `operator`
+- `admin`
+
+Mapping:
+
+- `public`: `/health`, `/auth/*`
+- `read`: system status, deployments, trading state, metrics, alerts, SSE
+- `operator`: safe control-plane writes like deployment lifecycle changes and explicit claim controls
+- `admin`: high-impact writes such as live trading intent ingress and order cancel/replace if we choose to keep those highest-privilege
+
+The current sidecar token remains read-only. Admin token and signed browser session retain full access.
+
+### 4. Operator surfaces
+
+`ployctl`
+- add `system metrics`
+- add `system alerts`
+
+`ploytui`
+- show alert summary and stale-source summary in the system section
+
+frontend
+- render alert state and stale-source signals in `SystemControl`
+- preserve EventSource-with-cookie flow; do not require custom headers for SSE
+
+### 5. Documentation
+
+Update startup/deploy runbooks so operators know:
+
+- which env vars govern heartbeat/stale thresholds
+- where to read active alerts
+- what counts as degraded vs recovering
+- which token class can read vs operate vs administer
+
+## Execution shape
+
+Land this in three atomic groups:
+
+1. contracts + daemon health/metrics/alerts state
+2. HTTP/SSE/CLI/TUI/frontend operator surfaces
+3. auth scope refinement + runbook updates
+
+## Non-goals
+
+- external alert delivery (Telegram, email, Feishu)
+- Prometheus exporter integration
+- deep live execution model changes
+- strategy or research-path changes

--- a/docs/plans/2026-03-23-platform-hardening-implementation-plan.md
+++ b/docs/plans/2026-03-23-platform-hardening-implementation-plan.md
@@ -1,0 +1,210 @@
+# Platform Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add internal metrics/alerts, stale-source degradation, and finer operator permissions to the workspace control-plane runtime.
+
+**Architecture:** Extend the existing `ployd` daemon state with a small health/heartbeat projection, expose it through new operator contracts and endpoints, then wire the same semantics through CLI/TUI/frontend while refining auth access classes from coarse token roles into capability bands.
+
+**Tech Stack:** Rust, Axum-style HTTP helpers, SSE event streaming, serde contracts, React frontend, focused `rtk cargo test` and `npm run build/lint`
+
+---
+
+### Task 1: Track the hardening lane
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Reference: `docs/plans/2026-03-23-platform-hardening-design.md`
+
+**Step 1: Add a new top-of-file tracker section**
+
+Record:
+- metrics/alerts
+- stale-source degradation
+- auth scope refinement
+
+**Step 2: Record file ownership**
+
+Call out:
+- `apps/ployd/src/runtime.rs`, `apps/ployd/src/http.rs`, `apps/ployd/src/config.rs`
+- `crates/ploy-platform/src/system.rs`
+- `crates/ploy-operator-contracts/src/{system,events}.rs`
+- `apps/ployctl/src/system.rs`
+- `apps/ploytui/src/lib.rs`
+- `ploy-frontend/src/{services/websocket.ts,pages/SystemControl.tsx,types/index.ts}`
+
+**Step 3: Commit the planning docs**
+
+```bash
+git add tasks/todo.md docs/plans/2026-03-23-platform-hardening-design.md docs/plans/2026-03-23-platform-hardening-implementation-plan.md
+git commit -m "docs: plan platform hardening work"
+```
+
+### Task 2: Add contracts and daemon health state
+
+**Files:**
+- Modify: `crates/ploy-operator-contracts/src/system.rs`
+- Modify: `crates/ploy-operator-contracts/src/events.rs`
+- Modify: `crates/ploy-operator-contracts/src/lib.rs`
+- Modify: `crates/ploy-platform/src/system.rs`
+- Modify: `apps/ployd/src/runtime.rs`
+- Modify: `apps/ployd/src/config.rs`
+
+**Step 1: Add failing contract/unit coverage**
+
+Write tests for:
+- metrics serialization
+- alert serialization
+- stale-source projection into system state
+
+**Step 2: Run the focused tests and confirm they fail**
+
+```bash
+rtk cargo test -p ploy-operator-contracts system -- --nocapture
+rtk cargo test -p ploy-platform system -- --nocapture
+```
+
+**Step 3: Add contract types**
+
+Add:
+- `PlatformMetrics`
+- `ActiveAlert`
+- `AlertSeverity`
+- `AlertKind`
+- `HeartbeatStatus`
+- `MetricsSnapshotEvent`
+- `AlertSnapshotEvent`
+
+**Step 4: Extend daemon/system state**
+
+Add source heartbeat tracking for:
+- deployment workers
+- live reconcile
+- venue connectivity
+- claim loop
+
+Add config thresholds for staleness windows.
+
+**Step 5: Project degraded/recovering from stale sources**
+
+Update the daemon tick path so stale critical sources raise alerts and mark the platform degraded; recovery should transition back through `recovering`.
+
+**Step 6: Run focused verification**
+
+```bash
+rtk cargo test -p ploy-operator-contracts -p ploy-platform -p ployd
+```
+
+**Step 7: Commit**
+
+```bash
+git add crates/ploy-operator-contracts crates/ploy-platform apps/ployd/src/runtime.rs apps/ployd/src/config.rs
+git commit -m "runtime: add platform metrics and stale-source health"
+```
+
+### Task 3: Expose metrics and alerts through operator surfaces
+
+**Files:**
+- Modify: `apps/ployd/src/http.rs`
+- Modify: `apps/ployctl/src/client.rs`
+- Modify: `apps/ployctl/src/system.rs`
+- Modify: `apps/ployctl/src/main.rs`
+- Modify: `apps/ploytui/src/lib.rs`
+- Modify: `ploy-frontend/src/services/websocket.ts`
+- Modify: `ploy-frontend/src/pages/SystemControl.tsx`
+- Modify: `ploy-frontend/src/types/index.ts`
+
+**Step 1: Add failing endpoint/client tests**
+
+Cover:
+- `/api/system/metrics`
+- `/api/system/alerts`
+- SSE event serialization for metrics/alerts
+- CLI rendering for the new snapshots
+
+**Step 2: Run the focused tests and confirm they fail**
+
+```bash
+rtk cargo test -p ployd http -- --nocapture
+rtk cargo test -p ployctl system -- --nocapture
+```
+
+**Step 3: Implement HTTP and SSE surfaces**
+
+Expose:
+- `GET /api/system/metrics`
+- `GET /api/system/alerts`
+- `metrics_snapshot`
+- `alert_snapshot`
+
+**Step 4: Wire CLI/TUI/frontend**
+
+- `ployctl system metrics`
+- `ployctl system alerts`
+- TUI system block shows alert count/stale-source summary
+- frontend renders metrics/alerts and handles new SSE event kinds
+
+**Step 5: Run verification**
+
+```bash
+rtk cargo test -p ployd -p ployctl -p ploytui
+cd ploy-frontend && npm run build && npm run lint
+```
+
+**Step 6: Commit**
+
+```bash
+git add apps/ployd/src/http.rs apps/ployctl apps/ploytui ploy-frontend
+git commit -m "operator: expose platform metrics and alerts"
+```
+
+### Task 4: Refine auth scopes and document the result
+
+**Files:**
+- Modify: `apps/ployd/src/http.rs`
+- Modify: `apps/ployctl/src/client.rs` if needed
+- Modify: `docs/runbooks/platform-startup.md`
+- Modify: `docs/runbooks/platform-deploy.md`
+- Modify: `README.md`
+
+**Step 1: Add failing auth tests**
+
+Cover:
+- read endpoints accepted for sidecar/admin
+- operator/admin split for write endpoints
+- browser session still works for SSE
+
+**Step 2: Run the focused auth tests**
+
+```bash
+rtk cargo test -p ployd auth -- --nocapture
+```
+
+**Step 3: Refine required access**
+
+Replace the coarse `ReadOnly/Admin` split with:
+- `Public`
+- `Read`
+- `Operator`
+- `Admin`
+
+Keep existing tokens/cookies; only change capability mapping.
+
+**Step 4: Update operator docs**
+
+Document new env vars, stale thresholds, alert endpoints, and access classes.
+
+**Step 5: Run final verification**
+
+```bash
+rtk cargo test -p ployd -p ployctl -p ploytui
+rtk cargo test --test platform_smoke --test platform_release_workflow
+cd ploy-frontend && npm run build && npm run lint
+```
+
+**Step 6: Commit**
+
+```bash
+git add apps/ployd/src/http.rs apps/ployctl/src/client.rs README.md docs/runbooks/platform-startup.md docs/runbooks/platform-deploy.md
+git commit -m "auth: refine operator access scopes"
+```

--- a/docs/runbooks/platform-deploy.md
+++ b/docs/runbooks/platform-deploy.md
@@ -67,6 +67,9 @@ Optional hardening:
 
 - Set `PLOY_ADMIN_TOKEN=...` in `/opt/ploy/.env` to require `Authorization: Bearer ...`
   or `x-ploy-admin-token` on the control-plane API.
+- Set `PLOY_OPERATOR_TOKEN=...` in `/opt/ploy/.env` if automation or `ployctl`
+  should be allowed to mutate deployments and trading controls without gaining
+  full admin access.
 - Set `PLOY_SIDECAR_AUTH_TOKEN=...` in `/opt/ploy/.env` if agent/sidecar clients
   only need read-only access to platform snapshots and `/api/events/stream`.
 - Set `PLOY_API_AUTH_COOKIE_SECRET=...` in `/opt/ploy/.env` if browser operator
@@ -78,11 +81,17 @@ Optional hardening:
   `PLOY_LIVE_RECONCILE_BACKOFF_MAX_MS=...` in `/opt/ploy/.env` if you want to
   tune live venue reconcile retry backoff under exchange/API outages.
 - `/opt/ploy/bin/ployctl` will automatically pick up `PLOY_ADMIN_TOKEN`,
-  `PLOY_API_ADMIN_TOKEN`, or `PLOY_API_KEY` from the host environment.
+  `PLOY_API_ADMIN_TOKEN`, `PLOY_API_KEY`, `PLOY_OPERATOR_TOKEN`,
+  `PLOY_API_OPERATOR_TOKEN`, or `PLOY_SIDECAR_AUTH_TOKEN` from the host
+  environment.
 - Browser operator sessions should authenticate through `/auth/login`; `ployd`
   will issue an `HttpOnly` same-site signed session cookie so the frontend and
   SSE event stream remain authenticated without persisting the raw admin token
   in browser storage.
+- Access bands are `public`, `read_only`, `operator`, and `admin`. `sidecar`
+  tokens stop at `read_only`; `operator` tokens can drive deployment controls
+  and trading mutations; only `admin` can read audit logs or mint browser
+  sessions through `/auth/login`.
 
 ## Post-Deploy Checks
 

--- a/docs/runbooks/platform-startup.md
+++ b/docs/runbooks/platform-startup.md
@@ -18,8 +18,10 @@ cargo run -p ployd
 ```
 
 If you want the control plane protected, export `PLOY_ADMIN_TOKEN` first.
-Optionally set `PLOY_SIDECAR_AUTH_TOKEN` for read-only sidecar/agent access.
-`ployctl` uses the admin bearer token surface directly. The frontend login
+Optionally set `PLOY_OPERATOR_TOKEN` for write-capable operator automation, or
+`PLOY_SIDECAR_AUTH_TOKEN` for read-only sidecar/agent access. `ployctl`
+automatically prefers admin credentials, then operator credentials, then the
+sidecar token. The frontend login
 flow uses `/auth/login`, which sets an `HttpOnly` same-site signed session
 cookie so `/api/events/stream` stays authenticated. Set
 `PLOY_API_AUTH_COOKIE_SECRET` too if you want those browser sessions to survive

--- a/ploy-frontend/src/pages/SystemControl.tsx
+++ b/ploy-frontend/src/pages/SystemControl.tsx
@@ -6,8 +6,19 @@ import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { ws } from '@/services/websocket';
 import type { WebSocketEvent } from '@/services/websocket';
+import type { ActiveAlert, PlatformMetrics } from '@/types';
 import { formatDuration } from '@/lib/utils';
-import { Play, Square, RotateCw, Activity, Database, Wifi, WifiOff } from 'lucide-react';
+import {
+  Play,
+  Square,
+  RotateCw,
+  Activity,
+  Database,
+  Wifi,
+  WifiOff,
+  AlertTriangle,
+  Clock,
+} from 'lucide-react';
 
 export function SystemControl() {
   const queryClient = useQueryClient();
@@ -16,6 +27,8 @@ export function SystemControl() {
   const [realtimeSnapshot, setRealtimeSnapshot] = useState<Awaited<
     ReturnType<typeof api.getSystemStatus>
   > | null>(null);
+  const [realtimeMetrics, setRealtimeMetrics] = useState<PlatformMetrics | null>(null);
+  const [realtimeAlerts, setRealtimeAlerts] = useState<ActiveAlert[] | null>(null);
 
   // Track WebSocket connection
   useEffect(() => {
@@ -44,16 +57,52 @@ export function SystemControl() {
     return unsub;
   }, [queryClient]);
 
+  useEffect(() => {
+    const unsub = ws.subscribe('metrics_snapshot', (event: WebSocketEvent) => {
+      if (event.type === 'metrics_snapshot') {
+        setRealtimeMetrics(event.data.metrics);
+        queryClient.setQueryData(['system', 'metrics'], event.data.metrics);
+      }
+    });
+    return unsub;
+  }, [queryClient]);
+
+  useEffect(() => {
+    const unsub = ws.subscribe('alert_snapshot', (event: WebSocketEvent) => {
+      if (event.type === 'alert_snapshot') {
+        setRealtimeAlerts(event.data.alerts);
+        queryClient.setQueryData(['system', 'alerts'], event.data.alerts);
+      }
+    });
+    return unsub;
+  }, [queryClient]);
+
   // Fallback polling at 30s (in case WebSocket disconnects)
-  const { data: status, isLoading } = useQuery({
+  const { data: status, isLoading: statusLoading } = useQuery({
     queryKey: ['system', 'status'],
     queryFn: () => api.getSystemStatus(),
+    refetchInterval: 30000,
+  });
+
+  const { data: metrics, isLoading: metricsLoading } = useQuery({
+    queryKey: ['system', 'metrics'],
+    queryFn: () => api.getSystemMetrics(),
+    refetchInterval: 30000,
+  });
+
+  const { data: alerts, isLoading: alertsLoading } = useQuery({
+    queryKey: ['system', 'alerts'],
+    queryFn: () => api.getSystemAlerts(),
     refetchInterval: 30000,
   });
 
   // Merge real-time status with polled data
   const effectiveStatus = realtimeStatus ?? realtimeSnapshot?.status ?? status?.status;
   const effectiveSnapshot = realtimeSnapshot ?? status;
+  const effectiveMetrics = realtimeMetrics ?? metrics;
+  const effectiveAlerts = realtimeAlerts ?? alerts ?? [];
+  const heartbeats = effectiveMetrics?.heartbeats ?? [];
+  const isLoading = statusLoading || metricsLoading || alertsLoading;
 
   const startMutation = useMutation({
     mutationFn: () => api.startSystem(),
@@ -128,7 +177,7 @@ export function SystemControl() {
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Uptime</span>
-                    <span className="font-medium">
+                  <span className="font-medium">
                     {effectiveSnapshot ? formatDuration(effectiveSnapshot.uptime_seconds) : '-'}
                   </span>
                 </div>
@@ -147,6 +196,108 @@ export function SystemControl() {
                       ? new Date(effectiveSnapshot.last_trade_time).toLocaleString('en-US')
                       : 'None'}
                   </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Last Reconcile</span>
+                  <span className="font-medium">
+                    {effectiveSnapshot?.last_live_reconcile_success_at
+                      ? new Date(effectiveSnapshot.last_live_reconcile_success_at).toLocaleString(
+                          'en-US'
+                        )
+                      : 'None'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Active Alerts</span>
+                  <span className="font-medium">{effectiveSnapshot?.active_alert_count ?? 0}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Stale Sources</span>
+                  <span className="font-medium">{effectiveSnapshot?.stale_source_count ?? 0}</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Runtime Metrics</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="rounded-lg border p-4">
+                    <div className="text-sm text-muted-foreground">Deployments</div>
+                    <div className="mt-1 text-lg font-semibold">
+                      {effectiveMetrics?.total_deployments ?? 0}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-4">
+                    <div className="text-sm text-muted-foreground">Live / Degraded</div>
+                    <div className="mt-1 text-lg font-semibold">
+                      {effectiveMetrics?.live_deployments ?? 0} /{' '}
+                      {effectiveMetrics?.degraded_deployments ?? 0}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-4">
+                    <div className="text-sm text-muted-foreground">Active Alerts</div>
+                    <div className="mt-1 text-lg font-semibold">
+                      {effectiveMetrics?.active_alerts ?? effectiveSnapshot?.active_alert_count ?? 0}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-4">
+                    <div className="text-sm text-muted-foreground">Stale Sources</div>
+                    <div className="mt-1 text-lg font-semibold">
+                      {effectiveMetrics?.stale_sources ?? effectiveSnapshot?.stale_source_count ?? 0}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4" />
+                    <span className="text-sm">Last Successful Reconcile</span>
+                  </div>
+                  <span className="text-sm font-medium">
+                    {effectiveMetrics?.last_live_reconcile_success_at ??
+                      effectiveSnapshot?.last_live_reconcile_success_at ??
+                      '-'}
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Heartbeats</div>
+                  {heartbeats.length === 0 ? (
+                    <div className="rounded-lg border p-3 text-sm text-muted-foreground">
+                      No heartbeat sources reported yet.
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      {heartbeats.map((heartbeat) => (
+                        <div
+                          key={heartbeat.source_id}
+                          className="flex items-center justify-between rounded-lg border p-3"
+                        >
+                          <div>
+                            <div className="text-sm font-medium">{heartbeat.source_id}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {heartbeat.source_kind} • stale after {heartbeat.stale_after_seconds}s
+                            </div>
+                            {heartbeat.message ? (
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                {heartbeat.message}
+                              </div>
+                            ) : null}
+                          </div>
+                          <Badge
+                            variant={heartbeat.state === 'healthy' ? 'success' : 'destructive'}
+                          >
+                            {heartbeat.state}
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </CardContent>
@@ -196,6 +347,45 @@ export function SystemControl() {
                   <p>Use emergency halt from the domain-specific control surface when positions must be unwound immediately.</p>
                   <p>Restart performs a pause/resume cycle and may take 30-60 seconds.</p>
                 </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Active Alerts</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {effectiveAlerts.length === 0 ? (
+                  <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+                    No active alerts.
+                  </div>
+                ) : (
+                  effectiveAlerts.map((alert) => (
+                    <div key={alert.alert_id} className="rounded-lg border p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex items-start gap-2">
+                          <AlertTriangle className="mt-0.5 h-4 w-4 text-warning" />
+                          <div>
+                            <div className="text-sm font-medium">{alert.message}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {alert.source_id} • {alert.kind}
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              Triggered {new Date(alert.triggered_at).toLocaleString('en-US')}
+                            </div>
+                          </div>
+                        </div>
+                        <Badge
+                          variant={alert.severity === 'critical' ? 'destructive' : 'outline'}
+                        >
+                          {alert.severity}
+                        </Badge>
+                      </div>
+                    </div>
+                  ))
+                )}
               </div>
             </CardContent>
           </Card>

--- a/ploy-frontend/src/services/api.ts
+++ b/ploy-frontend/src/services/api.ts
@@ -12,6 +12,8 @@ import type {
   RiskData,
   DesiredState,
   DeploymentState,
+  PlatformMetrics,
+  ActiveAlert,
 } from '@/types';
 
 const API_BASE = '/api';
@@ -161,6 +163,14 @@ class ApiService {
   // System endpoints
   async getSystemStatus(): Promise<SystemStatus> {
     return this.fetch<SystemStatus>('/system/status');
+  }
+
+  async getSystemMetrics(): Promise<PlatformMetrics> {
+    return this.fetch<PlatformMetrics>('/system/metrics');
+  }
+
+  async getSystemAlerts(): Promise<ActiveAlert[]> {
+    return this.fetch<ActiveAlert[]>('/system/alerts');
   }
 
   async startSystem(): Promise<SystemControlResponse> {

--- a/ploy-frontend/src/services/websocket.ts
+++ b/ploy-frontend/src/services/websocket.ts
@@ -1,7 +1,9 @@
 import type {
+  ActiveAlert,
   DeploymentSummary,
   LogEntry,
   MarketData,
+  PlatformMetrics,
   Position,
   SystemStatus,
   Trade,
@@ -16,7 +18,9 @@ export type WebSocketEvent =
   | { type: 'status'; data: { status: 'running' | 'stopped' | 'error' } }
   | { type: 'system_snapshot'; data: { system: SystemStatus } }
   | { type: 'deployment_snapshot'; data: { deployments: DeploymentSummary[] } }
-  | { type: 'trading_snapshot'; data: { trading: TradingStateSnapshot[] } };
+  | { type: 'trading_snapshot'; data: { trading: TradingStateSnapshot[] } }
+  | { type: 'metrics_snapshot'; data: { metrics: PlatformMetrics } }
+  | { type: 'alert_snapshot'; data: { alerts: ActiveAlert[] } };
 
 type ConnectionCallback = (connected: boolean) => void;
 
@@ -84,7 +88,9 @@ export class WebSocketService {
         t === 'status' ||
         t === 'system_snapshot' ||
         t === 'deployment_snapshot' ||
-        t === 'trading_snapshot'
+        t === 'trading_snapshot' ||
+        t === 'metrics_snapshot' ||
+        t === 'alert_snapshot'
       ) {
         this.emit({ type: t, data } as WebSocketEvent);
       }

--- a/ploy-frontend/src/types/index.ts
+++ b/ploy-frontend/src/types/index.ts
@@ -52,6 +52,47 @@ export interface SystemStatus {
   websocket_connected: boolean;
   database_connected: boolean;
   error_count_1h: number;
+  live_reconcile_failures: number;
+  next_live_reconcile_at: string | null;
+  last_live_reconcile_error: string | null;
+  active_alert_count: number;
+  stale_source_count: number;
+  last_live_reconcile_success_at: string | null;
+}
+
+export type HeartbeatState = 'healthy' | 'stale';
+
+export interface HeartbeatStatus {
+  source_id: string;
+  source_kind: string;
+  state: HeartbeatState;
+  last_seen_at: string | null;
+  stale_after_seconds: number;
+  message: string | null;
+}
+
+export type AlertSeverity = 'warning' | 'critical';
+export type AlertKind = 'source_stale';
+
+export interface ActiveAlert {
+  alert_id: string;
+  kind: AlertKind;
+  severity: AlertSeverity;
+  source_id: string;
+  message: string;
+  triggered_at: string;
+}
+
+export interface PlatformMetrics {
+  total_deployments: number;
+  live_deployments: number;
+  degraded_deployments: number;
+  active_alerts: number;
+  stale_sources: number;
+  live_reconcile_failures: number;
+  last_trade_time: string | null;
+  last_live_reconcile_success_at: string | null;
+  heartbeats: HeartbeatStatus[];
 }
 
 export interface SystemControlResponse {
@@ -165,7 +206,9 @@ export type WsMessage =
   | { type: 'status'; data: StatusUpdate }
   | { type: 'system_snapshot'; data: { system: SystemStatus } }
   | { type: 'deployment_snapshot'; data: { deployments: DeploymentSummary[] } }
-  | { type: 'trading_snapshot'; data: { trading: TradingStateSnapshot[] } };
+  | { type: 'trading_snapshot'; data: { trading: TradingStateSnapshot[] } }
+  | { type: 'metrics_snapshot'; data: { metrics: PlatformMetrics } }
+  | { type: 'alert_snapshot'; data: { alerts: ActiveAlert[] } };
 
 export interface PnLDataPoint {
   timestamp: string;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
+# Platform Hardening (2026-03-23)
+
+## Goal
+Finish the remaining production-hardening work on the workspace control-plane runtime: internal metrics/alerts, stale-source auto-degrade, and finer auth scopes.
+
+## File ownership
+
+- `apps/ployd/src/runtime.rs`, `apps/ployd/src/config.rs`
+  - owner: heartbeat tracking, stale-source degradation, metrics/alert state
+- `apps/ployd/src/http.rs`
+  - owner: metrics/alerts endpoints, SSE, auth scope mapping
+- `crates/ploy-platform/src/system.rs`
+  - owner: system health projection
+- `crates/ploy-operator-contracts/src/system.rs`, `crates/ploy-operator-contracts/src/events.rs`
+  - owner: wire contracts for metrics/alerts/stale-source state
+- `apps/ployctl/src/system.rs`, `apps/ployctl/src/main.rs`, `apps/ployctl/src/client.rs`
+  - owner: CLI operator surfaces
+- `apps/ploytui/src/lib.rs`
+  - owner: terminal operator rendering
+- `ploy-frontend/src/services/websocket.ts`, `ploy-frontend/src/pages/SystemControl.tsx`, `ploy-frontend/src/types/index.ts`
+  - owner: frontend operator rendering
+- `README.md`, `docs/runbooks/platform-startup.md`, `docs/runbooks/platform-deploy.md`
+  - owner: operator guidance
+
+## Tasks
+
+- [ ] Add platform metrics/alerts contracts and daemon health state.
+- [ ] Add stale-source heartbeat tracking and degraded/recovering projection.
+- [ ] Expose metrics/alerts through HTTP, SSE, CLI, TUI, and frontend.
+- [ ] Refine auth scopes from public/read-only/admin to capability bands.
+- [ ] Re-run focused Rust and frontend verification.
+
+## Progress notes
+
+- 2026-03-23: Confirmed `origin/main` is already the workspace/control-plane runtime; the old monolith review findings do not apply directly to this branch.
+- 2026-03-23: Hardening scope is limited to metrics/alerts, stale-source degradation, and auth scopes. External alert delivery remains out of scope.
+
 # Live Reconcile Backoff Hardening (2026-03-21)
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -27,7 +27,7 @@ Finish the remaining production-hardening work on the workspace control-plane ru
 - [x] Add platform metrics/alerts contracts and daemon health state.
 - [x] Add stale-source heartbeat tracking and degraded/recovering projection.
 - [x] Expose metrics/alerts through HTTP, SSE, CLI, TUI, and frontend.
-- [ ] Refine auth scopes from public/read-only/admin to capability bands.
+- [x] Refine auth scopes from public/read-only/admin to capability bands.
 - [x] Re-run focused Rust and frontend verification.
 
 ## Progress notes
@@ -41,6 +41,10 @@ Finish the remaining production-hardening work on the workspace control-plane ru
   - `rtk cargo test --test platform_smoke`
   - `cd ploy-frontend && npm run build`
   - `cd ploy-frontend && npm run lint`
+- 2026-03-23: Refined auth scopes to `public`, `read_only`, `operator`, and `admin`; added `PLOY_OPERATOR_TOKEN` / `PLOY_API_OPERATOR_TOKEN`, taught `ployctl` to prefer admin then operator then sidecar credentials, and kept browser login/session issuance on admin only.
+- 2026-03-23: Focused verification passed for auth scope refinement:
+  - `rtk cargo test -p ployd -p ployctl -p ploytui`
+  - `rtk cargo test --test platform_smoke`
 
 # Live Reconcile Backoff Hardening (2026-03-21)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -24,16 +24,23 @@ Finish the remaining production-hardening work on the workspace control-plane ru
 
 ## Tasks
 
-- [ ] Add platform metrics/alerts contracts and daemon health state.
-- [ ] Add stale-source heartbeat tracking and degraded/recovering projection.
-- [ ] Expose metrics/alerts through HTTP, SSE, CLI, TUI, and frontend.
+- [x] Add platform metrics/alerts contracts and daemon health state.
+- [x] Add stale-source heartbeat tracking and degraded/recovering projection.
+- [x] Expose metrics/alerts through HTTP, SSE, CLI, TUI, and frontend.
 - [ ] Refine auth scopes from public/read-only/admin to capability bands.
-- [ ] Re-run focused Rust and frontend verification.
+- [x] Re-run focused Rust and frontend verification.
 
 ## Progress notes
 
 - 2026-03-23: Confirmed `origin/main` is already the workspace/control-plane runtime; the old monolith review findings do not apply directly to this branch.
 - 2026-03-23: Hardening scope is limited to metrics/alerts, stale-source degradation, and auth scopes. External alert delivery remains out of scope.
+- 2026-03-23: Added platform metrics/alerts contracts and stale-source health tracking to `ployd`; system status now carries alert/stale-source summary, and operator events include `metrics_snapshot` plus `alert_snapshot`.
+- 2026-03-23: Exposed `/api/system/metrics` and `/api/system/alerts`, added `ployctl system metrics|alerts`, expanded `ploytui` to render metrics/alerts, and updated frontend `SystemControl` plus SSE parsing to surface heartbeat health and active alerts.
+- 2026-03-23: Focused verification passed:
+  - `rtk cargo test -p ploy-operator-contracts -p ploy-platform -p ployd -p ployctl -p ploytui`
+  - `rtk cargo test --test platform_smoke`
+  - `cd ploy-frontend && npm run build`
+  - `cd ploy-frontend && npm run lint`
 
 # Live Reconcile Backoff Hardening (2026-03-21)
 


### PR DESCRIPTION
## Summary

This PR finishes the remaining control-plane hardening work on top of the workspace runtime:

- adds stale-source health tracking and platform metrics/alerts state
- exposes metrics/alerts over HTTP, SSE, `ployctl`, `ploytui`, and the frontend
- refines auth scopes from `public/read_only/admin` to `public/read_only/operator/admin`

## What changed

### Runtime health and metrics
- add source heartbeat tracking and stale-source projection in `ploy-platform`
- extend `SystemStatus` with active alert / stale source summaries
- add shared wire contracts for `PlatformMetrics`, `ActiveAlert`, and heartbeat status
- publish `metrics_snapshot` and `alert_snapshot` in the operator event stream

### Operator surfaces
- add `GET /api/system/metrics`
- add `GET /api/system/alerts`
- add `ployctl system metrics`
- add `ployctl system alerts`
- extend `ploytui` to render metrics, heartbeats, and active alerts
- extend frontend `SystemControl` to show runtime metrics, heartbeats, and alerts

### Auth scope refinement
- add `PLOY_OPERATOR_TOKEN` / `PLOY_API_OPERATOR_TOKEN`
- keep sidecar tokens read-only
- allow operator tokens to mutate deployments and trading controls
- keep audit logs and browser session issuance admin-only
- teach `ployctl` to prefer admin, then operator, then sidecar credentials

### Docs and planning
- add platform hardening design and implementation docs
- update runbooks and README with the new auth scope model

## Verification

- `rtk cargo test -p ploy-operator-contracts -p ploy-platform -p ployd -p ployctl -p ploytui`
- `rtk cargo test --test platform_smoke`
- `cd ploy-frontend && npm run build`
- `cd ploy-frontend && npm run lint`

## Notes

This PR is intentionally limited to internal platform hardening. External alert delivery remains out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced operator-scoped authentication tokens (`PLOY_OPERATOR_TOKEN`) for deployment mutations and trading controls without requiring admin access
  * Added new CLI commands: `ployctl system metrics` and `ployctl system alerts` to monitor platform health and system performance
  * New system monitoring capabilities: platform metrics (deployment counts, alerts, stale sources), heartbeat tracking, and real-time alerts with severity levels
  * Enhanced UI with runtime metrics dashboard, active alerts card, and heartbeat status displays
  * New HTTP endpoints for retrieving system metrics and alerts data

* **Documentation**
  * Added platform hardening design and implementation planning documentation
  * Updated runbooks with operator token configuration and authentication access-band model (`public`, `read_only`, `operator`, `admin`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->