### PR TITLE
Restart core collectors during tango deploy

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -318,7 +318,9 @@ jobs:
             require_postgres
 
             systemctl enable --now ploy-binance-aggtrade-collector.service
+            systemctl restart ploy-binance-aggtrade-collector.service
             systemctl enable --now ploy-binance-lob-collector.service
+            systemctl restart ploy-binance-lob-collector.service
             if service_exists ploy-binance-price-collector.service; then
               systemctl restart ploy-binance-price-collector.service
             fi


### PR DESCRIPTION
## Summary

Restart the core Binance aggtrade and LOB collector units during the tango deployment workflow after installing the bundle.

## Why

`systemctl enable --now` does not restart already-running units. Without an explicit restart, the unit file can point at `/opt/ploy/scripts` while the existing process still runs an older script path.

## Verification

- Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`
- `git diff --check`
