### PR TITLE
fix: add missing fields in ExecutionRequest test constructors

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -691,6 +691,8 @@ mod tests {
                 side: TradeSide::Buy,
                 quantity: dec!(1),
                 limit_price: Some(dec!(0.55)),
+                order_type: OrderExecutionType::GTC,
+                aggressive_ticks: 0,
             })
             .expect("ack outcome");
 
@@ -719,6 +721,8 @@ mod tests {
                 side: TradeSide::Buy,
                 quantity: dec!(1),
                 limit_price: None,
+                order_type: OrderExecutionType::GTC,
+                aggressive_ticks: 0,
             })
             .expect_err("limit price should be required");
 


### PR DESCRIPTION
## Summary
Fix two test-only `ExecutionRequest` constructors missing the new `order_type` and `aggressive_ticks` fields added in #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests for execution gateway validation to ensure proper handling of order execution requests, including acknowledgment success and validation failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->