### PR TITLE
fix(feeds): relax dry-run rtds heartbeats

### DIFF
--- a/apps/ploy-runner/src/feeds.rs
+++ b/apps/ploy-runner/src/feeds.rs
@@ -5,12 +5,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration as StdDuration;
 
 use chrono::{DateTime, Timelike, Utc};
 use futures::StreamExt;
 use ploy_strategy_bundles::MarketUpdate;
 use polymarket_client_sdk::rtds::{Client as RtdsClient, EquityPriceMessage};
 use polymarket_client_sdk::types::U256;
+use polymarket_client_sdk::ws::config::{Config as PolymarketWsConfig, ReconnectConfig};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
@@ -18,10 +20,22 @@ use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, error, info, warn};
 
 use crate::reference_prices::{
-    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
-    ReferencePriceSource, infer_pyth_asset_class, market_symbol_to_binance_symbol,
-    normalize_reference_symbol, pyth_symbol, upsert_reference_price,
+    infer_pyth_asset_class, market_symbol_to_binance_symbol, normalize_reference_symbol,
+    pyth_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
+    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
 };
+
+const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
+
+fn rtds_market_data_ws_config() -> PolymarketWsConfig {
+    let mut config = PolymarketWsConfig::default();
+    // These feeds only need resilient market-data delivery. A wider heartbeat
+    // window avoids unnecessary reconnect churn on transient stalls.
+    config.heartbeat_interval = StdDuration::from_secs(15);
+    config.heartbeat_timeout = StdDuration::from_secs(45);
+    config.reconnect = ReconnectConfig::default();
+    config
+}
 
 /// Spawn a task that subscribes to Binance spot prices via RTDS WebSocket
 /// and publishes `MarketUpdate::SpotPrice` events in real-time.
@@ -46,8 +60,8 @@ pub fn spawn_spot_feed(
             "Starting RTDS WebSocket spot price feed"
         );
 
-        // Create RTDS client with default config (wss://ws-live-data.polymarket.com)
-        let client = RtdsClient::default();
+        let client = RtdsClient::new(POLYMARKET_RTDS_WS_ENDPOINT, rtds_market_data_ws_config())
+            .expect("RTDS market-data config should be valid");
 
         // Subscribe to crypto prices (Binance feed)
         let stream = match client.subscribe_crypto_prices(Some(symbols_upper.clone())) {
@@ -335,8 +349,8 @@ pub fn spawn_chainlink_feed(
             "Starting RTDS Chainlink price feed"
         );
 
-        // Create RTDS client
-        let client = RtdsClient::default();
+        let client = RtdsClient::new(POLYMARKET_RTDS_WS_ENDPOINT, rtds_market_data_ws_config())
+            .expect("RTDS market-data config should be valid");
 
         // Subscribe to all Chainlink symbols (None = all, Some(vec) = specific)
         // For now subscribe to all since we only have 7 symbols
@@ -464,7 +478,9 @@ pub fn spawn_pyth_reference_feed(
             join_set.spawn(async move {
                 let normalized_symbol = pyth_symbol(&subscribe_symbol);
                 let asset_class = infer_pyth_asset_class(&subscribe_symbol);
-                let client = RtdsClient::default();
+                let client =
+                    RtdsClient::new(POLYMARKET_RTDS_WS_ENDPOINT, rtds_market_data_ws_config())
+                        .expect("RTDS market-data config should be valid");
                 let stream =
                     match client.subscribe_equity_prices(Some(subscribe_symbol.clone()), true) {
                         Ok(stream) => stream,
@@ -713,5 +729,19 @@ fn reference_price_update(snapshot: &ReferencePriceSnapshot) -> MarketUpdate {
         full_accuracy_value: snapshot.full_accuracy_value.clone(),
         is_carried_forward: snapshot.is_carried_forward,
         ts: snapshot.source_timestamp,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rtds_market_data_ws_config;
+    use std::time::Duration;
+
+    #[test]
+    fn dry_run_rtds_market_data_uses_relaxed_ws_heartbeat_settings() {
+        let config = rtds_market_data_ws_config();
+        assert_eq!(config.heartbeat_interval, Duration::from_secs(15));
+        assert_eq!(config.heartbeat_timeout, Duration::from_secs(45));
+        assert!(config.reconnect.max_attempts.is_none());
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7378,3 +7378,32 @@ heartbeat window.
 - 2026-04-09: The only residual warning seen on host for collector PID `711917` was `Heartbeat timeout: no PONG received within 15s`. That cannot come from the main orderbook stream anymore because the collector CLOB client already uses a `45s` heartbeat timeout; it points at the remaining `RtdsClient::default()` Chainlink feed path, which still uses SDK defaults (`5s` interval / `15s` timeout).
 - 2026-04-09: `spawn_settlement_collector()` is HTTP polling, not WebSocket, so it is not part of the residual heartbeat problem.
 - 2026-04-09: Local validation passed with `CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo check -p ploy-runner --bin ploy-runner` and `CARGO_TARGET_DIR=/tmp/ploy-rtds-heartbeat rtk cargo test -p ploy-runner collector_market_data_uses_relaxed_ws_heartbeat_settings`.
+
+# Dry-Run RTDS Heartbeat Follow-up (2026-04-09)
+
+## Goal
+Eliminate the remaining `Heartbeat timeout: no PONG received within 15s` and
+related RTDS reconnect churn in the dry-run feed path by removing all uses of
+`RtdsClient::default()` from `apps/ploy-runner/src/feeds.rs`.
+
+## File ownership
+
+- `apps/ploy-runner/src/feeds.rs`
+  - owner: shared RTDS market-data WebSocket config for dry-run spot, Chainlink, and Pyth feeds
+- `tasks/todo.md`
+  - owner: root-cause notes and validation for the dry-run feed fix
+
+## Tasks
+
+- [x] Confirm which dry-run feeds still use the SDK default `5s/15s` RTDS heartbeat config.
+- [x] Add a shared relaxed RTDS market-data config in `feeds.rs`.
+- [x] Switch dry-run RTDS spot, Chainlink, and Pyth feeds to the shared config.
+- [x] Add focused regression coverage for the shared dry-run RTDS config.
+- [ ] Re-run targeted validation and redeploy `tango-1-1`.
+
+## Progress notes
+
+- 2026-04-09: `apps/ploy-runner/src/feeds.rs` still constructs three RTDS clients with `RtdsClient::default()`: `spawn_spot_feed()` for `crypto_prices`, `spawn_chainlink_feed()` for `chainlink_prices`, and `spawn_pyth_reference_feed()` for `equity_prices`.
+- 2026-04-09: Dry-run host PID `725622` still logged `Heartbeat timeout: no PONG received within 15s` plus `ResetWithoutClosingHandshake`, which matches the SDK default RTDS heartbeat policy and explains why the collector-only fix did not clean up the strategy service.
+- 2026-04-09: Added a shared `rtds_market_data_ws_config()` helper in `feeds.rs` and switched all three dry-run RTDS clients to `RtdsClient::new(..., rtds_market_data_ws_config())`, so the strategy service no longer uses the SDK default `5s/15s` heartbeat window on any market-data RTDS feed.
+- 2026-04-09: Local validation passed with `CARGO_TARGET_DIR=/tmp/ploy-dryrun-rtds rtk cargo test -p ploy-runner dry_run_rtds_market_data_uses_relaxed_ws_heartbeat_settings` and `CARGO_TARGET_DIR=/tmp/ploy-dryrun-rtds rtk cargo check -p ploy-runner --bin ploy-runner`.


### PR DESCRIPTION
## Summary
- add a shared relaxed RTDS market-data WebSocket config in feeds.rs
- stop using RtdsClient::default() for dry-run spot, Chainlink, and Pyth feeds
- document the dry-run RTDS heartbeat root cause and validation in tasks/todo.md

## Testing
- CARGO_TARGET_DIR=/tmp/ploy-dryrun-rtds rtk cargo test -p ploy-runner dry_run_rtds_market_data_uses_relaxed_ws_heartbeat_settings
- CARGO_TARGET_DIR=/tmp/ploy-dryrun-rtds rtk cargo check -p ploy-runner --bin ploy-runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced WebSocket configuration for market data feeds with explicit heartbeat settings (15-second intervals, 45-second timeouts) to improve connection stability and reliability.

* **Tests**
  * Added validation tests for heartbeat configuration settings across market data feed connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->