### PR TITLE
Harden ployd runtime and sidecar monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,6 +3295,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hmac",
+ "libc",
  "ploy-connectivity",
  "ploy-deployments",
  "ploy-operator-contracts",

--- a/apps/ploy-runner/src/scanner.rs
+++ b/apps/ploy-runner/src/scanner.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use ploy_strategy_bundles::MarketUpdate;
-use polymarket_client_sdk::gamma::Client as GammaClient;
 use polymarket_client_sdk::gamma::types::request::MarketsRequest;
+use polymarket_client_sdk::gamma::Client as GammaClient;
 use polymarket_client_sdk::types::U256;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
@@ -21,8 +21,8 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::crypto::discover_crypto_markets;
+use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
 use crate::feeds::spawn_quote_feed;
@@ -31,6 +31,8 @@ use crate::reference_prices::ReferencePriceRegistry;
 const SCAN_INTERVAL_SECS: u64 = 30;
 const SPORTS_DISCOVERY_REFRESH_SECS: i64 = 300;
 const SPORTS_DISCOVERY_LIMIT: i32 = 500;
+/// How far back to look for open positions that need recovery on startup.
+const RECOVERY_LOOKBACK_HOURS: i64 = 48;
 
 struct TrackedEvent {
     end_time: chrono::DateTime<Utc>,
@@ -57,6 +59,13 @@ pub fn spawn_market_scanner(
         let mut subscribed_tokens: HashSet<String> = HashSet::new();
         let mut quote_handles: Vec<JoinHandle<()>> = Vec::new();
         let mut last_sports_refresh: Option<DateTime<Utc>> = None;
+
+        // On startup, recover any open positions from events that expired while
+        // the runner was offline. These will never receive a new EventExpired from
+        // the live scanner, so we emit them now with official settlement outcomes.
+        if let Some(ref db) = pool {
+            recover_expired_open_positions(&tx, db).await;
+        }
 
         loop {
             let now = Utc::now();
@@ -158,6 +167,85 @@ pub fn spawn_market_scanner(
             tokio::time::sleep(std::time::Duration::from_secs(SCAN_INTERVAL_SECS)).await;
         }
     })
+}
+
+/// On startup, find events that expired while the runner was offline and still
+/// have open positions in `strategy_runtime_fills`. Emit `EventExpired` with
+/// the official settlement outcome from `pm_token_settlements` so the strategy
+/// can close those positions immediately.
+async fn recover_expired_open_positions(
+    tx: &broadcast::Sender<MarketUpdate>,
+    pool: &PgPool,
+) {
+    let lookback = Utc::now() - Duration::hours(RECOVERY_LOOKBACK_HOURS);
+
+    // Find open positions: BUY fills with no matching SELL, for events that
+    // ended before now. Join pm_market_metadata for end_time and
+    // pm_token_settlements for the official outcome.
+    let rows: Vec<(String, String, String, DateTime<Utc>, Option<bool>)> = match sqlx::query_as(
+        r#"
+        SELECT DISTINCT
+            f.event_id,
+            f.token_id,
+            COALESCE(f.symbol, '') AS symbol,
+            COALESCE(m.end_time, NOW() - INTERVAL '1 second') AS end_time,
+            CASE
+                WHEN s.resolved AND s.settled_price >= 0.99 THEN true
+                WHEN s.resolved AND s.settled_price <= 0.01 THEN false
+                ELSE NULL
+            END AS resolved_up_won
+        FROM strategy_runtime_fills f
+        LEFT JOIN pm_market_metadata m ON m.market_slug = f.event_id
+        LEFT JOIN pm_token_settlements s ON s.token_id = f.token_id
+        WHERE f.fill_side = 'BUY'
+          AND f.fill_timestamp >= $1
+          AND COALESCE(m.end_time, NOW()) < NOW()
+          AND NOT EXISTS (
+              SELECT 1 FROM strategy_runtime_fills s2
+              WHERE s2.token_id = f.token_id
+                AND s2.fill_side = 'SELL'
+                AND s2.intent_id LIKE 'settle_%'
+          )
+        "#,
+    )
+    .bind(lookback)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(error = %e, "Failed to query open positions for recovery");
+            return;
+        }
+    };
+
+    if rows.is_empty() {
+        debug!("Startup recovery: no expired open positions found");
+        return;
+    }
+
+    info!(
+        count = rows.len(),
+        "Startup recovery: emitting EventExpired for expired open positions"
+    );
+
+    // Group by event_id — one EventExpired per event is enough.
+    let mut seen_events: HashSet<String> = HashSet::new();
+    for (event_id, _token_id, _symbol, end_time, resolved_up_won) in rows {
+        if seen_events.insert(event_id.clone()) {
+            info!(
+                event_id = %event_id,
+                end_time = %end_time,
+                resolved_up_won = ?resolved_up_won,
+                "Recovery: emitting EventExpired",
+            );
+            let _ = tx.send(MarketUpdate::EventExpired {
+                event_id,
+                end_time,
+                resolved_up_won,
+            });
+        }
+    }
 }
 
 fn expire_tracked_events(
@@ -316,12 +404,10 @@ mod tests {
 
     #[test]
     fn token_id_parser_accepts_decimal_strings() {
-        assert!(
-            parse_token_id(
-                "27239049953613250678046988034203198692578441444398010699401021233149338414941"
-            )
-            .is_some()
-        );
+        assert!(parse_token_id(
+            "27239049953613250678046988034203198692578441444398010699401021233149338414941"
+        )
+        .is_some());
         assert!(parse_token_id("not-a-token").is_none());
     }
 

--- a/apps/ployd/Cargo.toml
+++ b/apps/ployd/Cargo.toml
@@ -10,6 +10,7 @@ description = "Ploy platform daemon workspace entry point"
 [dependencies]
 chrono.workspace = true
 hmac.workspace = true
+libc = "0.2"
 ploy-connectivity.workspace = true
 ploy-deployments.workspace = true
 ploy-operator-contracts.workspace = true

--- a/apps/ployd/src/config.rs
+++ b/apps/ployd/src/config.rs
@@ -1,3 +1,4 @@
+use rust_decimal::Decimal;
 use secrecy::SecretString;
 use std::path::PathBuf;
 
@@ -14,6 +15,8 @@ pub struct PlatformConfig {
     pub deployment_status_file: PathBuf,
     pub trading_state_file: PathBuf,
     pub audit_log_file: PathBuf,
+    pub proposals_file: PathBuf,
+    pub agent_runs_file: PathBuf,
     pub tick_interval_ms: u64,
     pub request_rate_limit_per_minute: u32,
     pub live_reconcile_backoff_base_ms: u64,
@@ -21,6 +24,9 @@ pub struct PlatformConfig {
     pub worker_heartbeat_stale_after_ms: u64,
     pub live_reconcile_stale_after_ms: u64,
     pub venue_stale_after_ms: u64,
+    pub circuit_breaker_enabled: bool,
+    pub circuit_breaker_pnl_floor: Option<Decimal>,
+    pub circuit_breaker_exposure_ceiling_multiplier: Option<Decimal>,
 }
 
 impl Default for PlatformConfig {
@@ -37,6 +43,8 @@ impl Default for PlatformConfig {
             deployment_status_file: runtime_root.join("deployments.json"),
             trading_state_file: runtime_root.join("trading-state.json"),
             audit_log_file: runtime_root.join("audit-log.jsonl"),
+            proposals_file: runtime_root.join("proposals.json"),
+            agent_runs_file: PathBuf::from("run/sidecar/agent-runs.jsonl"),
             runtime_root,
             tick_interval_ms: 1_000,
             request_rate_limit_per_minute: 240,
@@ -45,11 +53,37 @@ impl Default for PlatformConfig {
             worker_heartbeat_stale_after_ms: 15_000,
             live_reconcile_stale_after_ms: 15_000,
             venue_stale_after_ms: 15_000,
+            circuit_breaker_enabled: false,
+            circuit_breaker_pnl_floor: None,
+            circuit_breaker_exposure_ceiling_multiplier: None,
         }
     }
 }
 
 impl PlatformConfig {
+    pub fn normalized(&self) -> Self {
+        let mut config = self.clone();
+        let default = Self::default();
+
+        if config.status_file == default.status_file {
+            config.status_file = config.runtime_root.join("system-status.json");
+        }
+        if config.deployment_status_file == default.deployment_status_file {
+            config.deployment_status_file = config.runtime_root.join("deployments.json");
+        }
+        if config.trading_state_file == default.trading_state_file {
+            config.trading_state_file = config.runtime_root.join("trading-state.json");
+        }
+        if config.audit_log_file == default.audit_log_file {
+            config.audit_log_file = config.runtime_root.join("audit-log.jsonl");
+        }
+        if config.proposals_file == default.proposals_file {
+            config.proposals_file = config.runtime_root.join("proposals.json");
+        }
+
+        config
+    }
+
     pub fn from_env() -> Self {
         let mut config = Self::default();
 
@@ -110,6 +144,16 @@ impl PlatformConfig {
         } else {
             config.audit_log_file = config.runtime_root.join("audit-log.jsonl");
         }
+        if let Ok(value) = std::env::var("PLOY_PROPOSALS_FILE") {
+            config.proposals_file = PathBuf::from(value);
+        } else {
+            config.proposals_file = config.runtime_root.join("proposals.json");
+        }
+        if let Ok(value) = std::env::var("PLOY_AGENT_RUNS_FILE") {
+            config.agent_runs_file = PathBuf::from(value);
+        } else {
+            config.agent_runs_file = PathBuf::from("run/sidecar/agent-runs.jsonl");
+        }
         if let Ok(value) = std::env::var("PLOY_TICK_INTERVAL_MS") {
             if let Ok(parsed) = value.parse() {
                 config.tick_interval_ms = parsed;
@@ -145,8 +189,21 @@ impl PlatformConfig {
                 config.venue_stale_after_ms = parsed;
             }
         }
+        if let Ok(value) = std::env::var("PLOY_CIRCUIT_BREAKER_ENABLED") {
+            config.circuit_breaker_enabled = value == "true" || value == "1";
+        }
+        if let Ok(value) = std::env::var("PLOY_CIRCUIT_BREAKER_PNL_FLOOR") {
+            if let Ok(parsed) = value.parse::<Decimal>() {
+                config.circuit_breaker_pnl_floor = Some(parsed);
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_CIRCUIT_BREAKER_EXPOSURE_CEILING_MULTIPLIER") {
+            if let Ok(parsed) = value.parse::<Decimal>() {
+                config.circuit_breaker_exposure_ceiling_multiplier = Some(parsed);
+            }
+        }
 
-        config
+        config.normalized()
     }
 }
 
@@ -171,6 +228,7 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use secrecy::ExposeSecret;
+    use std::path::PathBuf;
 
     use super::PlatformConfig;
 
@@ -202,6 +260,14 @@ mod tests {
             config.audit_log_file.to_string_lossy(),
             "run/platform/audit-log.jsonl"
         );
+        assert_eq!(
+            config.proposals_file.to_string_lossy(),
+            "run/platform/proposals.json"
+        );
+        assert_eq!(
+            config.agent_runs_file.to_string_lossy(),
+            "run/sidecar/agent-runs.jsonl"
+        );
         assert_eq!(config.tick_interval_ms, 1_000);
         assert_eq!(config.request_rate_limit_per_minute, 240);
         assert_eq!(config.live_reconcile_backoff_base_ms, 1_000);
@@ -209,5 +275,35 @@ mod tests {
         assert_eq!(config.worker_heartbeat_stale_after_ms, 15_000);
         assert_eq!(config.live_reconcile_stale_after_ms, 15_000);
         assert_eq!(config.venue_stale_after_ms, 15_000);
+    }
+
+    #[test]
+    fn normalized_updates_runtime_root_derived_paths() {
+        let config = PlatformConfig {
+            runtime_root: PathBuf::from("/tmp/ploy-runtime"),
+            ..PlatformConfig::default()
+        }
+        .normalized();
+
+        assert_eq!(
+            config.status_file.to_string_lossy(),
+            "/tmp/ploy-runtime/system-status.json"
+        );
+        assert_eq!(
+            config.deployment_status_file.to_string_lossy(),
+            "/tmp/ploy-runtime/deployments.json"
+        );
+        assert_eq!(
+            config.trading_state_file.to_string_lossy(),
+            "/tmp/ploy-runtime/trading-state.json"
+        );
+        assert_eq!(
+            config.audit_log_file.to_string_lossy(),
+            "/tmp/ploy-runtime/audit-log.jsonl"
+        );
+        assert_eq!(
+            config.proposals_file.to_string_lossy(),
+            "/tmp/ploy-runtime/proposals.json"
+        );
     }
 }

--- a/apps/ployd/src/http.rs
+++ b/apps/ployd/src/http.rs
@@ -3,15 +3,18 @@ use crate::runtime::{next_paper_intent_id, PloyDaemon};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use ploy_operator_contracts::{
-    AlertSnapshotEvent, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
-    DeploymentControlRequest, DeploymentSnapshotEvent, IntentPurpose, MetricsSnapshotEvent,
-    OperatorEvent, OrderReplaceRequest, PaperIntentRequest, StatusUpdate, SystemSnapshotEvent,
-    SystemStatus, TradingSnapshotEvent,
+    AgentRunRecord, AlertSnapshotEvent, AuditLogEntry, ControlPlaneErrorResponse,
+    DeploymentApplyRequest, DeploymentControlRequest, DeploymentSnapshotEvent,
+    DeploymentDiagnosticsReport, DiagnosticsEvidence, DiagnosticsFinding, IntentPurpose,
+    MetricsSnapshotEvent, OperatorEvent, OrderReplaceRequest, OversightSnapshotEvent,
+    PaperIntentRequest, PlatformDiagnosticsReport, ProposalCreateRequest, ProposalDecisionRequest,
+    ProposalSnapshotEvent, StatusUpdate, SystemSnapshotEvent, SystemStatus,
+    TradingSnapshotEvent, compute_oversight_report,
 };
 use ploy_trading::{TradeSide, TradingIntent};
 use secrecy::{ExposeSecret, SecretString};
 use sha2::Sha256;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -306,10 +309,11 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
     let method = request_line.next().unwrap_or("GET");
     let path = request_line.next().unwrap_or("/");
     let client_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
-    let (configured_token, operator_token, sidecar_token, cookie_secret) = match configured_auth(state) {
-        Ok(auth) => auth,
-        Err(response) => return write_json_response(stream, response),
-    };
+    let (configured_token, operator_token, sidecar_token, cookie_secret) =
+        match configured_auth(state) {
+            Ok(auth) => auth,
+            Err(response) => return write_json_response(stream, response),
+        };
     let auth_level = request_auth_level(
         &request,
         configured_token
@@ -540,9 +544,16 @@ fn required_access(method: &str, path: &str) -> RequiredAccess {
         | ("GET", "/api/trading/state")
         | ("GET", "/api/events/stream") => RequiredAccess::ReadOnly,
         ("GET", "/api/audit/logs") => RequiredAccess::Admin,
+        ("GET", "/api/system/diagnose") => RequiredAccess::ReadOnly,
+        ("GET", "/api/agent/runs") => RequiredAccess::ReadOnly,
+        ("GET", _) if path.starts_with("/api/agent/runs/") => RequiredAccess::ReadOnly,
+        ("GET", "/api/proposals") | ("POST", "/api/proposals") => RequiredAccess::ReadOnly,
+        ("GET", _) if path.starts_with("/api/proposals/") => RequiredAccess::ReadOnly,
+        ("POST", _) if path.starts_with("/api/proposals/") => RequiredAccess::Operator,
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             RequiredAccess::ReadOnly
         }
+        ("GET", _) if path.starts_with("/api/trading/diagnose/") => RequiredAccess::ReadOnly,
         _ => RequiredAccess::Operator,
     }
 }
@@ -635,6 +646,479 @@ fn read_recent_audit_entries(path: &PathBuf, limit: usize) -> io::Result<Vec<Aud
         entries = entries.split_off(entries.len() - limit);
     }
     Ok(entries)
+}
+
+fn agent_runs_path(state: &Arc<AppState>) -> Result<PathBuf, (u16, String)> {
+    state
+        .daemon
+        .lock()
+        .map(|daemon| daemon.config.agent_runs_file.clone())
+        .map_err(|_| json_error(503, "daemon_lock_poisoned", None))
+}
+
+fn read_agent_runs(path: &PathBuf) -> io::Result<Vec<AgentRunRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let body = fs::read_to_string(path)?;
+    let mut runs = body
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<AgentRunRecord>(line).ok())
+        .collect::<Vec<_>>();
+    runs.reverse();
+    Ok(runs)
+}
+
+fn read_agent_run(path: &PathBuf, run_id: &str) -> io::Result<Option<AgentRunRecord>> {
+    Ok(read_agent_runs(path)?
+        .into_iter()
+        .find(|run| run.run_id == run_id))
+}
+
+fn build_platform_diagnostics_report(
+    daemon: &PloyDaemon,
+    state: &Arc<AppState>,
+) -> io::Result<PlatformDiagnosticsReport> {
+    let system = daemon.control_plane.system.status();
+    let metrics = daemon.platform_metrics();
+    let alerts = daemon.active_alerts();
+    let deployments = daemon.control_plane.deployments.summaries();
+    let trading = daemon.trading_state();
+    let oversight = compute_oversight_report(&system, &deployments, &trading);
+    let audit_entries = audit_log_path(state)
+        .ok()
+        .and_then(|path| read_recent_audit_entries(&path, 4).ok())
+        .unwrap_or_default();
+    let event_entries = recent_snapshot_evidence(daemon, 8, None);
+    let mut seen = BTreeSet::new();
+    let mut findings = Vec::new();
+
+    for alert in alerts {
+        let key = format!("{:?}:{}", alert.kind, alert.message);
+        if seen.insert(key) {
+            findings.push(DiagnosticsFinding {
+                severity: format!("{:?}", alert.severity).to_lowercase(),
+                kind: format!("{:?}", alert.kind).to_lowercase(),
+                message: alert.message.clone(),
+                first_observed_at: Some(alert.triggered_at.to_rfc3339()),
+                likely_causes: likely_causes_from_kind(&format!("{:?}", alert.kind).to_lowercase()),
+                operator_command: Some("ployctl system audit".to_string()),
+                evidence: vec![DiagnosticsEvidence {
+                    source: "system_alert".to_string(),
+                    label: alert.source_id.clone(),
+                    detail: format!("alert_id={}", alert.alert_id),
+                    observed_at: Some(alert.triggered_at.to_rfc3339()),
+                }],
+            });
+        }
+    }
+
+    for signal in oversight.signals {
+        // Include deployment_id in the dedupe key so findings from different
+        // deployments with the same kind/message are not collapsed into one.
+        let key = format!(
+            "{}:{}:{}",
+            signal.kind,
+            signal.message,
+            signal.deployment_id.as_deref().unwrap_or("platform")
+        );
+        if seen.insert(key) {
+            // Reuse the pre-built operator_command from recommended_actions so
+            // the command shown here always matches what build_operator_command
+            // produces (correct deployment id, config hints, etc.).
+            let target = signal
+                .deployment_id
+                .as_deref()
+                .unwrap_or("platform");
+            let operator_command = oversight
+                .recommended_actions
+                .iter()
+                .find(|a| a.kind == signal.recommended_action && a.target == target)
+                .map(|a| a.operator_command.clone())
+                .or_else(|| {
+                    // Fallback for signals that have no matching action entry.
+                    Some(format!("ployctl system status"))
+                });
+            findings.push(DiagnosticsFinding {
+                severity: signal.severity.clone(),
+                kind: signal.kind.clone(),
+                message: signal.message.clone(),
+                first_observed_at: Some(oversight.timestamp.clone()),
+                likely_causes: likely_causes_from_kind(&signal.kind),
+                operator_command,
+                evidence: signal
+                    .evidence
+                    .iter()
+                    .map(|detail| DiagnosticsEvidence {
+                        source: "oversight_signal".to_string(),
+                        label: signal.recommended_action.clone(),
+                        detail: detail.clone(),
+                        observed_at: Some(oversight.timestamp.clone()),
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    if metrics.live_reconcile_failures > 0 {
+        findings.push(DiagnosticsFinding {
+            severity: "warning".to_string(),
+            kind: "live_reconcile_failures".to_string(),
+            message: format!(
+                "live reconcile reported {} consecutive failures",
+                metrics.live_reconcile_failures
+            ),
+            first_observed_at: metrics
+                .last_live_reconcile_success_at
+                .map(|value| value.to_rfc3339()),
+            likely_causes: vec!["reconcile_loop_stalled".to_string()],
+            operator_command: Some("ployctl system audit".to_string()),
+            evidence: vec![DiagnosticsEvidence {
+                source: "system_metrics".to_string(),
+                label: "live_reconcile_failures".to_string(),
+                detail: format!("live_reconcile_failures={}", metrics.live_reconcile_failures),
+                observed_at: metrics
+                    .last_live_reconcile_success_at
+                    .map(|value| value.to_rfc3339()),
+            }],
+        });
+    }
+
+    let mut recent_evidence = audit_entries
+        .iter()
+        .map(audit_entry_to_evidence)
+        .collect::<Vec<_>>();
+    recent_evidence.extend(event_entries);
+    recent_evidence.truncate(8);
+
+    Ok(PlatformDiagnosticsReport {
+        generated_at: Utc::now().to_rfc3339(),
+        platform_status: system.status.clone(),
+        first_diverged_metric: if system.active_alert_count > 0 {
+            Some("active_alerts".to_string())
+        } else if system.stale_source_count > 0 {
+            Some("stale_sources".to_string())
+        } else if system.error_count_1h > 0 {
+            Some("error_count_1h".to_string())
+        } else if metrics.live_reconcile_failures > 0 {
+            Some("live_reconcile_failures".to_string())
+        } else {
+            findings.first().map(|finding| finding.kind.clone())
+        },
+        findings,
+        recent_evidence,
+    })
+}
+
+fn build_deployment_diagnostics_report(
+    daemon: &PloyDaemon,
+    state: &Arc<AppState>,
+    deployment_id: &str,
+) -> io::Result<DeploymentDiagnosticsReport> {
+    let system = daemon.control_plane.system.status();
+    let deployments = daemon.control_plane.deployments.summaries();
+    let deployment = deployments
+        .iter()
+        .find(|item| item.deployment_id == deployment_id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("deployment `{deployment_id}` was not found"),
+            )
+        })?;
+    let trading = daemon.trading_state();
+    let state_snapshot = trading
+        .iter()
+        .find(|item| item.deployment_id == deployment_id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("trading state for `{deployment_id}` was not found"),
+            )
+        })?;
+    let oversight = compute_oversight_report(&system, &deployments, &trading);
+    let audit_entries = audit_log_path(state)
+        .ok()
+        .and_then(|path| read_recent_audit_entries(&path, 8).ok())
+        .unwrap_or_default();
+    let mut recent_evidence = vec![DiagnosticsEvidence {
+        source: "current_snapshot".to_string(),
+        label: "trading_state".to_string(),
+        detail: format!(
+            "pending_intents={} active_orders={} open_positions={} total_gross_exposure={} net_pnl={}",
+            state_snapshot.risk.pending_intents,
+            state_snapshot.risk.active_orders,
+            state_snapshot.risk.open_positions,
+            state_snapshot.risk.total_gross_exposure,
+            state_snapshot.pnl.net_pnl,
+        ),
+        observed_at: Some(oversight.timestamp.clone()),
+    }];
+    recent_evidence.extend(
+        audit_entries
+            .iter()
+            .filter(|entry| {
+                entry.path.contains(deployment_id)
+                    || entry
+                        .message
+                        .as_deref()
+                        .map(|message| message.contains(deployment_id))
+                        .unwrap_or(false)
+            })
+            .map(audit_entry_to_evidence),
+    );
+    recent_evidence.extend(recent_snapshot_evidence(daemon, 12, Some(deployment_id)));
+    recent_evidence.truncate(8);
+
+    let mut findings = Vec::new();
+    for signal in oversight
+        .signals
+        .iter()
+        .filter(|signal| signal.deployment_id.as_deref() == Some(deployment_id))
+    {
+        let action = oversight
+            .recommended_actions
+            .iter()
+            .find(|action| action.target == deployment_id && action.kind == signal.recommended_action);
+        findings.push(DiagnosticsFinding {
+            severity: signal.severity.clone(),
+            kind: signal.kind.clone(),
+            message: signal.message.clone(),
+            first_observed_at: Some(oversight.timestamp.clone()),
+            likely_causes: likely_causes_from_kind(&signal.kind),
+            operator_command: action.map(|item| item.operator_command.clone()),
+            evidence: signal
+                .evidence
+                .iter()
+                .map(|detail| DiagnosticsEvidence {
+                    source: "oversight_signal".to_string(),
+                    label: signal.recommended_action.clone(),
+                    detail: detail.clone(),
+                    observed_at: Some(oversight.timestamp.clone()),
+                })
+                .collect(),
+        });
+    }
+
+    let desired_state = format!("{:?}", deployment.desired_state).to_lowercase();
+    let observed_state = format!("{:?}", deployment.observed_state).to_lowercase();
+    let primary_diagnosis = findings
+        .first()
+        .map(|finding| finding.kind.clone())
+        .unwrap_or_else(|| {
+            if desired_state != observed_state {
+                "state_mismatch".to_string()
+            } else {
+                "stable".to_string()
+            }
+        });
+
+    Ok(DeploymentDiagnosticsReport {
+        generated_at: Utc::now().to_rfc3339(),
+        deployment_id: deployment.deployment_id.clone(),
+        bundle_id: deployment.bundle_id.clone(),
+        runtime_mode: deployment.runtime_mode.clone(),
+        account_id: deployment.account_id.clone(),
+        desired_state: desired_state.clone(),
+        observed_state: observed_state.clone(),
+        max_gross_exposure: deployment.max_gross_exposure,
+        primary_diagnosis,
+        first_diverged_metric: if desired_state != observed_state {
+            Some("state_mismatch".to_string())
+        } else {
+            findings.first().map(|finding| finding.kind.clone())
+        },
+        metrics: ploy_operator_contracts::DeploymentDiagnosticsMetrics {
+            pending_intents: state_snapshot.risk.pending_intents,
+            active_orders: state_snapshot.risk.active_orders,
+            open_positions: state_snapshot.risk.open_positions,
+            fills: state_snapshot.fills.len(),
+            positions: state_snapshot.positions.len(),
+            gross_exposure: state_snapshot.risk.gross_exposure,
+            reserved_order_exposure: state_snapshot.risk.reserved_order_exposure,
+            total_gross_exposure: state_snapshot.risk.total_gross_exposure,
+            net_pnl: state_snapshot.pnl.net_pnl,
+        },
+        findings,
+        recent_evidence,
+    })
+}
+
+fn recent_snapshot_evidence(
+    daemon: &PloyDaemon,
+    limit: usize,
+    deployment_id: Option<&str>,
+) -> Vec<DiagnosticsEvidence> {
+    snapshot_events(daemon)
+        .into_iter()
+        .filter_map(|event| event_to_evidence(&event, deployment_id))
+        .take(limit)
+        .collect()
+}
+
+fn event_to_evidence(
+    event: &OperatorEvent,
+    deployment_id: Option<&str>,
+) -> Option<DiagnosticsEvidence> {
+    match event {
+        OperatorEvent::Log(log) => Some(DiagnosticsEvidence {
+            source: "event_stream".to_string(),
+            label: format!("log:{}", log.component),
+            detail: log.message.clone(),
+            observed_at: Some(log.timestamp.to_rfc3339()),
+        }),
+        OperatorEvent::Status(status) => Some(DiagnosticsEvidence {
+            source: "event_stream".to_string(),
+            label: "status".to_string(),
+            detail: format!("platform status={}", status.status),
+            observed_at: None,
+        }),
+        OperatorEvent::SystemSnapshot(event) => Some(DiagnosticsEvidence {
+            source: "event_stream".to_string(),
+            label: "system_snapshot".to_string(),
+            detail: format!(
+                "status={} errors_1h={} active_alerts={} stale_sources={}",
+                event.system.status,
+                event.system.error_count_1h,
+                event.system.active_alert_count,
+                event.system.stale_source_count,
+            ),
+            observed_at: event.system.last_trade_time.map(|value| value.to_rfc3339()),
+        }),
+        OperatorEvent::MetricsSnapshot(event) => Some(DiagnosticsEvidence {
+            source: "event_stream".to_string(),
+            label: "metrics_snapshot".to_string(),
+            detail: format!(
+                "deployments_total={} degraded={} active_alerts={} stale_sources={} live_reconcile_failures={}",
+                event.metrics.total_deployments,
+                event.metrics.degraded_deployments,
+                event.metrics.active_alerts,
+                event.metrics.stale_sources,
+                event.metrics.live_reconcile_failures,
+            ),
+            observed_at: event
+                .metrics
+                .last_live_reconcile_success_at
+                .map(|value| value.to_rfc3339()),
+        }),
+        OperatorEvent::AlertSnapshot(event) => event.alerts.first().map(|alert| DiagnosticsEvidence {
+            source: "event_stream".to_string(),
+            label: "alert_snapshot".to_string(),
+            detail: format!(
+                "{} {} {}",
+                format!("{:?}", alert.severity).to_lowercase(),
+                format!("{:?}", alert.kind).to_lowercase(),
+                alert.message
+            ),
+            observed_at: Some(alert.triggered_at.to_rfc3339()),
+        }),
+        OperatorEvent::OversightSnapshot(event) => {
+            if let Some(target) = deployment_id {
+                if !event.oversight.signals.iter().any(|signal| {
+                    signal.deployment_id.as_deref() == Some(target)
+                }) && !event
+                    .oversight
+                    .recommended_actions
+                    .iter()
+                    .any(|action| action.target == target)
+                {
+                    return None;
+                }
+            }
+            Some(DiagnosticsEvidence {
+                source: "event_stream".to_string(),
+                label: "oversight_snapshot".to_string(),
+                detail: format!(
+                    "platform_status={} signal_count={} deployments_reviewed={}",
+                    event.oversight.platform_status,
+                    event.oversight.signal_count,
+                    event.oversight.deployments_reviewed,
+                ),
+                observed_at: Some(event.oversight.timestamp.clone()),
+            })
+        }
+        OperatorEvent::ProposalSnapshot(event) => {
+            let count = deployment_id
+                .map(|target| {
+                    event.proposals
+                        .iter()
+                        .filter(|proposal| proposal.target_deployment_id == target)
+                        .count()
+                })
+                .unwrap_or(event.proposals.len());
+            if count == 0 {
+                return None;
+            }
+            Some(DiagnosticsEvidence {
+                source: "event_stream".to_string(),
+                label: "proposal_snapshot".to_string(),
+                detail: format!("proposals={count}"),
+                observed_at: None,
+            })
+        }
+        OperatorEvent::DeploymentSnapshot(event) => {
+            if let Some(target) = deployment_id {
+                if !event
+                    .deployments
+                    .iter()
+                    .any(|deployment| deployment.deployment_id == target)
+                {
+                    return None;
+                }
+            }
+            Some(DiagnosticsEvidence {
+                source: "event_stream".to_string(),
+                label: "deployment_snapshot".to_string(),
+                detail: format!("deployments={}", event.deployments.len()),
+                observed_at: None,
+            })
+        }
+        OperatorEvent::TradingSnapshot(event) => {
+            if let Some(target) = deployment_id {
+                if !event.trading.iter().any(|snapshot| snapshot.deployment_id == target) {
+                    return None;
+                }
+            }
+            Some(DiagnosticsEvidence {
+                source: "event_stream".to_string(),
+                label: "trading_snapshot".to_string(),
+                detail: format!("deployments={}", event.trading.len()),
+                observed_at: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn audit_entry_to_evidence(entry: &AuditLogEntry) -> DiagnosticsEvidence {
+    DiagnosticsEvidence {
+        source: "audit_log".to_string(),
+        label: format!("{} {}", entry.method, entry.path),
+        detail: format!(
+            "status={} auth={} required={} outcome={} client={} {}",
+            entry.status_code,
+            entry.auth_level,
+            entry.required_access,
+            entry.outcome,
+            entry.client_addr.as_deref().unwrap_or("-"),
+            entry.message.as_deref().unwrap_or("-"),
+        ),
+        observed_at: Some(entry.timestamp.to_rfc3339()),
+    }
+}
+
+fn likely_causes_from_kind(kind: &str) -> Vec<String> {
+    match kind {
+        "system_errors" => vec!["control_plane_instability".to_string()],
+        "state_mismatch" => vec!["worker_lifecycle_divergence".to_string()],
+        "order_buildup" => vec!["fill_quality_deterioration".to_string()],
+        "position_buildup" => vec!["exit_path_stalled".to_string()],
+        "exposure_watch" => vec!["risk_budget_pressure".to_string()],
+        "pnl_regression" => vec!["strategy_regime_shift".to_string()],
+        "source_stale" => vec!["data_feed_staleness".to_string()],
+        _ => Vec::new(),
+    }
 }
 
 fn extract_header<'a>(request: &'a str, name: &str) -> Option<&'a str> {
@@ -746,7 +1230,9 @@ fn auth_error_response(
 ) -> (u16, String) {
     let message = match required_access {
         RequiredAccess::Public => return (200, "{}".to_string()),
-        RequiredAccess::ReadOnly if sidecar_configured && !operator_configured && !admin_configured => {
+        RequiredAccess::ReadOnly
+            if sidecar_configured && !operator_configured && !admin_configured =>
+        {
             "control-plane sidecar, operator, or admin token is required".to_string()
         }
         RequiredAccess::ReadOnly => {
@@ -957,6 +1443,107 @@ fn handle_runtime_request(
             ),
             Err(response) => response,
         },
+        ("GET", "/api/system/diagnose") => match state.daemon.lock() {
+            Ok(daemon) => match build_platform_diagnostics_report(&daemon, state) {
+                Ok(report) => (
+                    200,
+                    serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
+                ),
+                Err(err) => json_error(500, "diagnostics_unavailable", Some(err.to_string())),
+            },
+            Err(_) => json_error(503, "daemon_lock_poisoned", None),
+        },
+        ("GET", "/api/agent/runs") => match agent_runs_path(state)
+            .map_err(|response| response)
+            .and_then(|path| {
+                read_agent_runs(&path).map_err(|err| {
+                    json_error(500, "agent_runs_unavailable", Some(err.to_string()))
+                })
+            }) {
+            Ok(runs) => (
+                200,
+                serde_json::to_string(&runs).unwrap_or_else(|_| "[]".to_string()),
+            ),
+            Err(response) => response,
+        },
+        ("GET", _) if path.starts_with("/api/agent/runs/") => {
+            let run_id = path.trim_start_matches("/api/agent/runs/");
+            match agent_runs_path(state)
+                .map_err(|response| response)
+                .and_then(|path| {
+                    read_agent_run(&path, run_id).map_err(|err| {
+                        json_error(500, "agent_runs_unavailable", Some(err.to_string()))
+                    })
+                }) {
+                Ok(Some(run)) => (
+                    200,
+                    serde_json::to_string(&run).unwrap_or_else(|_| "{}".to_string()),
+                ),
+                Ok(None) => json_error(
+                    404,
+                    "agent_run_not_found",
+                    Some(format!("agent run `{run_id}` was not found")),
+                ),
+                Err(response) => response,
+            }
+        }
+        ("GET", "/api/proposals") => match state.daemon.lock() {
+            Ok(daemon) => (
+                200,
+                serde_json::to_string(&daemon.proposals()).unwrap_or_else(|_| "[]".to_string()),
+            ),
+            Err(_) => json_error(503, "daemon_lock_poisoned", None),
+        },
+        ("GET", _) if path.starts_with("/api/proposals/") => {
+            let proposal_id = path.trim_start_matches("/api/proposals/");
+            match state.daemon.lock() {
+                Ok(daemon) => match daemon
+                    .proposals()
+                    .into_iter()
+                    .find(|proposal| proposal.proposal_id == proposal_id)
+                {
+                    Some(proposal) => (
+                        200,
+                        serde_json::to_string(&proposal).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    None => json_error(
+                        404,
+                        "proposal_not_found",
+                        Some(format!("proposal `{proposal_id}` was not found")),
+                    ),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", "/api/proposals") => {
+            let Some(body) = body else {
+                return json_error(400, "missing_body", None);
+            };
+            let request: ProposalCreateRequest = match serde_json::from_str(body) {
+                Ok(request) => request,
+                Err(err) => return json_error(400, "invalid_json", Some(err.to_string())),
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon.create_proposal(request).and_then(|proposal| {
+                    daemon.write_runtime_snapshots()?;
+                    publish_snapshot_events(&daemon, &state.events);
+                    Ok(proposal)
+                }) {
+                    Ok(proposal) => (
+                        200,
+                        serde_json::to_string(&proposal).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                        json_error(404, "deployment_not_found", Some(err.to_string()))
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::InvalidInput => {
+                        json_error(400, "invalid_request", Some(err.to_string()))
+                    }
+                    Err(err) => json_error(500, "proposal_create_failed", Some(err.to_string())),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             let deployment_id = path.trim_start_matches("/api/deployments/");
             match state.daemon.lock() {
@@ -970,6 +1557,23 @@ fn handle_runtime_request(
                         "deployment_not_found",
                         Some(format!("deployment `{deployment_id}` was not found")),
                     ),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("GET", _) if path.starts_with("/api/trading/diagnose/") => {
+            let deployment_id = path.trim_start_matches("/api/trading/diagnose/");
+            match state.daemon.lock() {
+                Ok(daemon) => match build_deployment_diagnostics_report(&daemon, state, deployment_id)
+                {
+                    Ok(report) => (
+                        200,
+                        serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                        json_error(404, "deployment_not_found", Some(err.to_string()))
+                    }
+                    Err(err) => json_error(500, "diagnostics_unavailable", Some(err.to_string())),
                 },
                 Err(_) => json_error(503, "daemon_lock_poisoned", None),
             }
@@ -1167,6 +1771,87 @@ fn handle_runtime_request(
                 Err(_) => json_error(503, "daemon_lock_poisoned", None),
             }
         }
+        ("POST", _) if path.starts_with("/api/proposals/") && path.ends_with("/approve") => {
+            let proposal_id = path
+                .trim_start_matches("/api/proposals/")
+                .trim_end_matches("/approve")
+                .trim_end_matches('/');
+            let request = body
+                .map(|raw| serde_json::from_str::<ProposalDecisionRequest>(raw))
+                .transpose()
+                .map_err(|err| json_error(400, "invalid_json", Some(err.to_string())));
+            let request = match request {
+                Ok(Some(request)) => request,
+                Ok(None) => ProposalDecisionRequest::default(),
+                Err(response) => return response,
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon.approve_proposal(proposal_id, request).and_then(
+                    |proposal| {
+                        daemon.write_runtime_snapshots()?;
+                        publish_snapshot_events(&daemon, &state.events);
+                        Ok(proposal)
+                    },
+                ) {
+                    Ok(Some(proposal)) => (
+                        200,
+                        serde_json::to_string(&proposal).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Ok(None) => json_error(
+                        404,
+                        "proposal_not_found",
+                        Some(format!("proposal `{proposal_id}` was not found")),
+                    ),
+                    Err(err) if err.kind() == io::ErrorKind::InvalidInput => {
+                        json_error(400, "invalid_request", Some(err.to_string()))
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                        json_error(404, "deployment_not_found", Some(err.to_string()))
+                    }
+                    Err(err) => json_error(500, "proposal_approve_failed", Some(err.to_string())),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
+        ("POST", _) if path.starts_with("/api/proposals/") && path.ends_with("/reject") => {
+            let proposal_id = path
+                .trim_start_matches("/api/proposals/")
+                .trim_end_matches("/reject")
+                .trim_end_matches('/');
+            let request = body
+                .map(|raw| serde_json::from_str::<ProposalDecisionRequest>(raw))
+                .transpose()
+                .map_err(|err| json_error(400, "invalid_json", Some(err.to_string())));
+            let request = match request {
+                Ok(Some(request)) => request,
+                Ok(None) => ProposalDecisionRequest::default(),
+                Err(response) => return response,
+            };
+            match state.daemon.lock() {
+                Ok(mut daemon) => match daemon.reject_proposal(proposal_id, request).and_then(
+                    |proposal| {
+                        daemon.write_runtime_snapshots()?;
+                        publish_snapshot_events(&daemon, &state.events);
+                        Ok(proposal)
+                    },
+                ) {
+                    Ok(Some(proposal)) => (
+                        200,
+                        serde_json::to_string(&proposal).unwrap_or_else(|_| "{}".to_string()),
+                    ),
+                    Ok(None) => json_error(
+                        404,
+                        "proposal_not_found",
+                        Some(format!("proposal `{proposal_id}` was not found")),
+                    ),
+                    Err(err) if err.kind() == io::ErrorKind::InvalidInput => {
+                        json_error(400, "invalid_request", Some(err.to_string()))
+                    }
+                    Err(err) => json_error(500, "proposal_reject_failed", Some(err.to_string())),
+                },
+                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+            }
+        }
         _ => json_error(404, "not_found", None),
     }
 }
@@ -1194,23 +1879,25 @@ fn intent_purpose_from_wire(purpose: IntentPurpose) -> ploy_trading::IntentPurpo
 
 pub fn snapshot_events(daemon: &PloyDaemon) -> Vec<OperatorEvent> {
     let system = daemon.control_plane.system.status();
+    let deployments = daemon.control_plane.deployments.summaries();
+    let trading = daemon.trading_state();
+    let oversight = compute_oversight_report(&system, &deployments, &trading);
+    let proposals = daemon.proposals();
     vec![
         OperatorEvent::Status(StatusUpdate {
             status: system.status.clone(),
         }),
         OperatorEvent::SystemSnapshot(SystemSnapshotEvent { system }),
-        OperatorEvent::DeploymentSnapshot(DeploymentSnapshotEvent {
-            deployments: daemon.control_plane.deployments.summaries(),
-        }),
-        OperatorEvent::TradingSnapshot(TradingSnapshotEvent {
-            trading: daemon.trading_state(),
-        }),
+        OperatorEvent::DeploymentSnapshot(DeploymentSnapshotEvent { deployments }),
+        OperatorEvent::TradingSnapshot(TradingSnapshotEvent { trading }),
         OperatorEvent::MetricsSnapshot(MetricsSnapshotEvent {
             metrics: daemon.platform_metrics(),
         }),
         OperatorEvent::AlertSnapshot(AlertSnapshotEvent {
             alerts: daemon.active_alerts(),
         }),
+        OperatorEvent::OversightSnapshot(OversightSnapshotEvent { oversight }),
+        OperatorEvent::ProposalSnapshot(ProposalSnapshotEvent { proposals }),
     ]
 }
 
@@ -1648,6 +2335,7 @@ mod tests {
             runtime_root: runtime_root.clone(),
             status_file: runtime_root.join("system-status.json"),
             deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
             ..crate::config::PlatformConfig::default()
         };
 
@@ -1848,16 +2536,12 @@ mod tests {
         assert_eq!(alerts_code, 200);
         let alerts: Vec<ploy_operator_contracts::ActiveAlert> =
             serde_json::from_str(&alerts_body).expect("alerts json");
-        assert!(
-            alerts
-                .iter()
-                .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale)
-        );
-        assert!(
-            alerts
-                .iter()
-                .any(|alert| alert.source_id.contains("live_reconcile"))
-        );
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.source_id.contains("live_reconcile")));
     }
 
     #[test]
@@ -1884,6 +2568,10 @@ mod tests {
         assert!(events.iter().any(|event| matches!(
             event,
             ploy_operator_contracts::OperatorEvent::AlertSnapshot(_)
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ploy_operator_contracts::OperatorEvent::OversightSnapshot(_)
         )));
     }
 
@@ -2290,5 +2978,282 @@ mod tests {
             handle_runtime_request("GET", "/api/deployments/missing.paper", None, &state);
         assert_eq!(status_code, 503);
         assert!(body.contains("\"error\":\"daemon_lock_poisoned\""));
+    }
+
+    #[test]
+    fn handle_runtime_request_reads_single_agent_run_detail() {
+        let root = temp_dir("runtime-agent-run-detail");
+        let runtime_root = root.join("run/platform");
+        let agent_runs_file = root.join("run/sidecar/agent-runs.jsonl");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(runtime_root.clone()).expect("create runtime root");
+        fs::create_dir_all(agent_runs_file.parent().expect("agent runs parent"))
+            .expect("create agent runs dir");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(&registry_file, "[]").expect("registry");
+        fs::write(
+            &agent_runs_file,
+            serde_json::json!({
+                "run_id": "run-operator-detail",
+                "cycle_kind": "oversight",
+                "status": "succeeded",
+                "started_at": Utc::now(),
+                "finished_at": Utc::now(),
+                "session_id": "session-1",
+                "model": "claude-sonnet-4.5",
+                "platform_status": "running",
+                "deployment_count": 1,
+                "oversight_signal_count": 2,
+                "oversight_playbook_count": 1,
+                "total_cost_usd": 0.12,
+                "tool_calls": [
+                    { "name": "mcp__research__check_oversight", "status": "succeeded" }
+                ],
+                "research_reports": 1,
+                "oversight_alerts": 1,
+                "operator_recommendations": 1,
+                "failure_reason": null,
+                "runtime_context": {
+                    "deployment_sample": ["example.paper paper example"],
+                    "oversight_signal_summary": ["critical order_buildup"],
+                    "oversight_playbook_summary": ["replay example.paper"],
+                    "diagnostic_candidates": ["example.paper"]
+                },
+                "output_summary": {
+                    "research_report_summaries": ["replay example.paper filled 12 events"],
+                    "oversight_alert_summaries": ["critical order_buildup"],
+                    "operator_recommendation_summaries": ["pause review example.paper"]
+                },
+                "evaluation": {
+                    "usefulness": "high",
+                    "research_reports": 1,
+                    "oversight_alerts": 1,
+                    "operator_recommendations": 1
+                }
+            })
+            .to_string(),
+        )
+        .expect("agent runs");
+
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            agent_runs_file,
+            ..crate::config::PlatformConfig::default()
+        };
+
+        let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let (status_code, body) =
+            handle_runtime_request("GET", "/api/agent/runs/run-operator-detail", None, &state);
+        assert_eq!(status_code, 200);
+        assert!(body.contains("\"run_id\":\"run-operator-detail\""));
+        assert!(body.contains("\"diagnostic_candidates\":[\"example.paper\"]"));
+    }
+
+    #[test]
+    fn handle_runtime_request_creates_and_lists_proposals() {
+        let root = temp_dir("runtime-proposals-create");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(runtime_root.clone()).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([
+                {
+                    "deployment_id": "example.paper",
+                    "bundle_id": "example",
+                    "runtime_mode": "paper",
+                    "desired_state": "running",
+                    "observed_state": "running"
+                }
+            ])
+            .to_string(),
+        )
+        .expect("registry");
+
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+
+        let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let create_body = serde_json::to_string(&ploy_operator_contracts::ProposalCreateRequest {
+            action_kind: ploy_operator_contracts::ProposalActionKind::PauseDeployment,
+            target_deployment_id: "example.paper".to_string(),
+            rationale: "pnl regression crossed threshold".to_string(),
+            evidence: vec!["net_pnl=-2.50".to_string()],
+            source_run_id: Some("run-123".to_string()),
+            proposed_max_gross_exposure: None,
+        })
+        .expect("proposal create json");
+
+        let (create_code, create_response) =
+            handle_runtime_request("POST", "/api/proposals", Some(&create_body), &state);
+        assert_eq!(create_code, 200);
+        assert!(create_response.contains("\"proposal_id\""));
+        assert!(create_response.contains("\"action_kind\":\"pause_deployment\""));
+
+        let (list_code, list_response) =
+            handle_runtime_request("GET", "/api/proposals", None, &state);
+        assert_eq!(list_code, 200);
+        assert!(list_response.contains("\"proposal_id\""));
+        assert!(list_response.contains("\"status\":\"pending\""));
+    }
+
+    #[test]
+    fn handle_runtime_request_reads_single_proposal_detail() {
+        let root = temp_dir("runtime-proposals-detail");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(runtime_root.clone()).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([
+                {
+                    "deployment_id": "example.paper",
+                    "bundle_id": "example",
+                    "runtime_mode": "paper",
+                    "desired_state": "running",
+                    "observed_state": "running"
+                }
+            ])
+            .to_string(),
+        )
+        .expect("registry");
+
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+
+        let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let create_body = serde_json::to_string(&ploy_operator_contracts::ProposalCreateRequest {
+            action_kind: ploy_operator_contracts::ProposalActionKind::PauseDeployment,
+            target_deployment_id: "example.paper".to_string(),
+            rationale: "drift crossed threshold".to_string(),
+            evidence: vec!["drawdown=3.20".to_string()],
+            source_run_id: Some("run-detail-1".to_string()),
+            proposed_max_gross_exposure: None,
+        })
+        .expect("proposal create json");
+
+        let (_, create_response) =
+            handle_runtime_request("POST", "/api/proposals", Some(&create_body), &state);
+        let proposal = serde_json::from_str::<ploy_operator_contracts::SafetyProposal>(
+            &create_response,
+        )
+        .expect("proposal json");
+
+        let (status_code, body) = handle_runtime_request(
+            "GET",
+            &format!("/api/proposals/{}", proposal.proposal_id),
+            None,
+            &state,
+        );
+        assert_eq!(status_code, 200);
+        assert!(body.contains(&proposal.proposal_id));
+        assert!(body.contains("\"source_run_id\":\"run-detail-1\""));
+    }
+
+    #[test]
+    fn handle_runtime_request_approves_pause_proposal_through_control_plane() {
+        let root = temp_dir("runtime-proposals-approve");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(runtime_root.clone()).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([
+                {
+                    "deployment_id": "example.paper",
+                    "bundle_id": "example",
+                    "runtime_mode": "paper",
+                    "desired_state": "running",
+                    "observed_state": "running"
+                }
+            ])
+            .to_string(),
+        )
+        .expect("registry");
+
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+
+        let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+
+        let create_body = serde_json::to_string(&ploy_operator_contracts::ProposalCreateRequest {
+            action_kind: ploy_operator_contracts::ProposalActionKind::PauseDeployment,
+            target_deployment_id: "example.paper".to_string(),
+            rationale: "orders accumulated too quickly".to_string(),
+            evidence: vec!["active_orders=8".to_string()],
+            source_run_id: Some("run-456".to_string()),
+            proposed_max_gross_exposure: None,
+        })
+        .expect("proposal create json");
+
+        let (_, create_response) =
+            handle_runtime_request("POST", "/api/proposals", Some(&create_body), &state);
+        let proposal_id = serde_json::from_str::<ploy_operator_contracts::SafetyProposal>(
+            &create_response,
+        )
+        .expect("proposal json")
+        .proposal_id;
+
+        let approve_body = serde_json::to_string(&ploy_operator_contracts::ProposalDecisionRequest {
+            decision_note: Some("approved in test".to_string()),
+        })
+        .expect("approve json");
+        let (approve_code, approve_response) = handle_runtime_request(
+            "POST",
+            &format!("/api/proposals/{proposal_id}/approve"),
+            Some(&approve_body),
+            &state,
+        );
+        assert_eq!(approve_code, 200);
+        assert!(approve_response.contains("\"status\":\"approved\""));
+
+        let (deployment_code, deployment_response) =
+            handle_runtime_request("GET", "/api/deployments/example.paper", None, &state);
+        assert_eq!(deployment_code, 200);
+        assert!(deployment_response.contains("\"desired_state\":\"paused\""));
     }
 }

--- a/apps/ployd/src/http.rs
+++ b/apps/ployd/src/http.rs
@@ -19,7 +19,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -30,7 +30,7 @@ use std::path::Path;
 
 #[derive(Debug)]
 pub struct AppState {
-    pub daemon: Arc<Mutex<PloyDaemon>>,
+    pub daemon: Arc<RwLock<PloyDaemon>>,
     pub events: Arc<EventBroker>,
 }
 
@@ -281,17 +281,35 @@ pub fn handle_api_request(
 pub fn spawn_server(state: Arc<AppState>) -> io::Result<thread::JoinHandle<()>> {
     let listen_addr = state
         .daemon
-        .lock()
+        .read()
         .map_err(|_| io::Error::new(io::ErrorKind::Other, "daemon lock poisoned"))?
         .config
         .listen_addr
         .clone();
+    let max_threads: usize = std::env::var("PLOY_MAX_HTTP_THREADS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(32);
     let listener = TcpListener::bind(&listen_addr)?;
+    let semaphore = Arc::new((Mutex::new(0_usize), Condvar::new()));
     Ok(thread::spawn(move || {
         for stream in listener.incoming().flatten() {
             let state = state.clone();
+            let semaphore = semaphore.clone();
+            {
+                let (lock, cvar) = &*semaphore;
+                let mut count = lock.lock().expect("semaphore lock");
+                while *count >= max_threads {
+                    count = cvar.wait(count).expect("semaphore wait");
+                }
+                *count += 1;
+            }
             thread::spawn(move || {
                 let _ = handle_connection(stream, &state);
+                let (lock, cvar) = &*semaphore;
+                let mut count = lock.lock().expect("semaphore lock");
+                *count -= 1;
+                cvar.notify_one();
             });
         }
     }))
@@ -468,7 +486,7 @@ fn configured_auth(
 > {
     state
         .daemon
-        .lock()
+        .read()
         .map(|daemon| {
             (
                 daemon.config.admin_token.clone(),
@@ -487,7 +505,7 @@ fn request_rate_limiter() -> &'static Mutex<RateLimiter> {
 fn request_rate_limit_per_minute(state: &Arc<AppState>) -> Result<u32, (u16, String)> {
     state
         .daemon
-        .lock()
+        .read()
         .map(|daemon| daemon.config.request_rate_limit_per_minute)
         .map_err(|_| json_error(503, "daemon_lock_poisoned", None))
 }
@@ -585,7 +603,7 @@ fn response_message(body: &str) -> Option<String> {
 fn audit_log_path(state: &Arc<AppState>) -> Result<PathBuf, (u16, String)> {
     state
         .daemon
-        .lock()
+        .read()
         .map(|daemon| daemon.config.audit_log_file.clone())
         .map_err(|_| json_error(503, "daemon_lock_poisoned", None))
 }
@@ -651,7 +669,7 @@ fn read_recent_audit_entries(path: &PathBuf, limit: usize) -> io::Result<Vec<Aud
 fn agent_runs_path(state: &Arc<AppState>) -> Result<PathBuf, (u16, String)> {
     state
         .daemon
-        .lock()
+        .read()
         .map(|daemon| daemon.config.agent_runs_file.clone())
         .map_err(|_| json_error(503, "daemon_lock_poisoned", None))
 }
@@ -1344,7 +1362,7 @@ fn handle_authenticated_runtime_request(
                 return (200, serde_json::json!({ "success": true }).to_string());
             }
 
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(daemon) => match daemon
                     .config
                     .admin_token
@@ -1393,7 +1411,7 @@ fn handle_runtime_request(
     state: &Arc<AppState>,
 ) -> (u16, String) {
     match (method, path) {
-        ("GET", "/health") | ("GET", "/api/system/status") => match state.daemon.lock() {
+        ("GET", "/health") | ("GET", "/api/system/status") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.control_plane.system.status())
@@ -1401,7 +1419,7 @@ fn handle_runtime_request(
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
-        ("GET", "/api/system/metrics") => match state.daemon.lock() {
+        ("GET", "/api/system/metrics") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.platform_metrics())
@@ -1409,14 +1427,14 @@ fn handle_runtime_request(
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
-        ("GET", "/api/system/alerts") => match state.daemon.lock() {
+        ("GET", "/api/system/alerts") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.active_alerts()).unwrap_or_else(|_| "[]".to_string()),
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
-        ("GET", "/api/deployments") => match state.daemon.lock() {
+        ("GET", "/api/deployments") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.control_plane.deployments.summaries())
@@ -1424,7 +1442,7 @@ fn handle_runtime_request(
             ),
             Err(_) => json_error(503, "daemon_lock_poisoned", None),
         },
-        ("GET", "/api/trading/state") => match state.daemon.lock() {
+        ("GET", "/api/trading/state") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.trading_state()).unwrap_or_else(|_| "[]".to_string()),
@@ -1443,7 +1461,7 @@ fn handle_runtime_request(
             ),
             Err(response) => response,
         },
-        ("GET", "/api/system/diagnose") => match state.daemon.lock() {
+        ("GET", "/api/system/diagnose") => match state.daemon.read() {
             Ok(daemon) => match build_platform_diagnostics_report(&daemon, state) {
                 Ok(report) => (
                     200,
@@ -1487,7 +1505,7 @@ fn handle_runtime_request(
                 Err(response) => response,
             }
         }
-        ("GET", "/api/proposals") => match state.daemon.lock() {
+        ("GET", "/api/proposals") => match state.daemon.read() {
             Ok(daemon) => (
                 200,
                 serde_json::to_string(&daemon.proposals()).unwrap_or_else(|_| "[]".to_string()),
@@ -1496,7 +1514,7 @@ fn handle_runtime_request(
         },
         ("GET", _) if path.starts_with("/api/proposals/") => {
             let proposal_id = path.trim_start_matches("/api/proposals/");
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(daemon) => match daemon
                     .proposals()
                     .into_iter()
@@ -1523,7 +1541,7 @@ fn handle_runtime_request(
                 Ok(request) => request,
                 Err(err) => return json_error(400, "invalid_json", Some(err.to_string())),
             };
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => match daemon.create_proposal(request).and_then(|proposal| {
                     daemon.write_runtime_snapshots()?;
                     publish_snapshot_events(&daemon, &state.events);
@@ -1546,7 +1564,7 @@ fn handle_runtime_request(
         }
         ("GET", _) if path.starts_with("/api/deployments/") && !path.ends_with("/control") => {
             let deployment_id = path.trim_start_matches("/api/deployments/");
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(daemon) => match daemon.inspect_deployment(deployment_id) {
                     Some(record) => (
                         200,
@@ -1563,7 +1581,7 @@ fn handle_runtime_request(
         }
         ("GET", _) if path.starts_with("/api/trading/diagnose/") => {
             let deployment_id = path.trim_start_matches("/api/trading/diagnose/");
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(daemon) => match build_deployment_diagnostics_report(&daemon, state, deployment_id)
                 {
                     Ok(report) => (
@@ -1597,7 +1615,7 @@ fn handle_runtime_request(
                     )),
                 );
             }
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => {
                     match daemon.apply_deployment(request).and_then(|record| {
                         daemon.write_runtime_snapshots()?;
@@ -1626,7 +1644,7 @@ fn handle_runtime_request(
                 Ok(request) => request,
                 Err(err) => return json_error(400, "invalid_json", Some(err.to_string())),
             };
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => {
                     match daemon
                         .control_deployment(deployment_id, request)
@@ -1665,7 +1683,7 @@ fn handle_runtime_request(
                 return json_error(404, "not_found", None);
             }
 
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => {
                     match daemon
                         .cancel_order(deployment_id, order_id)
@@ -1703,7 +1721,7 @@ fn handle_runtime_request(
                 Err(err) => return json_error(400, "invalid_json", Some(err.to_string())),
             };
 
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => {
                     match daemon
                         .replace_order(deployment_id, order_id, request)
@@ -1739,7 +1757,7 @@ fn handle_runtime_request(
                 Err(error) => return json_error(400, &error.error, error.message),
             };
 
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => {
                     let response = daemon.submit_intent(TradingIntent {
                         intent_id: next_paper_intent_id(deployment_id),
@@ -1785,7 +1803,7 @@ fn handle_runtime_request(
                 Ok(None) => ProposalDecisionRequest::default(),
                 Err(response) => return response,
             };
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => match daemon.approve_proposal(proposal_id, request).and_then(
                     |proposal| {
                         daemon.write_runtime_snapshots()?;
@@ -1827,7 +1845,7 @@ fn handle_runtime_request(
                 Ok(None) => ProposalDecisionRequest::default(),
                 Err(response) => return response,
             };
-            match state.daemon.lock() {
+            match state.daemon.write() {
                 Ok(mut daemon) => match daemon.reject_proposal(proposal_id, request).and_then(
                     |proposal| {
                         daemon.write_runtime_snapshots()?;
@@ -1913,7 +1931,7 @@ fn handle_event_stream(mut stream: TcpStream, state: &Arc<AppState>) -> io::Resu
         "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n"
     )?;
 
-    if let Ok(daemon) = state.daemon.lock() {
+    if let Ok(daemon) = state.daemon.read() {
         for event in snapshot_events(&daemon) {
             write_sse_event(&mut stream, &event)?;
         }
@@ -1955,7 +1973,7 @@ mod tests {
     use ploy_trading::{IntentPurpose as TradingIntentPurpose, TradeSide, TradingIntent};
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, RwLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -2052,7 +2070,7 @@ mod tests {
 
         let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2074,7 +2092,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2106,7 +2124,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2137,7 +2155,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2233,7 +2251,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2290,7 +2308,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2519,7 +2537,7 @@ mod tests {
         daemon.control_plane.system.refresh_source_health();
 
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2612,7 +2630,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2680,7 +2698,7 @@ mod tests {
         )
         .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2747,7 +2765,7 @@ mod tests {
             crate::runtime::PloyDaemon::boot_with_live_execution(&config, Box::new(gateway))
                 .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2830,7 +2848,7 @@ mod tests {
             crate::runtime::PloyDaemon::boot_with_live_execution(&config, Box::new(gateway))
                 .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2930,7 +2948,7 @@ mod tests {
             .expect("submit intent");
 
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2945,7 +2963,7 @@ mod tests {
         let daemon = crate::runtime::PloyDaemon::boot(&crate::config::PlatformConfig::default())
             .expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -2961,10 +2979,10 @@ mod tests {
     fn handle_runtime_request_reports_poisoned_lock_as_503() {
         let daemon = crate::runtime::PloyDaemon::boot(&crate::config::PlatformConfig::default())
             .expect("boot daemon");
-        let poisoned = Arc::new(Mutex::new(daemon));
+        let poisoned = Arc::new(RwLock::new(daemon));
         let poison_handle = poisoned.clone();
         let _ = std::thread::spawn(move || {
-            let _guard = poison_handle.lock().expect("lock daemon");
+            let _guard = poison_handle.write().expect("lock daemon");
             panic!("poison daemon lock for test");
         })
         .join();
@@ -3047,7 +3065,7 @@ mod tests {
 
         let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -3091,7 +3109,7 @@ mod tests {
 
         let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -3151,7 +3169,7 @@ mod tests {
 
         let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 
@@ -3216,7 +3234,7 @@ mod tests {
 
         let daemon = crate::runtime::PloyDaemon::boot(&config).expect("boot daemon");
         let state = Arc::new(AppState {
-            daemon: Arc::new(Mutex::new(daemon)),
+            daemon: Arc::new(RwLock::new(daemon)),
             events: Arc::new(EventBroker::default()),
         });
 

--- a/apps/ployd/src/main.rs
+++ b/apps/ployd/src/main.rs
@@ -7,14 +7,18 @@ use config::PlatformConfig;
 use events::EventBroker;
 use http::{publish_snapshot_events, AppState};
 use runtime::{run_shared_forever, PloyDaemon};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
+
+extern "C" fn shutdown_signal_handler(_sig: libc::c_int) {
+    runtime::request_shutdown();
+}
 
 fn main() {
     let config = PlatformConfig::from_env();
-    let daemon = Arc::new(Mutex::new(PloyDaemon::boot(&config).expect("boot ployd")));
+    let daemon = Arc::new(RwLock::new(PloyDaemon::boot(&config).expect("boot ployd")));
     let events = Arc::new(EventBroker::default());
     {
-        let mut daemon = daemon.lock().expect("daemon lock");
+        let mut daemon = daemon.write().expect("daemon lock");
         if let Err(err) = daemon.write_runtime_snapshots() {
             eprintln!("ployd boot degraded: {err}");
         }
@@ -25,7 +29,7 @@ fn main() {
         events: events.clone(),
     });
     let _server = http::spawn_server(state).expect("start ployd http server");
-    let daemon_guard = daemon.lock().expect("daemon lock");
+    let daemon_guard = daemon.read().expect("daemon lock");
     let status = daemon_guard.control_plane.system.status();
     let worker_count = daemon_guard.supervisor.workers().count();
 
@@ -34,5 +38,12 @@ fn main() {
     eprintln!("workers={worker_count}");
 
     drop(daemon_guard);
+
+    // Register signal handlers for graceful shutdown
+    unsafe {
+        libc::signal(libc::SIGTERM, shutdown_signal_handler as libc::sighandler_t);
+        libc::signal(libc::SIGINT, shutdown_signal_handler as libc::sighandler_t);
+    }
+
     run_shared_forever(daemon, events).expect("run ployd");
 }

--- a/apps/ployd/src/runtime.rs
+++ b/apps/ployd/src/runtime.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -70,13 +70,14 @@ impl PloyDaemon {
         config: &PlatformConfig,
         live_execution: Box<dyn LiveExecutionGateway>,
     ) -> io::Result<Self> {
+        let config = config.normalized();
         let mut control_plane = ControlPlane::default();
         control_plane
             .system
             .set_status(format!("starting@{}", config.listen_addr));
 
         let mut daemon = Self {
-            config: config.clone(),
+            config,
             control_plane,
             supervisor: WorkerSupervisor::default(),
             trading: BTreeMap::new(),
@@ -381,6 +382,9 @@ impl PloyDaemon {
             self.control_plane
                 .deployments
                 .set_deployment_state(deployment_id, deployment_state);
+            if deployment_state == DeploymentState::Draining {
+                self.generate_drain_exit_intents(deployment_id);
+            }
         }
         if let Some(desired_state) = request.desired_state {
             self.control_plane
@@ -406,6 +410,46 @@ impl PloyDaemon {
             .get(deployment_id)
             .cloned()
             .or(Some(existing)))
+    }
+
+    fn generate_drain_exit_intents(&mut self, deployment_id: &str) {
+        let Some(runtime) = self.trading.get(deployment_id) else {
+            return;
+        };
+        let snapshot = runtime.snapshot(&BTreeMap::new());
+        let exit_intents: Vec<TradingIntent> = snapshot
+            .positions
+            .iter()
+            .filter(|p| p.net_qty != Decimal::ZERO)
+            .map(|p| {
+                let side = if p.net_qty > Decimal::ZERO {
+                    TradeSide::Sell
+                } else {
+                    TradeSide::Buy
+                };
+                let intent_id = next_paper_intent_id(deployment_id);
+                TradingIntent {
+                    intent_id,
+                    deployment_id: deployment_id.to_string(),
+                    market_id: p.token_id.clone(),
+                    token_id: p.token_id.clone(),
+                    side,
+                    quantity: p.net_qty.abs(),
+                    limit_price: Some(p.avg_entry_price),
+                    purpose: ploy_trading::IntentPurpose::Exit,
+                    created_at: Utc::now(),
+                }
+            })
+            .collect();
+
+        for intent in exit_intents {
+            let order_id = format!("order-{}", intent.intent_id);
+            let venue_order_id = format!("drain-{}", intent.intent_id);
+            if let Some(runtime) = self.trading.get_mut(deployment_id) {
+                runtime.submit_intent(intent, order_id.clone());
+                runtime.acknowledge_order(&order_id, venue_order_id);
+            }
+        }
     }
 
     pub fn submit_intent(&mut self, intent: TradingIntent) -> io::Result<PaperIntentResponse> {
@@ -1027,6 +1071,126 @@ impl PloyDaemon {
             .sum()
     }
 
+    fn evaluate_circuit_breakers(&mut self) {
+        let snapshots = self.trading_state();
+        for snapshot in &snapshots {
+            let deployment_id = &snapshot.deployment_id;
+
+            // PnL floor check
+            if let Some(pnl_floor) = self.config.circuit_breaker_pnl_floor {
+                if snapshot.pnl.net_pnl <= pnl_floor {
+                    self.trigger_circuit_breaker(
+                        deployment_id,
+                        ProposalActionKind::DrainDeployment,
+                        format!(
+                            "circuit breaker: net_pnl {} breached floor {}",
+                            snapshot.pnl.net_pnl, pnl_floor
+                        ),
+                        vec![
+                            format!("net_pnl={}", snapshot.pnl.net_pnl),
+                            format!("pnl_floor={}", pnl_floor),
+                        ],
+                    );
+                }
+            }
+
+            // Exposure ceiling check
+            if let Some(multiplier) = self.config.circuit_breaker_exposure_ceiling_multiplier {
+                if let Some(deployment) = self.control_plane.deployments.get(deployment_id) {
+                    if let Some(max_exposure) = deployment.max_gross_exposure {
+                        let ceiling = max_exposure * multiplier;
+                        if snapshot.risk.total_gross_exposure > ceiling {
+                            self.trigger_circuit_breaker(
+                                deployment_id,
+                                ProposalActionKind::PauseDeployment,
+                                format!(
+                                    "circuit breaker: exposure {} breached ceiling {} ({}x limit)",
+                                    snapshot.risk.total_gross_exposure, ceiling, multiplier
+                                ),
+                                vec![
+                                    format!("total_gross_exposure={}", snapshot.risk.total_gross_exposure),
+                                    format!("max_gross_exposure={}", max_exposure),
+                                    format!("ceiling_multiplier={}", multiplier),
+                                ],
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn trigger_circuit_breaker(
+        &mut self,
+        deployment_id: &str,
+        action_kind: ProposalActionKind,
+        rationale: String,
+        evidence: Vec<String>,
+    ) {
+        // Prevent duplicate triggers
+        let already_triggered = self.proposals.iter().any(|p| {
+            p.target_deployment_id == deployment_id
+                && p.status == ProposalStatus::Pending
+                && p.source_run_id.as_deref() == Some("circuit_breaker")
+        });
+        if already_triggered {
+            return;
+        }
+
+        eprintln!("ployd circuit breaker: {rationale}");
+
+        let proposal_id = format!("cb-{}-{}", deployment_id, Utc::now().timestamp_millis());
+        let proposal = SafetyProposal {
+            proposal_id: proposal_id.clone(),
+            action_kind,
+            target_deployment_id: deployment_id.to_string(),
+            status: ProposalStatus::Pending,
+            rationale: rationale.clone(),
+            evidence,
+            source_run_id: Some("circuit_breaker".to_string()),
+            proposed_max_gross_exposure: None,
+            created_at: Utc::now(),
+            decided_at: None,
+            decision_note: None,
+        };
+        self.proposals.push(proposal);
+
+        // Auto-execute: apply the action immediately
+        let result = match action_kind {
+            ProposalActionKind::PauseDeployment => self.control_deployment(
+                deployment_id,
+                DeploymentControlRequest {
+                    desired_state: Some(DesiredState::Paused),
+                    deployment_state: None,
+                },
+            ),
+            ProposalActionKind::DrainDeployment => self.control_deployment(
+                deployment_id,
+                DeploymentControlRequest {
+                    desired_state: None,
+                    deployment_state: Some(DeploymentState::Draining),
+                },
+            ),
+            ProposalActionKind::ReduceMaxExposure => Ok(None),
+        };
+
+        // Update proposal status
+        if let Some(p) = self.proposals.iter_mut().rev().find(|p| p.proposal_id == proposal_id) {
+            match result {
+                Ok(_) => {
+                    p.status = ProposalStatus::Approved;
+                    p.decided_at = Some(Utc::now());
+                    p.decision_note = Some("auto-approved by circuit breaker".to_string());
+                }
+                Err(err) => {
+                    p.status = ProposalStatus::Failed;
+                    p.decided_at = Some(Utc::now());
+                    p.decision_note = Some(format!("circuit breaker action failed: {err}"));
+                }
+            }
+        }
+    }
+
     fn load_registry(&mut self) -> io::Result<()> {
         if !self.config.registry_file.exists() {
             return Ok(());
@@ -1547,7 +1711,12 @@ fn intent_counts_toward_exposure(purpose: ploy_trading::IntentPurpose) -> bool {
 }
 
 fn intent_allowed_while_draining(purpose: ploy_trading::IntentPurpose) -> bool {
-    !matches!(purpose, ploy_trading::IntentPurpose::Entry)
+    matches!(
+        purpose,
+        ploy_trading::IntentPurpose::Exit
+            | ploy_trading::IntentPurpose::Reduce
+            | ploy_trading::IntentPurpose::Cancel
+    )
 }
 
 fn observed_state_for_desired(desired_state: DesiredState) -> ObservedState {
@@ -1588,14 +1757,14 @@ pub fn next_paper_intent_id(deployment_id: &str) -> String {
 }
 
 pub fn run_shared_forever(
-    daemon: Arc<Mutex<PloyDaemon>>,
+    daemon: Arc<RwLock<PloyDaemon>>,
     events: Arc<EventBroker>,
 ) -> io::Result<()> {
     loop {
         if shutdown_requested() {
             eprintln!("ployd: shutdown signal received, writing final snapshots");
             let mut daemon = daemon
-                .lock()
+                .write()
                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "daemon lock poisoned"))?;
             if let Err(err) = daemon.write_runtime_snapshots() {
                 eprintln!("ployd: final snapshot write failed: {err}");
@@ -1605,7 +1774,7 @@ pub fn run_shared_forever(
         }
         let tick_interval_ms = {
             let mut daemon = daemon
-                .lock()
+                .write()
                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "daemon lock poisoned"))?;
             if let Err(err) = daemon.write_runtime_snapshots() {
                 eprintln!("ployd tick degraded: {err}");

--- a/apps/ployd/src/runtime.rs
+++ b/apps/ployd/src/runtime.rs
@@ -11,7 +11,9 @@ use ploy_operator_contracts::{
     ActiveAlert, DeploymentApplyRequest, DeploymentControlRequest, DeploymentState, DesiredState,
     FillSnapshot, IntentPurpose, ObservedState, OrderControlResponse, OrderReplaceRequest,
     OrderSnapshot, PaperIntentResponse, PlatformMetrics, PnlSnapshotResponse,
-    PositionSnapshotResponse, RiskSnapshotResponse, TradingIntentSnapshot, TradingStateSnapshot,
+    PositionSnapshotResponse, ProposalActionKind, ProposalCreateRequest, ProposalDecisionRequest,
+    ProposalStatus, RiskSnapshotResponse, SafetyProposal, TradingIntentSnapshot,
+    TradingStateSnapshot,
 };
 use ploy_platform::{ControlPlane, DeploymentRecord};
 use ploy_trading::{OrderState, TradeSide, TradingIntent, TradingRuntime, TradingRuntimeSnapshot};
@@ -21,9 +23,20 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+pub fn request_shutdown() {
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+fn shutdown_requested() -> bool {
+    SHUTDOWN_REQUESTED.load(Ordering::SeqCst)
+}
 
 #[cfg(test)]
 use ploy_trading::FillRecord;
@@ -41,6 +54,7 @@ pub struct PloyDaemon {
     pub control_plane: ControlPlane,
     pub supervisor: WorkerSupervisor,
     pub trading: BTreeMap<String, TradingRuntime>,
+    proposals: Vec<SafetyProposal>,
     live_execution: Box<dyn LiveExecutionGateway>,
     live_reconcile_failures: u32,
     next_live_reconcile_at: Option<DateTime<Utc>>,
@@ -66,6 +80,7 @@ impl PloyDaemon {
             control_plane,
             supervisor: WorkerSupervisor::default(),
             trading: BTreeMap::new(),
+            proposals: Vec::new(),
             live_execution,
             live_reconcile_failures: 0,
             next_live_reconcile_at: None,
@@ -73,6 +88,7 @@ impl PloyDaemon {
         };
         daemon.load_registry()?;
         daemon.load_trading_snapshots()?;
+        daemon.load_proposals()?;
         if daemon.config.trading_state_file.exists() {
             daemon
                 .control_plane
@@ -101,6 +117,9 @@ impl PloyDaemon {
             Err(err) => self.mark_live_runtime_degraded(err),
         }
         self.refresh_source_health();
+        if self.config.circuit_breaker_enabled {
+            self.evaluate_circuit_breakers();
+        }
         if let Err(err) = self.persist_registry() {
             self.control_plane.system.set_database_connected(false);
             self.control_plane
@@ -124,6 +143,7 @@ impl PloyDaemon {
             &self.control_plane.deployments.summaries(),
         )?;
         write_json(&self.config.trading_state_file, &self.trading_state())?;
+        write_json(&self.config.proposals_file, &self.proposals)?;
         Ok(())
     }
 
@@ -134,7 +154,10 @@ impl PloyDaemon {
     pub fn platform_metrics(&self) -> PlatformMetrics {
         let records = self.control_plane.deployments.records();
         let total_deployments = records.len();
-        let live_deployments = records.iter().filter(|record| record.runtime_mode == "live").count();
+        let live_deployments = records
+            .iter()
+            .filter(|record| record.runtime_mode == "live")
+            .count();
         let degraded_deployments = records
             .iter()
             .filter(|record| record.observed_state == ObservedState::Degraded)
@@ -146,6 +169,10 @@ impl PloyDaemon {
 
     pub fn active_alerts(&self) -> Vec<ActiveAlert> {
         self.control_plane.system.active_alerts()
+    }
+
+    pub fn proposals(&self) -> Vec<SafetyProposal> {
+        self.proposals.clone()
     }
 
     pub fn trading_state(&self) -> Vec<TradingStateSnapshot> {
@@ -187,6 +214,158 @@ impl PloyDaemon {
             .get(&record.deployment_id)
             .cloned()
             .expect("deployment persisted"))
+    }
+
+    pub fn create_proposal(
+        &mut self,
+        request: ProposalCreateRequest,
+    ) -> io::Result<SafetyProposal> {
+        if self
+            .control_plane
+            .deployments
+            .get(&request.target_deployment_id)
+            .is_none()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "deployment `{}` was not found",
+                    request.target_deployment_id
+                ),
+            ));
+        }
+
+        if matches!(
+            request.action_kind,
+            ProposalActionKind::ReduceMaxExposure
+        ) && request.proposed_max_gross_exposure.is_none()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "reduce_max_exposure proposals require proposed_max_gross_exposure",
+            ));
+        }
+
+        let proposal = SafetyProposal {
+            proposal_id: next_proposal_id(&request.target_deployment_id),
+            action_kind: request.action_kind,
+            target_deployment_id: request.target_deployment_id,
+            status: ProposalStatus::Pending,
+            rationale: request.rationale,
+            evidence: request.evidence,
+            source_run_id: request.source_run_id,
+            proposed_max_gross_exposure: request.proposed_max_gross_exposure,
+            created_at: Utc::now(),
+            decided_at: None,
+            decision_note: None,
+        };
+        self.proposals.push(proposal.clone());
+        Ok(proposal)
+    }
+
+    pub fn approve_proposal(
+        &mut self,
+        proposal_id: &str,
+        request: ProposalDecisionRequest,
+    ) -> io::Result<Option<SafetyProposal>> {
+        let index = match self
+            .proposals
+            .iter()
+            .position(|proposal| proposal.proposal_id == proposal_id)
+        {
+            Some(index) => index,
+            None => return Ok(None),
+        };
+
+        if self.proposals[index].status != ProposalStatus::Pending {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("proposal `{proposal_id}` is no longer pending"),
+            ));
+        }
+
+        let action_kind = self.proposals[index].action_kind;
+        let target_deployment_id = self.proposals[index].target_deployment_id.clone();
+        let proposed_max_gross_exposure = self.proposals[index].proposed_max_gross_exposure;
+        let decision_note = request
+            .decision_note
+            .clone()
+            .or_else(|| Some("approved by operator".to_string()));
+
+        let action_result = match action_kind {
+            ProposalActionKind::PauseDeployment => self.control_deployment(
+                &target_deployment_id,
+                DeploymentControlRequest {
+                    desired_state: Some(DesiredState::Paused),
+                    deployment_state: None,
+                },
+            ),
+            ProposalActionKind::DrainDeployment => self.control_deployment(
+                &target_deployment_id,
+                DeploymentControlRequest {
+                    desired_state: None,
+                    deployment_state: Some(DeploymentState::Draining),
+                },
+            ),
+            ProposalActionKind::ReduceMaxExposure => {
+                let max_gross_exposure = proposed_max_gross_exposure.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "proposal missing proposed_max_gross_exposure",
+                    )
+                })?;
+                self.set_deployment_max_gross_exposure(
+                    &target_deployment_id,
+                    Some(max_gross_exposure),
+                )?;
+                Ok(self.inspect_deployment(&target_deployment_id))
+            }
+        };
+
+        match action_result {
+            Ok(_) => {
+                let proposal = &mut self.proposals[index];
+                proposal.status = ProposalStatus::Approved;
+                proposal.decided_at = Some(Utc::now());
+                proposal.decision_note = decision_note;
+                Ok(Some(proposal.clone()))
+            }
+            Err(err) => {
+                let proposal = &mut self.proposals[index];
+                proposal.status = ProposalStatus::Failed;
+                proposal.decided_at = Some(Utc::now());
+                proposal.decision_note = Some(err.to_string());
+                Err(err)
+            }
+        }
+    }
+
+    pub fn reject_proposal(
+        &mut self,
+        proposal_id: &str,
+        request: ProposalDecisionRequest,
+    ) -> io::Result<Option<SafetyProposal>> {
+        let Some(proposal) = self
+            .proposals
+            .iter_mut()
+            .find(|proposal| proposal.proposal_id == proposal_id)
+        else {
+            return Ok(None);
+        };
+
+        if proposal.status != ProposalStatus::Pending {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("proposal `{proposal_id}` is no longer pending"),
+            ));
+        }
+
+        proposal.status = ProposalStatus::Rejected;
+        proposal.decided_at = Some(Utc::now());
+        proposal.decision_note = request
+            .decision_note
+            .or_else(|| Some("rejected by operator".to_string()));
+        Ok(Some(proposal.clone()))
     }
 
     pub fn control_deployment(
@@ -918,6 +1097,21 @@ impl PloyDaemon {
         Ok(())
     }
 
+    fn load_proposals(&mut self) -> io::Result<()> {
+        if !self.config.proposals_file.exists() {
+            return Ok(());
+        }
+
+        let raw = fs::read_to_string(&self.config.proposals_file)?;
+        if raw.trim().is_empty() {
+            return Ok(());
+        }
+
+        self.proposals = serde_json::from_str(&raw)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(())
+    }
+
     fn tick(&mut self) {
         let records = self.control_plane.deployments.records();
 
@@ -939,7 +1133,9 @@ impl PloyDaemon {
                         self.control_plane.system.note_source_heartbeat(
                             format!("worker:{}", record.deployment_id),
                             "worker",
-                            ChronoDuration::milliseconds(self.config.worker_heartbeat_stale_after_ms as i64),
+                            ChronoDuration::milliseconds(
+                                self.config.worker_heartbeat_stale_after_ms as i64,
+                            ),
                         );
                     }
                 }
@@ -989,7 +1185,10 @@ impl PloyDaemon {
                 .source_is_stale(&format!("worker:{}", record.deployment_id));
             let live_source_stale = record.runtime_mode == "live"
                 && (self.control_plane.system.source_is_stale("live_reconcile")
-                    || self.control_plane.system.source_is_stale("venue:polymarket"));
+                    || self
+                        .control_plane
+                        .system
+                        .source_is_stale("venue:polymarket"));
 
             if worker_stale || live_source_stale {
                 self.control_plane
@@ -1028,6 +1227,77 @@ impl PloyDaemon {
             &self.control_plane.deployments.records(),
         )
     }
+
+    fn set_deployment_max_gross_exposure(
+        &mut self,
+        deployment_id: &str,
+        max_gross_exposure: Option<Decimal>,
+    ) -> io::Result<()> {
+        // Validate against current exposure BEFORE mutating the registry so that
+        // a failed check never leaves a partially-applied limit in memory.
+        if let Some(limit) = max_gross_exposure {
+            if let Some(runtime) = self.trading.get(deployment_id) {
+                let current = runtime.snapshot(&BTreeMap::new()).risk.total_gross_exposure;
+                if current > limit {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "current exposure {} exceeds proposed limit {} for `{}`",
+                            current, limit, deployment_id
+                        ),
+                    ));
+                }
+            }
+        }
+
+        let record = self
+            .control_plane
+            .deployments
+            .set_max_gross_exposure(deployment_id, max_gross_exposure)
+            .cloned()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("deployment `{deployment_id}` was not found"),
+                )
+            })?;
+
+        self.persist_registry()?;
+
+        if self.trading.contains_key(&record.deployment_id) {
+            let _ = self.enforce_current_exposure_limit(&record);
+        }
+        Ok(())
+    }
+
+    fn enforce_current_exposure_limit(&self, record: &DeploymentRecord) -> io::Result<()> {
+        let Some(limit) = record.max_gross_exposure else {
+            return Ok(());
+        };
+        let Some(runtime) = self.trading.get(&record.deployment_id) else {
+            return Ok(());
+        };
+        let current = runtime.snapshot(&BTreeMap::new()).risk.total_gross_exposure;
+        if current > limit {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "current exposure {} exceeds proposed limit {} for `{}`",
+                    current, limit, record.deployment_id
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn next_proposal_id(target_deployment_id: &str) -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_millis();
+    let target = target_deployment_id.replace('.', "-");
+    format!("proposal-{target}-{millis}")
 }
 
 fn build_trading_state_snapshot(
@@ -1322,6 +1592,17 @@ pub fn run_shared_forever(
     events: Arc<EventBroker>,
 ) -> io::Result<()> {
     loop {
+        if shutdown_requested() {
+            eprintln!("ployd: shutdown signal received, writing final snapshots");
+            let mut daemon = daemon
+                .lock()
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "daemon lock poisoned"))?;
+            if let Err(err) = daemon.write_runtime_snapshots() {
+                eprintln!("ployd: final snapshot write failed: {err}");
+            }
+            eprintln!("ployd: shutdown complete");
+            return Ok(());
+        }
         let tick_interval_ms = {
             let mut daemon = daemon
                 .lock()
@@ -1346,7 +1627,9 @@ where
     fs::create_dir_all(parent)?;
     let body = serde_json::to_vec_pretty(value)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-    fs::write(path, body)
+    let tmp_path = path.with_extension("tmp");
+    fs::write(&tmp_path, &body)?;
+    fs::rename(&tmp_path, path)
 }
 
 #[cfg(test)]
@@ -2617,8 +2900,17 @@ mod tests {
 
         let alerts = daemon.active_alerts();
         assert_eq!(alerts.len(), 2);
-        assert!(alerts.iter().any(|alert| alert.source_id == "live_reconcile"));
-        assert!(alerts.iter().any(|alert| alert.source_id == "venue:polymarket"));
-        assert!(daemon.control_plane.system.status().status.starts_with("degraded@"));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.source_id == "live_reconcile"));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.source_id == "venue:polymarket"));
+        assert!(daemon
+            .control_plane
+            .system
+            .status()
+            .status
+            .starts_with("degraded@"));
     }
 }

--- a/crates/ploy-trading/src/lib.rs
+++ b/crates/ploy-trading/src/lib.rs
@@ -11,7 +11,7 @@ pub use intents::{IntentPurpose, TradeSide, TradingIntent};
 pub use orders::{OrderLedger, OrderRecord, OrderState};
 pub use pnl::PnlSnapshot;
 pub use positions::{PositionLedger, PositionSnapshot};
-pub use risk::{snapshot_from_state, RiskSnapshot};
+pub use risk::{snapshot_from_state, snapshot_from_state_with_prices, RiskSnapshot};
 pub use runtime::{TradeCashflowSummary, TradingRuntime, TradingRuntimeSnapshot};
 
 pub const CRATE_MARKER: &str = "ploy-trading";

--- a/crates/ploy-trading/src/risk.rs
+++ b/crates/ploy-trading/src/risk.rs
@@ -3,6 +3,7 @@ use crate::orders::OrderLedger;
 use crate::positions::PositionLedger;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RiskSnapshot {
@@ -19,9 +20,25 @@ pub fn snapshot_from_state(
     orders: &OrderLedger,
     positions: &PositionLedger,
 ) -> RiskSnapshot {
+    snapshot_from_state_with_prices(intents, orders, positions, &BTreeMap::new())
+}
+
+pub fn snapshot_from_state_with_prices(
+    intents: &[TradingIntent],
+    orders: &OrderLedger,
+    positions: &PositionLedger,
+    reference_prices: &BTreeMap<String, Decimal>,
+) -> RiskSnapshot {
     let gross_exposure = positions
         .positions()
-        .map(|position| position.net_qty.abs() * position.avg_entry_price)
+        .map(|position| {
+            let ref_price = reference_prices.get(&position.token_id).copied();
+            let price = match ref_price {
+                Some(rp) => rp.max(position.avg_entry_price),
+                None => position.avg_entry_price,
+            };
+            position.net_qty.abs() * price
+        })
         .sum();
 
     let reserved_order_exposure = intents
@@ -45,7 +62,11 @@ pub fn snapshot_from_state(
         })
         .map(|order| {
             let remaining_qty = (order.requested_qty - order.filled_qty).max(Decimal::ZERO);
-            remaining_qty * order.limit_price.unwrap_or(Decimal::ONE)
+            let price = order
+                .limit_price
+                .or_else(|| reference_prices.get(&order.token_id).copied())
+                .unwrap_or(Decimal::ONE);
+            remaining_qty * price
         })
         .sum();
 

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -77,6 +77,7 @@ pub struct TradingRuntime {
     orders: OrderLedger,
     fills: FillLedger,
     positions: PositionLedger,
+    cached_risk: Option<RiskSnapshot>,
 }
 
 impl TradingRuntime {
@@ -91,6 +92,7 @@ impl TradingRuntime {
             orders: OrderLedger::restore(snapshot.orders),
             fills: FillLedger::restore(snapshot.fills),
             positions,
+            cached_risk: None,
         }
     }
 
@@ -99,6 +101,7 @@ impl TradingRuntime {
         intent: TradingIntent,
         order_id: impl Into<String>,
     ) -> &crate::orders::OrderRecord {
+        self.cached_risk = None;
         self.intents.push(intent.clone());
         self.orders.insert_from_intent(order_id, &intent)
     }
@@ -108,6 +111,7 @@ impl TradingRuntime {
         order_id: &str,
         venue_order_id: impl Into<String>,
     ) -> Option<&crate::orders::OrderRecord> {
+        self.cached_risk = None;
         self.orders.acknowledge(order_id, venue_order_id)
     }
 
@@ -118,6 +122,7 @@ impl TradingRuntime {
         limit_price: Option<Decimal>,
         venue_order_id: impl Into<String>,
     ) -> Option<&crate::orders::OrderRecord> {
+        self.cached_risk = None;
         self.orders
             .replace(order_id, requested_qty, limit_price, venue_order_id)
     }
@@ -127,6 +132,7 @@ impl TradingRuntime {
         order_id: &str,
         reason: impl Into<String>,
     ) -> Option<&crate::orders::OrderRecord> {
+        self.cached_risk = None;
         self.orders.reject(order_id, reason)
     }
 
@@ -139,6 +145,7 @@ impl TradingRuntime {
     }
 
     pub fn cancel_order(&mut self, order_id: &str) -> Option<&crate::orders::OrderRecord> {
+        self.cached_risk = None;
         self.orders.cancel(order_id)
     }
 
@@ -156,6 +163,7 @@ impl TradingRuntime {
         if self.fills.contains(&fill.fill_id) {
             return false;
         }
+        self.cached_risk = None;
         self.orders.apply_fill(&fill);
         self.positions.apply_fill(&fill);
         self.fills.record(fill);
@@ -308,10 +316,7 @@ mod tests {
         assert_eq!(summary.deployed_capital(), dec!(10.00));
         assert_eq!(summary.net_pnl(), dec!(14.95));
         assert_eq!(
-            summary
-                .roi_on_deployed_capital()
-                .expect("roi")
-                .round_dp(4),
+            summary.roi_on_deployed_capital().expect("roi").round_dp(4),
             dec!(1.4950)
         );
     }

--- a/docs/plans/2026-04-06-hardening-trust-cutover-implementation-plan.md
+++ b/docs/plans/2026-04-06-hardening-trust-cutover-implementation-plan.md
@@ -1,0 +1,103 @@
+# Hardening And Trust-Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add source-health metrics, trust policies, and runbook updates so the expanded PM data plane can be operated safely after the earlier implementation phases land.
+
+**Architecture:** Build on the earlier phases rather than mixing hardening into the initial feature slices. Add explicit source-ranking policy, freshness metrics, and operator runbooks that define when new feeds and market families are considered trusted for historical research and operational use.
+
+**Tech Stack:** Rust metrics/snapshot code, docs/runbooks, `ployctl` status surfaces, existing tracker workflow
+
+---
+
+### Task 1: Add explicit trust-policy configuration and documentation
+
+**Files:**
+- Modify: `config/default.toml`
+- Create: `docs/runbooks/polymarket-data-trust-policy.md`
+- Modify: `docs/plans/2026-04-06-polymarket-expansion-master-plan.md`
+- Modify: `tasks/todo.md`
+
+- [ ] Add config documentation for:
+  - trusted quote sources
+  - trusted reference sources
+  - sports-state trust windows
+  - carried-forward price handling
+- [ ] Write a runbook that defines how a newly added source graduates from observed to trusted.
+- [ ] Link the trust-policy runbook from the master plan and tracker.
+
+Run:
+
+```bash
+rg -n "trust" config/default.toml docs/runbooks/polymarket-data-trust-policy.md tasks/todo.md
+```
+
+Expected: trust-policy terms appear in the config and runbook files.
+
+### Task 2: Add health/freshness projections for new feed families
+
+**Files:**
+- Modify: `apps/ployctl/src/system.rs`
+- Modify: `apps/ployctl/src/feeds.rs`
+- Modify: `apps/ployctl/src/client.rs`
+- Modify: `tasks/todo.md`
+
+- [ ] Add feed-health views covering:
+  - Chainlink crypto
+  - Binance crypto
+  - Pyth non-crypto
+  - Sports WebSocket
+- [ ] Surface freshness, carried-forward state, and stale-source warnings in the operator output.
+- [ ] Keep the output concise enough for terminal use.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-hardening rtk cargo test -p ployctl -- --nocapture
+```
+
+Expected: `ployctl` tests still pass after the health projection expansion.
+
+### Task 3: Add deployment and backtest runbooks for the expanded data plane
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/runbooks/polymarket-reference-feeds.md`
+- Create: `docs/runbooks/polymarket-sports-capture.md`
+- Create: `docs/runbooks/polymarket-backtest-data-sources.md`
+
+- [ ] Document how to enable and observe:
+  - Pyth reference capture
+  - sports-state capture
+  - backtest source selection
+- [ ] Document the explicit boundary that sports execution remains out of scope until later safeguards land.
+- [ ] Link all runbooks from the README and the master plan.
+
+Run:
+
+```bash
+rg -n "reference feeds|sports capture|backtest data sources" README.md docs/runbooks docs/plans/2026-04-06-polymarket-expansion-master-plan.md
+```
+
+Expected: the new runbooks are linked from README and the master plan.
+
+### Task 4: Capture the final verification matrix and rollout notes
+
+**Files:**
+- Modify: `tasks/todo.md`
+
+- [ ] Record the exact validation commands that must pass before trusting the expanded surface in everyday use.
+- [ ] Add a short rollout checklist covering:
+  - schema migration order
+  - capture dry-run checks
+  - replay/backtest parity checks
+  - operator CLI checks
+- [ ] Leave unresolved production enablement questions as explicit follow-ups rather than silent assumptions.
+
+Run:
+
+```bash
+/opt/homebrew/bin/rtk read tasks/todo.md
+```
+
+Expected: the tracker contains the rollout notes and verification matrix at the top.

--- a/migrations/033_fix_settlement_view_join_and_confirmed_flag.sql
+++ b/migrations/033_fix_settlement_view_join_and_confirmed_flag.sql
@@ -1,0 +1,199 @@
+-- Migration: 033_fix_settlement_view_join_and_confirmed_flag
+-- Description: Fix settlement_prices CTE to join only on token_id (not event_id+token_id),
+--              and add is_confirmed column to distinguish official vs spot-fallback settlements.
+--
+-- Root cause: The previous view joined settlement_prices on
+--   sp.event_id = f.event_id AND sp.token_id = f.token_id
+-- where sp.event_id was aliased from market_slug. But fills store event_id as a numeric
+-- string (e.g. "1888667") while pm_token_settlements.market_slug may be
+-- "eth-updown-5m-1775547900" for the same token. Since token_id is the PK of
+-- pm_token_settlements (unique), joining only on token_id is correct and sufficient.
+--
+-- Also adds is_confirmed: true when the exit price comes from official settlement data
+-- (either directly matched or corrected), false when using spot-price fallback.
+
+DROP VIEW IF EXISTS strategy_runtime_daily_track_record;
+DROP VIEW IF EXISTS strategy_runtime_event_track_record;
+
+CREATE VIEW strategy_runtime_event_track_record AS
+WITH settlement_prices AS (
+    SELECT
+        token_id,
+        CASE
+            WHEN settled_price >= 0.99 THEN 1.0::NUMERIC
+            WHEN settled_price <= 0.01 THEN 0.0::NUMERIC
+            ELSE settled_price
+        END AS official_price
+    FROM pm_token_settlements
+    WHERE resolved = true
+),
+normalized_fills AS (
+    SELECT
+        f.runtime_mode,
+        f.strategy_id,
+        f.deployment_id,
+        COALESCE(NULLIF(f.event_id, ''), f.intent_id) AS trade_key,
+        f.event_id,
+        f.intent_id,
+        f.symbol,
+        f.token_id,
+        f.market_side,
+        f.fill_side,
+        f.quantity,
+        f.price AS recorded_price,
+        sp.official_price AS official_settlement_price,
+        -- Use official settlement price for settlement exits when available
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE 'settle_%'
+                AND sp.official_price IS NOT NULL
+            THEN sp.official_price
+            ELSE f.price
+        END AS effective_price,
+        -- Flag when official price differs from what was recorded (spot fallback was wrong)
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE 'settle_%'
+                AND sp.official_price IS NOT NULL
+                AND ABS(f.price - sp.official_price) > 0.00000001::NUMERIC
+            THEN true
+            ELSE false
+        END AS settlement_corrected,
+        f.fee,
+        f.fill_timestamp
+    FROM strategy_runtime_fills f
+    LEFT JOIN settlement_prices sp ON sp.token_id = f.token_id
+),
+aggregated AS (
+    SELECT
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        MAX(event_id) AS event_id,
+        MIN(intent_id) AS intent_id,
+        MAX(symbol) AS symbol,
+        MAX(token_id) AS token_id,
+        MAX(market_side) AS market_side,
+        BOOL_OR(settlement_corrected) AS settlement_corrected,
+        MIN(fill_timestamp) AS first_fill_at,
+        MAX(fill_timestamp) AS last_fill_at,
+        MIN(fill_timestamp) FILTER (WHERE fill_side = 'BUY') AS opened_at,
+        MAX(fill_timestamp) FILTER (WHERE fill_side = 'SELL') AS closed_at,
+        COUNT(*) AS fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'BUY') AS buy_fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'SELL') AS sell_fill_count,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'BUY'), 0::NUMERIC) AS buy_quantity,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'SELL'), 0::NUMERIC) AS sell_quantity,
+        COALESCE(
+            SUM(quantity * recorded_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS recorded_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'BUY'),
+            0::NUMERIC
+        ) AS buy_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS sell_notional,
+        MAX(official_settlement_price) FILTER (
+            WHERE fill_side = 'SELL'
+              AND intent_id LIKE 'settle_%'
+              AND official_settlement_price IS NOT NULL
+        ) AS official_exit_price,
+        -- is_confirmed: true when exit price is backed by official settlement data
+        -- false when using spot-price fallback (current_spot >= open_price heuristic)
+        BOOL_OR(
+            fill_side = 'SELL'
+            AND intent_id LIKE 'settle_%'
+            AND official_settlement_price IS NOT NULL
+        ) AS has_official_settlement,
+        COALESCE(SUM(fee), 0::NUMERIC) AS total_fee
+    FROM normalized_fills
+    GROUP BY runtime_mode, strategy_id, deployment_id, trade_key
+)
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    trade_key,
+    event_id,
+    intent_id,
+    symbol,
+    token_id,
+    market_side,
+    first_fill_at,
+    last_fill_at,
+    opened_at,
+    closed_at,
+    fill_count,
+    buy_fill_count,
+    sell_fill_count,
+    buy_quantity,
+    sell_quantity,
+    buy_notional,
+    sell_notional,
+    recorded_sell_notional,
+    total_fee,
+    CASE
+        WHEN buy_quantity > 0 THEN buy_notional / buy_quantity
+        ELSE NULL
+    END AS avg_entry_price,
+    CASE
+        WHEN sell_quantity > 0 THEN recorded_sell_notional / sell_quantity
+        ELSE NULL
+    END AS recorded_exit_price,
+    official_exit_price,
+    CASE
+        WHEN sell_quantity > 0 THEN sell_notional / sell_quantity
+        ELSE NULL
+    END AS avg_exit_price,
+    settlement_corrected,
+    -- is_confirmed: the exit price is backed by official Polymarket settlement data.
+    -- When false, the exit used a spot-price heuristic (current >= open) which may be wrong.
+    has_official_settlement AS is_confirmed,
+    sell_notional - buy_notional AS gross_pnl,
+    sell_notional - buy_notional - total_fee AS net_pnl,
+    buy_quantity > 0
+        AND sell_quantity > 0
+        AND ABS(buy_quantity - sell_quantity) <= 0.00000001::NUMERIC AS is_closed,
+    CASE
+        WHEN buy_quantity > sell_quantity THEN buy_quantity - sell_quantity
+        ELSE 0::NUMERIC
+    END AS open_quantity
+FROM aggregated;
+
+CREATE VIEW strategy_runtime_daily_track_record AS
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date AS trading_day_cst,
+    COUNT(*) AS trade_count,
+    COUNT(*) FILTER (WHERE is_closed) AS closed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed) AS confirmed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND settlement_corrected) AS corrected_trade_count,
+    -- Win/loss counts for confirmed trades only (official settlement data)
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl > 0) AS winning_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl < 0) AS losing_trade_count,
+    -- Win/loss counts including spot-fallback settlements
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl > 0) AS winning_trade_count_all,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl < 0) AS losing_trade_count_all,
+    COALESCE(SUM(buy_notional), 0::NUMERIC) AS total_buy_notional,
+    COALESCE(SUM(sell_notional), 0::NUMERIC) AS total_sell_notional,
+    COALESCE(SUM(recorded_sell_notional), 0::NUMERIC) AS total_recorded_sell_notional,
+    COALESCE(SUM(total_fee), 0::NUMERIC) AS total_fee,
+    COALESCE(SUM(gross_pnl), 0::NUMERIC) AS gross_pnl,
+    COALESCE(SUM(net_pnl), 0::NUMERIC) AS net_pnl,
+    COALESCE(AVG(net_pnl), 0::NUMERIC) AS avg_net_pnl,
+    -- Confirmed-only PnL (excludes spot-fallback trades)
+    COALESCE(SUM(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_net_pnl,
+    COALESCE(AVG(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_avg_net_pnl,
+    COALESCE(SUM(open_quantity), 0::NUMERIC) AS residual_open_quantity
+FROM strategy_runtime_event_track_record
+GROUP BY
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date;

--- a/ploy-sidecar/src/index.ts
+++ b/ploy-sidecar/src/index.ts
@@ -1,26 +1,34 @@
 /**
  * Ploy Sidecar — Claude Agent SDK operator client
  *
- * Orchestrates NBA comeback research while staying grounded in the
+ * Runs research and oversight loops while staying grounded in the
  * trading-platform control plane:
- * 1. ESPN scan → live games with comeback potential
- * 2. Polymarket search → find corresponding markets
- * 3. Control-plane inspection → system status, deployments, trading state
- * 4. X.com sentiment research → WebSearch for injury/momentum
- * 5. Operator recommendation → deployment-aware recommendation or action
+ * 1. Control-plane inspection -> system status, deployments, trading state
+ * 2. Research tools -> replay, backtest, config compare
+ * 3. External context -> ESPN, Polymarket, WebSearch when useful
+ * 4. Oversight output -> alerts and operator recommendations only
  *
  * Architecture:
- *   Claude Sidecar (this)  →  research skills (ESPN, Polymarket, WebSearch)
- *                          →  ployd control plane (via Rust backend MCP)
+ *   Claude Sidecar (this)  ->  research skills (ESPN, Polymarket, WebSearch)
+ *                          ->  ployd control plane (via Rust backend MCP)
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { espnServer } from "./tools/espn.js";
 import { polymarketServer } from "./tools/polymarket.js";
+import { diagnosticsServer } from "./tools/diagnostics.js";
 import { ployBackendServer } from "./tools/ploy-backend.js";
-import { tradingOutputSchema } from "./schemas/output.js";
+import { researchServer, runPloyResearchCommand } from "./tools/research.js";
+import { researchOutputSchema } from "./schemas/output.js";
+import { collectDiagnosticCandidates } from "./runtime/diagnostics.js";
+import {
+  buildRunRecord,
+  newRunId,
+  recordAgentRun,
+  type AgentToolCallRecord,
+} from "./runtime/run-recorder.js";
 
-// ── Config ──────────────────────────────────────────
+// -- Config ---------------------------------------------------------
 
 function isMiniMaxAnthropicEndpoint(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false;
@@ -46,12 +54,10 @@ function applyMiniMaxCompatEnv(): string | null {
   const minimaxModel = process.env.MINIMAX_ANTHROPIC_MODEL || "MiniMax-M2.5";
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY?.trim();
 
-  // MiniMax Anthropic-compatible endpoint expects Authorization header.
   if (anthropicApiKey && !process.env.ANTHROPIC_CUSTOM_HEADERS) {
     process.env.ANTHROPIC_CUSTOM_HEADERS = `Authorization: Bearer ${anthropicApiKey}`;
   }
 
-  // Map Claude aliases to the MiniMax model unless user already set custom mappings.
   if (!process.env.ANTHROPIC_DEFAULT_OPUS_MODEL) {
     process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = minimaxModel;
   }
@@ -72,57 +78,41 @@ const MAX_BUDGET = parseFloat(process.env.SIDECAR_MAX_BUDGET_USD || "1.00");
 const DRY_RUN = process.env.SIDECAR_DRY_RUN !== "false";
 const PLOY_API = process.env.PLOY_API_URL || "http://localhost:8081";
 
-// ── System Prompt ───────────────────────────────────
+// -- System Prompt --------------------------------------------------
 
 const SYSTEM_PROMPT = `You are the Ploy Trading Platform Sidecar.
 
 ## Your Mission
-Run NBA comeback research loops while staying grounded in the trading platform control plane.
-You are an operator-facing research client, not a direct execution path.
+Run research and oversight loops while staying grounded in the trading platform control plane.
+You are an operator-facing research and monitoring client, not a strategy or execution path.
 
 ## Control Plane Contract
 - Deployments are resources with deployment_id, desired_state, and observed_state.
 - Trading state comes from canonical /api/trading/state snapshots.
 - Do not assume legacy /api/sidecar/*, /api/config, or enable/disable endpoints exist.
-- If you need to change the platform, use apply_deployment, set_deployment_state, or submit_paper_intent.
-- Prefer paper deployments unless the operator explicitly asks for a different runtime mode.
+- Use control-plane read APIs first: get_system_status, get_trading_state, list_deployments, get_deployment.
+- Research tools are read-only/operator-safe: replay_deployment, run_backtest, and compare_configs.
+- Do not submit intents or mutate deployment state from this sidecar loop.
 
 ## Decision Framework
-1. **Inspect platform**: Use ploy-backend.get_system_status, get_trading_state, and list_deployments first
-2. **Scan**: Use espn.scoreboard to find live games in Q3 or late Q3/early Q4
-3. **Filter**: Only consider games where:
-   - A team is trailing by 1-15 points
-   - Quarter is 3 (ideal) or early Q4
-   - At least 8 minutes of game time remaining
-4. **Market lookup**: Use polymarket.search_markets to find the corresponding market
-5. **Risk check**: Calculate reward-to-risk ratio = (1 - price) / price
-   - ONLY proceed if RR ≥ 4.0x (price ≤ $0.20)
-   - Calculate EV = estimated_win_prob - price (need EV ≥ 5%)
-   - Calculate Kelly fraction = EV / (1 - price), cap at 25%
-6. **X.com research**: Use WebSearch to check X.com/Twitter for:
-   - Injury updates during the game
-   - Momentum shifts (runs, key plays)
-   - Betting sentiment
-7. **Recommendation**: Produce a deployment-aware recommendation or paper-only platform action
+1. Inspect platform health, deployment resources, and trading snapshots first.
+2. Look for suspicious deployments, behavior drift, exposure growth, order buildup, or PnL deterioration.
+3. Start from deterministic oversight_signals and oversight_playbook in the runtime context; do not ignore them without explanation.
+4. Prefer the Rust-provided oversight_playbook before inventing a different next step.
+5. Use replay_deployment, run_backtest, and compare_configs when they help explain current state.
+5a. Use diagnose_platform or diagnose_deployment when you need evidence-backed root-cause context before making a recommendation.
+6. Use ESPN, Polymarket, and WebSearch only as external diagnostic context, never as direct trade triggers.
+7. Return oversight alerts and operator recommendations only. Recommendations may include replay, backtest, config compare, diagnostics, pause review, proposal creation, or human review.
 
 ## Safety Rules (NEVER violate)
-- Never claim an order was submitted unless you actually called submit_paper_intent on a paper deployment
-- Never start or create a non-paper deployment unless explicitly instructed
-- Always default to PASS or MONITOR when uncertain
-- Parse failures → PASS (never trade on garbage)
-
-## Scoring Comeback Probability
-Historical NBA comeback rates by deficit at end of Q3:
-- 1-3 pts: 35-45% (barely trailing, not a comeback scenario)
-- 4-6 pts: 20-30% (moderate trail)
-- 7-10 pts: 10-20% (significant trail — sweet spot for underpriced YES)
-- 11-15 pts: 5-12% (deep trail — needs big discount)
-- 16+ pts: <5% (too unlikely)
-
-Adjust for: team strength, home/away, rest days, key player status.
+- Never submit a trading intent from this loop.
+- Never mutate deployment state from this loop.
+- If evidence is strong enough to justify operator review, you may create a safety proposal. Proposal creation is allowed because it still requires explicit operator approval before any runtime action happens.
+- Never present an external market scan as a direct trade recommendation.
+- Default to MONITOR or HUMAN_FOLLOW_UP when evidence is incomplete.
 
 ## Output Format
-Return structured JSON with scan_summary, opportunities[], and operator_actions[].
+Return structured JSON with summary, research_reports[], oversight_alerts[], and operator_recommendations[].
 `;
 
 type RuntimeContext = {
@@ -154,10 +144,15 @@ type RuntimeContext = {
     stopped: number;
     sample: Array<{
       deployment_id: string;
+      bundle_id: string;
+      runtime_mode: string;
       desired_state: string;
       observed_state: string;
     }>;
   } | null;
+  oversight_signals: OversightSignal[];
+  oversight_playbook: OversightAction[];
+  diagnostic_candidates: string[];
 };
 
 type TradingSnapshot = {
@@ -176,8 +171,37 @@ type TradingSnapshot = {
 
 type DeploymentSummary = {
   deployment_id: string;
+  bundle_id: string;
+  runtime_mode: string;
   desired_state: string;
   observed_state: string;
+};
+
+type OversightSignal = {
+  severity: "info" | "warning" | "critical";
+  kind: string;
+  deployment_id?: string;
+  message: string;
+  recommended_action: string;
+  evidence: string[];
+};
+
+type OversightAction = {
+  kind: string;
+  target: string;
+  rationale: string;
+  operator_command: string;
+  config_hint?: string | null;
+  evidence: string[];
+};
+
+type OversightReport = {
+  timestamp: string;
+  platform_status: string;
+  deployments_reviewed: number;
+  signal_count: number;
+  signals: OversightSignal[];
+  recommended_actions: OversightAction[];
 };
 
 async function backendFetchJson<T>(path: string): Promise<T | null> {
@@ -203,8 +227,17 @@ async function backendFetchJson<T>(path: string): Promise<T | null> {
   }
 }
 
+async function buildOversightReport(): Promise<OversightReport | null> {
+  try {
+    const output = await runPloyResearchCommand(["oversight"]);
+    return JSON.parse(output) as OversightReport;
+  } catch {
+    return null;
+  }
+}
+
 async function buildRuntimeContext(): Promise<RuntimeContext> {
-  const [system, trading, deployments] = await Promise.all([
+  const [system, trading, deployments, oversightReport] = await Promise.all([
     backendFetchJson<{
       status: string;
       uptime_seconds: number;
@@ -212,6 +245,7 @@ async function buildRuntimeContext(): Promise<RuntimeContext> {
     }>("/api/system/status"),
     backendFetchJson<TradingSnapshot[]>("/api/trading/state"),
     backendFetchJson<DeploymentSummary[]>("/api/deployments"),
+    buildOversightReport(),
   ]);
 
   const tradingSnapshots = Array.isArray(trading) ? trading : [];
@@ -266,23 +300,48 @@ async function buildRuntimeContext(): Promise<RuntimeContext> {
           stopped: deploymentSnapshots.filter((d) => d.desired_state === "stopped").length,
           sample: deploymentSnapshots.slice(0, 12).map((d) => ({
             deployment_id: d.deployment_id,
+            bundle_id: d.bundle_id,
+            runtime_mode: d.runtime_mode,
             desired_state: d.desired_state,
             observed_state: d.observed_state,
           })),
         }
       : null,
+    oversight_signals: Array.isArray(oversightReport?.signals) ? oversightReport.signals : [],
+    oversight_playbook: Array.isArray(oversightReport?.recommended_actions)
+      ? oversightReport.recommended_actions
+      : [],
+    diagnostic_candidates: collectDiagnosticCandidates(
+      Array.isArray(oversightReport?.signals) ? oversightReport.signals : []
+    ),
   };
 }
 
-// ── Main Loop ───────────────────────────────────────
+// -- Main Loop ------------------------------------------------------
 
 async function runScanCycle(): Promise<void> {
   const timestamp = new Date().toISOString();
+  const runId = newRunId();
+  const startedAt = new Date().toISOString();
   console.log(`\n[${timestamp}] Starting scan cycle (model=${MODEL}, dry_run=${DRY_RUN})`);
+  console.log(`  Run ID: ${runId}`);
+
+  let sessionId: string | null = null;
+  let totalCostUsd: number | null = null;
+  let failureReason: string | null = null;
+  let resultOutput: unknown = null;
+  let runtimeContext: RuntimeContext = {
+    system: null,
+    trading: null,
+    deployments: null,
+    oversight_signals: [],
+    oversight_playbook: [],
+    diagnostic_candidates: [],
+  };
+  const toolCalls: AgentToolCallRecord[] = [];
 
   try {
-    const runtimeContext = await buildRuntimeContext();
-    let resultOutput: unknown = null;
+    runtimeContext = await buildRuntimeContext();
 
     for await (const message of query({
       prompt: `Current time: ${timestamp}
@@ -290,14 +349,15 @@ async function runScanCycle(): Promise<void> {
 Runtime context snapshot:
 ${JSON.stringify(runtimeContext, null, 2)}
 
-Run a full NBA comeback trading scan cycle:
-1. Check the ESPN scoreboard for today's live games
-2. Identify any Q3/Q4 comeback opportunities
-3. For each opportunity, search Polymarket for the market
-4. Compute risk metrics (RR, EV, Kelly)
-5. If any pass the 4x RR filter, research X.com for sentiment
-6. Compare the idea against current deployment resources and trading snapshots
-7. Return operator actions or paper-intent recommendations only when they fit the control-plane contract
+Run one research-and-oversight cycle:
+1. Inspect the platform state and deployment snapshots first
+2. Start from the deterministic oversight_signals and oversight_playbook in the runtime context
+3. Identify suspicious deployments, drift signals, or operational anomalies
+4. Prefer the Rust-provided oversight_playbook before inventing a different next step
+5. Use replay_deployment, run_backtest, compare_configs, diagnose_platform, and diagnose_deployment when they help explain the current state
+6. If the evidence supports an operator-mediated safety action, use create_safety_proposal instead of suggesting a hidden mutation
+7. Use ESPN, Polymarket, and WebSearch only as external context when relevant
+8. Return alerts and operator recommendations only; do not propose direct trading actions
 
 Return your structured analysis.`,
       options: {
@@ -309,12 +369,19 @@ ${JSON.stringify(runtimeContext, null, 2)}`,
         mcpServers: {
           espn: espnServer,
           polymarket: polymarketServer,
+          diagnostics: diagnosticsServer,
           "ploy-backend": ployBackendServer,
+          research: researchServer,
         },
         allowedTools: [
           "mcp__espn__*",
           "mcp__polymarket__*",
-          "mcp__ploy-backend__*",
+          "mcp__ploy-backend__get_system_status",
+          "mcp__ploy-backend__get_trading_state",
+          "mcp__ploy-backend__list_deployments",
+          "mcp__ploy-backend__get_deployment",
+          "mcp__diagnostics__*",
+          "mcp__research__*",
           "WebSearch",
           "WebFetch",
         ],
@@ -323,13 +390,14 @@ ${JSON.stringify(runtimeContext, null, 2)}`,
         permissionMode: "bypassPermissions",
         outputFormat: {
           type: "json_schema",
-          schema: tradingOutputSchema,
+          schema: researchOutputSchema,
         },
       },
     })) {
       switch (message.type) {
         case "system":
           if (message.subtype === "init") {
+            sessionId = message.session_id;
             console.log(`  Session: ${message.session_id}`);
             const mcpStatus = (message as any).mcp_servers;
             if (mcpStatus) {
@@ -341,10 +409,10 @@ ${JSON.stringify(runtimeContext, null, 2)}`,
           break;
 
         case "assistant":
-          // Log tool calls for observability
           for (const block of message.message.content) {
             if ("name" in block) {
               console.log(`  Tool: ${block.name}`);
+              toolCalls.push({ name: block.name, status: "called" });
             }
           }
           break;
@@ -352,67 +420,203 @@ ${JSON.stringify(runtimeContext, null, 2)}`,
         case "result":
           if (message.subtype === "success") {
             resultOutput = (message as any).structured_output;
-            const cost = (message as any).total_cost_usd || 0;
-            console.log(`  Completed. Cost: $${cost.toFixed(4)}`);
+            totalCostUsd = (message as any).total_cost_usd || 0;
+            console.log(`  Completed. Cost: $${(totalCostUsd ?? 0).toFixed(4)}`);
           } else {
+            failureReason = `query_result:${message.subtype}`;
             console.error(`  Scan failed: ${message.subtype}`);
           }
           break;
       }
     }
 
-    // Log structured output
     if (resultOutput) {
       const output = resultOutput as {
-        scan_summary?: { games_scanned?: number; comeback_candidates?: number };
-        opportunities?: Array<{ action: string; trailing_team: string; deficit: number }>;
-        operator_actions?: Array<{ kind: string; target: string; status: string }>;
+        summary?: {
+          platform_status?: string;
+          deployments_reviewed?: number;
+          research_tasks?: number;
+        };
+        research_reports?: Array<{ kind: string; subject: string; status: string }>;
+        oversight_alerts?: Array<{ severity: string; kind: string; deployment_id?: string }>;
+        operator_recommendations?: Array<{ kind: string; target: string }>;
       };
 
       console.log(`\n  Summary:`);
-      console.log(`    Games scanned: ${output.scan_summary?.games_scanned || 0}`);
-      console.log(`    Candidates: ${output.scan_summary?.comeback_candidates || 0}`);
-      console.log(`    Opportunities: ${output.opportunities?.length || 0}`);
-      console.log(`    Operator actions: ${output.operator_actions?.length || 0}`);
+      console.log(`    Platform: ${output.summary?.platform_status || "unknown"}`);
+      console.log(`    Deployments reviewed: ${output.summary?.deployments_reviewed || 0}`);
+      console.log(`    Research tasks: ${output.summary?.research_tasks || 0}`);
+      console.log(`    Deterministic signals: ${runtimeContext.oversight_signals.length}`);
+      console.log(`    Playbook actions: ${runtimeContext.oversight_playbook.length}`);
+      console.log(`    Diagnostic candidates: ${runtimeContext.diagnostic_candidates.length}`);
+      console.log(`    Alerts: ${output.oversight_alerts?.length || 0}`);
+      console.log(`    Recommendations: ${output.operator_recommendations?.length || 0}`);
 
-      for (const opp of output.opportunities || []) {
+      for (const signal of runtimeContext.oversight_signals) {
         console.log(
-          `    → ${opp.trailing_team} (down ${opp.deficit}) — ${opp.action}`
+          `    = Signal: ${signal.severity} ${signal.kind} ${signal.deployment_id || "global"}`
         );
       }
 
-      for (const action of output.operator_actions || []) {
-        console.log(
-          `    ★ Action: ${action.kind} ${action.target} — ${action.status}`
-        );
+      for (const action of runtimeContext.oversight_playbook) {
+        console.log(`    = Playbook: ${action.kind} ${action.target}`);
+        console.log(`      command: ${action.operator_command}`);
+        if (action.config_hint) {
+          console.log(`      config: ${action.config_hint}`);
+        }
+      }
+
+      for (const deploymentId of runtimeContext.diagnostic_candidates) {
+        console.log(`    = Diagnose candidate: ${deploymentId}`);
+      }
+
+      for (const report of output.research_reports || []) {
+        console.log(`    -> Research: ${report.kind} ${report.subject} - ${report.status}`);
+      }
+
+      for (const alert of output.oversight_alerts || []) {
+        console.log(`    ! Alert: ${alert.severity} ${alert.kind} ${alert.deployment_id || "global"}`);
+      }
+
+      for (const recommendation of output.operator_recommendations || []) {
+        console.log(`    * Recommendation: ${recommendation.kind} ${recommendation.target}`);
       }
     }
   } catch (err) {
+    failureReason = err instanceof Error ? err.message : String(err);
     console.error(`  Error in scan cycle:`, err);
+  } finally {
+    const finishedAt = new Date().toISOString();
+    const record = buildRunRecord({
+      runId,
+      startedAt,
+      finishedAt,
+      sessionId,
+      model: MODEL,
+      runtimeContext,
+      toolCalls,
+      structuredOutput: (typeof resultOutput === "object" && resultOutput !== null
+        ? (resultOutput as {
+            research_reports?: Array<unknown>;
+            oversight_alerts?: Array<unknown>;
+            operator_recommendations?: Array<unknown>;
+          })
+        : null),
+      totalCostUsd,
+      failureReason,
+    });
+
+    try {
+      await recordAgentRun(record);
+      console.log(`  Trace saved: run/sidecar/agent-runs.jsonl`);
+    } catch (recordErr) {
+      console.error("  Failed to persist run trace:", recordErr);
+    }
   }
 }
 
-// ── Entry Point ─────────────────────────────────────
+// -- Entry Point ----------------------------------------------------
 
 async function main() {
   console.log("╔════════════════════════════════════════╗");
   console.log("║  Ploy Sidecar — Operator Client        ║");
-  console.log("║  NBA Research + Deployment Console     ║");
+  console.log("║  Research + Oversight Console          ║");
   console.log("╚════════════════════════════════════════╝");
   console.log(`  Model: ${MODEL}`);
   console.log(`  Dry run: ${DRY_RUN}`);
   console.log(`  Poll interval: ${POLL_INTERVAL / 1000}s`);
   console.log(`  Max budget/cycle: $${MAX_BUDGET}`);
   if (minimaxCompatModel) {
-    console.log(`  MiniMax compat: enabled (alias → ${minimaxCompatModel})`);
+    console.log(`  MiniMax compat: enabled (alias -> ${minimaxCompatModel})`);
   }
   console.log("");
 
-  // Run first cycle immediately
-  await runScanCycle();
+  let scanInProgress = false;
+  let immediateRescanRequested = false;
 
-  // Then run on interval
-  setInterval(runScanCycle, POLL_INTERVAL);
+  async function guardedScan() {
+    if (scanInProgress) {
+      immediateRescanRequested = true;
+      return;
+    }
+    scanInProgress = true;
+    try {
+      await runScanCycle();
+    } finally {
+      scanInProgress = false;
+      if (immediateRescanRequested) {
+        immediateRescanRequested = false;
+        setTimeout(() => guardedScan(), 5_000);
+      }
+    }
+  }
+
+  await guardedScan();
+  setInterval(guardedScan, POLL_INTERVAL);
+
+  // SSE listener for real-time critical signal detection
+  startSSEListener(() => guardedScan());
+}
+
+function startSSEListener(onCriticalSignal: () => void): void {
+  const sseEnabled = process.env.SIDECAR_SSE_ENABLED !== "false";
+  if (!sseEnabled) return;
+
+  const sseUrl = `${PLOY_API}/api/events/stream`;
+  const sidecarToken = process.env.PLOY_SIDECAR_AUTH_TOKEN;
+
+  function connect() {
+    console.log("  SSE: connecting to event stream...");
+    const headers: Record<string, string> = {};
+    if (sidecarToken) {
+      headers["Authorization"] = `Bearer ${sidecarToken}`;
+    }
+
+    fetch(sseUrl, { headers })
+      .then(async (response) => {
+        if (!response.ok || !response.body) {
+          console.error(`  SSE: connection failed (${response.status}), retrying in 30s`);
+          setTimeout(connect, 30_000);
+          return;
+        }
+        console.log("  SSE: connected");
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            try {
+              const event = JSON.parse(line.slice(6));
+              const signals: OversightSignal[] = event.oversight?.signals || event.signals || [];
+              if (signals.some((s) => s.severity === "critical")) {
+                console.log("  SSE: critical signal detected, triggering immediate scan");
+                onCriticalSignal();
+              }
+            } catch {
+              // ignore parse errors (keep-alive comments, etc.)
+            }
+          }
+        }
+        console.log("  SSE: disconnected, reconnecting in 5s");
+        setTimeout(connect, 5_000);
+      })
+      .catch((err: Error) => {
+        console.error(`  SSE: error: ${err.message}, retrying in 30s`);
+        setTimeout(connect, 30_000);
+      });
+  }
+
+  connect();
 }
 
 main().catch((err) => {

--- a/ploy-sidecar/src/tools/research.ts
+++ b/ploy-sidecar/src/tools/research.ts
@@ -1,0 +1,195 @@
+/**
+ * Research MCP Tools — operator-safe replay/backtest/config-compare wrappers.
+ *
+ * These tools shell out to `ployctl research ...` so the sidecar stays aligned
+ * with the canonical operator surface instead of inventing a parallel path.
+ */
+
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const execFileAsync = promisify(execFile);
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+async function resolvePloyctlBin(): Promise<string> {
+  const candidates = [
+    process.env.PLOYCTL_BIN,
+    "ployctl",
+    resolve(process.cwd(), "../target/debug/ployctl"),
+    resolve(process.cwd(), "target/debug/ployctl"),
+    resolve(moduleDir, "../../../target/debug/ployctl"),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    if (candidate === "ployctl") {
+      // Check whether ployctl is actually on PATH before accepting it.
+      // Without this check the bare name is returned immediately and all
+      // local-build fallbacks below are never tried, causing ENOENT on
+      // checkouts where ployctl is only available as a local debug binary.
+      try {
+        const { execFileSync } = await import("node:child_process");
+        execFileSync("which", ["ployctl"], { stdio: "ignore" });
+        return candidate;
+      } catch {
+        continue;
+      }
+    }
+
+    try {
+      await access(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error(
+    "Unable to find ployctl binary. Set PLOYCTL_BIN or build ployctl locally first."
+  );
+}
+
+export async function runPloyctlCommand(args: string[]): Promise<string> {
+  const ployctlBin = await resolvePloyctlBin();
+
+  try {
+    const { stdout, stderr } = await execFileAsync(ployctlBin, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      maxBuffer: 1024 * 1024,
+    });
+
+    const output = [stdout, stderr]
+      .map((chunk) => chunk.trim())
+      .filter(Boolean)
+      .join("\n");
+
+    return output || "ployctl research completed with no output";
+  } catch (error: any) {
+    const stderr = typeof error?.stderr === "string" ? error.stderr.trim() : "";
+    const stdout = typeof error?.stdout === "string" ? error.stdout.trim() : "";
+    const status = error?.code ?? "unknown";
+    const detail = [stderr, stdout, error?.message].filter(Boolean).join("\n");
+    throw new Error(`ployctl failed (${status}): ${detail}`);
+  }
+}
+
+export async function runPloyResearchCommand(args: string[]): Promise<string> {
+  return runPloyctlCommand(["research", ...args]);
+}
+
+export const researchServer = createSdkMcpServer({
+  name: "research",
+  version: "1.0.0",
+  tools: [
+    tool(
+      "replay_deployment",
+      "Replay realized fills for one deployment via `ployctl research replay`. Read-only.",
+      {
+        deployment_id: z.string().describe("Deployment resource id to replay"),
+      },
+      async ({ deployment_id }) => {
+        try {
+          const output = await runPloyResearchCommand(["replay", deployment_id]);
+          return {
+            content: [{ type: "text" as const, text: output }],
+          };
+        } catch (error: any) {
+          return {
+            content: [{ type: "text" as const, text: error.message }],
+            isError: true,
+          };
+        }
+      }
+    ),
+
+    tool(
+      "run_backtest",
+      "Run an operator-safe backtest through `ployctl research backtest`. Uses synthetic data unless db_url is provided.",
+      {
+        config_path: z
+          .string()
+          .optional()
+          .describe("Unified strategy config TOML path. Defaults to the canonical PM5D config."),
+        db_url: z
+          .string()
+          .optional()
+          .describe("Optional Postgres URL for historical market data replay."),
+        start_date: z
+          .string()
+          .optional()
+          .describe("Optional inclusive start date in YYYY-MM-DD format."),
+        end_date: z
+          .string()
+          .optional()
+          .describe("Optional inclusive end date in YYYY-MM-DD format."),
+      },
+      async ({ config_path, db_url, start_date, end_date }) => {
+        try {
+          const args = ["backtest"];
+          if (config_path) args.push("--config", config_path);
+          if (db_url) args.push("--db-url", db_url);
+          if (start_date) args.push("--start-date", start_date);
+          if (end_date) args.push("--end-date", end_date);
+
+          const output = await runPloyResearchCommand(args);
+          return {
+            content: [{ type: "text" as const, text: output }],
+          };
+        } catch (error: any) {
+          return {
+            content: [{ type: "text" as const, text: error.message }],
+            isError: true,
+          };
+        }
+      }
+    ),
+
+    tool(
+      "compare_configs",
+      "Compare two strategy config TOML files through `ployctl research compare`. Read-only.",
+      {
+        left_path: z.string().describe("Left-hand config TOML path"),
+        right_path: z.string().describe("Right-hand config TOML path"),
+      },
+      async ({ left_path, right_path }) => {
+        try {
+          const output = await runPloyResearchCommand(["compare", left_path, right_path]);
+          return {
+            content: [{ type: "text" as const, text: output }],
+          };
+        } catch (error: any) {
+          return {
+            content: [{ type: "text" as const, text: error.message }],
+            isError: true,
+          };
+        }
+      }
+    ),
+
+    tool(
+      "check_oversight",
+      "Run deterministic oversight checks through `ployctl research oversight`. Read-only.",
+      {},
+      async () => {
+        try {
+          const output = await runPloyResearchCommand(["oversight"]);
+          return {
+            content: [{ type: "text" as const, text: output }],
+          };
+        } catch (error: any) {
+          return {
+            content: [{ type: "text" as const, text: error.message }],
+            isError: true,
+          };
+        }
+      }
+    ),
+  ],
+});


### PR DESCRIPTION
## Summary
- harden `ployd` snapshot persistence and shutdown handling with atomic writes and signal-driven graceful shutdown
- improve runtime stability with circuit-breaker controls, `RwLock`-based daemon access, and bounded HTTP thread concurrency
- tighten operator oversight by teaching the sidecar to react immediately to critical SSE signals and by improving trading risk snapshot handling

## Testing
- `CARGO_TARGET_DIR=/tmp/ployd-hardening-pr /opt/homebrew/bin/rtk cargo test -p ployd -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ployd-hardening-pr /opt/homebrew/bin/rtk cargo test -p ploy-trading -- --nocapture`
- `cd /Users/proerror/Documents/ploy/ploy-sidecar && npm run build`