### PR TITLE
Fix live safety review findings

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -94,6 +94,7 @@ pub enum CancellationOutcome {
 pub enum ReplaceOutcome {
     Replaced { venue_order_id: String },
     Rejected { reason: String },
+    PartialFailure { reason: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -594,7 +595,7 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
             ExecutionOutcome::Acknowledged { venue_order_id } => {
                 Ok(ReplaceOutcome::Replaced { venue_order_id })
             }
-            ExecutionOutcome::Rejected { reason } => Ok(ReplaceOutcome::Rejected { reason }),
+            ExecutionOutcome::Rejected { reason } => Ok(ReplaceOutcome::PartialFailure { reason }),
         }
     }
 }
@@ -745,11 +746,12 @@ fn normalize_execution_amount(
 
 fn tracked_trade_fill(tracked_order: &TrackedOrder, trade: &TradeResponse) -> Option<FillRecord> {
     if trade.taker_order_id == tracked_order.venue_order_id {
+        let side = trade_side(trade.side.clone())?;
         return Some(FillRecord {
             fill_id: tracked_fill_id(tracked_order, &trade.id),
             order_id: tracked_order.order_id.clone(),
             token_id: tracked_order.token_id.clone(),
-            side: trade_side(trade.side.clone()),
+            side,
             quantity: trade.size,
             price: trade.price,
             fee: fee_from_bps(trade.size, trade.price, trade.fee_rate_bps),
@@ -761,19 +763,20 @@ fn tracked_trade_fill(tracked_order: &TrackedOrder, trade: &TradeResponse) -> Op
         .maker_orders
         .iter()
         .find(|maker_order| maker_order.order_id == tracked_order.venue_order_id)
-        .map(|maker_order| tracked_maker_fill(tracked_order, trade, maker_order))
+        .and_then(|maker_order| tracked_maker_fill(tracked_order, trade, maker_order))
 }
 
 fn tracked_maker_fill(
     tracked_order: &TrackedOrder,
     trade: &TradeResponse,
     maker_order: &MakerOrder,
-) -> FillRecord {
-    FillRecord {
+) -> Option<FillRecord> {
+    let side = trade_side(maker_order.side.clone())?;
+    Some(FillRecord {
         fill_id: tracked_fill_id(tracked_order, &trade.id),
         order_id: tracked_order.order_id.clone(),
         token_id: tracked_order.token_id.clone(),
-        side: trade_side(maker_order.side.clone()),
+        side,
         quantity: maker_order.matched_amount,
         price: maker_order.price,
         fee: fee_from_bps(
@@ -782,18 +785,18 @@ fn tracked_maker_fill(
             maker_order.fee_rate_bps,
         ),
         timestamp: trade.match_time,
-    }
+    })
 }
 
 fn tracked_fill_id(tracked_order: &TrackedOrder, trade_id: &str) -> String {
     format!("{trade_id}:{}", tracked_order.order_id)
 }
 
-fn trade_side(side: Side) -> TradeSide {
+fn trade_side(side: Side) -> Option<TradeSide> {
     match side {
-        Side::Buy => TradeSide::Buy,
-        Side::Sell => TradeSide::Sell,
-        _ => TradeSide::Buy,
+        Side::Buy => Some(TradeSide::Buy),
+        Side::Sell => Some(TradeSide::Sell),
+        _ => None,
     }
 }
 
@@ -808,12 +811,12 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        execution_price_override, normalize_aggressive_price, normalize_execution_amount,
-        normalize_order_notional, normalize_order_quantity, polymarket_signature_type_from_env,
-        tracked_trade_fill, unique_token_ids, CancellationOutcome, CancellationRequest,
-        ExecutionError, ExecutionOutcome, ExecutionRequest, LiveExecutionGateway,
-        OrderExecutionType, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
-        ReplaceRequest, StaticExecutionGateway, TrackedOrder, WalletSignatureType,
+        CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
+        ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
+        PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
+        TrackedOrder, WalletSignatureType, execution_price_override, normalize_aggressive_price,
+        normalize_execution_amount, normalize_order_notional, normalize_order_quantity,
+        polymarket_signature_type_from_env, tracked_trade_fill, trade_side, unique_token_ids,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -914,6 +917,11 @@ mod tests {
         assert_eq!(buy.as_inner(), dec!(15.00));
         assert!(sell.is_shares());
         assert_eq!(sell.as_inner(), dec!(24.46));
+    }
+
+    #[test]
+    fn unknown_venue_trade_side_is_not_mapped_to_buy() {
+        assert_eq!(trade_side(Side::Unknown), None);
     }
 
     #[test]
@@ -1041,20 +1049,22 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000001")
                     .expect("maker address"),
             )
-            .maker_orders(vec![MakerOrder::builder()
-                .order_id("venue-order-b")
-                .owner(ApiKey::nil())
-                .maker_address(
-                    Address::from_str("0x0000000000000000000000000000000000000002")
-                        .expect("second maker address"),
-                )
-                .matched_amount(dec!(2))
-                .price(dec!(0.56))
-                .fee_rate_bps(dec!(4))
-                .asset_id(U256::from(1_u64))
-                .outcome("YES")
-                .side(polymarket_client_sdk::clob::types::Side::Sell)
-                .build()])
+            .maker_orders(vec![
+                MakerOrder::builder()
+                    .order_id("venue-order-b")
+                    .owner(ApiKey::nil())
+                    .maker_address(
+                        Address::from_str("0x0000000000000000000000000000000000000002")
+                            .expect("second maker address"),
+                    )
+                    .matched_amount(dec!(2))
+                    .price(dec!(0.56))
+                    .fee_rate_bps(dec!(4))
+                    .asset_id(U256::from(1_u64))
+                    .outcome("YES")
+                    .side(polymarket_client_sdk::clob::types::Side::Sell)
+                    .build(),
+            ])
             .transaction_hash(B256::ZERO)
             .trader_side(TraderSide::Taker)
             .build();

--- a/crates/ploy-platform-runtime/src/runtime_support.rs
+++ b/crates/ploy-platform-runtime/src/runtime_support.rs
@@ -164,13 +164,28 @@ pub fn restore_trading_runtime(snapshot: TradingStateSnapshot) -> io::Result<Tra
             })
         })
         .collect::<io::Result<Vec<_>>>()?;
+    let positions = snapshot
+        .positions
+        .into_iter()
+        .map(|position| ploy_trading::PositionSnapshot {
+            token_id: position.token_id,
+            net_qty: position.net_qty,
+            avg_entry_price: position.avg_entry_price,
+            realized_pnl: position.realized_pnl,
+        })
+        .collect();
+    let pnl = ploy_trading::PnlSnapshot {
+        realized_pnl: snapshot.pnl.realized_pnl,
+        unrealized_pnl: snapshot.pnl.unrealized_pnl,
+        total_fees: snapshot.pnl.total_fees,
+    };
 
     Ok(TradingRuntime::restore(TradingRuntimeSnapshot {
         intents,
         orders,
         fills,
-        positions: Vec::new(),
-        pnl: Default::default(),
+        positions,
+        pnl,
         risk: Default::default(),
     }))
 }
@@ -334,19 +349,33 @@ where
 mod tests {
     use super::{
         build_order_control_response, live_reconcile_backoff_ms, observed_state_for_desired,
-        order_state_from_wire, order_state_wire, trade_side_from_wire, trade_side_wire,
+        order_state_from_wire, order_state_wire, restore_trading_runtime, trade_side_from_wire,
+        trade_side_wire,
     };
-    use ploy_operator_contracts::{DeploymentState, DesiredState, ObservedState};
+    use ploy_operator_contracts::{
+        DeploymentState, DesiredState, ObservedState, PnlSnapshotResponse,
+        PositionSnapshotResponse, RiskSnapshotResponse, TradingStateSnapshot,
+    };
     use ploy_trading::{OrderRecord, OrderState, TradeSide};
     use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn state_and_side_wire_formats_round_trip() {
         assert_eq!(trade_side_wire(TradeSide::Buy), "buy");
         assert_eq!(trade_side_from_wire("sell").unwrap(), TradeSide::Sell);
-        assert_eq!(order_state_wire(OrderState::PartiallyFilled), "partially_filled");
-        assert_eq!(order_state_from_wire("acknowledged").unwrap(), OrderState::Acknowledged);
-        assert_eq!(observed_state_for_desired(DesiredState::Running), ObservedState::Starting);
+        assert_eq!(
+            order_state_wire(OrderState::PartiallyFilled),
+            "partially_filled"
+        );
+        assert_eq!(
+            order_state_from_wire("acknowledged").unwrap(),
+            OrderState::Acknowledged
+        );
+        assert_eq!(
+            observed_state_for_desired(DesiredState::Running),
+            ObservedState::Starting
+        );
         assert_eq!(DeploymentState::Enabled, DeploymentState::Enabled);
     }
 
@@ -380,5 +409,34 @@ mod tests {
         assert_eq!(response.deployment_id, "dep-1");
         assert_eq!(response.state, "acknowledged");
         assert_eq!(response.venue_order_id.as_deref(), Some("venue-1"));
+    }
+
+    #[test]
+    fn restore_trading_runtime_preserves_persisted_position_exposure() {
+        let runtime = restore_trading_runtime(TradingStateSnapshot {
+            deployment_id: "dep-1".to_string(),
+            runtime_mode: "live".to_string(),
+            positions: vec![PositionSnapshotResponse {
+                token_id: "token-1".to_string(),
+                net_qty: dec!(4),
+                avg_entry_price: dec!(0.25),
+                realized_pnl: dec!(0.5),
+            }],
+            pnl: PnlSnapshotResponse {
+                realized_pnl: dec!(0.5),
+                unrealized_pnl: Decimal::ZERO,
+                total_fees: dec!(0.02),
+                net_pnl: dec!(0.48),
+            },
+            risk: RiskSnapshotResponse::default(),
+            ..TradingStateSnapshot::default()
+        })
+        .expect("restore runtime");
+
+        let restored = runtime.snapshot(&Default::default());
+        assert_eq!(restored.positions.len(), 1);
+        assert_eq!(restored.positions[0].net_qty, dec!(4));
+        assert_eq!(restored.pnl.total_fees, dec!(0.02));
+        assert_eq!(restored.risk.gross_exposure, dec!(1.00));
     }
 }

--- a/crates/ploy-platform-runtime/src/trade_control.rs
+++ b/crates/ploy-platform-runtime/src/trade_control.rs
@@ -125,7 +125,10 @@ pub fn replace_order(
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
-                    format!("intent `{}` for order `{order_id}` was not found", order.intent_id),
+                    format!(
+                        "intent `{}` for order `{order_id}` was not found",
+                        order.intent_id
+                    ),
                 )
             })?;
 
@@ -139,7 +142,12 @@ pub fn replace_order(
         }) {
             Ok(ReplaceOutcome::Replaced { venue_order_id }) => {
                 let updated = runtime
-                    .replace_order(order_id, request.quantity, request.limit_price, venue_order_id)
+                    .replace_order(
+                        order_id,
+                        request.quantity,
+                        request.limit_price,
+                        venue_order_id,
+                    )
                     .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
                 Ok(build_order_control_response(
                     deployment_id.to_string(),
@@ -150,6 +158,12 @@ pub fn replace_order(
                 io::ErrorKind::InvalidInput,
                 format!("live replace rejected: {reason}"),
             )),
+            Ok(ReplaceOutcome::PartialFailure { reason }) => {
+                let message = format!("live replace partially failed after cancel: {reason}");
+                let _ = runtime.cancel_order(order_id);
+                let _ = runtime.record_order_error(order_id, message.clone());
+                Err(io::Error::other(message))
+            }
             Err(err) => {
                 let _ = runtime.record_order_error(order_id, err.to_string());
                 Err(io_error_from_execution_error(err))
@@ -159,7 +173,12 @@ pub fn replace_order(
         let next_revision = order.revision + 1;
         let venue_order_id = format!("paper-{order_id}-r{next_revision}");
         let updated = runtime
-            .replace_order(order_id, request.quantity, request.limit_price, venue_order_id)
+            .replace_order(
+                order_id,
+                request.quantity,
+                request.limit_price,
+                venue_order_id,
+            )
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
         Ok(build_order_control_response(
             deployment_id.to_string(),
@@ -171,10 +190,14 @@ pub fn replace_order(
 #[cfg(test)]
 mod tests {
     use super::{cancel_order, replace_order};
-    use ploy_connectivity::{CancellationOutcome, ExecutionError, StaticExecutionGateway};
-    use ploy_operator_contracts::{DeploymentState, DesiredState, ObservedState, OrderReplaceRequest};
+    use ploy_connectivity::{
+        CancellationOutcome, ExecutionError, ReplaceOutcome, StaticExecutionGateway,
+    };
+    use ploy_operator_contracts::{
+        DeploymentState, DesiredState, ObservedState, OrderReplaceRequest,
+    };
     use ploy_platform::DeploymentRecord;
-    use ploy_trading::{IntentPurpose, TradeSide, TradingIntent, TradingRuntime};
+    use ploy_trading::{IntentPurpose, OrderState, TradeSide, TradingIntent, TradingRuntime};
     use rust_decimal_macros::dec;
     use std::io::ErrorKind;
 
@@ -216,8 +239,14 @@ mod tests {
         let mut runtime = seeded_runtime();
         let gateway = StaticExecutionGateway::acknowledged("venue-1")
             .with_cancel_result(Ok(CancellationOutcome::Canceled));
-        let response = cancel_order(&mut runtime, &gateway, &live_deployment(), "example.live", "order-1")
-            .expect("cancel");
+        let response = cancel_order(
+            &mut runtime,
+            &gateway,
+            &live_deployment(),
+            "example.live",
+            "order-1",
+        )
+        .expect("cancel");
         assert_eq!(response.state, "canceled");
     }
 
@@ -234,7 +263,8 @@ mod tests {
             fee: dec!(0.01),
             timestamp: chrono::Utc::now(),
         });
-        let gateway = StaticExecutionGateway::failed(ExecutionError::Transport("offline".to_string()));
+        let gateway =
+            StaticExecutionGateway::failed(ExecutionError::Transport("offline".to_string()));
         let error = replace_order(
             &mut runtime,
             &gateway,
@@ -249,5 +279,37 @@ mod tests {
         )
         .expect_err("invalid quantity");
         assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn replace_partial_failure_marks_order_canceled_with_error() {
+        let mut runtime = seeded_runtime();
+        let gateway = StaticExecutionGateway::acknowledged("venue-1").with_replace_result(Ok(
+            ReplaceOutcome::PartialFailure {
+                reason: "submit rejected".to_string(),
+            },
+        ));
+
+        let error = replace_order(
+            &mut runtime,
+            &gateway,
+            &live_deployment(),
+            "example.live",
+            "order-1",
+            OrderReplaceRequest {
+                quantity: dec!(2),
+                limit_price: Some(dec!(0.47)),
+            },
+            dec!(2),
+        )
+        .expect_err("partial failure should be surfaced");
+
+        assert_eq!(error.kind(), ErrorKind::Other);
+        let order = runtime.order("order-1").expect("order");
+        assert_eq!(order.state, OrderState::Canceled);
+        assert_eq!(
+            order.last_error.as_deref(),
+            Some("live replace partially failed after cancel: submit rejected")
+        );
     }
 }

--- a/crates/ploy-trading/src/positions.rs
+++ b/crates/ploy-trading/src/positions.rs
@@ -1,7 +1,7 @@
 use crate::fills::FillRecord;
 use crate::pnl::PnlSnapshot;
-use rust_decimal::prelude::Signed;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::Signed;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -20,6 +20,16 @@ pub struct PositionLedger {
 }
 
 impl PositionLedger {
+    pub fn restore(positions: Vec<PositionSnapshot>, total_fees: Decimal) -> Self {
+        Self {
+            positions: positions
+                .into_iter()
+                .map(|position| (position.token_id.clone(), position))
+                .collect(),
+            total_fees,
+        }
+    }
+
     pub fn apply_fill(&mut self, fill: &FillRecord) {
         let signed_qty = fill.quantity * fill.side.sign();
         let position = self

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -3,7 +3,7 @@ use crate::intents::{TradeSide, TradingIntent};
 use crate::orders::OrderLedger;
 use crate::pnl::PnlSnapshot;
 use crate::positions::{PositionLedger, PositionSnapshot};
-use crate::risk::{snapshot_from_state, RiskSnapshot};
+use crate::risk::{RiskSnapshot, snapshot_from_state};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -81,10 +81,15 @@ pub struct TradingRuntime {
 
 impl TradingRuntime {
     pub fn restore(snapshot: TradingRuntimeSnapshot) -> Self {
-        let mut positions = PositionLedger::default();
-        for fill in &snapshot.fills {
-            positions.apply_fill(fill);
-        }
+        let positions = if snapshot.positions.is_empty() {
+            let mut positions = PositionLedger::default();
+            for fill in &snapshot.fills {
+                positions.apply_fill(fill);
+            }
+            positions
+        } else {
+            PositionLedger::restore(snapshot.positions, snapshot.pnl.total_fees)
+        };
 
         Self {
             intents: snapshot.intents,
@@ -210,8 +215,8 @@ impl TradingRuntime {
 mod tests {
     use super::TradingRuntime;
     use crate::{
-        FillRecord, IntentPurpose, OrderRecord, OrderState, TradeSide, TradingIntent,
-        TradingRuntimeSnapshot,
+        FillRecord, IntentPurpose, OrderRecord, OrderState, PnlSnapshot, PositionSnapshot,
+        TradeSide, TradingIntent, TradingRuntimeSnapshot,
     };
     use chrono::Utc;
     use rust_decimal::Decimal;
@@ -272,6 +277,34 @@ mod tests {
     }
 
     #[test]
+    fn restore_preserves_persisted_positions_when_fills_are_absent() {
+        let snapshot = TradingRuntimeSnapshot {
+            positions: vec![PositionSnapshot {
+                token_id: "token-1".to_string(),
+                net_qty: dec!(3),
+                avg_entry_price: dec!(0.42),
+                realized_pnl: dec!(0.7),
+            }],
+            pnl: PnlSnapshot {
+                realized_pnl: dec!(0.7),
+                unrealized_pnl: Decimal::ZERO,
+                total_fees: dec!(0.03),
+            },
+            ..TradingRuntimeSnapshot::default()
+        };
+
+        let runtime = TradingRuntime::restore(snapshot);
+        let restored = runtime.snapshot(&BTreeMap::new());
+
+        assert_eq!(restored.positions.len(), 1);
+        assert_eq!(restored.positions[0].net_qty, dec!(3));
+        assert_eq!(restored.pnl.realized_pnl, dec!(0.7));
+        assert_eq!(restored.pnl.total_fees, dec!(0.03));
+        assert_eq!(restored.risk.open_positions, 1);
+        assert_eq!(restored.risk.gross_exposure, dec!(1.26));
+    }
+
+    #[test]
     fn cashflow_summary_treats_quantity_as_shares_not_dollars() {
         let now = Utc::now();
         let snapshot = TradingRuntimeSnapshot {
@@ -308,10 +341,7 @@ mod tests {
         assert_eq!(summary.deployed_capital(), dec!(10.00));
         assert_eq!(summary.net_pnl(), dec!(14.95));
         assert_eq!(
-            summary
-                .roi_on_deployed_capital()
-                .expect("roi")
-                .round_dp(4),
+            summary.roi_on_deployed_capital().expect("roi").round_dp(4),
             dec!(1.4950)
         );
     }


### PR DESCRIPTION
## Summary
- Skip fills with unknown venue trade sides instead of mapping them to buy
- Preserve persisted positions and fee totals when restoring trading runtime snapshots
- Surface live replace cancel-then-submit failures as partial failures and mark the local order canceled with the error recorded

## Verification
- rtk cargo test -p ploy-connectivity --lib
- rtk cargo test -p ploy-trading --lib
- rtk cargo test -p ploy-platform-runtime --lib

## Notes
- Full workspace cargo fmt --check still reports pre-existing unrelated formatting drift, so this branch used rustfmt only on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trading state persistence now accurately restores positions and profit/loss calculations from saved snapshots, ensuring your trading context is preserved across sessions.

* **Bug Fixes**
  * Enhanced order replacement failure handling with detailed error reporting and corrected order state management.
  * Improved trade side validation to reject unknown sides instead of applying default mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->