### PR TITLE
fix(vendor): add missing DeserializeOwned import in polymarket SDK

### DIFF
--- a/vendor/polymarket-client-sdk/src/serde_helpers.rs
+++ b/vendor/polymarket-client-sdk/src/serde_helpers.rs
@@ -9,18 +9,14 @@
     feature = "data",
     feature = "gamma",
 ))]
-use serde_json::Value;
-
-#[cfg(all(
-    feature = "tracing",
-    any(
-        feature = "bridge",
-        feature = "clob",
-        feature = "data",
-        feature = "gamma"
-    )
-))]
 use serde::de::DeserializeOwned;
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma",
+))]
+use serde_json::Value;
 
 /// A `serde_as` type that deserializes strings or integers as `String`.
 ///


### PR DESCRIPTION
## Summary
- Fix pre-existing CI build failure in vendor SDK
- `deserialize_with_warnings` requires `DeserializeOwned` but import was gated behind `tracing` feature

## Test plan
- [x] `cargo check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)