### PR TITLE
ci: three-tier deploy — add deploy-trade workflow, move backtest to ploy-ci-1

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -34,10 +34,12 @@ env:
 
 jobs:
   backtest:
-    name: Run backtest on tango-1-1
-    runs-on: [self-hosted, tango-1-1]
+    # NOTE: ploy-ci-1 is an on-demand instance. Start it manually before
+    # triggering this workflow. The self-hosted runner must be online.
+    name: Run backtest on ploy-ci-1
+    runs-on: [self-hosted, ploy-ci-1]
     timeout-minutes: 30
-    environment: tango-1-1
+    environment: ploy-ci-1
 
     steps:
       - name: Checkout code
@@ -59,6 +61,6 @@ jobs:
         run: |
           ./target/release/examples/run_backtest \
             --config "${CONFIG}" \
-            --db-url "postgresql://postgres:postgres@localhost:5432/ploy" \
+            --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --start-date "${START_DATE}" \
             --end-date "${END_DATE}"

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -1,0 +1,134 @@
+name: Deploy to ploy-trade-1
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to deploy (branch, tag, or SHA)"
+        required: true
+        default: "main"
+
+concurrency:
+  group: deploy-trade-1
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  PLATFORM_TARGET: x86_64-unknown-linux-gnu
+  DEPLOY_HOST: ploy-trade-1
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy to ploy-trade-1
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.PLATFORM_TARGET }}
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-trade-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-trade-
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
+
+      - name: Build new-ploy-runner
+        run: |
+          cargo build --release --locked \
+            --target "${PLATFORM_TARGET}" \
+            -p new-ploy-runner
+          strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.PLOY_TRADE_1_SSH_KEY }}' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          cat > ~/.ssh/config <<EOF
+          Host ploy-trade-1
+            HostName ${{ secrets.PLOY_TRADE_1_HOST }}
+            User root
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Deploy binary and configs
+        run: |
+          scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" ploy-trade-1:/opt/ploy/bin/ploy-runner
+          scp config/strategies/02-pm5d.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
+          scp config/strategies/02-pm5d.live.toml ploy-trade-1:/opt/ploy/config/strategies/
+          scp config/strategies/02-pm5d-threelayer.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
+
+          ssh ploy-trade-1 bash <<'REMOTE'
+            set -euo pipefail
+            chmod +x /opt/ploy/bin/ploy-runner
+
+            systemctl daemon-reload
+
+            if systemctl is-active --quiet ployd.service; then
+              systemctl restart ployd.service
+            fi
+            if systemctl is-active --quiet ploy-strategy-dryrun.service; then
+              systemctl restart ploy-strategy-dryrun.service
+            fi
+
+            sleep 5
+
+            # Verify services came back up
+            if systemctl is-enabled --quiet ployd.service; then
+              systemctl is-active --quiet ployd.service
+              echo "ployd.service: active"
+            fi
+            if systemctl is-enabled --quiet ploy-strategy-dryrun.service; then
+              systemctl is-active --quiet ploy-strategy-dryrun.service
+              echo "ploy-strategy-dryrun.service: active"
+            fi
+          REMOTE
+
+      - name: Verify deployment
+        run: |
+          ssh ploy-trade-1 bash <<'VERIFY'
+            echo "=== Binary ==="
+            ls -la /opt/ploy/bin/ploy-runner
+            /opt/ploy/bin/ploy-runner --version || true
+
+            echo "=== Strategy configs ==="
+            ls -la /opt/ploy/config/strategies/02-pm5d*.toml
+
+            echo "=== Services ==="
+            systemctl list-units 'ploy-*' --no-pager || true
+          VERIFY
+
+      - name: Deployment summary
+        run: |
+          echo "## Deployment to ploy-trade-1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Binary: \`ploy-runner\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: \`ploy-trade-1\` (\`${{ secrets.PLOY_TRADE_1_HOST }}\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Strategy configs: \`02-pm5d.unified.toml\`, \`02-pm5d.live.toml\`, \`02-pm5d-threelayer.unified.toml\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Services restarted: \`ployd\`, \`ploy-strategy-dryrun\` (if active)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- New `deploy-trade.yml` workflow: builds on GitHub hosted runner, deploys ploy-runner + configs to ploy-trade-1 via SSH
- Modified `backtest.yml`: runs on `[self-hosted, ploy-ci-1]` with remote DB connection to tango-1-1

## Secrets configured
- `PLOY_TRADE_1_SSH_KEY` ✓
- `PLOY_TRADE_1_HOST` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations for testing and deployment infrastructure.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->