### PR TITLE
Fix tango factor research deploy features

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
+            --features db,polars-export \
             -p ploy-research --example factor_research
           strip "target/${PLATFORM_TARGET}/release/examples/factor_research" || true
 


### PR DESCRIPTION
## Summary
- Add explicit `--features db,polars-export` when building the `factor_research` example in the tango deploy workflow

## Why
- #108 made `ploy-research` lean by default
- `factor_research` has `required-features = ["db", "polars-export"]`, so the deploy workflow can no longer rely on default features

## Verification
- Failed deploy run 24766969344 showed the missing feature flags at `Build factor-research`
