### PR TITLE
Add trading friction and fix Sharpe fill pairing in optimizer

### DIFF
--- a/config/strategies/02-pm5d-threelayer.unified.toml
+++ b/config/strategies/02-pm5d-threelayer.unified.toml
@@ -48,11 +48,11 @@ three_layer_stop_distance_pct = 0.0152
 three_layer_max_pm_lag_secs = 15
 
 [execution]
-use_spread = false
-spread_pct = 0.02
+use_spread = true
+spread_pct = 0.08
 enable_partial_fills = false
 min_fill_pct = 0.5
-enable_market_impact = false
+enable_market_impact = true
 impact_coefficient = 0.1
 default_depth_shares = 500
 

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -689,7 +689,6 @@ fn run_backtest(
     let snapshot = runtime.trading().snapshot(&BTreeMap::new());
     let cashflow = snapshot.fill_cashflow_summary();
     let net_pnl = cashflow.net_pnl().to_string().parse::<f64>().unwrap_or(0.0);
-    let trade_count = result.fills_recorded as usize / 2;
 
     let fills = &snapshot.fills;
     let mut by_token: HashMap<&str, Vec<&ploy_trading::FillRecord>> = HashMap::new();
@@ -714,6 +713,7 @@ fn run_backtest(
             }
         }
     }
+    let trade_count = per_trade_pnl.len();
 
     let sharpe = if per_trade_pnl.len() < 5 {
         -999.0

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -694,7 +694,10 @@ fn run_backtest(
     let fills = &snapshot.fills;
     let mut by_token: HashMap<&str, Vec<&ploy_trading::FillRecord>> = HashMap::new();
     for fill in fills {
-        by_token.entry(fill.token_id.as_str()).or_default().push(fill);
+        by_token
+            .entry(fill.token_id.as_str())
+            .or_default()
+            .push(fill);
     }
     let mut per_trade_pnl = Vec::new();
     for token_fills in by_token.values() {

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -52,7 +52,7 @@ use ploy_strategy_bundles::{
 use ploy_trading::TradeSide;
 use rust_decimal_macros::dec;
 use sqlx::postgres::PgPoolOptions;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
@@ -665,7 +665,16 @@ fn run_backtest(
 
     let strategy = build_strategy(strategy_variant, config);
     let feed = source.open()?;
-    let executor = SimulatedExecutor::new(SimulatedExecutorConfig::default());
+    let executor = SimulatedExecutor::new(SimulatedExecutorConfig {
+        use_spread: true,
+        spread_pct: dec!(0.08),
+        enable_partial_fills: false,
+        depth_multiple: dec!(5.0),
+        min_fill_pct: dec!(0.5),
+        enable_market_impact: true,
+        impact_coefficient: dec!(0.1),
+        default_depth_shares: 500,
+    });
     let recorder = Box::new(NullRecorder);
     let runtime_config = RuntimeConfig {
         mode: RuntimeMode::Backtest,
@@ -683,17 +692,23 @@ fn run_backtest(
     let trade_count = result.fills_recorded as usize / 2;
 
     let fills = &snapshot.fills;
+    let mut by_token: HashMap<&str, Vec<&ploy_trading::FillRecord>> = HashMap::new();
+    for fill in fills {
+        by_token.entry(fill.token_id.as_str()).or_default().push(fill);
+    }
     let mut per_trade_pnl = Vec::new();
-    let mut index = 0;
-    while index + 1 < fills.len() {
-        let entry = &fills[index];
-        let exit = &fills[index + 1];
-        if entry.side == TradeSide::Buy && exit.side == TradeSide::Sell {
-            let pnl = (exit.price - entry.price) * entry.quantity - entry.fee;
-            per_trade_pnl.push(pnl.to_string().parse::<f64>().unwrap_or(0.0));
-            index += 2;
-        } else {
-            index += 1;
+    for token_fills in by_token.values() {
+        let mut i = 0;
+        while i + 1 < token_fills.len() {
+            let entry = token_fills[i];
+            let exit = token_fills[i + 1];
+            if entry.side == TradeSide::Buy && exit.side == TradeSide::Sell {
+                let pnl = (exit.price - entry.price) * entry.quantity - entry.fee - exit.fee;
+                per_trade_pnl.push(pnl.to_string().parse::<f64>().unwrap_or(0.0));
+                i += 2;
+            } else {
+                i += 1;
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Optimizer produces unrealistic results: Sharpe 100, $54k PnL over 5 days.

## Root Causes

1. **Zero-friction fills** — `SimulatedExecutor` used `Default` config (spread=false, impact=false). Every fill at perfect quoted price with no slippage.

2. **Cross-symbol Sharpe pairing** — Per-trade PnL paired fills sequentially `[i, i+1]`, but with 6 symbols running concurrently, fills are interleaved by time. A BTC entry gets paired with an ETH exit, producing nonsense per-trade PnL and inflated Sharpe.

## Fixes

1. Enable spread (8% proportional ≈ 2c half-spread at mid) and market impact (0.1 coefficient, 500-share depth) in the optimizer's executor. Update TOML `[execution]` to match.

2. Group fills by `token_id` before pairing. Also deduct `exit.fee` which was previously omitted.

## Verification

- `cargo check` and all tests pass
- After merge, re-run optimize workflow — Sharpe should drop to realistic range (<10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Trading execution now enables spread-based execution and market impact handling for more realistic market simulations

* **Improvements**
  * Backtest calculations enhanced with per-token trade grouping and refined profit/loss computation for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->