### PR TITLE
Expand Polymarket research and reference surfaces

### DIFF
--- a/apps/ploy-runner/src/collector.rs
+++ b/apps/ploy-runner/src/collector.rs
@@ -24,9 +24,9 @@ use tokio::time::sleep;
 use tracing::{error, info, warn};
 
 use crate::reference_prices::{
-    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
-    ReferencePriceSource, latest_reference_price, market_symbol_to_chainlink_symbol,
-    new_reference_price_registry, normalize_reference_symbol, upsert_reference_price,
+    latest_reference_price, market_symbol_to_chainlink_symbol, new_reference_price_registry,
+    normalize_reference_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
+    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
 };
 
 /// Configuration for the quote collector.
@@ -899,8 +899,9 @@ fn hex_to_decimal_string(hex: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        OrderBookLevel, TokenMetadata, best_tradeable_ask, best_tradeable_bid, book_timestamp,
-        hex_to_decimal_string, normalize_token_id, serialize_orderbook_levels, snapshot_context,
+        best_tradeable_ask, best_tradeable_bid, book_timestamp, hex_to_decimal_string,
+        normalize_token_id, serialize_orderbook_levels, snapshot_context, OrderBookLevel,
+        TokenMetadata,
     };
     use chrono::{TimeZone, Utc};
     use rust_decimal_macros::dec;

--- a/apps/ploy-runner/src/discovery/crypto.rs
+++ b/apps/ploy-runner/src/discovery/crypto.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 use crate::discovery::types::{MarketDescriptor, MarketFamily, MarketSemantics, SettlementSource};
 use crate::reference_prices::{
-    ReferencePriceRegistry, ReferencePriceSource, latest_reference_price,
-    market_symbol_to_chainlink_symbol,
+    latest_reference_price, market_symbol_to_chainlink_symbol, ReferencePriceRegistry,
+    ReferencePriceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -161,8 +161,8 @@ mod tests {
 
     use super::discover_crypto_markets;
     use crate::reference_prices::{
-        ReferenceAssetClass, ReferencePriceKey, ReferencePriceSnapshot, ReferencePriceSource,
-        new_reference_price_registry, upsert_reference_price,
+        new_reference_price_registry, upsert_reference_price, ReferenceAssetClass,
+        ReferencePriceKey, ReferencePriceSnapshot, ReferencePriceSource,
     };
 
     #[tokio::test]

--- a/apps/ploy-runner/src/discovery/sports.rs
+++ b/apps/ploy-runner/src/discovery/sports.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use polymarket_client_sdk::gamma::Client as GammaClient;
 use polymarket_client_sdk::gamma::types::request::{MarketsRequest, TeamsRequest};
 use polymarket_client_sdk::gamma::types::response::{Event, Market, Team};
+use polymarket_client_sdk::gamma::Client as GammaClient;
 use serde_json::Value;
 
 use crate::discovery::types::{MarketDescriptor, MarketFamily, MarketSemantics, SettlementSource};

--- a/apps/ploy-runner/src/feeds.rs
+++ b/apps/ploy-runner/src/feeds.rs
@@ -18,9 +18,9 @@ use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, error, info, warn};
 
 use crate::reference_prices::{
-    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
-    ReferencePriceSource, infer_pyth_asset_class, market_symbol_to_binance_symbol,
-    normalize_reference_symbol, pyth_symbol, upsert_reference_price,
+    infer_pyth_asset_class, market_symbol_to_binance_symbol, normalize_reference_symbol,
+    pyth_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
+    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
 };
 
 /// Spawn a task that subscribes to Binance spot prices via RTDS WebSocket

--- a/apps/ploy-runner/src/reference_prices.rs
+++ b/apps/ploy-runner/src/reference_prices.rs
@@ -128,10 +128,10 @@ pub async fn latest_reference_price(
 #[cfg(test)]
 mod tests {
     use super::{
-        ReferenceAssetClass, ReferencePriceKey, ReferencePriceSnapshot, ReferencePriceSource,
         infer_pyth_asset_class, latest_reference_price, market_symbol_to_binance_symbol,
         market_symbol_to_chainlink_symbol, new_reference_price_registry, pyth_symbol,
-        upsert_reference_price,
+        upsert_reference_price, ReferenceAssetClass, ReferencePriceKey, ReferencePriceSnapshot,
+        ReferencePriceSource,
     };
     use chrono::{TimeZone, Utc};
     use rust_decimal_macros::dec;

--- a/apps/ploy-runner/src/scanner.rs
+++ b/apps/ploy-runner/src/scanner.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use ploy_strategy_bundles::MarketUpdate;
-use polymarket_client_sdk::gamma::Client as GammaClient;
 use polymarket_client_sdk::gamma::types::request::MarketsRequest;
+use polymarket_client_sdk::gamma::Client as GammaClient;
 use polymarket_client_sdk::types::U256;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
@@ -21,8 +21,8 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::crypto::discover_crypto_markets;
+use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
 use crate::feeds::spawn_quote_feed;
@@ -31,6 +31,8 @@ use crate::reference_prices::ReferencePriceRegistry;
 const SCAN_INTERVAL_SECS: u64 = 30;
 const SPORTS_DISCOVERY_REFRESH_SECS: i64 = 300;
 const SPORTS_DISCOVERY_LIMIT: i32 = 500;
+/// How far back to look for open positions that need recovery on startup.
+const RECOVERY_LOOKBACK_HOURS: i64 = 48;
 
 struct TrackedEvent {
     end_time: chrono::DateTime<Utc>,
@@ -57,6 +59,13 @@ pub fn spawn_market_scanner(
         let mut subscribed_tokens: HashSet<String> = HashSet::new();
         let mut quote_handles: Vec<JoinHandle<()>> = Vec::new();
         let mut last_sports_refresh: Option<DateTime<Utc>> = None;
+
+        // On startup, recover any open positions from events that expired while
+        // the runner was offline. These will never receive a new EventExpired from
+        // the live scanner, so we emit them now with official settlement outcomes.
+        if let Some(ref db) = pool {
+            recover_expired_open_positions(&tx, db).await;
+        }
 
         loop {
             let now = Utc::now();
@@ -158,6 +167,85 @@ pub fn spawn_market_scanner(
             tokio::time::sleep(std::time::Duration::from_secs(SCAN_INTERVAL_SECS)).await;
         }
     })
+}
+
+/// On startup, find events that expired while the runner was offline and still
+/// have open positions in `strategy_runtime_fills`. Emit `EventExpired` with
+/// the official settlement outcome from `pm_token_settlements` so the strategy
+/// can close those positions immediately.
+async fn recover_expired_open_positions(
+    tx: &broadcast::Sender<MarketUpdate>,
+    pool: &PgPool,
+) {
+    let lookback = Utc::now() - Duration::hours(RECOVERY_LOOKBACK_HOURS);
+
+    // Find open positions: BUY fills with no matching SELL, for events that
+    // ended before now. Join pm_market_catalog on market_id because runtime
+    // event_id uses the compatibility market id, not market_slug.
+    let rows: Vec<(String, String, String, DateTime<Utc>, Option<bool>)> = match sqlx::query_as(
+        r#"
+        SELECT DISTINCT
+            f.event_id,
+            f.token_id,
+            COALESCE(f.symbol, '') AS symbol,
+            COALESCE(c.end_time, NOW() - INTERVAL '1 second') AS end_time,
+            CASE
+                WHEN s.resolved AND s.settled_price >= 0.99 THEN true
+                WHEN s.resolved AND s.settled_price <= 0.01 THEN false
+                ELSE NULL
+            END AS resolved_up_won
+        FROM strategy_runtime_fills f
+        LEFT JOIN pm_market_catalog c ON c.market_id = f.event_id
+        LEFT JOIN pm_token_settlements s ON s.token_id = f.token_id
+        WHERE f.fill_side = 'BUY'
+          AND f.fill_timestamp >= $1
+          AND COALESCE(c.end_time, NOW()) < NOW()
+          AND NOT EXISTS (
+              SELECT 1 FROM strategy_runtime_fills s2
+              WHERE s2.token_id = f.token_id
+                AND s2.fill_side = 'SELL'
+                AND s2.intent_id LIKE 'settle_%'
+          )
+        "#,
+    )
+    .bind(lookback)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(error = %e, "Failed to query open positions for recovery");
+            return;
+        }
+    };
+
+    if rows.is_empty() {
+        debug!("Startup recovery: no expired open positions found");
+        return;
+    }
+
+    info!(
+        count = rows.len(),
+        "Startup recovery: emitting EventExpired for expired open positions"
+    );
+
+    // Group by event_id — one EventExpired per event is enough.
+    let mut seen_events: HashSet<String> = HashSet::new();
+    for (event_id, _token_id, _symbol, end_time, resolved_up_won) in rows {
+        if seen_events.insert(event_id.clone()) {
+            info!(
+                event_id = %event_id,
+                end_time = %end_time,
+                resolved_up_won = ?resolved_up_won,
+                "Recovery: emitting EventExpired",
+            );
+            let _ = tx.send(MarketUpdate::EventExpired {
+                event_id,
+                end_time,
+                resolved_up_won,
+            });
+        }
+    }
 }
 
 fn expire_tracked_events(
@@ -316,12 +404,10 @@ mod tests {
 
     #[test]
     fn token_id_parser_accepts_decimal_strings() {
-        assert!(
-            parse_token_id(
-                "27239049953613250678046988034203198692578441444398010699401021233149338414941"
-            )
-            .is_some()
-        );
+        assert!(parse_token_id(
+            "27239049953613250678046988034203198692578441444398010699401021233149338414941"
+        )
+        .is_some());
         assert!(parse_token_id("not-a-token").is_none());
     }
 

--- a/apps/ploy-runner/src/sports_feed.rs
+++ b/apps/ploy-runner/src/sports_feed.rs
@@ -336,7 +336,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use ploy_strategy_bundles::MarketUpdate;
 
-    use super::{SportsDescriptor, SportsDescriptorCache, parse_message_text};
+    use super::{parse_message_text, SportsDescriptor, SportsDescriptorCache};
 
     #[test]
     fn fixture_messages_normalize_into_sports_state_updates() {

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -15,11 +15,11 @@
 
 use chrono::{NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
+use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
     feed::load_from_database, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
     RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyRuntime,
 };
-use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_trading::TradeSide;
 use rust_decimal_macros::dec;
 use sqlx::postgres::PgPoolOptions;
@@ -27,9 +27,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
-    args.windows(2)
-        .find(|w| w[0] == flag)
-        .map(|w| w[1].clone())
+    args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
 }
 
 fn parse_date_start(s: &str) -> chrono::DateTime<Utc> {
@@ -96,7 +94,11 @@ fn run_backtest(config: DirectionalConfig, data: &[MarketUpdate]) -> (f64, usize
     } else {
         let n = per_trade_pnl.len() as f64;
         let mean = per_trade_pnl.iter().sum::<f64>() / n;
-        let variance = per_trade_pnl.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n;
+        let variance = per_trade_pnl
+            .iter()
+            .map(|x| (x - mean).powi(2))
+            .sum::<f64>()
+            / n;
         let std_dev = variance.sqrt();
         if std_dev < 1e-9 {
             0.0
@@ -118,8 +120,13 @@ fn make_config(
 ) -> DirectionalConfig {
     DirectionalConfig {
         symbols: vec![
-            "BTCUSDT".into(), "ETHUSDT".into(), "SOLUSDT".into(),
-            "XRPUSDT".into(), "DOGEUSDT".into(), "HYPEUSDT".into(), "BNBUSDT".into(),
+            "BTCUSDT".into(),
+            "ETHUSDT".into(),
+            "SOLUSDT".into(),
+            "XRPUSDT".into(),
+            "DOGEUSDT".into(),
+            "HYPEUSDT".into(),
+            "BNBUSDT".into(),
         ],
         vol_floor: 0.001,
         min_probability,
@@ -143,9 +150,9 @@ fn main() {
 
     let db_url = flag_value(&args, "--db-url").expect("--db-url required");
     let train_start = flag_value(&args, "--train-start").unwrap_or_else(|| "2026-04-01".into());
-    let train_end   = flag_value(&args, "--train-end").unwrap_or_else(|| "2026-04-03".into());
-    let val_start   = flag_value(&args, "--val-start").unwrap_or_else(|| "2026-04-04".into());
-    let val_end     = flag_value(&args, "--val-end").unwrap_or_else(|| "2026-04-04".into());
+    let train_end = flag_value(&args, "--train-end").unwrap_or_else(|| "2026-04-03".into());
+    let val_start = flag_value(&args, "--val-start").unwrap_or_else(|| "2026-04-04".into());
+    let val_end = flag_value(&args, "--val-end").unwrap_or_else(|| "2026-04-04".into());
     let n_trials: usize = flag_value(&args, "--trials")
         .and_then(|s| s.parse().ok())
         .unwrap_or(200);
@@ -161,25 +168,40 @@ fn main() {
         .build()
         .unwrap();
 
-    let pool = rt.block_on(
-        PgPoolOptions::new().max_connections(3).connect(&db_url)
-    ).expect("DB connection failed");
+    let pool = rt
+        .block_on(PgPoolOptions::new().max_connections(3).connect(&db_url))
+        .expect("DB connection failed");
 
     let symbols: Vec<String> = vec![
-        "BTCUSDT".into(), "ETHUSDT".into(), "SOLUSDT".into(),
-        "XRPUSDT".into(), "DOGEUSDT".into(), "HYPEUSDT".into(), "BNBUSDT".into(),
+        "BTCUSDT".into(),
+        "ETHUSDT".into(),
+        "SOLUSDT".into(),
+        "XRPUSDT".into(),
+        "DOGEUSDT".into(),
+        "HYPEUSDT".into(),
+        "BNBUSDT".into(),
     ];
 
     eprintln!("Loading training data ({} → {})...", train_start, train_end);
-    let train_data = rt.block_on(
-        load_from_database(&pool, &symbols, parse_date_start(&train_start), parse_date_end(&train_end))
-    ).expect("Failed to load training data");
+    let train_data = rt
+        .block_on(load_from_database(
+            &pool,
+            &symbols,
+            parse_date_start(&train_start),
+            parse_date_end(&train_end),
+        ))
+        .expect("Failed to load training data");
     eprintln!("  {} updates loaded", train_data.len());
 
     eprintln!("Loading validation data ({} → {})...", val_start, val_end);
-    let val_data = rt.block_on(
-        load_from_database(&pool, &symbols, parse_date_start(&val_start), parse_date_end(&val_end))
-    ).expect("Failed to load validation data");
+    let val_data = rt
+        .block_on(load_from_database(
+            &pool,
+            &symbols,
+            parse_date_start(&val_start),
+            parse_date_end(&val_end),
+        ))
+        .expect("Failed to load validation data");
     eprintln!("  {} updates loaded\n", val_data.len());
 
     let train_data = Arc::new(train_data);
@@ -244,7 +266,11 @@ fn main() {
     // Validate on held-out window
     eprintln!("\n=== Validation (held-out) ===");
     let val_config = make_config(
-        best_min_prob, best_min_edge, best_cooldown, best_min_time, best_max_time,
+        best_min_prob,
+        best_min_edge,
+        best_cooldown,
+        best_min_time,
+        best_max_time,
     );
     let (val_pnl, val_trades, val_sharpe) = run_backtest(val_config, &val_data);
     eprintln!("Val Sharpe:  {val_sharpe:.3}");
@@ -267,12 +293,19 @@ fn main() {
 
     // Top 10 trials
     let mut all_trials = study.trials();
-    all_trials.sort_by(|a, b| b.value.partial_cmp(&a.value).unwrap_or(std::cmp::Ordering::Equal));
+    all_trials.sort_by(|a, b| {
+        b.value
+            .partial_cmp(&a.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     eprintln!("\n=== Top 10 Trials ===");
-    eprintln!("{:<6} {:<8} {:<8} {:<8} {:<10} {:<10}",
-        "Trial", "Sharpe", "p_min", "edge", "cooldown", "min_time");
+    eprintln!(
+        "{:<6} {:<8} {:<8} {:<8} {:<10} {:<10}",
+        "Trial", "Sharpe", "p_min", "edge", "cooldown", "min_time"
+    );
     for t in all_trials.iter().take(10) {
-        eprintln!("{:<6} {:<8.3} {:<8.3} {:<8.4} {:<10} {:<10}",
+        eprintln!(
+            "{:<6} {:<8.3} {:<8.3} {:<8.4} {:<10} {:<10}",
             t.id,
             t.value,
             t.get(&p_min_prob).unwrap_or(0.0),

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -15,10 +15,10 @@
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
+    config::FullConfig,
+    feed::{load_from_database_with_options, HistoricalLoadOptions},
     DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, RuntimeConfig, RuntimeMode,
     SimulatedExecutor, SimulatedExecutorConfig, StrategyRuntime,
-    config::FullConfig,
-    feed::{HistoricalLoadOptions, load_from_database_with_options},
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;

--- a/crates/ploy-strategy-bundles/src/feed/database.rs
+++ b/crates/ploy-strategy-bundles/src/feed/database.rs
@@ -844,8 +844,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        EventMetadataRow, MarketUpdate, build_event_updates, hex_to_decimal_string,
-        normalize_token_id,
+        build_event_updates, hex_to_decimal_string, normalize_token_id, EventMetadataRow,
+        MarketUpdate,
     };
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/feed/mod.rs
+++ b/crates/ploy-strategy-bundles/src/feed/mod.rs
@@ -5,7 +5,7 @@ mod historical;
 mod live;
 mod recorded;
 
-pub use database::{HistoricalLoadOptions, load_from_database, load_from_database_with_options};
+pub use database::{load_from_database, load_from_database_with_options, HistoricalLoadOptions};
 pub use historical::HistoricalFeed;
 pub use live::LiveFeed;
 pub use recorded::{RecordedFeed, RecordedFeedError, RecordedMarketUpdate, RecordingFeed};

--- a/docs/plans/2026-04-06-backtest-replay-expansion-implementation-plan.md
+++ b/docs/plans/2026-04-06-backtest-replay-expansion-implementation-plan.md
@@ -1,0 +1,120 @@
+# Backtest And Replay Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the historical and replay backtest stack so it can consume the new reference-price and sports-state datasets while preserving existing crypto research behavior and keeping settlement data correctly backfillable.
+
+**Architecture:** Extend the database loader in `ploy-strategy-bundles` to read the newly captured `reference_price_ticks`, normalized market catalog rows, and `sports_state_events`, then thread those updates through historical and replay modes. Preserve replay as the gold-standard parity path, keep historical source-ranking explicit instead of silently trusting every new table, and retain an official settlement completion/backfill path so missing outcomes can be repaired deterministically.
+
+**Tech Stack:** Rust, SQLx query helpers, canonical `MarketUpdate` replay, `ploy-research`, `ploy-strategy-bundles` integration tests
+
+---
+
+### Task 1: Add historical loader support for new sources
+
+**Files:**
+- Modify: `crates/ploy-strategy-bundles/src/feed/database.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/mod.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/historical.rs`
+- Modify: `crates/ploy-strategy-bundles/src/config.rs`
+
+- [ ] Add loader helpers for:
+  - `reference_price_ticks`
+  - `sports_state_events`
+  - normalized market catalog reads where needed for context
+- [ ] Keep `pm_token_settlements` and any future settlement-completion tables as the source of truth for resolved outcomes; do not regress to inferred-only settlement.
+- [ ] Add config flags that let a backtest opt into:
+  - crypto-only
+  - crypto + non-crypto reference data
+  - crypto + sports state
+- [ ] Preserve the existing trusted-source policy for PM quotes instead of loosening it in this phase.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-backtest-expansion rtk cargo check -p ploy-strategy-bundles --all-targets
+```
+
+Expected: the strategy-bundles crate compiles with the expanded loader path.
+
+### Task 2: Make replay mode understand the expanded event stream
+
+**Files:**
+- Modify: `crates/ploy-strategy-bundles/src/feed/recorded.rs`
+- Modify: `crates/ploy-strategy-bundles/src/engine.rs`
+- Modify: `apps/ploy-runner/src/main.rs`
+
+- [ ] Ensure recorded NDJSON logs include the new sports-state and any new metadata-bearing updates in stable sequence order.
+- [ ] Keep replay mode deterministic when mixed feed families appear in one capture.
+- [ ] Add one runner-level smoke path that can replay a mixed captured session without requiring live network access.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-backtest-expansion rtk cargo test -p ploy-strategy-bundles recorded_updates_replay_to_the_same_runtime_result -- --exact --nocapture
+```
+
+Expected: replay parity still passes after the event-stream expansion.
+
+### Task 3: Add research-facing backtest coverage for sports and non-crypto reference data
+
+**Files:**
+- Modify: `crates/ploy-research/src/backtesting.rs`
+- Modify: `crates/ploy-research/src/replay.rs`
+- Create: `crates/ploy-strategy-bundles/tests/reference_price_backtest.rs`
+- Create: `crates/ploy-strategy-bundles/tests/sports_backtest.rs`
+
+- [ ] Add fixture-backed integration tests showing that:
+  - non-crypto reference ticks load and remain time-ordered
+  - sports-state updates load and replay
+  - existing crypto scenarios still pass unchanged
+- [ ] Add at least one regression test proving a run with initially missing settlement rows can be repaired once official settlement rows are backfilled.
+- [ ] Keep the tests focused on feed correctness and runtime stability, not on inventing a sports strategy in this phase.
+- [ ] Expose simple research helpers in `ploy-research` for replaying fills from the expanded feed world without changing its public contract unnecessarily.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-backtest-expansion rtk cargo test -p ploy-strategy-bundles -- --nocapture
+CARGO_TARGET_DIR=/tmp/ploy-backtest-expansion rtk cargo test -p ploy-research -- --nocapture
+```
+
+Expected: both crates pass their focused backtest/replay coverage.
+
+### Task 4: Add reference-data and sports examples for operator iteration
+
+**Files:**
+- Modify: `crates/ploy-strategy-bundles/examples/run_backtest.rs`
+- Modify: `crates/ploy-strategy-bundles/examples/optimize_backtest.rs`
+- Create: `config/strategies/reference-data.backtest.toml`
+- Create: `config/strategies/sports-observation.backtest.toml`
+
+- [ ] Add one example config that demonstrates loading non-crypto reference data in backtest mode.
+- [ ] Add one example config that demonstrates sports-state-inclusive replay/backtest mode.
+- [ ] Keep the examples observational unless a corresponding strategy actually consumes the extra inputs.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-backtest-expansion rtk cargo check -p ploy-strategy-bundles --examples
+```
+
+Expected: examples compile with the new config surface.
+
+### Task 5: Record trust rules and verification results
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Modify: `docs/plans/2026-04-06-polymarket-expansion-master-plan.md`
+
+- [ ] Document which historical sources are trusted by default after this phase.
+- [ ] Record the verification matrix outcomes in `tasks/todo.md`.
+- [ ] Leave explicit notes for the later hardening/trust-cutover phase instead of silently broadening trust.
+
+Run:
+
+```bash
+rg -n "trusted|reference_price_ticks|sports_state_events" tasks/todo.md docs/plans/2026-04-06-polymarket-expansion-master-plan.md
+```
+
+Expected: the tracker and master plan mention the new source-ranking rules.

--- a/docs/plans/2026-04-06-market-discovery-normalization-implementation-plan.md
+++ b/docs/plans/2026-04-06-market-discovery-normalization-implementation-plan.md
@@ -1,0 +1,127 @@
+# Market Discovery And Metadata Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current crypto-only market scanning heuristics with a normalized market-discovery layer that can describe crypto and sports PM markets consistently.
+
+**Architecture:** Introduce an explicit discovery subsystem in `ploy-runner` and a normalized market descriptor persisted in the database. Keep the current crypto scan behavior as the first adapter, then add sports-aware Gamma discovery using `/sports`, `/teams`, and `/sports/market-types`. Upgrade the sidecar tools to consume the same normalized shape instead of title-only event search.
+
+**Tech Stack:** Rust, vendored Gamma client, TypeScript sidecar tools, SQLx migrations, existing runner scanner flow, focused `rtk cargo check` and `npm` build checks
+
+---
+
+### Task 1: Create the normalized market-catalog contract
+
+**Files:**
+- Create: `apps/ploy-runner/src/discovery/mod.rs`
+- Create: `apps/ploy-runner/src/discovery/types.rs`
+- Create: `migrations/028_pm_market_catalog.sql`
+- Modify: `apps/ploy-runner/src/main.rs`
+- Modify: `tasks/todo.md`
+
+- [ ] Add a market descriptor type that records:
+  - market family
+  - event ID
+  - market ID
+  - slug
+  - symbol/reference symbol
+  - settlement source
+  - league or asset family
+  - start/end times
+  - token IDs
+  - market semantics (`updown`, `moneyline`, `yesno`, etc.)
+- [ ] Add a `pm_market_catalog` table that stores the normalized descriptor alongside the raw Gamma payload.
+- [ ] Wire the new discovery module into `main.rs` without deleting the legacy scanner entrypoint yet.
+
+Run:
+
+```bash
+rg -n "pm_market_catalog|MarketFamily|MarketDescriptor" apps/ploy-runner/src/discovery migrations
+```
+
+Expected: the new descriptor and migration names exist in the planned locations.
+
+### Task 2: Migrate the crypto window scanner onto the new discovery subsystem
+
+**Files:**
+- Create: `apps/ploy-runner/src/discovery/crypto.rs`
+- Modify: `apps/ploy-runner/src/scanner.rs`
+- Modify: `apps/ploy-runner/src/discovery/mod.rs`
+- Modify: `apps/ploy-runner/src/feeds.rs`
+
+- [ ] Move the current crypto discovery logic into `discovery/crypto.rs`.
+- [ ] Replace question-string-only symbol inference with a normalization helper that emits an explicit reference symbol and settlement source.
+- [ ] Persist discovered crypto markets into `pm_market_catalog` in addition to the existing compatibility metadata table.
+- [ ] Keep emitting the existing `EventDiscovered` compatibility path so current crypto runtime behavior does not break during this phase.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-discovery rtk cargo check -p ploy-runner --all-targets
+```
+
+Expected: the runner compiles with the crypto adapter living under the new discovery subsystem.
+
+### Task 3: Add sports-aware Gamma discovery
+
+**Files:**
+- Create: `apps/ploy-runner/src/discovery/sports.rs`
+- Modify: `vendor/polymarket-client-sdk/src/gamma/client.rs`
+- Modify: `vendor/polymarket-client-sdk/tests/gamma.rs`
+- Modify: `apps/ploy-runner/src/discovery/types.rs`
+
+- [ ] Add a sports discovery adapter that uses Gamma sports endpoints instead of title-only search.
+- [ ] Normalize league/team metadata into the market descriptor so sports markets can be joined later to live sports state.
+- [ ] Add focused vendored Gamma tests or runner-level tests that prove sports metadata requests remain stable.
+- [ ] Persist sports descriptors to `pm_market_catalog` even before sports live-state ingestion exists.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-discovery rtk cargo test -p polymarket-client-sdk gamma -- --nocapture
+CARGO_TARGET_DIR=/tmp/ploy-discovery rtk cargo check -p ploy-runner --all-targets
+```
+
+Expected: Gamma coverage passes and the runner still compiles.
+
+### Task 4: Upgrade the sidecar Polymarket tools to consume normalized discovery
+
+**Files:**
+- Modify: `ploy-sidecar/src/tools/polymarket.ts`
+- Modify: `ploy-sidecar/src/index.ts`
+- Modify: `ploy-sidecar/src/schemas/output.ts`
+- Modify: `ploy-sidecar/package.json`
+
+- [ ] Replace the current `events?title=...` search-only tool with:
+  - family-aware search
+  - sports lookup by team/league/slug
+  - snapshot enrichment that reports normalized market metadata
+- [ ] Keep the existing simple search behavior available as a fallback mode for unstructured operator prompts.
+- [ ] Update the sidecar output schema so downstream agent prompts can reference market family and settlement source explicitly.
+
+Run:
+
+```bash
+cd ploy-sidecar && npm run build
+```
+
+Expected: the sidecar builds successfully with the new Polymarket tool contract.
+
+### Task 5: Validate discovery parity and capture the new workflow
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Modify: `docs/plans/2026-04-06-polymarket-expansion-master-plan.md`
+
+- [ ] Run focused checks for runner compile health and sidecar build health.
+- [ ] Smoke one crypto query and one sports query through the new normalized discovery path.
+- [ ] Record the verification commands and outcomes in `tasks/todo.md`.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-discovery rtk cargo check -p ploy-runner --all-targets
+cd ploy-sidecar && npm run build
+```
+
+Expected: both build steps pass and the new discovery surfaces are documented in the tracker.

--- a/docs/plans/2026-04-06-polymarket-expansion-master-plan.md
+++ b/docs/plans/2026-04-06-polymarket-expansion-master-plan.md
@@ -1,0 +1,365 @@
+# Polymarket Expansion Master Plan
+
+## Goal
+
+Upgrade the workspace so it can support Polymarket's expanded market surface across:
+
+- Chainlink-backed high-frequency crypto markets
+- Pyth-backed equities, FX, metals, and commodities
+- sports market discovery and live-state ingestion
+- unified CLI/operator visibility
+- historical backtest and recorded replay flows that understand the new market families
+
+## Working Assumptions
+
+- Crypto 5m/15m markets remain the first-class live strategy target and must keep working throughout the refactor.
+- Pyth-backed non-crypto markets are required for data capture, discovery, and backtest support in this project phase.
+- Sports support is required for discovery, metadata normalization, live score/game-state ingestion, and backtest/research support.
+- Sports-specific live order execution must be planned with stricter safeguards because PM sports books clear at game start; execution support can ship after the data and backtest foundations are in place.
+- Existing research/backtest trust boundaries stay conservative: new sources do not become default truth until validated.
+- Settlement data must remain explicitly backfillable and correctable from official PM sources; no phase may introduce a path where unresolved or stale settlement gaps become silently accepted as final truth.
+
+## Current-State Constraints
+
+- RTDS support in the vendored SDK only exposes typed helpers for `crypto_prices` and `crypto_prices_chainlink`.
+- The live runner already depends on Chainlink RTDS to populate `price_to_beat` for crypto markets.
+- Market discovery in the live runner is still tuned to short-dated crypto up/down windows and relies on hardcoded symbol inference from market questions.
+- `ployctl` currently exposes control-plane status, trading state, and deployment operations, but no market-data or discovery commands.
+- The sidecar Polymarket tool only performs title-based Gamma event search and point-in-time market snapshots.
+- Historical database backtests already replay canonical `MarketUpdate` sequences and can fall back from `clob_quote_ticks` to `clob_orderbook_snapshots`, but they do not yet model the broader reference-price universe or sports state feeds.
+
+## Architecture Direction
+
+The refactor should converge on one shared model:
+
+1. **Reference data layer**
+   - A unified reference-price subsystem for Binance, Chainlink, and Pyth-originated feeds.
+   - Shared caches plus persisted time series with source metadata and freshness semantics.
+
+2. **Market discovery layer**
+   - Family-specific discovery adapters:
+     - short-dated crypto binary windows
+     - sports event markets
+     - Pyth-backed event markets when PM expands them into new categories
+   - A normalized internal market descriptor with explicit market family, reference symbol, settlement source, lifecycle timestamps, and token metadata.
+
+3. **Runtime/event layer**
+   - `MarketUpdate` remains the runtime contract, but the event vocabulary needs to expand around market metadata and external state updates.
+   - Live feeds, recorded replay, and historical DB loaders must all be able to produce the same canonical semantics.
+
+4. **Operator/CLI layer**
+   - `ployctl` exposes inspection and diagnostics for discovery state, reference feeds, and captured market families.
+   - `ploy-sidecar` exposes richer search/discovery tools for sports, crypto, and reference-feed-aware lookup.
+
+5. **Research/backtest layer**
+   - Historical backtests gain explicit support for multiple reference-price sources and sports event-state inputs.
+   - Replay mode remains the parity path for live-session reproduction.
+   - Settlement completion/backfill remains a first-class data-quality requirement, not a best-effort cleanup step.
+
+## Workstreams
+
+### Workstream 1: Vendored Polymarket SDK RTDS Expansion
+
+**Primary files**
+
+- `vendor/polymarket-client-sdk/src/rtds/client.rs`
+- `vendor/polymarket-client-sdk/src/rtds/types/request.rs`
+- `vendor/polymarket-client-sdk/src/rtds/types/response.rs`
+- `vendor/polymarket-client-sdk/examples/rtds_crypto_prices.rs`
+- `vendor/polymarket-client-sdk/tests/websocket.rs`
+
+**Objectives**
+
+- Add typed `equity_prices` support for Pyth-backed feeds.
+- Add response models for:
+  - live equity price updates
+  - historical subscribe snapshots
+  - carried-forward closed-session prices
+- Fix subscription serialization so `equity_prices` emits filters in the format the official RTDS docs require.
+- Preserve `subscribe_raw` for forward compatibility, but stop depending on raw-topic parsing for first-class feed families that the repo actively uses.
+
+**Deliverable**
+
+A vendored SDK that can subscribe to Chainlink crypto and Pyth equity/commodity feeds without downstream custom protocol hacks.
+
+### Workstream 2: Unified Reference-Price Feed Layer
+
+**Primary files**
+
+- `apps/ploy-runner/src/feeds.rs`
+- `apps/ploy-runner/src/main.rs`
+- `apps/ploy-runner/src/collector.rs`
+- `crates/ploy-strategy-bundles/src/traits.rs`
+- `config/default.toml`
+
+**Objectives**
+
+- Replace the narrow `ChainlinkPriceCache` concept with a generalized reference-price registry keyed by:
+  - normalized symbol
+  - source
+  - timestamp/freshness
+  - asset class
+- Keep crypto runtime behavior intact while adding:
+  - Pyth `equity_prices` capture
+  - symbol normalization for `AAPL`, `XAUUSD`, `WTI`, `EURUSD`, etc.
+- Decide whether `MarketUpdate::SpotPrice` stays generic enough or whether a new event type is needed for non-crypto reference ticks.
+- Add config for subscribing to non-crypto reference symbols by family.
+
+**Deliverable**
+
+One feed subsystem that can power runtime discovery, backtest loading, and operator diagnostics across crypto and non-crypto reference markets.
+
+### Workstream 3: Market Discovery Refactor
+
+**Primary files**
+
+- `apps/ploy-runner/src/scanner.rs`
+- `apps/ploy-runner/src/main.rs`
+- `ploy-sidecar/src/tools/polymarket.ts`
+- `vendor/polymarket-client-sdk/src/gamma/client.rs`
+- `config/default.toml`
+
+**Objectives**
+
+- Split discovery into explicit adapters instead of one crypto-only scanner.
+- Introduce a normalized market descriptor with fields for:
+  - market family
+  - exchange/league
+  - PM event ID / market ID / slug
+  - up/down or yes/no semantics
+  - reference symbol and settlement source
+  - start/end timestamps
+  - lifecycle rules
+- Use Gamma sports endpoints (`/sports`, `/teams`, `/sports/market-types`) where applicable instead of title-only heuristics.
+- Make sidecar search return richer typed results and not depend solely on `events?title=...`.
+
+**Deliverable**
+
+Discovery that can reliably find and describe crypto, sports, and future PM market families without brittle question-string matching.
+
+### Workstream 4: Sports Live-State Ingestion
+
+**Primary files**
+
+- `apps/ploy-runner/src/` new `sports.rs` or `sports_feed.rs`
+- `apps/ploy-runner/src/main.rs`
+- `crates/ploy-strategy-bundles/src/traits.rs`
+- `crates/ploy-strategy-bundles/src/feed/recorded.rs`
+- new persistence migrations for sports state if needed
+
+**Objectives**
+
+- Add a client for the PM Sports WebSocket.
+- Normalize live game state into canonical runtime updates:
+  - score
+  - period
+  - status
+  - elapsed
+  - finished timestamp
+- Attach sports state to discovered PM sports markets through slug/team mapping.
+- Record sports state in replay logs so live sessions can be reproduced exactly.
+- Plan, but do not prematurely enable, sports execution paths that ignore the game-start orderbook reset behavior.
+
+**Deliverable**
+
+The platform can ingest live sports state and use it in research, diagnostics, recorded replay, and later strategy logic without enabling sports live execution yet.
+
+### Workstream 5: Historical Database And Replay Backtest Upgrade
+
+**Primary files**
+
+- `crates/ploy-strategy-bundles/src/feed/database.rs`
+- `crates/ploy-strategy-bundles/src/feed/recorded.rs`
+- `crates/ploy-strategy-bundles/src/feed/historical.rs`
+- `crates/ploy-strategy-bundles/src/config.rs`
+- `crates/ploy-research/src/backtesting.rs`
+- `crates/ploy-research/src/replay.rs`
+- `crates/ploy-strategy-bundles/tests/backtest_integration.rs`
+
+**Objectives**
+
+- Extend the historical loader to understand new persisted sources:
+  - Pyth/equity reference prices
+  - sports state timelines
+  - richer market metadata
+- Define source-ranking rules for non-crypto markets analogous to the current PM quote trust model.
+- Keep replay as the gold-standard parity path for live captures.
+- Make backtests asset-class aware:
+  - crypto binary windows
+  - sports event markets
+  - future non-crypto PM contracts that settle against Pyth feeds
+- Ensure historical resolution semantics stay official and explicit.
+
+**Deliverable**
+
+The backtest system can replay and evaluate strategies across the expanded PM market surface without relying on crypto-only assumptions, while still anchoring settlement repair on official PM settlement rows and keeping additive sources behind explicit loader flags until trust cutover.
+
+### Workstream 6: CLI And Operator Surface Upgrade
+
+**Primary files**
+
+- `apps/ployctl/src/main.rs`
+- `apps/ployctl/src/client.rs`
+- `apps/ployctl/src/` new `markets.rs`
+- `apps/ployctl/src/` new `feeds.rs`
+- `ploy-sidecar/src/index.ts`
+- `ploy-sidecar/src/tools/polymarket.ts`
+
+**Objectives**
+
+- Add `ployctl` commands for:
+  - market discovery inspection
+  - reference feed health/status
+  - capture/source freshness
+  - targeted market snapshot inspection by family
+- Keep `ployctl` aligned with the control-plane model rather than turning it into an ad hoc raw API shell.
+- Upgrade sidecar Polymarket tools to expose:
+  - family-aware market search
+  - sports lookup by team/league/slug
+  - reference-feed-aware snapshots
+
+**Deliverable**
+
+Operators and agents can see what markets exist, what feeds are healthy, and what data the backtest/runtime can actually trust.
+
+### Workstream 7: Schema, Persistence, And Migration
+
+**Primary files**
+
+- `migrations/`
+- `crates/ploy-strategy-bundles/src/feed/database.rs`
+- `apps/ploy-runner/src/collector.rs`
+- `apps/ploy-runner/src/scanner.rs`
+
+**Objectives**
+
+- Decide whether to extend existing tables or add explicit new ones for:
+  - non-crypto reference ticks
+  - sports game-state events
+  - normalized market metadata by family
+- Avoid writing family-specific hacks into `pm_market_metadata` when the shape differs materially from short-dated crypto markets.
+- Preserve compatibility with existing historical crypto data and trusted PM quote paths.
+
+**Deliverable**
+
+A migration path that supports the new market families without corrupting the assumptions of existing research tables.
+
+## Recommended Phase Order
+
+### Phase 1: Protocol And Data Foundations
+
+- Workstream 1
+- Workstream 2
+- schema slice from Workstream 7
+
+**Why first**
+
+Everything else depends on being able to subscribe to and persist the new reference-price families correctly.
+
+### Phase 2: Discovery And Metadata Normalization
+
+- Workstream 3
+- remaining schema slice from Workstream 7
+
+**Why second**
+
+CLI, runtime wiring, and backtest ingestion all need one normalized view of what a PM market is.
+
+### Phase 3: Sports State Ingestion
+
+- Workstream 4
+
+**Why third**
+
+Sports support is not just more markets; it introduces a second live-state channel and different lifecycle semantics.
+
+### Phase 4: Historical/Replay Backtest Upgrade
+
+- Workstream 5
+
+**Why fourth**
+
+Once the new sources and descriptors exist, the backtest system can ingest them without speculative schema churn.
+
+### Phase 5: CLI And Sidecar Upgrade
+
+- Workstream 6
+
+**Why fifth**
+
+CLI surfaces should reflect the real system model after the underlying discovery/feed contracts settle.
+
+### Phase 6: Hardening And Strategy Enablement
+
+- trust cutovers
+- source-health metrics
+- sports execution guardrails
+- documentation and runbook refresh
+
+## Verification Matrix
+
+Each phase needs a proof target before moving on.
+
+### Foundation verification
+
+- Vendored SDK tests for `equity_prices` subscribe/unsubscribe and deserialization
+- Focused `rtk cargo check` for `ploy-runner` and touched crates
+- smoke collector run against a small Pyth symbol set
+
+### Discovery verification
+
+- unit tests for symbol/market-family normalization
+- snapshot tests for sidecar search results
+- Gamma integration checks for sports endpoints
+
+### Sports verification
+
+- recorded fixtures for Sports WebSocket messages
+- replay parity tests proving sports state survives record/replay
+- DB persistence checks for sports state capture
+
+### Backtest verification
+
+- integration tests for historical loader across:
+  - crypto-only
+  - non-crypto reference data
+  - sports market + sports state
+- regression tests that existing crypto backtests still pass unchanged
+
+### CLI verification
+
+- parser tests for new `ployctl` subcommands
+- snapshot tests for human-readable output
+- end-to-end tests against fixture-backed control-plane snapshots where possible
+
+## Risks
+
+- The vendored SDK may need broader RTDS abstractions than a one-topic patch if PM expands the protocol again.
+- Sports markets can look tradable but have very different execution risk because orders are cancelled around start time.
+- Non-crypto reference prices can produce stale carried-forward values outside market hours; the runtime and backtest path must not treat those as live ticks.
+- Overloading crypto-oriented tables with sports/non-crypto semantics will make the historical loader brittle.
+
+## Explicit Non-Goals For The First Execution Pass
+
+- Shipping a production-ready sports market-making strategy before sports state ingestion and lifecycle safeguards are proven
+- Treating newly captured Pyth or sports data as trusted historical truth without validation windows
+- Replacing replay mode with the historical DB path; replay remains the canonical live-session parity tool
+
+## Proposed Execution Split
+
+After approval, execution should be split into these implementation plans:
+
+1. **RTDS + reference-price foundation**
+   - `docs/plans/2026-04-06-rtds-reference-foundation-implementation-plan.md`
+2. **Discovery + metadata normalization**
+   - `docs/plans/2026-04-06-market-discovery-normalization-implementation-plan.md`
+3. **Sports live-state capture**
+   - `docs/plans/2026-04-06-sports-data-capture-implementation-plan.md`
+4. **Backtest/replay expansion**
+   - `docs/plans/2026-04-06-backtest-replay-expansion-implementation-plan.md`
+5. **CLI + sidecar operator surface**
+   - `docs/plans/2026-04-06-cli-operator-surface-implementation-plan.md`
+6. **Hardening, docs, and trust-cutover**
+   - `docs/plans/2026-04-06-hardening-trust-cutover-implementation-plan.md`
+
+This keeps each plan independently testable and avoids one giant cross-cutting patch set.

--- a/docs/plans/2026-04-06-rtds-reference-foundation-implementation-plan.md
+++ b/docs/plans/2026-04-06-rtds-reference-foundation-implementation-plan.md
@@ -1,0 +1,158 @@
+# RTDS And Reference-Price Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class Pyth `equity_prices` support and a unified reference-price capture foundation without regressing the existing Chainlink/Binance crypto path.
+
+**Architecture:** Extend the vendored Polymarket RTDS client with typed `equity_prices` request/response support, then introduce a repo-owned reference-price registry and persistence path in `ploy-runner`. Keep the current crypto runtime behavior intact by treating the new foundation as an additive data plane in phase 1.
+
+**Tech Stack:** Rust, vendored `polymarket-client-sdk`, Tokio streams, SQLx migrations, existing `ploy-runner` feed wiring, targeted `rtk cargo test/check`
+
+---
+
+### Task 1: Track the foundation lane and freeze the file map
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Modify: `docs/plans/2026-04-06-polymarket-expansion-master-plan.md`
+- Create: `docs/plans/2026-04-06-rtds-reference-foundation-implementation-plan.md`
+
+- [ ] Add a dedicated tracker section at the top of `tasks/todo.md` for the RTDS/reference-price lane.
+- [ ] Link this plan from the master plan under the execution split.
+- [ ] Verify the new plan file exists.
+
+Run:
+
+```bash
+ls docs/plans | rg 'rtds-reference-foundation'
+```
+
+Expected: `2026-04-06-rtds-reference-foundation-implementation-plan.md`
+
+### Task 2: Extend the vendored RTDS request/response model for `equity_prices`
+
+**Files:**
+- Modify: `vendor/polymarket-client-sdk/src/rtds/types/request.rs`
+- Modify: `vendor/polymarket-client-sdk/src/rtds/types/response.rs`
+- Modify: `vendor/polymarket-client-sdk/src/rtds/client.rs`
+- Modify: `vendor/polymarket-client-sdk/src/rtds/mod.rs`
+
+- [ ] Add a `Subscription::equity_prices(symbol: Option<String>, msg_type: &str)` constructor that serializes filters in the same JSON-string form the official RTDS docs require.
+- [ ] Add typed response models for:
+  - live updates
+  - subscribe snapshot/backfill messages
+  - carried-forward closed-session flags
+- [ ] Add `RtdsMessage::as_equity_price_update()` and `RtdsMessage::as_equity_price_snapshot()` helpers.
+- [ ] Add `Client::subscribe_equity_prices(symbol: Option<String>, include_snapshot: bool)` and `Client::unsubscribe_equity_prices(symbol: Option<String>)`.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo test -p polymarket-client-sdk rtds -- --nocapture
+```
+
+Expected: the RTDS-focused vendored SDK tests pass.
+
+### Task 3: Add example and regression coverage for Pyth-backed feeds
+
+**Files:**
+- Create: `vendor/polymarket-client-sdk/examples/rtds_equity_prices.rs`
+- Modify: `vendor/polymarket-client-sdk/tests/websocket.rs`
+- Modify: `vendor/polymarket-client-sdk/examples/rtds_crypto_prices.rs`
+
+- [ ] Add a minimal example that subscribes to `AAPL` and `XAUUSD`, logs both snapshot and update payloads, and documents the lowercase payload semantics.
+- [ ] Add regression tests that prove:
+  - `equity_prices` filters serialize as escaped JSON strings
+  - update payloads deserialize
+  - snapshot payloads deserialize
+  - unsubscribe requests target the correct topic/type pair
+- [ ] Keep the existing crypto example aligned with the expanded API docs so the two feed families are parallel.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo test -p polymarket-client-sdk websocket -- --nocapture
+```
+
+Expected: the websocket protocol tests pass with new `equity_prices` coverage.
+
+### Task 4: Introduce a repo-owned reference-price registry in `ploy-runner`
+
+**Files:**
+- Create: `apps/ploy-runner/src/reference_prices.rs`
+- Modify: `apps/ploy-runner/src/feeds.rs`
+- Modify: `apps/ploy-runner/src/main.rs`
+- Modify: `apps/ploy-runner/src/collector.rs`
+- Modify: `apps/ploy-runner/Cargo.toml`
+
+- [ ] Extract the current `ChainlinkPriceCache` ownership out of `feeds.rs` into a new `reference_prices.rs` module.
+- [ ] Define one normalized cache key shape that can represent:
+  - `btcusdt` Binance spot
+  - `btc/usd` Chainlink
+  - `aapl`, `xauusd`, `wti`, `eurusd` Pyth
+- [ ] Add a `ReferencePriceRegistry` API that records:
+  - normalized symbol
+  - source
+  - asset class
+  - last value
+  - last update timestamp
+  - carried-forward flag when applicable
+- [ ] Rewire the existing crypto spot and Chainlink tasks to publish into the new registry.
+- [ ] Add a new Pyth RTDS task in `feeds.rs` that subscribes to configured non-crypto symbols and also writes into the same registry.
+- [ ] Keep scanner/runtime callers on the existing crypto path for now; phase 1 is foundation, not a strategy-runtime semantic change.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo check -p ploy-runner --all-targets
+```
+
+Expected: `ploy-runner` compiles with the new registry module and Pyth feed wiring.
+
+### Task 5: Persist non-crypto reference ticks with explicit source metadata
+
+**Files:**
+- Create: `migrations/027_reference_price_ticks.sql`
+- Modify: `apps/ploy-runner/src/feeds.rs`
+- Modify: `apps/ploy-runner/src/main.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/database.rs`
+
+- [ ] Add a migration for `reference_price_ticks` with columns for:
+  - `symbol`
+  - `source`
+  - `asset_class`
+  - `price`
+  - `full_accuracy_value` nullable
+  - `price_time`
+  - `received_at`
+  - `is_carried_forward`
+- [ ] Persist Pyth/equity ticks into this table at live capture time.
+- [ ] Add a small reader helper in `feed/database.rs` that can later be used by the backtest-expansion phase without wiring it into the default loader yet.
+- [ ] Leave existing `binance_price_ticks` and crypto quote tables untouched.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo check -p ploy-runner -p ploy-strategy-bundles --all-targets
+```
+
+Expected: both crates compile with the new migration-backed persistence path.
+
+### Task 6: Verify the foundation slice end-to-end
+
+**Files:**
+- Modify: `tasks/todo.md`
+
+- [ ] Run focused tests for the vendored SDK and `ploy-runner`.
+- [ ] Run one smoke path that starts the runner with a tiny configured Pyth symbol set in dry-run mode or a fixture-backed mode.
+- [ ] Record the exact commands and outcomes in `tasks/todo.md`.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo test -p polymarket-client-sdk rtds -- --nocapture
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo test -p ploy-runner -- --nocapture
+CARGO_TARGET_DIR=/tmp/ploy-rtds-foundation rtk cargo check -p ploy-runner -p ploy-strategy-bundles --all-targets
+```
+
+Expected: tests pass and the runner compiles cleanly for the new foundation slice.

--- a/docs/plans/2026-04-06-sports-data-capture-implementation-plan.md
+++ b/docs/plans/2026-04-06-sports-data-capture-implementation-plan.md
@@ -1,0 +1,129 @@
+# Sports Discovery, Data Capture, And Backtest-Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Polymarket sports live-state capture and persistence so sports markets can be discovered, recorded, and replayed for research/backtest use without enabling sports live execution yet.
+
+**Architecture:** Add a dedicated sports feed client for the Polymarket Sports WebSocket, normalize live game-state messages into canonical internal events, persist them to a sports-state table, and make the events recordable in replay logs. This phase ends at discovery + data capture + backtest support, not live trading.
+
+**Tech Stack:** Rust, WebSocket client code in `ploy-runner`, SQLx migrations, canonical `MarketUpdate` recording/replay, fixture-driven tests
+
+---
+
+### Task 1: Add a canonical sports-state event contract
+
+**Files:**
+- Modify: `crates/ploy-strategy-bundles/src/traits.rs`
+- Modify: `crates/ploy-strategy-bundles/src/engine.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/recorded.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/historical.rs`
+- Modify: `crates/ploy-strategy-bundles/src/lib.rs`
+
+- [ ] Add a `MarketUpdate::SportsState` variant carrying:
+  - `game_id`
+  - `league`
+  - `slug`
+  - `home_team`
+  - `away_team`
+  - `status`
+  - `period`
+  - `score`
+  - `elapsed`
+  - `live`
+  - `ended`
+  - `finished_at`
+  - event timestamp
+- [ ] Make the runtime and recorded feed paths accept and preserve the new variant without affecting existing crypto strategy behavior.
+- [ ] Add unit coverage proving `SportsState` survives record/replay round-trips.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-sports-data rtk cargo test -p ploy-strategy-bundles recorded -- --nocapture
+```
+
+Expected: the recorded-feed tests pass with the new sports event variant.
+
+### Task 2: Add the live Polymarket Sports WebSocket client
+
+**Files:**
+- Create: `apps/ploy-runner/src/sports_feed.rs`
+- Modify: `apps/ploy-runner/src/main.rs`
+- Modify: `apps/ploy-runner/Cargo.toml`
+- Modify: `apps/ploy-runner/src/discovery/sports.rs`
+
+- [ ] Add a sports feed module that connects to `wss://sports-api.polymarket.com/ws`, handles `ping`/`pong`, and parses `sport_result` payloads.
+- [ ] Normalize payloads into `MarketUpdate::SportsState`.
+- [ ] Attach the feed to the runner only when sports market families are configured.
+- [ ] Join sports-state messages to normalized sports market descriptors by slug and league.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-sports-data rtk cargo check -p ploy-runner --all-targets
+```
+
+Expected: `ploy-runner` compiles with the new sports feed module.
+
+### Task 3: Persist sports state for historical replay
+
+**Files:**
+- Create: `migrations/029_sports_state_events.sql`
+- Modify: `apps/ploy-runner/src/sports_feed.rs`
+- Modify: `crates/ploy-strategy-bundles/src/feed/database.rs`
+
+- [ ] Add a `sports_state_events` table storing the normalized sports game-state timeline.
+- [ ] Persist each normalized sports-state message with explicit source and received timestamps.
+- [ ] Add a historical loader helper in `feed/database.rs` that can read sports-state rows back into `MarketUpdate::SportsState`.
+- [ ] Do not yet turn sports-state loading on by default for all backtests; the backtest-expansion phase will wire that policy.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-sports-data rtk cargo check -p ploy-runner -p ploy-strategy-bundles --all-targets
+```
+
+Expected: both crates compile with sports-state persistence support.
+
+### Task 4: Add fixture-backed sports ingestion tests
+
+**Files:**
+- Create: `apps/ploy-runner/tests/sports_feed.rs`
+- Create: `apps/ploy-runner/tests/fixtures/polymarket_sports_ws.jsonl`
+- Modify: `crates/ploy-strategy-bundles/tests/backtest_integration.rs`
+
+- [ ] Add fixture messages that cover:
+  - scheduled
+  - in-progress
+  - break/halftime
+  - final/ended
+- [ ] Prove the sports feed parser converts them into canonical `SportsState` updates.
+- [ ] Add one integration test that records a short mixed crypto+sports stream and replays it successfully.
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/ploy-sports-data rtk cargo test -p ploy-runner sports_feed -- --nocapture
+CARGO_TARGET_DIR=/tmp/ploy-sports-data rtk cargo test -p ploy-strategy-bundles backtest_integration -- --nocapture
+```
+
+Expected: parser and replay-parity tests pass.
+
+### Task 5: Document the sports boundary explicitly
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Modify: `docs/plans/2026-04-06-polymarket-expansion-master-plan.md`
+- Modify: `README.md`
+
+- [ ] Record that this phase covers sports discovery, data capture, and backtest support only.
+- [ ] Add a brief README note that sports live execution remains out of scope until lifecycle safeguards are added later.
+- [ ] Capture the verification commands and results in `tasks/todo.md`.
+
+Run:
+
+```bash
+rg -n "sports.*discovery|sports.*data capture|sports.*backtest support" README.md docs/plans tasks/todo.md
+```
+
+Expected: the scope boundary appears in the tracker and planning docs.

--- a/ploy-sidecar/src/tools/polymarket.ts
+++ b/ploy-sidecar/src/tools/polymarket.ts
@@ -1,8 +1,8 @@
 /**
- * Polymarket MCP Tools — Direct API calls to Polymarket CLOB.
+ * Polymarket MCP tools.
  *
- * Provides market search and snapshot capabilities for the sidecar.
- * These hit the public Polymarket API directly.
+ * Exposes family-aware search and normalized market snapshots so operator
+ * prompts can reason about crypto and sports markets with one contract.
  */
 
 import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
@@ -11,60 +11,331 @@ import { z } from "zod";
 const CLOB_BASE = "https://clob.polymarket.com";
 const GAMMA_BASE = "https://gamma-api.polymarket.com";
 
+type MarketFamily = "crypto" | "sports";
+type SettlementSource = "chainlink" | "official_polymarket";
+
+function buildUrl(path: string, params: Record<string, string | number | boolean | undefined>): string {
+  const url = new URL(path, `${GAMMA_BASE}/`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === "") continue;
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+async function fetchJson(url: string): Promise<any> {
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status} for ${url}`);
+  }
+  return resp.json();
+}
+
+function parseJsonArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || value.length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value || "").trim().toLowerCase();
+}
+
+function inferCryptoSymbol(text: string): string | null {
+  const upper = text.toUpperCase();
+  if (upper.includes("BITCOIN") || upper.includes("BTC")) return "BTCUSDT";
+  if (upper.includes("ETHEREUM") || upper.includes("ETH")) return "ETHUSDT";
+  if (upper.includes("SOLANA") || upper.includes("SOL ")) return "SOLUSDT";
+  if (upper.includes("XRP")) return "XRPUSDT";
+  if (upper.includes("DOGECOIN") || upper.includes("DOGE")) return "DOGEUSDT";
+  if (upper.includes("HYPE")) return "HYPEUSDT";
+  if (upper.includes("BNB") || upper.includes("BINANCE COIN")) return "BNBUSDT";
+  return null;
+}
+
+function mapChainlinkSymbol(symbol: string | null): string | null {
+  if (!symbol) return null;
+  const base = symbol.replace(/USDT$/i, "").toLowerCase();
+  return `${base}/usd`;
+}
+
+function inferFamily(event: any, market: any): MarketFamily {
+  if (
+    market?.sportsMarketType ||
+    market?.gameId ||
+    event?.gameId ||
+    event?.sportsradarMatchId ||
+    event?.homeTeamName ||
+    event?.awayTeamName
+  ) {
+    return "sports";
+  }
+  return "crypto";
+}
+
+function normalizeSemantics(family: MarketFamily, market: any): string {
+  if (family === "crypto") return "updown";
+
+  const raw = normalizeText(market?.sportsMarketType);
+  if (raw === "moneyline") return "moneyline";
+  if (raw.includes("spread")) return "spread";
+  if (raw.includes("total")) return "total";
+  if (raw === "yesno" || raw === "yes_no") return "yesno";
+  return "unknown";
+}
+
+function normalizeDescriptor(market: any, event?: any) {
+  const family = inferFamily(event, market);
+  const question = market?.question || event?.title || null;
+  const strategySymbol = family === "crypto" ? inferCryptoSymbol(question || "") : null;
+  const outcomePrices = parseJsonArray(market?.outcomePrices);
+  const tokenIds = parseJsonArray(market?.clobTokenIds).map(String);
+  const settlementSource: SettlementSource =
+    family === "crypto" ? "chainlink" : "official_polymarket";
+
+  return {
+    market_family: family,
+    event_id: event?.id || market?.gameId || null,
+    event_slug: event?.slug || null,
+    market_id: String(market?.id || market?.conditionId || market?.slug || ""),
+    market_slug: market?.slug || null,
+    title: question,
+    strategy_symbol: strategySymbol,
+    reference_symbol:
+      family === "crypto"
+        ? mapChainlinkSymbol(strategySymbol)
+        : event?.sportsradarMatchId || market?.gameId || null,
+    settlement_source: settlementSource,
+    league:
+      event?.subcategory ||
+      market?.subcategory ||
+      event?.category ||
+      market?.category ||
+      null,
+    sport:
+      family === "crypto"
+        ? "crypto"
+        : event?.category || market?.category || event?.subcategory || market?.subcategory || null,
+    start_time: market?.eventStartTime || event?.startTime || market?.startDate || event?.startDate || null,
+    end_time: market?.endDate || event?.endDate || null,
+    token_ids: tokenIds,
+    market_semantics: normalizeSemantics(family, market),
+    home_team: event?.homeTeamName || null,
+    away_team: event?.awayTeamName || null,
+    active: market?.active ?? event?.active ?? null,
+    accepting_orders: market?.acceptingOrders ?? null,
+    condition_id: market?.conditionId || null,
+    price_yes: outcomePrices.length > 0 ? outcomePrices[0] : null,
+    price_no: outcomePrices.length > 1 ? outcomePrices[1] : null,
+    volume: market?.volumeNum ?? market?.volume ?? null,
+    liquidity: market?.liquidityNum ?? market?.liquidity ?? null,
+  };
+}
+
+function matchesSearch(
+  descriptor: ReturnType<typeof normalizeDescriptor>,
+  args: {
+    query?: string;
+    family?: "any" | "crypto" | "sports";
+    league?: string;
+    team?: string;
+    slug?: string;
+  }
+): boolean {
+  if (args.family && args.family !== "any" && descriptor.market_family !== args.family) {
+    return false;
+  }
+
+  if (args.slug) {
+    const target = normalizeText(args.slug);
+    const marketSlug = normalizeText(descriptor.market_slug);
+    const eventSlug = normalizeText(descriptor.event_slug);
+    if (marketSlug !== target && eventSlug !== target) {
+      return false;
+    }
+  }
+
+  if (args.league) {
+    if (!normalizeText(descriptor.league).includes(normalizeText(args.league))) {
+      return false;
+    }
+  }
+
+  if (args.team) {
+    const target = normalizeText(args.team);
+    const teamFields = [
+      descriptor.home_team,
+      descriptor.away_team,
+      descriptor.title,
+      descriptor.market_slug,
+      descriptor.event_slug,
+    ]
+      .filter(Boolean)
+      .map(normalizeText);
+
+    if (!teamFields.some((value) => value.includes(target))) {
+      return false;
+    }
+  }
+
+  if (args.query) {
+    const target = normalizeText(args.query);
+    const searchable = [
+      descriptor.title,
+      descriptor.market_slug,
+      descriptor.event_slug,
+      descriptor.home_team,
+      descriptor.away_team,
+      descriptor.league,
+      descriptor.sport,
+      descriptor.strategy_symbol,
+      descriptor.reference_symbol,
+    ]
+      .filter(Boolean)
+      .map(normalizeText);
+
+    if (!searchable.some((value) => value.includes(target))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function fetchEventSearch(query: string, limit: number): Promise<any[]> {
+  const url = buildUrl("events", {
+    active: true,
+    limit,
+    title: query,
+  });
+  const events = (await fetchJson(url)) as any[];
+  return events.flatMap((event) =>
+    (event.markets || []).map((market: any) => ({
+      descriptor: normalizeDescriptor(market, event),
+      raw_event: event,
+      raw_market: market,
+    }))
+  );
+}
+
+async function fetchBroadMarketSearch(limit: number): Promise<any[]> {
+  const url = buildUrl("markets", {
+    closed: false,
+    limit,
+  });
+  const markets = (await fetchJson(url)) as any[];
+  return markets.map((market) => ({
+    descriptor: normalizeDescriptor(market),
+    raw_event: null,
+    raw_market: market,
+  }));
+}
+
+async function resolveGammaMarket(args: {
+  market_id?: string;
+  market_slug?: string;
+  condition_id?: string;
+}): Promise<{ descriptor: ReturnType<typeof normalizeDescriptor> | null; raw_market: any | null }> {
+  if (args.market_id) {
+    const market = await fetchJson(`${GAMMA_BASE}/markets/${encodeURIComponent(args.market_id)}`);
+    return { descriptor: normalizeDescriptor(market), raw_market: market };
+  }
+
+  if (args.market_slug) {
+    const results = await fetchJson(
+      buildUrl("markets", {
+        closed: false,
+        limit: 1,
+        slug: args.market_slug,
+      })
+    );
+    const market = Array.isArray(results) ? results[0] : null;
+    return {
+      descriptor: market ? normalizeDescriptor(market) : null,
+      raw_market: market,
+    };
+  }
+
+  return { descriptor: null, raw_market: null };
+}
+
 export const polymarketServer = createSdkMcpServer({
   name: "polymarket",
-  version: "1.0.0",
+  version: "2.0.0",
   tools: [
     tool(
       "search_markets",
-      "Search Polymarket for active markets matching a query. Returns market slugs, questions, prices, and condition IDs.",
+      "Search Polymarket using a normalized discovery contract. Supports generic query search plus family-aware sports lookup by team, league, or slug.",
       {
-        query: z.string().describe("Search query (e.g., 'Lakers vs Celtics', 'NBA champion')"),
-        limit: z.number().min(1).max(20).optional().describe("Max results (default 10)"),
+        query: z.string().optional().describe("Free-text search query"),
+        family: z
+          .enum(["any", "crypto", "sports"])
+          .optional()
+          .describe("Restrict results to a market family"),
+        league: z.string().optional().describe("Sports league filter (e.g. NBA, LaLiga)"),
+        team: z.string().optional().describe("Team filter for sports markets"),
+        slug: z.string().optional().describe("Exact market or event slug"),
+        limit: z.number().min(1).max(50).optional().describe("Max results (default 10)"),
       },
       async (args) => {
         const limit = args.limit || 10;
+        const broadSearchLimit = Math.max(limit * 5, 50);
 
         try {
-          const resp = await fetch(
-            `${GAMMA_BASE}/events?active=true&limit=${limit}&title=${encodeURIComponent(args.query)}`
-          );
+          let results: Array<{
+            descriptor: ReturnType<typeof normalizeDescriptor>;
+            raw_event: any;
+            raw_market: any;
+          }> = [];
 
-          if (!resp.ok) {
-            return {
-              content: [{ type: "text" as const, text: `Polymarket search error: ${resp.status}` }],
-              isError: true,
-            };
+          if (args.query) {
+            results = await fetchEventSearch(args.query, broadSearchLimit);
           }
 
-          const events = await resp.json();
+          const needsBroadSearch =
+            results.length === 0 || args.family === "sports" || !!args.league || !!args.team || !!args.slug;
 
-          const results = (events as any[]).map((event: any) => ({
-            event_id: event.id,
-            title: event.title,
-            slug: event.slug,
-            active: event.active,
-            end_date: event.endDate,
-            markets: (event.markets || []).map((m: any) => ({
-              condition_id: m.conditionId,
-              question: m.question,
-              slug: m.slug,
-              outcome_yes_price: m.outcomePrices
-                ? JSON.parse(m.outcomePrices)[0]
-                : null,
-              outcome_no_price: m.outcomePrices
-                ? JSON.parse(m.outcomePrices)[1]
-                : null,
-              volume: m.volume,
-              liquidity: m.liquidity,
-            })),
-          }));
+          if (needsBroadSearch) {
+            const broadResults = await fetchBroadMarketSearch(broadSearchLimit);
+            const deduped = new Map<string, typeof broadResults[number]>();
+            for (const item of [...results, ...broadResults]) {
+              deduped.set(item.descriptor.market_id, item);
+            }
+            results = [...deduped.values()];
+          }
+
+          const filtered = results
+            .filter((item) => matchesSearch(item.descriptor, args))
+            .slice(0, limit)
+            .map((item) => ({
+              ...item.descriptor,
+              raw_condition_id: item.raw_market?.conditionId || null,
+            }));
 
           return {
             content: [
               {
                 type: "text" as const,
-                text: JSON.stringify({ query: args.query, count: results.length, results }, null, 2),
+                text: JSON.stringify(
+                  {
+                    filters: {
+                      query: args.query || null,
+                      family: args.family || "any",
+                      league: args.league || null,
+                      team: args.team || null,
+                      slug: args.slug || null,
+                    },
+                    count: filtered.length,
+                    results: filtered,
+                  },
+                  null,
+                  2
+                ),
               },
             ],
           };
@@ -79,80 +350,74 @@ export const polymarketServer = createSdkMcpServer({
 
     tool(
       "market_snapshot",
-      "Get detailed snapshot of a specific Polymarket market. Returns best bid/ask, last trade price, and order book depth.",
+      "Get a normalized Polymarket market snapshot. Can resolve by condition_id, market_id, or market_slug, and optionally fetch a token order book.",
       {
-        condition_id: z
-          .string()
-          .describe("Polymarket condition ID (hex string)"),
-        token_id: z
-          .string()
-          .optional()
-          .describe("Specific token ID to get order book for"),
+        condition_id: z.string().optional().describe("Polymarket condition ID"),
+        market_id: z.string().optional().describe("Gamma market ID"),
+        market_slug: z.string().optional().describe("Gamma market slug"),
+        token_id: z.string().optional().describe("Specific token ID for order book lookup"),
       },
       async (args) => {
         try {
-          // Get market info
-          const marketResp = await fetch(
-            `${CLOB_BASE}/markets/${args.condition_id}`
-          );
+          const gamma = await resolveGammaMarket(args);
+          const conditionId = args.condition_id || gamma.descriptor?.condition_id || null;
 
-          if (!marketResp.ok) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Market not found: ${marketResp.status}`,
-                },
-              ],
-              isError: true,
-            };
+          let clobMarket: any = null;
+          if (conditionId) {
+            const marketResp = await fetch(`${CLOB_BASE}/markets/${conditionId}`);
+            if (marketResp.ok) {
+              clobMarket = await marketResp.json();
+            }
           }
 
-          const market = await marketResp.json();
-
-          // Get order book if token_id provided
           let orderbook = null;
           if (args.token_id) {
-            const obResp = await fetch(
-              `${CLOB_BASE}/book?token_id=${args.token_id}`
-            );
+            const obResp = await fetch(`${CLOB_BASE}/book?token_id=${args.token_id}`);
             if (obResp.ok) {
               orderbook = await obResp.json();
             }
           }
 
-          const snapshot: any = {
-            condition_id: market.condition_id,
-            question: market.question,
-            tokens: market.tokens,
-            active: market.active,
-            closed: market.closed,
-            minimum_order_size: market.minimum_order_size,
-            minimum_tick_size: market.minimum_tick_size,
-          };
-
-          if (orderbook) {
-            const bids = orderbook.bids || [];
-            const asks = orderbook.asks || [];
-            snapshot.orderbook = {
-              best_bid: bids.length > 0 ? bids[0].price : null,
-              best_ask: asks.length > 0 ? asks[0].price : null,
-              bid_depth: bids.slice(0, 5),
-              ask_depth: asks.slice(0, 5),
-              spread:
-                bids.length > 0 && asks.length > 0
-                  ? (
-                      parseFloat(asks[0].price) - parseFloat(bids[0].price)
-                    ).toFixed(4)
-                  : null,
-            };
-          }
+          const bids = orderbook?.bids || [];
+          const asks = orderbook?.asks || [];
 
           return {
             content: [
               {
                 type: "text" as const,
-                text: JSON.stringify(snapshot, null, 2),
+                text: JSON.stringify(
+                  {
+                    descriptor: gamma.descriptor,
+                    clob_snapshot: clobMarket
+                      ? {
+                          condition_id: clobMarket.condition_id,
+                          question: clobMarket.question,
+                          active: clobMarket.active,
+                          closed: clobMarket.closed,
+                          minimum_order_size: clobMarket.minimum_order_size,
+                          minimum_tick_size: clobMarket.minimum_tick_size,
+                          tokens: clobMarket.tokens,
+                        }
+                      : null,
+                    orderbook: orderbook
+                      ? {
+                          token_id: args.token_id,
+                          best_bid: bids.length > 0 ? bids[0].price : null,
+                          best_ask: asks.length > 0 ? asks[0].price : null,
+                          bid_depth: bids.slice(0, 5),
+                          ask_depth: asks.slice(0, 5),
+                          spread:
+                            bids.length > 0 && asks.length > 0
+                              ? (
+                                  parseFloat(asks[0].price) - parseFloat(bids[0].price)
+                                ).toFixed(4)
+                              : null,
+                        }
+                      : null,
+                  },
+                  null,
+                  2
+                ),
               },
             ],
           };

--- a/vendor/polymarket-client-sdk/src/rtds/client.rs
+++ b/vendor/polymarket-client-sdk/src/rtds/client.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use futures::future;
 use futures::Stream;
 use futures::StreamExt as _;
+use futures::future;
 
 use super::subscription::{SimpleParser, SubscriptionManager, TopicType};
 use super::types::request::Subscription;
@@ -197,9 +197,9 @@ impl<S: State> Client<S> {
             future::ready(match msg_result {
                 Ok(msg) => match msg.as_crypto_price() {
                     Some(price) => {
-                        let matches_request = requested_symbols.as_ref().is_none_or(|symbols| {
-                            symbols.contains(&price.symbol.to_lowercase())
-                        });
+                        let matches_request = requested_symbols
+                            .as_ref()
+                            .is_none_or(|symbols| symbols.contains(&price.symbol.to_lowercase()));
                         matches_request.then_some(Ok(price))
                     }
                     None => None,

--- a/vendor/polymarket-client-sdk/src/rtds/subscription.rs
+++ b/vendor/polymarket-client-sdk/src/rtds/subscription.rs
@@ -221,10 +221,9 @@ impl SubscriptionManager {
 
         let target_topics: Vec<TopicType> = subscriptions
             .iter()
-            .map(|subscription| TopicType::new(
-                subscription.topic.clone(),
-                subscription.msg_type.clone(),
-            ))
+            .map(|subscription| {
+                TopicType::new(subscription.topic.clone(), subscription.msg_type.clone())
+            })
             .collect();
 
         // Store auth for re-subscription on reconnect.
@@ -360,30 +359,32 @@ impl SubscriptionManager {
                 .collect();
 
             for matching_topic in matching_topics {
-                if let Entry::Occupied(mut entry) = self.subscribed_topics.entry(matching_topic.clone()) {
-                let refcount = entry.get_mut();
-                *refcount = refcount.saturating_sub(1);
-                if *refcount == 0 {
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!(
-                        topic = %matching_topic.topic,
-                        msg_type = %matching_topic.msg_type,
-                        filters = ?matching_topic.filters,
-                        "Unsubscribing from RTDS topic"
-                    );
+                if let Entry::Occupied(mut entry) =
+                    self.subscribed_topics.entry(matching_topic.clone())
+                {
+                    let refcount = entry.get_mut();
+                    *refcount = refcount.saturating_sub(1);
+                    if *refcount == 0 {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            topic = %matching_topic.topic,
+                            msg_type = %matching_topic.msg_type,
+                            filters = ?matching_topic.filters,
+                            "Unsubscribing from RTDS topic"
+                        );
 
-                    // Send unsubscribe while holding the entry lock to prevent
-                    // a concurrent subscribe from racing with us
-                    let request = SubscriptionRequest::unsubscribe(vec![Subscription {
-                        topic: matching_topic.topic.clone(),
-                        msg_type: matching_topic.msg_type.clone(),
-                        filters: matching_topic.filters.clone(),
-                        clob_auth: None,
-                    }]);
-                    self.connection.send(&request)?;
-                    entry.remove();
+                        // Send unsubscribe while holding the entry lock to prevent
+                        // a concurrent subscribe from racing with us
+                        let request = SubscriptionRequest::unsubscribe(vec![Subscription {
+                            topic: matching_topic.topic.clone(),
+                            msg_type: matching_topic.msg_type.clone(),
+                            filters: matching_topic.filters.clone(),
+                            clob_auth: None,
+                        }]);
+                        self.connection.send(&request)?;
+                        entry.remove();
+                    }
                 }
-            }
             }
         }
 

--- a/vendor/polymarket-client-sdk/src/serde_helpers.rs
+++ b/vendor/polymarket-client-sdk/src/serde_helpers.rs
@@ -12,7 +12,6 @@
 use serde_json::Value;
 
 #[cfg(all(
-    feature = "tracing",
     any(
         feature = "bridge",
         feature = "clob",


### PR DESCRIPTION
## Summary
- extend runner and strategy bundle feed surfaces for RTDS/reference prices, market discovery, and richer backtest inputs
- normalize the sidecar Polymarket market tools around family-aware descriptors and snapshots
- add the implementation plans that document the backtest, RTDS, discovery, and sports data expansion work

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-pr82 /opt/homebrew/bin/rtk cargo test -p ploy-runner -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-pr82 /opt/homebrew/bin/rtk cargo test -p ploy-strategy-bundles -- --nocapture
- cd /Users/proerror/Documents/ploy/ploy-sidecar && npm run build