### PR TITLE
fix(healthcheck): use grep -qE instead of grep -E

### DIFF
--- a/.github/workflows/healthcheck-tango-1-1.yml
+++ b/.github/workflows/healthcheck-tango-1-1.yml
@@ -81,7 +81,7 @@ jobs:
             require_service_guardrails ploy-quote-collector.service
 
             if journalctl -u ploy-strategy-directional-dryrun.service --since '15 minutes ago' --no-pager \
-              | grep -E "DB connection failed|running without persistence|Signal recorder disabled"; then
+              | grep -qE "DB connection failed|running without persistence|Signal recorder disabled"; then
               echo "dry-run persistence degraded within the last 15 minutes" >&2
               exit 1
             fi


### PR DESCRIPTION
## Summary

**Root Cause:** The healthcheck script uses `set -euo pipefail`. When `journalctl | grep -E` finds no matches, grep returns exit code 1, which triggers `set -e` and causes the script to fail incorrectly — even though the service is actually healthy.

**Fix:** Change `grep -E` to `grep -qE` (quiet mode). This suppresses output and properly handles the exit code within the `if` condition without triggering `set -e`.

**Verification:**
- tango-1-1 services are all running correctly:
  - `ploy-platform.service` - active (running) 22h
  - `ploy-strategy-directional-dryrun.service` - active (running) 9h
  - `ploy-quote-collector.service` - active (running)

**Testing:** Merge this PR and the next healthcheck run should pass.