### PR TITLE
Run tango collectors from deployed opt tree

### DIFF
--- a/deployment/systemd/ploy-binance-aggtrade-collector.service
+++ b/deployment/systemd/ploy-binance-aggtrade-collector.service
@@ -5,13 +5,13 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/root/ploy
+WorkingDirectory=/opt/ploy
 Environment=BINANCE_AGGTRADE_SYMBOLS=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT
 Environment=BINANCE_AGGTRADE_COMMIT_BATCH_SIZE=50
 Environment=BINANCE_AGGTRADE_COMMIT_INTERVAL_SECS=1.0
 Environment=BINANCE_AGGTRADE_REPORT_INTERVAL_SECS=60
 Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
-ExecStart=/usr/bin/python3 /root/ploy/scripts/binance_aggtrade_collector.py
+ExecStart=/usr/bin/python3 /opt/ploy/scripts/binance_aggtrade_collector.py
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/deployment/systemd/ploy-binance-lob-collector.service
+++ b/deployment/systemd/ploy-binance-lob-collector.service
@@ -5,14 +5,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/root/ploy
+WorkingDirectory=/opt/ploy
 Environment=BINANCE_LOB_SYMBOLS=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT
 Environment=BINANCE_LOB_LEVELS=20
 Environment=BINANCE_LOB_COMMIT_BATCH_SIZE=25
 Environment=BINANCE_LOB_COMMIT_INTERVAL_SECS=1.0
 Environment=BINANCE_LOB_REPORT_INTERVAL_SECS=60
 Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
-ExecStart=/usr/bin/python3 /root/ploy/scripts/binance_lob_collector.py
+ExecStart=/usr/bin/python3 /opt/ploy/scripts/binance_lob_collector.py
 Restart=always
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary

Point the tango Binance collector systemd units at `/opt/ploy/scripts`, matching the scripts installed by the deploy bundle.

## Why

The deploy workflow installs collector scripts into `/opt/ploy/scripts`, but the units still executed `/root/ploy/scripts`. That means the services can remain healthy while not actually using the freshly deployed artifacts.

## Verification

- `git diff --check`
