### PR TITLE
docs: add remote live dry-run deployment drill

### DIFF
--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -60,14 +60,18 @@ jobs:
           bundle_root="dist/platform-bundle"
           mkdir -p \
             "${bundle_root}/bin" \
+            "${bundle_root}/config/deployments" \
             "${bundle_root}/data/state" \
             "${bundle_root}/deployment" \
-            "${bundle_root}/scripts"
+            "${bundle_root}/scripts" \
+            "${bundle_root}/scripts/drills"
           install -m 755 "target/${PLATFORM_TARGET}/release/ployd" "${bundle_root}/bin/ployd"
           install -m 755 "target/${PLATFORM_TARGET}/release/ployctl" "${bundle_root}/bin/ployctl"
           install -m 755 "target/${PLATFORM_TARGET}/release/ploytui" "${bundle_root}/bin/ploytui"
           install -m 644 deployment/ployd.service "${bundle_root}/deployment/ployd.service"
           install -m 755 scripts/install-platform-service.sh "${bundle_root}/scripts/install-platform-service.sh"
+          install -m 755 scripts/drills/live_dry_run.sh "${bundle_root}/scripts/drills/live_dry_run.sh"
+          install -m 644 config/deployments/example.live.dry-run.json "${bundle_root}/config/deployments/example.live.dry-run.json.sample"
           install -m 644 data/state/deployments.json.sample "${bundle_root}/data/state/deployments.json.sample"
           tar czf dist/ploy-platform.tar.gz -C "${bundle_root}" .
 
@@ -124,12 +128,14 @@ jobs:
               SUDO="sudo"
             fi
 
-            $SUDO mkdir -p "${DEPLOY_ROOT}/bin" "${DEPLOY_ROOT}/deployment" "${DEPLOY_ROOT}/scripts" "${DEPLOY_ROOT}/data/state"
+            $SUDO mkdir -p "${DEPLOY_ROOT}/bin" "${DEPLOY_ROOT}/config/deployments" "${DEPLOY_ROOT}/deployment" "${DEPLOY_ROOT}/scripts" "${DEPLOY_ROOT}/scripts/drills" "${DEPLOY_ROOT}/data/state"
             $SUDO install -m 755 "${WORKDIR}/bin/ployd" "${DEPLOY_ROOT}/bin/ployd"
             $SUDO install -m 755 "${WORKDIR}/bin/ployctl" "${DEPLOY_ROOT}/bin/ployctl"
             $SUDO install -m 755 "${WORKDIR}/bin/ploytui" "${DEPLOY_ROOT}/bin/ploytui"
             $SUDO install -m 644 "${WORKDIR}/deployment/ployd.service" "${DEPLOY_ROOT}/deployment/ployd.service"
             $SUDO install -m 755 "${WORKDIR}/scripts/install-platform-service.sh" "${DEPLOY_ROOT}/scripts/install-platform-service.sh"
+            $SUDO install -m 755 "${WORKDIR}/scripts/drills/live_dry_run.sh" "${DEPLOY_ROOT}/scripts/drills/live_dry_run.sh"
+            $SUDO install -m 644 "${WORKDIR}/config/deployments/example.live.dry-run.json.sample" "${DEPLOY_ROOT}/config/deployments/example.live.dry-run.json.sample"
             if [ ! -f "${DEPLOY_ROOT}/data/state/deployments.json" ]; then
               $SUDO install -m 644 "${WORKDIR}/data/state/deployments.json.sample" "${DEPLOY_ROOT}/data/state/deployments.json"
             fi
@@ -141,8 +147,12 @@ jobs:
             curl -fsS http://127.0.0.1:8081/health
             curl -N --max-time 2 http://127.0.0.1:8081/api/events/stream || true
             # Verify the deployed operator client path: ployctl system status
+            # Verify the deployed operator client path: ployctl system metrics
+            # Verify the deployed operator client path: ployctl system alerts
             # Verify the deployed operator client path: ployctl trading status
             "${DEPLOY_ROOT}/bin/ployctl" system status
+            "${DEPLOY_ROOT}/bin/ployctl" system metrics
+            "${DEPLOY_ROOT}/bin/ployctl" system alerts
             "${DEPLOY_ROOT}/bin/ployctl" trading status
             "${DEPLOY_ROOT}/bin/ploytui" || true
 
@@ -151,3 +161,4 @@ jobs:
           echo "## Platform Release" >> "$GITHUB_STEP_SUMMARY"
           echo "- Bundle: \`ployd + ployctl + ploytui\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Service: \`ployd.service\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Drill: \`/opt/ploy/scripts/drills/live_dry_run.sh\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -51,10 +51,19 @@ Runbooks:
 
 - [`docs/runbooks/platform-startup.md`](docs/runbooks/platform-startup.md)
 - [`docs/runbooks/platform-deploy.md`](docs/runbooks/platform-deploy.md)
+- [`docs/runbooks/live-deployment-checklist.md`](docs/runbooks/live-deployment-checklist.md)
+- [`docs/runbooks/live-dry-run-drill.md`](docs/runbooks/live-dry-run-drill.md)
 
 Default release workflow:
 
 - `.github/workflows/release-platform.yml`
+
+Remote live-host acceptance path:
+
+- deploy with [`docs/runbooks/platform-deploy.md`](docs/runbooks/platform-deploy.md)
+- validate the host with [`docs/runbooks/live-deployment-checklist.md`](docs/runbooks/live-deployment-checklist.md)
+- run the dry-run acceptance drill from [`docs/runbooks/live-dry-run-drill.md`](docs/runbooks/live-dry-run-drill.md)
+- only then move to manual live go/no-go review
 
 Compatibility note:
 

--- a/config/deployments/README.md
+++ b/config/deployments/README.md
@@ -6,6 +6,14 @@ Each manifest should describe one deployment resource.
 The current minimal operator path uses JSON manifests such as
 `config/deployments/example.paper.json`.
 
+Current examples:
+
+- `example.paper.json`
+  - local or remote paper deployment smoke path
+- `example.live.dry-run.json`
+  - remote live-host readiness drill
+  - still uses `runtime_mode: "paper"` so the drill never touches real funds
+
 Each manifest includes:
 
 - `deployment_id`
@@ -14,3 +22,6 @@ Each manifest includes:
 - `desired_state`
 
 The operator manages deployment resources. The platform manages the worker processes behind them.
+
+Do not point the dry-run drill at a real live manifest. The drill is meant to
+prove host readiness, not to enable production trading.

--- a/config/deployments/example.live.dry-run.json
+++ b/config/deployments/example.live.dry-run.json
@@ -1,0 +1,8 @@
+{
+  "deployment_id": "example.live.dry-run",
+  "bundle_id": "example-drill",
+  "account_id": "acct-live-drill",
+  "max_gross_exposure": "2.00",
+  "runtime_mode": "paper",
+  "desired_state": "running"
+}

--- a/docs/plans/2026-03-24-live-dry-run-drill-design.md
+++ b/docs/plans/2026-03-24-live-dry-run-drill-design.md
@@ -1,0 +1,148 @@
+# Live Dry-Run Drill Design
+
+**Date:** 2026-03-24
+
+## Goal
+
+Add a repeatable remote-host acceptance path for the workspace control-plane runtime so an operator can validate a live host with `ployctl` before enabling real trading.
+
+The flow must prove:
+
+- `ployd` is healthy and reachable on the host
+- auth, audit, metrics, and alerts are wired correctly
+- a paper deployment can be applied, inspected, paused, resumed, and stopped
+- stale-source / reconcile health is visible through the operator surface
+
+The flow must not:
+
+- place real live orders
+- trigger real redeem / auto-claim actions
+- depend on the retired single-binary runtime
+
+## Constraints
+
+- Target environment is a single remote host with `ployd.service` managed by `systemd`.
+- Operator actions run through `/opt/ploy/bin/ployctl`.
+- The drill should be safe to repeat on the same host.
+- The drill should work with either admin or operator credentials, but it should not require browser login flows.
+- Current `ployctl` on `origin/main` does not have `claims ...` commands, so claim readiness has to be inferred from `system status`, `system metrics`, and `system alerts`.
+
+## Approaches Considered
+
+### 1. Docs only
+
+Write a checklist and rely on manual command entry.
+
+Pros:
+
+- smallest code change
+
+Cons:
+
+- too easy to skip steps
+- hard to repeat consistently across hosts
+- poor fit for pre-live game-day drills
+
+### 2. Checklist plus repeatable drill script
+
+Add a human-facing checklist and a machine-executable remote drill script that drives `ployctl`.
+
+Pros:
+
+- repeatable and operator-friendly
+- keeps the live host acceptance path explicit
+- does not require new daemon features
+
+Cons:
+
+- script needs careful cleanup to stay idempotent
+
+### 3. Full live rehearsal
+
+Bake real live order / redeem behavior into the acceptance path.
+
+Pros:
+
+- highest fidelity
+
+Cons:
+
+- crosses the user's dry-run boundary
+- creates unnecessary financial and operational risk
+
+## Chosen Design
+
+Use approach 2.
+
+The repo will gain a dedicated dry-run acceptance layer with four artifacts:
+
+1. `docs/runbooks/live-deployment-checklist.md`
+2. `docs/runbooks/live-dry-run-drill.md`
+3. `scripts/drills/live_dry_run.sh`
+4. `config/deployments/example.live.dry-run.json`
+
+## Flow
+
+### A. Remote live deployment checklist
+
+This is the operator-facing go/no-go document. It covers:
+
+- host prerequisites and required environment variables
+- which credentials are required for remote `ployctl`
+- how to distinguish dry-run acceptance from real live enablement
+- what a passing host looks like before moving to manual live confirmation
+
+### B. Dry-run drill script
+
+The script runs on the remote host and performs five stages:
+
+1. Baseline service checks
+   - `systemctl is-active ployd`
+   - `curl /health`
+   - `ployctl system status`
+   - `ployctl system metrics`
+   - `ployctl system alerts`
+   - `ployctl system audit`
+2. Configuration presence checks
+   - ensure `/opt/ploy/.env` exists
+   - verify required operator/auth/live env keys are present
+   - verify runtime directories and snapshot files exist
+3. Paper deployment drill
+   - apply a paper-mode manifest intended for live-host dry runs
+   - inspect the deployment
+   - pause / resume / stop it
+4. Trading and claim readiness projection
+   - inspect `ployctl trading status`
+   - fail on active critical alerts
+   - surface stale-source / reconcile issues from `system metrics` and `system alerts`
+5. Final result
+   - print `PASS`, `WARN`, or `FAIL`
+   - state whether the host is ready to proceed to human live confirmation
+
+### C. Manifest strategy
+
+The sample manifest is named `example.live.dry-run.json` to make its purpose obvious, but it remains a `paper` deployment so the drill never touches real funds.
+
+## Error Handling
+
+- Any failed required step exits non-zero.
+- Missing required credentials/config files fail immediately with a clear message.
+- Active critical alerts fail the drill.
+- Non-critical degraded states can produce `WARN` if they do not invalidate the dry-run path.
+- Cleanup runs on exit to stop the drill deployment if it was created.
+
+## Validation
+
+Implementation is complete when:
+
+- the script passes `bash -n`
+- the script can run locally in a parameter-validation mode without side effects
+- runbooks clearly separate deploy, dry-run acceptance, and real live enablement
+- README routes operators to the new checklist and drill docs
+
+## Out of Scope
+
+- real live order / cancel / redeem rehearsal
+- external alert channels
+- new daemon APIs just for the drill
+- rewriting `ployctl` to add claim-specific commands

--- a/docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md
+++ b/docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md
@@ -1,0 +1,230 @@
+# Live Dry-Run Drill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a repeatable remote-host dry-run acceptance checklist and `ployctl`-driven drill script that validates live-host readiness without touching real funds.
+
+**Architecture:** The change is documentation-first with one operator script. The script relies only on the existing `ployd` HTTP surface, `systemd`, `curl`, and `ployctl`; it creates a paper deployment for the drill, validates platform health, and cleans up on exit. Runbooks route operators through three distinct phases: deploy, dry-run acceptance, and manual live enablement.
+
+**Tech Stack:** Bash, systemd, curl, ployctl, Markdown runbooks, JSON deployment manifest
+
+---
+
+### Task 1: Document the approved design and track the work
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Create: `docs/plans/2026-03-24-live-dry-run-drill-design.md`
+- Create: `docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md`
+
+**Step 1: Record the task in the tracker**
+
+Add a dedicated section at the top of `tasks/todo.md` describing the goal, file ownership, tasks, and progress notes for the live dry-run drill.
+
+**Step 2: Save the approved design**
+
+Write the already-approved dry-run drill design to `docs/plans/2026-03-24-live-dry-run-drill-design.md`.
+
+**Step 3: Save this implementation plan**
+
+Write the implementation plan to `docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md`.
+
+**Step 4: Verify the docs exist**
+
+Run:
+
+```bash
+ls docs/plans | rg 'live-dry-run-drill'
+```
+
+Expected: both design and implementation plan files appear.
+
+### Task 2: Add the sample dry-run deployment manifest
+
+**Files:**
+- Create: `config/deployments/example.live.dry-run.json`
+- Modify: `config/deployments/README.md`
+
+**Step 1: Add the drill manifest**
+
+Create a JSON manifest with:
+
+- a distinct `deployment_id`
+- `runtime_mode: "paper"`
+- a drill-specific `account_id`
+- a conservative `max_gross_exposure`
+- `desired_state: "running"`
+
+**Step 2: Clarify the boundary**
+
+Update `config/deployments/README.md` to distinguish:
+
+- live deployment manifests
+- paper drill manifests
+- the fact that the drill manifest is for readiness checks only
+
+**Step 3: Validate the manifest shape**
+
+Run:
+
+```bash
+python3 -m json.tool config/deployments/example.live.dry-run.json >/dev/null
+```
+
+Expected: command exits 0.
+
+### Task 3: Write the remote dry-run drill script
+
+**Files:**
+- Create: `scripts/drills/live_dry_run.sh`
+
+**Step 1: Write the script skeleton**
+
+The script should:
+
+- use `set -euo pipefail`
+- accept `--host-root`, `--addr`, `--manifest`, and `--deployment-id`
+- default to `/opt/ploy`, `http://127.0.0.1:8081`, and the new sample manifest
+
+**Step 2: Add baseline checks**
+
+Implement:
+
+- `systemctl is-active ployd`
+- `curl -fsS $ADDR/health`
+- `ployctl system status`
+- `ployctl system metrics`
+- `ployctl system alerts`
+- `ployctl system audit`
+
+**Step 3: Add config and path presence checks**
+
+Require:
+
+- `/opt/ploy/.env`
+- key live/operator env variables present in `.env`
+- runtime snapshot files under `/opt/ploy/run/platform/`
+
+**Step 4: Add paper deployment drill**
+
+Implement:
+
+- `ployctl deployments apply <manifest>`
+- `ployctl deployments inspect <id>`
+- `ployctl deployments pause <id>`
+- `ployctl deployments resume <id>`
+- `ployctl deployments stop <id>`
+
+Add cleanup with `trap` so the deployment is stopped even on failure.
+
+**Step 5: Add final pass/fail output**
+
+Emit a clear final summary with `PASS`, `WARN`, or `FAIL`.
+
+**Step 6: Validate shell syntax**
+
+Run:
+
+```bash
+bash -n scripts/drills/live_dry_run.sh
+```
+
+Expected: command exits 0.
+
+### Task 4: Write operator runbooks for acceptance and drill execution
+
+**Files:**
+- Create: `docs/runbooks/live-deployment-checklist.md`
+- Create: `docs/runbooks/live-dry-run-drill.md`
+
+**Step 1: Write the checklist**
+
+Document:
+
+- host prerequisites
+- required env vars
+- auth expectations
+- go/no-go checks before moving toward real live enablement
+
+**Step 2: Write the drill walkthrough**
+
+Document:
+
+- what the script checks
+- what it intentionally does not do
+- how to run it on the remote host
+- how to interpret `PASS`, `WARN`, and `FAIL`
+
+**Step 3: Link the sample manifest**
+
+Reference `config/deployments/example.live.dry-run.json` explicitly in the drill runbook.
+
+### Task 5: Route README and existing runbooks to the new acceptance path
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/runbooks/platform-deploy.md`
+- Modify: `docs/runbooks/platform-startup.md`
+
+**Step 1: Update README routing**
+
+Add links that direct operators to:
+
+- the deploy runbook
+- the live deployment checklist
+- the dry-run drill runbook
+
+**Step 2: Update deploy/startup runbooks**
+
+Clarify that:
+
+- deployment/install is separate from acceptance
+- the dry-run drill is the default remote-host readiness path
+- real live enablement happens only after the dry-run passes
+
+**Step 3: Check for consistent terminology**
+
+Run:
+
+```bash
+rg -n "dry-run drill|live deployment checklist|example.live.dry-run" README.md docs/runbooks config/deployments
+```
+
+Expected: the new routing terms appear in the intended docs.
+
+### Task 6: Run focused verification and capture results
+
+**Files:**
+- Modify: `tasks/todo.md`
+
+**Step 1: Run doc/script checks**
+
+Run:
+
+```bash
+bash -n scripts/drills/live_dry_run.sh
+python3 -m json.tool config/deployments/example.live.dry-run.json >/dev/null
+```
+
+Expected: both commands exit 0.
+
+**Step 2: Run focused regression coverage**
+
+Run:
+
+```bash
+rtk cargo test --test platform_smoke
+```
+
+Expected: PASS.
+
+**Step 3: Update progress notes**
+
+Record the commands run and the outcome in `tasks/todo.md`.
+
+**Step 4: Commit**
+
+```bash
+git add tasks/todo.md docs/plans/2026-03-24-live-dry-run-drill-design.md docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md docs/runbooks/live-deployment-checklist.md docs/runbooks/live-dry-run-drill.md docs/runbooks/platform-deploy.md docs/runbooks/platform-startup.md README.md config/deployments/README.md config/deployments/example.live.dry-run.json scripts/drills/live_dry_run.sh
+git commit -m "docs: add live dry-run deployment drill"
+```

--- a/docs/runbooks/live-deployment-checklist.md
+++ b/docs/runbooks/live-deployment-checklist.md
@@ -1,0 +1,98 @@
+# Live Deployment Checklist
+
+## Goal
+
+Validate a remote `ployd` host before enabling real live trading.
+
+This checklist is the operator-facing go/no-go gate. It assumes:
+
+- `ployd.service` is already installed on the host
+- validation happens remotely through `/opt/ploy/bin/ployctl`
+- the default acceptance path is a dry-run drill using a paper deployment
+
+## Before You Start
+
+- Confirm you are on the workspace-default release path:
+  - `.github/workflows/release-platform.yml`
+  - `deployment/ployd.service`
+  - `scripts/install-platform-service.sh`
+- Confirm the host has:
+  - `/opt/ploy/bin/ployd`
+  - `/opt/ploy/bin/ployctl`
+  - `/opt/ploy/.env`
+- Confirm `ployd` is the only long-running platform process.
+
+## Required Host Inputs
+
+At minimum, `/opt/ploy/.env` should define:
+
+- `PLOY_ADMIN_TOKEN`
+- `POLYMARKET_PRIVATE_KEY`
+
+Recommended:
+
+- `PLOY_OPERATOR_TOKEN` for remote `ployctl` mutation without full admin access
+- `PLOY_API_AUTH_COOKIE_SECRET` if browser sessions are used
+- `POLY_SIGNATURE_TYPE`
+- `POLY_FUNDER` when `POLY_SIGNATURE_TYPE=proxy` or `POLY_SIGNATURE_TYPE=gnosis_safe`
+
+## Baseline Service Checks
+
+Run on the remote host:
+
+```bash
+systemctl is-active ployd
+curl -fsS http://127.0.0.1:8081/health
+/opt/ploy/bin/ployctl system status
+/opt/ploy/bin/ployctl system metrics
+/opt/ploy/bin/ployctl system alerts
+/opt/ploy/bin/ployctl system audit
+```
+
+Go only if:
+
+- `ployd` is active
+- `/health` returns success
+- `ployctl system status` is `running`, `recovering`, or `degraded`
+- no critical alerts are active
+
+Stop if:
+
+- `/health` fails
+- `system status` is unexpected
+- `system alerts` contains critical entries
+
+## Dry-Run Acceptance Path
+
+The default host acceptance path is:
+
+1. Run the dry-run drill script:
+
+```bash
+/opt/ploy/scripts/drills/live_dry_run.sh
+```
+
+2. Confirm the script reports `PASS` or an understood `WARN`.
+3. Review any warnings before considering real live enablement.
+
+The drill uses a paper deployment and does not touch real funds.
+
+## Manual Review Before Real Live Enablement
+
+Only consider real live enablement after the dry-run drill passes and you have
+manually reviewed:
+
+- `ployctl system status`
+- `ployctl system metrics`
+- `ployctl system alerts`
+- `ployctl trading status`
+- the most recent audit log entries
+
+## Not Covered By This Checklist
+
+This checklist does not:
+
+- place live orders
+- cancel live venue orders
+- trigger real redeem / claim flows
+- replace a separate game-day rehearsal for production funds

--- a/docs/runbooks/live-dry-run-drill.md
+++ b/docs/runbooks/live-dry-run-drill.md
@@ -1,0 +1,96 @@
+# Live Dry-Run Drill
+
+## Goal
+
+Run a repeatable remote-host readiness drill for a future live deployment
+without placing real orders.
+
+The drill is intentionally conservative:
+
+- it runs through `ployctl`
+- it validates the deployed `ployd` host
+- it applies a paper deployment only
+- it never submits real live trading or redeem actions
+
+## What The Script Checks
+
+`scripts/drills/live_dry_run.sh` performs:
+
+1. daemon baseline
+   - `systemctl is-active ployd`
+   - `/health`
+   - `ployctl system status`
+   - `ployctl system metrics`
+   - `ployctl system alerts`
+   - `ployctl system audit`
+2. config and credential presence
+   - `/opt/ploy/.env`
+   - operator/admin token presence
+   - live signing env presence
+   - runtime snapshot files
+3. paper deployment drill
+   - apply
+   - inspect
+   - pause
+   - resume
+   - stop
+4. trading readiness projection
+   - `ployctl trading status`
+   - stale-source and reconcile warning output
+
+## What The Script Does Not Do
+
+The drill does not:
+
+- place live orders
+- cancel or replace live venue orders
+- run a real redeem / claim loop
+- prove venue-side money movement
+
+It is a host readiness drill, not a production trading rehearsal.
+
+## Sample Manifest
+
+The default drill manifest is:
+
+- [`config/deployments/example.live.dry-run.json`](../../config/deployments/example.live.dry-run.json)
+
+It is named after the live-host drill but runs in `paper` mode on purpose.
+
+## Remote Usage
+
+Run on the host:
+
+```bash
+/opt/ploy/scripts/drills/live_dry_run.sh
+```
+
+Optional overrides:
+
+```bash
+/opt/ploy/scripts/drills/live_dry_run.sh \
+  --host-root /opt/ploy \
+  --addr http://127.0.0.1:8081 \
+  --manifest /opt/ploy/config/deployments/example.live.dry-run.json \
+  --deployment-id example.live.dry-run
+```
+
+## Result Interpretation
+
+- `PASS`
+  - the host passed the dry-run and is ready for manual live go/no-go review
+- `WARN`
+  - the host passed baseline checks, but there are degraded or stale signals to review
+- `FAIL`
+  - the host is not ready to proceed toward real live enablement
+
+Critical alerts fail the drill immediately.
+
+## Follow-On Action
+
+If the drill passes, return to:
+
+- [`docs/runbooks/live-deployment-checklist.md`](./live-deployment-checklist.md)
+- [`docs/runbooks/platform-deploy.md`](./platform-deploy.md)
+
+and complete the remaining operator review before any real live deployment is enabled.

--- a/docs/runbooks/platform-deploy.md
+++ b/docs/runbooks/platform-deploy.md
@@ -22,6 +22,12 @@ Deployment resources are managed separately from the daemon process. Operators
 apply a deployment manifest and then use `ployctl` to inspect or change desired
 state.
 
+This runbook covers deploy/install only. Remote host acceptance now has its own
+path:
+
+- [`live-deployment-checklist.md`](./live-deployment-checklist.md)
+- [`live-dry-run-drill.md`](./live-dry-run-drill.md)
+
 ## CI Bundle Contents
 
 The release bundle contains:
@@ -47,6 +53,8 @@ After the bundle lands on the host, the deploy workflow:
    - `systemctl status ployd`
    - `curl -fsS http://127.0.0.1:8081/health`
    - `/opt/ploy/bin/ployctl system status`
+   - `/opt/ploy/bin/ployctl system metrics`
+   - `/opt/ploy/bin/ployctl system alerts`
    - `/opt/ploy/bin/ployctl system audit`
    - `/opt/ploy/bin/ployctl trading status`
    - `/opt/ploy/bin/ploytui`
@@ -93,6 +101,18 @@ Optional hardening:
   and trading mutations; only `admin` can read audit logs or mint browser
   sessions through `/auth/login`.
 
+## Remote Acceptance
+
+After deployment succeeds, do not enable real live trading immediately.
+
+Run:
+
+1. [`live-deployment-checklist.md`](./live-deployment-checklist.md)
+2. [`live-dry-run-drill.md`](./live-dry-run-drill.md)
+
+The dry-run drill uses a paper deployment on the live host so you can verify
+control-plane and worker behavior without touching real funds.
+
 ## Post-Deploy Checks
 
 ```bash
@@ -100,6 +120,8 @@ sudo systemctl status ployd --no-pager
 sudo journalctl -u ployd -n 200 --no-pager
 curl -fsS http://127.0.0.1:8081/health
 /opt/ploy/bin/ployctl system status
+/opt/ploy/bin/ployctl system metrics
+/opt/ploy/bin/ployctl system alerts
 /opt/ploy/bin/ployctl system audit
 /opt/ploy/bin/ployctl trading status
 /opt/ploy/bin/ployctl deployments list
@@ -116,6 +138,10 @@ daemon as live-venue degraded even if the process is still up.
 Use a deployment manifest like
 [`config/deployments/example.paper.json`](../../config/deployments/example.paper.json)
 as the template for remote deployment resources.
+
+For remote live-host readiness checks, use the paper-mode drill manifest
+[`config/deployments/example.live.dry-run.json`](../../config/deployments/example.live.dry-run.json)
+and the drill script from [`live-dry-run-drill.md`](./live-dry-run-drill.md).
 
 ```bash
 /opt/ploy/bin/ployctl deployments apply /opt/ploy/config/deployments/example.paper.json

--- a/docs/runbooks/platform-startup.md
+++ b/docs/runbooks/platform-startup.md
@@ -9,6 +9,12 @@ Start the single-host trading platform runtime with:
 - one operator client path through `ployctl`
 - one optional terminal console through `ploytui`
 
+This runbook covers daemon startup and local/operator smoke checks. Remote
+live-host acceptance is documented separately in:
+
+- [`live-deployment-checklist.md`](./live-deployment-checklist.md)
+- [`live-dry-run-drill.md`](./live-dry-run-drill.md)
+
 ## Default Local Flow
 
 1. Check the daemon boots:
@@ -35,6 +41,8 @@ retry backoff during exchange/API outages.
 
 ```bash
 cargo run -p ployctl -- system status
+cargo run -p ployctl -- system metrics
+cargo run -p ployctl -- system alerts
 cargo run -p ployctl -- system audit
 cargo run -p ployctl -- trading status
 cargo run -p ployctl -- deployments list
@@ -56,6 +64,8 @@ The current operator flow is:
 ployd
 ployctl deployments apply config/deployments/example.paper.json
 ployctl system status
+ployctl system metrics
+ployctl system alerts
 ployctl system audit
 ployctl trading status
 ployctl deployments list
@@ -77,3 +87,10 @@ for authenticated control-plane actions, and `ployctl system audit` reads the
 latest entries back over `/api/audit/logs`. `ployctl system status` now also
 shows `live_reconcile_failures`, `next_live_reconcile_at`, and
 `last_live_reconcile_error`, which are the primary live-venue outage signals.
+
+For a remote host that is intended to run future live trading, the default next
+step after startup is the dry-run acceptance drill:
+
+```bash
+/opt/ploy/scripts/drills/live_dry_run.sh
+```

--- a/scripts/drills/live_dry_run.sh
+++ b/scripts/drills/live_dry_run.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST_ROOT="/opt/ploy"
+ADDR="http://127.0.0.1:8081"
+MANIFEST=""
+DEPLOYMENT_ID=""
+PLOYCTL=""
+DRILL_APPLIED=0
+WARNINGS=0
+
+usage() {
+  cat <<'EOF'
+Usage: live_dry_run.sh [--host-root /opt/ploy] [--addr http://127.0.0.1:8081] [--manifest /opt/ploy/config/deployments/example.live.dry-run.json] [--deployment-id example.live.dry-run]
+
+Remote-host dry-run acceptance drill for the ploy workspace control plane.
+This script validates host readiness with ployctl and a paper deployment only.
+It does not place real live orders or trigger real redeem actions.
+EOF
+}
+
+log_step() {
+  printf '\n[%s] %s\n' "step" "$1"
+}
+
+note() {
+  printf '[info] %s\n' "$1"
+}
+
+warn() {
+  printf '[warn] %s\n' "$1"
+  WARNINGS=$((WARNINGS + 1))
+}
+
+fail() {
+  printf '[fail] %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+extract_value() {
+  local line="$1"
+  local key="$2"
+  printf '%s\n' "$line" | tr ' ' '\n' | awk -F= -v k="$key" '$1 == k { print $2 }'
+}
+
+env_has_key() {
+  local key="$1"
+  grep -Eq "^[[:space:]]*${key}=" "$ENV_FILE"
+}
+
+env_has_any_key() {
+  local key
+  for key in "$@"; do
+    if env_has_key "$key"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+require_env_key() {
+  local key="$1"
+  env_has_key "$key" || fail "required env key missing from ${ENV_FILE}: ${key}"
+}
+
+require_any_env_key() {
+  local label="$1"
+  shift
+  env_has_any_key "$@" || fail "required ${label} missing from ${ENV_FILE}: one of [$*]"
+}
+
+source_env_file() {
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+}
+
+cleanup() {
+  if [[ "$DRILL_APPLIED" -eq 1 ]]; then
+    note "stopping drill deployment ${DEPLOYMENT_ID}"
+    "$PLOYCTL" deployments stop "$DEPLOYMENT_ID" >/dev/null 2>&1 || true
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host-root)
+      HOST_ROOT="$2"
+      shift 2
+      ;;
+    --addr)
+      ADDR="$2"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST="$2"
+      shift 2
+      ;;
+    --deployment-id)
+      DEPLOYMENT_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+PLOYCTL="${HOST_ROOT}/bin/ployctl"
+ENV_FILE="${HOST_ROOT}/.env"
+RUNTIME_ROOT="${HOST_ROOT}/run/platform"
+STATE_ROOT="${HOST_ROOT}/data/state"
+MANIFEST="${MANIFEST:-${HOST_ROOT}/config/deployments/example.live.dry-run.json}"
+
+if [[ -z "${DEPLOYMENT_ID}" && -f "${MANIFEST}" ]]; then
+  DEPLOYMENT_ID="$(python3 - "$MANIFEST" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    print(json.load(handle)["deployment_id"])
+PY
+)"
+fi
+
+[[ -n "${DEPLOYMENT_ID}" ]] || fail "deployment id could not be determined"
+
+trap cleanup EXIT
+
+require_command systemctl
+require_command curl
+require_command python3
+[[ -x "${PLOYCTL}" ]] || fail "missing ployctl binary: ${PLOYCTL}"
+[[ -f "${ENV_FILE}" ]] || fail "missing env file: ${ENV_FILE}"
+[[ -f "${MANIFEST}" ]] || fail "missing drill manifest: ${MANIFEST}"
+
+source_env_file
+
+log_step "daemon baseline"
+[[ "$(systemctl is-active ployd)" == "active" ]] || fail "ployd.service is not active"
+curl -fsS "${ADDR}/health" >/dev/null
+STATUS_OUTPUT="$("${PLOYCTL}" system status)"
+METRICS_OUTPUT="$("${PLOYCTL}" system metrics)"
+ALERTS_OUTPUT="$("${PLOYCTL}" system alerts)"
+AUDIT_OUTPUT="$("${PLOYCTL}" system audit)"
+printf '%s\n' "${STATUS_OUTPUT}"
+printf '%s\n' "${METRICS_OUTPUT}"
+printf '%s\n' "${ALERTS_OUTPUT}"
+printf '%s\n' "${AUDIT_OUTPUT}"
+
+SYSTEM_STATE="$(extract_value "${STATUS_OUTPUT}" "status")"
+case "${SYSTEM_STATE}" in
+  running)
+    ;;
+  degraded|recovering|starting)
+    warn "system status is ${SYSTEM_STATE}"
+    ;;
+  *)
+    fail "unexpected system status: ${SYSTEM_STATE}"
+    ;;
+esac
+
+if [[ "${ALERTS_OUTPUT}" != "none" ]]; then
+  if printf '%s\n' "${ALERTS_OUTPUT}" | grep -q ' critical '; then
+    fail "critical alerts are active"
+  fi
+  warn "non-critical alerts are active"
+fi
+
+STALE_SOURCES="$(extract_value "${METRICS_OUTPUT}" "stale_sources")"
+if [[ -n "${STALE_SOURCES}" && "${STALE_SOURCES}" != "0" ]]; then
+  warn "stale sources reported: ${STALE_SOURCES}"
+fi
+
+log_step "config and credential presence"
+require_any_env_key "operator credential" \
+  "PLOY_ADMIN_TOKEN" \
+  "PLOY_API_ADMIN_TOKEN" \
+  "PLOY_API_KEY" \
+  "PLOY_OPERATOR_TOKEN" \
+  "PLOY_API_OPERATOR_TOKEN"
+if ! env_has_key "PLOY_OPERATOR_TOKEN" && ! env_has_key "PLOY_API_OPERATOR_TOKEN"; then
+  warn "operator token not configured; dry-run will rely on admin credentials"
+fi
+require_env_key "POLYMARKET_PRIVATE_KEY"
+if env_has_key "POLY_SIGNATURE_TYPE"; then
+  SIGNATURE_TYPE="$(grep -E '^[[:space:]]*POLY_SIGNATURE_TYPE=' "${ENV_FILE}" | tail -n 1 | cut -d= -f2- | tr -d '[:space:]')"
+  if [[ "${SIGNATURE_TYPE}" == "proxy" || "${SIGNATURE_TYPE}" == "gnosis_safe" ]]; then
+    require_env_key "POLY_FUNDER"
+  fi
+fi
+[[ -f "${STATE_ROOT}/deployments.json" ]] || fail "missing deployments state file: ${STATE_ROOT}/deployments.json"
+[[ -f "${RUNTIME_ROOT}/system-status.json" ]] || fail "missing system status snapshot: ${RUNTIME_ROOT}/system-status.json"
+[[ -f "${RUNTIME_ROOT}/deployments.json" ]] || fail "missing deployment snapshot: ${RUNTIME_ROOT}/deployments.json"
+[[ -f "${RUNTIME_ROOT}/trading-state.json" ]] || fail "missing trading state snapshot: ${RUNTIME_ROOT}/trading-state.json"
+[[ -f "${RUNTIME_ROOT}/audit-log.jsonl" ]] || fail "missing audit log: ${RUNTIME_ROOT}/audit-log.jsonl"
+
+log_step "paper deployment drill"
+APPLY_OUTPUT="$("${PLOYCTL}" deployments apply "${MANIFEST}")"
+DRILL_APPLIED=1
+printf '%s\n' "${APPLY_OUTPUT}"
+INSPECT_OUTPUT="$("${PLOYCTL}" deployments inspect "${DEPLOYMENT_ID}")"
+printf '%s\n' "${INSPECT_OUTPUT}"
+"${PLOYCTL}" deployments pause "${DEPLOYMENT_ID}" >/dev/null
+"${PLOYCTL}" deployments resume "${DEPLOYMENT_ID}" >/dev/null
+"${PLOYCTL}" deployments stop "${DEPLOYMENT_ID}" >/dev/null
+DRILL_APPLIED=0
+
+FINAL_INSPECT="$("${PLOYCTL}" deployments inspect "${DEPLOYMENT_ID}")"
+printf '%s\n' "${FINAL_INSPECT}"
+
+log_step "trading readiness"
+TRADING_OUTPUT="$("${PLOYCTL}" trading status)"
+printf '%s\n' "${TRADING_OUTPUT}"
+
+LIVE_RECONCILE_FAILURES="$(extract_value "${STATUS_OUTPUT}" "live_reconcile_failures")"
+if [[ -n "${LIVE_RECONCILE_FAILURES}" && "${LIVE_RECONCILE_FAILURES}" != "0" ]]; then
+  warn "live reconcile failures reported: ${LIVE_RECONCILE_FAILURES}"
+fi
+
+log_step "result"
+if [[ "${WARNINGS}" -gt 0 ]]; then
+  printf 'WARN: remote host passed the dry-run drill with %s warning(s); review alerts before enabling real live trading.\n' "${WARNINGS}"
+else
+  printf 'PASS: remote host passed the dry-run drill and is ready for manual live go/no-go review.\n'
+fi

--- a/scripts/install-platform-service.sh
+++ b/scripts/install-platform-service.sh
@@ -15,17 +15,23 @@ fi
 sudo mkdir -p \
   "${ROOT_DIR}/bin" \
   "${ROOT_DIR}/config" \
+  "${ROOT_DIR}/config/deployments" \
   "${ROOT_DIR}/data/state" \
   "${ROOT_DIR}/deployment" \
   "${ROOT_DIR}/logs" \
   "${ROOT_DIR}/run/platform" \
-  "${ROOT_DIR}/scripts"
+  "${ROOT_DIR}/scripts" \
+  "${ROOT_DIR}/scripts/drills"
 sudo chown -R ploy:ploy "${ROOT_DIR}"
 
 sudo install -m 0644 "${SERVICE_SRC}" "${SERVICE_DST}"
 
 if [[ -f "${ROOT_DIR}/data/state/deployments.json.sample" && ! -f "${ROOT_DIR}/data/state/deployments.json" ]]; then
   sudo cp "${ROOT_DIR}/data/state/deployments.json.sample" "${ROOT_DIR}/data/state/deployments.json"
+fi
+
+if [[ -f "${ROOT_DIR}/config/deployments/example.live.dry-run.json.sample" && ! -f "${ROOT_DIR}/config/deployments/example.live.dry-run.json" ]]; then
+  sudo cp "${ROOT_DIR}/config/deployments/example.live.dry-run.json.sample" "${ROOT_DIR}/config/deployments/example.live.dry-run.json"
 fi
 
 sudo touch "${ROOT_DIR}/.env"
@@ -49,7 +55,7 @@ ensure_env_default "${ROOT_DIR}/.env" "PLOY_LISTEN_ADDR" "127.0.0.1:8081"
 ensure_env_default "${ROOT_DIR}/.env" "PLOY_TICK_INTERVAL_MS" "1000"
 
 sudo chmod 600 "${ROOT_DIR}/.env"
-sudo chown ploy:ploy "${ROOT_DIR}/.env" "${ROOT_DIR}/data/state/deployments.json" 2>/dev/null || true
+sudo chown ploy:ploy "${ROOT_DIR}/.env" "${ROOT_DIR}/data/state/deployments.json" "${ROOT_DIR}/config/deployments/example.live.dry-run.json" 2>/dev/null || true
 
 sudo systemctl daemon-reload
 sudo systemctl enable ployd
@@ -61,5 +67,8 @@ echo "  sudo systemctl start ployd          # Start the platform daemon"
 echo "  sudo systemctl status ployd         # Check daemon status"
 echo "  sudo journalctl -u ployd -f         # Tail daemon logs"
 echo "  ${ROOT_DIR}/bin/ployctl system status"
+echo "  ${ROOT_DIR}/bin/ployctl system metrics"
+echo "  ${ROOT_DIR}/bin/ployctl system alerts"
 echo "  ${ROOT_DIR}/bin/ployctl trading status"
+echo "  ${ROOT_DIR}/scripts/drills/live_dry_run.sh"
 echo "  ${ROOT_DIR}/bin/ploytui"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# Live Dry-Run Deployment Drill (2026-03-25)
+
+## Goal
+Add a repeatable remote-host dry-run acceptance path for the workspace control-plane runtime: an operator-facing live deployment checklist plus a `ployctl`-driven drill script that proves host readiness without touching real funds.
+
+## File ownership
+
+- `docs/plans/2026-03-24-live-dry-run-drill-design.md`
+  - owner: approved design for the dry-run acceptance flow
+- `docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md`
+  - owner: bite-sized implementation plan for this task
+- `docs/runbooks/live-deployment-checklist.md`
+  - owner: operator go/no-go checklist for remote live host readiness
+- `docs/runbooks/live-dry-run-drill.md`
+  - owner: script walkthrough and boundaries
+- `scripts/drills/live_dry_run.sh`
+  - owner: repeatable remote-host dry-run acceptance script
+- `config/deployments/example.live.dry-run.json`
+  - owner: paper-mode manifest used by the dry-run drill
+- `README.md`, `docs/runbooks/platform-deploy.md`, `docs/runbooks/platform-startup.md`, `config/deployments/README.md`
+  - owner: route users to the new deploy/acceptance/drill docs and clarify paper-vs-live boundaries
+
+## Tasks
+
+- [x] Write the approved design doc and implementation plan for the live dry-run drill.
+- [x] Add the remote live deployment checklist and dry-run drill runbook.
+- [x] Add a repeatable `ployctl`-driven drill script plus a paper-mode manifest for live-host readiness checks.
+- [x] Update README/runbooks/config docs to point operators at the new acceptance path.
+- [x] Run shell/doc-focused validation and record the results.
+
+## Progress notes
+
+- 2026-03-25: Created clean worktree `session-live-dry-run` from `origin/main` (`acd313f5`) to avoid unrelated dirty changes on the root `main` checkout.
+- 2026-03-25: Confirmed current `origin/main` already has platform metrics/alerts/auth-scope hardening, but does not yet ship a dedicated remote-host dry-run checklist or drill script.
+- 2026-03-25: Saved the approved design to `docs/plans/2026-03-24-live-dry-run-drill-design.md` and the implementation plan to `docs/plans/2026-03-25-live-dry-run-drill-implementation-plan.md`.
+- 2026-03-25: Added `docs/runbooks/live-deployment-checklist.md`, `docs/runbooks/live-dry-run-drill.md`, `scripts/drills/live_dry_run.sh`, and `config/deployments/example.live.dry-run.json`.
+- 2026-03-25: Routed `README.md`, `platform-deploy.md`, `platform-startup.md`, `config/deployments/README.md`, `release-platform.yml`, and `install-platform-service.sh` to the new remote-host acceptance path so the drill script is bundled and installed on deploy hosts.
+- 2026-03-25: Validation passed:
+  - `bash -n scripts/drills/live_dry_run.sh`
+  - `bash -n scripts/install-platform-service.sh`
+  - `python3 -m json.tool config/deployments/example.live.dry-run.json >/dev/null`
+  - `scripts/drills/live_dry_run.sh --help`
+  - `rtk cargo test --test platform_smoke`
+
 # Platform Hardening (2026-03-23)
 
 ## Goal


### PR DESCRIPTION
## Summary
- add a remote live-host acceptance checklist and a dedicated dry-run drill runbook
- add a repeatable `/opt/ploy/scripts/drills/live_dry_run.sh` script plus a paper-mode drill manifest
- bundle and install the drill assets in `release-platform.yml` and `install-platform-service.sh`

## Details
- new runbooks:
  - `docs/runbooks/live-deployment-checklist.md`
  - `docs/runbooks/live-dry-run-drill.md`
- new operator assets:
  - `scripts/drills/live_dry_run.sh`
  - `config/deployments/example.live.dry-run.json`
- updated routing in `README.md`, `platform-deploy.md`, `platform-startup.md`, and `config/deployments/README.md`
- updated release/install flow so remote hosts receive the drill script and sample manifest under `/opt/ploy`

## Validation
- `bash -n scripts/drills/live_dry_run.sh`
- `bash -n scripts/install-platform-service.sh`
- `python3 -m json.tool config/deployments/example.live.dry-run.json >/dev/null`
- `scripts/drills/live_dry_run.sh --help`
- `rtk cargo test --test platform_smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote live-host acceptance drill for deployment validation before enabling production trading
  * Extended system health monitoring to include metrics and alerts verification

* **Documentation**
  * Added operator runbooks for deployment checklists and dry-run acceptance procedures
  * Introduced sample deployment configurations and updated guidance for remote acceptance workflows
  * Enhanced deployment and startup documentation with new remote validation checkpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->