### PR TITLE
fix(collector): reuse relaxed heartbeat for chainlink rtds

### DIFF
--- a/apps/ploy-runner/src/collector.rs
+++ b/apps/ploy-runner/src/collector.rs
@@ -25,9 +25,9 @@ use tokio::time::sleep;
 use tracing::{error, info, warn};
 
 use crate::reference_prices::{
-    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
-    ReferencePriceSource, latest_reference_price, market_symbol_to_chainlink_symbol,
-    new_reference_price_registry, normalize_reference_symbol, upsert_reference_price,
+    latest_reference_price, market_symbol_to_chainlink_symbol, new_reference_price_registry,
+    normalize_reference_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
+    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
 };
 
 /// Configuration for the quote collector.
@@ -88,6 +88,7 @@ struct PersistResult {
 }
 
 const POLYMARKET_CLOB_WS_ENDPOINT: &str = "wss://ws-subscriptions-clob.polymarket.com";
+const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
 
 fn is_tradeable_price(price: Decimal) -> bool {
     price > rust_decimal_macros::dec!(0.02) && price < rust_decimal_macros::dec!(0.98)
@@ -142,7 +143,7 @@ fn book_timestamp(timestamp_ms: i64) -> Option<DateTime<Utc>> {
     DateTime::from_timestamp_millis(timestamp_ms)
 }
 
-fn quote_collector_ws_config() -> PolymarketWsConfig {
+fn collector_market_data_ws_config() -> PolymarketWsConfig {
     let mut config = PolymarketWsConfig::default();
     // The collector only needs a healthy market-data stream, not a tightly policed
     // heartbeat. A wider window reduces needless reconnect churn on transient stalls.
@@ -210,8 +211,11 @@ impl QuoteCollector {
             info!(tokens = asset_ids.len(), "Subscribing to orderbook updates");
 
             // Create WebSocket client and subscribe
-            let client = ClobWsClient::new(POLYMARKET_CLOB_WS_ENDPOINT, quote_collector_ws_config())
-                .expect("collector WebSocket config should be valid");
+            let client = ClobWsClient::new(
+                POLYMARKET_CLOB_WS_ENDPOINT,
+                collector_market_data_ws_config(),
+            )
+            .expect("collector WebSocket config should be valid");
             let stream = match client.subscribe_orderbook(asset_ids) {
                 Ok(s) => s,
                 Err(e) => {
@@ -588,7 +592,11 @@ impl QuoteCollector {
 
             info!(symbols = ?symbols_chainlink, "Starting Chainlink price feed");
 
-            let client = RtdsClient::default();
+            let client = RtdsClient::new(
+                POLYMARKET_RTDS_WS_ENDPOINT,
+                collector_market_data_ws_config(),
+            )
+            .expect("collector RTDS WebSocket config should be valid");
             let stream = match client.subscribe_chainlink_prices(None) {
                 Ok(s) => s,
                 Err(e) => {
@@ -913,9 +921,9 @@ fn hex_to_decimal_string(hex: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        OrderBookLevel, TokenMetadata, best_tradeable_ask, best_tradeable_bid, book_timestamp,
-        hex_to_decimal_string, normalize_token_id, quote_collector_ws_config,
-        serialize_orderbook_levels, snapshot_context,
+        best_tradeable_ask, best_tradeable_bid, book_timestamp, collector_market_data_ws_config,
+        hex_to_decimal_string, normalize_token_id, serialize_orderbook_levels, snapshot_context,
+        OrderBookLevel, TokenMetadata,
     };
     use chrono::{TimeZone, Utc};
     use rust_decimal_macros::dec;
@@ -1002,8 +1010,8 @@ mod tests {
     }
 
     #[test]
-    fn quote_collector_uses_relaxed_ws_heartbeat_settings() {
-        let config = quote_collector_ws_config();
+    fn collector_market_data_uses_relaxed_ws_heartbeat_settings() {
+        let config = collector_market_data_ws_config();
         assert_eq!(config.heartbeat_interval, Duration::from_secs(15));
         assert_eq!(config.heartbeat_timeout, Duration::from_secs(45));
         assert!(config.reconnect.max_attempts.is_none());

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7351,3 +7351,30 @@ fully applied on-host.
 - 2026-04-08: Host verification after deploy: `ploy-strategy-directional-dryrun` and `ploy-quote-collector` are active, required systemd guardrails are present, no `cargo`/`rustc` build remains on-host, and recent `clob_orderbook_snapshots` / `clob_quote_ticks` rows continue to grow.
 - 2026-04-08: Residual runtime risk remains in `ploy-quote-collector`: the service keeps ingesting data, but recent journals still show repeated WebSocket heartbeat timeouts and `ResetWithoutClosingHandshake` reconnect churn.
 - 2026-04-08: After relaxing the collector heartbeat window, the dominant failure mode shifted from heartbeat timeout to `Subscription lagged, missed N messages`, which points at the SDK broadcast buffer saturating under orderbook bursts while the collector is busy persisting each update.
+
+# Collector RTDS Heartbeat Follow-up (2026-04-09)
+
+## Goal
+Eliminate the last residual WebSocket heartbeat timeout in `ploy-quote-collector`
+by fixing the remaining RTDS client that still uses the SDK's default `5s/15s`
+heartbeat window.
+
+## File ownership
+
+- `apps/ploy-runner/src/collector.rs`
+  - owner: align Chainlink RTDS client heartbeat config with the collector's relaxed market-data settings
+- `tasks/todo.md`
+  - owner: track the root-cause confirmation and verification notes for the residual warning
+
+## Tasks
+
+- [x] Confirm the residual `Heartbeat timeout: no PONG received within 15s` cannot come from the main orderbook stream.
+- [x] Reuse the relaxed market-data WS config for the Chainlink RTDS client.
+- [x] Add focused regression coverage for the shared collector market-data WS config.
+- [ ] Re-run targeted runner validation and redeploy `tango-1-1`.
+
+## Progress notes
+
+- 2026-04-09: The only residual warning seen on host for collector PID `711917` was `Heartbeat timeout: no PONG received within 15s`. That cannot come from the main orderbook stream anymore because the collector CLOB client already uses a `45s` heartbeat timeout; it points at the remaining `RtdsClient::default()` Chainlink feed path, which still uses SDK defaults (`5s` interval / `15s` timeout).
+- 2026-04-09: `spawn_settlement_collector()` is HTTP polling, not WebSocket, so it is not part of the residual heartbeat problem.
+- 2026-04-09: Local validation passed with `CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo check -p ploy-runner --bin ploy-runner` and `CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo test -p ploy-runner collector_market_data_uses_relaxed_ws_heartbeat_settings`.


### PR DESCRIPTION
## Summary
- reuse the collector market-data WebSocket config for the Chainlink RTDS client
- keep the relaxed 15s/45s heartbeat policy consistent across both collector WS feeds
- record the residual-heartbeat root cause and validation in tasks/todo.md

## Testing
- CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo check -p ploy-runner --bin ploy-runner
- CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo test -p ploy-runner collector_market_data_uses_relaxed_ws_heartbeat_settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal WebSocket configuration management for improved system initialization.
  * Updated endpoint routing and standardized configuration helper functions.

* **Documentation**
  * Updated task tracking with investigation notes on WebSocket heartbeat timeout resolution and planned validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->