### PR TITLE
platform: port relay-backed account auto-claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2975,12 +2976,19 @@ dependencies = [
 name = "ploy-connectivity"
 version = "0.1.0"
 dependencies = [
+ "alloy",
+ "base64",
  "chrono",
+ "hmac",
  "ploy-trading",
  "polymarket-client-sdk",
+ "reqwest",
  "rust_decimal",
  "rust_decimal_macros",
  "secrecy 0.8.0",
+ "serde",
+ "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -3521,7 +3529,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3549,6 +3559,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5009,6 +5020,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/apps/ployctl/src/claims.rs
+++ b/apps/ployctl/src/claims.rs
@@ -1,0 +1,232 @@
+use crate::client::ControlPlaneClient;
+
+pub fn render_claim_statuses(client: &ControlPlaneClient) -> Result<String, String> {
+    Ok(client
+        .claim_statuses()?
+        .into_iter()
+        .map(|status| {
+            format!(
+                "{} enabled={} mode={} loop={} pending_count={} pending_notional={} last_claim={} next_retry={} last_error={}",
+                status.account_id,
+                status.enabled,
+                status.runtime_mode,
+                format!("{:?}", status.loop_state).to_lowercase(),
+                status.pending_redeemable_count,
+                status.pending_redeemable_notional,
+                status
+                    .last_claim_at
+                    .map(|value| value.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+                status
+                    .next_retry_at
+                    .map(|value| value.to_rfc3339())
+                    .unwrap_or_else(|| "-".to_string()),
+                status.last_error.unwrap_or_else(|| "-".to_string()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+pub fn render_claim_detail(
+    client: &ControlPlaneClient,
+    account_id: &str,
+) -> Result<String, String> {
+    client.inspect_claims(account_id).map(|detail| {
+        format!(
+            "{} enabled={} loop={} pending={} history={}",
+            detail.status.account_id,
+            detail.status.enabled,
+            format!("{:?}", detail.status.loop_state).to_lowercase(),
+            detail.redeemable_positions.len(),
+            detail.claim_history.len(),
+        )
+    })
+}
+
+pub fn run_claims(client: &ControlPlaneClient, account_id: &str) -> Result<String, String> {
+    client.run_claims(account_id).map(render_action)
+}
+
+pub fn rescan_claims(client: &ControlPlaneClient, account_id: &str) -> Result<String, String> {
+    client.rescan_claims(account_id).map(render_action)
+}
+
+pub fn pause_claims(client: &ControlPlaneClient, account_id: &str) -> Result<String, String> {
+    client.pause_claims(account_id).map(render_action)
+}
+
+pub fn resume_claims(client: &ControlPlaneClient, account_id: &str) -> Result<String, String> {
+    client.resume_claims(account_id).map(render_action)
+}
+
+fn render_action(response: ploy_operator_contracts::AccountClaimActionResponse) -> String {
+    format!(
+        "{} state={} message={}",
+        response.account_id,
+        format!("{:?}", response.state).to_lowercase(),
+        response.message,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        pause_claims, render_claim_detail, render_claim_statuses, rescan_claims, resume_claims,
+        run_claims,
+    };
+    use crate::client::ControlPlaneClient;
+    use chrono::Utc;
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("duration")
+            .as_nanos();
+        std::env::temp_dir().join(format!("ployctl-claims-{label}-{unique}"))
+    }
+
+    #[test]
+    fn renders_snapshot_backed_claim_statuses() {
+        let runtime_root = temp_dir("status");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+        fs::write(
+            runtime_root.join("account-claims.json"),
+            serde_json::json!([{
+                "status": {
+                    "account_id": "acct-live",
+                    "enabled": true,
+                    "runtime_mode": "live",
+                    "loop_state": "running",
+                    "last_scan_at": null,
+                    "last_claim_at": null,
+                    "last_error": null,
+                    "consecutive_failures": 0,
+                    "next_retry_at": null,
+                    "pending_redeemable_count": 1,
+                    "pending_redeemable_notional": "5.00"
+                },
+                "redeemable_positions": [],
+                "claim_history": []
+            }])
+            .to_string(),
+        )
+        .expect("write claim state");
+
+        let client = ControlPlaneClient::from_runtime_root(&runtime_root);
+        let output = render_claim_statuses(&client).expect("claim statuses");
+        assert!(output.contains("acct-live"));
+        assert!(output.contains("pending_notional=5.00"));
+    }
+
+    #[test]
+    fn renders_claim_detail_from_http() {
+        let runtime_root = temp_dir("detail");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).expect("read request");
+            let body = serde_json::json!({
+                "status": {
+                    "account_id": "acct-live",
+                    "enabled": true,
+                    "runtime_mode": "live",
+                    "loop_state": "running",
+                    "last_scan_at": null,
+                    "last_claim_at": null,
+                    "last_error": null,
+                    "consecutive_failures": 0,
+                    "next_retry_at": null,
+                    "pending_redeemable_count": 1,
+                    "pending_redeemable_notional": "5.00"
+                },
+                "redeemable_positions": [{
+                    "account_id": "acct-live",
+                    "condition_id": "condition-1",
+                    "market_id": "market-1",
+                    "token_ids": ["1"],
+                    "outcome_labels": ["YES"],
+                    "redeemable_size": "5.00",
+                    "estimated_payout": "5.00",
+                    "detected_at": Utc::now(),
+                    "claim_state": "detected"
+                }],
+                "claim_history": []
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(&runtime_root);
+        client.control_plane_addr = addr.to_string();
+        let output = render_claim_detail(&client, "acct-live").expect("claim detail");
+        assert!(output.contains("acct-live"));
+        assert!(output.contains("pending=1"));
+    }
+
+    #[test]
+    fn renders_claim_actions() {
+        for (path, runner) in [
+            (
+                "/api/accounts/acct-live/claims/run",
+                run_claims as fn(&ControlPlaneClient, &str) -> Result<String, String>,
+            ),
+            ("/api/accounts/acct-live/claims/rescan", rescan_claims),
+            ("/api/accounts/acct-live/claims/pause", pause_claims),
+            ("/api/accounts/acct-live/claims/resume", resume_claims),
+        ] {
+            let runtime_root = temp_dir("action");
+            fs::create_dir_all(&runtime_root).expect("create runtime root");
+
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+            let addr = listener.local_addr().expect("local addr");
+            thread::spawn(move || {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let mut request = [0_u8; 2048];
+                let bytes = stream.read(&mut request).expect("read request");
+                let request = String::from_utf8_lossy(&request[..bytes]);
+                assert!(request.starts_with(&format!("POST {path}")));
+                let body = serde_json::json!({
+                    "account_id": "acct-live",
+                    "state": "accepted",
+                    "message": "ok"
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write response");
+            });
+
+            let client = ControlPlaneClient {
+                control_plane_addr: addr.to_string(),
+                admin_token: None,
+                operator_token: None,
+                sidecar_token: None,
+                runtime_root,
+            };
+            let output = runner(&client, "acct-live").expect("action output");
+            assert!(output.contains("acct-live"));
+            assert!(output.contains("state=accepted"));
+        }
+    }
+}

--- a/apps/ployctl/src/client.rs
+++ b/apps/ployctl/src/client.rs
@@ -1,8 +1,8 @@
 use ploy_operator_contracts::{
-    ActiveAlert, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
-    DeploymentControlRequest, DeploymentState, DeploymentSummary, DesiredState, OperatorEvent,
-    OrderControlResponse, OrderReplaceRequest, PlatformMetrics, SystemStatus,
-    TradingStateSnapshot,
+    AccountClaimActionResponse, AccountClaimDetailResponse, AccountClaimStatus, ActiveAlert,
+    AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
+    DeploymentState, DeploymentSummary, DesiredState, OperatorEvent, OrderControlResponse,
+    OrderReplaceRequest, PlatformMetrics, SystemStatus, TradingStateSnapshot,
 };
 use serde::de::DeserializeOwned;
 use std::fs;
@@ -63,6 +63,46 @@ impl ControlPlaneClient {
 
     pub fn audit_logs(&self) -> Result<Vec<AuditLogEntry>, String> {
         self.get_json("/api/audit/logs")
+    }
+
+    pub fn claim_statuses(&self) -> Result<Vec<AccountClaimStatus>, String> {
+        match self.read_claim_status_over_http() {
+            Ok(snapshot) => Ok(snapshot),
+            Err(err) if !should_fallback_to_snapshot(&err) => Err(err),
+            Err(_) => Ok(self
+                .read_claim_detail_snapshot()?
+                .into_iter()
+                .map(|detail| detail.status)
+                .collect()),
+        }
+    }
+
+    pub fn inspect_claims(&self, account_id: &str) -> Result<AccountClaimDetailResponse, String> {
+        match self.read_claim_detail_over_http(account_id) {
+            Ok(detail) => Ok(detail),
+            Err(err) if should_fallback_to_snapshot(&err) => self
+                .read_claim_detail_snapshot()?
+                .into_iter()
+                .find(|detail| detail.status.account_id == account_id)
+                .ok_or_else(|| format!("account `{account_id}` was not found")),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn run_claims(&self, account_id: &str) -> Result<AccountClaimActionResponse, String> {
+        self.send_empty("POST", &format!("/api/accounts/{account_id}/claims/run"))
+    }
+
+    pub fn rescan_claims(&self, account_id: &str) -> Result<AccountClaimActionResponse, String> {
+        self.send_empty("POST", &format!("/api/accounts/{account_id}/claims/rescan"))
+    }
+
+    pub fn pause_claims(&self, account_id: &str) -> Result<AccountClaimActionResponse, String> {
+        self.send_empty("POST", &format!("/api/accounts/{account_id}/claims/pause"))
+    }
+
+    pub fn resume_claims(&self, account_id: &str) -> Result<AccountClaimActionResponse, String> {
+        self.send_empty("POST", &format!("/api/accounts/{account_id}/claims/resume"))
     }
 
     pub fn system_metrics(&self) -> Result<PlatformMetrics, String> {
@@ -259,6 +299,12 @@ impl ControlPlaneClient {
         serde_json::from_str(&body).map_err(|err| format!("parse trading state snapshot: {err}"))
     }
 
+    fn read_claim_detail_snapshot(&self) -> Result<Vec<AccountClaimDetailResponse>, String> {
+        let body = fs::read_to_string(self.runtime_root.join("account-claims.json"))
+            .map_err(|err| format!("read claim state snapshot: {err}"))?;
+        serde_json::from_str(&body).map_err(|err| format!("parse claim state snapshot: {err}"))
+    }
+
     fn read_status_over_http(&self) -> Result<SystemStatus, String> {
         self.get_json("/api/system/status")
     }
@@ -273,6 +319,17 @@ impl ControlPlaneClient {
 
     fn read_trading_state_over_http(&self) -> Result<Vec<TradingStateSnapshot>, String> {
         self.get_json("/api/trading/state")
+    }
+
+    fn read_claim_status_over_http(&self) -> Result<Vec<AccountClaimStatus>, String> {
+        self.get_json("/api/accounts/claims")
+    }
+
+    fn read_claim_detail_over_http(
+        &self,
+        account_id: &str,
+    ) -> Result<AccountClaimDetailResponse, String> {
+        self.get_json(&format!("/api/accounts/{account_id}/claims"))
     }
 
     fn get_json<T>(&self, path: &str) -> Result<T, String>

--- a/apps/ployctl/src/lib.rs
+++ b/apps/ployctl/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod claims;
 pub mod client;
 pub mod deployments;
 pub mod system;

--- a/apps/ployctl/src/main.rs
+++ b/apps/ployctl/src/main.rs
@@ -1,4 +1,4 @@
-use ployctl::{client::ControlPlaneClient, deployments, system, trading};
+use ployctl::{claims, client::ControlPlaneClient, deployments, system, trading};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Command {
@@ -15,6 +15,12 @@ enum Command {
         rust_decimal::Decimal,
         Option<rust_decimal::Decimal>,
     ),
+    ClaimsList,
+    ClaimsInspect(String),
+    ClaimsRun(String),
+    ClaimsRescan(String),
+    ClaimsPause(String),
+    ClaimsResume(String),
     DeploymentsList,
     DeploymentsInspect(String),
     DeploymentsApply(String),
@@ -80,6 +86,22 @@ impl Command {
                     limit_price,
                 ))
             }
+            [_bin, claims, list] if claims == "claims" && list == "list" => Ok(Self::ClaimsList),
+            [_bin, claims, inspect, account_id] if claims == "claims" && inspect == "inspect" => {
+                Ok(Self::ClaimsInspect(account_id.clone()))
+            }
+            [_bin, claims, run, account_id] if claims == "claims" && run == "run" => {
+                Ok(Self::ClaimsRun(account_id.clone()))
+            }
+            [_bin, claims, rescan, account_id] if claims == "claims" && rescan == "rescan" => {
+                Ok(Self::ClaimsRescan(account_id.clone()))
+            }
+            [_bin, claims, pause, account_id] if claims == "claims" && pause == "pause" => {
+                Ok(Self::ClaimsPause(account_id.clone()))
+            }
+            [_bin, claims, resume, account_id] if claims == "claims" && resume == "resume" => {
+                Ok(Self::ClaimsResume(account_id.clone()))
+            }
             [_bin, deployments, list] if deployments == "deployments" && list == "list" => {
                 Ok(Self::DeploymentsList)
             }
@@ -128,7 +150,7 @@ impl Command {
             {
                 Ok(Self::DeploymentsArchive(deployment_id.clone()))
             }
-            _ => Err("usage: ployctl system status | ployctl system metrics | ployctl system alerts | ployctl system audit | ployctl trading status | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
+            _ => Err("usage: ployctl system status | ployctl system metrics | ployctl system alerts | ployctl system audit | ployctl trading status | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl claims list | ployctl claims inspect <account-id> | ployctl claims run <account-id> | ployctl claims rescan <account-id> | ployctl claims pause <account-id> | ployctl claims resume <account-id> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
         }
     }
 }
@@ -163,6 +185,12 @@ fn execute(command: Command, client: &ControlPlaneClient) -> Result<String, Stri
         Command::TradingReplace(deployment_id, order_id, quantity, limit_price) => {
             trading::replace_order(client, &deployment_id, &order_id, quantity, limit_price)
         }
+        Command::ClaimsList => claims::render_claim_statuses(client),
+        Command::ClaimsInspect(account_id) => claims::render_claim_detail(client, &account_id),
+        Command::ClaimsRun(account_id) => claims::run_claims(client, &account_id),
+        Command::ClaimsRescan(account_id) => claims::rescan_claims(client, &account_id),
+        Command::ClaimsPause(account_id) => claims::pause_claims(client, &account_id),
+        Command::ClaimsResume(account_id) => claims::resume_claims(client, &account_id),
         Command::DeploymentsList => deployments::render_deployments(client),
         Command::DeploymentsInspect(deployment_id) => {
             deployments::render_deployment(client, &deployment_id)
@@ -308,6 +336,22 @@ mod tests {
                 Some(rust_decimal::Decimal::new(57, 2)),
             )
         );
+    }
+
+    #[test]
+    fn parses_claims_inspect_command() {
+        let command =
+            Command::parse(&["ployctl", "claims", "inspect", "acct-live"].map(str::to_string))
+                .expect("command");
+        assert_eq!(command, Command::ClaimsInspect("acct-live".to_string()));
+    }
+
+    #[test]
+    fn parses_claims_run_command() {
+        let command =
+            Command::parse(&["ployctl", "claims", "run", "acct-live"].map(str::to_string))
+                .expect("command");
+        assert_eq!(command, Command::ClaimsRun("acct-live".to_string()));
     }
 
     #[test]

--- a/apps/ployd/src/config.rs
+++ b/apps/ployd/src/config.rs
@@ -13,9 +13,13 @@ pub struct PlatformConfig {
     pub status_file: PathBuf,
     pub deployment_status_file: PathBuf,
     pub trading_state_file: PathBuf,
+    pub claim_state_file: PathBuf,
     pub audit_log_file: PathBuf,
     pub tick_interval_ms: u64,
+    pub claim_tick_interval_ms: u64,
     pub request_rate_limit_per_minute: u32,
+    pub claim_backoff_base_ms: u64,
+    pub claim_backoff_max_ms: u64,
     pub live_reconcile_backoff_base_ms: u64,
     pub live_reconcile_backoff_max_ms: u64,
     pub worker_heartbeat_stale_after_ms: u64,
@@ -36,10 +40,14 @@ impl Default for PlatformConfig {
             status_file: runtime_root.join("system-status.json"),
             deployment_status_file: runtime_root.join("deployments.json"),
             trading_state_file: runtime_root.join("trading-state.json"),
+            claim_state_file: runtime_root.join("account-claims.json"),
             audit_log_file: runtime_root.join("audit-log.jsonl"),
             runtime_root,
             tick_interval_ms: 1_000,
+            claim_tick_interval_ms: 30_000,
             request_rate_limit_per_minute: 240,
+            claim_backoff_base_ms: 5_000,
+            claim_backoff_max_ms: 120_000,
             live_reconcile_backoff_base_ms: 1_000,
             live_reconcile_backoff_max_ms: 30_000,
             worker_heartbeat_stale_after_ms: 15_000,
@@ -105,6 +113,11 @@ impl PlatformConfig {
         } else {
             config.trading_state_file = config.runtime_root.join("trading-state.json");
         }
+        if let Ok(value) = std::env::var("PLOY_ACCOUNT_CLAIM_STATE_FILE") {
+            config.claim_state_file = PathBuf::from(value);
+        } else {
+            config.claim_state_file = config.runtime_root.join("account-claims.json");
+        }
         if let Ok(value) = std::env::var("PLOY_AUDIT_LOG_FILE") {
             config.audit_log_file = PathBuf::from(value);
         } else {
@@ -118,6 +131,21 @@ impl PlatformConfig {
         if let Ok(value) = std::env::var("PLOY_REQUEST_RATE_LIMIT_PER_MINUTE") {
             if let Ok(parsed) = value.parse() {
                 config.request_rate_limit_per_minute = parsed;
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_CLAIM_TICK_INTERVAL_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.claim_tick_interval_ms = parsed;
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_CLAIM_BACKOFF_BASE_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.claim_backoff_base_ms = parsed;
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_CLAIM_BACKOFF_MAX_MS") {
+            if let Ok(parsed) = value.parse() {
+                config.claim_backoff_max_ms = parsed;
             }
         }
         if let Ok(value) = std::env::var("PLOY_LIVE_RECONCILE_BACKOFF_BASE_MS") {
@@ -199,11 +227,18 @@ mod tests {
             "run/platform/trading-state.json"
         );
         assert_eq!(
+            config.claim_state_file.to_string_lossy(),
+            "run/platform/account-claims.json"
+        );
+        assert_eq!(
             config.audit_log_file.to_string_lossy(),
             "run/platform/audit-log.jsonl"
         );
         assert_eq!(config.tick_interval_ms, 1_000);
+        assert_eq!(config.claim_tick_interval_ms, 30_000);
         assert_eq!(config.request_rate_limit_per_minute, 240);
+        assert_eq!(config.claim_backoff_base_ms, 5_000);
+        assert_eq!(config.claim_backoff_max_ms, 120_000);
         assert_eq!(config.live_reconcile_backoff_base_ms, 1_000);
         assert_eq!(config.live_reconcile_backoff_max_ms, 30_000);
         assert_eq!(config.worker_heartbeat_stale_after_ms, 15_000);

--- a/apps/ployd/src/http.rs
+++ b/apps/ployd/src/http.rs
@@ -538,8 +538,12 @@ fn required_access(method: &str, path: &str) -> RequiredAccess {
         | ("GET", "/api/system/alerts")
         | ("GET", "/api/deployments")
         | ("GET", "/api/trading/state")
+        | ("GET", "/api/accounts/claims")
         | ("GET", "/api/events/stream") => RequiredAccess::ReadOnly,
         ("GET", "/api/audit/logs") => RequiredAccess::Admin,
+        ("GET", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims") => {
+            RequiredAccess::ReadOnly
+        }
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             RequiredAccess::ReadOnly
         }
@@ -562,6 +566,28 @@ fn required_access_name(required_access: RequiredAccess) -> &'static str {
         RequiredAccess::ReadOnly => "read_only",
         RequiredAccess::Operator => "operator",
         RequiredAccess::Admin => "admin",
+    }
+}
+
+fn account_claim_action_account_id<'a>(path: &'a str, suffix: &str) -> Option<&'a str> {
+    path.strip_prefix("/api/accounts/")
+        .and_then(|path| path.strip_suffix(suffix))
+        .map(|path| path.trim_end_matches('/'))
+        .filter(|account_id| !account_id.is_empty())
+}
+
+fn claim_action_error_response(err: io::Error, account_id: &str) -> (u16, String) {
+    match err.kind() {
+        io::ErrorKind::NotFound => json_error(
+            404,
+            "account_not_found",
+            Some(format!("account `{account_id}` was not found")),
+        ),
+        io::ErrorKind::InvalidInput => json_error(400, "invalid_request", Some(err.to_string())),
+        io::ErrorKind::InvalidData => {
+            json_error(503, "claim_backend_misconfigured", Some(err.to_string()))
+        }
+        _ => json_error(500, "claim_action_failed", Some(err.to_string())),
     }
 }
 
@@ -945,6 +971,14 @@ fn handle_runtime_request(
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
+        ("GET", "/api/accounts/claims") => match state.daemon.lock() {
+            Ok(daemon) => (
+                200,
+                serde_json::to_string(&daemon.claim_statuses())
+                    .unwrap_or_else(|_| "[]".to_string()),
+            ),
+            Err(_) => json_error(503, "daemon_lock_poisoned", None),
+        },
         ("GET", "/api/audit/logs") => match audit_log_path(state)
             .map_err(|response| response)
             .and_then(|path| {
@@ -957,6 +991,27 @@ fn handle_runtime_request(
             ),
             Err(response) => response,
         },
+        ("GET", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims") => {
+            let Some(account_id) = account_claim_action_account_id(path, "/claims") else {
+                return json_error(404, "not_found", None);
+            };
+            match state.daemon.lock() {
+                Ok(daemon) => match daemon.inspect_account_claims(account_id) {
+                    Some(detail) => (
+                        200,
+                        serde_json::to_string(&detail).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    None => claim_action_error_response(
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            format!("account `{account_id}` was not found"),
+                        ),
+                        account_id,
+                    ),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             let deployment_id = path.trim_start_matches("/api/deployments/");
             match state.daemon.lock() {
@@ -1046,6 +1101,88 @@ fn handle_runtime_request(
                         Err(err) => json_error(500, "control_failed", Some(err.to_string())),
                     }
                 }
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims/run") => {
+            let Some(account_id) = account_claim_action_account_id(path, "/claims/run") else {
+                return json_error(404, "not_found", None);
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon.run_account_claims(account_id).and_then(|response| {
+                    daemon.write_runtime_snapshots()?;
+                    publish_snapshot_events(&daemon, &state.events);
+                    Ok(response)
+                }) {
+                    Ok(response) => (
+                        200,
+                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) => claim_action_error_response(err, account_id),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims/rescan") => {
+            let Some(account_id) = account_claim_action_account_id(path, "/claims/rescan") else {
+                return json_error(404, "not_found", None);
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon
+                    .rescan_account_claims(account_id)
+                    .and_then(|response| {
+                        daemon.write_runtime_snapshots()?;
+                        publish_snapshot_events(&daemon, &state.events);
+                        Ok(response)
+                    }) {
+                    Ok(response) => (
+                        200,
+                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) => claim_action_error_response(err, account_id),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims/pause") => {
+            let Some(account_id) = account_claim_action_account_id(path, "/claims/pause") else {
+                return json_error(404, "not_found", None);
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon
+                    .set_account_claim_enabled(account_id, false)
+                    .and_then(|response| {
+                        daemon.write_runtime_snapshots()?;
+                        publish_snapshot_events(&daemon, &state.events);
+                        Ok(response)
+                    }) {
+                    Ok(response) => (
+                        200,
+                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) => claim_action_error_response(err, account_id),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", _) if path.starts_with("/api/accounts/") && path.ends_with("/claims/resume") => {
+            let Some(account_id) = account_claim_action_account_id(path, "/claims/resume") else {
+                return json_error(404, "not_found", None);
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon
+                    .set_account_claim_enabled(account_id, true)
+                    .and_then(|response| {
+                        daemon.write_runtime_snapshots()?;
+                        publish_snapshot_events(&daemon, &state.events);
+                        Ok(response)
+                    }) {
+                    Ok(response) => (
+                        200,
+                        serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) => claim_action_error_response(err, account_id),
+                },
                 Err(_) => json_error(503, "daemon_lock_poisoned", None),
             }
         }
@@ -2290,5 +2427,38 @@ mod tests {
             handle_runtime_request("GET", "/api/deployments/missing.paper", None, &state);
         assert_eq!(status_code, 503);
         assert!(body.contains("\"error\":\"daemon_lock_poisoned\""));
+    }
+
+    #[test]
+    fn handle_runtime_request_reads_claim_state_from_shared_daemon() {
+        let daemon = crate::runtime::PloyDaemon::boot(&crate::config::PlatformConfig::default())
+            .expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let (status_code, body) = handle_runtime_request("GET", "/api/accounts/claims", None, &state);
+        assert_eq!(status_code, 200);
+        assert!(body.starts_with('['));
+    }
+
+    #[test]
+    fn handle_runtime_request_runs_account_claims() {
+        let daemon = crate::runtime::PloyDaemon::boot(&crate::config::PlatformConfig::default())
+            .expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let (status_code, body) = handle_runtime_request(
+            "POST",
+            "/api/accounts/acct-live/claims/run",
+            None,
+            &state,
+        );
+        assert!(matches!(status_code, 200 | 404));
+        assert!(body.contains("acct-live") || body.contains("not found"));
     }
 }

--- a/apps/ployd/src/runtime.rs
+++ b/apps/ployd/src/runtime.rs
@@ -3,21 +3,26 @@ use crate::events::EventBroker;
 use crate::http::publish_snapshot_events;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ploy_connectivity::{
-    CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome, ExecutionRequest,
-    LiveExecutionGateway, PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, TrackedOrder,
+    CancellationOutcome, CancellationRequest, ClaimError, ClaimGateway, ClaimRequest,
+    ClaimResult, ExecutionError, ExecutionOutcome, ExecutionRequest, LiveExecutionGateway,
+    PolymarketClaimGateway, PolymarketExecutionGateway, RedeemablePosition, ReplaceOutcome,
+    ReplaceRequest, StaticClaimGateway, TrackedOrder,
 };
 use ploy_deployments::{WorkerLaunchSpec, WorkerSupervisor};
 use ploy_operator_contracts::{
-    ActiveAlert, DeploymentApplyRequest, DeploymentControlRequest, DeploymentState, DesiredState,
-    FillSnapshot, IntentPurpose, ObservedState, OrderControlResponse, OrderReplaceRequest,
-    OrderSnapshot, PaperIntentResponse, PlatformMetrics, PnlSnapshotResponse,
-    PositionSnapshotResponse, RiskSnapshotResponse, TradingIntentSnapshot, TradingStateSnapshot,
+    AccountClaimActionResponse, AccountClaimActionState, AccountClaimDetailResponse,
+    AccountClaimStatus, ActiveAlert, ClaimExecutionOutcome, ClaimExecutionRecord, ClaimLoopState,
+    ClaimPositionState, DeploymentApplyRequest, DeploymentControlRequest, DeploymentState,
+    DesiredState, FillSnapshot, IntentPurpose, ObservedState, OrderControlResponse,
+    OrderReplaceRequest, OrderSnapshot, PaperIntentResponse, PlatformMetrics,
+    PnlSnapshotResponse, PositionSnapshotResponse, RedeemablePositionSnapshot,
+    RiskSnapshotResponse, TradingIntentSnapshot, TradingStateSnapshot,
 };
-use ploy_platform::{ControlPlane, DeploymentRecord};
+use ploy_platform::{AccountClaimDetail, AccountClaimSnapshot, ControlPlane, DeploymentRecord};
 use ploy_trading::{OrderState, TradeSide, TradingIntent, TradingRuntime, TradingRuntimeSnapshot};
 use rust_decimal::Decimal;
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -42,6 +47,7 @@ pub struct PloyDaemon {
     pub supervisor: WorkerSupervisor,
     pub trading: BTreeMap<String, TradingRuntime>,
     live_execution: Box<dyn LiveExecutionGateway>,
+    claim_gateway: Box<dyn ClaimGateway>,
     live_reconcile_failures: u32,
     next_live_reconcile_at: Option<DateTime<Utc>>,
     last_live_reconcile_error: Option<String>,
@@ -49,12 +55,24 @@ pub struct PloyDaemon {
 
 impl PloyDaemon {
     pub fn boot(config: &PlatformConfig) -> io::Result<Self> {
-        Self::boot_with_live_execution(config, Box::new(PolymarketExecutionGateway::from_env()))
+        Self::boot_with_gateways(
+            config,
+            Box::new(PolymarketExecutionGateway::from_env()),
+            Box::new(PolymarketClaimGateway::from_env()),
+        )
     }
 
     pub fn boot_with_live_execution(
         config: &PlatformConfig,
         live_execution: Box<dyn LiveExecutionGateway>,
+    ) -> io::Result<Self> {
+        Self::boot_with_gateways(config, live_execution, Box::new(StaticClaimGateway::default()))
+    }
+
+    pub fn boot_with_gateways(
+        config: &PlatformConfig,
+        live_execution: Box<dyn LiveExecutionGateway>,
+        claim_gateway: Box<dyn ClaimGateway>,
     ) -> io::Result<Self> {
         let mut control_plane = ControlPlane::default();
         control_plane
@@ -67,12 +85,14 @@ impl PloyDaemon {
             supervisor: WorkerSupervisor::default(),
             trading: BTreeMap::new(),
             live_execution,
+            claim_gateway,
             live_reconcile_failures: 0,
             next_live_reconcile_at: None,
             last_live_reconcile_error: None,
         };
         daemon.load_registry()?;
         daemon.load_trading_snapshots()?;
+        daemon.load_claim_snapshots()?;
         if daemon.config.trading_state_file.exists() {
             daemon
                 .control_plane
@@ -95,6 +115,10 @@ impl PloyDaemon {
         }
         self.control_plane.system.set_database_connected(true);
         self.tick();
+        self.sync_account_claims();
+        if let Err(err) = self.run_auto_claim_loops() {
+            self.mark_claim_runtime_degraded(err);
+        }
         match self.reconcile_live_fills() {
             Ok(ReconcileStatus::Applied(_) | ReconcileStatus::Noop) => self.mark_runtime_healthy(),
             Ok(ReconcileStatus::BackoffActive) => {}
@@ -124,6 +148,7 @@ impl PloyDaemon {
             &self.control_plane.deployments.summaries(),
         )?;
         write_json(&self.config.trading_state_file, &self.trading_state())?;
+        write_json(&self.config.claim_state_file, &self.claim_details())?;
         Ok(())
     }
 
@@ -146,6 +171,76 @@ impl PloyDaemon {
 
     pub fn active_alerts(&self) -> Vec<ActiveAlert> {
         self.control_plane.system.active_alerts()
+    }
+
+    pub fn claim_statuses(&self) -> Vec<AccountClaimStatus> {
+        self.control_plane.accounts.statuses()
+    }
+
+    pub fn claim_details(&self) -> Vec<AccountClaimDetailResponse> {
+        self.control_plane.accounts.details()
+    }
+
+    pub fn inspect_account_claims(&self, account_id: &str) -> Option<AccountClaimDetailResponse> {
+        self.control_plane
+            .accounts
+            .detail(account_id)
+            .map(AccountClaimDetail::response)
+    }
+
+    pub fn run_account_claims(
+        &mut self,
+        account_id: &str,
+    ) -> io::Result<AccountClaimActionResponse> {
+        self.refresh_account_claims(account_id, true)
+    }
+
+    pub fn rescan_account_claims(
+        &mut self,
+        account_id: &str,
+    ) -> io::Result<AccountClaimActionResponse> {
+        self.refresh_account_claims(account_id, false)
+    }
+
+    pub fn set_account_claim_enabled(
+        &mut self,
+        account_id: &str,
+        enabled: bool,
+    ) -> io::Result<AccountClaimActionResponse> {
+        let Some(current) = self.control_plane.accounts.get(account_id).cloned() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("account `{account_id}` was not found"),
+            ));
+        };
+        if current.runtime_mode != "live" {
+            return Ok(AccountClaimActionResponse {
+                account_id: account_id.to_string(),
+                state: AccountClaimActionState::NotSupported,
+                message: format!("account `{account_id}` is not a live account"),
+            });
+        }
+        self.control_plane.accounts.set_enabled(account_id, enabled);
+        if enabled {
+            self.control_plane.system.note_source_heartbeat(
+                format!("claims:{account_id}"),
+                "claims",
+                ChronoDuration::milliseconds(self.config.claim_tick_interval_ms as i64),
+            );
+        } else {
+            self.control_plane
+                .system
+                .clear_source(&format!("claims:{account_id}"));
+        }
+        Ok(AccountClaimActionResponse {
+            account_id: account_id.to_string(),
+            state: AccountClaimActionState::Accepted,
+            message: if enabled {
+                "automatic claim loop resumed".to_string()
+            } else {
+                "automatic claim loop paused".to_string()
+            },
+        })
     }
 
     pub fn trading_state(&self) -> Vec<TradingStateSnapshot> {
@@ -728,6 +823,18 @@ impl PloyDaemon {
         }
     }
 
+    fn mark_claim_runtime_degraded(&mut self, err: io::Error) {
+        self.control_plane
+            .system
+            .mark_degraded(&self.config.listen_addr);
+        self.control_plane.system.note_source_failure(
+            "claims",
+            "claims",
+            ChronoDuration::milliseconds(self.config.claim_tick_interval_ms as i64),
+            err.to_string(),
+        );
+    }
+
     fn record_live_reconcile_failure(&mut self, err: &io::Error) {
         let failures = self.live_reconcile_failures.saturating_add(1);
         self.live_reconcile_failures = failures;
@@ -746,6 +853,16 @@ impl PloyDaemon {
             self.config.live_reconcile_backoff_base_ms,
             self.config.live_reconcile_backoff_max_ms,
         );
+        Utc::now() + chrono::Duration::milliseconds(backoff_ms as i64)
+    }
+
+    fn next_claim_retry_at(&self, failures: u32) -> DateTime<Utc> {
+        let factor = 1_u64.checked_shl(failures.saturating_sub(1).min(20)).unwrap_or(0);
+        let backoff_ms = self
+            .config
+            .claim_backoff_base_ms
+            .saturating_mul(factor.max(1))
+            .min(self.config.claim_backoff_max_ms);
         Utc::now() + chrono::Duration::milliseconds(backoff_ms as i64)
     }
 
@@ -916,6 +1033,259 @@ impl PloyDaemon {
         }
 
         Ok(())
+    }
+
+    fn load_claim_snapshots(&mut self) -> io::Result<()> {
+        if !self.config.claim_state_file.exists() {
+            return Ok(());
+        }
+
+        let raw = fs::read_to_string(&self.config.claim_state_file)?;
+        if raw.trim().is_empty() {
+            return Ok(());
+        }
+
+        let records: Vec<AccountClaimDetail> = serde_json::from_str(&raw)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        self.control_plane.accounts.restore(records);
+        Ok(())
+    }
+
+    fn sync_account_claims(&mut self) {
+        let live_accounts: BTreeSet<String> = self
+            .control_plane
+            .deployments
+            .records()
+            .into_iter()
+            .filter(|record| {
+                record.runtime_mode == "live"
+                    && record.deployment_state != DeploymentState::Archived
+            })
+            .map(|record| record.account_id)
+            .collect();
+
+        self.control_plane.accounts.retain_accounts(&live_accounts);
+        for account_id in &live_accounts {
+            if self.control_plane.accounts.get(account_id).is_none() {
+                self.control_plane
+                    .accounts
+                    .upsert(AccountClaimSnapshot::for_runtime_mode(account_id, "live"));
+            }
+        }
+    }
+
+    fn refresh_account_claims(
+        &mut self,
+        account_id: &str,
+        execute_claims: bool,
+    ) -> io::Result<AccountClaimActionResponse> {
+        let Some(status) = self.control_plane.accounts.get(account_id).cloned() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("account `{account_id}` was not found"),
+            ));
+        };
+        if status.runtime_mode != "live" {
+            return Ok(AccountClaimActionResponse {
+                account_id: account_id.to_string(),
+                state: AccountClaimActionState::NotSupported,
+                message: format!("account `{account_id}` is not a live account"),
+            });
+        }
+
+        let scan_time = Utc::now();
+        let positions = self
+            .claim_gateway
+            .discover_redeemable_positions(account_id)
+            .map_err(io_error_from_claim_error)?;
+        self.control_plane
+            .accounts
+            .mark_scan_complete(account_id, scan_time);
+
+        let detected_count = positions.len();
+        let remaining = if execute_claims {
+            let (remaining, claim_error) =
+                self.execute_account_claims(account_id, positions, scan_time);
+            if let Some(err) = claim_error {
+                let failures = self
+                    .control_plane
+                    .accounts
+                    .get(account_id)
+                    .map(|current| current.consecutive_failures.saturating_add(1))
+                    .unwrap_or(1);
+                let next_retry_at = Some(self.next_claim_retry_at(failures));
+                self.control_plane
+                    .accounts
+                    .mark_degraded(account_id, err.to_string(), next_retry_at);
+                self.mark_claim_runtime_degraded(err);
+            } else {
+                self.control_plane.accounts.mark_running(account_id);
+                self.control_plane.system.note_source_heartbeat(
+                    format!("claims:{account_id}"),
+                    "claims",
+                    ChronoDuration::milliseconds(self.config.claim_tick_interval_ms as i64),
+                );
+            }
+            remaining
+        } else {
+            positions
+                .into_iter()
+                .map(|position| {
+                    redeemable_position_snapshot(
+                        account_id,
+                        scan_time,
+                        position,
+                        ClaimPositionState::Detected,
+                    )
+                })
+                .collect()
+        };
+
+        let claimed_count = detected_count.saturating_sub(remaining.len());
+        self.control_plane
+            .accounts
+            .set_redeemable_positions(account_id, remaining);
+
+        let message = if execute_claims {
+            format!("claim run completed: detected={detected_count} claimed={claimed_count}")
+        } else {
+            format!("claim rescan completed: detected={detected_count}")
+        };
+
+        Ok(AccountClaimActionResponse {
+            account_id: account_id.to_string(),
+            state: AccountClaimActionState::Accepted,
+            message,
+        })
+    }
+
+    fn run_auto_claim_loops(&mut self) -> io::Result<()> {
+        let account_ids: Vec<String> = self
+            .control_plane
+            .accounts
+            .statuses()
+            .into_iter()
+            .filter(|status| {
+                status.enabled
+                    && status.runtime_mode == "live"
+                    && status.loop_state != ClaimLoopState::Paused
+                    && status
+                        .next_retry_at
+                        .map(|next| next <= Utc::now())
+                        .unwrap_or(true)
+            })
+            .map(|status| status.account_id)
+            .collect();
+
+        for account_id in account_ids {
+            let scan_time = Utc::now();
+            let positions = self
+                .claim_gateway
+                .discover_redeemable_positions(&account_id)
+                .map_err(io_error_from_claim_error)?;
+            self.control_plane
+                .accounts
+                .mark_scan_complete(&account_id, scan_time);
+
+            let (remaining, claim_error) =
+                self.execute_account_claims(&account_id, positions, scan_time);
+            self.control_plane
+                .accounts
+                .set_redeemable_positions(&account_id, remaining);
+            if let Some(err) = claim_error {
+                let failures = self
+                    .control_plane
+                    .accounts
+                    .get(&account_id)
+                    .map(|status| status.consecutive_failures.saturating_add(1))
+                    .unwrap_or(1);
+                let next_retry_at = Some(self.next_claim_retry_at(failures));
+                self.control_plane
+                    .accounts
+                    .mark_degraded(&account_id, err.to_string(), next_retry_at);
+                self.mark_claim_runtime_degraded(err);
+            } else {
+                self.control_plane.accounts.mark_running(&account_id);
+                self.control_plane.system.note_source_heartbeat(
+                    format!("claims:{account_id}"),
+                    "claims",
+                    ChronoDuration::milliseconds(self.config.claim_tick_interval_ms as i64),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn execute_account_claims(
+        &mut self,
+        account_id: &str,
+        positions: Vec<RedeemablePosition>,
+        detected_at: DateTime<Utc>,
+    ) -> (Vec<RedeemablePositionSnapshot>, Option<io::Error>) {
+        let mut remaining = Vec::new();
+        let mut last_error = None;
+
+        for position in positions {
+            let request = ClaimRequest {
+                account_id: position.account_id.clone(),
+                wallet_address: position.wallet_address.clone(),
+                condition_id: position.condition_id.clone(),
+                outcome_indexes: position.outcome_indexes.clone(),
+                outcome_amounts: position.outcome_amounts.clone(),
+                negative_risk: position.negative_risk,
+            };
+            let amount_claimed = position
+                .outcome_amounts
+                .iter()
+                .copied()
+                .fold(Decimal::ZERO, |acc, value| acc + value);
+
+            match self.claim_gateway.claim(&request) {
+                Ok(result) => {
+                    self.control_plane.accounts.append_claim_record(
+                        account_id,
+                        ClaimExecutionRecord {
+                            claim_id: next_claim_id(account_id, &position.condition_id),
+                            account_id: account_id.to_string(),
+                            condition_id: position.condition_id.clone(),
+                            submitted_at: detected_at,
+                            completed_at: Some(Utc::now()),
+                            tx_hash: Some(result.tx_hash),
+                            amount_claimed: result.amount_claimed,
+                            outcome: ClaimExecutionOutcome::Confirmed,
+                            error_message: None,
+                        },
+                    );
+                }
+                Err(err) => {
+                    let error_message = err.to_string();
+                    last_error = Some(io_error_from_claim_error(err));
+                    self.control_plane.accounts.append_claim_record(
+                        account_id,
+                        ClaimExecutionRecord {
+                            claim_id: next_claim_id(account_id, &position.condition_id),
+                            account_id: account_id.to_string(),
+                            condition_id: position.condition_id.clone(),
+                            submitted_at: detected_at,
+                            completed_at: Some(Utc::now()),
+                            tx_hash: None,
+                            amount_claimed,
+                            outcome: ClaimExecutionOutcome::Failed,
+                            error_message: Some(error_message),
+                        },
+                    );
+                    remaining.push(redeemable_position_snapshot(
+                        account_id,
+                        detected_at,
+                        position,
+                        ClaimPositionState::Failed,
+                    ));
+                }
+            }
+        }
+
+        (remaining, last_error)
     }
 
     fn tick(&mut self) {
@@ -1315,6 +1685,42 @@ pub fn next_paper_intent_id(deployment_id: &str) -> String {
         .expect("system time")
         .as_millis();
     format!("{deployment_id}-{unique}")
+}
+
+fn io_error_from_claim_error(err: ClaimError) -> io::Error {
+    let kind = match err {
+        ClaimError::Configuration(_) => io::ErrorKind::InvalidData,
+        ClaimError::Validation(_) => io::ErrorKind::InvalidInput,
+        ClaimError::Transport(_) => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, err.to_string())
+}
+
+fn redeemable_position_snapshot(
+    account_id: &str,
+    detected_at: DateTime<Utc>,
+    position: RedeemablePosition,
+    claim_state: ClaimPositionState,
+) -> RedeemablePositionSnapshot {
+    RedeemablePositionSnapshot {
+        account_id: account_id.to_string(),
+        condition_id: position.condition_id,
+        market_id: position.market_id,
+        token_ids: position.token_ids,
+        outcome_labels: position.outcome_labels,
+        redeemable_size: position.redeemable_size,
+        estimated_payout: position.estimated_payout,
+        detected_at,
+        claim_state,
+    }
+}
+
+fn next_claim_id(account_id: &str, condition_id: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("claim-{account_id}-{condition_id}-{nanos}")
 }
 
 pub fn run_shared_forever(

--- a/crates/ploy-connectivity/Cargo.toml
+++ b/crates/ploy-connectivity/Cargo.toml
@@ -8,10 +8,17 @@ repository.workspace = true
 description = "Ploy connectivity crate"
 
 [dependencies]
+alloy = { version = "1.5.2", features = ["dyn-abi", "providers", "reqwest", "signer-local", "sol-types"], default-features = false }
+base64 = "0.22"
+hmac.workspace = true
 ploy-trading.workspace = true
-polymarket-client-sdk = { path = "../../vendor/polymarket-client-sdk", features = ["clob"] }
+polymarket-client-sdk = { path = "../../vendor/polymarket-client-sdk", features = ["clob", "ctf", "data"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 rust_decimal.workspace = true
 secrecy.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread"] }
 

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -1,18 +1,103 @@
+use alloy::core::sol;
+use alloy::dyn_abi::Eip712Domain;
+use alloy::primitives::{keccak256, Address as AlloyAddress, B256, Bytes, U256 as AlloyU256};
+use alloy::sol_types::{SolCall, SolStruct as _};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use hmac::{Hmac, Mac as _};
 use ploy_trading::{FillRecord, TradeSide};
 use polymarket_client_sdk::auth::{LocalSigner, Signer};
 use polymarket_client_sdk::clob::types::request::TradesRequest;
 use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
 use polymarket_client_sdk::clob::types::{OrderType, Side, SignatureType};
 use polymarket_client_sdk::clob::{Client, Config};
+use polymarket_client_sdk::data::types::request::PositionsRequest;
+use polymarket_client_sdk::data::types::response::Position as DataPosition;
+use polymarket_client_sdk::data::Client as DataClient;
+use polymarket_client_sdk::derive_proxy_wallet;
+use polymarket_client_sdk::derive_safe_wallet;
 use polymarket_client_sdk::types::{Address, U256};
-use polymarket_client_sdk::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk::{POLYGON, PRIVATE_KEY_VAR, contract_config, wallet_contract_config};
+use reqwest::blocking::Client as BlockingHttpClient;
 use rust_decimal::Decimal;
 use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 pub const CRATE_MARKER: &str = "ploy-connectivity";
 const DEFAULT_POLY_CLOB_HOST: &str = "https://clob.polymarket.com";
+const DEFAULT_POLY_DATA_HOST: &str = "https://data-api.polymarket.com";
+const DEFAULT_POLYGON_RPC_URL: &str = "https://polygon.drpc.org";
+const DEFAULT_POLY_RELAYER_URL: &str = "https://relayer-v2.polymarket.com";
+const DEFAULT_RELAY_POLL_FREQUENCY_MS: u64 = 2_000;
+const DEFAULT_RELAY_MAX_POLLS: usize = 30;
+const DEFAULT_PROXY_GAS_LIMIT: u64 = 10_000_000;
+const POLY_RELAYER_URL_VAR: &str = "POLYMARKET_RELAYER_URL";
+const POLY_RELAYER_URL_ALIAS: &str = "POLY_RELAYER_URL";
+const POLY_BUILDER_API_KEY_VAR: &str = "POLY_BUILDER_API_KEY";
+const POLY_BUILDER_API_KEY_ALIAS: &str = "BUILDER_API_KEY";
+const POLY_BUILDER_SECRET_VAR: &str = "POLY_BUILDER_SECRET";
+const POLY_BUILDER_SECRET_ALIAS: &str = "BUILDER_SECRET";
+const POLY_BUILDER_PASS_PHRASE_VAR: &str = "POLY_BUILDER_PASS_PHRASE";
+const POLY_BUILDER_PASSPHRASE_VAR: &str = "POLY_BUILDER_PASSPHRASE";
+const POLY_BUILDER_PASS_PHRASE_ALIAS: &str = "BUILDER_PASS_PHRASE";
+const POLY_RELAY_HUB: &str = "0xD216153c06E857cD7f72665E0aF1d7D82172F494";
+
+sol! {
+    #[derive(Debug)]
+    struct RelayProxyTransaction {
+        uint8 typeCode;
+        address to;
+        uint256 value;
+        bytes data;
+    }
+
+    #[derive(Debug)]
+    struct SafeTx {
+        address to;
+        uint256 value;
+        bytes data;
+        uint8 operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+        uint256 nonce;
+    }
+
+    #[derive(Debug)]
+    struct CreateProxy {
+        address paymentToken;
+        uint256 payment;
+        address paymentReceiver;
+    }
+
+    interface IConditionalTokensRelay {
+        function redeemPositions(
+            address collateralToken,
+            bytes32 parentCollectionId,
+            bytes32 conditionId,
+            uint256[] calldata indexSets
+        ) external;
+    }
+
+    interface INegRiskAdapterRelay {
+        function redeemPositions(
+            bytes32 conditionId,
+            uint256[] calldata amounts
+        ) external;
+    }
+
+    interface IProxyWalletFactoryRelay {
+        function proxy(RelayProxyTransaction[] calldata txns) external;
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionRequest {
@@ -47,6 +132,38 @@ pub struct ReplaceRequest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct RedeemablePosition {
+    pub account_id: String,
+    pub wallet_address: String,
+    pub condition_id: String,
+    pub market_id: Option<String>,
+    pub token_ids: Vec<String>,
+    pub outcome_labels: Vec<String>,
+    pub outcome_indexes: Vec<u8>,
+    pub outcome_amounts: Vec<Decimal>,
+    pub redeemable_size: Decimal,
+    pub estimated_payout: Decimal,
+    pub negative_risk: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimRequest {
+    pub account_id: String,
+    pub wallet_address: String,
+    pub condition_id: String,
+    pub outcome_indexes: Vec<u8>,
+    pub outcome_amounts: Vec<Decimal>,
+    pub negative_risk: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimResult {
+    pub tx_hash: String,
+    pub block_number: u64,
+    pub amount_claimed: Decimal,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum ExecutionOutcome {
     Acknowledged { venue_order_id: String },
     Rejected { reason: String },
@@ -65,6 +182,16 @@ pub enum ReplaceOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ClaimError {
+    #[error("claim misconfigured: {0}")]
+    Configuration(String),
+    #[error("claim validation failed: {0}")]
+    Validation(String),
+    #[error("claim transport failed: {0}")]
+    Transport(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ExecutionError {
     #[error("live execution misconfigured: {0}")]
     Configuration(String),
@@ -72,6 +199,105 @@ pub enum ExecutionError {
     Validation(String),
     #[error("live execution transport failed: {0}")]
     Transport(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimBackend {
+    RelayProxy,
+    RelaySafe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimRelayTxType {
+    Proxy,
+    Safe,
+}
+
+#[derive(Debug, Clone)]
+struct BuilderApiCredentials {
+    api_key: SecretString,
+    secret: SecretString,
+    passphrase: SecretString,
+}
+
+#[derive(Debug, Clone, Default)]
+struct BuilderAuthConfig {
+    local: Option<BuilderApiCredentials>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RelayerSignatureParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gas_price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    relayer_fee: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gas_limit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    relay_hub: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    relay: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    safe_txn_gas: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_gas: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gas_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refund_receiver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payment_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payment_receiver: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RelayerTransactionRequest {
+    #[serde(rename = "type")]
+    tx_type: String,
+    from: String,
+    to: String,
+    #[serde(rename = "proxyWallet", skip_serializing_if = "Option::is_none")]
+    proxy_wallet: Option<String>,
+    data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+    signature: String,
+    #[serde(rename = "signatureParams")]
+    signature_params: RelayerSignatureParams,
+    metadata: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayerNoncePayload {
+    nonce: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayerRelayPayload {
+    address: String,
+    nonce: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayerSubmitResponse {
+    #[serde(rename = "transactionID")]
+    transaction_id: String,
+    state: String,
+    #[serde(rename = "transactionHash")]
+    transaction_hash: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayerTransaction {
+    state: String,
+    #[serde(rename = "transactionHash")]
+    transaction_hash: String,
 }
 
 pub trait LiveExecutionGateway: Send + Sync + std::fmt::Debug {
@@ -87,12 +313,38 @@ pub trait LiveExecutionGateway: Send + Sync + std::fmt::Debug {
     ) -> Result<Vec<FillRecord>, ExecutionError>;
 }
 
+pub trait ClaimGateway: Send + Sync + std::fmt::Debug {
+    fn discover_redeemable_positions(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<RedeemablePosition>, ClaimError>;
+
+    fn claim(&self, request: &ClaimRequest) -> Result<ClaimResult, ClaimError>;
+}
+
 #[derive(Debug, Clone)]
 pub struct StaticExecutionGateway {
     result: Result<ExecutionOutcome, ExecutionError>,
     cancel_result: Result<CancellationOutcome, ExecutionError>,
     replace_result: Result<ReplaceOutcome, ExecutionError>,
     reconcile_result: Result<Vec<FillRecord>, ExecutionError>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticClaimGateway {
+    positions: Result<Vec<RedeemablePosition>, ClaimError>,
+    claim_result: Result<ClaimResult, ClaimError>,
+}
+
+impl Default for StaticClaimGateway {
+    fn default() -> Self {
+        Self {
+            positions: Ok(Vec::new()),
+            claim_result: Err(ClaimError::Transport(
+                "static claim gateway result not configured".to_string(),
+            )),
+        }
+    }
 }
 
 impl StaticExecutionGateway {
@@ -158,6 +410,26 @@ impl StaticExecutionGateway {
     }
 }
 
+impl StaticClaimGateway {
+    pub fn with_positions(mut self, positions: Vec<RedeemablePosition>) -> Self {
+        self.positions = Ok(positions);
+        self
+    }
+
+    pub fn with_positions_result(
+        mut self,
+        result: Result<Vec<RedeemablePosition>, ClaimError>,
+    ) -> Self {
+        self.positions = result;
+        self
+    }
+
+    pub fn with_claim_result(mut self, result: Result<ClaimResult, ClaimError>) -> Self {
+        self.claim_result = result;
+        self
+    }
+}
+
 impl LiveExecutionGateway for StaticExecutionGateway {
     fn submit(&self, _request: &ExecutionRequest) -> Result<ExecutionOutcome, ExecutionError> {
         self.result.clone()
@@ -179,6 +451,19 @@ impl LiveExecutionGateway for StaticExecutionGateway {
 
     fn replace(&self, _request: &ReplaceRequest) -> Result<ReplaceOutcome, ExecutionError> {
         self.replace_result.clone()
+    }
+}
+
+impl ClaimGateway for StaticClaimGateway {
+    fn discover_redeemable_positions(
+        &self,
+        _account_id: &str,
+    ) -> Result<Vec<RedeemablePosition>, ClaimError> {
+        self.positions.clone()
+    }
+
+    fn claim(&self, _request: &ClaimRequest) -> Result<ClaimResult, ClaimError> {
+        self.claim_result.clone()
     }
 }
 
@@ -212,7 +497,7 @@ impl FromStr for WalletSignatureType {
         match value {
             "eoa" => Ok(Self::Eoa),
             "proxy" => Ok(Self::Proxy),
-            "gnosis_safe" => Ok(Self::GnosisSafe),
+            "gnosis_safe" | "gnosis-safe" => Ok(Self::GnosisSafe),
             other => Err(ExecutionError::Configuration(format!(
                 "unsupported POLY_SIGNATURE_TYPE `{other}`"
             ))),
@@ -262,6 +547,160 @@ impl PolymarketExecutionConfig {
 }
 
 #[derive(Debug, Clone)]
+pub struct PolymarketClaimConfig {
+    pub data_host: String,
+    pub rpc_url: String,
+    pub relayer_url: String,
+    pub private_key: Option<SecretString>,
+    pub signature_type: WalletSignatureType,
+    builder_auth: BuilderAuthConfig,
+}
+
+impl Default for PolymarketClaimConfig {
+    fn default() -> Self {
+        Self {
+            data_host: DEFAULT_POLY_DATA_HOST.to_string(),
+            rpc_url: std::env::var("POLYGON_RPC_URL")
+                .or_else(|_| std::env::var("POLYMARKET_RPC_URL"))
+                .unwrap_or_else(|_| DEFAULT_POLYGON_RPC_URL.to_string()),
+            relayer_url: read_env(POLY_RELAYER_URL_VAR)
+                .or_else(|| read_env(POLY_RELAYER_URL_ALIAS))
+                .unwrap_or_else(|| DEFAULT_POLY_RELAYER_URL.to_string()),
+            private_key: std::env::var(PRIVATE_KEY_VAR).ok().map(SecretString::from),
+            signature_type: std::env::var("POLY_SIGNATURE_TYPE")
+                .ok()
+                .or_else(|| std::env::var("POLYMARKET_SIGNATURE_TYPE").ok())
+                .map(|value| WalletSignatureType::from_str(&value))
+                .transpose()
+                .unwrap_or(None)
+                .unwrap_or_default(),
+            builder_auth: BuilderAuthConfig::from_env(),
+        }
+    }
+}
+
+impl PolymarketClaimConfig {
+    pub fn from_env() -> Self {
+        let mut config = Self::default();
+        if let Ok(value) = std::env::var("POLY_DATA_HOST") {
+            config.data_host = value;
+        }
+        if let Ok(value) = std::env::var("POLYMARKET_DATA_HOST") {
+            config.data_host = value;
+        }
+        if let Ok(value) = std::env::var("POLYMARKET_PRIVATE_KEY") {
+            if !value.trim().is_empty() {
+                config.private_key = Some(SecretString::from(value));
+            }
+        }
+        config
+    }
+
+    fn claim_backend(&self) -> Result<ClaimBackend, ClaimError> {
+        match claim_relay_tx_type(self.signature_type)? {
+            ClaimRelayTxType::Proxy => Ok(ClaimBackend::RelayProxy),
+            ClaimRelayTxType::Safe => Ok(ClaimBackend::RelaySafe),
+        }
+    }
+}
+
+impl BuilderAuthConfig {
+    fn from_env() -> Self {
+        let api_key = read_env(POLY_BUILDER_API_KEY_VAR).or_else(|| read_env(POLY_BUILDER_API_KEY_ALIAS));
+        let secret = read_env(POLY_BUILDER_SECRET_VAR).or_else(|| read_env(POLY_BUILDER_SECRET_ALIAS));
+        let passphrase = read_env(POLY_BUILDER_PASS_PHRASE_VAR)
+            .or_else(|| read_env(POLY_BUILDER_PASSPHRASE_VAR))
+            .or_else(|| read_env(POLY_BUILDER_PASS_PHRASE_ALIAS));
+
+        let local = match (api_key, secret, passphrase) {
+            (Some(api_key), Some(secret), Some(passphrase)) => Some(BuilderApiCredentials {
+                api_key: SecretString::from(api_key),
+                secret: SecretString::from(secret),
+                passphrase: SecretString::from(passphrase),
+            }),
+            _ => None,
+        };
+
+        Self { local }
+    }
+
+    fn headers(
+        &self,
+        method: &str,
+        path: &str,
+        body: &str,
+    ) -> Result<Vec<(String, String)>, ClaimError> {
+        let Some(local) = &self.local else {
+            return Err(ClaimError::Configuration(
+                "relay-first auto-claim requires builder credentials".to_string(),
+            ));
+        };
+
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|err| ClaimError::Transport(format!("compute builder timestamp: {err}")))?
+            .as_secs() as i64;
+        let signature = build_builder_signature(
+            local.secret.expose_secret(),
+            timestamp,
+            method,
+            path,
+            body,
+        )?;
+
+        Ok(vec![
+            (
+                "POLY_BUILDER_API_KEY".to_string(),
+                local.api_key.expose_secret().to_string(),
+            ),
+            (
+                "POLY_BUILDER_PASSPHRASE".to_string(),
+                local.passphrase.expose_secret().to_string(),
+            ),
+            ("POLY_BUILDER_SIGNATURE".to_string(), signature),
+            (
+                "POLY_BUILDER_TIMESTAMP".to_string(),
+                timestamp.to_string(),
+            ),
+        ])
+    }
+}
+
+fn claim_relay_tx_type(signature_type: WalletSignatureType) -> Result<ClaimRelayTxType, ClaimError> {
+    match signature_type {
+        WalletSignatureType::Proxy => Ok(ClaimRelayTxType::Proxy),
+        WalletSignatureType::GnosisSafe => Ok(ClaimRelayTxType::Safe),
+        WalletSignatureType::Eoa => Err(ClaimError::Configuration(
+            "relay-first auto-claim requires POLY_SIGNATURE_TYPE=proxy or gnosis_safe".to_string(),
+        )),
+    }
+}
+
+fn read_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[derive(Debug, Clone)]
+pub struct PolymarketClaimGateway {
+    config: PolymarketClaimConfig,
+}
+
+impl PolymarketClaimGateway {
+    pub fn from_env() -> Self {
+        Self {
+            config: PolymarketClaimConfig::from_env(),
+        }
+    }
+
+    pub fn new(config: PolymarketClaimConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct PolymarketExecutionGateway {
     config: PolymarketExecutionConfig,
 }
@@ -275,6 +714,89 @@ impl PolymarketExecutionGateway {
 
     pub fn new(config: PolymarketExecutionConfig) -> Self {
         Self { config }
+    }
+}
+
+impl PolymarketClaimGateway {
+    fn claim_via_relayer(&self, request: &ClaimRequest, backend: ClaimBackend) -> Result<ClaimResult, ClaimError> {
+        let private_key = self
+            .config
+            .private_key
+            .as_ref()
+            .map(ExposeSecret::expose_secret)
+            .ok_or_else(|| {
+                ClaimError::Configuration(format!("{PRIVATE_KEY_VAR} is not configured"))
+            })?;
+        let relayer_url = self.config.relayer_url.as_str();
+        let signer = LocalSigner::from_str(private_key)
+            .map_err(|err| ClaimError::Configuration(format!("invalid {PRIVATE_KEY_VAR}: {err}")))?
+            .with_chain_id(Some(POLYGON));
+        let owner = signer.address();
+        let (target, calldata) = build_claim_transaction(request)?;
+        let client = BlockingHttpClient::builder()
+            .timeout(Duration::from_secs(20))
+            .build()
+            .map_err(|err| ClaimError::Transport(format!("build relayer client: {err}")))?;
+
+        let submit_request = match backend {
+            ClaimBackend::RelayProxy => {
+                let relay_payload = fetch_relay_payload(&client, relayer_url, owner)?;
+                let proxy_factory = wallet_contract_config(POLYGON)
+                    .and_then(|config| config.proxy_factory)
+                    .ok_or_else(|| {
+                        ClaimError::Configuration(
+                            "proxy wallet factory is not configured for this chain".to_string(),
+                        )
+                    })?;
+                let wrapped = build_proxy_request(
+                    &signer,
+                    owner,
+                    proxy_factory,
+                    target,
+                    calldata,
+                    &relay_payload,
+                    Some(self.config.rpc_url.as_str()),
+                    None,
+                )?;
+                wrapped
+            }
+            ClaimBackend::RelaySafe => {
+                ensure_safe_wallet_deployed(
+                    &client,
+                    relayer_url,
+                    &self.config.builder_auth,
+                    &signer,
+                    owner,
+                )?;
+                let nonce = fetch_safe_nonce(&client, relayer_url, owner)?;
+                build_safe_request(&signer, owner, target, calldata, &nonce)?
+            }
+        };
+
+        let submit_body = serde_json::to_string(&submit_request)
+            .map_err(|err| ClaimError::Transport(format!("serialize relayer request: {err}")))?;
+        let submit_response = submit_relayer_transaction(
+            &client,
+            relayer_url,
+            &self.config.builder_auth,
+            &submit_body,
+        )?;
+        let mined = wait_for_relayer_transaction(
+            &client,
+            relayer_url,
+            &submit_response.transaction_id,
+        )?;
+        let block_number = fetch_receipt_block_number(&self.config.rpc_url, &mined.transaction_hash)?;
+
+        Ok(ClaimResult {
+            tx_hash: mined.transaction_hash,
+            block_number,
+            amount_claimed: request
+                .outcome_amounts
+                .iter()
+                .copied()
+                .fold(Decimal::ZERO, |acc, value| acc + value),
+        })
     }
 }
 
@@ -557,11 +1079,740 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
     }
 }
 
+impl ClaimGateway for PolymarketClaimGateway {
+    fn discover_redeemable_positions(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<RedeemablePosition>, ClaimError> {
+        let private_key = self
+            .config
+            .private_key
+            .as_ref()
+            .map(ExposeSecret::expose_secret)
+            .ok_or_else(|| {
+                ClaimError::Configuration(format!("{PRIVATE_KEY_VAR} is not configured"))
+            })?;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| ClaimError::Transport(format!("create tokio runtime: {err}")))?;
+
+        runtime.block_on(async {
+            let signer = LocalSigner::from_str(private_key)
+                .map_err(|err| {
+                    ClaimError::Configuration(format!("invalid {PRIVATE_KEY_VAR}: {err}"))
+                })?
+                .with_chain_id(Some(POLYGON));
+            let wallet_address = claim_wallet_address(&signer, self.config.signature_type)?;
+            let data_client = DataClient::new(&self.config.data_host)
+                .map_err(|err| ClaimError::Transport(format!("build data client: {err}")))?;
+            let request = PositionsRequest::builder()
+                .user(wallet_address)
+                .redeemable(true)
+                .build();
+            let positions = data_client.positions(&request).await.map_err(|err| {
+                ClaimError::Transport(format!("load redeemable positions: {err}"))
+            })?;
+
+            Ok(collapse_redeemable_positions(
+                account_id,
+                &wallet_address.to_string(),
+                positions,
+            ))
+        })
+    }
+
+    fn claim(&self, request: &ClaimRequest) -> Result<ClaimResult, ClaimError> {
+        self.claim_via_relayer(request, self.config.claim_backend()?)
+    }
+}
+
 fn polymarket_side(side: TradeSide) -> Side {
     match side {
         TradeSide::Buy => Side::Buy,
         TradeSide::Sell => Side::Sell,
     }
+}
+
+fn claim_wallet_address<S: Signer>(
+    signer: &S,
+    signature_type: WalletSignatureType,
+) -> Result<Address, ClaimError> {
+    match signature_type {
+        WalletSignatureType::Eoa => Ok(signer.address()),
+        WalletSignatureType::Proxy => {
+            derive_proxy_wallet(signer.address(), POLYGON).ok_or_else(|| {
+                ClaimError::Configuration("could not derive proxy wallet address".to_string())
+            })
+        }
+        WalletSignatureType::GnosisSafe => derive_safe_wallet(signer.address(), POLYGON)
+            .ok_or_else(|| {
+                ClaimError::Configuration("could not derive gnosis safe address".to_string())
+            }),
+    }
+}
+
+fn build_builder_signature(
+    secret: &str,
+    timestamp: i64,
+    method: &str,
+    path: &str,
+    body: &str,
+) -> Result<String, ClaimError> {
+    let secret = BASE64_STANDARD
+        .decode(secret)
+        .map_err(|err| ClaimError::Configuration(format!("decode builder secret: {err}")))?;
+    let mut mac = Hmac::<Sha256>::new_from_slice(&secret)
+        .map_err(|err| ClaimError::Configuration(format!("build builder hmac: {err}")))?;
+    mac.update(format!("{timestamp}{method}{path}{body}").as_bytes());
+    let signature = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+    Ok(signature.replace('+', "-").replace('/', "_"))
+}
+
+fn build_claim_transaction(
+    request: &ClaimRequest,
+) -> Result<(AlloyAddress, Vec<u8>), ClaimError> {
+    let config = contract_config(POLYGON, request.negative_risk).ok_or_else(|| {
+        ClaimError::Configuration(format!(
+            "missing Polymarket contract config for chain {POLYGON}"
+        ))
+    })?;
+    let condition_id = B256::from_str(&request.condition_id).map_err(|err| {
+        ClaimError::Validation(format!(
+            "invalid condition_id `{}`: {err}",
+            request.condition_id
+        ))
+    })?;
+
+    if request.negative_risk {
+        let adapter = config.neg_risk_adapter.ok_or_else(|| {
+            ClaimError::Configuration("neg-risk adapter is not configured".to_string())
+        })?;
+        let calldata = INegRiskAdapterRelay::redeemPositionsCall {
+            conditionId: condition_id,
+            amounts: neg_risk_amounts(&request.outcome_indexes, &request.outcome_amounts)?,
+        }
+        .abi_encode();
+        Ok((adapter, calldata))
+    } else {
+        let calldata = IConditionalTokensRelay::redeemPositionsCall {
+            collateralToken: config.collateral,
+            parentCollectionId: B256::ZERO,
+            conditionId: condition_id,
+            indexSets: redeem_index_sets(&request.outcome_indexes),
+        }
+        .abi_encode();
+        Ok((config.conditional_tokens, calldata))
+    }
+}
+
+fn fetch_relay_payload(
+    client: &BlockingHttpClient,
+    relayer_url: &str,
+    owner: AlloyAddress,
+) -> Result<RelayerRelayPayload, ClaimError> {
+    client
+        .get(format!("{relayer_url}/relay-payload"))
+        .query(&[
+            ("address", owner.to_string()),
+            ("type", "PROXY".to_string()),
+        ])
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| ClaimError::Transport(format!("load relay payload: {err}")))?
+        .json()
+        .map_err(|err| ClaimError::Transport(format!("parse relay payload: {err}")))
+}
+
+fn fetch_safe_nonce(
+    client: &BlockingHttpClient,
+    relayer_url: &str,
+    owner: AlloyAddress,
+) -> Result<RelayerNoncePayload, ClaimError> {
+    client
+        .get(format!("{relayer_url}/nonce"))
+        .query(&[
+            ("address", owner.to_string()),
+            ("type", "SAFE".to_string()),
+        ])
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| ClaimError::Transport(format!("load safe nonce: {err}")))?
+        .json()
+        .map_err(|err| ClaimError::Transport(format!("parse safe nonce: {err}")))
+}
+
+fn ensure_safe_wallet_deployed(
+    client: &BlockingHttpClient,
+    relayer_url: &str,
+    builder_auth: &BuilderAuthConfig,
+    signer: &(impl Signer + Sync),
+    owner: AlloyAddress,
+) -> Result<(), ClaimError> {
+    #[derive(Deserialize)]
+    struct DeployedPayload {
+        deployed: bool,
+    }
+
+    let safe_address = derive_safe_wallet(owner, POLYGON).ok_or_else(|| {
+        ClaimError::Configuration("could not derive gnosis safe address".to_string())
+    })?;
+
+    let payload: DeployedPayload = client
+        .get(format!("{relayer_url}/deployed"))
+        .query(&[("address", safe_address.to_string())])
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| ClaimError::Transport(format!("load safe deployment status: {err}")))?
+        .json()
+        .map_err(|err| ClaimError::Transport(format!("parse safe deployment status: {err}")))?;
+
+    if payload.deployed {
+        return Ok(());
+    }
+
+    let safe_factory = wallet_contract_config(POLYGON)
+        .map(|config| config.safe_factory)
+        .ok_or_else(|| {
+            ClaimError::Configuration("safe wallet factory is not configured for this chain".to_string())
+        })?;
+    let request = build_safe_create_request(signer, owner, safe_factory)?;
+    let body = serde_json::to_string(&request)
+        .map_err(|err| ClaimError::Transport(format!("serialize safe deploy request: {err}")))?;
+    let submit = submit_relayer_transaction(client, relayer_url, builder_auth, &body)?;
+    wait_for_relayer_transaction(client, relayer_url, &submit.transaction_id)?;
+    Ok(())
+}
+
+fn estimate_proxy_gas_limit(
+    rpc_url: Option<&str>,
+    from: AlloyAddress,
+    to: AlloyAddress,
+    data: &[u8],
+) -> Option<u64> {
+    #[derive(Serialize)]
+    struct JsonRpcRequest<'a> {
+        jsonrpc: &'static str,
+        method: &'static str,
+        params: [EstimateGasParams<'a>; 1],
+        id: u8,
+    }
+
+    #[derive(Serialize)]
+    struct EstimateGasParams<'a> {
+        from: &'a str,
+        to: &'a str,
+        data: &'a str,
+    }
+
+    #[derive(Deserialize)]
+    struct JsonRpcResponse {
+        result: Option<String>,
+    }
+
+    let rpc_url = rpc_url?;
+    let client = BlockingHttpClient::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .ok()?;
+    let from = from.to_string();
+    let to = to.to_string();
+    let data = format!("0x{}", alloy::hex::encode(data));
+    let payload = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: "eth_estimateGas",
+        params: [EstimateGasParams {
+            from: &from,
+            to: &to,
+            data: &data,
+        }],
+        id: 1,
+    };
+    let response: JsonRpcResponse = client.post(rpc_url).json(&payload).send().ok()?.json().ok()?;
+    let result = response.result?;
+    u64::from_str_radix(result.trim_start_matches("0x"), 16).ok()
+}
+
+fn build_proxy_request<S: Signer + Sync>(
+    signer: &S,
+    owner: AlloyAddress,
+    proxy_factory: AlloyAddress,
+    target: AlloyAddress,
+    calldata: Vec<u8>,
+    relay_payload: &RelayerRelayPayload,
+    rpc_url: Option<&str>,
+    gas_limit_override: Option<u64>,
+) -> Result<RelayerTransactionRequest, ClaimError> {
+    let relay_address = AlloyAddress::from_str(&relay_payload.address).map_err(|err| {
+        ClaimError::Transport(format!("invalid relayer relay address `{}`: {err}", relay_payload.address))
+    })?;
+    let relay_hub = AlloyAddress::from_str(POLY_RELAY_HUB)
+        .map_err(|err| ClaimError::Configuration(format!("invalid relay hub: {err}")))?;
+    let proxy_wallet = derive_proxy_wallet(owner, POLYGON).ok_or_else(|| {
+        ClaimError::Configuration("could not derive proxy wallet address".to_string())
+    })?;
+    let proxy_call_data = IProxyWalletFactoryRelay::proxyCall {
+        txns: vec![RelayProxyTransaction {
+            to: target,
+            typeCode: 1,
+            data: Bytes::from(calldata),
+            value: AlloyU256::ZERO,
+        }],
+    }
+    .abi_encode();
+    let gas_limit = gas_limit_override
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| {
+            estimate_proxy_gas_limit(rpc_url, owner, proxy_factory, &proxy_call_data)
+                .unwrap_or(DEFAULT_PROXY_GAS_LIMIT)
+                .to_string()
+        });
+    let nonce = AlloyU256::from_str(&relay_payload.nonce)
+        .map_err(|err| ClaimError::Transport(format!("invalid relay nonce `{}`: {err}", relay_payload.nonce)))?;
+    let relay_struct_hash = keccak256([
+        b"rlx:".as_slice(),
+        owner.as_slice(),
+        proxy_factory.as_slice(),
+        proxy_call_data.as_slice(),
+        AlloyU256::ZERO.to_be_bytes::<32>().as_slice(),
+        AlloyU256::ZERO.to_be_bytes::<32>().as_slice(),
+        AlloyU256::from_str(&gas_limit)
+            .map_err(|err| ClaimError::Transport(format!("invalid proxy gas limit `{gas_limit}`: {err}")))?
+            .to_be_bytes::<32>()
+            .as_slice(),
+        nonce.to_be_bytes::<32>().as_slice(),
+        relay_hub.as_slice(),
+        relay_address.as_slice(),
+    ]
+    .concat());
+    let signature = sign_personal_message(signer, relay_struct_hash.as_slice())?;
+
+    Ok(RelayerTransactionRequest {
+        tx_type: "PROXY".to_string(),
+        from: owner.to_string(),
+        to: proxy_factory.to_string(),
+        proxy_wallet: Some(proxy_wallet.to_string()),
+        data: format!("0x{}", alloy::hex::encode(proxy_call_data)),
+        nonce: Some(relay_payload.nonce.clone()),
+        signature,
+        signature_params: RelayerSignatureParams {
+            gas_price: Some("0".to_string()),
+            relayer_fee: Some("0".to_string()),
+            gas_limit: Some(gas_limit),
+            relay_hub: Some(POLY_RELAY_HUB.to_string()),
+            relay: Some(relay_payload.address.clone()),
+            operation: None,
+            safe_txn_gas: None,
+            base_gas: None,
+            gas_token: None,
+            refund_receiver: None,
+            payment_token: None,
+            payment: None,
+            payment_receiver: None,
+        },
+        metadata: "auto-redeem".to_string(),
+    })
+}
+
+fn build_safe_request<S: Signer + Sync>(
+    signer: &S,
+    owner: AlloyAddress,
+    target: AlloyAddress,
+    calldata: Vec<u8>,
+    nonce: &RelayerNoncePayload,
+) -> Result<RelayerTransactionRequest, ClaimError> {
+    let _safe_factory = wallet_contract_config(POLYGON)
+        .map(|config| config.safe_factory)
+        .ok_or_else(|| {
+            ClaimError::Configuration("safe wallet factory is not configured for this chain".to_string())
+        })?;
+    let safe_address = derive_safe_wallet(owner, POLYGON).ok_or_else(|| {
+        ClaimError::Configuration("could not derive gnosis safe address".to_string())
+    })?;
+    let nonce = AlloyU256::from_str(&nonce.nonce)
+        .map_err(|err| ClaimError::Transport(format!("invalid safe nonce `{}`: {err}", nonce.nonce)))?;
+    let domain = Eip712Domain {
+        chain_id: Some(AlloyU256::from(POLYGON)),
+        verifying_contract: Some(safe_address),
+        ..Eip712Domain::default()
+    };
+    let safe_tx = SafeTx {
+        to: target,
+        value: AlloyU256::ZERO,
+        data: Bytes::from(calldata.clone()),
+        operation: 0,
+        safeTxGas: AlloyU256::ZERO,
+        baseGas: AlloyU256::ZERO,
+        gasPrice: AlloyU256::ZERO,
+        gasToken: AlloyAddress::ZERO,
+        refundReceiver: AlloyAddress::ZERO,
+        nonce,
+    };
+    let signature =
+        sign_personal_message(signer, safe_tx.eip712_signing_hash(&domain).as_slice())?;
+    let packed_signature = pack_safe_signature(&signature)?;
+
+    Ok(RelayerTransactionRequest {
+        tx_type: "SAFE".to_string(),
+        from: owner.to_string(),
+        to: target.to_string(),
+        proxy_wallet: Some(safe_address.to_string()),
+        data: format!("0x{}", alloy::hex::encode(calldata)),
+        nonce: Some(nonce.to_string()),
+        signature: packed_signature,
+        signature_params: RelayerSignatureParams {
+            gas_price: Some("0".to_string()),
+            relayer_fee: None,
+            gas_limit: None,
+            relay_hub: None,
+            relay: None,
+            operation: Some("0".to_string()),
+            safe_txn_gas: Some("0".to_string()),
+            base_gas: Some("0".to_string()),
+            gas_token: Some(AlloyAddress::ZERO.to_string()),
+            refund_receiver: Some(AlloyAddress::ZERO.to_string()),
+            payment_token: None,
+            payment: None,
+            payment_receiver: None,
+        },
+        metadata: "auto-redeem".to_string(),
+    })
+}
+
+fn build_safe_create_request<S: Signer + Sync>(
+    signer: &S,
+    owner: AlloyAddress,
+    safe_factory: AlloyAddress,
+) -> Result<RelayerTransactionRequest, ClaimError> {
+    let domain = Eip712Domain {
+        name: Some(std::borrow::Cow::Borrowed("Polymarket Contract Proxy Factory")),
+        chain_id: Some(AlloyU256::from(POLYGON)),
+        verifying_contract: Some(safe_factory),
+        ..Eip712Domain::default()
+    };
+    let create_proxy = CreateProxy {
+        paymentToken: AlloyAddress::ZERO,
+        payment: AlloyU256::ZERO,
+        paymentReceiver: AlloyAddress::ZERO,
+    };
+    let signature = sign_raw_hash(signer, create_proxy.eip712_signing_hash(&domain))?;
+    let safe_address = derive_safe_wallet(owner, POLYGON).ok_or_else(|| {
+        ClaimError::Configuration("could not derive gnosis safe address".to_string())
+    })?;
+
+    Ok(RelayerTransactionRequest {
+        tx_type: "SAFE-CREATE".to_string(),
+        from: owner.to_string(),
+        to: safe_factory.to_string(),
+        proxy_wallet: Some(safe_address.to_string()),
+        data: "0x".to_string(),
+        nonce: None,
+        signature,
+        signature_params: RelayerSignatureParams {
+            gas_price: None,
+            relayer_fee: None,
+            gas_limit: None,
+            relay_hub: None,
+            relay: None,
+            operation: None,
+            safe_txn_gas: None,
+            base_gas: None,
+            gas_token: None,
+            refund_receiver: None,
+            payment_token: Some(AlloyAddress::ZERO.to_string()),
+            payment: Some("0".to_string()),
+            payment_receiver: Some(AlloyAddress::ZERO.to_string()),
+        },
+        metadata: "auto-redeem-safe-deploy".to_string(),
+    })
+}
+
+fn sign_personal_message<S: Signer + Sync>(signer: &S, message: &[u8]) -> Result<String, ClaimError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| ClaimError::Transport(format!("create tokio runtime: {err}")))?;
+    runtime
+        .block_on(async { signer.sign_message(message).await })
+        .map(|sig| sig.to_string())
+        .map_err(|err| ClaimError::Transport(format!("sign relayer payload: {err}")))
+}
+
+fn sign_raw_hash<S: Signer + Sync>(signer: &S, hash: B256) -> Result<String, ClaimError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| ClaimError::Transport(format!("create tokio runtime: {err}")))?;
+    runtime
+        .block_on(async { signer.sign_hash(&hash).await })
+        .map(|sig| sig.to_string())
+        .map_err(|err| ClaimError::Transport(format!("sign relayer payload: {err}")))
+}
+
+fn pack_safe_signature(signature: &str) -> Result<String, ClaimError> {
+    let sig = signature
+        .strip_prefix("0x")
+        .ok_or_else(|| ClaimError::Transport("safe signature missing 0x prefix".to_string()))?;
+    if sig.len() != 130 {
+        return Err(ClaimError::Transport(format!(
+            "safe signature has unexpected length {}",
+            sig.len()
+        )));
+    }
+
+    let mut v = u8::from_str_radix(&sig[128..130], 16)
+        .map_err(|err| ClaimError::Transport(format!("parse safe signature v: {err}")))?;
+    v = match v {
+        0 | 1 => v + 31,
+        27 | 28 => v + 4,
+        other => {
+            return Err(ClaimError::Transport(format!(
+                "invalid safe signature v {other}"
+            )))
+        }
+    };
+
+    let r = AlloyU256::from_str_radix(&sig[0..64], 16)
+        .map_err(|err| ClaimError::Transport(format!("parse safe signature r: {err}")))?;
+    let s = AlloyU256::from_str_radix(&sig[64..128], 16)
+        .map_err(|err| ClaimError::Transport(format!("parse safe signature s: {err}")))?;
+
+    let mut out = Vec::with_capacity(65);
+    out.extend_from_slice(&r.to_be_bytes::<32>());
+    out.extend_from_slice(&s.to_be_bytes::<32>());
+    out.push(v);
+    Ok(format!("0x{}", alloy::hex::encode(out)))
+}
+
+fn submit_relayer_transaction(
+    client: &BlockingHttpClient,
+    relayer_url: &str,
+    builder_auth: &BuilderAuthConfig,
+    body: &str,
+) -> Result<RelayerSubmitResponse, ClaimError> {
+    let mut request = client
+        .post(format!("{relayer_url}/submit"))
+        .header("content-type", "application/json")
+        .body(body.to_string());
+    for (name, value) in builder_auth.headers("POST", "/submit", body)? {
+        request = request.header(name, value);
+    }
+    request
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| ClaimError::Transport(format!("submit relayer transaction: {err}")))?
+        .json()
+        .map_err(|err| ClaimError::Transport(format!("parse relayer submit response: {err}")))
+}
+
+fn wait_for_relayer_transaction(
+    client: &BlockingHttpClient,
+    relayer_url: &str,
+    transaction_id: &str,
+) -> Result<RelayerTransaction, ClaimError> {
+    for _ in 0..DEFAULT_RELAY_MAX_POLLS {
+        let transactions: Vec<RelayerTransaction> = client
+            .get(format!("{relayer_url}/transaction"))
+            .query(&[("id", transaction_id)])
+            .send()
+            .and_then(|response| response.error_for_status())
+            .map_err(|err| ClaimError::Transport(format!("load relayer transaction: {err}")))?
+            .json()
+            .map_err(|err| ClaimError::Transport(format!("parse relayer transaction: {err}")))?;
+
+        if let Some(transaction) = transactions.into_iter().next() {
+            match transaction.state.as_str() {
+                "STATE_MINED" | "STATE_CONFIRMED" => return Ok(transaction),
+                "STATE_FAILED" | "STATE_INVALID" => {
+                    return Err(ClaimError::Transport(format!(
+                        "relayer transaction `{transaction_id}` failed with state {}",
+                        transaction.state
+                    )))
+                }
+                _ => {}
+            }
+        }
+        thread::sleep(Duration::from_millis(DEFAULT_RELAY_POLL_FREQUENCY_MS));
+    }
+
+    Err(ClaimError::Transport(format!(
+        "timed out waiting for relayer transaction `{transaction_id}`"
+    )))
+}
+
+fn fetch_receipt_block_number(rpc_url: &str, transaction_hash: &str) -> Result<u64, ClaimError> {
+    #[derive(Serialize)]
+    struct JsonRpcRequest<'a> {
+        jsonrpc: &'static str,
+        method: &'static str,
+        params: [&'a str; 1],
+        id: u8,
+    }
+
+    #[derive(Deserialize)]
+    struct JsonRpcResponse {
+        result: Option<TransactionReceipt>,
+        error: Option<JsonRpcError>,
+    }
+
+    #[derive(Deserialize)]
+    struct TransactionReceipt {
+        #[serde(rename = "blockNumber")]
+        block_number: Option<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct JsonRpcError {
+        message: String,
+    }
+
+    let client = BlockingHttpClient::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|err| ClaimError::Transport(format!("build rpc client: {err}")))?;
+    let payload = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: "eth_getTransactionReceipt",
+        params: [transaction_hash],
+        id: 1,
+    };
+    let response: JsonRpcResponse = client
+        .post(rpc_url)
+        .json(&payload)
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| ClaimError::Transport(format!("load transaction receipt: {err}")))?
+        .json()
+        .map_err(|err| ClaimError::Transport(format!("parse transaction receipt: {err}")))?;
+
+    if let Some(error) = response.error {
+        return Err(ClaimError::Transport(format!(
+            "polygon rpc returned receipt error: {}",
+            error.message
+        )));
+    }
+
+    let block_number = response
+        .result
+        .and_then(|receipt| receipt.block_number)
+        .ok_or_else(|| {
+            ClaimError::Transport(format!(
+                "receipt for transaction `{transaction_hash}` is not available yet"
+            ))
+        })?;
+
+    u64::from_str_radix(block_number.trim_start_matches("0x"), 16).map_err(|err| {
+        ClaimError::Transport(format!(
+            "parse receipt block number `{block_number}`: {err}"
+        ))
+    })
+}
+
+fn collapse_redeemable_positions(
+    account_id: &str,
+    wallet_address: &str,
+    positions: Vec<DataPosition>,
+) -> Vec<RedeemablePosition> {
+    let mut grouped: BTreeMap<String, RedeemablePosition> = BTreeMap::new();
+
+    for position in positions {
+        if !position.redeemable || position.size <= Decimal::ZERO {
+            continue;
+        }
+
+        let condition_id = position.condition_id.to_string();
+        let entry = grouped
+            .entry(condition_id.clone())
+            .or_insert_with(|| RedeemablePosition {
+                account_id: account_id.to_string(),
+                wallet_address: wallet_address.to_string(),
+                condition_id: condition_id.clone(),
+                market_id: position
+                    .event_id
+                    .clone()
+                    .or_else(|| Some(position.slug.clone())),
+                token_ids: Vec::new(),
+                outcome_labels: Vec::new(),
+                outcome_indexes: Vec::new(),
+                outcome_amounts: Vec::new(),
+                redeemable_size: Decimal::ZERO,
+                estimated_payout: Decimal::ZERO,
+                negative_risk: position.negative_risk,
+            });
+
+        entry.token_ids.push(position.asset.to_string());
+        entry.outcome_labels.push(position.outcome);
+        entry.outcome_indexes.push(position.outcome_index as u8);
+        entry.outcome_amounts.push(position.size);
+        entry.redeemable_size += position.size;
+        entry.estimated_payout += position.size;
+        entry.negative_risk = entry.negative_risk || position.negative_risk;
+    }
+
+    grouped.into_values().collect()
+}
+
+fn redeem_index_sets(outcome_indexes: &[u8]) -> Vec<U256> {
+    if outcome_indexes.is_empty() {
+        return vec![U256::from(1_u8), U256::from(2_u8)];
+    }
+
+    let mut index_sets: Vec<U256> = outcome_indexes
+        .iter()
+        .map(|index| U256::from(u64::from(*index) + 1))
+        .collect();
+    index_sets.sort();
+    index_sets.dedup();
+    index_sets
+}
+
+fn neg_risk_amounts(
+    outcome_indexes: &[u8],
+    outcome_amounts: &[Decimal],
+) -> Result<Vec<U256>, ClaimError> {
+    if outcome_indexes.len() != outcome_amounts.len() {
+        return Err(ClaimError::Validation(
+            "outcome_indexes and outcome_amounts length mismatch".to_string(),
+        ));
+    }
+
+    let mut amounts = [Decimal::ZERO, Decimal::ZERO];
+    for (index, amount) in outcome_indexes.iter().zip(outcome_amounts.iter()) {
+        match *index {
+            0 | 1 => amounts[*index as usize] += *amount,
+            other => {
+                return Err(ClaimError::Validation(format!(
+                    "unsupported neg-risk outcome index `{other}`"
+                )))
+            }
+        }
+    }
+
+    amounts
+        .iter()
+        .map(|amount| decimal_to_usdc_u256(*amount))
+        .collect()
+}
+
+fn decimal_to_usdc_u256(amount: Decimal) -> Result<U256, ClaimError> {
+    if amount < Decimal::ZERO {
+        return Err(ClaimError::Validation(format!(
+            "claim amount must be non-negative, got {amount}"
+        )));
+    }
+
+    let scaled = amount * Decimal::from(1_000_000_u64);
+    if !scaled.fract().is_zero() {
+        return Err(ClaimError::Validation(format!(
+            "claim amount exceeds USDC precision: {amount}"
+        )));
+    }
+
+    let raw: u64 = scaled
+        .try_into()
+        .map_err(|_| ClaimError::Validation(format!("claim amount too large: {amount}")))?;
+    Ok(U256::from(raw))
 }
 
 fn tracked_trade_fill(tracked_order: &TrackedOrder, trade: &TradeResponse) -> Option<FillRecord> {
@@ -629,16 +1880,21 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        tracked_trade_fill, CancellationOutcome, CancellationRequest, ExecutionError,
-        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, PolymarketExecutionConfig,
-        PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
-        TrackedOrder, WalletSignatureType,
+        build_proxy_request, build_safe_create_request, build_safe_request, claim_relay_tx_type,
+        tracked_trade_fill, BuilderAuthConfig, CancellationOutcome, CancellationRequest,
+        ClaimGateway, ClaimRelayTxType, ClaimRequest, ClaimResult, DEFAULT_POLY_RELAYER_URL,
+        ExecutionError, ExecutionOutcome, ExecutionRequest, LiveExecutionGateway,
+        PolymarketClaimConfig, PolymarketExecutionConfig, PolymarketExecutionGateway,
+        RedeemablePosition, RelayerNoncePayload, RelayerRelayPayload, ReplaceOutcome,
+        ReplaceRequest, StaticClaimGateway, StaticExecutionGateway, TrackedOrder,
+        WalletSignatureType,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
-    use polymarket_client_sdk::auth::ApiKey;
+    use polymarket_client_sdk::auth::{ApiKey, LocalSigner, Signer};
     use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
     use polymarket_client_sdk::clob::types::{TradeStatusType, TraderSide};
+    use polymarket_client_sdk::{POLYGON, wallet_contract_config};
     use polymarket_client_sdk::types::{Address, B256, U256};
     use rust_decimal_macros::dec;
     use std::str::FromStr;
@@ -829,5 +2085,178 @@ mod tests {
         assert_eq!(taker_fill.fill_id, "trade-1:order-a");
         assert_eq!(maker_fill.fill_id, "trade-1:order-b");
         assert_ne!(taker_fill.fill_id, maker_fill.fill_id);
+    }
+
+    #[test]
+    fn static_claim_gateway_replays_redeemable_positions() {
+        let gateway = StaticClaimGateway::default().with_positions(vec![RedeemablePosition {
+            account_id: "acct-live".to_string(),
+            wallet_address: "0xwallet".to_string(),
+            condition_id: "0xcondition".to_string(),
+            market_id: Some("market-1".to_string()),
+            token_ids: vec!["1".to_string(), "2".to_string()],
+            outcome_labels: vec!["YES".to_string(), "NO".to_string()],
+            outcome_indexes: vec![0, 1],
+            outcome_amounts: vec![dec!(3), dec!(0)],
+            redeemable_size: dec!(3),
+            estimated_payout: dec!(3),
+            negative_risk: false,
+        }]);
+
+        let positions = gateway
+            .discover_redeemable_positions("acct-live")
+            .expect("positions");
+
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].condition_id, "0xcondition");
+        assert_eq!(positions[0].wallet_address, "0xwallet");
+    }
+
+    #[test]
+    fn static_claim_gateway_replays_claim_result() {
+        let gateway = StaticClaimGateway::default().with_claim_result(Ok(ClaimResult {
+            tx_hash: "0xtx".to_string(),
+            block_number: 123,
+            amount_claimed: dec!(4.2),
+        }));
+
+        let result = gateway
+            .claim(&ClaimRequest {
+                account_id: "acct-live".to_string(),
+                wallet_address: "0xwallet".to_string(),
+                condition_id: "0xcondition".to_string(),
+                outcome_indexes: vec![0, 1],
+                outcome_amounts: vec![dec!(4.2), dec!(0)],
+                negative_risk: false,
+            })
+            .expect("claim result");
+
+        assert_eq!(result.tx_hash, "0xtx");
+        assert_eq!(result.block_number, 123);
+        assert_eq!(result.amount_claimed, dec!(4.2));
+    }
+
+    #[test]
+    fn claim_config_has_default_rpc_url() {
+        let config = PolymarketClaimConfig::default();
+        assert!(!config.rpc_url.is_empty());
+    }
+
+    #[test]
+    fn claim_config_has_default_relayer_url() {
+        let config = PolymarketClaimConfig::default();
+        assert_eq!(config.relayer_url, DEFAULT_POLY_RELAYER_URL);
+    }
+
+    #[test]
+    fn claim_relay_tx_type_rejects_eoa_signature_type() {
+        let err = claim_relay_tx_type(WalletSignatureType::Eoa).expect_err("eoa unsupported");
+        assert!(err.to_string().contains("relay-first auto-claim"));
+    }
+
+    #[test]
+    fn claim_relay_tx_type_maps_proxy_and_safe_wallets() {
+        assert_eq!(
+            claim_relay_tx_type(WalletSignatureType::Proxy).expect("proxy relay type"),
+            ClaimRelayTxType::Proxy
+        );
+        assert_eq!(
+            claim_relay_tx_type(WalletSignatureType::GnosisSafe).expect("safe relay type"),
+            ClaimRelayTxType::Safe
+        );
+    }
+
+    #[test]
+    fn builder_auth_requires_credentials_for_relayer_claims() {
+        let err = BuilderAuthConfig::default()
+            .headers("POST", "/submit", "{}")
+            .expect_err("missing builder credentials should fail");
+        assert!(err.to_string().contains("builder credentials"));
+    }
+
+    #[test]
+    fn proxy_request_signature_matches_official_vector() {
+        let signer = LocalSigner::from_str(
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        )
+        .expect("signer")
+        .with_chain_id(Some(POLYGON));
+        let owner = signer.address();
+        let proxy_factory = wallet_contract_config(POLYGON)
+            .and_then(|config| config.proxy_factory)
+            .expect("proxy factory");
+        let target = alloy::primitives::Address::from_str("0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")
+            .expect("usdc");
+        let calldata = alloy::hex::decode("095ea7b30000000000000000000000004d97dcd97ec945f40cf65f87097ace5ea0476045ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+            .expect("approve calldata");
+        let request = build_proxy_request(
+            &signer,
+            owner,
+            proxy_factory,
+            target,
+            calldata,
+            &RelayerRelayPayload {
+                address: "0xae700edfd9ab986395f3999fe11177b9903a52f1".to_string(),
+                nonce: "0".to_string(),
+            },
+            None,
+            Some(85_338),
+        )
+        .expect("proxy request");
+
+        assert_eq!(
+            request.signature,
+            "0x4c18e2d2294a00d686714aff8e7936ab657cb4655dfccb2b556efadcb7e835f800dc2fecec69c501e29bb36ecb54b4da6b7c410c4dc740a33af2afde2b77297e1b"
+        );
+    }
+
+    #[test]
+    fn safe_request_signature_matches_official_vector() {
+        let signer = LocalSigner::from_str(
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        )
+        .expect("signer")
+        .with_chain_id(Some(POLYGON));
+        let owner = signer.address();
+        let target = alloy::primitives::Address::from_str("0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")
+            .expect("usdc");
+        let calldata = alloy::hex::decode("095ea7b30000000000000000000000004d97dcd97ec945f40cf65f87097ace5ea0476045ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+            .expect("approve calldata");
+        let request = build_safe_request(
+            &signer,
+            owner,
+            target,
+            calldata,
+            &RelayerNoncePayload {
+                nonce: "0".to_string(),
+            },
+        )
+        .expect("safe request");
+
+        assert_eq!(
+            request.signature,
+            "0xf368488355b0566e99eff3bccc35e98b77d8f3a6e6866176188488c34f0305b07e4a4c600c7a1592e4ac1e96b5887ebff2cb26987a3ad501006b39944df098c21f"
+        );
+    }
+
+    #[test]
+    fn safe_create_request_signature_matches_official_vector() {
+        let signer = LocalSigner::from_str(
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        )
+        .expect("signer")
+        .with_chain_id(Some(POLYGON));
+        let owner = signer.address();
+        let safe_factory = wallet_contract_config(POLYGON)
+            .map(|config| config.safe_factory)
+            .expect("safe factory");
+        let request = build_safe_create_request(&signer, owner, safe_factory)
+            .expect("safe create request");
+
+        assert_eq!(
+            request.signature,
+            "0xe3e791c24134b7bebe93b4771bd07c7fe7bbe115eeb0bf629ac3b7a435e7ac8d05f979729d873f7d0e16205becf48ee450aa382bc28c65eedcd6454e81d81f921b"
+        );
+        assert_eq!(request.tx_type, "SAFE-CREATE");
     }
 }

--- a/crates/ploy-operator-contracts/src/claims.rs
+++ b/crates/ploy-operator-contracts/src/claims.rs
@@ -1,0 +1,224 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimLoopState {
+    Running,
+    Degraded,
+    Recovering,
+    Paused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimPositionState {
+    Detected,
+    Claiming,
+    Claimed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimExecutionOutcome {
+    Submitted,
+    Confirmed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountClaimActionState {
+    Accepted,
+    Rejected,
+    NotSupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountClaimStatus {
+    pub account_id: String,
+    pub enabled: bool,
+    pub runtime_mode: String,
+    pub loop_state: ClaimLoopState,
+    pub last_scan_at: Option<DateTime<Utc>>,
+    pub last_claim_at: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+    pub consecutive_failures: u32,
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub pending_redeemable_count: usize,
+    pub pending_redeemable_notional: Decimal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedeemablePositionSnapshot {
+    pub account_id: String,
+    pub condition_id: String,
+    pub market_id: Option<String>,
+    #[serde(default)]
+    pub token_ids: Vec<String>,
+    #[serde(default)]
+    pub outcome_labels: Vec<String>,
+    pub redeemable_size: Decimal,
+    pub estimated_payout: Decimal,
+    pub detected_at: DateTime<Utc>,
+    pub claim_state: ClaimPositionState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClaimExecutionRecord {
+    pub claim_id: String,
+    pub account_id: String,
+    pub condition_id: String,
+    pub submitted_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub tx_hash: Option<String>,
+    pub amount_claimed: Decimal,
+    pub outcome: ClaimExecutionOutcome,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountClaimActionResponse {
+    pub account_id: String,
+    pub state: AccountClaimActionState,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountClaimDetailResponse {
+    pub status: AccountClaimStatus,
+    #[serde(default)]
+    pub redeemable_positions: Vec<RedeemablePositionSnapshot>,
+    #[serde(default)]
+    pub claim_history: Vec<ClaimExecutionRecord>,
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal::Decimal;
+    use serde_json::json;
+
+    use super::{
+        AccountClaimActionResponse, AccountClaimActionState, AccountClaimStatus,
+        ClaimExecutionOutcome, ClaimExecutionRecord, ClaimLoopState, ClaimPositionState,
+        RedeemablePositionSnapshot,
+    };
+
+    #[test]
+    fn account_claim_status_uses_stable_wire_keys() {
+        let value = serde_json::to_value(AccountClaimStatus {
+            account_id: "acct-live".to_string(),
+            enabled: true,
+            runtime_mode: "live".to_string(),
+            loop_state: ClaimLoopState::Running,
+            last_scan_at: None,
+            last_claim_at: None,
+            last_error: None,
+            consecutive_failures: 0,
+            next_retry_at: None,
+            pending_redeemable_count: 2,
+            pending_redeemable_notional: Decimal::new(1250, 2),
+        })
+        .expect("serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "account_id": "acct-live",
+                "enabled": true,
+                "runtime_mode": "live",
+                "loop_state": "running",
+                "last_scan_at": null,
+                "last_claim_at": null,
+                "last_error": null,
+                "consecutive_failures": 0,
+                "next_retry_at": null,
+                "pending_redeemable_count": 2,
+                "pending_redeemable_notional": "12.50",
+            })
+        );
+    }
+
+    #[test]
+    fn redeemable_position_snapshot_uses_stable_wire_keys() {
+        let value = serde_json::to_value(RedeemablePositionSnapshot {
+            account_id: "acct-live".to_string(),
+            condition_id: "0xcondition".to_string(),
+            market_id: Some("market-1".to_string()),
+            token_ids: vec!["1".to_string(), "2".to_string()],
+            outcome_labels: vec!["YES".to_string(), "NO".to_string()],
+            redeemable_size: Decimal::new(300, 2),
+            estimated_payout: Decimal::new(300, 2),
+            detected_at: "2026-03-22T00:00:00Z".parse().expect("time"),
+            claim_state: ClaimPositionState::Detected,
+        })
+        .expect("serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "account_id": "acct-live",
+                "condition_id": "0xcondition",
+                "market_id": "market-1",
+                "token_ids": ["1", "2"],
+                "outcome_labels": ["YES", "NO"],
+                "redeemable_size": "3.00",
+                "estimated_payout": "3.00",
+                "detected_at": "2026-03-22T00:00:00Z",
+                "claim_state": "detected",
+            })
+        );
+    }
+
+    #[test]
+    fn claim_execution_record_uses_stable_wire_keys() {
+        let value = serde_json::to_value(ClaimExecutionRecord {
+            claim_id: "claim-1".to_string(),
+            account_id: "acct-live".to_string(),
+            condition_id: "0xcondition".to_string(),
+            submitted_at: "2026-03-22T00:00:00Z".parse().expect("time"),
+            completed_at: None,
+            tx_hash: Some("0xtx".to_string()),
+            amount_claimed: Decimal::new(300, 2),
+            outcome: ClaimExecutionOutcome::Submitted,
+            error_message: None,
+        })
+        .expect("serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "claim_id": "claim-1",
+                "account_id": "acct-live",
+                "condition_id": "0xcondition",
+                "submitted_at": "2026-03-22T00:00:00Z",
+                "completed_at": null,
+                "tx_hash": "0xtx",
+                "amount_claimed": "3.00",
+                "outcome": "submitted",
+                "error_message": null,
+            })
+        );
+    }
+
+    #[test]
+    fn account_claim_action_response_uses_stable_wire_keys() {
+        let value = serde_json::to_value(AccountClaimActionResponse {
+            account_id: "acct-live".to_string(),
+            state: AccountClaimActionState::Accepted,
+            message: "claim rescan accepted".to_string(),
+        })
+        .expect("serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "account_id": "acct-live",
+                "state": "accepted",
+                "message": "claim rescan accepted",
+            })
+        );
+    }
+}

--- a/crates/ploy-operator-contracts/src/lib.rs
+++ b/crates/ploy-operator-contracts/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod claims;
 pub mod deployments;
 pub mod errors;
 pub mod events;
@@ -6,6 +7,11 @@ pub mod system;
 pub mod trading;
 
 pub use audit::AuditLogEntry;
+pub use claims::{
+    AccountClaimActionResponse, AccountClaimActionState, AccountClaimDetailResponse,
+    AccountClaimStatus, ClaimExecutionOutcome, ClaimExecutionRecord, ClaimLoopState,
+    ClaimPositionState, RedeemablePositionSnapshot,
+};
 pub use deployments::{
     DeploymentApplyRequest, DeploymentControlRequest, DeploymentState, DeploymentStateSummary,
     DeploymentSummary, DesiredState, ObservedState,

--- a/crates/ploy-platform/src/accounts.rs
+++ b/crates/ploy-platform/src/accounts.rs
@@ -1,7 +1,332 @@
+use chrono::{DateTime, Utc};
+use ploy_operator_contracts::{
+    AccountClaimDetailResponse, AccountClaimStatus, ClaimExecutionRecord, ClaimLoopState,
+    RedeemablePositionSnapshot,
+};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountSnapshot {
     pub account_id: String,
     pub runtime_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountClaimSnapshot {
+    pub account_id: String,
+    pub enabled: bool,
+    pub runtime_mode: String,
+    pub loop_state: ClaimLoopState,
+    pub last_scan_at: Option<DateTime<Utc>>,
+    pub last_claim_at: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+    pub consecutive_failures: u32,
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub pending_redeemable_count: usize,
+    pub pending_redeemable_notional: Decimal,
+}
+
+impl AccountClaimSnapshot {
+    pub fn for_runtime_mode(
+        account_id: impl Into<String>,
+        runtime_mode: impl Into<String>,
+    ) -> Self {
+        let runtime_mode = runtime_mode.into();
+        let loop_state = if runtime_mode == "live" {
+            ClaimLoopState::Running
+        } else {
+            ClaimLoopState::Paused
+        };
+        let enabled = runtime_mode == "live";
+        Self {
+            account_id: account_id.into(),
+            enabled,
+            runtime_mode,
+            loop_state,
+            last_scan_at: None,
+            last_claim_at: None,
+            last_error: None,
+            consecutive_failures: 0,
+            next_retry_at: None,
+            pending_redeemable_count: 0,
+            pending_redeemable_notional: Decimal::ZERO,
+        }
+    }
+
+    pub fn status(&self) -> AccountClaimStatus {
+        AccountClaimStatus {
+            account_id: self.account_id.clone(),
+            enabled: self.enabled,
+            runtime_mode: self.runtime_mode.clone(),
+            loop_state: self.loop_state,
+            last_scan_at: self.last_scan_at,
+            last_claim_at: self.last_claim_at,
+            last_error: self.last_error.clone(),
+            consecutive_failures: self.consecutive_failures,
+            next_retry_at: self.next_retry_at,
+            pending_redeemable_count: self.pending_redeemable_count,
+            pending_redeemable_notional: self.pending_redeemable_notional,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountClaimDetail {
+    pub status: AccountClaimSnapshot,
+    #[serde(default)]
+    pub redeemable_positions: Vec<RedeemablePositionSnapshot>,
+    #[serde(default)]
+    pub claim_history: Vec<ClaimExecutionRecord>,
+}
+
+impl AccountClaimDetail {
+    fn new(status: AccountClaimSnapshot) -> Self {
+        Self {
+            status,
+            redeemable_positions: Vec::new(),
+            claim_history: Vec::new(),
+        }
+    }
+
+    pub fn response(&self) -> AccountClaimDetailResponse {
+        AccountClaimDetailResponse {
+            status: self.status.status(),
+            redeemable_positions: self.redeemable_positions.clone(),
+            claim_history: self.claim_history.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct AccountClaimRegistry {
+    accounts: BTreeMap<String, AccountClaimDetail>,
+}
+
+impl AccountClaimRegistry {
+    pub fn upsert(&mut self, snapshot: AccountClaimSnapshot) -> &AccountClaimDetail {
+        let account_id = snapshot.account_id.clone();
+        self.accounts
+            .entry(account_id.clone())
+            .and_modify(|detail| detail.status = snapshot.clone())
+            .or_insert_with(|| AccountClaimDetail::new(snapshot));
+        self.accounts
+            .get(&account_id)
+            .expect("claim account inserted")
+    }
+
+    pub fn get(&self, account_id: &str) -> Option<&AccountClaimSnapshot> {
+        self.accounts.get(account_id).map(|detail| &detail.status)
+    }
+
+    pub fn detail(&self, account_id: &str) -> Option<&AccountClaimDetail> {
+        self.accounts.get(account_id)
+    }
+
+    pub fn statuses(&self) -> Vec<AccountClaimStatus> {
+        self.accounts
+            .values()
+            .map(|detail| detail.status.status())
+            .collect()
+    }
+
+    pub fn details(&self) -> Vec<AccountClaimDetailResponse> {
+        self.accounts
+            .values()
+            .map(AccountClaimDetail::response)
+            .collect()
+    }
+
+    pub fn records(&self) -> Vec<AccountClaimDetail> {
+        self.accounts.values().cloned().collect()
+    }
+
+    pub fn restore(&mut self, records: Vec<AccountClaimDetail>) {
+        self.accounts.clear();
+        for record in records {
+            self.accounts.insert(record.status.account_id.clone(), record);
+        }
+    }
+
+    pub fn set_redeemable_positions(
+        &mut self,
+        account_id: &str,
+        redeemable_positions: Vec<RedeemablePositionSnapshot>,
+    ) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.pending_redeemable_count = redeemable_positions.len();
+        detail.status.pending_redeemable_notional = redeemable_positions
+            .iter()
+            .map(|position| position.estimated_payout)
+            .fold(Decimal::ZERO, |acc, value| acc + value);
+        detail.redeemable_positions = redeemable_positions;
+        Some(detail)
+    }
+
+    pub fn append_claim_record(
+        &mut self,
+        account_id: &str,
+        record: ClaimExecutionRecord,
+    ) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.last_claim_at = Some(record.submitted_at);
+        detail.claim_history.push(record);
+        Some(detail)
+    }
+
+    pub fn mark_scan_complete(
+        &mut self,
+        account_id: &str,
+        scanned_at: DateTime<Utc>,
+    ) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.last_scan_at = Some(scanned_at);
+        Some(detail)
+    }
+
+    pub fn mark_running(&mut self, account_id: &str) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.loop_state = ClaimLoopState::Running;
+        detail.status.consecutive_failures = 0;
+        detail.status.next_retry_at = None;
+        detail.status.last_error = None;
+        Some(detail)
+    }
+
+    pub fn mark_degraded(
+        &mut self,
+        account_id: &str,
+        error: String,
+        next_retry_at: Option<DateTime<Utc>>,
+    ) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.loop_state = ClaimLoopState::Degraded;
+        detail.status.consecutive_failures = detail.status.consecutive_failures.saturating_add(1);
+        detail.status.last_error = Some(error);
+        detail.status.next_retry_at = next_retry_at;
+        Some(detail)
+    }
+
+    pub fn set_enabled(&mut self, account_id: &str, enabled: bool) -> Option<&AccountClaimDetail> {
+        let detail = self.accounts.get_mut(account_id)?;
+        detail.status.enabled = enabled;
+        detail.status.loop_state = if enabled {
+            ClaimLoopState::Running
+        } else {
+            ClaimLoopState::Paused
+        };
+        Some(detail)
+    }
+
+    pub fn retain_accounts(&mut self, account_ids: &BTreeSet<String>) {
+        self.accounts
+            .retain(|account_id, _| account_ids.contains(account_id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use rust_decimal::Decimal;
+
+    use super::{AccountClaimRegistry, AccountClaimSnapshot, ClaimLoopState};
+    use ploy_operator_contracts::{
+        ClaimExecutionOutcome, ClaimExecutionRecord, ClaimPositionState, RedeemablePositionSnapshot,
+    };
+
+    #[test]
+    fn live_accounts_default_to_running_claim_loop() {
+        let snapshot = AccountClaimSnapshot::for_runtime_mode("acct-live", "live");
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.loop_state, ClaimLoopState::Running);
+        assert_eq!(snapshot.pending_redeemable_count, 0);
+        assert_eq!(snapshot.pending_redeemable_notional, Decimal::ZERO);
+    }
+
+    #[test]
+    fn registry_tracks_account_claim_snapshot_by_account_id() {
+        let mut registry = AccountClaimRegistry::default();
+        registry.upsert(AccountClaimSnapshot {
+            account_id: "acct-live".to_string(),
+            enabled: true,
+            runtime_mode: "live".to_string(),
+            loop_state: ClaimLoopState::Running,
+            last_scan_at: Some(Utc.with_ymd_and_hms(2026, 3, 22, 0, 0, 0).unwrap()),
+            last_claim_at: None,
+            last_error: None,
+            consecutive_failures: 0,
+            next_retry_at: None,
+            pending_redeemable_count: 2,
+            pending_redeemable_notional: Decimal::new(250, 2),
+        });
+
+        let stored = registry.get("acct-live").expect("snapshot");
+        assert_eq!(stored.account_id, "acct-live");
+        assert_eq!(stored.pending_redeemable_count, 2);
+        assert_eq!(stored.pending_redeemable_notional, Decimal::new(250, 2));
+    }
+
+    #[test]
+    fn registry_tracks_positions_and_claim_history() {
+        let mut registry = AccountClaimRegistry::default();
+        registry.upsert(AccountClaimSnapshot::for_runtime_mode("acct-live", "live"));
+
+        registry.set_redeemable_positions(
+            "acct-live",
+            vec![RedeemablePositionSnapshot {
+                account_id: "acct-live".to_string(),
+                condition_id: "condition-1".to_string(),
+                market_id: Some("market-1".to_string()),
+                token_ids: vec!["1".to_string()],
+                outcome_labels: vec!["YES".to_string()],
+                redeemable_size: Decimal::new(100, 2),
+                estimated_payout: Decimal::new(125, 2),
+                detected_at: Utc.with_ymd_and_hms(2026, 3, 22, 0, 0, 0).unwrap(),
+                claim_state: ClaimPositionState::Detected,
+            }],
+        );
+        registry.append_claim_record(
+            "acct-live",
+            ClaimExecutionRecord {
+                claim_id: "claim-1".to_string(),
+                account_id: "acct-live".to_string(),
+                condition_id: "condition-1".to_string(),
+                submitted_at: Utc.with_ymd_and_hms(2026, 3, 22, 0, 1, 0).unwrap(),
+                completed_at: None,
+                tx_hash: Some("0xtx".to_string()),
+                amount_claimed: Decimal::new(125, 2),
+                outcome: ClaimExecutionOutcome::Submitted,
+                error_message: None,
+            },
+        );
+
+        let detail = registry.detail("acct-live").expect("detail");
+        assert_eq!(detail.status.pending_redeemable_count, 1);
+        assert_eq!(detail.status.pending_redeemable_notional, Decimal::new(125, 2));
+        assert_eq!(detail.redeemable_positions.len(), 1);
+        assert_eq!(detail.claim_history.len(), 1);
+        assert_eq!(
+            detail.status.last_claim_at,
+            Some(Utc.with_ymd_and_hms(2026, 3, 22, 0, 1, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn registry_can_mark_degraded_and_running_again() {
+        let mut registry = AccountClaimRegistry::default();
+        registry.upsert(AccountClaimSnapshot::for_runtime_mode("acct-live", "live"));
+
+        registry.mark_degraded("acct-live", "relay unavailable".to_string(), None);
+        let degraded = registry.get("acct-live").expect("degraded");
+        assert_eq!(degraded.loop_state, ClaimLoopState::Degraded);
+        assert_eq!(degraded.consecutive_failures, 1);
+        assert_eq!(degraded.last_error.as_deref(), Some("relay unavailable"));
+
+        registry.mark_running("acct-live");
+        let running = registry.get("acct-live").expect("running");
+        assert_eq!(running.loop_state, ClaimLoopState::Running);
+        assert_eq!(running.consecutive_failures, 0);
+        assert!(running.last_error.is_none());
+    }
 }

--- a/crates/ploy-platform/src/control_plane.rs
+++ b/crates/ploy-platform/src/control_plane.rs
@@ -1,3 +1,4 @@
+use crate::accounts::AccountClaimRegistry;
 use crate::audit::AuditLog;
 use crate::deployments::DeploymentRegistry;
 use crate::health::{snapshot, HealthSnapshot};
@@ -5,6 +6,7 @@ use crate::system::SystemService;
 
 #[derive(Debug, Default)]
 pub struct ControlPlane {
+    pub accounts: AccountClaimRegistry,
     pub deployments: DeploymentRegistry,
     pub audit: AuditLog,
     pub system: SystemService,

--- a/crates/ploy-platform/src/lib.rs
+++ b/crates/ploy-platform/src/lib.rs
@@ -5,7 +5,7 @@ pub mod deployments;
 pub mod health;
 pub mod system;
 
-pub use accounts::AccountSnapshot;
+pub use accounts::{AccountClaimDetail, AccountClaimRegistry, AccountClaimSnapshot, AccountSnapshot};
 pub use audit::{AuditEvent, AuditLog};
 pub use control_plane::ControlPlane;
 pub use deployments::{DeploymentRecord, DeploymentRegistry};

--- a/docs/plans/2026-03-26-auto-claim-port-design.md
+++ b/docs/plans/2026-03-26-auto-claim-port-design.md
@@ -1,0 +1,170 @@
+# Auto-Claim Mainline Port Design
+
+Date: 2026-03-26
+Branch: `session/auto-claim-port`
+Base: `origin/main`
+
+## Context
+
+`origin/main` already absorbed the branch work for:
+
+- platform metrics and alerts
+- stale-source degradation
+- finer auth scopes
+- runtime-mode surfacing
+- live deployment dry-run drill docs
+
+The remaining unmerged product value from `session/auto-claim-hardening` is narrower:
+
+- relay-backed account auto-claim for live accounts
+- claims operator surface in `ployd` and `ployctl`
+
+This port must land on the current workspace/control-plane runtime without re-importing already-merged observability or documentation deltas.
+
+## Goal
+
+Add account-level, relay-backed Polymarket auto-claim to the current mainline runtime, with:
+
+- default-on auto-claim for live accounts
+- account claim state persisted under `run/platform`
+- `ployctl claims ...` operator commands
+- HTTP control-plane endpoints for claim read/write actions
+- snapshot-backed fallback reads, matching the rest of the control plane
+
+## Non-goals
+
+This port does not include:
+
+- external alert delivery
+- frontend/TUI claim dashboards unless already required by tests
+- full old-branch documentation rewrites
+- legacy claimer installer retirement
+- changes to the old monolith `src/` runtime
+
+## Desired behavior
+
+### Runtime model
+
+- Claims are tracked at the `account_id` level, not deployment level.
+- A live account gets an auto-claim loop by default.
+- Paper accounts do not claim and should report as not supported or paused.
+- The claim loop scans redeemable positions and immediately executes claims.
+- Claim failures degrade the account loop and schedule a retry with backoff.
+- Claim failures do not kill the daemon.
+
+### Control-plane surface
+
+Read endpoints:
+
+- `GET /api/accounts/claims`
+- `GET /api/accounts/:id/claims`
+
+Write endpoints:
+
+- `POST /api/accounts/:id/claims/run`
+- `POST /api/accounts/:id/claims/rescan`
+- `POST /api/accounts/:id/claims/pause`
+- `POST /api/accounts/:id/claims/resume`
+
+CLI surface:
+
+- `ployctl claims list`
+- `ployctl claims inspect <account-id>`
+- `ployctl claims run <account-id>`
+- `ployctl claims rescan <account-id>`
+- `ployctl claims pause <account-id>`
+- `ployctl claims resume <account-id>`
+
+### Persistence
+
+Claim state persists to `run/platform/account-claims.json`.
+
+The persisted detail contains:
+
+- account claim status
+- redeemable positions
+- claim history
+
+This mirrors the existing snapshot-backed control-plane pattern and allows read fallback when HTTP is unavailable.
+
+## Data model
+
+### Operator contracts
+
+Add a new `claims` contract module with:
+
+- `ClaimLoopState`
+- `ClaimPositionState`
+- `ClaimExecutionOutcome`
+- `AccountClaimActionState`
+- `AccountClaimStatus`
+- `RedeemablePositionSnapshot`
+- `ClaimExecutionRecord`
+- `AccountClaimActionResponse`
+- `AccountClaimDetailResponse`
+
+### Platform state
+
+Extend `ploy-platform` account ownership from the current `AccountSnapshot` stub to an `AccountClaimRegistry` that owns:
+
+- live account enrollment
+- status updates
+- redeemable position snapshots
+- claim execution history
+
+## Connectivity model
+
+The redeem backend is relay-first.
+
+`ploy-connectivity` should provide:
+
+- redeemable-position discovery for an account
+- relay-backed claim execution
+
+This reuses the auto-claim branch seam instead of the old direct-CTF claimer path.
+
+## Integration points
+
+### `ployd`
+
+`PloyDaemon` gains:
+
+- persisted claim state file support
+- account claim sync from live deployments
+- manual claim actions
+- automatic periodic claim loops
+
+### `ployctl`
+
+`ControlPlaneClient` gains:
+
+- claim reads over HTTP with snapshot fallback
+- claim action POSTs
+
+`main.rs` gains the `claims` command family.
+
+## Auth model
+
+Use the current mainline auth scopes.
+
+- read endpoints require read/operator/admin according to current control-plane policy
+- write claim actions require operator/admin, not sidecar-readonly
+
+No browser session or frontend auth changes are required for this minimal port.
+
+## Verification strategy
+
+Port work should be driven by failing tests first:
+
+1. contract serialization tests
+2. `ployctl` parsing and client tests
+3. `ployd` HTTP/runtime tests for claim endpoints and persistence
+4. smoke coverage proving the control-plane still boots and snapshots cleanly
+
+## Out-of-scope follow-up
+
+After this port lands, the next worthwhile follow-up is:
+
+- claim visualization in TUI/frontend
+- retirement of the legacy claimer installer and remaining old docs
+- claim-specific alerts wired into the already-merged observability system

--- a/docs/plans/2026-03-26-auto-claim-port-implementation-plan.md
+++ b/docs/plans/2026-03-26-auto-claim-port-implementation-plan.md
@@ -1,0 +1,116 @@
+# Auto-Claim Mainline Port Implementation Plan
+
+Date: 2026-03-26
+Branch: `session/auto-claim-port`
+
+## Scope
+
+Port the still-unmerged auto-claim functionality from `session/auto-claim-hardening` to latest `main`, while leaving already-merged observability, runtime-mode, and documentation work untouched.
+
+## Work phases
+
+### Phase 1: Contract and platform state
+
+Files:
+
+- `crates/ploy-operator-contracts/src/claims.rs`
+- `crates/ploy-operator-contracts/src/lib.rs`
+- `crates/ploy-platform/src/accounts.rs`
+- `crates/ploy-platform/src/control_plane.rs`
+- `crates/ploy-platform/src/lib.rs`
+
+Steps:
+
+1. Add the claims wire contract module and re-export it.
+2. Replace the `AccountSnapshot`-only account state with the branch-proven claim registry.
+3. Update platform tests to cover account claim state transitions.
+
+Verification:
+
+- `rtk cargo test -p ploy-operator-contracts -p ploy-platform`
+
+### Phase 2: Connectivity seam
+
+Files:
+
+- `crates/ploy-connectivity/src/lib.rs`
+
+Steps:
+
+1. Port the relay-backed claim gateway types and default implementation.
+2. Keep the surface minimal: discovery plus claim execution only.
+3. Avoid pulling in unrelated branch-only changes already present on main.
+
+Verification:
+
+- `rtk cargo test -p ploy-connectivity`
+
+### Phase 3: Daemon runtime and HTTP surface
+
+Files:
+
+- `apps/ployd/src/config.rs`
+- `apps/ployd/src/runtime.rs`
+- `apps/ployd/src/http.rs`
+
+Steps:
+
+1. Add claim snapshot file support to config and runtime snapshot writes.
+2. Sync live accounts from deployment registry into the account claim registry.
+3. Port manual and automatic claim loops.
+4. Expose claim read/write endpoints on the control plane.
+5. Persist account claim detail to `account-claims.json`.
+
+Verification:
+
+- `rtk cargo test -p ployd`
+
+### Phase 4: CLI operator surface
+
+Files:
+
+- `apps/ployctl/src/lib.rs`
+- `apps/ployctl/src/client.rs`
+- `apps/ployctl/src/main.rs`
+- `apps/ployctl/src/claims.rs`
+
+Steps:
+
+1. Add claim client methods.
+2. Add `ployctl claims` parsing and rendering.
+3. Use snapshot fallback for read paths, matching existing control-plane behavior.
+
+Verification:
+
+- `rtk cargo test -p ployctl`
+
+### Phase 5: Integration smoke
+
+Files:
+
+- `tests/platform_smoke.rs`
+
+Steps:
+
+1. Extend smoke coverage only where necessary to cover claim snapshot persistence or endpoint reachability.
+2. Keep the smoke test lightweight and aligned with current mainline contracts.
+
+Verification:
+
+- `rtk cargo test --test platform_smoke`
+
+## Stop conditions
+
+Stop and re-evaluate if:
+
+- the port requires reintroducing already-merged observability code
+- the claim gateway cannot be isolated from unrelated branch changes
+- current mainline auth scope assumptions conflict with claim write endpoints
+
+## Done when
+
+- `ployd` persists account claim state and exposes claim endpoints
+- `ployctl claims ...` works
+- relay-backed claim discovery and execution are present
+- focused Rust tests pass
+- no already-merged branch noise is reintroduced

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,63 @@
+# Auto-Claim Mainline Port (2026-03-26)
+
+## Goal
+Port the remaining unmerged value from `session/auto-claim-hardening` onto the latest `main`: relay-backed account auto-claim plus the claims operator surface. Do not re-import observability, runtime-mode, or doc changes that are already in main.
+
+## File ownership
+
+- `docs/plans/2026-03-26-auto-claim-port-design.md`
+  - owner: approved scope and behavior for the minimal auto-claim port
+- `docs/plans/2026-03-26-auto-claim-port-implementation-plan.md`
+  - owner: staged implementation and verification plan
+- `crates/ploy-operator-contracts/src/claims.rs`, `crates/ploy-operator-contracts/src/lib.rs`
+  - owner: claims wire contract
+- `crates/ploy-platform/src/accounts.rs`, `crates/ploy-platform/src/control_plane.rs`, `crates/ploy-platform/src/lib.rs`
+  - owner: account claim registry and control-plane ownership
+- `crates/ploy-connectivity/src/lib.rs`
+  - owner: relay-backed redeem discovery/execution seam
+- `apps/ployd/src/config.rs`, `apps/ployd/src/runtime.rs`, `apps/ployd/src/http.rs`
+  - owner: daemon claim loop, persistence, and HTTP handlers
+- `apps/ployctl/src/lib.rs`, `apps/ployctl/src/main.rs`, `apps/ployctl/src/client.rs`, `apps/ployctl/src/claims.rs`
+  - owner: CLI claim commands and client methods
+- `tests/platform_smoke.rs`
+  - owner: end-to-end smoke coverage for the claims control-plane
+
+## Tasks
+
+- [x] Write the design doc and implementation plan for the mainline auto-claim port.
+- [x] Add failing tests for the claims wire contract and operator surface on current main.
+- [x] Port the minimal claims contract and account registry into `ploy-platform`.
+- [x] Port the relay-backed claim discovery/execution seam into `ploy-connectivity` and `ployd`.
+- [x] Add `ployctl claims ...` plus HTTP endpoints and snapshot persistence.
+- [x] Re-run focused Rust verification and record what still remains out of scope.
+
+## Progress notes
+
+- 2026-03-26: Created clean worktree `session/auto-claim-port` from `origin/main` (`fee0ea90`) so the port can land on the latest mainline without reusing old branch state.
+- 2026-03-26: Audited `session/auto-claim-hardening` and confirmed current main already contains the branch's observability, auth-scope, runtime-mode, and dry-run deploy doc work. The still-missing value is limited to relay-backed account auto-claim and the claims operator surface.
+- 2026-03-26: Verified current main lacks `ployctl claims` commands and the account claim control-plane contract; `crates/ploy-platform/src/accounts.rs` is still only `AccountSnapshot`.
+- 2026-03-26: Added the new claims contract module, expanded `ploy-platform` account ownership into a persisted claim registry, and wired `ployctl claims list|inspect|run|rescan|pause|resume` onto the current mainline client.
+- 2026-03-26: Ported the relay-backed claim gateway from `session/auto-claim-hardening` into `ploy-connectivity`, then integrated `ployd` claim snapshots, live-account sync, auto-claim loops, and `/api/accounts/*/claims` endpoints without re-importing already-merged observability or docs work.
+- 2026-03-26: Focused verification passed:
+  - `rtk cargo test -p ployctl parses_claims_run_command -- --exact`
+  - `rtk cargo test -p ployd handle_runtime_request_reads_claim_state_from_shared_daemon -- --exact`
+  - `rtk cargo test -p ployd handle_runtime_request_runs_account_claims -- --exact`
+  - `rtk cargo test -p ploy-connectivity static_claim_gateway_replays_redeemable_positions -- --exact`
+  - `rtk cargo test -p ploy-connectivity -p ploy-operator-contracts -p ploy-platform -p ployctl -p ployd`
+  - `rtk cargo test --test platform_smoke`
+
+## Review
+
+- Delivered on current `main`:
+  - relay-backed claim connectivity seam
+  - account-level claim state registry and persistence
+  - `ployd` auto-claim loop and claim HTTP endpoints
+  - `ployctl claims` operator surface
+- Intentionally left out of this port:
+  - TUI/frontend claim dashboards
+  - legacy claimer installer retirement
+  - extra claim-specific metrics beyond the existing stale-source health projection
+
 # Live Dry-Run Deployment Drill (2026-03-25)
 
 ## Goal


### PR DESCRIPTION
## Summary
- port the remaining relay-backed account auto-claim functionality from `session/auto-claim-hardening` onto latest `main`
- add account claim registry/state persistence plus `ployd` auto-claim loop and `/api/accounts/*/claims` runtime endpoints
- add `ployctl claims list|inspect|run|rescan|pause|resume` and snapshot/http claim reads

## Validation
- rtk cargo test -p ployctl parses_claims_run_command -- --exact
- rtk cargo test -p ployd handle_runtime_request_reads_claim_state_from_shared_daemon -- --exact
- rtk cargo test -p ployd handle_runtime_request_runs_account_claims -- --exact
- rtk cargo test -p ploy-connectivity static_claim_gateway_replays_redeemable_positions -- --exact
- rtk cargo test -p ploy-connectivity -p ploy-operator-contracts -p ploy-platform -p ployctl -p ployd
- rtk cargo test --test platform_smoke


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ployctl claims` command family supporting list, inspect, run, rescan, pause, and resume operations
  * Added HTTP API endpoints for querying claim statuses and managing individual account claims
  * Implemented automated claim execution with state persistence and intelligent retry logic for enabled accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->