### PR TITLE
Add optimize-backtest to deploy pipeline

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -75,12 +75,20 @@ jobs:
             -p ploy-research --example factor_research
           strip "target/${PLATFORM_TARGET}/release/examples/factor_research" || true
 
+      - name: Build optimize-backtest
+        run: |
+          cargo build --release --locked \
+            --target "${PLATFORM_TARGET}" \
+            -p ploy-strategy-bundles --example optimize_backtest
+          strip "target/${PLATFORM_TARGET}/release/examples/optimize_backtest" || true
+
       - name: Build deploy bundle
         run: |
           rm -rf dist
           mkdir -p dist/bin dist/config/strategies dist/migrations dist/deployment/systemd dist/scripts
           cp target/${PLATFORM_TARGET}/release/new-ploy-runner dist/bin/ploy-runner
           cp target/${PLATFORM_TARGET}/release/examples/factor_research dist/bin/factor-research
+          cp target/${PLATFORM_TARGET}/release/examples/optimize_backtest dist/bin/optimize-backtest
           cp config/strategies/02-pm5d.unified.toml dist/config/strategies/02-pm5d.unified.toml
           cp config/strategies/02-pm5d.live.toml dist/config/strategies/02-pm5d.live.toml
           cp config/strategies/02-pm5d-threelayer.unified.toml dist/config/strategies/02-pm5d-threelayer.unified.toml
@@ -283,6 +291,7 @@ jobs:
             # Install artifacts into the live runtime root used by systemd.
             install -m 0755 ./bin/ploy-runner ${DEPLOY_ROOT}/bin/ploy-runner
             install -m 0755 ./bin/factor-research ${DEPLOY_ROOT}/bin/factor-research
+            install -m 0755 ./bin/optimize-backtest ${DEPLOY_ROOT}/bin/optimize-backtest
             install -m 0644 ./config/strategies/02-pm5d.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.unified.toml
             install -m 0644 ./config/strategies/02-pm5d.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.live.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml


### PR DESCRIPTION
Ship the parameter optimization binary to tango-1-1 for re-tuning with corrected settlement logic.