### PR TITLE
feat(research): P&L simulation in factor research

### DIFF
--- a/crates/ploy-research/examples/factor_research.rs
+++ b/crates/ploy-research/examples/factor_research.rs
@@ -271,6 +271,7 @@ async fn main() {
     );
 
     let mut all_metrics = Vec::new();
+    let mut all_observations = Vec::new();
     let mut total_observations = 0usize;
     let mut total_event_rows = 0usize;
 
@@ -311,6 +312,7 @@ async fn main() {
 
         total_observations += observations.len();
         total_event_rows += event_rows.len();
+        all_observations.push(observations);
         all_metrics.push(metrics);
     }
 
@@ -318,6 +320,93 @@ async fn main() {
 
     eprintln!("\nobservation_rows={}", total_observations);
     eprintln!("event_rows={}", total_event_rows);
+
+    // === Simple P&L Simulation ===
+    // For each event, simulate a trade at the last observation before settlement.
+    // Entry: buy UP if model_prob_up > pm_up_ask + fee, buy DOWN if (1-model_prob_up) > pm_down_ask + fee
+    // Exit: hold to settlement ($1 win, $0 loss)
+    let mut total_trades = 0u32;
+    let mut wins = 0u32;
+    let mut total_pnl = 0.0f64;
+    let mut total_stake = 0.0f64;
+    let stake_per_trade = 25.0; // $25 per trade
+
+    for observations in &all_observations {
+        // Group by event_id, take last observation per event
+        let mut last_obs: std::collections::HashMap<&str, &ploy_research::FactorObservation> =
+            std::collections::HashMap::new();
+        for obs in observations.iter() {
+            let entry = last_obs.entry(obs.event_id.as_str()).or_insert(obs);
+            if obs.tick_ts > entry.tick_ts {
+                *entry = obs;
+            }
+        }
+
+        for obs in last_obs.values() {
+            if !obs.pm_up_ask.is_finite() || !obs.model_prob_up.is_finite() {
+                continue;
+            }
+            let fee_up = 0.02 * obs.pm_up_ask * (1.0 - obs.pm_up_ask);
+            let fee_down = if obs.pm_down_ask.is_finite() {
+                0.02 * obs.pm_down_ask * (1.0 - obs.pm_down_ask)
+            } else {
+                continue;
+            };
+
+            let edge_up = obs.model_prob_up - obs.pm_up_ask - fee_up;
+            let edge_down = (1.0 - obs.model_prob_up) - obs.pm_down_ask - fee_down;
+
+            // Pick the side with more edge, if any exceeds min_edge
+            let min_edge = 0.02;
+            let (took_trade, won) = if edge_up >= min_edge && edge_up >= edge_down {
+                // Buy UP
+                let pnl = if obs.settlement_up == 1.0 {
+                    stake_per_trade * (1.0 / obs.pm_up_ask - 1.0) - stake_per_trade * fee_up / obs.pm_up_ask
+                } else {
+                    -stake_per_trade - stake_per_trade * fee_up / obs.pm_up_ask
+                };
+                total_pnl += pnl;
+                total_stake += stake_per_trade;
+                (true, obs.settlement_up == 1.0)
+            } else if edge_down >= min_edge {
+                // Buy DOWN
+                let pnl = if obs.settlement_up == 0.0 {
+                    stake_per_trade * (1.0 / obs.pm_down_ask - 1.0) - stake_per_trade * fee_down / obs.pm_down_ask
+                } else {
+                    -stake_per_trade - stake_per_trade * fee_down / obs.pm_down_ask
+                };
+                total_pnl += pnl;
+                total_stake += stake_per_trade;
+                (true, obs.settlement_up == 0.0)
+            } else {
+                (false, false)
+            };
+
+            if took_trade {
+                total_trades += 1;
+                if won {
+                    wins += 1;
+                }
+            }
+        }
+    }
+
+    let win_rate = if total_trades > 0 {
+        wins as f64 / total_trades as f64 * 100.0
+    } else {
+        0.0
+    };
+    let roi = if total_stake > 0.0 {
+        total_pnl / total_stake * 100.0
+    } else {
+        0.0
+    };
+
+    eprintln!("\n=== P&L Simulation (last-tick entry, min_edge=2%) ===");
+    eprintln!(
+        "trades={} wins={} win_rate={:.1}% pnl=${:.2} stake=${:.0} roi={:.2}%",
+        total_trades, wins, win_rate, total_pnl, total_stake, roi
+    );
 
     let mut settlement_metrics: Vec<_> = aggregated
         .iter()

--- a/crates/ploy-research/examples/factor_research.rs
+++ b/crates/ploy-research/examples/factor_research.rs
@@ -6,6 +6,7 @@ use ploy_research::{
 use ploy_strategy_bundles::feed::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_strategy_bundles::traits::MarketUpdate;
 use sqlx::postgres::PgPoolOptions;
+use std::time::Duration;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 struct ValidWindowRow {
@@ -184,7 +185,8 @@ async fn main() {
     eprintln!("loading factor research range {start} -> {end} for {:?}", symbols);
 
     let pool = PgPoolOptions::new()
-        .max_connections(3)
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(120))
         .connect(&db_url)
         .await
         .expect("database connection failed");

--- a/scripts/refresh_research_valid_windows.sh
+++ b/scripts/refresh_research_valid_windows.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create or refresh the research_valid_windows materialized view on a remote host.
+#
+# Usage:
+#   ./scripts/refresh_research_valid_windows.sh
+#   PLOY_RESEARCH_HOST=tango-1-1 ./scripts/refresh_research_valid_windows.sh
+#
+# Behavior:
+# - Ensures migration 036 SQL is applied (idempotent CREATE MATERIALIZED VIEW IF NOT EXISTS)
+# - Refreshes the matview if it already exists
+#
+# Notes:
+# - Runs entirely on the remote host against localhost PostgreSQL
+# - Does not build Rust on the host
+
+HOST="${PLOY_RESEARCH_HOST:-tango-1-1}"
+MIGRATION_PATH="${PLOY_RESEARCH_MIGRATION_PATH:-/opt/ploy/migrations/036_research_valid_windows_matview.sql}"
+
+ssh "${HOST}" 'bash -s' <<'REMOTE'
+set -euo pipefail
+
+if [[ -f /opt/ploy/.env ]]; then
+  # shellcheck disable=SC1091
+  source /opt/ploy/.env >/dev/null 2>&1 || true
+fi
+
+DB_URL="${PLOY_RESEARCH_DB_URL:-${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/ploy}}"
+MIGRATION_PATH="${PLOY_RESEARCH_MIGRATION_PATH:-/opt/ploy/migrations/036_research_valid_windows_matview.sql}"
+
+if [[ ! -f "${MIGRATION_PATH}" ]]; then
+  echo "missing migration: ${MIGRATION_PATH}" >&2
+  exit 2
+fi
+
+echo "applying ${MIGRATION_PATH}"
+psql "${DB_URL}" -v ON_ERROR_STOP=1 -f "${MIGRATION_PATH}"
+
+echo "refreshing research_valid_windows"
+psql "${DB_URL}" -v ON_ERROR_STOP=1 <<'SQL'
+REFRESH MATERIALIZED VIEW CONCURRENTLY research_valid_windows;
+SQL
+
+echo "done"
+REMOTE

--- a/scripts/run_factor_research.sh
+++ b/scripts/run_factor_research.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 #   ./scripts/run_factor_research.sh \
 #     --start-date 2026-04-01 --end-date 2026-04-13 \
 #     --symbols BTCUSDT,ETHUSDT --max-windows 20
+#   # Optional first step when the materialized view exists:
+#   ./scripts/refresh_research_valid_windows.sh
 #
 # The binary connects to localhost:5432 on the remote host (no SSH tunnel needed).
 # stderr streams back in real time. Pipe through `tee` to save locally:
@@ -21,6 +23,6 @@ exec ssh "${HOST}" systemd-run --scope --quiet \
   -p MemoryMax=768M \
   -p MemoryHigh=512M \
   "${BINARY}" \
-  --db-url "'${DB_URL}'" \
+  --db-url "${DB_URL}" \
   --discover-valid-5m-windows \
   "$@"

--- a/scripts/run_factor_research_matrix.sh
+++ b/scripts/run_factor_research_matrix.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run factor research sequentially across multiple symbols on the remote host.
+# This avoids overloading PostgreSQL with concurrent research jobs.
+#
+# Usage:
+#   ./scripts/run_factor_research_matrix.sh \
+#     --symbols ETHUSDT,SOLUSDT,XRPUSDT,BNBUSDT,DOGEUSDT \
+#     --start-date 2026-04-09 \
+#     --end-date 2026-04-11 \
+#     --max-windows 12 \
+#     --lob-sample-secs 5
+#
+# Results are written to ./tmp/factor-research/<symbol>.log by default.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${PLOY_RESEARCH_OUTPUT_DIR:-${ROOT_DIR}/tmp/factor-research}"
+DEFAULT_SYMBOLS="ETHUSDT,SOLUSDT,XRPUSDT,BNBUSDT,DOGEUSDT"
+
+mkdir -p "${OUTPUT_DIR}"
+
+symbols_csv="${DEFAULT_SYMBOLS}"
+args=()
+
+while (($#)); do
+  case "$1" in
+    --symbols)
+      shift
+      symbols_csv="${1:?missing value for --symbols}"
+      ;;
+    *)
+      args+=("$1")
+      ;;
+  esac
+  shift || true
+done
+
+IFS=',' read -r -a symbols <<< "${symbols_csv}"
+
+for sym in "${symbols[@]}"; do
+  sym="$(echo "${sym}" | xargs)"
+  [[ -z "${sym}" ]] && continue
+
+  log_file="${OUTPUT_DIR}/${sym}.log"
+  echo "=== ${sym} ==="
+  "${ROOT_DIR}/scripts/run_factor_research.sh" \
+    --symbols "${sym}" \
+    "${args[@]}" \
+    2>&1 | tee "${log_file}"
+  echo
+done


### PR DESCRIPTION
## Summary
- Add simple P&L simulation to factor_research example
- For each event, simulates entry at last observation if model edge > 2%
- Reports trades, win rate, P&L, ROI

## Test plan
- [x] cargo test -p ploy-research passes
- [ ] Deploy and run on tango-1-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added P&L simulation to factor research analysis, calculating trades and ROI metrics based on model probabilities and market prices.
  * New scripts for research workflow: refresh database views and execute analysis across multiple trading symbols sequentially.

* **Chores**
  * Updated database connection configuration and parameter formatting in research scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->