### PR TITLE
Align optimize symbols with dry-run (6 symbols, no HYPE)

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -30,7 +30,7 @@ on:
       symbols:
         description: "Comma-separated symbols to optimize"
         required: false
-        default: "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT"
+        default: "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT"
       data_dir:
         description: "Local Parquet data dir (rsynced from tango)"
         required: false


### PR DESCRIPTION
Remove HYPEUSDT from default optimize symbols to match dry-run config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow dispatch inputs for the optimization process with new parameter names (train_start/train_end, val_start/val_end, trials).
  * Increased optimization job timeout from 60 to 120 minutes for extended processing.
  * Refined optimization workflow build and execution pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->