### PR TITLE
Bound PM5D optimize replay before scaling windows

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -1,4 +1,4 @@
-name: Optimize three_layer params
+name: Optimize three_layer params (tick-preserving)
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ on:
       train_end:
         description: "Train end date (YYYY-MM-DD)"
         required: true
-        default: "2026-04-19"
+        default: "2026-04-15"
       val_start:
         description: "Validation start date (YYYY-MM-DD)"
         required: true
@@ -22,19 +22,55 @@ on:
       val_end:
         description: "Validation end date (YYYY-MM-DD)"
         required: true
-        default: "2026-04-22"
+        default: "2026-04-20"
       trials:
         description: "Number of optimization trials"
         required: true
-        default: "300"
+        default: "5"
       symbols:
         description: "Comma-separated symbols to optimize"
         required: false
-        default: "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT"
+        default: "BTCUSDT,ETHUSDT"
       data_dir:
         description: "Local Parquet data dir (rsynced from tango)"
         required: false
         default: "/tmp/ploy-parquet"
+      max_preflight_rows:
+        description: "Fail before replay when estimated train+val rows exceed this"
+        required: false
+        default: "15000000"
+      max_preflight_bytes:
+        description: "Fail before replay when local Parquet bytes exceed this (supports GiB)"
+        required: false
+        default: "80GiB"
+      max_symbols:
+        description: "Fail before replay when symbol count exceeds this"
+        required: false
+        default: "6"
+      max_days:
+        description: "Fail before replay when train start through validation end exceeds this many days"
+        required: false
+        default: "8"
+      allow_large_window:
+        description: "Override preflight guardrails after bounded smoke/host-health checks"
+        required: false
+        default: "false"
+      preflight_only:
+        description: "Only produce the manifest and exit before replay/optimization"
+        required: false
+        default: "false"
+      max_updates:
+        description: "Optional smoke-only runtime update cap; blank is canonical full replay"
+        required: false
+        default: ""
+      duckdb_memory_limit:
+        description: "DuckDB memory_limit for preflight/replay"
+        required: false
+        default: "6GB"
+      optimize_timeout_minutes:
+        description: "Process timeout for optimize_backtest"
+        required: false
+        default: "90"
 
 concurrency:
   group: optimize-${{ github.ref }}
@@ -132,9 +168,95 @@ jobs:
             root@172.16.0.204:/opt/ploy/data/parquet/ \
             ${{ github.event.inputs.data_dir }}/
 
-      - name: Run optimize
+      - name: Prepare DuckDB spill directory
         run: |
+          DUCKDB_TEMP_DIR="${RUNNER_TEMP:-/tmp}/ploy-optimize-duckdb-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "${DUCKDB_TEMP_DIR}"
+          mkdir -p "${DUCKDB_TEMP_DIR}"
+          echo "PLOY_DUCKDB_TEMP_DIR=${DUCKDB_TEMP_DIR}" >> "${GITHUB_ENV}"
+          echo "PLOY_DUCKDB_MEMORY_LIMIT=${{ github.event.inputs.duckdb_memory_limit }}" >> "${GITHUB_ENV}"
+          echo "DuckDB spill directory: ${DUCKDB_TEMP_DIR}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Preflight Parquet manifest
+        run: |
+          set -euo pipefail
           . /home/runner/.cargo/env
+
+          health_summary() {
+            echo "## Optimize preflight host health" >> "${GITHUB_STEP_SUMMARY}"
+            {
+              echo '```'
+              date -u
+              free -h || true
+              df -h "${{ github.event.inputs.data_dir }}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+              ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          }
+          trap 'status=$?; health_summary; rm -rf "${PLOY_DUCKDB_TEMP_DIR}"; exit ${status}' EXIT
+
+          extra_flags=()
+          if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
+            extra_flags+=(--allow-large-window)
+          fi
+          if [ -n "${{ github.event.inputs.max_updates }}" ]; then
+            extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
+          fi
+
+          ./target/release/examples/optimize_backtest \
+            --preflight-only \
+            --strategy-variant three_layer \
+            --data-dir "${{ github.event.inputs.data_dir }}" \
+            --train-start "${{ github.event.inputs.train_start }}" \
+            --train-end "${{ github.event.inputs.train_end }}" \
+            --val-start "${{ github.event.inputs.val_start }}" \
+            --val-end "${{ github.event.inputs.val_end }}" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --trials "${{ github.event.inputs.trials }}" \
+            --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
+            --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
+            --max-symbols "${{ github.event.inputs.max_symbols }}" \
+            --max-days "${{ github.event.inputs.max_days }}" \
+            --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
+            --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+            "${extra_flags[@]}"
+
+      - name: Run optimize
+        if: ${{ github.event.inputs.preflight_only != 'true' }}
+        run: |
+          set -euo pipefail
+          . /home/runner/.cargo/env
+          rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
+          mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
+
+          health_summary() {
+            echo "## Optimize host health" >> "${GITHUB_STEP_SUMMARY}"
+            {
+              echo '```'
+              date -u
+              free -h || true
+              df -h "${{ github.event.inputs.data_dir }}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+              ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          }
+          cleanup() {
+            status=$?
+            health_summary
+            rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
+            exit "${status}"
+          }
+          trap cleanup EXIT
+
+          extra_flags=()
+          if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
+            extra_flags+=(--allow-large-window)
+          fi
+          if [ -n "${{ github.event.inputs.max_updates }}" ]; then
+            extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
+          fi
+
+          timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
           ./target/release/examples/optimize_backtest \
             --strategy-variant three_layer \
             --data-dir "${{ github.event.inputs.data_dir }}" \
@@ -143,4 +265,11 @@ jobs:
             --val-start "${{ github.event.inputs.val_start }}" \
             --val-end "${{ github.event.inputs.val_end }}" \
             --symbols "${{ github.event.inputs.symbols }}" \
-            --trials "${{ github.event.inputs.trials }}"
+            --trials "${{ github.event.inputs.trials }}" \
+            --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
+            --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
+            --max-symbols "${{ github.event.inputs.max_symbols }}" \
+            --max-days "${{ github.event.inputs.max_days }}" \
+            --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
+            --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+            "${extra_flags[@]}"

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -1,4 +1,7 @@
-//! Hyperparameter optimization for PM5D strategy variants using TPE (Bayesian).
+//! Hyperparameter optimization for PM5D strategy variants.
+//!
+//! Directional/reversal use TPE (Bayesian). The `three_layer` branch currently
+//! uses random sampling and is labeled that way in runtime output.
 //!
 //! Usage (PostgreSQL):
 //!   cargo run --release -p ploy-strategy-bundles --example optimize_backtest -- \
@@ -35,14 +38,14 @@
 //! When using --data-dir without explicit --val-start/--val-end, the last 40%
 //! of the train range is used as validation (train covers first 60%).
 
-use chrono::{NaiveDate, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_feed_loaders::{
     load_from_database_with_options, HistoricalLoadOptions as DbHistoricalLoadOptions,
 };
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
+    DirectionalStrategy, Feed, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
     RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
     StrategyRuntime, ThreeLayerStrategy,
 };
@@ -52,43 +55,192 @@ use sqlx::postgres::PgPoolOptions;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-/// Load data from Parquet files into a Vec<MarketUpdate>.
-/// Uses StreamingParquetFeed (same code path as backtest) to ensure
-/// identical data processing — token ID normalization, event timing, etc.
-#[cfg(feature = "parquet-feed")]
-fn load_from_parquet_vec(
-    data_dir: &str,
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
+}
+
+fn flag_present(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn parse_usize_flag(args: &[String], flag: &str, default: usize) -> usize {
+    flag_value(args, flag)
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_u64_flag(args: &[String], flag: &str, default: u64) -> u64 {
+    flag_value(args, flag)
+        .and_then(|raw| parse_bytes(&raw))
+        .unwrap_or(default)
+}
+
+fn parse_bytes(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let split_at = trimmed
+        .find(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+        .unwrap_or(trimmed.len());
+    let (number, unit) = trimmed.split_at(split_at);
+    let value: f64 = number.parse().ok()?;
+    let multiplier = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1.0,
+        "k" | "kb" | "kib" => 1024.0,
+        "m" | "mb" | "mib" => 1024.0 * 1024.0,
+        "g" | "gb" | "gib" => 1024.0 * 1024.0 * 1024.0,
+        "t" | "tb" | "tib" => 1024.0 * 1024.0 * 1024.0 * 1024.0,
+        _ => return None,
+    };
+    Some((value * multiplier) as u64)
+}
+
+fn display_bytes(bytes: u64) -> String {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    if bytes as f64 >= GIB {
+        format!("{:.2} GiB", bytes as f64 / GIB)
+    } else if bytes as f64 >= MIB {
+        format!("{:.2} MiB", bytes as f64 / MIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn algorithm_label(strategy_variant: &str) -> &'static str {
+    match strategy_variant {
+        "three_layer" => "random_sampling",
+        _ => "TPE",
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PreflightLimits {
+    max_rows: usize,
+    max_bytes: u64,
+    max_symbols: usize,
+    max_days: i64,
+    allow_large_window: bool,
+}
+
+#[derive(Debug, Default)]
+struct SourcePreflight {
+    source: &'static str,
+    rows: usize,
+    bytes: u64,
+}
+
+#[derive(Debug, Default)]
+struct SplitPreflight {
+    label: &'static str,
+    sources: Vec<SourcePreflight>,
+}
+
+impl SplitPreflight {
+    fn total_rows(&self) -> usize {
+        self.sources.iter().map(|source| source.rows).sum()
+    }
+
+    fn total_bytes(&self) -> u64 {
+        self.sources.iter().map(|source| source.bytes).sum()
+    }
+}
+
+#[derive(Debug, Default)]
+struct PreflightManifest {
+    splits: Vec<SplitPreflight>,
+}
+
+impl PreflightManifest {
+    fn total_rows(&self) -> usize {
+        self.splits.iter().map(SplitPreflight::total_rows).sum()
+    }
+
+    fn max_split_bytes(&self) -> u64 {
+        self.splits
+            .iter()
+            .map(SplitPreflight::total_bytes)
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn print(&self) {
+        eprintln!("=== Parquet Preflight Manifest ===");
+        for split in &self.splits {
+            eprintln!(
+                "{}: rows={} bytes={}",
+                split.label,
+                split.total_rows(),
+                display_bytes(split.total_bytes())
+            );
+            for source in &split.sources {
+                eprintln!(
+                    "  {:<18} rows={:<12} bytes={}",
+                    source.source,
+                    source.rows,
+                    display_bytes(source.bytes)
+                );
+            }
+        }
+        eprintln!(
+            "Total estimated rows={} max_split_bytes={}",
+            self.total_rows(),
+            display_bytes(self.max_split_bytes())
+        );
+        eprintln!("Preflight preserves raw LOB and aggTrade cadence; it only counts rows.");
+        eprintln!();
+    }
+}
+
+fn validate_preflight(
+    manifest: &PreflightManifest,
     symbols: &[String],
     from: chrono::DateTime<Utc>,
     to: chrono::DateTime<Utc>,
-) -> Vec<MarketUpdate> {
-    use ploy_strategy_bundles::feed::parquet_stream::StreamingParquetFeed;
-    use ploy_strategy_bundles::traits::Feed;
-
-    let options = ploy_strategy_bundles::feed::HistoricalLoadOptions::default();
-    let mut feed = StreamingParquetFeed::new(data_dir, symbols, from, to, &options);
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-    let mut updates = Vec::new();
-    rt.block_on(async {
-        while let Some(update) = feed.next().await {
-            updates.push(update);
-        }
-    });
-    updates
-}
-
-#[cfg(not(feature = "parquet-feed"))]
-fn load_from_parquet_vec(
-    _data_dir: &str,
-    _symbols: &[String],
-    _from: chrono::DateTime<Utc>,
-    _to: chrono::DateTime<Utc>,
-) -> Vec<MarketUpdate> {
-    panic!("Parquet support requires --features parquet-feed")
-}
-
-fn flag_value(args: &[String], flag: &str) -> Option<String> {
-    args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
+    limits: &PreflightLimits,
+) -> std::result::Result<(), String> {
+    if limits.allow_large_window {
+        return Ok(());
+    }
+    let days = (to.date_naive() - from.date_naive()).num_days().abs() + 1;
+    let rows = manifest.total_rows();
+    let bytes = manifest.max_split_bytes();
+    let mut failures = Vec::new();
+    if rows > limits.max_rows {
+        failures.push(format!(
+            "estimated rows {rows} exceed --max-preflight-rows {}",
+            limits.max_rows
+        ));
+    }
+    if bytes > limits.max_bytes {
+        failures.push(format!(
+            "estimated bytes {} exceed --max-preflight-bytes {}",
+            display_bytes(bytes),
+            display_bytes(limits.max_bytes)
+        ));
+    }
+    if symbols.len() > limits.max_symbols {
+        failures.push(format!(
+            "symbol count {} exceeds --max-symbols {}",
+            symbols.len(),
+            limits.max_symbols
+        ));
+    }
+    if days > limits.max_days {
+        failures.push(format!(
+            "date span {days} days exceeds --max-days {}",
+            limits.max_days
+        ));
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{}; rerun with --allow-large-window only after bounded smoke/host-health checks",
+            failures.join("; ")
+        ))
+    }
 }
 
 fn parse_date_start(raw: &str) -> chrono::DateTime<Utc> {
@@ -115,6 +267,236 @@ fn parse_timestamp(raw: &str) -> chrono::DateTime<Utc> {
         .with_timezone(&Utc)
 }
 
+#[cfg(feature = "parquet-feed")]
+fn parquet_preflight_manifest(
+    data_dir: &str,
+    symbols: &[String],
+    train_from: chrono::DateTime<Utc>,
+    train_to: chrono::DateTime<Utc>,
+    val_from: chrono::DateTime<Utc>,
+    val_to: chrono::DateTime<Utc>,
+) -> std::result::Result<PreflightManifest, Box<dyn std::error::Error>> {
+    let conn = open_duckdb_for_preflight()?;
+    Ok(PreflightManifest {
+        splits: vec![
+            split_preflight(&conn, "train", data_dir, symbols, train_from, train_to)?,
+            split_preflight(&conn, "val", data_dir, symbols, val_from, val_to)?,
+        ],
+    })
+}
+
+#[cfg(not(feature = "parquet-feed"))]
+fn parquet_preflight_manifest(
+    _data_dir: &str,
+    _symbols: &[String],
+    _train_from: chrono::DateTime<Utc>,
+    _train_to: chrono::DateTime<Utc>,
+    _val_from: chrono::DateTime<Utc>,
+    _val_to: chrono::DateTime<Utc>,
+) -> std::result::Result<PreflightManifest, Box<dyn std::error::Error>> {
+    Err("Parquet preflight requires --features parquet-feed".into())
+}
+
+#[cfg(feature = "parquet-feed")]
+fn open_duckdb_for_preflight() -> std::result::Result<duckdb::Connection, Box<dyn std::error::Error>>
+{
+    let memory_limit =
+        std::env::var("PLOY_DUCKDB_MEMORY_LIMIT").unwrap_or_else(|_| "6GB".to_string());
+    let temp_dir =
+        std::env::var("PLOY_DUCKDB_TEMP_DIR").unwrap_or_else(|_| "/tmp/duckdb_spill".to_string());
+    std::fs::create_dir_all(&temp_dir)?;
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch(&format!(
+        "SET memory_limit='{}'; SET temp_directory='{}';",
+        memory_limit.replace('\'', "''"),
+        temp_dir.replace('\'', "''")
+    ))?;
+    Ok(conn)
+}
+
+#[cfg(feature = "parquet-feed")]
+fn split_preflight(
+    conn: &duckdb::Connection,
+    label: &'static str,
+    data_dir: &str,
+    symbols: &[String],
+    from: chrono::DateTime<Utc>,
+    to: chrono::DateTime<Utc>,
+) -> std::result::Result<SplitPreflight, Box<dyn std::error::Error>> {
+    use chrono::Duration;
+
+    const WARMUP_MINUTES: i64 = 30;
+    let from_str = from.to_rfc3339();
+    let to_str = to.to_rfc3339();
+    let spot_from_str = (from - Duration::minutes(WARMUP_MINUTES)).to_rfc3339();
+    let sym_filter = parquet_symbol_filter_sql(symbols);
+
+    Ok(SplitPreflight {
+        label,
+        sources: vec![
+            SourcePreflight {
+                source: "spot",
+                rows: count_parquet_rows(
+                    conn,
+                    data_dir,
+                    "binance_price_ticks",
+                    "trade_time",
+                    &spot_from_str,
+                    &to_str,
+                    &sym_filter,
+                )?,
+                bytes: parquet_dir_bytes(data_dir, "binance_price_ticks")?,
+            },
+            SourcePreflight {
+                source: "agg_trade",
+                rows: count_parquet_rows(
+                    conn,
+                    data_dir,
+                    "binance_agg_trade_ticks",
+                    "trade_time",
+                    &from_str,
+                    &to_str,
+                    &sym_filter,
+                )?,
+                bytes: parquet_dir_bytes(data_dir, "binance_agg_trade_ticks")?,
+            },
+            SourcePreflight {
+                source: "lob",
+                rows: count_parquet_rows(
+                    conn,
+                    data_dir,
+                    "binance_lob_ticks",
+                    "event_time",
+                    &from_str,
+                    &to_str,
+                    &sym_filter,
+                )?,
+                bytes: parquet_dir_bytes(data_dir, "binance_lob_ticks")?,
+            },
+            SourcePreflight {
+                source: "pm_quote",
+                rows: count_quote_rows(conn, data_dir, &from_str, &to_str)?,
+                bytes: parquet_dir_bytes(data_dir, "clob_quote_ticks")?,
+            },
+            SourcePreflight {
+                source: "pm_event",
+                rows: count_event_rows(conn, data_dir, symbols, &from_str, &to_str)?,
+                bytes: parquet_dir_bytes(data_dir, "pm_market_metadata")?,
+            },
+        ],
+    })
+}
+
+#[cfg(feature = "parquet-feed")]
+fn count_parquet_rows(
+    conn: &duckdb::Connection,
+    data_dir: &str,
+    source_dir: &str,
+    ts_col: &str,
+    from_str: &str,
+    to_str: &str,
+    sym_filter: &str,
+) -> std::result::Result<usize, Box<dyn std::error::Error>> {
+    let dir = format!("{data_dir}/{source_dir}");
+    if !std::path::Path::new(&dir).exists() {
+        return Ok(0);
+    }
+    let glob = format!("{dir}/*.parquet");
+    let sql = format!(
+        "SELECT count(*)::BIGINT FROM read_parquet('{glob}') \
+         WHERE {ts_col} >= TIMESTAMPTZ '{from_str}' \
+           AND {ts_col} <= TIMESTAMPTZ '{to_str}' \
+           {sym_filter}"
+    );
+    let rows: i64 = conn.query_row(&sql, [], |row| row.get(0))?;
+    Ok(rows.max(0) as usize)
+}
+
+#[cfg(feature = "parquet-feed")]
+fn count_quote_rows(
+    conn: &duckdb::Connection,
+    data_dir: &str,
+    from_str: &str,
+    to_str: &str,
+) -> std::result::Result<usize, Box<dyn std::error::Error>> {
+    let dir = format!("{data_dir}/clob_quote_ticks");
+    if !std::path::Path::new(&dir).exists() {
+        return Ok(0);
+    }
+    let glob = format!("{dir}/*.parquet");
+    let sql = format!(
+        "SELECT count(*)::BIGINT FROM read_parquet('{glob}') \
+         WHERE received_at >= TIMESTAMPTZ '{from_str}' \
+           AND received_at <= TIMESTAMPTZ '{to_str}' \
+           AND source IN ('polymarket_ws', 'polymarket_ws_collector', 'ploy_runner_live') \
+           AND best_bid IS NOT NULL AND best_ask IS NOT NULL \
+           AND (best_bid > 0.01 AND best_bid < 0.99 OR best_ask > 0.01 AND best_ask < 0.99)"
+    );
+    let rows: i64 = conn.query_row(&sql, [], |row| row.get(0))?;
+    Ok(rows.max(0) as usize)
+}
+
+#[cfg(feature = "parquet-feed")]
+fn count_event_rows(
+    conn: &duckdb::Connection,
+    data_dir: &str,
+    symbols: &[String],
+    from_str: &str,
+    to_str: &str,
+) -> std::result::Result<usize, Box<dyn std::error::Error>> {
+    let dir = format!("{data_dir}/pm_market_metadata");
+    if !std::path::Path::new(&dir).exists() {
+        return Ok(0);
+    }
+    let glob = format!("{dir}/*.parquet");
+    let sym_filter = parquet_symbol_filter_sql(symbols);
+    let sql = format!(
+        "SELECT count(*)::BIGINT * 2 FROM read_parquet('{glob}') \
+         WHERE end_time >= TIMESTAMPTZ '{from_str}' \
+           AND start_time <= TIMESTAMPTZ '{to_str}' \
+           {sym_filter} \
+           AND raw_market IS NOT NULL"
+    );
+    let rows: i64 = conn.query_row(&sql, [], |row| row.get(0))?;
+    Ok(rows.max(0) as usize)
+}
+
+#[cfg(feature = "parquet-feed")]
+fn parquet_dir_bytes(
+    data_dir: &str,
+    source_dir: &str,
+) -> std::result::Result<u64, Box<dyn std::error::Error>> {
+    let dir = std::path::Path::new(data_dir).join(source_dir);
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut bytes = 0;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "parquet")
+        {
+            bytes += entry.metadata()?.len();
+        }
+    }
+    Ok(bytes)
+}
+
+#[cfg(feature = "parquet-feed")]
+fn parquet_symbol_filter_sql(symbols: &[String]) -> String {
+    if symbols.is_empty() {
+        return String::new();
+    }
+    let list = symbols
+        .iter()
+        .map(|s| format!("'{}'", s.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("AND symbol IN ({list})")
+}
+
 fn canonical_strategy_variant(raw: &str) -> String {
     match raw.trim().to_ascii_lowercase().as_str() {
         "" | "directional" | "v1" | "v2" | "v3" | "pm5d_v1" | "pm5d_v2" | "pm5d_v3" => {
@@ -137,25 +519,158 @@ fn build_strategy(strategy_variant: &str, config: DirectionalConfig) -> Box<dyn 
     }
 }
 
-/// Run a single backtest and return (net_pnl, trade_count, sharpe).
+#[derive(Clone)]
+enum ReplaySource {
+    DbEager {
+        label: String,
+        updates: Arc<[MarketUpdate]>,
+    },
+    ParquetStream {
+        label: String,
+        data_dir: String,
+        symbols: Vec<String>,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    },
+}
+
+impl ReplaySource {
+    fn db_eager(label: &str, updates: Vec<MarketUpdate>) -> Self {
+        Self::DbEager {
+            label: label.to_string(),
+            updates: Arc::from(updates.into_boxed_slice()),
+        }
+    }
+
+    fn parquet_stream(
+        label: &str,
+        data_dir: &str,
+        symbols: &[String],
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> Self {
+        Self::ParquetStream {
+            label: label.to_string(),
+            data_dir: data_dir.to_string(),
+            symbols: symbols.to_vec(),
+            from,
+            to,
+        }
+    }
+
+    fn label(&self) -> &str {
+        match self {
+            Self::DbEager { label, .. } | Self::ParquetStream { label, .. } => label,
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::DbEager { .. } => "db-eager",
+            Self::ParquetStream { .. } => "parquet-stream",
+        }
+    }
+
+    fn update_hint(&self) -> Option<usize> {
+        match self {
+            Self::DbEager { updates, .. } => Some(updates.len()),
+            Self::ParquetStream { .. } => None,
+        }
+    }
+
+    fn validate(&self) -> std::result::Result<(), String> {
+        match self {
+            Self::DbEager { .. } => Ok(()),
+            Self::ParquetStream { data_dir, .. } => {
+                #[cfg(not(feature = "parquet-feed"))]
+                {
+                    let _ = data_dir;
+                    Err("--data-dir requires the `parquet-feed` feature".to_string())
+                }
+
+                #[cfg(feature = "parquet-feed")]
+                {
+                    if std::path::Path::new(data_dir).exists() {
+                        Ok(())
+                    } else {
+                        Err(format!("Parquet data directory does not exist: {data_dir}"))
+                    }
+                }
+            }
+        }
+    }
+
+    fn open(&self) -> std::result::Result<Box<dyn Feed>, String> {
+        match self {
+            Self::DbEager { updates, .. } => {
+                Ok(Box::new(HistoricalFeed::shared(Arc::clone(updates))))
+            }
+            Self::ParquetStream {
+                data_dir,
+                symbols,
+                from,
+                to,
+                ..
+            } => {
+                #[cfg(not(feature = "parquet-feed"))]
+                {
+                    let _ = (data_dir, symbols, from, to);
+                    Err("--data-dir requires the `parquet-feed` feature".to_string())
+                }
+
+                #[cfg(feature = "parquet-feed")]
+                {
+                    use ploy_strategy_bundles::feed::parquet_stream::StreamingParquetFeed;
+
+                    self.validate()?;
+                    let mut options = ploy_strategy_bundles::feed::HistoricalLoadOptions::default();
+                    // Optimizer replay is tick-preserving. Do not sample away LOB
+                    // or aggTrade rows; the strategy consumes both at live cadence.
+                    options.lob_sample_secs = 1;
+                    Ok(Box::new(StreamingParquetFeed::new(
+                        data_dir, symbols, *from, *to, &options,
+                    )))
+                }
+            }
+        }
+    }
+}
+
+struct BacktestOutcome {
+    net_pnl: f64,
+    trade_count: usize,
+    sharpe: f64,
+    updates_processed: u64,
+    elapsed_secs: f64,
+}
+
+fn source_hint(source: &ReplaySource) -> String {
+    source
+        .update_hint()
+        .map(|updates| updates.to_string())
+        .unwrap_or_else(|| "streaming".to_string())
+}
+
+/// Run a single backtest and return compact analyzer-style metrics.
 fn run_backtest(
     strategy_variant: &str,
     config: DirectionalConfig,
-    data: Arc<[MarketUpdate]>,
-) -> (f64, usize, f64) {
+    source: &ReplaySource,
+    max_updates: Option<u64>,
+) -> std::result::Result<BacktestOutcome, String> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .unwrap();
+        .map_err(|error| format!("failed to create tokio runtime: {error}"))?;
 
     let strategy = build_strategy(strategy_variant, config);
-    let feed = HistoricalFeed::shared(data);
+    let feed = source.open()?;
     let executor = SimulatedExecutor::new(SimulatedExecutorConfig::default());
     let recorder = Box::new(NullRecorder);
     let runtime_config = RuntimeConfig {
         mode: RuntimeMode::Backtest,
         throttle_hz: None,
-        max_updates: None,
+        max_updates,
         skip_settlement_exits: false,
     };
 
@@ -200,7 +715,13 @@ fn run_backtest(
         }
     };
 
-    (net_pnl, trade_count, sharpe)
+    Ok(BacktestOutcome {
+        net_pnl,
+        trade_count,
+        sharpe,
+        updates_processed: result.updates_processed,
+        elapsed_secs: result.elapsed_secs,
+    })
 }
 
 fn make_directional_config(
@@ -424,6 +945,25 @@ fn main() {
     let n_trials: usize = flag_value(&args, "--trials")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(200);
+    let preflight_only =
+        flag_present(&args, "--preflight-only") || flag_present(&args, "--preflight");
+    let preflight_limits = PreflightLimits {
+        max_rows: parse_usize_flag(&args, "--max-preflight-rows", 15_000_000),
+        max_bytes: parse_u64_flag(&args, "--max-preflight-bytes", 80 * 1024 * 1024 * 1024),
+        max_symbols: parse_usize_flag(&args, "--max-symbols", 6),
+        max_days: parse_usize_flag(&args, "--max-days", 8) as i64,
+        allow_large_window: flag_present(&args, "--allow-large-window"),
+    };
+    if let Some(memory_limit) = flag_value(&args, "--duckdb-memory-limit") {
+        std::env::set_var("PLOY_DUCKDB_MEMORY_LIMIT", memory_limit);
+    }
+    if let Some(temp_dir) = flag_value(&args, "--duckdb-temp-dir") {
+        std::env::set_var("PLOY_DUCKDB_TEMP_DIR", temp_dir);
+    }
+    let max_updates: Option<u64> = flag_value(&args, "--max-updates").map(|raw| {
+        raw.parse()
+            .unwrap_or_else(|_| panic!("Invalid --max-updates: {raw}"))
+    });
     let symbols: Vec<String> = symbols_arg
         .split(',')
         .map(str::trim)
@@ -445,7 +985,15 @@ fn main() {
     );
     eprintln!("Symbols: {:?}", symbols);
     eprintln!("Official-only settlement: {}", require_official_settlement);
-    eprintln!("Trials: {n_trials}  Algorithm: TPE");
+    eprintln!(
+        "Trials: {n_trials}  Algorithm: {}",
+        algorithm_label(&strategy_variant)
+    );
+    if let Some(max_updates) = max_updates {
+        eprintln!(
+            "Smoke bound: max_updates={max_updates} (truncated replay; non-canonical result)"
+        );
+    }
     eprintln!();
 
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -470,27 +1018,36 @@ fn main() {
         .map(parse_timestamp)
         .unwrap_or_else(|| parse_date_end(&val_end));
 
-    let (train_data, val_data) = if let Some(ref dir) = data_dir {
-        eprintln!(
-            "Loading training data from Parquet ({} → {})...",
-            train_start, train_end
-        );
-        let train = load_from_parquet_vec(dir, &symbols, train_from, train_to);
-        eprintln!("  {} updates loaded", train.len());
-        eprintln!(
-            "Loading validation data from Parquet ({} → {})...",
-            val_start, val_end
-        );
-        let val = load_from_parquet_vec(dir, &symbols, val_from, val_to);
-        eprintln!("  {} updates loaded\n", val.len());
-        (train, val)
+    let (train_source, val_source) = if let Some(ref dir) = data_dir {
+        let manifest =
+            parquet_preflight_manifest(dir, &symbols, train_from, train_to, val_from, val_to)
+                .expect("Failed to build Parquet preflight manifest");
+        manifest.print();
+        if let Err(error) =
+            validate_preflight(&manifest, &symbols, train_from, val_to, &preflight_limits)
+        {
+            eprintln!("ERROR: optimize preflight rejected this request: {error}");
+            std::process::exit(2);
+        }
+        if preflight_only {
+            eprintln!("Preflight-only mode complete; exiting before replay/optimization.");
+            return;
+        }
+
+        (
+            ReplaySource::parquet_stream("train", dir, &symbols, train_from, train_to),
+            ReplaySource::parquet_stream("validation", dir, &symbols, val_from, val_to),
+        )
     } else {
         let db_url = db_url.as_deref().unwrap();
         let pool = rt
             .block_on(PgPoolOptions::new().max_connections(3).connect(db_url))
             .expect("DB connection failed");
 
-        eprintln!("Loading training data ({} → {})...", train_start, train_end);
+        eprintln!(
+            "Loading training data into db-eager replay ({} → {})...",
+            train_start, train_end
+        );
         let train = rt
             .block_on(load_from_database_with_options(
                 &pool,
@@ -505,7 +1062,10 @@ fn main() {
             .expect("Failed to load training data");
         eprintln!("  {} updates loaded", train.len());
 
-        eprintln!("Loading validation data ({} → {})...", val_start, val_end);
+        eprintln!(
+            "Loading validation data into db-eager replay ({} → {})...",
+            val_start, val_end
+        );
         let val = rt
             .block_on(load_from_database_with_options(
                 &pool,
@@ -519,11 +1079,25 @@ fn main() {
             ))
             .expect("Failed to load validation data");
         eprintln!("  {} updates loaded\n", val.len());
-        (train, val)
+        (
+            ReplaySource::db_eager("train", train),
+            ReplaySource::db_eager("validation", val),
+        )
     };
 
-    let train_data: Arc<[MarketUpdate]> = Arc::from(train_data.into_boxed_slice());
-    let val_data: Arc<[MarketUpdate]> = Arc::from(val_data.into_boxed_slice());
+    eprintln!(
+        "Replay source train: {} [{}] updates={}",
+        train_source.label(),
+        train_source.kind(),
+        source_hint(&train_source)
+    );
+    eprintln!(
+        "Replay source validation: {} [{}] updates={}",
+        val_source.label(),
+        val_source.kind(),
+        source_hint(&val_source)
+    );
+
     let symbols_ref = Arc::new(symbols.clone());
     let study: Study<f64> = Study::maximize(TpeSampler::new());
 
@@ -533,7 +1107,7 @@ fn main() {
         let p_pm_lag = IntParam::new(20, 120).name("reversal_max_pm_lag_secs");
         let p_min_edge = FloatParam::new(-0.05, 0.01).name("min_edge");
 
-        let train_ref = Arc::clone(&train_data);
+        let train_ref = train_source.clone();
         let symbols_ref_c = Arc::clone(&symbols_ref);
 
         let p_max_distance_c = p_max_distance.clone();
@@ -557,23 +1131,35 @@ fn main() {
                 };
 
                 let config = make_reversal_config(symbols_ref_c.as_slice(), &params);
-                let (net_pnl, trades, sharpe) =
-                    run_backtest("reversal", config, Arc::clone(&train_ref));
-                let score = if trades == 0 {
+                let outcome = match run_backtest("reversal", config, &train_ref, max_updates) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        eprintln!(
+                            "  Trial {:>3}: source={} error={error}",
+                            trial.id(),
+                            train_ref.kind()
+                        );
+                        return Ok::<f64, Error>(-1_000_000.0);
+                    }
+                };
+                let score = if outcome.trade_count == 0 {
                     -100.0
-                } else if trades < 5 {
-                    net_pnl
+                } else if outcome.trade_count < 5 {
+                    outcome.net_pnl
                 } else {
-                    sharpe
+                    outcome.sharpe
                 };
 
                 eprintln!(
-                    "  Trial {:>3}: score={:>7.3} sharpe={:>7.3} pnl=${:>8.2} trades={:>4} dist={:.4} flip={} drift={:.5} lob={:.2} ask={:.3} lag={}",
+                    "  Trial {:>3}: source={} score={:>7.3} sharpe={:>7.3} pnl=${:>8.2} trades={:>4} updates={} elapsed={:.1}s dist={:.4} flip={} drift={:.5} lob={:.2} ask={:.3} lag={}",
                     trial.id(),
+                    train_ref.kind(),
                     score,
-                    sharpe,
-                    net_pnl,
-                    trades,
+                    outcome.sharpe,
+                    outcome.net_pnl,
+                    outcome.trade_count,
+                    outcome.updates_processed,
+                    outcome.elapsed_secs,
                     params.max_distance_pct,
                     params.max_drift_flip_age_secs,
                     params.min_post_flip_drift,
@@ -642,11 +1228,14 @@ fn main() {
 
         eprintln!("\n=== Validation (held-out) ===");
         let val_config = make_reversal_config(symbols_ref.as_slice(), &best_params);
-        let (val_pnl, val_trades, val_sharpe) =
-            run_backtest("reversal", val_config, Arc::clone(&val_data));
-        eprintln!("Val Sharpe:  {val_sharpe:.3}");
-        eprintln!("Val PnL:     ${val_pnl:.2}");
-        eprintln!("Val Trades:  {val_trades}");
+        let val_outcome = run_backtest("reversal", val_config, &val_source, max_updates)
+            .expect("Validation backtest failed");
+        eprintln!("Val Source:  {}", val_source.kind());
+        eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
+        eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
+        eprintln!("Val Trades:  {}", val_outcome.trade_count);
+        eprintln!("Val Updates: {}", val_outcome.updates_processed);
+        eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
 
         eprintln!("\n=== Config Snippet ===");
         eprintln!(
@@ -724,7 +1313,7 @@ fn main() {
         let sample =
             |rng: &mut dyn FnMut() -> f64, lo: f64, hi: f64| -> f64 { lo + rng() * (hi - lo) };
 
-        let train_ref = Arc::clone(&train_data);
+        let train_ref = train_source.clone();
         let symbols_ref_c = Arc::clone(&symbols_ref);
         let mut best_score = f64::NEG_INFINITY;
         let mut best_params_opt: Option<ThreeLayerSearchParams> = None;
@@ -760,20 +1349,33 @@ fn main() {
             };
 
             let config = make_three_layer_config(symbols_ref_c.as_slice(), &params);
-            let (net_pnl, trades, sharpe) =
-                run_backtest("three_layer", config, Arc::clone(&train_ref));
+            let outcome = match run_backtest("three_layer", config, &train_ref, max_updates) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    eprintln!(
+                        "iter {:>3}/{}: source={} error={error}",
+                        iter + 1,
+                        n_trials,
+                        train_ref.kind()
+                    );
+                    continue;
+                }
+            };
 
             // Sharpe = mean(pnl_per_trade) / std(pnl_per_trade) * sqrt(trades_per_year)
             // Penalty for < 5 trades already applied inside run_backtest (-999.0)
-            let score = sharpe;
+            let score = outcome.sharpe;
 
             eprintln!(
-                "iter {:>3}/{}: sharpe={:>7.3} trades={:>4} pnl=${:>8.2} | params: dir_prob={:.3} dist_sigma={:.3} conf={:.3} drift={:.5} edge={:.3} rr={:.2} tp={:.3} stop={:.4} cd={}s",
+                "iter {:>3}/{}: source={} sharpe={:>7.3} trades={:>4} pnl=${:>8.2} updates={} elapsed={:.1}s | params: dir_prob={:.3} dist_sigma={:.3} conf={:.3} drift={:.5} edge={:.3} rr={:.2} tp={:.3} stop={:.4} cd={}s",
                 iter + 1,
                 n_trials,
-                sharpe,
-                trades,
-                net_pnl,
+                train_ref.kind(),
+                outcome.sharpe,
+                outcome.trade_count,
+                outcome.net_pnl,
+                outcome.updates_processed,
+                outcome.elapsed_secs,
                 min_direction_prob,
                 min_distance_over_sigma,
                 min_confirmation_score,
@@ -787,8 +1389,8 @@ fn main() {
 
             if score > best_score {
                 best_score = score;
-                best_pnl = net_pnl;
-                best_trades = trades;
+                best_pnl = outcome.net_pnl;
+                best_trades = outcome.trade_count;
                 best_params_opt = Some(ThreeLayerSearchParams {
                     min_direction_prob,
                     min_distance_over_sigma,
@@ -814,11 +1416,14 @@ fn main() {
 
         eprintln!("\n=== Validation (held-out, out-of-sample) ===");
         let val_config = make_three_layer_config(symbols_ref.as_slice(), &best_params);
-        let (val_pnl, val_trades, val_sharpe) =
-            run_backtest("three_layer", val_config, Arc::clone(&val_data));
-        eprintln!("Val Sharpe:  {val_sharpe:.3}");
-        eprintln!("Val PnL:     ${val_pnl:.2}");
-        eprintln!("Val Trades:  {val_trades}");
+        let val_outcome = run_backtest("three_layer", val_config, &val_source, max_updates)
+            .expect("Validation backtest failed");
+        eprintln!("Val Source:  {}", val_source.kind());
+        eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
+        eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
+        eprintln!("Val Trades:  {}", val_outcome.trade_count);
+        eprintln!("Val Updates: {}", val_outcome.updates_processed);
+        eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
 
         eprintln!("\n=== Best Config (TOML) ===");
         eprintln!("# Paste into [strategy] section of your config file");
@@ -868,7 +1473,7 @@ fn main() {
         let p_min_time = IntParam::new(20, 120).name("min_time_remaining_secs");
         let p_max_time = IntParam::new(180, 300).name("max_time_remaining_secs");
 
-        let train_ref = Arc::clone(&train_data);
+        let train_ref = train_source.clone();
         let symbols_ref_c = Arc::clone(&symbols_ref);
         let p_min_prob_c = p_min_prob.clone();
         let p_min_edge_c = p_min_edge.clone();
@@ -899,22 +1504,34 @@ fn main() {
                     min_time,
                     max_time,
                 );
-                let (net_pnl, trades, sharpe) =
-                    run_backtest("directional", config, Arc::clone(&train_ref));
+                let outcome = match run_backtest("directional", config, &train_ref, max_updates) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        eprintln!(
+                            "  Trial {:>3}: source={} error={error}",
+                            trial.id(),
+                            train_ref.kind()
+                        );
+                        return Ok::<f64, Error>(-1_000_000.0);
+                    }
+                };
 
                 eprintln!(
-                    "  Trial {:>3}: sharpe={:>7.3}  pnl=${:>8.2}  trades={:>4}  p={:.3}  edge={:.4}  max={:.2}  cd={}s",
+                    "  Trial {:>3}: source={} sharpe={:>7.3}  pnl=${:>8.2}  trades={:>4}  updates={} elapsed={:.1}s  p={:.3}  edge={:.4}  max={:.2}  cd={}s",
                     trial.id(),
-                    sharpe,
-                    net_pnl,
-                    trades,
+                    train_ref.kind(),
+                    outcome.sharpe,
+                    outcome.net_pnl,
+                    outcome.trade_count,
+                    outcome.updates_processed,
+                    outcome.elapsed_secs,
                     min_prob,
                     min_edge,
                     max_entry,
                     cooldown
                 );
 
-                Ok(sharpe)
+                Ok(outcome.sharpe)
             })
             .expect("Optimization failed");
 
@@ -945,11 +1562,14 @@ fn main() {
             best_min_time,
             best_max_time,
         );
-        let (val_pnl, val_trades, val_sharpe) =
-            run_backtest("directional", val_config, Arc::clone(&val_data));
-        eprintln!("Val Sharpe:  {val_sharpe:.3}");
-        eprintln!("Val PnL:     ${val_pnl:.2}");
-        eprintln!("Val Trades:  {val_trades}");
+        let val_outcome = run_backtest("directional", val_config, &val_source, max_updates)
+            .expect("Validation backtest failed");
+        eprintln!("Val Source:  {}", val_source.kind());
+        eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
+        eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
+        eprintln!("Val Trades:  {}", val_outcome.trade_count);
+        eprintln!("Val Updates: {}", val_outcome.updates_processed);
+        eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
 
         eprintln!("\n=== Config Snippet ===");
         eprintln!("min_probability = {best_min_prob:.4}");

--- a/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
@@ -31,12 +31,24 @@ use std::thread;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use thiserror::Error;
 
 use super::options::HistoricalLoadOptions;
 use crate::traits::{Feed, MarketUpdate};
 
 /// Bounded channel capacity — limits how far ahead the background thread runs.
 const CHANNEL_CAPACITY: usize = 1000;
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum StreamingParquetFeedError {
+    #[error("StreamingParquetFeed background worker failed: {0}")]
+    Background(String),
+}
+
+enum FeedMessage {
+    Update(MarketUpdate),
+    Error(StreamingParquetFeedError),
+}
 
 /// Streaming Parquet feed backed by a DuckDB background thread.
 ///
@@ -46,7 +58,8 @@ const CHANNEL_CAPACITY: usize = 1000;
 /// than the channel buffer in memory. Events are loaded separately (~11K rows)
 /// and merged via two-pointer in the send loop.
 pub struct StreamingParquetFeed {
-    receiver: Receiver<MarketUpdate>,
+    receiver: Receiver<FeedMessage>,
+    error: Option<StreamingParquetFeedError>,
     /// Keep the thread handle so it is joined on drop (prevents leaks).
     _worker: thread::JoinHandle<()>,
 }
@@ -63,29 +76,57 @@ impl StreamingParquetFeed {
         to: DateTime<Utc>,
         options: &HistoricalLoadOptions,
     ) -> Self {
-        let (tx, rx) = mpsc::sync_channel::<MarketUpdate>(CHANNEL_CAPACITY);
+        let (tx, rx) = mpsc::sync_channel::<FeedMessage>(CHANNEL_CAPACITY);
 
         let data_dir = data_dir.to_string();
         let symbols = symbols.to_vec();
         let lob_sample_secs = options.lob_sample_secs;
 
         let worker = thread::spawn(move || {
+            let error_tx = tx.clone();
             if let Err(e) = run_background(&data_dir, &symbols, from, to, lob_sample_secs, tx) {
-                tracing::warn!(error = %e, "StreamingParquetFeed background thread error");
+                let error = StreamingParquetFeedError::Background(e.to_string());
+                tracing::error!(error = %error, "StreamingParquetFeed background thread error");
+                let _ = error_tx.send(FeedMessage::Error(error));
             }
         });
 
         Self {
             receiver: rx,
+            error: None,
             _worker: worker,
         }
+    }
+
+    /// Read the next update, returning any background DuckDB/row-conversion
+    /// failure instead of making it look like ordinary feed exhaustion.
+    pub fn next_result(&mut self) -> Result<Option<MarketUpdate>, StreamingParquetFeedError> {
+        if let Some(error) = self.error.clone() {
+            return Err(error);
+        }
+
+        match self.receiver.recv() {
+            Ok(FeedMessage::Update(update)) => Ok(Some(update)),
+            Ok(FeedMessage::Error(error)) => {
+                self.error = Some(error.clone());
+                Err(error)
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn background_error(&self) -> Option<&StreamingParquetFeedError> {
+        self.error.as_ref()
     }
 }
 
 #[async_trait]
 impl Feed for StreamingParquetFeed {
     async fn next(&mut self) -> Option<MarketUpdate> {
-        self.receiver.recv().ok()
+        match self.next_result() {
+            Ok(update) => update,
+            Err(error) => panic!("{error}"),
+        }
     }
 }
 
@@ -104,13 +145,11 @@ fn run_background(
     from: DateTime<Utc>,
     to: DateTime<Utc>,
     lob_sample_secs: u32,
-    tx: SyncSender<MarketUpdate>,
+    tx: SyncSender<FeedMessage>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use chrono::Duration;
     use duckdb::Connection;
-    use rust_decimal::Decimal;
     use std::path::Path;
-    use std::sync::Arc;
     use tracing::info;
 
     const WARMUP_MINUTES: i64 = 30;
@@ -119,9 +158,17 @@ fn run_background(
         return Ok(());
     }
 
-    std::fs::create_dir_all("/tmp/duckdb_spill").ok();
+    let memory_limit =
+        std::env::var("PLOY_DUCKDB_MEMORY_LIMIT").unwrap_or_else(|_| "6GB".to_string());
+    let temp_dir =
+        std::env::var("PLOY_DUCKDB_TEMP_DIR").unwrap_or_else(|_| "/tmp/duckdb_spill".to_string());
+    std::fs::create_dir_all(&temp_dir).ok();
     let conn = Connection::open_in_memory()?;
-    conn.execute_batch("SET memory_limit='6GB'; SET temp_directory='/tmp/duckdb_spill';")?;
+    conn.execute_batch(&format!(
+        "SET memory_limit='{}'; SET temp_directory='{}';",
+        memory_limit.replace('\'', "''"),
+        temp_dir.replace('\'', "''")
+    ))?;
 
     let sym_filter = symbol_filter_sql(symbols);
     let spot_from = from - Duration::minutes(WARMUP_MINUTES);
@@ -148,6 +195,7 @@ fn run_background(
     if Path::new(&format!("{data_dir}/binance_price_ticks")).exists() {
         parts.push(format!(
             "SELECT epoch_us(trade_time)::BIGINT AS ts_us, \
+                    {SPOT_SOURCE_RANK} AS source_rank, \
                     'spot' AS typ, \
                     symbol AS s1, NULL AS s2, \
                     CAST(price AS DOUBLE) AS f1, 0.0 AS f2, 0.0 AS f3, 0.0 AS f4, \
@@ -165,6 +213,7 @@ fn run_background(
     if Path::new(&format!("{data_dir}/binance_agg_trade_ticks")).exists() {
         parts.push(format!(
             "SELECT epoch_us(trade_time)::BIGINT AS ts_us, \
+                    {AGG_SOURCE_RANK} AS source_rank, \
                     'agg' AS typ, \
                     symbol AS s1, NULL AS s2, \
                     CAST(price AS DOUBLE) AS f1, CAST(quantity AS DOUBLE) AS f2, \
@@ -184,6 +233,7 @@ fn run_background(
     if Path::new(&format!("{data_dir}/binance_lob_ticks")).exists() {
         parts.push(format!(
             "SELECT epoch_us(event_time)::BIGINT AS ts_us, \
+                    {LOB_SOURCE_RANK} AS source_rank, \
                     'lob' AS typ, \
                     symbol AS s1, NULL AS s2, \
                     CAST(COALESCE(obi_5, 0.0) AS DOUBLE) AS f1, \
@@ -201,10 +251,11 @@ fn run_background(
     // PM quotes — align with database.rs: DISTINCT ON per-second per-token, trusted sources only
     if Path::new(&format!("{data_dir}/clob_quote_ticks")).exists() {
         parts.push(format!(
-            "SELECT ts_us, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
+            "SELECT ts_us, source_rank, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
              FROM ( \
                  SELECT DISTINCT ON (date_trunc('second', received_at), token_id) \
                         EPOCH_US(received_at)::BIGINT AS ts_us, \
+                        {QUOTE_SOURCE_RANK} AS source_rank, \
                         'quote' AS typ, \
                         token_id AS s1, NULL AS s2, \
                         CAST(best_bid AS DOUBLE) AS f1, CAST(best_ask AS DOUBLE) AS f2, \
@@ -224,17 +275,14 @@ fn run_background(
     if parts.is_empty() {
         // No data tables found — just send events
         for (_, update) in &events {
-            if tx.send(update.clone()).is_err() {
+            if send_update(&tx, update.clone()).is_err() {
                 return Ok(());
             }
         }
         return Ok(());
     }
 
-    let union_sql = format!(
-        "SELECT * FROM ({}) ORDER BY ts_us",
-        parts.join(" UNION ALL ")
-    );
+    let union_sql = build_union_sql(&parts);
 
     // ── 3. Stream UNION ALL results, merging events via two-pointer ─────────
     let mut stmt = match conn.prepare(&union_sql) {
@@ -260,119 +308,38 @@ fn run_background(
 
     let mut total = 0usize;
     for row in rows {
-        let (ts_us, typ, s1, _s2, f1_opt, f2_opt, f3_opt, f4_opt, i1_opt, b1_opt) = match row {
-            Ok(r) => r,
-            Err(_e) => {
-                break;
-            }
-        };
-        let f1 = f1_opt.unwrap_or(0.0);
-        let f2 = f2_opt.unwrap_or(0.0);
-        let f3 = f3_opt.unwrap_or(0.0);
-        let f4 = f4_opt.unwrap_or(0.0);
-        let i1 = i1_opt.unwrap_or(0);
-        let b1 = b1_opt.unwrap_or(false);
+        let (ts_us, typ, s1, _s2, f1_opt, f2_opt, f3_opt, f4_opt, i1_opt, b1_opt) = row?;
 
         // Insert any events that should come before this row
-        while evt_idx < events.len() && events[evt_idx].0 <= ts_us {
-            if tx.send(events[evt_idx].1.clone()).is_err() {
+        while evt_idx < events.len() && should_send_event_before_row(events[evt_idx].0, ts_us) {
+            if send_update(&tx, events[evt_idx].1.clone()).is_err() {
                 return Ok(());
             }
             evt_idx += 1;
         }
 
-        let ts = DateTime::from_timestamp_micros(ts_us).unwrap_or_default();
-
-        match typ.as_str() {
-            "spot" => {
-                let symbol: Arc<str> = Arc::from(s1.unwrap_or_default());
-                let price = Decimal::try_from(f1).unwrap_or_default();
-                if tx
-                    .send(MarketUpdate::SpotPrice { symbol, price, ts })
-                    .is_err()
-                {
-                    return Ok(());
-                }
+        let row = StreamRow {
+            ts_us,
+            typ,
+            s1,
+            f1: f1_opt,
+            f2: f2_opt,
+            f3: f3_opt,
+            f4: f4_opt,
+            i1: i1_opt,
+            b1: b1_opt,
+        };
+        for update in market_updates_from_row(row) {
+            if send_update(&tx, update).is_err() {
+                return Ok(());
             }
-            "agg" => {
-                let symbol: Arc<str> = Arc::from(s1.unwrap_or_default());
-                let price = Decimal::try_from(f1).unwrap_or_default();
-                let quantity = Decimal::try_from(f2).unwrap_or_default();
-                if tx
-                    .send(MarketUpdate::AggTrade {
-                        symbol,
-                        agg_trade_id: i1 as u64,
-                        price,
-                        quantity,
-                        is_buyer_maker: b1,
-                        ts,
-                    })
-                    .is_err()
-                {
-                    return Ok(());
-                }
-            }
-            "lob" => {
-                let symbol: Arc<str> = Arc::from(s1.unwrap_or_default());
-                let obi = f1;
-                let spread_bps = f2 as u32;
-                let bid_depth_near = f3;
-                let ask_depth_near = f4;
-                // Send both L2 and L2Depth (matching original behavior)
-                if tx
-                    .send(MarketUpdate::L2 {
-                        symbol: Arc::clone(&symbol),
-                        obi,
-                        spread_bps,
-                        ts,
-                    })
-                    .is_err()
-                {
-                    return Ok(());
-                }
-                if tx
-                    .send(MarketUpdate::L2Depth {
-                        symbol,
-                        obi,
-                        spread_bps,
-                        bid_depth_near,
-                        ask_depth_near,
-                        ts,
-                    })
-                    .is_err()
-                {
-                    return Ok(());
-                }
-            }
-            "quote" => {
-                let token_id: Arc<str> = Arc::from(s1.unwrap_or_default());
-                let bid = f1_opt.and_then(|v| Decimal::try_from(v).ok());
-                let ask = f2_opt.and_then(|v| Decimal::try_from(v).ok());
-                if bid.is_none() && ask.is_none() {
-                    continue;
-                }
-                if tx
-                    .send(MarketUpdate::Quote {
-                        token_id,
-                        bid,
-                        ask,
-                        bid_size: None,
-                        ask_size: None,
-                        ts,
-                    })
-                    .is_err()
-                {
-                    return Ok(());
-                }
-            }
-            _ => continue,
         }
         total += 1;
     }
 
     // Send remaining events after the UNION ALL stream is exhausted
     while evt_idx < events.len() {
-        if tx.send(events[evt_idx].1.clone()).is_err() {
+        if send_update(&tx, events[evt_idx].1.clone()).is_err() {
             break;
         }
         evt_idx += 1;
@@ -386,6 +353,97 @@ fn run_background(
     Ok(())
 }
 
+#[cfg(feature = "parquet-feed")]
+fn send_update(
+    tx: &SyncSender<FeedMessage>,
+    update: MarketUpdate,
+) -> Result<(), mpsc::SendError<FeedMessage>> {
+    tx.send(FeedMessage::Update(update))
+}
+
+#[cfg(feature = "parquet-feed")]
+#[derive(Debug)]
+struct StreamRow {
+    ts_us: i64,
+    typ: String,
+    s1: Option<String>,
+    f1: Option<f64>,
+    f2: Option<f64>,
+    f3: Option<f64>,
+    f4: Option<f64>,
+    i1: Option<i64>,
+    b1: Option<bool>,
+}
+
+#[cfg(feature = "parquet-feed")]
+fn market_updates_from_row(row: StreamRow) -> Vec<MarketUpdate> {
+    use rust_decimal::Decimal;
+    use std::sync::Arc;
+
+    let ts = DateTime::from_timestamp_micros(row.ts_us).unwrap_or_default();
+    match row.typ.as_str() {
+        "spot" => {
+            let symbol: Arc<str> = Arc::from(row.s1.unwrap_or_default());
+            let price = Decimal::try_from(row.f1.unwrap_or(0.0)).unwrap_or_default();
+            vec![MarketUpdate::SpotPrice { symbol, price, ts }]
+        }
+        "agg" => {
+            let symbol: Arc<str> = Arc::from(row.s1.unwrap_or_default());
+            let price = Decimal::try_from(row.f1.unwrap_or(0.0)).unwrap_or_default();
+            let quantity = Decimal::try_from(row.f2.unwrap_or(0.0)).unwrap_or_default();
+            vec![MarketUpdate::AggTrade {
+                symbol,
+                agg_trade_id: row.i1.unwrap_or(0) as u64,
+                price,
+                quantity,
+                is_buyer_maker: row.b1.unwrap_or(false),
+                ts,
+            }]
+        }
+        "lob" => {
+            let symbol: Arc<str> = Arc::from(row.s1.unwrap_or_default());
+            let obi = row.f1.unwrap_or(0.0);
+            let spread_bps = row.f2.unwrap_or(0.0) as u32;
+            let bid_depth_near = row.f3.unwrap_or(0.0);
+            let ask_depth_near = row.f4.unwrap_or(0.0);
+            vec![
+                MarketUpdate::L2 {
+                    symbol: Arc::clone(&symbol),
+                    obi,
+                    spread_bps,
+                    ts,
+                },
+                MarketUpdate::L2Depth {
+                    symbol,
+                    obi,
+                    spread_bps,
+                    bid_depth_near,
+                    ask_depth_near,
+                    ts,
+                },
+            ]
+        }
+        "quote" => {
+            let token_id: Arc<str> = Arc::from(row.s1.unwrap_or_default());
+            let bid = row.f1.and_then(|v| Decimal::try_from(v).ok());
+            let ask = row.f2.and_then(|v| Decimal::try_from(v).ok());
+            if bid.is_none() && ask.is_none() {
+                Vec::new()
+            } else {
+                vec![MarketUpdate::Quote {
+                    token_id,
+                    bid,
+                    ask,
+                    bid_size: None,
+                    ask_size: None,
+                    ts,
+                }]
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
 /// Stub for when the feature flag is disabled.
 #[cfg(not(feature = "parquet-feed"))]
 fn run_background(
@@ -394,12 +452,45 @@ fn run_background(
     _from: DateTime<Utc>,
     _to: DateTime<Utc>,
     _lob_sample_secs: u32,
-    _tx: SyncSender<MarketUpdate>,
+    _tx: SyncSender<FeedMessage>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "parquet-feed")]
+const SPOT_SOURCE_RANK: u8 = 10;
+#[cfg(feature = "parquet-feed")]
+const AGG_SOURCE_RANK: u8 = 20;
+#[cfg(feature = "parquet-feed")]
+const LOB_SOURCE_RANK: u8 = 30;
+#[cfg(feature = "parquet-feed")]
+const QUOTE_SOURCE_RANK: u8 = 40;
+
+#[cfg(feature = "parquet-feed")]
+fn build_union_sql(parts: &[String]) -> String {
+    format!(
+        "SELECT ts_us, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
+         FROM ({}) \
+         ORDER BY ts_us, source_rank, s1, i1, f1, f2, f3, f4",
+        parts.join(" UNION ALL ")
+    )
+}
+
+#[cfg(feature = "parquet-feed")]
+fn should_send_event_before_row(event_ts_us: i64, row_ts_us: i64) -> bool {
+    event_ts_us <= row_ts_us
+}
+
+#[cfg(feature = "parquet-feed")]
+fn event_sort_key(update: &MarketUpdate) -> (u8, String) {
+    match update {
+        MarketUpdate::EventDiscovered { event_id, .. } => (0, event_id.to_string()),
+        MarketUpdate::EventExpired { event_id, .. } => (1, event_id.to_string()),
+        _ => (2, String::new()),
+    }
+}
 
 /// Load event rows (EventDiscovered + EventExpired pairs) into a sorted Vec.
 ///
@@ -512,7 +603,9 @@ fn load_events_vec(
         ));
     }
 
-    events.sort_by_key(|(ts, _)| *ts);
+    events.sort_by(|(left_ts, left), (right_ts, right)| {
+        (*left_ts, event_sort_key(left)).cmp(&(*right_ts, event_sort_key(right)))
+    });
     Ok(events)
 }
 
@@ -527,4 +620,184 @@ fn symbol_filter_sql(symbols: &[String]) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!("AND symbol IN ({list})")
+}
+
+#[cfg(all(test, feature = "parquet-feed"))]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use rust_decimal_macros::dec;
+    use std::sync::Arc;
+
+    #[test]
+    fn next_result_returns_background_error() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        tx.send(FeedMessage::Error(StreamingParquetFeedError::Background(
+            "duckdb exploded".to_string(),
+        )))
+        .unwrap();
+        drop(tx);
+
+        let worker = thread::spawn(|| {});
+        let mut feed = StreamingParquetFeed {
+            receiver: rx,
+            error: None,
+            _worker: worker,
+        };
+
+        let err = feed
+            .next_result()
+            .expect_err("stream error must be observable");
+        assert_eq!(
+            err,
+            StreamingParquetFeedError::Background("duckdb exploded".to_string())
+        );
+        assert_eq!(feed.background_error(), Some(&err));
+    }
+
+    #[test]
+    fn union_query_orders_same_timestamp_sources_deterministically() {
+        let sql = build_union_sql(&["SELECT 1 AS ts_us, 10 AS source_rank, 'spot' AS typ, 'BTCUSDT' AS s1, NULL AS s2, 1.0 AS f1, 0.0 AS f2, 0.0 AS f3, 0.0 AS f4, 0 AS i1, false AS b1".to_string()]);
+
+        assert!(sql.contains("SELECT ts_us, typ, s1, s2, f1, f2, f3, f4, i1, b1"));
+        assert!(sql.contains("ORDER BY ts_us, source_rank, s1, i1, f1, f2, f3, f4"));
+        assert!(SPOT_SOURCE_RANK < AGG_SOURCE_RANK);
+        assert!(AGG_SOURCE_RANK < LOB_SOURCE_RANK);
+        assert!(LOB_SOURCE_RANK < QUOTE_SOURCE_RANK);
+    }
+
+    #[test]
+    fn events_are_emitted_before_same_timestamp_rows() {
+        assert!(should_send_event_before_row(1_000, 1_000));
+        assert!(should_send_event_before_row(999, 1_000));
+        assert!(!should_send_event_before_row(1_001, 1_000));
+    }
+
+    #[test]
+    fn lifecycle_events_sort_discovered_before_expired_at_same_timestamp() {
+        let ts = Utc.timestamp_micros(1_000_000).unwrap();
+        let mut events = vec![
+            (
+                1_000_000,
+                MarketUpdate::EventExpired {
+                    event_id: Arc::from("event-a"),
+                    end_time: ts,
+                    resolved_up_won: None,
+                },
+            ),
+            (
+                1_000_000,
+                MarketUpdate::EventDiscovered {
+                    event_id: Arc::from("event-a"),
+                    symbol: Arc::from("BTCUSDT"),
+                    up_token: Arc::from("up"),
+                    down_token: Arc::from("down"),
+                    end_time: ts,
+                    window_secs: 300,
+                    price_to_beat: Some(dec!(50000)),
+                    resolved_up_won: None,
+                },
+            ),
+        ];
+
+        events.sort_by(|(left_ts, left), (right_ts, right)| {
+            (*left_ts, event_sort_key(left)).cmp(&(*right_ts, event_sort_key(right)))
+        });
+
+        assert!(matches!(events[0].1, MarketUpdate::EventDiscovered { .. }));
+        assert!(matches!(events[1].1, MarketUpdate::EventExpired { .. }));
+    }
+
+    #[test]
+    fn lob_row_emits_l2_then_l2_depth() {
+        let updates = market_updates_from_row(StreamRow {
+            ts_us: 1_000_000,
+            typ: "lob".to_string(),
+            s1: Some("BTCUSDT".to_string()),
+            f1: Some(0.25),
+            f2: Some(3.0),
+            f3: Some(12.5),
+            f4: Some(13.5),
+            i1: None,
+            b1: None,
+        });
+
+        assert_eq!(updates.len(), 2);
+        assert!(matches!(updates[0], MarketUpdate::L2 { .. }));
+        assert!(matches!(updates[1], MarketUpdate::L2Depth { .. }));
+    }
+
+    #[test]
+    fn agg_row_emits_one_tick_level_trade() {
+        let updates = market_updates_from_row(StreamRow {
+            ts_us: 1_000_000,
+            typ: "agg".to_string(),
+            s1: Some("BTCUSDT".to_string()),
+            f1: Some(51000.0),
+            f2: Some(0.42),
+            f3: None,
+            f4: None,
+            i1: Some(123),
+            b1: Some(true),
+        });
+
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            MarketUpdate::AggTrade {
+                agg_trade_id,
+                is_buyer_maker,
+                ..
+            } => {
+                assert_eq!(*agg_trade_id, 123);
+                assert!(*is_buyer_maker);
+            }
+            other => panic!("expected AggTrade, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quote_row_without_bid_or_ask_is_filtered() {
+        let updates = market_updates_from_row(StreamRow {
+            ts_us: 1_000_000,
+            typ: "quote".to_string(),
+            s1: Some("token".to_string()),
+            f1: None,
+            f2: None,
+            f3: None,
+            f4: None,
+            i1: None,
+            b1: None,
+        });
+
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn sql_keeps_lob_and_aggtrade_full_cadence_but_filters_pm_quotes() {
+        let source = include_str!("parquet_stream.rs");
+        let agg_section = section_between(source, "// Agg trades", "// LOB");
+        let lob_section = section_between(source, "// LOB", "// PM quotes");
+        let quote_section = section_between(source, "// PM quotes", "if parts.is_empty()");
+
+        for section in [agg_section, lob_section] {
+            let lower = section.to_ascii_lowercase();
+            assert!(!lower.contains("date_trunc"));
+            assert!(!lower.contains("distinct on"));
+            assert!(!lower.contains("sample"));
+            assert!(!lower.contains("bucket"));
+        }
+        assert!(agg_section.contains("agg_trade_id"));
+        assert!(lob_section.contains("event_time"));
+        assert!(quote_section.contains(
+            "source IN ('polymarket_ws', 'polymarket_ws_collector', 'ploy_runner_live')"
+        ));
+        assert!(quote_section.contains("best_bid IS NOT NULL AND best_ask IS NOT NULL"));
+    }
+
+    fn section_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+        let start_idx = source.find(start).expect("start marker");
+        let tail = &source[start_idx..];
+        let end_idx = tail.find(end).expect("end marker");
+        &tail[..end_idx]
+    }
 }

--- a/docs/architecture/pm5d-tick-preserving-optimize-guardrails.md
+++ b/docs/architecture/pm5d-tick-preserving-optimize-guardrails.md
@@ -1,0 +1,144 @@
+# PM5D Tick-Preserving Optimize Guardrails
+
+Date: 2026-04-23
+
+Status: accepted for the tick-preserving optimize redesign team slice
+
+## Context
+
+The PM5D optimize workflow made `ploy-ci-1` unreachable during the Apr 15-22
+multi-symbol Parquet run. The failure mode was resource exhaustion around a
+large replay, not a strategy decision failure. The recovery work must keep the
+market-data semantics intact: Binance spot ticks, `aggTrade`, LOB depth,
+Polymarket quotes, and event lifecycle updates remain full-cadence replay
+inputs.
+
+The user explicitly rejected downsampling LOB or `aggTrade` as the fix. Any
+optimizer guardrail must fail before an unsafe replay starts, or stream the same
+ticks with bounded resource use. It must not silently sample, aggregate, or omit
+microstructure events.
+
+## Decision
+
+Use resource guardrails and faithful streaming before adding faster
+approximation layers:
+
+- Add a cheap preflight/manifest phase before heavy replay.
+- Bound DuckDB/process behavior with explicit memory, temp-directory, timeout,
+  and host-health reporting controls.
+- Remove Parquet full-window train/validation `Vec<MarketUpdate>` /
+  `Arc<[MarketUpdate]>` materialization from the optimizer path.
+- Keep DB eager replay scoped and labeled separately from Parquet streaming.
+- Surface background Parquet/DuckDB feed failures as optimizer failures.
+- Add parity tests before replacing the current timestamp ordering or adding a
+  chunked k-way merge feed.
+- Treat feature-tape acceleration as a later ADR after faithful raw-tick replay
+  is safe and measured.
+
+## Non-Negotiable Replay Contract
+
+The canonical PM5D optimizer replay must preserve:
+
+- one emitted update per source row for spot and `aggTrade`;
+- LOB source rows without time downsampling;
+- dual LOB emission order when one row produces both `L2` and `L2Depth`;
+- deterministic same-timestamp ordering across spot, `aggTrade`, LOB, PM quote,
+  and event lifecycle updates;
+- PM quote filtering/trusted-source behavior from the historical feed path;
+- settlement lifecycle behavior, including unresolved-event handling.
+
+Any `--max-updates` or smoke limit is non-canonical validation only. It may prove
+the binary and workflow wiring, but it cannot be reported as a production-scale
+optimization result.
+
+## Runbook
+
+Before starting a full optimize run:
+
+1. Run the preflight/manifest step for the exact requested symbols and date
+   windows.
+2. Confirm the manifest prints source-level counts for spot, `aggTrade`, LOB,
+   PM quotes, events, estimated bytes, and split coverage.
+3. Confirm the run is below configured row/byte/symbol/day thresholds, or that
+   `--allow-large-window` is explicit and justified in the job summary.
+4. Confirm DuckDB temp/spill output is isolated to a run-specific directory that
+   can be cleaned at job end.
+5. Confirm process timeout and post-run host-health steps are active.
+
+Safe validation sequence:
+
+1. Preflight-only on the Apr 15-22 six-symbol window.
+2. Bounded optimize smoke on two symbols, one-day train/validation, five trials.
+3. Narrow six-symbol smoke on a short timestamp window, one to three trials.
+4. Only scale toward the original Apr 15-22 six-symbol request after the runner
+   remains online and idle after each bounded run.
+
+Post-run host-health evidence should record:
+
+- GitHub runner online/busy state;
+- no lingering `Runner.Worker`, `optimize_backtest`, `duckdb`, `cargo`, or
+  `rustc` process from the run;
+- memory/swap/disk state;
+- DuckDB temp/spill directory cleanup result;
+- manifest update counts and trial throughput.
+
+## Job Summary Text
+
+Each optimize workflow run should append a compact summary with this shape:
+
+```markdown
+## PM5D optimize guardrails
+
+- Replay mode: faithful raw-tick Parquet streaming / DB eager / smoke-limited
+- Canonical result: yes/no
+- Symbols: ...
+- Train: ... to ...
+- Validation: ... to ...
+- Source counts: spot=..., aggTrade=..., LOB=..., quotes=..., events=...
+- Estimated rows/bytes: ...
+- Guardrail decision: pass/fail/override
+- DuckDB temp dir: ...
+- Timeout: ...
+- Trials completed: ...
+- Updates processed: ...
+- Runner health after run: online=..., busy=..., lingering_processes=...
+- Notes: LOB and aggTrade were not downsampled.
+```
+
+If a guardrail blocks the run, the summary should still include the manifest and
+the exact threshold that failed. A blocked preflight is a successful safety
+outcome when it prevents runner loss.
+
+## Integration Checklist
+
+For the team lead merge/cherry-pick:
+
+- Confirm workflow and optimizer CLI flags have matching names.
+- Confirm preflight can run without starting the optimizer replay loop.
+- Confirm Parquet optimizer mode no longer builds full-window train/validation
+  `Vec<MarketUpdate>` or `Arc<[MarketUpdate]>`.
+- Confirm DB eager behavior is unchanged or explicitly tested if changed.
+- Confirm `StreamingParquetFeed` background errors fail the optimizer.
+- Confirm same-timestamp and LOB dual-emission parity tests exist before any
+  chunked merge implementation becomes canonical.
+- Confirm `tasks/todo.md` includes the final bounded-run evidence before
+  attempting the original large window again.
+- Confirm docs and workflow summary text never describe smoke-limited or
+  `--max-updates` runs as canonical optimization results.
+
+## Rejected Alternatives
+
+- Downsample LOB or `aggTrade`: rejected because it changes the signal the
+  strategy is intended to evaluate.
+- Add swap and keep eager full-window replay: rejected because the previous host
+  failure already showed the runner can become unreachable under this shape.
+- Jump directly to feature tapes: rejected until faithful raw-tick replay has
+  parity tests and bounded-resource evidence.
+
+## Consequences
+
+Initial guarded runs may be slower than the old eager path. That is acceptable
+because the first recovery requirement is preserving replay correctness while
+keeping `ploy-ci-1` reachable. If faithful streaming remains too slow or DuckDB
+global sorting still spills unsafely, the next architecture slice is a measured
+chunked k-way Parquet merge feed with parity tests as the gate.

--- a/docs/runbooks/tick-preserving-optimize-verification.md
+++ b/docs/runbooks/tick-preserving-optimize-verification.md
@@ -1,0 +1,154 @@
+# Tick-Preserving Optimize Verification Matrix
+
+Date: 2026-04-23
+
+This runbook defines the bounded checks for PM5D `optimize_backtest` recovery.
+It is intentionally verification-only: do not use it to justify LOB or
+aggTrade downsampling, and do not run heavy Parquet replay on a local Mac.
+
+## Invariants
+
+- Binance LOB cadence stays at collector/replay fidelity. Do not add a sample,
+  bucket, or stride layer to `binance_lob_ticks`.
+- Binance aggTrade replay stays tick-level. Do not replace it with candles or
+  per-second aggregates.
+- PM quote replay remains full resolution for trusted quote sources.
+- `--max-updates` is smoke-only evidence. Any run using it is non-canonical.
+- The Apr 15-22 six-symbol window is blocked until preflight, two-symbol smoke,
+  narrow six-symbol smoke, and host-health checks have all passed.
+
+## Cheap Local Checks
+
+These are safe on the developer machine because they only inspect files.
+
+```bash
+./scripts/check_optimize_verification_gates.sh
+```
+
+Expected result before the recovery gates land: `FAIL`, with missing controls
+listed. Expected result before any full-window rerun: `PASS`.
+
+For source edits in other lanes, use only narrow checks unless the operator has
+explicitly accepted local Rust/DuckDB/Parquet load:
+
+```bash
+cargo fmt --check --package ploy-strategy-bundles
+```
+
+If Rust source changed and local build cost is acceptable, this is the maximum
+local compile check for this lane:
+
+```bash
+cargo check -p ploy-strategy-bundles \
+  --features ploy-strategy-bundles/parquet-feed \
+  --example optimize_backtest
+```
+
+Do not run `cargo test -p ploy-strategy-bundles --features parquet-feed --lib`
+locally for this recovery unless the operator explicitly accepts the local
+DuckDB/Parquet compile cost.
+
+## Required CI/Self-Hosted Sequence
+
+Run these on `ploy-ci-1` or another isolated runner, not on the local Mac.
+The commands assume Stage 1 has added workflow inputs for run mode, preflight
+limits, large-window override, DuckDB memory/temp controls, and optional
+`max_updates`.
+
+### 1. Preflight Only: Full Apr 15-22 Six Symbols
+
+This measures the dangerous window without replaying or optimizing.
+
+```bash
+gh workflow run optimize.yml \
+  -f git_ref=<branch-or-sha> \
+  -f run_mode=preflight \
+  -f train_start=2026-04-15 \
+  -f train_end=2026-04-19 \
+  -f val_start=2026-04-20 \
+  -f val_end=2026-04-22 \
+  -f symbols=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT \
+  -f trials=0 \
+  -f allow_large_window=false \
+  -f max_preflight_rows=<approved-row-limit> \
+  -f max_preflight_bytes=<approved-byte-limit> \
+  -f duckdb_memory_limit=4GB \
+  -f duckdb_temp_dir=/tmp/ploy-duckdb-optimize
+```
+
+Pass evidence:
+
+- source-level row/byte counts for spot, aggTrade, LOB, PM quotes, and events;
+- command exits before replay when thresholds are exceeded;
+- runner remains online and SSH-able after the job.
+
+### 2. Bounded Optimize Smoke: Two Symbols, One Day, Five Trials
+
+This proves the optimizer can complete a small faithful replay.
+
+```bash
+gh workflow run optimize.yml \
+  -f git_ref=<branch-or-sha> \
+  -f run_mode=optimize \
+  -f train_start=2026-04-15 \
+  -f train_end=2026-04-15 \
+  -f val_start=2026-04-16 \
+  -f val_end=2026-04-16 \
+  -f symbols=BTCUSDT,ETHUSDT \
+  -f trials=5 \
+  -f allow_large_window=false \
+  -f max_updates= \
+  -f duckdb_memory_limit=4GB \
+  -f duckdb_temp_dir=/tmp/ploy-duckdb-optimize
+```
+
+Pass evidence:
+
+- nonzero updates processed for train and validation;
+- validation completes;
+- output labels any random-search branch honestly;
+- host-health check shows no lingering `Runner.Worker`, `optimize_backtest`,
+  `duckdb`, `cargo`, or `rustc` processes.
+
+### 3. Narrow Six-Symbol Smoke: Timestamp Window, One To Three Trials
+
+This proves six-symbol ordering and source mix without the full multi-day load.
+
+```bash
+gh workflow run optimize.yml \
+  -f git_ref=<branch-or-sha> \
+  -f run_mode=optimize \
+  -f train_start_ts=2026-04-15T00:00:00Z \
+  -f train_end_ts=2026-04-15T01:00:00Z \
+  -f val_start_ts=2026-04-15T01:00:00Z \
+  -f val_end_ts=2026-04-15T02:00:00Z \
+  -f symbols=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT \
+  -f trials=3 \
+  -f allow_large_window=false \
+  -f max_updates= \
+  -f duckdb_memory_limit=4GB \
+  -f duckdb_temp_dir=/tmp/ploy-duckdb-optimize
+```
+
+Pass evidence:
+
+- all six symbols appear in the manifest and replay summary;
+- aggTrade and LOB counts are nonzero where data exists;
+- replay completes or fails legibly without host loss;
+- runner returns to online and idle.
+
+## Full Window Gate
+
+Do not run the original Apr 15-22 six-symbol optimization unless all of these
+are true:
+
+- `./scripts/check_optimize_verification_gates.sh` passes on the branch;
+- full-window preflight has passed or failed before replay with clear sizing
+  output;
+- two-symbol smoke has passed;
+- narrow six-symbol smoke has passed;
+- post-run host-health evidence is attached for every prior job;
+- the command uses an explicit `allow_large_window=true` override.
+
+The full command must not be a workflow default. It must be an intentional,
+operator-approved dispatch after the gates above.

--- a/scripts/check_optimize_verification_gates.sh
+++ b/scripts/check_optimize_verification_gates.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="${repo_root}/.github/workflows/optimize.yml"
+optimizer="${repo_root}/crates/ploy-strategy-bundles/examples/optimize_backtest.rs"
+
+failures=()
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    failures+=("missing required file: ${path#${repo_root}/}")
+  fi
+}
+
+require_text() {
+  local path="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "${needle}" "${path}"; then
+    failures+=("${label}: missing '${needle}' in ${path#${repo_root}/}")
+  fi
+}
+
+require_any_text() {
+  local path="$1"
+  local label="$2"
+  shift 2
+  local found=0
+  local needle
+  for needle in "$@"; do
+    if grep -Fq -- "${needle}" "${path}"; then
+      found=1
+      break
+    fi
+  done
+  if [[ "${found}" -eq 0 ]]; then
+    failures+=("${label}: missing all of [$*] in ${path#${repo_root}/}")
+  fi
+}
+
+require_file "${workflow}"
+require_file "${optimizer}"
+
+if [[ -f "${workflow}" ]]; then
+  require_any_text "${workflow}" "preflight-only workflow gate" "run_mode" "preflight_only" "preflight-only"
+  require_any_text "${workflow}" "large-window explicit override" "allow_large_window" "allow-large-window"
+  require_any_text "${workflow}" "preflight row threshold" "max_preflight_rows" "max-preflight-rows"
+  require_any_text "${workflow}" "preflight byte threshold" "max_preflight_bytes" "max-preflight-bytes"
+  require_any_text "${workflow}" "smoke max-updates control" "max_updates" "max-updates"
+  require_any_text "${workflow}" "DuckDB memory guard" "duckdb_memory_limit" "duckdb-memory-limit"
+  require_any_text "${workflow}" "DuckDB temp-dir isolation" "duckdb_temp_dir" "duckdb-temp-dir"
+  require_text "${workflow}" "timeout" "optimize process timeout wrapper"
+
+  if ! python3 - "${workflow}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+lines = Path(sys.argv[1]).read_text().splitlines()
+
+def default_for(input_name):
+    in_input = False
+    for line in lines:
+        if re.match(rf"^\s+{re.escape(input_name)}:\s*$", line):
+            in_input = True
+            continue
+        if in_input and re.match(r"^\s{6}\S", line):
+            return None
+        if in_input:
+            match = re.match(r"^\s+default:\s*[\"']?([^\"'\n]+)", line)
+            if match:
+                return match.group(1).strip()
+    return None
+
+train_start = default_for("train_start")
+train_end = default_for("train_end")
+val_start = default_for("val_start")
+val_end = default_for("val_end")
+trials_raw = default_for("trials")
+symbols_raw = default_for("symbols") or ""
+symbols = [item.strip() for item in symbols_raw.split(",") if item.strip()]
+try:
+    trials = int(trials_raw or "0")
+except ValueError:
+    trials = 0
+
+unsafe_full_window = (
+    train_start == "2026-04-15"
+    and train_end == "2026-04-19"
+    and val_start == "2026-04-20"
+    and val_end == "2026-04-22"
+    and len(symbols) >= 6
+    and trials >= 50
+)
+
+if unsafe_full_window:
+    print(
+        "unsafe workflow defaults still target Apr 15-22 with "
+        f"{len(symbols)} symbols and {trials} trials"
+    )
+    sys.exit(1)
+PY
+  then
+    failures+=("workflow defaults must not dispatch full Apr 15-22 six-symbol optimize before gates")
+  fi
+fi
+
+if [[ -f "${optimizer}" ]]; then
+  require_text "${optimizer}" "--preflight" "optimizer preflight mode"
+  require_text "${optimizer}" "--max-updates" "optimizer max-updates smoke control"
+  require_text "${optimizer}" "--allow-large-window" "optimizer large-window override"
+  require_text "${optimizer}" "--duckdb-memory-limit" "optimizer DuckDB memory limit"
+  require_text "${optimizer}" "--duckdb-temp-dir" "optimizer DuckDB temp dir"
+
+  if grep -Eq "sample|downsample|bucket|stride" "${optimizer}"; then
+    if ! grep -Fq "non-canonical" "${optimizer}"; then
+      failures+=("optimizer contains sampling language without non-canonical smoke labeling")
+    fi
+  fi
+fi
+
+if [[ "${#failures[@]}" -gt 0 ]]; then
+  echo "FAIL: optimize verification gates are not ready"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
+fi
+
+echo "PASS: optimize verification gates are ready for bounded CI/self-hosted checks"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,6 +23,25 @@
 - 2026-04-23: Cloud-side reboot restored `ploy-ci-1`; ECS StartTime became `2026-04-23T06:47Z`, and GitHub runner returned `online`.
 - 2026-04-23: Bounded smoke run `24821322891` on branch `fix/optimize-resource-controls` succeeded with `BTCUSDT,ETHUSDT`, `5` trials, and one-day train/val; it loaded `9,505,974` updates per split, completed validation, and left the runner `online`.
 
+### Tick-preserving optimize redesign review
+
+- 2026-04-23: Team execution lane split is active under `execute-omx-plans-tick-preserv`. Documentation/integration lane owns ADR/runbook text and merge checklist only; source implementation remains with the workflow, optimizer, feed, and verification lanes.
+- 2026-04-23: Added `docs/architecture/pm5d-tick-preserving-optimize-guardrails.md` as the durable ADR/runbook for the redesign. The doc records the non-negotiable replay contract: no LOB or `aggTrade` downsampling, full-cadence Parquet replay, observable feed errors, and non-canonical labeling for smoke/max-update runs.
+- 2026-04-23: Integration checklist for the lead merge:
+  - workflow and optimizer CLI flags must match exactly;
+  - preflight/manifest must run before any heavy replay loop;
+  - Parquet optimizer mode must not build full-window train/validation `Vec<MarketUpdate>` or `Arc<[MarketUpdate]>`;
+  - DB eager replay must remain unchanged or be covered by explicit tests;
+  - `StreamingParquetFeed` background/DuckDB failures must become optimizer failures;
+  - replay parity tests must lock same-timestamp ordering, event lifecycle insertion, LOB `L2` then `L2Depth` emission, PM quote filtering, and proof that LOB/`aggTrade` are not omitted;
+  - smoke-limited runs must be labeled non-canonical in workflow output and job summaries.
+- 2026-04-23: Required bounded verification sequence before retrying the original Apr 15-22 six-symbol workload:
+  - preflight-only on the Apr 15-22 six-symbol window;
+  - two-symbol one-day train/validation smoke with five trials;
+  - narrow six-symbol smoke with one to three trials;
+  - post-run host-health evidence showing runner online/idle state, no lingering optimizer/DuckDB/build processes, memory/swap/disk state, and DuckDB temp cleanup.
+- 2026-04-23: Local documentation verification for the integration lane used only lightweight checks: Markdown file inspection, `git diff --check`, and status/diff review. No local Rust/DuckDB/Parquet build or replay workload was run.
+
 ## Host Role Split Follow-up (2026-04-20)
 
 ### Files


### PR DESCRIPTION
## Summary
- add preflight/resource gates and bounded defaults to optimize.yml
- stream Parquet replay per optimizer trial instead of materializing train/validation windows
- surface StreamingParquetFeed background failures and add verification/runbook docs

## Verification
- ./scripts/check_optimize_verification_gates.sh
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/examples/optimize_backtest.rs crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
- git diff --check
- rtk cargo check -p ploy-strategy-bundles --example optimize_backtest
- rtk cargo check -p ploy-strategy-bundles --features parquet-feed --example optimize_backtest

## Not tested
- DuckDB-backed Parquet runtime execution
- remote self-hosted bounded workflow dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimization workflow now includes a preflight validation step before main execution.
  * Added resource limit controls (memory, timeout, data row/byte caps) and behavior toggles to gate optimization runs.
  * Improved error handling and propagation during data replay operations.

* **Documentation**
  * New architecture specification for optimization guardrails.
  * Verification runbook with staged testing process and gate script.

* **Tests**
  * Added comprehensive unit tests for streaming behavior and ordering guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->