### PR TITLE
fix: add missing price_to_beat field to backtest_integration test

### DIFF
--- a/crates/ploy-strategy-bundles/tests/backtest_integration.rs
+++ b/crates/ploy-strategy-bundles/tests/backtest_integration.rs
@@ -35,6 +35,7 @@ fn build_scenario() -> Vec<MarketUpdate> {
         down_token: "dn-btc-001".into(),
         end_time: event_end,
         window_secs: 300,
+        price_to_beat: None,
     });
 
     // 3. Polymarket quotes — UP token cheap at 0.30


### PR DESCRIPTION
Fix CI failure: `backtest_integration` test was missing the `price_to_beat: None` field in `MarketUpdate::EventDiscovered` — same root cause as PR #74 which only fixed the example file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced backtest integration test with explicit configuration for event-discovery market updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->