### PR TITLE
Add an event-root dataset pipeline for binary-event ML work

### DIFF
--- a/crates/ploy-research/examples/factor_research.rs
+++ b/crates/ploy-research/examples/factor_research.rs
@@ -1,14 +1,16 @@
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::factors::{pearson_ic, spearman_ic};
 use ploy_research::{
-    aggregate_factor_metrics, build_event_summaries, build_factor_observations_with_lob,
-    factor_metrics, load_research_lob_snapshots_sampled, FactorObservation,
+    DatasetSourceWindow, EventMetadataChronologyInput, EventRootDatasetBuildRequest,
+    FactorObservation, aggregate_factor_metrics, build_event_root_dataset, build_event_summaries,
+    build_factor_observations_with_lob, export_event_root_dataset_parquet, factor_metrics,
+    load_research_lob_snapshots_sampled, standard_event_root_dataset_artifacts,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -17,6 +19,14 @@ struct ValidWindowRow {
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
     event_count: i64,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct EventMetadataRow {
+    market_slug: String,
+    symbol: String,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
 }
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
@@ -239,6 +249,85 @@ async fn discover_valid_windows(
     .expect("valid window discovery failed")
 }
 
+async fn load_event_chronology_inputs(
+    pool: &sqlx::PgPool,
+    observations: &[FactorObservation],
+) -> Vec<EventMetadataChronologyInput> {
+    let event_ids = observed_event_ids(observations);
+
+    if event_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let rows: Vec<EventMetadataRow> = sqlx::query_as(
+        r#"
+        SELECT
+            market_slug,
+            symbol,
+            start_time,
+            end_time
+        FROM pm_market_metadata
+        WHERE market_slug = ANY($1)
+          AND EXTRACT(EPOCH FROM (end_time - start_time)) = 300
+        ORDER BY end_time, symbol, market_slug
+        "#,
+    )
+    .bind(&event_ids)
+    .fetch_all(pool)
+    .await
+    .expect("event dataset metadata query failed");
+
+    event_metadata_rows_to_chronology_inputs(&event_ids, rows)
+}
+
+fn observed_event_ids(observations: &[FactorObservation]) -> Vec<String> {
+    observations
+        .iter()
+        .map(|row| row.event_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn event_metadata_rows_to_chronology_inputs(
+    event_ids: &[String],
+    rows: Vec<EventMetadataRow>,
+) -> Vec<EventMetadataChronologyInput> {
+    let mut by_event_id = BTreeMap::new();
+    for row in rows {
+        if by_event_id.insert(row.market_slug.clone(), row).is_some() {
+            panic!("duplicate pm_market_metadata row for observed event id");
+        }
+    }
+
+    let missing_event_ids: Vec<_> = event_ids
+        .iter()
+        .filter(|event_id| !by_event_id.contains_key(event_id.as_str()))
+        .cloned()
+        .collect();
+    if !missing_event_ids.is_empty() {
+        panic!(
+            "missing canonical pm_market_metadata rows for observed event ids: {}",
+            missing_event_ids.join(",")
+        );
+    }
+
+    event_ids
+        .iter()
+        .map(|event_id| {
+            let row = by_event_id
+                .remove(event_id.as_str())
+                .expect("event metadata presence was checked");
+            EventMetadataChronologyInput {
+                event_id: event_id.clone(),
+                symbol: row.symbol,
+                start_time: Some(row.start_time),
+                end_time: Some(row.end_time),
+            }
+        })
+        .collect()
+}
+
 /// Slices a sorted slice to items whose timestamp falls in `[start, end]`.
 /// Precondition: `items` must be sorted by `ts_fn` in ascending order.
 fn slice_by_time<'a, T>(
@@ -339,7 +428,10 @@ fn summarize_regime_factors(
     let mut grouped: BTreeMap<(&'static str, String, String), Vec<&TimeBucketMetric>> =
         BTreeMap::new();
 
-    for metric in metrics.iter().filter(|metric| metric.spearman_ic.is_finite()) {
+    for metric in metrics
+        .iter()
+        .filter(|metric| metric.spearman_ic.is_finite())
+    {
         for regime in regimes {
             if metric.bucket_start_secs >= regime.start_secs
                 && metric.bucket_end_secs <= regime.end_secs
@@ -481,9 +573,13 @@ fn build_time_bucket_metrics(
         let bucket_start_secs = (row.time_remaining_secs / bin_secs) * bin_secs;
 
         for factor in factors {
-            let Some(x) = row_factor_value(row, factor) else { continue };
+            let Some(x) = row_factor_value(row, factor) else {
+                continue;
+            };
             for label in labels {
-                let Some(y) = row_label_value(row, label) else { continue };
+                let Some(y) = row_label_value(row, label) else {
+                    continue;
+                };
                 let entry = grouped
                     .entry((label.clone(), factor.clone(), bucket_start_secs))
                     .or_default();
@@ -567,7 +663,10 @@ async fn persist_time_bucket_metrics(
     .await
     .expect("create research_time_conditioned_factor_metrics index");
 
-    let mut tx = pool.begin().await.expect("begin time-ic persistence transaction");
+    let mut tx = pool
+        .begin()
+        .await
+        .expect("begin time-ic persistence transaction");
     for metric in metrics {
         sqlx::query(
             r#"
@@ -626,12 +725,18 @@ async fn persist_time_bucket_metrics(
         .await
         .expect("insert time-conditioned factor metric");
     }
-    tx.commit().await.expect("commit time-ic persistence transaction");
+    tx.commit()
+        .await
+        .expect("commit time-ic persistence transaction");
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_entry_targets, descending_abs_f64_cmp, parse_entry_target_token};
+    use super::{
+        EventMetadataRow, build_entry_targets, descending_abs_f64_cmp,
+        event_metadata_rows_to_chronology_inputs, parse_entry_target_token,
+    };
+    use chrono::{TimeZone, Utc};
 
     #[test]
     fn descending_abs_f64_cmp_handles_non_finite_values() {
@@ -661,13 +766,71 @@ mod tests {
         let sec1 = targets.iter().find(|target| target.seconds == 1).unwrap();
 
         assert!(sec10.tolerance_secs <= 5);
-        assert!(sec1.tolerance_secs <= 1);
+        assert!(sec1.tolerance_secs <= 2);
     }
 
     #[test]
     fn parse_entry_target_token_supports_descending_ranges() {
         assert_eq!(parse_entry_target_token("300:296:2"), vec![300, 298, 296]);
         assert_eq!(parse_entry_target_token("5"), vec![5]);
+    }
+
+    #[test]
+    fn event_metadata_rows_to_chronology_inputs_preserves_observed_event_set() {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let event_ids = vec!["evt-b".to_string(), "evt-a".to_string()];
+        let rows = vec![
+            EventMetadataRow {
+                market_slug: "evt-a".to_string(),
+                symbol: "BTCUSDT".to_string(),
+                start_time: start,
+                end_time: start + chrono::Duration::minutes(5),
+            },
+            EventMetadataRow {
+                market_slug: "evt-b".to_string(),
+                symbol: "ETHUSDT".to_string(),
+                start_time: start + chrono::Duration::minutes(5),
+                end_time: start + chrono::Duration::minutes(10),
+            },
+        ];
+
+        let inputs = event_metadata_rows_to_chronology_inputs(&event_ids, rows);
+
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].event_id, "evt-b");
+        assert_eq!(inputs[0].symbol, "ETHUSDT");
+        assert_eq!(inputs[1].event_id, "evt-a");
+        assert_eq!(inputs[1].symbol, "BTCUSDT");
+    }
+
+    #[test]
+    #[should_panic(expected = "missing canonical pm_market_metadata rows")]
+    fn event_metadata_rows_to_chronology_inputs_fails_on_missing_metadata() {
+        let event_ids = vec!["evt-missing".to_string()];
+        let _ = event_metadata_rows_to_chronology_inputs(&event_ids, Vec::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate pm_market_metadata row")]
+    fn event_metadata_rows_to_chronology_inputs_fails_on_duplicate_metadata() {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let event_ids = vec!["evt-a".to_string()];
+        let rows = vec![
+            EventMetadataRow {
+                market_slug: "evt-a".to_string(),
+                symbol: "BTCUSDT".to_string(),
+                start_time: start,
+                end_time: start + chrono::Duration::minutes(5),
+            },
+            EventMetadataRow {
+                market_slug: "evt-a".to_string(),
+                symbol: "BTCUSDT".to_string(),
+                start_time: start,
+                end_time: start + chrono::Duration::minutes(5),
+            },
+        ];
+
+        let _ = event_metadata_rows_to_chronology_inputs(&event_ids, rows);
     }
 }
 
@@ -764,10 +927,16 @@ async fn main() {
     //   min_pm_lag_secs: only trade when quote is stale enough to exploit
     //     (spot has moved but PM hasn't updated yet → mispricing window)
     let three_layer_max_pm_lag_secs = flag_value(&args, "--three-layer-max-pm-lag")
-        .map(|raw| raw.parse::<f64>().unwrap_or_else(|_| panic!("invalid --three-layer-max-pm-lag: {raw}")))
+        .map(|raw| {
+            raw.parse::<f64>()
+                .unwrap_or_else(|_| panic!("invalid --three-layer-max-pm-lag: {raw}"))
+        })
         .unwrap_or(f64::INFINITY); // default: no upper limit
     let three_layer_min_pm_lag_secs = flag_value(&args, "--three-layer-min-pm-lag")
-        .map(|raw| raw.parse::<f64>().unwrap_or_else(|_| panic!("invalid --three-layer-min-pm-lag: {raw}")))
+        .map(|raw| {
+            raw.parse::<f64>()
+                .unwrap_or_else(|_| panic!("invalid --three-layer-min-pm-lag: {raw}"))
+        })
         .unwrap_or(0.0); // default: no lower limit
     let three_layer_middle_vol_adjust = flag_value(&args, "--three-layer-middle-vol-adjust")
         .map(|raw| {
@@ -783,8 +952,13 @@ async fn main() {
         .unwrap_or(0.08);
     let export_parquet: Option<std::path::PathBuf> =
         flag_value(&args, "--export-parquet").map(std::path::PathBuf::from);
+    let export_event_dataset: Option<std::path::PathBuf> =
+        flag_value(&args, "--export-event-dataset").map(std::path::PathBuf::from);
 
-    eprintln!("loading factor research range {start} -> {end} for {:?}", symbols);
+    eprintln!(
+        "loading factor research range {start} -> {end} for {:?}",
+        symbols
+    );
 
     let pool = PgPoolOptions::new()
         .max_connections(1)
@@ -805,7 +979,10 @@ async fn main() {
         discovered
     } else {
         vec![ValidWindowRow {
-            symbol: symbols.first().cloned().unwrap_or_else(|| "BTCUSDT".to_string()),
+            symbol: symbols
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "BTCUSDT".to_string()),
             start_time: start,
             end_time: end,
             event_count: 0,
@@ -813,16 +990,8 @@ async fn main() {
     };
 
     // Compute global time range covering all windows for bulk load.
-    let global_start = windows
-        .iter()
-        .map(|w| w.start_time)
-        .min()
-        .unwrap_or(start);
-    let global_end = windows
-        .iter()
-        .map(|w| w.end_time)
-        .max()
-        .unwrap_or(end);
+    let global_start = windows.iter().map(|w| w.start_time).min().unwrap_or(start);
+    let global_end = windows.iter().map(|w| w.end_time).max().unwrap_or(end);
 
     // Collect all unique symbols across windows.
     let bulk_symbols: Vec<String> = {
@@ -864,7 +1033,11 @@ async fn main() {
     )
     .await
     .expect("bulk lob snapshot load failed");
-    eprintln!("load_research_lob_snapshots_sampled (sample_secs={}): {:?}", lob_sample_secs, t1.elapsed());
+    eprintln!(
+        "load_research_lob_snapshots_sampled (sample_secs={}): {:?}",
+        lob_sample_secs,
+        t1.elapsed()
+    );
 
     eprintln!(
         "bulk loaded {} updates, {} lob snapshots",
@@ -919,25 +1092,54 @@ async fn main() {
     }
 
     let aggregated = aggregate_factor_metrics(&all_metrics);
+    let flat_obs: Vec<FactorObservation> = all_observations
+        .iter()
+        .flat_map(|rows| rows.iter().cloned())
+        .collect();
 
     if let Some(ref parquet_path) = export_parquet {
-        let flat_obs: Vec<FactorObservation> = all_observations
-            .iter()
-            .flat_map(|rows| rows.iter().cloned())
-            .collect();
         tracing::info!(path = %parquet_path.display(), observations = flat_obs.len(), "Exporting observations to Parquet");
         ploy_research::export_observations_parquet(&flat_obs, parquet_path)
             .expect("Parquet export failed");
         tracing::info!(path = %parquet_path.display(), "Parquet export complete");
     }
 
+    if let Some(ref dataset_dir) = export_event_dataset {
+        tracing::info!(path = %dataset_dir.display(), observations = flat_obs.len(), "Exporting event-root dataset");
+        let chronology_events = load_event_chronology_inputs(&pool, &flat_obs).await;
+        let dataset_request = EventRootDatasetBuildRequest::new(
+            &flat_obs,
+            chronology_events,
+            DatasetSourceWindow {
+                start_time: global_start,
+                end_time: global_end,
+                symbols: bulk_symbols.clone(),
+            },
+            standard_event_root_dataset_artifacts(),
+            Utc::now(),
+        );
+        let dataset_build =
+            build_event_root_dataset(dataset_request).expect("event-root dataset build failed");
+        export_event_root_dataset_parquet(&dataset_build, dataset_dir)
+            .expect("event-root dataset export failed");
+        eprintln!(
+            "\n=== Event Dataset Export ===\npath={}\nevents={} observations={}\nevents_by_split train={} val={} test={}\nobservations_by_split train={} val={} test={}",
+            dataset_dir.display(),
+            dataset_build.manifest.stats.total_events,
+            dataset_build.manifest.stats.total_observations,
+            dataset_build.manifest.stats.events_per_split.train,
+            dataset_build.manifest.stats.events_per_split.val,
+            dataset_build.manifest.stats.events_per_split.test,
+            dataset_build.manifest.stats.observations_per_split.train,
+            dataset_build.manifest.stats.observations_per_split.val,
+            dataset_build.manifest.stats.observations_per_split.test,
+        );
+        tracing::info!(path = %dataset_dir.display(), "Event-root dataset export complete");
+    }
+
     if !time_ic_factors.is_empty() {
-        let flat_rows: Vec<FactorObservation> = all_observations
-            .iter()
-            .flat_map(|rows| rows.iter().cloned())
-            .collect();
         let mut time_bucket_metrics = build_time_bucket_metrics(
-            &flat_rows,
+            &flat_obs,
             &time_ic_factors,
             &time_ic_labels,
             time_ic_bin_secs,
@@ -1023,17 +1225,14 @@ async fn main() {
             } else {
                 eprintln!(
                     "time_conditioned_ic_db_verify scope={} persisted_rows={} strongest=none",
-                    analysis_scope,
-                    persisted_rows
+                    analysis_scope, persisted_rows
                 );
             }
         }
 
         eprintln!(
             "\n=== Time-Conditioned IC (bin={}s, max={}s, min_points={}) ===",
-            time_ic_bin_secs,
-            time_ic_max_secs,
-            time_ic_min_points
+            time_ic_bin_secs, time_ic_max_secs, time_ic_min_points
         );
         for metric in &time_bucket_metrics {
             eprintln!(
@@ -1156,16 +1355,11 @@ async fn main() {
     }
 
     impl SimStats {
-        fn record(
-            &mut self,
-            won: bool,
-            pnl: f64,
-            stake: f64,
-            entry_price: f64,
-            reward_risk: f64,
-        ) {
+        fn record(&mut self, won: bool, pnl: f64, stake: f64, entry_price: f64, reward_risk: f64) {
             self.trades += 1;
-            if won { self.wins += 1; }
+            if won {
+                self.wins += 1;
+            }
             self.pnl += pnl;
             self.stake += stake;
             self.pnl_series.push(pnl);
@@ -1178,10 +1372,18 @@ async fn main() {
             }
         }
         fn win_rate(&self) -> f64 {
-            if self.trades > 0 { self.wins as f64 / self.trades as f64 * 100.0 } else { 0.0 }
+            if self.trades > 0 {
+                self.wins as f64 / self.trades as f64 * 100.0
+            } else {
+                0.0
+            }
         }
         fn roi(&self) -> f64 {
-            if self.stake > 0.0 { self.pnl / self.stake * 100.0 } else { 0.0 }
+            if self.stake > 0.0 {
+                self.pnl / self.stake * 100.0
+            } else {
+                0.0
+            }
         }
         fn avg_entry_price(&self) -> f64 {
             if self.priced_trades > 0 {
@@ -1227,7 +1429,9 @@ async fn main() {
     }
 
     impl MultiFactorModel {
-        fn new() -> Self { Self { data: Vec::new() } }
+        fn new() -> Self {
+            Self { data: Vec::new() }
+        }
 
         fn push(&mut self, factors: [f64; MF_N], settlement: f64) {
             if factors.iter().all(|f| f.is_finite()) && (settlement == 0.0 || settlement == 1.0) {
@@ -1239,15 +1443,21 @@ async fn main() {
         /// Returns (weights, means, stds) or None if insufficient data.
         fn fit(&self) -> Option<([f64; MF_N], [f64; MF_N], [f64; MF_N])> {
             let n = self.data.len();
-            if n < 100 { return None; }
+            if n < 100 {
+                return None;
+            }
 
             let mut means = [0.0f64; MF_N];
             let mut y_mean = 0.0f64;
             for (x, y) in &self.data {
-                for i in 0..MF_N { means[i] += x[i]; }
+                for i in 0..MF_N {
+                    means[i] += x[i];
+                }
                 y_mean += y;
             }
-            for i in 0..MF_N { means[i] /= n as f64; }
+            for i in 0..MF_N {
+                means[i] /= n as f64;
+            }
             y_mean /= n as f64;
 
             let mut stds = [0.0f64; MF_N];
@@ -1262,7 +1472,9 @@ async fn main() {
                     cov[i] += dx * dy;
                 }
             }
-            for i in 0..MF_N { stds[i] = (stds[i] / n as f64).sqrt(); }
+            for i in 0..MF_N {
+                stds[i] = (stds[i] / n as f64).sqrt();
+            }
             y_var = (y_var / n as f64).sqrt();
 
             // Pearson correlation as weight
@@ -1277,7 +1489,13 @@ async fn main() {
         }
 
         /// Predict P(up) for a new observation using IC-weighted z-scores + sigmoid.
-        fn predict(&self, factors: &[f64; MF_N], weights: &[f64; MF_N], means: &[f64; MF_N], stds: &[f64; MF_N]) -> f64 {
+        fn predict(
+            &self,
+            factors: &[f64; MF_N],
+            weights: &[f64; MF_N],
+            means: &[f64; MF_N],
+            stds: &[f64; MF_N],
+        ) -> f64 {
             let mut composite = 0.0f64;
             for i in 0..MF_N {
                 if stds[i] > 1e-12 && factors[i].is_finite() {
@@ -1294,8 +1512,10 @@ async fn main() {
     // Entry time targets: test entering at different points in the 5-minute window.
     // Use a denser hybrid grid in the final minute by default.
     let entry_targets_raw = flag_value(&args, "--entry-targets-secs");
-    let entry_tolerance_secs = flag_value(&args, "--entry-tolerance-secs")
-        .map(|raw| raw.parse::<i64>().unwrap_or_else(|_| panic!("invalid tolerance: {raw}")));
+    let entry_tolerance_secs = flag_value(&args, "--entry-tolerance-secs").map(|raw| {
+        raw.parse::<i64>()
+            .unwrap_or_else(|_| panic!("invalid tolerance: {raw}"))
+    });
     let entry_targets = build_entry_targets(entry_targets_raw.as_deref(), entry_tolerance_secs);
 
     let stake_per_trade = 25.0f64;
@@ -1316,14 +1536,19 @@ async fn main() {
     }
     let mut entry_results: Vec<(String, EntryStats)> = entry_targets
         .iter()
-        .map(|target| (target.label.clone(), EntryStats {
-            total_events: 0,
-            covered_events: 0,
-            combined: SimStats::default(),
-            mf: SimStats::default(),
-            mf_lob: SimStats::default(),
-            three_layer: SimStats::default(),
-        }))
+        .map(|target| {
+            (
+                target.label.clone(),
+                EntryStats {
+                    total_events: 0,
+                    covered_events: 0,
+                    combined: SimStats::default(),
+                    mf: SimStats::default(),
+                    mf_lob: SimStats::default(),
+                    three_layer: SimStats::default(),
+                },
+            )
+        })
         .collect();
 
     #[derive(Default)]
@@ -1410,14 +1635,26 @@ async fn main() {
                     let cp = 1.0 - obs.model_prob_up;
                     let edge_up = cp - obs.pm_up_ask - fee_up;
                     let edge_down = (1.0 - cp) - obs.pm_down_ask - fee_down;
-                    let lob_score = obs.obi_10 + obs.depth_imbalance
-                        - 0.5 * obs.microprice_offset_bps.signum();
+                    let lob_score =
+                        obs.obi_10 + obs.depth_imbalance - 0.5 * obs.microprice_offset_bps.signum();
                     if edge_up >= min_edge && edge_up >= edge_down && lob_score > 0.0 {
                         let (p, w) = pnl_up(obs.settlement_up == 1.0);
-                        stats.combined.record(w, p, stake_per_trade, obs.pm_up_ask, obs.reward_risk_up);
+                        stats.combined.record(
+                            w,
+                            p,
+                            stake_per_trade,
+                            obs.pm_up_ask,
+                            obs.reward_risk_up,
+                        );
                     } else if edge_down >= min_edge && lob_score < 0.0 {
                         let (p, w) = pnl_down(obs.settlement_up == 0.0);
-                        stats.combined.record(w, p, stake_per_trade, obs.pm_down_ask, obs.reward_risk_down);
+                        stats.combined.record(
+                            w,
+                            p,
+                            stake_per_trade,
+                            obs.pm_down_ask,
+                            obs.reward_risk_down,
+                        );
                     }
                 }
 
@@ -1429,10 +1666,18 @@ async fn main() {
                     let edge_down = (1.0 - mf_p) - obs.pm_down_ask - fee_down;
                     if edge_up >= min_edge && edge_up >= edge_down {
                         let (p, w) = pnl_up(obs.settlement_up == 1.0);
-                        stats.mf.record(w, p, stake_per_trade, obs.pm_up_ask, obs.reward_risk_up);
+                        stats
+                            .mf
+                            .record(w, p, stake_per_trade, obs.pm_up_ask, obs.reward_risk_up);
                     } else if edge_down >= min_edge {
                         let (p, w) = pnl_down(obs.settlement_up == 0.0);
-                        stats.mf.record(w, p, stake_per_trade, obs.pm_down_ask, obs.reward_risk_down);
+                        stats.mf.record(
+                            w,
+                            p,
+                            stake_per_trade,
+                            obs.pm_down_ask,
+                            obs.reward_risk_down,
+                        );
                     }
                 }
 
@@ -1442,14 +1687,26 @@ async fn main() {
                     let mf_p = mf_model.predict(&fv, weights, means, stds);
                     let edge_up = mf_p - obs.pm_up_ask - fee_up;
                     let edge_down = (1.0 - mf_p) - obs.pm_down_ask - fee_down;
-                    let lob_score = obs.obi_10 + obs.depth_imbalance
-                        - 0.5 * obs.microprice_offset_bps.signum();
+                    let lob_score =
+                        obs.obi_10 + obs.depth_imbalance - 0.5 * obs.microprice_offset_bps.signum();
                     if edge_up >= min_edge && edge_up >= edge_down && lob_score > 0.0 {
                         let (p, w) = pnl_up(obs.settlement_up == 1.0);
-                        stats.mf_lob.record(w, p, stake_per_trade, obs.pm_up_ask, obs.reward_risk_up);
+                        stats.mf_lob.record(
+                            w,
+                            p,
+                            stake_per_trade,
+                            obs.pm_up_ask,
+                            obs.reward_risk_up,
+                        );
                     } else if edge_down >= min_edge && lob_score < 0.0 {
                         let (p, w) = pnl_down(obs.settlement_up == 0.0);
-                        stats.mf_lob.record(w, p, stake_per_trade, obs.pm_down_ask, obs.reward_risk_down);
+                        stats.mf_lob.record(
+                            w,
+                            p,
+                            stake_per_trade,
+                            obs.pm_down_ask,
+                            obs.reward_risk_down,
+                        );
                     }
                 }
 
@@ -1469,7 +1726,8 @@ async fn main() {
                         && obs.reward_risk_up.is_finite()
                         && obs.reward_risk_down.is_finite()
                     {
-                        let independent_state_up = (1.0 - obs.model_prob_up).clamp(1e-4, 1.0 - 1e-4);
+                        let independent_state_up =
+                            (1.0 - obs.model_prob_up).clamp(1e-4, 1.0 - 1e-4);
                         let p_three_up = match regime {
                             "early" => independent_state_up,
                             "middle" => {
@@ -1478,7 +1736,9 @@ async fn main() {
                                 } else {
                                     0.0
                                 };
-                                (0.65 * independent_state_up + 0.35 * obs.fair_prob_up_clean + vol_adjust)
+                                (0.65 * independent_state_up
+                                    + 0.35 * obs.fair_prob_up_clean
+                                    + vol_adjust)
                                     .clamp(1e-4, 1.0 - 1e-4)
                             }
                             _ => 0.5,
@@ -1525,7 +1785,13 @@ async fn main() {
                                     && obs.reward_risk_up >= three_layer_reward_risk_min
                                 {
                                     let (p, w) = pnl_up(obs.settlement_up == 1.0);
-                                    stats.three_layer.record(w, p, stake_per_trade, obs.pm_up_ask, obs.reward_risk_up);
+                                    stats.three_layer.record(
+                                        w,
+                                        p,
+                                        stake_per_trade,
+                                        obs.pm_up_ask,
+                                        obs.reward_risk_up,
+                                    );
                                 }
                             } else {
                                 let edge = (1.0 - p_three_up) - (obs.pm_down_ask + fee_down);
@@ -1535,7 +1801,13 @@ async fn main() {
                                     && obs.reward_risk_down >= three_layer_reward_risk_min
                                 {
                                     let (p, w) = pnl_down(obs.settlement_up == 0.0);
-                                    stats.three_layer.record(w, p, stake_per_trade, obs.pm_down_ask, obs.reward_risk_down);
+                                    stats.three_layer.record(
+                                        w,
+                                        p,
+                                        stake_per_trade,
+                                        obs.pm_down_ask,
+                                        obs.reward_risk_down,
+                                    );
                                 }
                             }
                         }
@@ -1567,8 +1839,7 @@ async fn main() {
                 let fee_up = 0.02 * obs.pm_up_ask * (1.0 - obs.pm_up_ask);
                 let fee_down = 0.02 * obs.pm_down_ask * (1.0 - obs.pm_down_ask);
 
-                let independent_state_up =
-                    (1.0 - obs.model_prob_up).clamp(1e-4, 1.0 - 1e-4);
+                let independent_state_up = (1.0 - obs.model_prob_up).clamp(1e-4, 1.0 - 1e-4);
                 let p_three_up = match regime {
                     "early" => independent_state_up,
                     "middle" => {
@@ -1577,9 +1848,7 @@ async fn main() {
                         } else {
                             0.0
                         };
-                        (0.65 * independent_state_up
-                            + 0.35 * obs.fair_prob_up_clean
-                            + vol_adjust)
+                        (0.65 * independent_state_up + 0.35 * obs.fair_prob_up_clean + vol_adjust)
                             .clamp(1e-4, 1.0 - 1e-4)
                     }
                     _ => 0.5,
@@ -1597,8 +1866,7 @@ async fn main() {
                     "early" => true,
                     "middle" => {
                         if obs.vol_gap.is_finite() {
-                            (*side_up && obs.vol_gap > 0.0)
-                                || (!*side_up && obs.vol_gap < 0.0)
+                            (*side_up && obs.vol_gap > 0.0) || (!*side_up && obs.vol_gap < 0.0)
                         } else {
                             false
                         }
@@ -1627,10 +1895,17 @@ async fn main() {
                 let (pre_fill_edge, pre_fill_rr) = if side_up {
                     (p_three_up - (obs.pm_up_ask + fee_up), obs.reward_risk_up)
                 } else {
-                    ((1.0 - p_three_up) - (obs.pm_down_ask + fee_down), obs.reward_risk_down)
+                    (
+                        (1.0 - p_three_up) - (obs.pm_down_ask + fee_down),
+                        obs.reward_risk_down,
+                    )
                 };
 
-                let entry_price = if side_up { obs.pm_up_ask } else { obs.pm_down_ask };
+                let entry_price = if side_up {
+                    obs.pm_up_ask
+                } else {
+                    obs.pm_down_ask
+                };
 
                 if pre_fill_edge < min_edge || pre_fill_rr < three_layer_reward_risk_min {
                     continue;
@@ -1654,8 +1929,16 @@ async fn main() {
                 // Fill simulation using orderbook depth.
                 // order_shares = how many shares we need to buy at entry_price
                 let order_shares = stake_per_trade / entry_price;
-                let ask_size = if side_up { obs.pm_up_ask_size } else { obs.pm_down_ask_size };
-                let bid_size = if side_up { obs.pm_up_bid_size } else { obs.pm_down_bid_size };
+                let ask_size = if side_up {
+                    obs.pm_up_ask_size
+                } else {
+                    obs.pm_down_ask_size
+                };
+                let bid_size = if side_up {
+                    obs.pm_up_bid_size
+                } else {
+                    obs.pm_down_bid_size
+                };
 
                 // Liquidity filter: skip if ask_size is known and below threshold
                 if three_layer_min_liquidity > 0.0
@@ -1667,17 +1950,22 @@ async fn main() {
 
                 // Price impact: if best ask can't fill our full order, we walk up one tick.
                 // This is conservative — real impact could be larger for thin books.
-                let fill_price = if ask_size.is_finite() && ask_size > 0.0 && ask_size < order_shares {
-                    (entry_price + 0.01).min(0.99) // one tick slippage
-                } else {
-                    entry_price
-                };
+                let fill_price =
+                    if ask_size.is_finite() && ask_size > 0.0 && ask_size < order_shares {
+                        (entry_price + 0.01).min(0.99) // one tick slippage
+                    } else {
+                        entry_price
+                    };
 
                 // Recalculate edge and pnl with actual fill price
                 let fill_fee = 0.02 * fill_price * (1.0 - fill_price);
                 let (edge, reward_risk, won, pnl) = if side_up {
                     let e = p_three_up - (fill_price + fill_fee);
-                    let rr = if fill_price > 0.0 { (1.0 / fill_price) - 1.0 } else { 0.0 };
+                    let rr = if fill_price > 0.0 {
+                        (1.0 / fill_price) - 1.0
+                    } else {
+                        0.0
+                    };
                     let p = if obs.settlement_up == 1.0 {
                         stake_per_trade * (1.0 / fill_price - 1.0)
                             - stake_per_trade * fill_fee / fill_price
@@ -1687,7 +1975,11 @@ async fn main() {
                     (e, rr, obs.settlement_up == 1.0, p)
                 } else {
                     let e = (1.0 - p_three_up) - (fill_price + fill_fee);
-                    let rr = if fill_price > 0.0 { (1.0 / fill_price) - 1.0 } else { 0.0 };
+                    let rr = if fill_price > 0.0 {
+                        (1.0 / fill_price) - 1.0
+                    } else {
+                        0.0
+                    };
                     let p = if obs.settlement_up == 0.0 {
                         stake_per_trade * (1.0 / fill_price - 1.0)
                             - stake_per_trade * fill_fee / fill_price
@@ -1707,18 +1999,34 @@ async fn main() {
                     reward_risk,
                 );
                 match regime {
-                    "early" => three_layer_one_trade
-                        .early
-                        .record(won, pnl, stake_per_trade, fill_price, reward_risk),
-                    "middle" => three_layer_one_trade
-                        .middle
-                        .record(won, pnl, stake_per_trade, fill_price, reward_risk),
-                    "late" => three_layer_one_trade
-                        .late
-                        .record(won, pnl, stake_per_trade, fill_price, reward_risk),
-                    _ => three_layer_one_trade
-                        .expiry
-                        .record(won, pnl, stake_per_trade, fill_price, reward_risk),
+                    "early" => three_layer_one_trade.early.record(
+                        won,
+                        pnl,
+                        stake_per_trade,
+                        fill_price,
+                        reward_risk,
+                    ),
+                    "middle" => three_layer_one_trade.middle.record(
+                        won,
+                        pnl,
+                        stake_per_trade,
+                        fill_price,
+                        reward_risk,
+                    ),
+                    "late" => three_layer_one_trade.late.record(
+                        won,
+                        pnl,
+                        stake_per_trade,
+                        fill_price,
+                        reward_risk,
+                    ),
+                    _ => three_layer_one_trade.expiry.record(
+                        won,
+                        pnl,
+                        stake_per_trade,
+                        fill_price,
+                        reward_risk,
+                    ),
                 }
                 break;
             }
@@ -1748,22 +2056,29 @@ async fn main() {
     );
     eprintln!(
         "{:<8} {:<14} {:<43} {:<43} {:<43} {:<43}",
-        "entry",
-        "coverage",
-        "D.Combined",
-        "G.MultiFactor",
-        "H.MF+LOB",
-        "I.ThreeLayer"
+        "entry", "coverage", "D.Combined", "G.MultiFactor", "H.MF+LOB", "I.ThreeLayer"
     );
     for (label, stats) in &entry_results {
         eprintln!(
             "{:<8} {:<14} t={:<4} w={:<4} wr={:>5.1}% roi={:>7.2}% | t={:<4} w={:<4} wr={:>5.1}% roi={:>7.2}% | t={:<4} w={:<4} wr={:>5.1}% roi={:>7.2}% | t={:<4} w={:<4} wr={:>5.1}% roi={:>7.2}%",
             label,
             format!("{}/{}", stats.covered_events, stats.total_events),
-            stats.combined.trades, stats.combined.wins, stats.combined.win_rate(), stats.combined.roi(),
-            stats.mf.trades, stats.mf.wins, stats.mf.win_rate(), stats.mf.roi(),
-            stats.mf_lob.trades, stats.mf_lob.wins, stats.mf_lob.win_rate(), stats.mf_lob.roi(),
-            stats.three_layer.trades, stats.three_layer.wins, stats.three_layer.win_rate(), stats.three_layer.roi(),
+            stats.combined.trades,
+            stats.combined.wins,
+            stats.combined.win_rate(),
+            stats.combined.roi(),
+            stats.mf.trades,
+            stats.mf.wins,
+            stats.mf.win_rate(),
+            stats.mf.roi(),
+            stats.mf_lob.trades,
+            stats.mf_lob.wins,
+            stats.mf_lob.win_rate(),
+            stats.mf_lob.roi(),
+            stats.three_layer.trades,
+            stats.three_layer.wins,
+            stats.three_layer.win_rate(),
+            stats.three_layer.roi(),
         );
     }
 
@@ -1818,20 +2133,26 @@ async fn main() {
             let mean_pnl = series.iter().sum::<f64>() / n as f64;
             let variance = series.iter().map(|x| (x - mean_pnl).powi(2)).sum::<f64>() / n as f64;
             let std_pnl = variance.sqrt();
-            let downside_variance = series.iter()
+            let downside_variance = series
+                .iter()
                 .filter(|&&x| x < 0.0)
                 .map(|x| x.powi(2))
-                .sum::<f64>() / n as f64;
+                .sum::<f64>()
+                / n as f64;
             let downside_std = downside_variance.sqrt();
 
             // Sharpe (per-trade, annualized assuming ~6 trades/day × 365)
             let trades_per_year = 6.0_f64 * 365.0;
             let sharpe = if std_pnl > 0.0 {
                 (mean_pnl / std_pnl) * trades_per_year.sqrt()
-            } else { 0.0 };
+            } else {
+                0.0
+            };
             let sortino = if downside_std > 0.0 {
                 (mean_pnl / downside_std) * trades_per_year.sqrt()
-            } else { 0.0 };
+            } else {
+                0.0
+            };
 
             // Max drawdown on actual series
             let mut peak = 0.0f64;
@@ -1839,19 +2160,38 @@ async fn main() {
             let mut max_dd = 0.0f64;
             for &p in series {
                 equity += p;
-                if equity > peak { peak = equity; }
+                if equity > peak {
+                    peak = equity;
+                }
                 let dd = peak - equity;
-                if dd > max_dd { max_dd = dd; }
+                if dd > max_dd {
+                    max_dd = dd;
+                }
             }
-            let max_dd_pct = if peak > 0.0 { max_dd / (bankroll_start + peak) * 100.0 } else { 0.0 };
+            let max_dd_pct = if peak > 0.0 {
+                max_dd / (bankroll_start + peak) * 100.0
+            } else {
+                0.0
+            };
 
-            eprintln!("\n=== Monte Carlo Analysis ({} trades, bankroll={}U, stake={}U) ===", n, bankroll_start, stake);
+            eprintln!(
+                "\n=== Monte Carlo Analysis ({} trades, bankroll={}U, stake={}U) ===",
+                n, bankroll_start, stake
+            );
             eprintln!("Actual series:");
-            eprintln!("  mean_pnl/trade={:.2}U  std={:.2}U  sharpe={:.2}  sortino={:.2}", mean_pnl, std_pnl, sharpe, sortino);
-            eprintln!("  max_drawdown={:.2}U ({:.1}% of peak equity)", max_dd, max_dd_pct);
-            eprintln!("  total_pnl={:.2}U  roi_on_bankroll={:.1}%",
+            eprintln!(
+                "  mean_pnl/trade={:.2}U  std={:.2}U  sharpe={:.2}  sortino={:.2}",
+                mean_pnl, std_pnl, sharpe, sortino
+            );
+            eprintln!(
+                "  max_drawdown={:.2}U ({:.1}% of peak equity)",
+                max_dd, max_dd_pct
+            );
+            eprintln!(
+                "  total_pnl={:.2}U  roi_on_bankroll={:.1}%",
                 series.iter().sum::<f64>(),
-                series.iter().sum::<f64>() / bankroll_start * 100.0);
+                series.iter().sum::<f64>() / bankroll_start * 100.0
+            );
 
             // --- Monte Carlo bootstrap ---
             const MC_RUNS: usize = 10_000;
@@ -1875,58 +2215,87 @@ async fn main() {
                     let p = series[idx];
 
                     equity += p;
-                    if equity > peak { peak = equity; }
+                    if equity > peak {
+                        peak = equity;
+                    }
                     let dd = peak - equity;
-                    if dd > max_dd { max_dd = dd; }
+                    if dd > max_dd {
+                        max_dd = dd;
+                    }
 
                     // Ruin: bankroll + equity < stake (can't place next trade)
-                    if bankroll_start + equity < stake { ruined = true; }
+                    if bankroll_start + equity < stake {
+                        ruined = true;
+                    }
                 }
 
                 mc_final_pnl.push(equity);
                 mc_max_dd.push(max_dd);
-                if ruined { ruin_count += 1; }
+                if ruined {
+                    ruin_count += 1;
+                }
             }
 
             mc_final_pnl.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             mc_max_dd.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-            let p5_pnl  = mc_final_pnl[(MC_RUNS as f64 * 0.05) as usize];
+            let p5_pnl = mc_final_pnl[(MC_RUNS as f64 * 0.05) as usize];
             let p25_pnl = mc_final_pnl[(MC_RUNS as f64 * 0.25) as usize];
             let p50_pnl = mc_final_pnl[(MC_RUNS as f64 * 0.50) as usize];
             let p75_pnl = mc_final_pnl[(MC_RUNS as f64 * 0.75) as usize];
             let p95_pnl = mc_final_pnl[(MC_RUNS as f64 * 0.95) as usize];
 
-            let p50_dd  = mc_max_dd[(MC_RUNS as f64 * 0.50) as usize];
-            let p90_dd  = mc_max_dd[(MC_RUNS as f64 * 0.90) as usize];
-            let p95_dd  = mc_max_dd[(MC_RUNS as f64 * 0.95) as usize];
-            let p99_dd  = mc_max_dd[(MC_RUNS as f64 * 0.99) as usize];
+            let p50_dd = mc_max_dd[(MC_RUNS as f64 * 0.50) as usize];
+            let p90_dd = mc_max_dd[(MC_RUNS as f64 * 0.90) as usize];
+            let p95_dd = mc_max_dd[(MC_RUNS as f64 * 0.95) as usize];
+            let p99_dd = mc_max_dd[(MC_RUNS as f64 * 0.99) as usize];
 
             let ruin_prob = ruin_count as f64 / MC_RUNS as f64 * 100.0;
 
-            eprintln!("\nMonte Carlo ({} simulations, bootstrap resampling):", MC_RUNS);
-            eprintln!("  Final P&L distribution (same {} trades, random order):", n);
-            eprintln!("    p5={:.0}U  p25={:.0}U  p50={:.0}U  p75={:.0}U  p95={:.0}U",
-                p5_pnl, p25_pnl, p50_pnl, p75_pnl, p95_pnl);
+            eprintln!(
+                "\nMonte Carlo ({} simulations, bootstrap resampling):",
+                MC_RUNS
+            );
+            eprintln!(
+                "  Final P&L distribution (same {} trades, random order):",
+                n
+            );
+            eprintln!(
+                "    p5={:.0}U  p25={:.0}U  p50={:.0}U  p75={:.0}U  p95={:.0}U",
+                p5_pnl, p25_pnl, p50_pnl, p75_pnl, p95_pnl
+            );
             eprintln!("  Max drawdown distribution:");
-            eprintln!("    p50={:.0}U  p90={:.0}U  p95={:.0}U  p99={:.0}U",
-                p50_dd, p90_dd, p95_dd, p99_dd);
+            eprintln!(
+                "    p50={:.0}U  p90={:.0}U  p95={:.0}U  p99={:.0}U",
+                p50_dd, p90_dd, p95_dd, p99_dd
+            );
             eprintln!("  Ruin probability (bankroll < stake): {:.2}%", ruin_prob);
 
             // --- Strategy summary ---
             eprintln!("\n=== Strategy Core ===");
             eprintln!("Name:    ThreeLayer (State→Direction, LOB→Confirm, R/R→Filter)");
-            eprintln!("Markets: Polymarket 5-minute binary options on crypto (BTC/ETH/DOGE/SOL/XRP/BNB)");
+            eprintln!(
+                "Markets: Polymarket 5-minute binary options on crypto (BTC/ETH/DOGE/SOL/XRP/BNB)"
+            );
             eprintln!("Regimes:");
             eprintln!("  early  (271-300s): direction = contrarian(model_prob_up), gate = always");
-            eprintln!("  middle ( 61-270s): direction = 0.65*contrarian + 0.35*fair_prob_up_clean + vol_gap_adjust");
+            eprintln!(
+                "  middle ( 61-270s): direction = 0.65*contrarian + 0.35*fair_prob_up_clean + vol_gap_adjust"
+            );
             eprintln!("                     gate = vol_gap must agree with direction");
             eprintln!("  expiry (  0- 60s): NO TRADE (thin liquidity, PM price converged)");
             eprintln!("Layer 1 (Direction): fair_prob_up_clean, vol_gap, distance_over_sigma");
-            eprintln!("Layer 2 (Confirm):   drift_30s + obi_10 + depth_imbalance + cum_mprice_drift_5m");
-            eprintln!("                     need >= {} of 4 LOB signals to agree", three_layer_confirmations_min);
-            eprintln!("Layer 3 (R/R):       edge >= 2%, reward_risk >= {:.1}, entry_price <= {:.2}",
-                three_layer_reward_risk_min, three_layer_max_entry_price);
+            eprintln!(
+                "Layer 2 (Confirm):   drift_30s + obi_10 + depth_imbalance + cum_mprice_drift_5m"
+            );
+            eprintln!(
+                "                     need >= {} of 4 LOB signals to agree",
+                three_layer_confirmations_min
+            );
+            eprintln!(
+                "Layer 3 (R/R):       edge >= 2%, reward_risk >= {:.1}, entry_price <= {:.2}",
+                three_layer_reward_risk_min, three_layer_max_entry_price
+            );
         }
     }
 
@@ -1953,8 +2322,10 @@ async fn main() {
         let mut signals: Vec<EventSignal> = Vec::new();
 
         for observations in &all_observations {
-            let mut by_event: std::collections::HashMap<&str, Vec<&ploy_research::FactorObservation>> =
-                std::collections::HashMap::new();
+            let mut by_event: std::collections::HashMap<
+                &str,
+                Vec<&ploy_research::FactorObservation>,
+            > = std::collections::HashMap::new();
             for obs in observations.iter() {
                 by_event.entry(obs.event_id.as_str()).or_default().push(obs);
             }
@@ -1965,13 +2336,20 @@ async fn main() {
             for event_obs in by_event.values() {
                 // Find first qualifying observation (same logic as one-trade sim)
                 for obs in event_obs.iter() {
-                    if !obs.pm_up_ask.is_finite() || !obs.pm_down_ask.is_finite()
-                        || !obs.model_prob_up.is_finite() || !obs.fair_prob_up_clean.is_finite()
-                        || !obs.reward_risk_up.is_finite() || !obs.reward_risk_down.is_finite()
-                    { continue; }
+                    if !obs.pm_up_ask.is_finite()
+                        || !obs.pm_down_ask.is_finite()
+                        || !obs.model_prob_up.is_finite()
+                        || !obs.fair_prob_up_clean.is_finite()
+                        || !obs.reward_risk_up.is_finite()
+                        || !obs.reward_risk_down.is_finite()
+                    {
+                        continue;
+                    }
 
                     let regime = three_layer_regime(obs.time_remaining_secs);
-                    if regime == "expiry" { continue; }
+                    if regime == "expiry" {
+                        continue;
+                    }
 
                     let fee_up = 0.02 * obs.pm_up_ask * (1.0 - obs.pm_up_ask);
                     let fee_down = 0.02 * obs.pm_down_ask * (1.0 - obs.pm_down_ask);
@@ -1981,45 +2359,74 @@ async fn main() {
                         "middle" => {
                             let vol_adj = if obs.vol_gap.is_finite() {
                                 three_layer_middle_vol_adjust * sign_vote(obs.vol_gap) as f64
-                            } else { 0.0 };
+                            } else {
+                                0.0
+                            };
                             (0.65 * independent_state_up + 0.35 * obs.fair_prob_up_clean + vol_adj)
                                 .clamp(1e-4, 1.0 - 1e-4)
                         }
                         _ => 0.5,
                     };
 
-                    let side_up_opt = if p_three_up > 0.5 { Some(true) }
-                        else if p_three_up < 0.5 { Some(false) }
-                        else { None };
+                    let side_up_opt = if p_three_up > 0.5 {
+                        Some(true)
+                    } else if p_three_up < 0.5 {
+                        Some(false)
+                    } else {
+                        None
+                    };
                     let side_up_opt = side_up_opt.filter(|su| match regime {
                         "early" => true,
-                        "middle" => obs.vol_gap.is_finite() && (
-                            (*su && obs.vol_gap > 0.0) || (!*su && obs.vol_gap < 0.0)),
+                        "middle" => {
+                            obs.vol_gap.is_finite()
+                                && ((*su && obs.vol_gap > 0.0) || (!*su && obs.vol_gap < 0.0))
+                        }
                         _ => false,
                     });
                     let Some(side_up) = side_up_opt else { continue };
 
-                    let lob_votes = [sign_vote(obs.drift_30s), sign_vote(obs.obi_10),
-                        sign_vote(obs.depth_imbalance), sign_vote(obs.cum_mprice_drift_5m)];
+                    let lob_votes = [
+                        sign_vote(obs.drift_30s),
+                        sign_vote(obs.obi_10),
+                        sign_vote(obs.depth_imbalance),
+                        sign_vote(obs.cum_mprice_drift_5m),
+                    ];
                     let desired = if side_up { 1 } else { -1 };
                     let confirmations = lob_votes.iter().filter(|&&v| v == desired).count();
 
-                    let entry_price = if side_up { obs.pm_up_ask } else { obs.pm_down_ask };
-                    let pre_fill_rr = if side_up { obs.reward_risk_up } else { obs.reward_risk_down };
+                    let entry_price = if side_up {
+                        obs.pm_up_ask
+                    } else {
+                        obs.pm_down_ask
+                    };
+                    let pre_fill_rr = if side_up {
+                        obs.reward_risk_up
+                    } else {
+                        obs.reward_risk_down
+                    };
                     let pre_fill_edge = if side_up {
                         p_three_up - (obs.pm_up_ask + fee_up)
                     } else {
                         (1.0 - p_three_up) - (obs.pm_down_ask + fee_down)
                     };
-                    if pre_fill_edge < min_edge { continue; }
+                    if pre_fill_edge < min_edge {
+                        continue;
+                    }
 
                     // Fill price (same logic as main sim)
-                    let ask_size = if side_up { obs.pm_up_ask_size } else { obs.pm_down_ask_size };
+                    let ask_size = if side_up {
+                        obs.pm_up_ask_size
+                    } else {
+                        obs.pm_down_ask_size
+                    };
                     let order_shares = stake_per_trade / entry_price;
-                    let had_slippage = ask_size.is_finite() && ask_size > 0.0 && ask_size < order_shares;
+                    let had_slippage =
+                        ask_size.is_finite() && ask_size > 0.0 && ask_size < order_shares;
                     let fill_price = if had_slippage {
                         (entry_price + 0.01).min(0.99)
-                    } else { entry_price };
+                    } else {
+                        entry_price
+                    };
 
                     let fill_fee = 0.02 * fill_price * (1.0 - fill_price);
                     let pnl_win = stake_per_trade * (1.0 / fill_price - 1.0)
@@ -2038,8 +2445,16 @@ async fn main() {
                         pre_fill_rr,
                         pm_lag_secs: obs.pm_lag_secs,
                         settlement_up: obs.settlement_up,
-                        pnl_if_up: if obs.settlement_up == 1.0 { pnl_win } else { pnl_lose },
-                        pnl_if_down: if obs.settlement_up == 0.0 { pnl_win } else { pnl_lose },
+                        pnl_if_up: if obs.settlement_up == 1.0 {
+                            pnl_win
+                        } else {
+                            pnl_lose
+                        },
+                        pnl_if_down: if obs.settlement_up == 0.0 {
+                            pnl_win
+                        } else {
+                            pnl_lose
+                        },
                     });
                     break; // one trade per event
                 }
@@ -2056,9 +2471,16 @@ async fn main() {
         let min_pm_lags = [0.0f64, 5.0, 10.0]; // 0 = no filter
 
         struct SweepResult {
-            max_entry: f64, confirm: usize, rr_min: f64,
-            max_pm_lag: f64, min_pm_lag: f64,
-            trades: u32, win_rate: f64, roi: f64, sharpe: f64, max_dd: f64,
+            max_entry: f64,
+            confirm: usize,
+            rr_min: f64,
+            max_pm_lag: f64,
+            min_pm_lag: f64,
+            trades: u32,
+            win_rate: f64,
+            roi: f64,
+            sharpe: f64,
+            max_dd: f64,
         }
         let mut sweep_results: Vec<SweepResult> = Vec::new();
 
@@ -2067,112 +2489,217 @@ async fn main() {
                 for &rr_min in &rr_mins {
                     for &max_pm_lag in &max_pm_lags {
                         for &min_pm_lag in &min_pm_lags {
-                    let mut pnl_series: Vec<f64> = Vec::new();
-                    let mut wins = 0u32;
+                            let mut pnl_series: Vec<f64> = Vec::new();
+                            let mut wins = 0u32;
 
-                    for sig in &signals {
-                        if sig.fill_price > max_entry { continue; }
-                        if sig.confirmations < confirm { continue; }
-                        if sig.pre_fill_rr < rr_min { continue; }
-                        if sig.pm_lag_secs.is_finite() {
-                            if sig.pm_lag_secs > max_pm_lag { continue; }
-                            if sig.pm_lag_secs < min_pm_lag { continue; }
-                        }
+                            for sig in &signals {
+                                if sig.fill_price > max_entry {
+                                    continue;
+                                }
+                                if sig.confirmations < confirm {
+                                    continue;
+                                }
+                                if sig.pre_fill_rr < rr_min {
+                                    continue;
+                                }
+                                if sig.pm_lag_secs.is_finite() {
+                                    if sig.pm_lag_secs > max_pm_lag {
+                                        continue;
+                                    }
+                                    if sig.pm_lag_secs < min_pm_lag {
+                                        continue;
+                                    }
+                                }
 
-                        let pnl = if sig.side_up { sig.pnl_if_up } else { sig.pnl_if_down };
-                        let won = (sig.side_up && sig.settlement_up == 1.0)
-                            || (!sig.side_up && sig.settlement_up == 0.0);
-                        pnl_series.push(pnl);
-                        if won { wins += 1; }
-                    }
+                                let pnl = if sig.side_up {
+                                    sig.pnl_if_up
+                                } else {
+                                    sig.pnl_if_down
+                                };
+                                let won = (sig.side_up && sig.settlement_up == 1.0)
+                                    || (!sig.side_up && sig.settlement_up == 0.0);
+                                pnl_series.push(pnl);
+                                if won {
+                                    wins += 1;
+                                }
+                            }
 
-                    let n = pnl_series.len();
-                    if n < 5 { continue; }
+                            let n = pnl_series.len();
+                            if n < 5 {
+                                continue;
+                            }
 
-                    let total_pnl: f64 = pnl_series.iter().sum();
-                    let total_stake = n as f64 * stake_per_trade;
-                    let roi = total_pnl / total_stake * 100.0;
-                    let win_rate = wins as f64 / n as f64 * 100.0;
+                            let total_pnl: f64 = pnl_series.iter().sum();
+                            let total_stake = n as f64 * stake_per_trade;
+                            let roi = total_pnl / total_stake * 100.0;
+                            let win_rate = wins as f64 / n as f64 * 100.0;
 
-                    let mean = total_pnl / n as f64;
-                    let std = (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64).sqrt();
-                    let sharpe = if std > 1e-9 { mean / std * (6.0_f64 * 365.0).sqrt() } else { 0.0 };
+                            let mean = total_pnl / n as f64;
+                            let std = (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>()
+                                / n as f64)
+                                .sqrt();
+                            let sharpe = if std > 1e-9 {
+                                mean / std * (6.0_f64 * 365.0).sqrt()
+                            } else {
+                                0.0
+                            };
 
-                    let mut peak = 0.0f64;
-                    let mut equity = 0.0f64;
-                    let mut max_dd = 0.0f64;
-                    for &p in &pnl_series {
-                        equity += p;
-                        if equity > peak { peak = equity; }
-                        let dd = peak - equity;
-                        if dd > max_dd { max_dd = dd; }
-                    }
+                            let mut peak = 0.0f64;
+                            let mut equity = 0.0f64;
+                            let mut max_dd = 0.0f64;
+                            for &p in &pnl_series {
+                                equity += p;
+                                if equity > peak {
+                                    peak = equity;
+                                }
+                                let dd = peak - equity;
+                                if dd > max_dd {
+                                    max_dd = dd;
+                                }
+                            }
 
-                    sweep_results.push(SweepResult { max_entry, confirm, rr_min,
-                        max_pm_lag, min_pm_lag,
-                        trades: n as u32, win_rate, roi, sharpe, max_dd });
+                            sweep_results.push(SweepResult {
+                                max_entry,
+                                confirm,
+                                rr_min,
+                                max_pm_lag,
+                                min_pm_lag,
+                                trades: n as u32,
+                                win_rate,
+                                roi,
+                                sharpe,
+                                max_dd,
+                            });
                         } // min_pm_lag
-                        } // max_pm_lag
+                    } // max_pm_lag
                 }
             }
         }
 
         // Sort by Sharpe descending
-        sweep_results.sort_by(|a, b| b.sharpe.partial_cmp(&a.sharpe).unwrap_or(std::cmp::Ordering::Equal));
+        sweep_results.sort_by(|a, b| {
+            b.sharpe
+                .partial_cmp(&a.sharpe)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
-        eprintln!("\n=== Parameter Grid Sweep (top 20 by Sharpe, {} pre-qualified events) ===", signals.len());
-        eprintln!("{:<8} {:<8} {:<6} {:<10} {:<10} {:<7} {:<7} {:<8} {:<8} {:<8}",
-            "max_ent", "confirm", "rr", "max_lag", "min_lag", "trades", "wr%", "roi%", "sharpe", "max_dd");
+        eprintln!(
+            "\n=== Parameter Grid Sweep (top 20 by Sharpe, {} pre-qualified events) ===",
+            signals.len()
+        );
+        eprintln!(
+            "{:<8} {:<8} {:<6} {:<10} {:<10} {:<7} {:<7} {:<8} {:<8} {:<8}",
+            "max_ent",
+            "confirm",
+            "rr",
+            "max_lag",
+            "min_lag",
+            "trades",
+            "wr%",
+            "roi%",
+            "sharpe",
+            "max_dd"
+        );
         for r in sweep_results.iter().take(20) {
-            let max_lag_str = if r.max_pm_lag.is_infinite() { "∞".to_string() } else { format!("{:.0}", r.max_pm_lag) };
-            eprintln!("{:<8.2} {:<8} {:<6.1} {:<10} {:<10.0} {:<7} {:<7.1} {:<8.1} {:<8.2} {:<8.0}",
-                r.max_entry, r.confirm, r.rr_min, max_lag_str, r.min_pm_lag,
-                r.trades, r.win_rate, r.roi, r.sharpe, r.max_dd);
+            let max_lag_str = if r.max_pm_lag.is_infinite() {
+                "∞".to_string()
+            } else {
+                format!("{:.0}", r.max_pm_lag)
+            };
+            eprintln!(
+                "{:<8.2} {:<8} {:<6.1} {:<10} {:<10.0} {:<7} {:<7.1} {:<8.1} {:<8.2} {:<8.0}",
+                r.max_entry,
+                r.confirm,
+                r.rr_min,
+                max_lag_str,
+                r.min_pm_lag,
+                r.trades,
+                r.win_rate,
+                r.roi,
+                r.sharpe,
+                r.max_dd
+            );
         }
 
         // Per-symbol breakdown for the current (default) parameters
-        eprintln!("\n=== Per-Symbol Breakdown (max_entry={:.2}, confirm>={}, rr>={:.1}) ===",
-            three_layer_max_entry_price, three_layer_confirmations_min, three_layer_reward_risk_min);
-        eprintln!("{:<12} {:<7} {:<7} {:<8} {:<8} {:<10}", "symbol", "trades", "wr%", "roi%", "avg_entry", "slippage%");
-        let mut sym_map: std::collections::HashMap<&str, (u32, u32, f64, f64, f64, u32)> = std::collections::HashMap::new();
+        eprintln!(
+            "\n=== Per-Symbol Breakdown (max_entry={:.2}, confirm>={}, rr>={:.1}) ===",
+            three_layer_max_entry_price, three_layer_confirmations_min, three_layer_reward_risk_min
+        );
+        eprintln!(
+            "{:<12} {:<7} {:<7} {:<8} {:<8} {:<10}",
+            "symbol", "trades", "wr%", "roi%", "avg_entry", "slippage%"
+        );
+        let mut sym_map: std::collections::HashMap<&str, (u32, u32, f64, f64, f64, u32)> =
+            std::collections::HashMap::new();
         for sig in &signals {
-            if sig.fill_price > three_layer_max_entry_price { continue; }
-            if sig.confirmations < three_layer_confirmations_min { continue; }
-            if sig.pre_fill_rr < three_layer_reward_risk_min { continue; }
-            let pnl = if sig.side_up { sig.pnl_if_up } else { sig.pnl_if_down };
+            if sig.fill_price > three_layer_max_entry_price {
+                continue;
+            }
+            if sig.confirmations < three_layer_confirmations_min {
+                continue;
+            }
+            if sig.pre_fill_rr < three_layer_reward_risk_min {
+                continue;
+            }
+            let pnl = if sig.side_up {
+                sig.pnl_if_up
+            } else {
+                sig.pnl_if_down
+            };
             let won = (sig.side_up && sig.settlement_up == 1.0)
                 || (!sig.side_up && sig.settlement_up == 0.0);
-            let e = sym_map.entry(sig.symbol.as_str()).or_insert((0, 0, 0.0, 0.0, 0.0, 0));
+            let e = sym_map
+                .entry(sig.symbol.as_str())
+                .or_insert((0, 0, 0.0, 0.0, 0.0, 0));
             e.0 += 1;
-            if won { e.1 += 1; }
+            if won {
+                e.1 += 1;
+            }
             e.2 += pnl;
             e.3 += stake_per_trade;
             e.4 += sig.fill_price;
-            if sig.had_slippage { e.5 += 1; }
+            if sig.had_slippage {
+                e.5 += 1;
+            }
         }
         let mut sym_vec: Vec<_> = sym_map.iter().collect();
-        sym_vec.sort_by(|a, b| b.1.2.partial_cmp(&a.1.2).unwrap_or(std::cmp::Ordering::Equal));
+        sym_vec.sort_by(|a, b| {
+            b.1.2
+                .partial_cmp(&a.1.2)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         for (sym, (trades, wins, pnl, stake, price_sum, slippage_count)) in &sym_vec {
             let wr = *wins as f64 / *trades as f64 * 100.0;
             let roi = pnl / stake * 100.0;
             let avg_entry = price_sum / *trades as f64;
             let slippage_pct = *slippage_count as f64 / *trades as f64 * 100.0;
-            eprintln!("{:<12} {:<7} {:<7.1} {:<8.1} {:<8.3} {:<10.1}", sym, trades, wr, roi, avg_entry, slippage_pct);
+            eprintln!(
+                "{:<12} {:<7} {:<7.1} {:<8.1} {:<8.3} {:<10.1}",
+                sym, trades, wr, roi, avg_entry, slippage_pct
+            );
         }
 
         // === Per-Symbol Grid Sweep ===
         // Find optimal parameters for each symbol independently.
         let all_symbols: Vec<String> = {
             let mut seen = std::collections::HashSet::new();
-            signals.iter().filter(|s| seen.insert(s.symbol.clone())).map(|s| s.symbol.clone()).collect()
+            signals
+                .iter()
+                .filter(|s| seen.insert(s.symbol.clone()))
+                .map(|s| s.symbol.clone())
+                .collect()
         };
 
         eprintln!("\n=== Per-Symbol Best Parameters (by Sharpe) ===");
-        eprintln!("{:<12} {:<8} {:<8} {:<6} {:<7} {:<7} {:<8} {:<8} {:<8}",
-            "symbol", "max_ent", "confirm", "rr", "trades", "wr%", "roi%", "sharpe", "max_dd");
+        eprintln!(
+            "{:<12} {:<8} {:<8} {:<6} {:<7} {:<7} {:<8} {:<8} {:<8}",
+            "symbol", "max_ent", "confirm", "rr", "trades", "wr%", "roi%", "sharpe", "max_dd"
+        );
 
         // Store best params per symbol for portfolio construction
-        let mut best_params: std::collections::HashMap<String, (f64, usize, f64)> = std::collections::HashMap::new();
+        let mut best_params: std::collections::HashMap<String, (f64, usize, f64)> =
+            std::collections::HashMap::new();
 
         for sym in &all_symbols {
             let mut best: Option<(f64, usize, f64, u32, f64, f64, f64, f64)> = None; // (max_entry, confirm, rr, trades, wr, roi, sharpe, max_dd)
@@ -2184,45 +2711,75 @@ async fn main() {
                         let mut wins = 0u32;
 
                         for sig in signals.iter().filter(|s| &s.symbol == sym) {
-                            if sig.fill_price > max_entry { continue; }
-                            if sig.confirmations < confirm { continue; }
-                            if sig.pre_fill_rr < rr_min { continue; }
-                            let pnl = if sig.side_up { sig.pnl_if_up } else { sig.pnl_if_down };
+                            if sig.fill_price > max_entry {
+                                continue;
+                            }
+                            if sig.confirmations < confirm {
+                                continue;
+                            }
+                            if sig.pre_fill_rr < rr_min {
+                                continue;
+                            }
+                            let pnl = if sig.side_up {
+                                sig.pnl_if_up
+                            } else {
+                                sig.pnl_if_down
+                            };
                             let won = (sig.side_up && sig.settlement_up == 1.0)
                                 || (!sig.side_up && sig.settlement_up == 0.0);
                             pnl_series.push(pnl);
-                            if won { wins += 1; }
+                            if won {
+                                wins += 1;
+                            }
                         }
 
                         let n = pnl_series.len();
-                        if n < 3 { continue; }
+                        if n < 3 {
+                            continue;
+                        }
 
                         let total_pnl: f64 = pnl_series.iter().sum();
                         let total_stake = n as f64 * stake_per_trade;
                         let roi = total_pnl / total_stake * 100.0;
                         let wr = wins as f64 / n as f64 * 100.0;
                         let mean = total_pnl / n as f64;
-                        let std = (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64).sqrt();
-                        let sharpe = if std > 1e-9 { mean / std * (6.0_f64 * 365.0).sqrt() } else { 0.0 };
+                        let std = (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>()
+                            / n as f64)
+                            .sqrt();
+                        let sharpe = if std > 1e-9 {
+                            mean / std * (6.0_f64 * 365.0).sqrt()
+                        } else {
+                            0.0
+                        };
 
-                        let mut peak = 0.0f64; let mut equity = 0.0f64; let mut max_dd = 0.0f64;
+                        let mut peak = 0.0f64;
+                        let mut equity = 0.0f64;
+                        let mut max_dd = 0.0f64;
                         for &p in &pnl_series {
                             equity += p;
-                            if equity > peak { peak = equity; }
+                            if equity > peak {
+                                peak = equity;
+                            }
                             let dd = peak - equity;
-                            if dd > max_dd { max_dd = dd; }
+                            if dd > max_dd {
+                                max_dd = dd;
+                            }
                         }
 
                         if best.is_none() || sharpe > best.unwrap().6 {
-                            best = Some((max_entry, confirm, rr_min, n as u32, wr, roi, sharpe, max_dd));
+                            best = Some((
+                                max_entry, confirm, rr_min, n as u32, wr, roi, sharpe, max_dd,
+                            ));
                         }
                     }
                 }
             }
 
             if let Some((me, co, rr, tr, wr, roi, sh, dd)) = best {
-                eprintln!("{:<12} {:<8.2} {:<8} {:<6.1} {:<7} {:<7.1} {:<8.1} {:<8.2} {:<8.0}",
-                    sym, me, co, rr, tr, wr, roi, sh, dd);
+                eprintln!(
+                    "{:<12} {:<8.2} {:<8} {:<6.1} {:<7} {:<7.1} {:<8.1} {:<8.2} {:<8.0}",
+                    sym, me, co, rr, tr, wr, roi, sh, dd
+                );
                 best_params.insert(sym.clone(), (me, co, rr));
             }
         }
@@ -2233,41 +2790,81 @@ async fn main() {
         let mut portfolio_trades: Vec<(DateTime<Utc>, &str, f64)> = Vec::new(); // (ts, symbol, pnl)
 
         for sig in &signals {
-            let (max_entry, confirm, rr_min) = best_params
-                .get(&sig.symbol)
-                .copied()
-                .unwrap_or((three_layer_max_entry_price, three_layer_confirmations_min, three_layer_reward_risk_min));
+            let (max_entry, confirm, rr_min) = best_params.get(&sig.symbol).copied().unwrap_or((
+                three_layer_max_entry_price,
+                three_layer_confirmations_min,
+                three_layer_reward_risk_min,
+            ));
 
-            if sig.fill_price > max_entry { continue; }
-            if sig.confirmations < confirm { continue; }
-            if sig.pre_fill_rr < rr_min { continue; }
+            if sig.fill_price > max_entry {
+                continue;
+            }
+            if sig.confirmations < confirm {
+                continue;
+            }
+            if sig.pre_fill_rr < rr_min {
+                continue;
+            }
 
-            let pnl = if sig.side_up { sig.pnl_if_up } else { sig.pnl_if_down };
+            let pnl = if sig.side_up {
+                sig.pnl_if_up
+            } else {
+                sig.pnl_if_down
+            };
             portfolio_trades.push((sig.entry_ts, sig.symbol.as_str(), pnl));
         }
 
         portfolio_trades.sort_by_key(|(ts, _, _)| *ts);
 
         // Print equity curve (one row per trade, cumulative P&L)
-        eprintln!("\n=== Portfolio Equity Curve (per-symbol optimal params, {} trades) ===", portfolio_trades.len());
-        eprintln!("{:<26} {:<12} {:<8} {:<10} {:<10}", "ts", "symbol", "pnl", "cum_pnl", "drawdown");
+        eprintln!(
+            "\n=== Portfolio Equity Curve (per-symbol optimal params, {} trades) ===",
+            portfolio_trades.len()
+        );
+        eprintln!(
+            "{:<26} {:<12} {:<8} {:<10} {:<10}",
+            "ts", "symbol", "pnl", "cum_pnl", "drawdown"
+        );
         let mut cum_pnl = 0.0f64;
         let mut peak_pnl = 0.0f64;
         let mut max_portfolio_dd = 0.0f64;
         let mut portfolio_wins = 0u32;
         for (ts, sym, pnl) in &portfolio_trades {
             cum_pnl += pnl;
-            if cum_pnl > peak_pnl { peak_pnl = cum_pnl; }
+            if cum_pnl > peak_pnl {
+                peak_pnl = cum_pnl;
+            }
             let dd = peak_pnl - cum_pnl;
-            if dd > max_portfolio_dd { max_portfolio_dd = dd; }
-            if *pnl > 0.0 { portfolio_wins += 1; }
-            eprintln!("{:<26} {:<12} {:<8.2} {:<10.2} {:<10.2}", ts.format("%Y-%m-%d %H:%M:%S"), sym, pnl, cum_pnl, dd);
+            if dd > max_portfolio_dd {
+                max_portfolio_dd = dd;
+            }
+            if *pnl > 0.0 {
+                portfolio_wins += 1;
+            }
+            eprintln!(
+                "{:<26} {:<12} {:<8.2} {:<10.2} {:<10.2}",
+                ts.format("%Y-%m-%d %H:%M:%S"),
+                sym,
+                pnl,
+                cum_pnl,
+                dd
+            );
         }
         let n_port = portfolio_trades.len();
-        let port_wr = if n_port > 0 { portfolio_wins as f64 / n_port as f64 * 100.0 } else { 0.0 };
-        let port_roi = if n_port > 0 { cum_pnl / (n_port as f64 * stake_per_trade) * 100.0 } else { 0.0 };
-        eprintln!("\nPortfolio summary: trades={} wins={} wr={:.1}% total_pnl={:.2}U roi={:.1}% max_dd={:.0}U",
-            n_port, portfolio_wins, port_wr, cum_pnl, port_roi, max_portfolio_dd);
+        let port_wr = if n_port > 0 {
+            portfolio_wins as f64 / n_port as f64 * 100.0
+        } else {
+            0.0
+        };
+        let port_roi = if n_port > 0 {
+            cum_pnl / (n_port as f64 * stake_per_trade) * 100.0
+        } else {
+            0.0
+        };
+        eprintln!(
+            "\nPortfolio summary: trades={} wins={} wr={:.1}% total_pnl={:.2}U roi={:.1}% max_dd={:.0}U",
+            n_port, portfolio_wins, port_wr, cum_pnl, port_roi, max_portfolio_dd
+        );
 
         // === Walk-Forward Validation ===
         // Split signals chronologically: first half = train, second half = test.
@@ -2278,105 +2875,213 @@ async fn main() {
             let mid_idx = sorted_signals.len() / 2;
             let split_ts = sorted_signals[mid_idx].entry_ts;
 
-            let train_signals: Vec<&EventSignal> = signals.iter()
-                .filter(|s| s.entry_ts < split_ts)
-                .collect();
-            let test_signals: Vec<&EventSignal> = signals.iter()
-                .filter(|s| s.entry_ts >= split_ts)
-                .collect();
+            let train_signals: Vec<&EventSignal> =
+                signals.iter().filter(|s| s.entry_ts < split_ts).collect();
+            let test_signals: Vec<&EventSignal> =
+                signals.iter().filter(|s| s.entry_ts >= split_ts).collect();
 
-                eprintln!("\n=== Walk-Forward Validation ===");
-                eprintln!("Train: before {} ({} signals)", split_ts.format("%Y-%m-%d %H:%M"), train_signals.len());
-                eprintln!("Test:  from   {} ({} signals)", split_ts.format("%Y-%m-%d %H:%M"), test_signals.len());
+            eprintln!("\n=== Walk-Forward Validation ===");
+            eprintln!(
+                "Train: before {} ({} signals)",
+                split_ts.format("%Y-%m-%d %H:%M"),
+                train_signals.len()
+            );
+            eprintln!(
+                "Test:  from   {} ({} signals)",
+                split_ts.format("%Y-%m-%d %H:%M"),
+                test_signals.len()
+            );
 
-                // Find best params on train set
-                let mut best_train: Option<(f64, usize, f64, f64)> = None; // (max_entry, confirm, rr, sharpe)
-                for &max_entry in &max_entry_prices {
-                    for &confirm in &confirm_mins {
-                        for &rr_min in &rr_mins {
-                            let pnl_series: Vec<f64> = train_signals.iter()
-                                .filter(|s| s.fill_price <= max_entry
+            // Find best params on train set
+            let mut best_train: Option<(f64, usize, f64, f64)> = None; // (max_entry, confirm, rr, sharpe)
+            for &max_entry in &max_entry_prices {
+                for &confirm in &confirm_mins {
+                    for &rr_min in &rr_mins {
+                        let pnl_series: Vec<f64> = train_signals
+                            .iter()
+                            .filter(|s| {
+                                s.fill_price <= max_entry
                                     && s.confirmations >= confirm
-                                    && s.pre_fill_rr >= rr_min)
-                                .map(|s| if s.side_up { s.pnl_if_up } else { s.pnl_if_down })
-                                .collect();
-                            if pnl_series.len() < 10 { continue; }
-                            let n = pnl_series.len() as f64;
-                            let mean = pnl_series.iter().sum::<f64>() / n;
-                            let std = (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n).sqrt();
-                            let sharpe = if std > 0.0 { mean / std * (6.0 * 365.0_f64).sqrt() } else { 0.0 };
-                            if best_train.map_or(true, |(_, _, _, s)| sharpe > s) {
-                                best_train = Some((max_entry, confirm, rr_min, sharpe));
-                            }
+                                    && s.pre_fill_rr >= rr_min
+                            })
+                            .map(|s| {
+                                if s.side_up {
+                                    s.pnl_if_up
+                                } else {
+                                    s.pnl_if_down
+                                }
+                            })
+                            .collect();
+                        if pnl_series.len() < 10 {
+                            continue;
+                        }
+                        let n = pnl_series.len() as f64;
+                        let mean = pnl_series.iter().sum::<f64>() / n;
+                        let std =
+                            (pnl_series.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n).sqrt();
+                        let sharpe = if std > 0.0 {
+                            mean / std * (6.0 * 365.0_f64).sqrt()
+                        } else {
+                            0.0
+                        };
+                        if best_train.map_or(true, |(_, _, _, s)| sharpe > s) {
+                            best_train = Some((max_entry, confirm, rr_min, sharpe));
                         }
                     }
                 }
+            }
 
-                if let Some((best_max_entry, best_confirm, best_rr, train_sharpe)) = best_train {
-                    // Evaluate on test set with train-optimized params
-                    let test_pnl: Vec<f64> = test_signals.iter()
-                        .filter(|s| s.fill_price <= best_max_entry
+            if let Some((best_max_entry, best_confirm, best_rr, train_sharpe)) = best_train {
+                // Evaluate on test set with train-optimized params
+                let test_pnl: Vec<f64> = test_signals
+                    .iter()
+                    .filter(|s| {
+                        s.fill_price <= best_max_entry
                             && s.confirmations >= best_confirm
-                            && s.pre_fill_rr >= best_rr)
-                        .map(|s| if s.side_up { s.pnl_if_up } else { s.pnl_if_down })
-                        .collect();
+                            && s.pre_fill_rr >= best_rr
+                    })
+                    .map(|s| {
+                        if s.side_up {
+                            s.pnl_if_up
+                        } else {
+                            s.pnl_if_down
+                        }
+                    })
+                    .collect();
 
-                    let test_n = test_pnl.len();
-                    let test_wins = test_pnl.iter().filter(|&&p| p > 0.0).count();
-                    let test_total = test_pnl.iter().sum::<f64>();
-                    let test_stake = test_n as f64 * stake_per_trade;
-                    let test_wr = if test_n > 0 { test_wins as f64 / test_n as f64 * 100.0 } else { 0.0 };
-                    let test_roi = if test_stake > 0.0 { test_total / test_stake * 100.0 } else { 0.0 };
-                    let test_mean = if test_n > 0 { test_total / test_n as f64 } else { 0.0 };
-                    let test_std = if test_n > 1 {
-                        (test_pnl.iter().map(|x| (x - test_mean).powi(2)).sum::<f64>() / test_n as f64).sqrt()
-                    } else { 0.0 };
-                    let test_sharpe = if test_std > 0.0 { test_mean / test_std * (6.0 * 365.0_f64).sqrt() } else { 0.0 };
+                let test_n = test_pnl.len();
+                let test_wins = test_pnl.iter().filter(|&&p| p > 0.0).count();
+                let test_total = test_pnl.iter().sum::<f64>();
+                let test_stake = test_n as f64 * stake_per_trade;
+                let test_wr = if test_n > 0 {
+                    test_wins as f64 / test_n as f64 * 100.0
+                } else {
+                    0.0
+                };
+                let test_roi = if test_stake > 0.0 {
+                    test_total / test_stake * 100.0
+                } else {
+                    0.0
+                };
+                let test_mean = if test_n > 0 {
+                    test_total / test_n as f64
+                } else {
+                    0.0
+                };
+                let test_std = if test_n > 1 {
+                    (test_pnl
+                        .iter()
+                        .map(|x| (x - test_mean).powi(2))
+                        .sum::<f64>()
+                        / test_n as f64)
+                        .sqrt()
+                } else {
+                    0.0
+                };
+                let test_sharpe = if test_std > 0.0 {
+                    test_mean / test_std * (6.0 * 365.0_f64).sqrt()
+                } else {
+                    0.0
+                };
 
-                    // Also evaluate train set with same params for comparison
-                    let train_pnl: Vec<f64> = train_signals.iter()
-                        .filter(|s| s.fill_price <= best_max_entry
+                // Also evaluate train set with same params for comparison
+                let train_pnl: Vec<f64> = train_signals
+                    .iter()
+                    .filter(|s| {
+                        s.fill_price <= best_max_entry
                             && s.confirmations >= best_confirm
-                            && s.pre_fill_rr >= best_rr)
-                        .map(|s| if s.side_up { s.pnl_if_up } else { s.pnl_if_down })
-                        .collect();
-                    let train_n = train_pnl.len();
-                    let train_wins = train_pnl.iter().filter(|&&p| p > 0.0).count();
-                    let train_total = train_pnl.iter().sum::<f64>();
-                    let train_stake = train_n as f64 * stake_per_trade;
-                    let train_wr = if train_n > 0 { train_wins as f64 / train_n as f64 * 100.0 } else { 0.0 };
-                    let train_roi = if train_stake > 0.0 { train_total / train_stake * 100.0 } else { 0.0 };
+                            && s.pre_fill_rr >= best_rr
+                    })
+                    .map(|s| {
+                        if s.side_up {
+                            s.pnl_if_up
+                        } else {
+                            s.pnl_if_down
+                        }
+                    })
+                    .collect();
+                let train_n = train_pnl.len();
+                let train_wins = train_pnl.iter().filter(|&&p| p > 0.0).count();
+                let train_total = train_pnl.iter().sum::<f64>();
+                let train_stake = train_n as f64 * stake_per_trade;
+                let train_wr = if train_n > 0 {
+                    train_wins as f64 / train_n as f64 * 100.0
+                } else {
+                    0.0
+                };
+                let train_roi = if train_stake > 0.0 {
+                    train_total / train_stake * 100.0
+                } else {
+                    0.0
+                };
 
-                    eprintln!("Best params (by train Sharpe): max_entry={:.2} confirm>={} rr>={:.1}",
-                        best_max_entry, best_confirm, best_rr);
-                    eprintln!("{:<8} {:<8} {:<8} {:<8} {:<8} {:<8}",
-                        "period", "trades", "wr%", "roi%", "sharpe", "verdict");
-                    eprintln!("{:<8} {:<8} {:<8.1} {:<8.1} {:<8.2} {:<8}",
-                        "train", train_n, train_wr, train_roi, train_sharpe, "in-sample");
-                    eprintln!("{:<8} {:<8} {:<8.1} {:<8.1} {:<8.2} {:<8}",
-                        "test", test_n, test_wr, test_roi, test_sharpe,
-                        if test_sharpe > 1.0 { "VALID" } else if test_sharpe > 0.0 { "WEAK" } else { "FAIL" });
-
-                    let decay = if train_sharpe > 0.0 { (1.0 - test_sharpe / train_sharpe) * 100.0 } else { 0.0 };
-                    eprintln!("Sharpe decay: {:.1}% (train={:.2} → test={:.2})", decay, train_sharpe, test_sharpe);
-                    if test_wr > 55.0 && test_roi > 0.0 {
-                        eprintln!("Verdict: OUT-OF-SAMPLE POSITIVE — signal likely real");
-                    } else if test_wr > 50.0 {
-                        eprintln!("Verdict: MARGINAL — weak signal, needs more data");
+                eprintln!(
+                    "Best params (by train Sharpe): max_entry={:.2} confirm>={} rr>={:.1}",
+                    best_max_entry, best_confirm, best_rr
+                );
+                eprintln!(
+                    "{:<8} {:<8} {:<8} {:<8} {:<8} {:<8}",
+                    "period", "trades", "wr%", "roi%", "sharpe", "verdict"
+                );
+                eprintln!(
+                    "{:<8} {:<8} {:<8.1} {:<8.1} {:<8.2} {:<8}",
+                    "train", train_n, train_wr, train_roi, train_sharpe, "in-sample"
+                );
+                eprintln!(
+                    "{:<8} {:<8} {:<8.1} {:<8.1} {:<8.2} {:<8}",
+                    "test",
+                    test_n,
+                    test_wr,
+                    test_roi,
+                    test_sharpe,
+                    if test_sharpe > 1.0 {
+                        "VALID"
+                    } else if test_sharpe > 0.0 {
+                        "WEAK"
                     } else {
-                        eprintln!("Verdict: OVERFIT — in-sample only, no real edge");
+                        "FAIL"
                     }
+                );
+
+                let decay = if train_sharpe > 0.0 {
+                    (1.0 - test_sharpe / train_sharpe) * 100.0
+                } else {
+                    0.0
+                };
+                eprintln!(
+                    "Sharpe decay: {:.1}% (train={:.2} → test={:.2})",
+                    decay, train_sharpe, test_sharpe
+                );
+                if test_wr > 55.0 && test_roi > 0.0 {
+                    eprintln!("Verdict: OUT-OF-SAMPLE POSITIVE — signal likely real");
+                } else if test_wr > 50.0 {
+                    eprintln!("Verdict: MARGINAL — weak signal, needs more data");
+                } else {
+                    eprintln!("Verdict: OVERFIT — in-sample only, no real edge");
                 }
+            }
         }
     }
 
     // Print final multi-factor weights
-    if let Some((weights, _, _)) = mf_model.fit() {        let names = [
-            "obi_10", "depth_imbal", "depth_accel", "spread_bps",
-            "cum_obi_d5m", "cum_dep_d5m", "cum_mp_d5m", "cum_trd_i5m",
-            "drift_10s", "drift_30s", "pm_lag_secs",
+    if let Some((weights, _, _)) = mf_model.fit() {
+        let names = [
+            "obi_10",
+            "depth_imbal",
+            "depth_accel",
+            "spread_bps",
+            "cum_obi_d5m",
+            "cum_dep_d5m",
+            "cum_mp_d5m",
+            "cum_trd_i5m",
+            "drift_10s",
+            "drift_30s",
+            "pm_lag_secs",
         ];
-        eprintln!("\n=== Multi-Factor Weights (IC vs settlement, {} obs) ===", mf_model.data.len());
+        eprintln!(
+            "\n=== Multi-Factor Weights (IC vs settlement, {} obs) ===",
+            mf_model.data.len()
+        );
         for (i, name) in names.iter().enumerate() {
             eprintln!("  {:<14} w={:>7.4}", name, weights[i]);
         }
@@ -2392,11 +3097,17 @@ async fn main() {
             let bucket_size = (pairs.len() / N_BUCKETS).max(1);
             eprintln!(
                 "\n=== Calibration: d/σ → P(up) ({} obs, {} per bucket) ===",
-                pairs.len(), bucket_size
+                pairs.len(),
+                bucket_size
             );
-            eprintln!("{:<12} {:<12} {:<8} {:<12} {:<12}", "d/σ_lo", "d/σ_hi", "n", "emp_win%", "model_cdf%");
+            eprintln!(
+                "{:<12} {:<12} {:<8} {:<12} {:<12}",
+                "d/σ_lo", "d/σ_hi", "n", "emp_win%", "model_cdf%"
+            );
             for chunk in pairs.chunks(bucket_size) {
-                if chunk.is_empty() { continue; }
+                if chunk.is_empty() {
+                    continue;
+                }
                 let lo = chunk.first().unwrap().0;
                 let hi = chunk.last().unwrap().0;
                 let n = chunk.len();
@@ -2407,10 +3118,20 @@ async fn main() {
                     let sign = if mid_z < 0.0 { -1.0 } else { 1.0 };
                     let x = mid_z.abs();
                     let t = 1.0 / (1.0 + 0.3275911 * x);
-                    let poly = t * (0.254829592 + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+                    let poly = t
+                        * (0.254829592
+                            + t * (-0.284496736
+                                + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
                     0.5 * (1.0 + sign * (1.0 - poly * (-x * x / 2.0).exp()))
                 };
-                eprintln!("{:<12.4} {:<12.4} {:<8} {:<12.1} {:<12.1}", lo, hi, n, emp_rate, model_cdf * 100.0);
+                eprintln!(
+                    "{:<12.4} {:<12.4} {:<8} {:<12.1} {:<12.1}",
+                    lo,
+                    hi,
+                    n,
+                    emp_rate,
+                    model_cdf * 100.0
+                );
             }
         }
     }
@@ -2419,9 +3140,8 @@ async fn main() {
         .iter()
         .filter(|metric| metric.label == "settlement_up" && metric.mean_spearman_ic.is_finite())
         .collect();
-    settlement_metrics.sort_by(|a, b| {
-        descending_abs_f64_cmp(a.mean_spearman_ic, b.mean_spearman_ic)
-    });
+    settlement_metrics
+        .sort_by(|a, b| descending_abs_f64_cmp(a.mean_spearman_ic, b.mean_spearman_ic));
 
     let mut lag_metrics: Vec<_> = aggregated
         .iter()

--- a/crates/ploy-research/src/dataset/builder.rs
+++ b/crates/ploy-research/src/dataset/builder.rs
@@ -1,0 +1,501 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+
+use crate::factors::{
+    FactorObservation, TaskGrainDerivedArtifacts, build_task_grain_derived_artifacts_for_event_ids,
+};
+
+use super::{
+    CANONICAL_REGIME_VERSION, DATASET_MANIFEST_VERSION, DatasetArtifacts, DatasetBuildManifest,
+    DatasetBuildStats, DatasetLabelContract, DatasetSourceWindow, DatasetSplit,
+    DatasetSplitAssignment, DatasetSplitCounts, DatasetSplitPolicy, EventIndexEntry,
+    EventMetadataChronologyInput, SplitBuildError, assign_chronological_event_splits,
+    build_canonical_event_chronology,
+};
+
+#[derive(Debug, Clone)]
+pub struct EventRootDatasetBuildRequest<'a> {
+    pub observations: &'a [FactorObservation],
+    pub chronology_events: Vec<EventMetadataChronologyInput>,
+    pub source_window: DatasetSourceWindow,
+    pub artifacts: DatasetArtifacts,
+    pub built_at: DateTime<Utc>,
+    pub split_policy: DatasetSplitPolicy,
+    pub labels: DatasetLabelContract,
+    pub feature_families: Vec<String>,
+    pub regime_version: String,
+}
+
+impl<'a> EventRootDatasetBuildRequest<'a> {
+    pub fn new(
+        observations: &'a [FactorObservation],
+        chronology_events: Vec<EventMetadataChronologyInput>,
+        source_window: DatasetSourceWindow,
+        artifacts: DatasetArtifacts,
+        built_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            observations,
+            chronology_events,
+            source_window,
+            artifacts,
+            built_at,
+            split_policy: DatasetSplitPolicy::default(),
+            labels: DatasetLabelContract::default(),
+            feature_families: Vec::new(),
+            regime_version: CANONICAL_REGIME_VERSION.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EventRootDatasetBuild {
+    pub event_index: Vec<EventIndexEntry>,
+    pub split_assignments: Vec<DatasetSplitAssignment>,
+    pub split_artifacts: DatasetSplitDerivedArtifacts,
+    pub manifest: DatasetBuildManifest,
+}
+
+#[derive(Debug, Clone)]
+pub struct DatasetSplitDerivedArtifacts {
+    pub train: TaskGrainDerivedArtifacts,
+    pub val: TaskGrainDerivedArtifacts,
+    pub test: TaskGrainDerivedArtifacts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DatasetBuildError {
+    Split(SplitBuildError),
+    DuplicateSplitAssignment { event_id: String },
+    SplitAssignmentOrderMismatch { expected: String, found: String },
+    ObservationEventMissingFromIndex { event_id: String },
+    ManifestContract { message: String },
+}
+
+impl From<SplitBuildError> for DatasetBuildError {
+    fn from(error: SplitBuildError) -> Self {
+        Self::Split(error)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ObservationStats {
+    observation_row_count: usize,
+    settlement_label_available: bool,
+    repricing_label_row_count_30s: usize,
+}
+
+pub fn build_event_root_dataset(
+    request: EventRootDatasetBuildRequest<'_>,
+) -> Result<EventRootDatasetBuild, DatasetBuildError> {
+    let chronology = build_canonical_event_chronology(request.chronology_events);
+    let split_assignments =
+        assign_chronological_event_splits(&chronology.ordered_events, &request.split_policy)?;
+
+    let mut assignment_by_event_id = BTreeMap::new();
+    for assignment in &split_assignments {
+        if assignment_by_event_id
+            .insert(assignment.event_id.as_str(), assignment)
+            .is_some()
+        {
+            return Err(DatasetBuildError::DuplicateSplitAssignment {
+                event_id: assignment.event_id.clone(),
+            });
+        }
+    }
+
+    let mut observation_stats_by_event_id: BTreeMap<&str, ObservationStats> = BTreeMap::new();
+    for observation in request.observations {
+        if !assignment_by_event_id.contains_key(observation.event_id.as_str()) {
+            return Err(DatasetBuildError::ObservationEventMissingFromIndex {
+                event_id: observation.event_id.clone(),
+            });
+        }
+
+        let stats = observation_stats_by_event_id
+            .entry(observation.event_id.as_str())
+            .or_default();
+        stats.observation_row_count += 1;
+        stats.settlement_label_available |= observation.settlement_up.is_finite();
+        stats.repricing_label_row_count_30s += usize::from(
+            observation
+                .future_up_ask_change_30s
+                .is_some_and(f64::is_finite),
+        );
+    }
+
+    let mut event_index = Vec::with_capacity(split_assignments.len());
+    for (event, assignment) in chronology
+        .ordered_events
+        .iter()
+        .zip(split_assignments.iter())
+    {
+        if event.event_id != assignment.event_id {
+            return Err(DatasetBuildError::SplitAssignmentOrderMismatch {
+                expected: event.event_id.clone(),
+                found: assignment.event_id.clone(),
+            });
+        }
+
+        let observation_stats = observation_stats_by_event_id
+            .get(event.event_id.as_str())
+            .copied()
+            .unwrap_or_default();
+
+        event_index.push(EventIndexEntry {
+            event_id: event.event_id.clone(),
+            symbol: event.symbol.clone(),
+            start_time: event.start_time,
+            end_time: event.end_time,
+            split: assignment.split,
+            split_rank: assignment.split_rank,
+            observation_row_count: observation_stats.observation_row_count,
+            settlement_label_available: observation_stats.settlement_label_available,
+            repricing_label_row_count_30s: observation_stats.repricing_label_row_count_30s,
+            regime_version: request.regime_version.clone(),
+        });
+    }
+
+    let split_artifacts = DatasetSplitDerivedArtifacts {
+        train: build_task_grain_derived_artifacts_for_event_ids(
+            request.observations,
+            split_event_ids(&split_assignments, DatasetSplit::Train),
+        ),
+        val: build_task_grain_derived_artifacts_for_event_ids(
+            request.observations,
+            split_event_ids(&split_assignments, DatasetSplit::Val),
+        ),
+        test: build_task_grain_derived_artifacts_for_event_ids(
+            request.observations,
+            split_event_ids(&split_assignments, DatasetSplit::Test),
+        ),
+    };
+
+    let manifest = DatasetBuildManifest {
+        manifest_version: DATASET_MANIFEST_VERSION,
+        built_at: request.built_at,
+        source_window: request.source_window,
+        split_policy: request.split_policy,
+        labels: request.labels,
+        feature_families: request.feature_families,
+        regime_version: request.regime_version,
+        artifacts: request.artifacts,
+        stats: DatasetBuildStats {
+            total_events: event_index.len(),
+            total_observations: request.observations.len(),
+            events_per_split: split_counts_for_events(&event_index),
+            observations_per_split: split_counts_for_observations(
+                request.observations,
+                &assignment_by_event_id,
+            ),
+            skip_counts: chronology.skip_counts,
+        },
+    };
+
+    manifest
+        .validate_contract()
+        .map_err(|message| DatasetBuildError::ManifestContract { message })?;
+
+    Ok(EventRootDatasetBuild {
+        event_index,
+        split_assignments,
+        split_artifacts,
+        manifest,
+    })
+}
+
+fn split_event_ids(
+    split_assignments: &[DatasetSplitAssignment],
+    split: DatasetSplit,
+) -> BTreeSet<String> {
+    split_assignments
+        .iter()
+        .filter(|assignment| assignment.split == split)
+        .map(|assignment| assignment.event_id.clone())
+        .collect()
+}
+
+fn split_counts_for_events(event_index: &[EventIndexEntry]) -> DatasetSplitCounts {
+    let mut counts = DatasetSplitCounts::default();
+    for entry in event_index {
+        increment_split_count(&mut counts, entry.split, 1);
+    }
+    counts
+}
+
+fn split_counts_for_observations(
+    observations: &[FactorObservation],
+    assignment_by_event_id: &BTreeMap<&str, &DatasetSplitAssignment>,
+) -> DatasetSplitCounts {
+    let mut counts = DatasetSplitCounts::default();
+    for observation in observations {
+        if let Some(assignment) = assignment_by_event_id.get(observation.event_id.as_str()) {
+            increment_split_count(&mut counts, assignment.split, 1);
+        }
+    }
+    counts
+}
+
+fn increment_split_count(counts: &mut DatasetSplitCounts, split: DatasetSplit, amount: usize) {
+    match split {
+        DatasetSplit::Train => counts.train += amount,
+        DatasetSplit::Val => counts.val += amount,
+        DatasetSplit::Test => counts.test += amount,
+    }
+}
+
+pub fn standard_event_root_dataset_artifacts() -> DatasetArtifacts {
+    use super::DatasetSplitArtifactPaths;
+
+    DatasetArtifacts {
+        event_index: "event_index.parquet".to_string(),
+        event_manifest: "event_manifest.json".to_string(),
+        split_assignments: "split_assignments.parquet".to_string(),
+        observations: DatasetSplitArtifactPaths {
+            train: "observations_train.parquet".to_string(),
+            val: "observations_val.parquet".to_string(),
+            test: "observations_test.parquet".to_string(),
+        },
+        event_summaries: DatasetSplitArtifactPaths {
+            train: "event_summaries_train.parquet".to_string(),
+            val: "event_summaries_val.parquet".to_string(),
+            test: "event_summaries_test.parquet".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DatasetBuildError, EventRootDatasetBuildRequest, build_event_root_dataset,
+        standard_event_root_dataset_artifacts,
+    };
+    use crate::dataset::{DatasetSourceWindow, DatasetSplit, EventMetadataChronologyInput};
+    use crate::factors::FactorObservation;
+    use chrono::{Duration, TimeZone, Utc};
+    use std::collections::HashSet;
+
+    #[test]
+    fn builder_materializes_event_root_splits_without_leakage() {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let chronology_events = synthetic_chronology_events(140, start);
+        let observations = synthetic_observations(140, start);
+        let request = EventRootDatasetBuildRequest::new(
+            &observations,
+            chronology_events,
+            source_window(start, 140),
+            standard_event_root_dataset_artifacts(),
+            start,
+        );
+
+        let build = build_event_root_dataset(request).expect("dataset build should succeed");
+
+        assert_eq!(build.event_index.len(), 140);
+        assert_eq!(build.split_assignments.len(), 140);
+        assert_eq!(build.manifest.stats.events_per_split.train, 98);
+        assert_eq!(build.manifest.stats.events_per_split.val, 21);
+        assert_eq!(build.manifest.stats.events_per_split.test, 21);
+        assert_eq!(build.manifest.stats.observations_per_split.train, 196);
+        assert_eq!(build.manifest.stats.observations_per_split.val, 42);
+        assert_eq!(build.manifest.stats.observations_per_split.test, 42);
+        assert_eq!(build.split_artifacts.train.observation_row_count(), 196);
+        assert_eq!(build.split_artifacts.val.event_summary_count(), 21);
+        assert_eq!(
+            build.split_artifacts.test.repricing_label_row_count_30s(),
+            21
+        );
+        build
+            .manifest
+            .validate_contract()
+            .expect("manifest contract should remain valid");
+
+        for entry in &build.event_index {
+            assert_eq!(entry.observation_row_count, 2);
+            assert!(entry.settlement_label_available);
+            assert_eq!(entry.repricing_label_row_count_30s, 1);
+        }
+
+        let train_ids: HashSet<_> = build
+            .split_artifacts
+            .train
+            .event_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let val_ids: HashSet<_> = build
+            .split_artifacts
+            .val
+            .event_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let test_ids: HashSet<_> = build
+            .split_artifacts
+            .test
+            .event_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+
+        assert!(train_ids.is_disjoint(&val_ids));
+        assert!(train_ids.is_disjoint(&test_ids));
+        assert!(val_ids.is_disjoint(&test_ids));
+    }
+
+    #[test]
+    fn builder_fails_when_an_observation_cannot_be_split_by_event_id() {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let chronology_events = synthetic_chronology_events(140, start);
+        let mut observations = synthetic_observations(140, start);
+        observations.push(synthetic_observation(
+            "evt-outside",
+            "BTCUSDT",
+            start,
+            0,
+            1.0,
+            Some(0.01),
+        ));
+
+        let request = EventRootDatasetBuildRequest::new(
+            &observations,
+            chronology_events,
+            source_window(start, 140),
+            standard_event_root_dataset_artifacts(),
+            start,
+        );
+
+        let error = build_event_root_dataset(request).expect_err("dataset build should fail");
+        assert_eq!(
+            error,
+            DatasetBuildError::ObservationEventMissingFromIndex {
+                event_id: "evt-outside".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn builder_carries_chronology_skip_counts_into_the_manifest() {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let mut chronology_events = synthetic_chronology_events(140, start);
+        chronology_events.push(EventMetadataChronologyInput {
+            event_id: "evt-missing-end".to_string(),
+            symbol: "BTCUSDT".to_string(),
+            start_time: Some(start),
+            end_time: None,
+        });
+        let observations = synthetic_observations(140, start);
+        let request = EventRootDatasetBuildRequest::new(
+            &observations,
+            chronology_events,
+            source_window(start, 140),
+            standard_event_root_dataset_artifacts(),
+            start,
+        );
+
+        let build = build_event_root_dataset(request).expect("dataset build should succeed");
+
+        assert_eq!(build.event_index.len(), 140);
+        assert_eq!(build.manifest.stats.skip_counts.missing_end_time, 1);
+        assert_eq!(build.manifest.stats.skip_counts.missing_timing_fields, 1);
+    }
+
+    fn synthetic_chronology_events(
+        count: usize,
+        start: chrono::DateTime<Utc>,
+    ) -> Vec<EventMetadataChronologyInput> {
+        (0..count)
+            .rev()
+            .map(|idx| EventMetadataChronologyInput {
+                event_id: format!("evt-{idx:03}"),
+                symbol: if idx % 2 == 0 { "BTCUSDT" } else { "ETHUSDT" }.to_string(),
+                start_time: Some(start + Duration::minutes(idx as i64 * 5)),
+                end_time: Some(start + Duration::minutes(idx as i64 * 5 + 5)),
+            })
+            .collect()
+    }
+
+    fn synthetic_observations(
+        count: usize,
+        start: chrono::DateTime<Utc>,
+    ) -> Vec<FactorObservation> {
+        (0..count)
+            .flat_map(|idx| {
+                let event_id = format!("evt-{idx:03}");
+                let symbol = if idx % 2 == 0 { "BTCUSDT" } else { "ETHUSDT" };
+                let event_start = start + Duration::minutes(idx as i64 * 5);
+                [
+                    synthetic_observation(&event_id, symbol, event_start, 0, 1.0, Some(0.01)),
+                    synthetic_observation(&event_id, symbol, event_start, 1, 1.0, None),
+                ]
+            })
+            .collect()
+    }
+
+    fn source_window(start: chrono::DateTime<Utc>, event_count: usize) -> DatasetSourceWindow {
+        DatasetSourceWindow {
+            start_time: start,
+            end_time: start + Duration::minutes(event_count as i64 * 5),
+            symbols: vec!["BTCUSDT".to_string(), "ETHUSDT".to_string()],
+        }
+    }
+
+    fn synthetic_observation(
+        event_id: &str,
+        symbol: &str,
+        event_start: chrono::DateTime<Utc>,
+        row_idx: i64,
+        settlement_up: f64,
+        repricing_label: Option<f64>,
+    ) -> FactorObservation {
+        FactorObservation {
+            event_id: event_id.to_string(),
+            symbol: symbol.to_string(),
+            tick_ts: event_start + Duration::seconds(row_idx * 30),
+            time_remaining_secs: 300 - row_idx * 30,
+            signed_distance_to_beat: 0.0,
+            abs_distance_to_beat: 0.0,
+            drift_10s: 0.0,
+            drift_30s: 0.0,
+            flip_age_secs: 0.0,
+            post_flip_drift: 0.0,
+            sigma_horizon: 1.0,
+            fair_prob_up: 0.5,
+            fair_prob_up_clean: 0.5,
+            prob_disagreement: 0.0,
+            implied_sigma_horizon: 0.1,
+            vol_gap: 0.0,
+            distance_over_sigma: 0.0,
+            model_prob_up: 0.5,
+            model_edge_up: 0.0,
+            reward_risk_up: 1.0,
+            reward_risk_down: 1.0,
+            obi: 0.0,
+            spread_bps: 1.0,
+            microprice_offset_bps: 0.0,
+            bid_depth_near: 0.0,
+            ask_depth_near: 0.0,
+            depth_ratio: 1.0,
+            depth_imbalance: 0.0,
+            depth_far_ratio: 1.0,
+            depth_acceleration: 0.0,
+            obi_10: 0.0,
+            pm_up_bid: 0.49,
+            pm_up_ask: 0.51,
+            pm_up_bid_size: 10.0,
+            pm_up_ask_size: 11.0,
+            pm_down_bid: 0.49,
+            pm_down_ask: 0.51,
+            pm_down_bid_size: 12.0,
+            pm_down_ask_size: 13.0,
+            pm_lag_secs: 0.0,
+            settlement_up,
+            future_up_ask_change_30s: repricing_label,
+            future_up_ask_change_60s: None,
+            cum_obi_delta_5m: 0.0,
+            cum_depth_delta_5m: 0.0,
+            cum_mprice_drift_5m: 0.0,
+            cum_trade_imbalance_5m: 0.0,
+        }
+    }
+}

--- a/crates/ploy-research/src/dataset/chronology.rs
+++ b/crates/ploy-research/src/dataset/chronology.rs
@@ -1,0 +1,119 @@
+use chrono::{DateTime, Utc};
+
+use super::{DatasetSkipCounts, EventChronologyKey};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventMetadataChronologyInput {
+    pub event_id: String,
+    pub symbol: String,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventChronologyBuild {
+    pub ordered_events: Vec<EventChronologyKey>,
+    pub skip_counts: DatasetSkipCounts,
+}
+
+pub fn build_canonical_event_chronology(
+    events: impl IntoIterator<Item = EventMetadataChronologyInput>,
+) -> EventChronologyBuild {
+    let mut skip_counts = DatasetSkipCounts::default();
+    let mut ordered_events = Vec::new();
+
+    for event in events {
+        match (event.start_time, event.end_time) {
+            (Some(start_time), Some(end_time)) => ordered_events.push(EventChronologyKey {
+                event_id: event.event_id,
+                symbol: event.symbol,
+                start_time,
+                end_time,
+            }),
+            (None, Some(_)) => {
+                skip_counts.missing_start_time += 1;
+                skip_counts.missing_timing_fields += 1;
+            }
+            (Some(_), None) => {
+                skip_counts.missing_end_time += 1;
+                skip_counts.missing_timing_fields += 1;
+            }
+            (None, None) => {
+                skip_counts.missing_start_time += 1;
+                skip_counts.missing_end_time += 1;
+                skip_counts.missing_timing_fields += 1;
+            }
+        }
+    }
+
+    ordered_events.sort_by(|lhs, rhs| {
+        lhs.end_time
+            .cmp(&rhs.end_time)
+            .then_with(|| lhs.symbol.cmp(&rhs.symbol))
+            .then_with(|| lhs.event_id.cmp(&rhs.event_id))
+    });
+
+    EventChronologyBuild {
+        ordered_events,
+        skip_counts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EventMetadataChronologyInput, build_canonical_event_chronology};
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn chronology_is_reproducible_and_skips_missing_timing_fields() {
+        let result = build_canonical_event_chronology(vec![
+            EventMetadataChronologyInput {
+                event_id: "evt-c".to_string(),
+                symbol: "ETH".to_string(),
+                start_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap()),
+                end_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 5, 0).unwrap()),
+            },
+            EventMetadataChronologyInput {
+                event_id: "evt-a".to_string(),
+                symbol: "BTC".to_string(),
+                start_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap()),
+                end_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 4, 0).unwrap()),
+            },
+            EventMetadataChronologyInput {
+                event_id: "evt-b".to_string(),
+                symbol: "BTC".to_string(),
+                start_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 1, 0).unwrap()),
+                end_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 5, 0).unwrap()),
+            },
+            EventMetadataChronologyInput {
+                event_id: "evt-d".to_string(),
+                symbol: "SOL".to_string(),
+                start_time: None,
+                end_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 5, 0).unwrap()),
+            },
+            EventMetadataChronologyInput {
+                event_id: "evt-e".to_string(),
+                symbol: "SOL".to_string(),
+                start_time: Some(Utc.with_ymd_and_hms(2026, 4, 1, 0, 2, 0).unwrap()),
+                end_time: None,
+            },
+            EventMetadataChronologyInput {
+                event_id: "evt-f".to_string(),
+                symbol: "ARB".to_string(),
+                start_time: None,
+                end_time: None,
+            },
+        ]);
+
+        let ordered_event_ids: Vec<_> = result
+            .ordered_events
+            .iter()
+            .map(|event| event.event_id.as_str())
+            .collect();
+
+        assert_eq!(ordered_event_ids, vec!["evt-a", "evt-b", "evt-c"]);
+        assert_eq!(result.skip_counts.missing_start_time, 2);
+        assert_eq!(result.skip_counts.missing_end_time, 2);
+        assert_eq!(result.skip_counts.missing_timing_fields, 3);
+    }
+}

--- a/crates/ploy-research/src/dataset/contracts.rs
+++ b/crates/ploy-research/src/dataset/contracts.rs
@@ -1,0 +1,349 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const DATASET_MANIFEST_VERSION: u32 = 1;
+pub const CANONICAL_REGIME_VERSION: &str = "pm_binary_v1";
+pub const SETTLEMENT_LABEL: &str = "settlement_up";
+pub const REPRICING_LABEL_30S: &str = "future_up_ask_change_30s";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatasetSplit {
+    Train,
+    Val,
+    Test,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChronologyAnchor {
+    EndTime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChronologyOrdering {
+    EndTimeSymbolEventId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSplitPolicy {
+    pub chronology_anchor: ChronologyAnchor,
+    pub chronology_ordering: ChronologyOrdering,
+    pub train_percent: u8,
+    pub val_percent: u8,
+    pub test_percent: u8,
+    pub min_unique_events: usize,
+    pub min_eval_events: usize,
+}
+
+impl Default for DatasetSplitPolicy {
+    fn default() -> Self {
+        Self {
+            chronology_anchor: ChronologyAnchor::EndTime,
+            chronology_ordering: ChronologyOrdering::EndTimeSymbolEventId,
+            train_percent: 70,
+            val_percent: 15,
+            test_percent: 15,
+            min_unique_events: 3,
+            min_eval_events: 20,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventChronologyKey {
+    pub event_id: String,
+    pub symbol: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSplitAssignment {
+    pub event_id: String,
+    pub symbol: String,
+    pub end_time: DateTime<Utc>,
+    pub ordered_event_index: usize,
+    pub split: DatasetSplit,
+    pub split_rank: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventIndexEntry {
+    pub event_id: String,
+    pub symbol: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub split: DatasetSplit,
+    pub split_rank: usize,
+    pub observation_row_count: usize,
+    pub settlement_label_available: bool,
+    pub repricing_label_row_count_30s: usize,
+    pub regime_version: String,
+}
+
+impl EventIndexEntry {
+    pub fn chronology_key(&self) -> EventChronologyKey {
+        EventChronologyKey {
+            event_id: self.event_id.clone(),
+            symbol: self.symbol.clone(),
+            start_time: self.start_time,
+            end_time: self.end_time,
+        }
+    }
+
+    pub fn split_assignment(&self, ordered_event_index: usize) -> DatasetSplitAssignment {
+        DatasetSplitAssignment {
+            event_id: self.event_id.clone(),
+            symbol: self.symbol.clone(),
+            end_time: self.end_time,
+            ordered_event_index,
+            split: self.split,
+            split_rank: self.split_rank,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSplitCounts {
+    pub train: usize,
+    pub val: usize,
+    pub test: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSkipCounts {
+    pub missing_start_time: usize,
+    pub missing_end_time: usize,
+    pub missing_timing_fields: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSplitArtifactPaths {
+    pub train: String,
+    pub val: String,
+    pub test: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetArtifacts {
+    pub event_index: String,
+    pub event_manifest: String,
+    pub split_assignments: String,
+    pub observations: DatasetSplitArtifactPaths,
+    pub event_summaries: DatasetSplitArtifactPaths,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetLabelContract {
+    pub observation_labels: Vec<String>,
+    pub event_summary_labels: Vec<String>,
+}
+
+impl Default for DatasetLabelContract {
+    fn default() -> Self {
+        Self {
+            observation_labels: vec![REPRICING_LABEL_30S.to_string()],
+            event_summary_labels: vec![SETTLEMENT_LABEL.to_string()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSourceWindow {
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetBuildStats {
+    pub total_events: usize,
+    pub total_observations: usize,
+    pub events_per_split: DatasetSplitCounts,
+    pub observations_per_split: DatasetSplitCounts,
+    pub skip_counts: DatasetSkipCounts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetBuildManifest {
+    pub manifest_version: u32,
+    pub built_at: DateTime<Utc>,
+    pub source_window: DatasetSourceWindow,
+    pub split_policy: DatasetSplitPolicy,
+    pub labels: DatasetLabelContract,
+    pub feature_families: Vec<String>,
+    pub regime_version: String,
+    pub artifacts: DatasetArtifacts,
+    pub stats: DatasetBuildStats,
+}
+
+impl DatasetBuildManifest {
+    pub fn validate_contract(&self) -> Result<(), String> {
+        if self.manifest_version != DATASET_MANIFEST_VERSION {
+            return Err(format!(
+                "manifest_version {} does not match contract {}",
+                self.manifest_version, DATASET_MANIFEST_VERSION
+            ));
+        }
+
+        if self.split_policy != DatasetSplitPolicy::default() {
+            return Err("manifest split policy does not match the canonical first-slice contract".to_string());
+        }
+
+        if !self
+            .labels
+            .observation_labels
+            .iter()
+            .any(|label| label == REPRICING_LABEL_30S)
+        {
+            return Err(format!(
+                "observation labels must include {REPRICING_LABEL_30S}"
+            ));
+        }
+
+        if !self
+            .labels
+            .event_summary_labels
+            .iter()
+            .any(|label| label == SETTLEMENT_LABEL)
+        {
+            return Err(format!(
+                "event summary labels must include {SETTLEMENT_LABEL}"
+            ));
+        }
+
+        if self.regime_version.trim().is_empty() {
+            return Err("regime_version must not be empty".to_string());
+        }
+
+        for path in [
+            &self.artifacts.event_index,
+            &self.artifacts.event_manifest,
+            &self.artifacts.split_assignments,
+            &self.artifacts.observations.train,
+            &self.artifacts.observations.val,
+            &self.artifacts.observations.test,
+            &self.artifacts.event_summaries.train,
+            &self.artifacts.event_summaries.val,
+            &self.artifacts.event_summaries.test,
+        ] {
+            if path.trim().is_empty() {
+                return Err("artifact paths must not be empty".to_string());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DatasetArtifacts, DatasetBuildManifest, DatasetBuildStats, DatasetLabelContract,
+        DatasetSkipCounts, DatasetSourceWindow, DatasetSplit, DatasetSplitArtifactPaths,
+        DatasetSplitCounts, DatasetSplitPolicy, EventIndexEntry, CANONICAL_REGIME_VERSION,
+        DATASET_MANIFEST_VERSION,
+    };
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn split_policy_pins_the_first_contract() {
+        let policy = DatasetSplitPolicy::default();
+        assert_eq!(policy.train_percent, 70);
+        assert_eq!(policy.val_percent, 15);
+        assert_eq!(policy.test_percent, 15);
+        assert_eq!(policy.min_unique_events, 3);
+        assert_eq!(policy.min_eval_events, 20);
+    }
+
+    #[test]
+    fn event_index_entry_projects_canonical_contract_views() {
+        let entry = EventIndexEntry {
+            event_id: "evt-1".to_string(),
+            symbol: "BTC".to_string(),
+            start_time: Utc.with_ymd_and_hms(2026, 4, 1, 12, 0, 0).unwrap(),
+            end_time: Utc.with_ymd_and_hms(2026, 4, 1, 12, 5, 0).unwrap(),
+            split: DatasetSplit::Train,
+            split_rank: 7,
+            observation_row_count: 42,
+            settlement_label_available: true,
+            repricing_label_row_count_30s: 30,
+            regime_version: CANONICAL_REGIME_VERSION.to_string(),
+        };
+
+        let chronology = entry.chronology_key();
+        assert_eq!(chronology.event_id, "evt-1");
+        assert_eq!(chronology.symbol, "BTC");
+        assert_eq!(chronology.end_time, entry.end_time);
+
+        let assignment = entry.split_assignment(11);
+        assert_eq!(assignment.event_id, "evt-1");
+        assert_eq!(assignment.split, DatasetSplit::Train);
+        assert_eq!(assignment.ordered_event_index, 11);
+        assert_eq!(assignment.split_rank, 7);
+    }
+
+    #[test]
+    fn manifest_round_trips_and_validates() {
+        let manifest = DatasetBuildManifest {
+            manifest_version: DATASET_MANIFEST_VERSION,
+            built_at: Utc.with_ymd_and_hms(2026, 4, 24, 0, 0, 0).unwrap(),
+            source_window: DatasetSourceWindow {
+                start_time: Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap(),
+                end_time: Utc.with_ymd_and_hms(2026, 4, 7, 23, 59, 59).unwrap(),
+                symbols: vec!["BTC".to_string(), "ETH".to_string()],
+            },
+            split_policy: DatasetSplitPolicy::default(),
+            labels: DatasetLabelContract::default(),
+            feature_families: vec!["microstructure".to_string(), "repricing".to_string()],
+            regime_version: CANONICAL_REGIME_VERSION.to_string(),
+            artifacts: DatasetArtifacts {
+                event_index: "event_index.parquet".to_string(),
+                event_manifest: "event_manifest.json".to_string(),
+                split_assignments: "split_assignments.parquet".to_string(),
+                observations: DatasetSplitArtifactPaths {
+                    train: "observations_train.parquet".to_string(),
+                    val: "observations_val.parquet".to_string(),
+                    test: "observations_test.parquet".to_string(),
+                },
+                event_summaries: DatasetSplitArtifactPaths {
+                    train: "event_summaries_train.parquet".to_string(),
+                    val: "event_summaries_val.parquet".to_string(),
+                    test: "event_summaries_test.parquet".to_string(),
+                },
+            },
+            stats: DatasetBuildStats {
+                total_events: 120,
+                total_observations: 4_800,
+                events_per_split: DatasetSplitCounts {
+                    train: 84,
+                    val: 18,
+                    test: 18,
+                },
+                observations_per_split: DatasetSplitCounts {
+                    train: 3_360,
+                    val: 720,
+                    test: 720,
+                },
+                skip_counts: DatasetSkipCounts {
+                    missing_start_time: 2,
+                    missing_end_time: 1,
+                    missing_timing_fields: 3,
+                },
+            },
+        };
+
+        manifest.validate_contract().expect("manifest must validate");
+
+        let json = serde_json::to_string_pretty(&manifest).expect("manifest serializes");
+        let reparsed: DatasetBuildManifest =
+            serde_json::from_str(&json).expect("manifest deserializes");
+
+        assert_eq!(reparsed, manifest);
+        reparsed
+            .validate_contract()
+            .expect("round-tripped manifest must still validate");
+    }
+}

--- a/crates/ploy-research/src/dataset/export.rs
+++ b/crates/ploy-research/src/dataset/export.rs
@@ -1,0 +1,424 @@
+use std::fs::{File, create_dir_all};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use polars::io::parquet::write::ParquetWriter;
+use polars::prelude::*;
+
+use crate::factors::{EventFactorSummary, export_observations_parquet};
+
+use super::{DatasetSplit, DatasetSplitAssignment, EventIndexEntry, EventRootDatasetBuild};
+
+#[derive(Debug)]
+pub enum DatasetExportError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    ManifestContract { message: String },
+    Polars(PolarsError),
+}
+
+impl From<std::io::Error> for DatasetExportError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for DatasetExportError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<PolarsError> for DatasetExportError {
+    fn from(error: PolarsError) -> Self {
+        Self::Polars(error)
+    }
+}
+
+pub fn event_index_to_frame(rows: &[EventIndexEntry]) -> PolarsResult<DataFrame> {
+    df![
+        "event_id" => rows.iter().map(|row| row.event_id.as_str()).collect::<Vec<_>>(),
+        "symbol" => rows.iter().map(|row| row.symbol.as_str()).collect::<Vec<_>>(),
+        "start_time" => rows.iter().map(|row| row.start_time.timestamp_millis()).collect::<Vec<_>>(),
+        "end_time" => rows.iter().map(|row| row.end_time.timestamp_millis()).collect::<Vec<_>>(),
+        "split" => rows.iter().map(|row| split_name(row.split)).collect::<Vec<_>>(),
+        "split_rank" => rows.iter().map(|row| row.split_rank as i64).collect::<Vec<_>>(),
+        "observation_row_count" => rows.iter().map(|row| row.observation_row_count as i64).collect::<Vec<_>>(),
+        "settlement_label_available" => rows.iter().map(|row| row.settlement_label_available).collect::<Vec<_>>(),
+        "repricing_label_row_count_30s" => rows.iter().map(|row| row.repricing_label_row_count_30s as i64).collect::<Vec<_>>(),
+        "regime_version" => rows.iter().map(|row| row.regime_version.as_str()).collect::<Vec<_>>(),
+    ]
+}
+
+pub fn split_assignments_to_frame(rows: &[DatasetSplitAssignment]) -> PolarsResult<DataFrame> {
+    df![
+        "event_id" => rows.iter().map(|row| row.event_id.as_str()).collect::<Vec<_>>(),
+        "symbol" => rows.iter().map(|row| row.symbol.as_str()).collect::<Vec<_>>(),
+        "end_time" => rows.iter().map(|row| row.end_time.timestamp_millis()).collect::<Vec<_>>(),
+        "ordered_event_index" => rows.iter().map(|row| row.ordered_event_index as i64).collect::<Vec<_>>(),
+        "split" => rows.iter().map(|row| split_name(row.split)).collect::<Vec<_>>(),
+        "split_rank" => rows.iter().map(|row| row.split_rank as i64).collect::<Vec<_>>(),
+    ]
+}
+
+pub fn event_summaries_to_frame(rows: &[EventFactorSummary]) -> PolarsResult<DataFrame> {
+    df![
+        "event_id" => rows.iter().map(|row| row.event_id.as_str()).collect::<Vec<_>>(),
+        "symbol" => rows.iter().map(|row| row.symbol.as_str()).collect::<Vec<_>>(),
+        "last_tick_ts" => rows.iter().map(|row| row.last_tick_ts.timestamp_millis()).collect::<Vec<_>>(),
+        "settlement_up" => rows.iter().map(|row| row.settlement_up).collect::<Vec<_>>(),
+        "signed_distance_to_beat" => rows.iter().map(|row| row.signed_distance_to_beat).collect::<Vec<_>>(),
+        "abs_distance_to_beat" => rows.iter().map(|row| row.abs_distance_to_beat).collect::<Vec<_>>(),
+        "drift_10s" => rows.iter().map(|row| row.drift_10s).collect::<Vec<_>>(),
+        "drift_30s" => rows.iter().map(|row| row.drift_30s).collect::<Vec<_>>(),
+        "flip_age_secs" => rows.iter().map(|row| row.flip_age_secs).collect::<Vec<_>>(),
+        "post_flip_drift" => rows.iter().map(|row| row.post_flip_drift).collect::<Vec<_>>(),
+        "sigma_horizon" => rows.iter().map(|row| row.sigma_horizon).collect::<Vec<_>>(),
+        "fair_prob_up" => rows.iter().map(|row| row.fair_prob_up).collect::<Vec<_>>(),
+        "fair_prob_up_clean" => rows.iter().map(|row| row.fair_prob_up_clean).collect::<Vec<_>>(),
+        "prob_disagreement" => rows.iter().map(|row| row.prob_disagreement).collect::<Vec<_>>(),
+        "implied_sigma_horizon" => rows.iter().map(|row| row.implied_sigma_horizon).collect::<Vec<_>>(),
+        "vol_gap" => rows.iter().map(|row| row.vol_gap).collect::<Vec<_>>(),
+        "distance_over_sigma" => rows.iter().map(|row| row.distance_over_sigma).collect::<Vec<_>>(),
+        "model_prob_up" => rows.iter().map(|row| row.model_prob_up).collect::<Vec<_>>(),
+        "model_edge_up" => rows.iter().map(|row| row.model_edge_up).collect::<Vec<_>>(),
+        "reward_risk_up" => rows.iter().map(|row| row.reward_risk_up).collect::<Vec<_>>(),
+        "reward_risk_down" => rows.iter().map(|row| row.reward_risk_down).collect::<Vec<_>>(),
+        "obi" => rows.iter().map(|row| row.obi).collect::<Vec<_>>(),
+        "spread_bps" => rows.iter().map(|row| row.spread_bps).collect::<Vec<_>>(),
+        "microprice_offset_bps" => rows.iter().map(|row| row.microprice_offset_bps).collect::<Vec<_>>(),
+        "bid_depth_near" => rows.iter().map(|row| row.bid_depth_near).collect::<Vec<_>>(),
+        "ask_depth_near" => rows.iter().map(|row| row.ask_depth_near).collect::<Vec<_>>(),
+        "depth_ratio" => rows.iter().map(|row| row.depth_ratio).collect::<Vec<_>>(),
+        "depth_imbalance" => rows.iter().map(|row| row.depth_imbalance).collect::<Vec<_>>(),
+        "depth_far_ratio" => rows.iter().map(|row| row.depth_far_ratio).collect::<Vec<_>>(),
+        "depth_acceleration" => rows.iter().map(|row| row.depth_acceleration).collect::<Vec<_>>(),
+        "obi_10" => rows.iter().map(|row| row.obi_10).collect::<Vec<_>>(),
+        "pm_up_bid" => rows.iter().map(|row| row.pm_up_bid).collect::<Vec<_>>(),
+        "pm_up_ask" => rows.iter().map(|row| row.pm_up_ask).collect::<Vec<_>>(),
+        "pm_up_bid_size" => rows.iter().map(|row| row.pm_up_bid_size).collect::<Vec<_>>(),
+        "pm_up_ask_size" => rows.iter().map(|row| row.pm_up_ask_size).collect::<Vec<_>>(),
+        "pm_down_bid" => rows.iter().map(|row| row.pm_down_bid).collect::<Vec<_>>(),
+        "pm_down_ask" => rows.iter().map(|row| row.pm_down_ask).collect::<Vec<_>>(),
+        "pm_down_bid_size" => rows.iter().map(|row| row.pm_down_bid_size).collect::<Vec<_>>(),
+        "pm_down_ask_size" => rows.iter().map(|row| row.pm_down_ask_size).collect::<Vec<_>>(),
+        "pm_lag_secs" => rows.iter().map(|row| row.pm_lag_secs).collect::<Vec<_>>(),
+        "cum_obi_delta_5m" => rows.iter().map(|row| row.cum_obi_delta_5m).collect::<Vec<_>>(),
+        "cum_depth_delta_5m" => rows.iter().map(|row| row.cum_depth_delta_5m).collect::<Vec<_>>(),
+        "cum_mprice_drift_5m" => rows.iter().map(|row| row.cum_mprice_drift_5m).collect::<Vec<_>>(),
+        "cum_trade_imbalance_5m" => rows.iter().map(|row| row.cum_trade_imbalance_5m).collect::<Vec<_>>(),
+    ]
+}
+
+pub fn export_event_root_dataset_parquet(
+    build: &EventRootDatasetBuild,
+    output_root: &Path,
+) -> Result<(), DatasetExportError> {
+    build
+        .manifest
+        .validate_contract()
+        .map_err(|message| DatasetExportError::ManifestContract { message })?;
+
+    write_manifest_json(build, output_root)?;
+    write_parquet(
+        event_index_to_frame(&build.event_index)?,
+        &artifact_path(output_root, &build.manifest.artifacts.event_index),
+    )?;
+    write_parquet(
+        split_assignments_to_frame(&build.split_assignments)?,
+        &artifact_path(output_root, &build.manifest.artifacts.split_assignments),
+    )?;
+
+    export_observations_with_parent_dirs(
+        &build.split_artifacts.train.observation_rows,
+        &artifact_path(output_root, &build.manifest.artifacts.observations.train),
+    )?;
+    export_observations_with_parent_dirs(
+        &build.split_artifacts.val.observation_rows,
+        &artifact_path(output_root, &build.manifest.artifacts.observations.val),
+    )?;
+    export_observations_with_parent_dirs(
+        &build.split_artifacts.test.observation_rows,
+        &artifact_path(output_root, &build.manifest.artifacts.observations.test),
+    )?;
+
+    write_parquet(
+        event_summaries_to_frame(&build.split_artifacts.train.event_summaries)?,
+        &artifact_path(output_root, &build.manifest.artifacts.event_summaries.train),
+    )?;
+    write_parquet(
+        event_summaries_to_frame(&build.split_artifacts.val.event_summaries)?,
+        &artifact_path(output_root, &build.manifest.artifacts.event_summaries.val),
+    )?;
+    write_parquet(
+        event_summaries_to_frame(&build.split_artifacts.test.event_summaries)?,
+        &artifact_path(output_root, &build.manifest.artifacts.event_summaries.test),
+    )?;
+
+    Ok(())
+}
+
+fn write_manifest_json(
+    build: &EventRootDatasetBuild,
+    output_root: &Path,
+) -> Result<(), DatasetExportError> {
+    let path = artifact_path(output_root, &build.manifest.artifacts.event_manifest);
+    ensure_parent_dir(&path)?;
+    let file = File::create(path)?;
+    serde_json::to_writer_pretty(file, &build.manifest)?;
+    Ok(())
+}
+
+fn export_observations_with_parent_dirs(
+    rows: &[crate::factors::FactorObservation],
+    path: &Path,
+) -> Result<(), DatasetExportError> {
+    ensure_parent_dir(path)?;
+    export_observations_parquet(rows, path)?;
+    Ok(())
+}
+
+fn write_parquet(mut df: DataFrame, path: &Path) -> Result<(), DatasetExportError> {
+    ensure_parent_dir(path)?;
+    let file = File::create(path).map_err(|error| PolarsError::IO {
+        error: Arc::new(error),
+        msg: None,
+    })?;
+    ParquetWriter::new(file).finish(&mut df)?;
+    Ok(())
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+fn artifact_path(output_root: &Path, artifact: &str) -> PathBuf {
+    let artifact_path = Path::new(artifact);
+    if artifact_path.is_absolute() {
+        artifact_path.to_path_buf()
+    } else {
+        output_root.join(artifact_path)
+    }
+}
+
+fn split_name(split: DatasetSplit) -> &'static str {
+    match split {
+        DatasetSplit::Train => "train",
+        DatasetSplit::Val => "val",
+        DatasetSplit::Test => "test",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        event_index_to_frame, event_summaries_to_frame, export_event_root_dataset_parquet,
+        split_assignments_to_frame,
+    };
+    use crate::dataset::{
+        DatasetSourceWindow, EventMetadataChronologyInput, EventRootDatasetBuildRequest,
+        build_event_root_dataset, standard_event_root_dataset_artifacts,
+    };
+    use crate::factors::FactorObservation;
+    use chrono::{Duration, TimeZone, Utc};
+    use std::collections::HashSet;
+    use std::fs;
+
+    #[test]
+    fn frames_preserve_dataset_artifact_row_grain() {
+        let build = synthetic_build();
+
+        assert_eq!(
+            event_index_to_frame(&build.event_index).unwrap().height(),
+            140
+        );
+        assert_eq!(
+            split_assignments_to_frame(&build.split_assignments)
+                .unwrap()
+                .height(),
+            140
+        );
+        assert_eq!(
+            event_summaries_to_frame(&build.split_artifacts.train.event_summaries)
+                .unwrap()
+                .height(),
+            98
+        );
+        assert_eq!(
+            event_summaries_to_frame(&build.split_artifacts.val.event_summaries)
+                .unwrap()
+                .height(),
+            21
+        );
+        assert_eq!(
+            event_summaries_to_frame(&build.split_artifacts.test.event_summaries)
+                .unwrap()
+                .height(),
+            21
+        );
+    }
+
+    #[test]
+    fn export_writes_manifest_and_all_split_parquet_artifacts() {
+        let build = synthetic_build();
+        let root = std::env::temp_dir().join(format!(
+            "ploy-event-root-export-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        export_event_root_dataset_parquet(&build, &root).expect("export should succeed");
+
+        let expected_paths = [
+            &build.manifest.artifacts.event_manifest,
+            &build.manifest.artifacts.event_index,
+            &build.manifest.artifacts.split_assignments,
+            &build.manifest.artifacts.observations.train,
+            &build.manifest.artifacts.observations.val,
+            &build.manifest.artifacts.observations.test,
+            &build.manifest.artifacts.event_summaries.train,
+            &build.manifest.artifacts.event_summaries.val,
+            &build.manifest.artifacts.event_summaries.test,
+        ];
+
+        for artifact in expected_paths {
+            let path = root.join(artifact);
+            let metadata = fs::metadata(&path).unwrap_or_else(|_| {
+                panic!("expected artifact to exist: {}", path.display());
+            });
+            assert!(
+                metadata.len() > 0,
+                "expected artifact to be non-empty: {}",
+                path.display()
+            );
+        }
+
+        let manifest_json =
+            fs::read_to_string(root.join(&build.manifest.artifacts.event_manifest)).unwrap();
+        assert!(manifest_json.contains("\"total_events\": 140"));
+        assert!(manifest_json.contains("\"total_observations\": 280"));
+
+        fs::remove_dir_all(root).expect("temporary export directory should be removed");
+    }
+
+    fn synthetic_build() -> crate::dataset::EventRootDatasetBuild {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        let chronology_events = synthetic_chronology_events(140, start);
+        let observations = synthetic_observations(140, start);
+        let request = EventRootDatasetBuildRequest::new(
+            &observations,
+            chronology_events,
+            DatasetSourceWindow {
+                start_time: start,
+                end_time: start + Duration::minutes(700),
+                symbols: vec!["BTCUSDT".to_string(), "ETHUSDT".to_string()],
+            },
+            standard_event_root_dataset_artifacts(),
+            start,
+        );
+
+        build_event_root_dataset(request).expect("synthetic dataset should build")
+    }
+
+    fn synthetic_chronology_events(
+        count: usize,
+        start: chrono::DateTime<Utc>,
+    ) -> Vec<EventMetadataChronologyInput> {
+        (0..count)
+            .rev()
+            .map(|idx| EventMetadataChronologyInput {
+                event_id: format!("evt-{idx:03}"),
+                symbol: if idx % 2 == 0 { "BTCUSDT" } else { "ETHUSDT" }.to_string(),
+                start_time: Some(start + Duration::minutes(idx as i64 * 5)),
+                end_time: Some(start + Duration::minutes(idx as i64 * 5 + 5)),
+            })
+            .collect()
+    }
+
+    fn synthetic_observations(
+        count: usize,
+        start: chrono::DateTime<Utc>,
+    ) -> Vec<FactorObservation> {
+        let selected_test_label_events: HashSet<usize> = (119..140).collect();
+        (0..count)
+            .flat_map(|idx| {
+                let event_id = format!("evt-{idx:03}");
+                let symbol = if idx % 2 == 0 { "BTCUSDT" } else { "ETHUSDT" };
+                let event_start = start + Duration::minutes(idx as i64 * 5);
+                [
+                    synthetic_observation(
+                        &event_id,
+                        symbol,
+                        event_start,
+                        0,
+                        1.0,
+                        selected_test_label_events.contains(&idx).then_some(0.01),
+                    ),
+                    synthetic_observation(&event_id, symbol, event_start, 1, 1.0, None),
+                ]
+            })
+            .collect()
+    }
+
+    fn synthetic_observation(
+        event_id: &str,
+        symbol: &str,
+        event_start: chrono::DateTime<Utc>,
+        row_idx: i64,
+        settlement_up: f64,
+        repricing_label: Option<f64>,
+    ) -> FactorObservation {
+        FactorObservation {
+            event_id: event_id.to_string(),
+            symbol: symbol.to_string(),
+            tick_ts: event_start + Duration::seconds(row_idx * 30),
+            time_remaining_secs: 300 - row_idx * 30,
+            signed_distance_to_beat: 0.0,
+            abs_distance_to_beat: 0.0,
+            drift_10s: 0.0,
+            drift_30s: 0.0,
+            flip_age_secs: 0.0,
+            post_flip_drift: 0.0,
+            sigma_horizon: 1.0,
+            fair_prob_up: 0.5,
+            fair_prob_up_clean: 0.5,
+            prob_disagreement: 0.0,
+            implied_sigma_horizon: 0.1,
+            vol_gap: 0.0,
+            distance_over_sigma: 0.0,
+            model_prob_up: 0.5,
+            model_edge_up: 0.0,
+            reward_risk_up: 1.0,
+            reward_risk_down: 1.0,
+            obi: 0.0,
+            spread_bps: 1.0,
+            microprice_offset_bps: 0.0,
+            bid_depth_near: 0.0,
+            ask_depth_near: 0.0,
+            depth_ratio: 1.0,
+            depth_imbalance: 0.0,
+            depth_far_ratio: 1.0,
+            depth_acceleration: 0.0,
+            obi_10: 0.0,
+            pm_up_bid: 0.49,
+            pm_up_ask: 0.51,
+            pm_up_bid_size: 10.0,
+            pm_up_ask_size: 11.0,
+            pm_down_bid: 0.49,
+            pm_down_ask: 0.51,
+            pm_down_bid_size: 12.0,
+            pm_down_ask_size: 13.0,
+            pm_lag_secs: 0.0,
+            settlement_up,
+            future_up_ask_change_30s: repricing_label,
+            future_up_ask_change_60s: None,
+            cum_obi_delta_5m: 0.0,
+            cum_depth_delta_5m: 0.0,
+            cum_mprice_drift_5m: 0.0,
+            cum_trade_imbalance_5m: 0.0,
+        }
+    }
+}

--- a/crates/ploy-research/src/dataset/mod.rs
+++ b/crates/ploy-research/src/dataset/mod.rs
@@ -1,7 +1,12 @@
+mod builder;
 mod chronology;
 mod contracts;
 mod split;
 
+pub use builder::{
+    DatasetBuildError, DatasetSplitDerivedArtifacts, EventRootDatasetBuild,
+    EventRootDatasetBuildRequest, build_event_root_dataset, standard_event_root_dataset_artifacts,
+};
 pub use chronology::{
     EventChronologyBuild, EventMetadataChronologyInput, build_canonical_event_chronology,
 };

--- a/crates/ploy-research/src/dataset/mod.rs
+++ b/crates/ploy-research/src/dataset/mod.rs
@@ -1,0 +1,15 @@
+mod chronology;
+mod contracts;
+mod split;
+
+pub use chronology::{
+    EventChronologyBuild, EventMetadataChronologyInput, build_canonical_event_chronology,
+};
+pub use contracts::{
+    CANONICAL_REGIME_VERSION, ChronologyAnchor, ChronologyOrdering, DATASET_MANIFEST_VERSION,
+    DatasetArtifacts, DatasetBuildManifest, DatasetBuildStats, DatasetLabelContract,
+    DatasetSkipCounts, DatasetSourceWindow, DatasetSplit, DatasetSplitArtifactPaths,
+    DatasetSplitAssignment, DatasetSplitCounts, DatasetSplitPolicy, EventChronologyKey,
+    EventIndexEntry, REPRICING_LABEL_30S, SETTLEMENT_LABEL,
+};
+pub use split::{SplitBuildError, assign_chronological_event_splits};

--- a/crates/ploy-research/src/dataset/mod.rs
+++ b/crates/ploy-research/src/dataset/mod.rs
@@ -1,6 +1,8 @@
 mod builder;
 mod chronology;
 mod contracts;
+#[cfg(feature = "polars-export")]
+mod export;
 mod split;
 
 pub use builder::{
@@ -16,5 +18,10 @@ pub use contracts::{
     DatasetSkipCounts, DatasetSourceWindow, DatasetSplit, DatasetSplitArtifactPaths,
     DatasetSplitAssignment, DatasetSplitCounts, DatasetSplitPolicy, EventChronologyKey,
     EventIndexEntry, REPRICING_LABEL_30S, SETTLEMENT_LABEL,
+};
+#[cfg(feature = "polars-export")]
+pub use export::{
+    DatasetExportError, event_index_to_frame, event_summaries_to_frame,
+    export_event_root_dataset_parquet, split_assignments_to_frame,
 };
 pub use split::{SplitBuildError, assign_chronological_event_splits};

--- a/crates/ploy-research/src/dataset/split.rs
+++ b/crates/ploy-research/src/dataset/split.rs
@@ -1,0 +1,183 @@
+use std::collections::HashSet;
+
+use super::{DatasetSplit, DatasetSplitAssignment, DatasetSplitPolicy, EventChronologyKey};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SplitBuildError {
+    DuplicateEventId {
+        event_id: String,
+    },
+    TooFewUniqueEvents {
+        found: usize,
+        min_required: usize,
+    },
+    EvalSplitTooSmall {
+        split: DatasetSplit,
+        found: usize,
+        min_required: usize,
+    },
+}
+
+pub fn assign_chronological_event_splits(
+    ordered_events: &[EventChronologyKey],
+    policy: &DatasetSplitPolicy,
+) -> Result<Vec<DatasetSplitAssignment>, SplitBuildError> {
+    let mut seen = HashSet::with_capacity(ordered_events.len());
+    for event in ordered_events {
+        if !seen.insert(event.event_id.as_str()) {
+            return Err(SplitBuildError::DuplicateEventId {
+                event_id: event.event_id.clone(),
+            });
+        }
+    }
+
+    let unique_events = ordered_events.len();
+    if unique_events < policy.min_unique_events {
+        return Err(SplitBuildError::TooFewUniqueEvents {
+            found: unique_events,
+            min_required: policy.min_unique_events,
+        });
+    }
+
+    let train_count = unique_events * usize::from(policy.train_percent) / 100;
+    let val_count = unique_events * usize::from(policy.val_percent) / 100;
+    let test_count = unique_events.saturating_sub(train_count + val_count);
+
+    if val_count < policy.min_eval_events {
+        return Err(SplitBuildError::EvalSplitTooSmall {
+            split: DatasetSplit::Val,
+            found: val_count,
+            min_required: policy.min_eval_events,
+        });
+    }
+
+    if test_count < policy.min_eval_events {
+        return Err(SplitBuildError::EvalSplitTooSmall {
+            split: DatasetSplit::Test,
+            found: test_count,
+            min_required: policy.min_eval_events,
+        });
+    }
+
+    let mut assignments = Vec::with_capacity(unique_events);
+    let mut train_rank = 0;
+    let mut val_rank = 0;
+    let mut test_rank = 0;
+
+    for (ordered_event_index, event) in ordered_events.iter().enumerate() {
+        let split = if ordered_event_index < train_count {
+            let split = DatasetSplit::Train;
+            let rank = train_rank;
+            train_rank += 1;
+            (split, rank)
+        } else if ordered_event_index < train_count + val_count {
+            let split = DatasetSplit::Val;
+            let rank = val_rank;
+            val_rank += 1;
+            (split, rank)
+        } else {
+            let split = DatasetSplit::Test;
+            let rank = test_rank;
+            test_rank += 1;
+            (split, rank)
+        };
+
+        assignments.push(DatasetSplitAssignment {
+            event_id: event.event_id.clone(),
+            symbol: event.symbol.clone(),
+            end_time: event.end_time,
+            ordered_event_index,
+            split: split.0,
+            split_rank: split.1,
+        });
+    }
+
+    Ok(assignments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SplitBuildError, assign_chronological_event_splits};
+    use crate::dataset::{DatasetSplit, DatasetSplitPolicy, EventChronologyKey};
+    use chrono::{Duration, TimeZone, Utc};
+    use std::collections::{HashMap, HashSet};
+
+    fn synthetic_events(count: usize) -> Vec<EventChronologyKey> {
+        let start = Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap();
+        (0..count)
+            .map(|idx| EventChronologyKey {
+                event_id: format!("evt-{idx:03}"),
+                symbol: if idx % 2 == 0 { "BTC" } else { "ETH" }.to_string(),
+                start_time: start + Duration::minutes(idx as i64),
+                end_time: start + Duration::minutes(idx as i64 + 5),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn split_assignment_is_chronological_and_leakage_safe() {
+        let assignments = assign_chronological_event_splits(
+            &synthetic_events(140),
+            &DatasetSplitPolicy::default(),
+        )
+        .expect("split assignment should succeed");
+
+        assert_eq!(assignments.len(), 140);
+
+        let split_counts = assignments
+            .iter()
+            .fold(HashMap::new(), |mut counts, assignment| {
+                *counts.entry(assignment.split).or_insert(0usize) += 1;
+                counts
+            });
+        assert_eq!(split_counts.get(&DatasetSplit::Train), Some(&98));
+        assert_eq!(split_counts.get(&DatasetSplit::Val), Some(&21));
+        assert_eq!(split_counts.get(&DatasetSplit::Test), Some(&21));
+
+        for window in assignments.windows(2) {
+            assert!(
+                window[0].ordered_event_index < window[1].ordered_event_index,
+                "assignment ordering must remain chronological"
+            );
+        }
+
+        let unique_event_ids: HashSet<_> = assignments
+            .iter()
+            .map(|assignment| assignment.event_id.as_str())
+            .collect();
+        assert_eq!(unique_event_ids.len(), assignments.len());
+    }
+
+    #[test]
+    fn split_assignment_fails_when_unique_events_are_too_small() {
+        let error =
+            assign_chronological_event_splits(&synthetic_events(2), &DatasetSplitPolicy::default())
+                .expect_err("split assignment should fail");
+
+        assert_eq!(
+            error,
+            SplitBuildError::TooFewUniqueEvents {
+                found: 2,
+                min_required: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn split_assignment_fails_when_eval_split_is_below_threshold() {
+        let error = assign_chronological_event_splits(
+            &synthetic_events(100),
+            &DatasetSplitPolicy::default(),
+        )
+        .expect_err("split assignment should fail");
+
+        assert_eq!(
+            error,
+            SplitBuildError::EvalSplitTooSmall {
+                split: DatasetSplit::Val,
+                found: 15,
+                min_required: 20,
+            }
+        );
+    }
+}

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -113,6 +113,37 @@ pub struct EventFactorSummary {
 }
 
 #[derive(Debug, Clone)]
+pub struct TaskGrainDerivedArtifacts {
+    pub event_ids: Vec<String>,
+    pub observation_rows: Vec<FactorObservation>,
+    pub event_summaries: Vec<EventFactorSummary>,
+}
+
+impl TaskGrainDerivedArtifacts {
+    pub fn observation_row_count(&self) -> usize {
+        self.observation_rows.len()
+    }
+
+    pub fn event_summary_count(&self) -> usize {
+        self.event_summaries.len()
+    }
+
+    pub fn repricing_label_row_count_30s(&self) -> usize {
+        self.observation_rows
+            .iter()
+            .filter(|row| row.future_up_ask_change_30s.is_some_and(f64::is_finite))
+            .count()
+    }
+
+    pub fn settlement_label_event_count(&self) -> usize {
+        self.event_summaries
+            .iter()
+            .filter(|row| row.settlement_up.is_finite())
+            .count()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct FactorMetric {
     pub label: String,
     pub factor: String,
@@ -1122,6 +1153,45 @@ pub fn build_event_summaries(rows: &[FactorObservation]) -> Vec<EventFactorSumma
         .collect()
 }
 
+pub fn build_task_grain_derived_artifacts_for_event_ids<I, S>(
+    rows: &[FactorObservation],
+    event_ids: I,
+) -> TaskGrainDerivedArtifacts
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let selected_event_ids: std::collections::BTreeSet<String> = event_ids
+        .into_iter()
+        .map(|event_id| event_id.as_ref().to_string())
+        .collect();
+
+    let mut observation_rows: Vec<FactorObservation> = rows
+        .iter()
+        .filter(|row| selected_event_ids.contains(&row.event_id))
+        .cloned()
+        .collect();
+    observation_rows.sort_by(|lhs, rhs| {
+        lhs.event_id
+            .cmp(&rhs.event_id)
+            .then(lhs.tick_ts.cmp(&rhs.tick_ts))
+            .then(lhs.symbol.cmp(&rhs.symbol))
+    });
+
+    let mut event_summaries = build_event_summaries(&observation_rows);
+    event_summaries.sort_by(|lhs, rhs| {
+        lhs.event_id
+            .cmp(&rhs.event_id)
+            .then(lhs.last_tick_ts.cmp(&rhs.last_tick_ts))
+            .then(lhs.symbol.cmp(&rhs.symbol))
+    });
+
+    TaskGrainDerivedArtifacts {
+        event_ids: selected_event_ids.into_iter().collect(),
+        observation_rows,
+        event_summaries,
+    }
+}
 pub fn factor_metrics(
     rows: &[FactorObservation],
     event_rows: &[EventFactorSummary],

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -1782,10 +1782,73 @@ pub fn export_observations_parquet(
 
 #[cfg(test)]
 mod tests {
-    use super::{FactorObservation, LabelField, attach_future_pm_labels, pearson_ic, spearman_ic};
+    use super::{
+        FactorObservation, LabelField, attach_future_pm_labels,
+        build_task_grain_derived_artifacts_for_event_ids, pearson_ic, spearman_ic,
+    };
     use chrono::Utc;
     #[cfg(feature = "db")]
     use serde_json::json;
+
+    fn test_factor_observation(
+        event_id: &str,
+        symbol: &str,
+        tick_ts_secs: i64,
+        settlement_up: f64,
+        future_up_ask_change_30s: Option<f64>,
+    ) -> FactorObservation {
+        FactorObservation {
+            event_id: event_id.into(),
+            symbol: symbol.into(),
+            tick_ts: chrono::DateTime::from_timestamp(tick_ts_secs, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            time_remaining_secs: 60,
+            signed_distance_to_beat: 0.0,
+            abs_distance_to_beat: 0.0,
+            drift_10s: 0.0,
+            drift_30s: 0.0,
+            flip_age_secs: 0.0,
+            post_flip_drift: 0.0,
+            sigma_horizon: 1.0,
+            fair_prob_up: 0.5,
+            fair_prob_up_clean: 0.5,
+            prob_disagreement: 0.0,
+            implied_sigma_horizon: 0.2,
+            vol_gap: 0.0,
+            distance_over_sigma: 0.0,
+            model_prob_up: 0.5,
+            model_edge_up: 0.0,
+            reward_risk_up: 1.0,
+            reward_risk_down: 1.0,
+            obi: 0.0,
+            spread_bps: 0.0,
+            microprice_offset_bps: 0.0,
+            bid_depth_near: 1.0,
+            ask_depth_near: 1.0,
+            depth_ratio: 1.0,
+            depth_imbalance: 0.0,
+            depth_far_ratio: 1.0,
+            depth_acceleration: 0.0,
+            obi_10: 0.0,
+            pm_up_bid: 0.49,
+            pm_up_ask: 0.50,
+            pm_up_bid_size: 1.0,
+            pm_up_ask_size: 1.0,
+            pm_down_bid: 0.49,
+            pm_down_ask: 0.50,
+            pm_down_bid_size: 1.0,
+            pm_down_ask_size: 1.0,
+            pm_lag_secs: 0.0,
+            settlement_up,
+            future_up_ask_change_30s,
+            future_up_ask_change_60s: None,
+            cum_obi_delta_5m: 0.0,
+            cum_depth_delta_5m: 0.0,
+            cum_mprice_drift_5m: 0.0,
+            cum_trade_imbalance_5m: 0.0,
+        }
+    }
 
     #[test]
     fn pearson_ic_detects_positive_relationship() {
@@ -1985,6 +2048,70 @@ mod tests {
             .find(|row| row.tick_ts == ts0)
             .expect("first row");
         assert_eq!(first.future_up_ask_change_30s, Some(0.15));
+    }
+
+    #[test]
+    fn derived_artifacts_filter_to_selected_events_and_preserve_task_grains() {
+        let rows = vec![
+            test_factor_observation("evt-b", "ETHUSDT", 20, 0.0, Some(-0.20)),
+            test_factor_observation("evt-a", "BTCUSDT", 30, 1.0, None),
+            test_factor_observation("evt-c", "SOLUSDT", 15, 1.0, Some(0.30)),
+            test_factor_observation("evt-a", "BTCUSDT", 10, 1.0, Some(0.10)),
+            test_factor_observation("evt-b", "BTCUSDT", 20, 0.0, None),
+        ];
+
+        let artifacts = build_task_grain_derived_artifacts_for_event_ids(&rows, ["evt-b", "evt-a"]);
+
+        assert_eq!(artifacts.event_ids, vec!["evt-a", "evt-b"]);
+        assert_eq!(artifacts.observation_row_count(), 4);
+        assert_eq!(artifacts.event_summary_count(), 2);
+        assert_eq!(artifacts.repricing_label_row_count_30s(), 2);
+        assert_eq!(artifacts.settlement_label_event_count(), 2);
+
+        let observation_keys: Vec<(&str, i64, &str)> = artifacts
+            .observation_rows
+            .iter()
+            .map(|row| {
+                (
+                    row.event_id.as_str(),
+                    row.tick_ts.timestamp(),
+                    row.symbol.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            observation_keys,
+            vec![
+                ("evt-a", 10, "BTCUSDT"),
+                ("evt-a", 30, "BTCUSDT"),
+                ("evt-b", 20, "BTCUSDT"),
+                ("evt-b", 20, "ETHUSDT"),
+            ]
+        );
+
+        let summary_keys: Vec<(&str, i64, &str)> = artifacts
+            .event_summaries
+            .iter()
+            .map(|row| {
+                (
+                    row.event_id.as_str(),
+                    row.last_tick_ts.timestamp(),
+                    row.symbol.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            summary_keys,
+            vec![("evt-a", 30, "BTCUSDT"), ("evt-b", 20, "BTCUSDT")]
+        );
+        assert_eq!(
+            artifacts
+                .event_summaries
+                .iter()
+                .map(|row| row.settlement_up)
+                .collect::<Vec<_>>(),
+            vec![1.0, 0.0]
+        );
     }
 
     #[cfg(feature = "db")]

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -12,12 +12,14 @@ pub mod signal;
 pub use backtesting::{run_backtest, BacktestReport};
 pub use dataset::{
     CANONICAL_REGIME_VERSION, ChronologyAnchor, ChronologyOrdering, DATASET_MANIFEST_VERSION,
-    DatasetArtifacts, DatasetBuildManifest, DatasetBuildStats, DatasetLabelContract,
-    DatasetSkipCounts, DatasetSourceWindow, DatasetSplit, DatasetSplitArtifactPaths,
-    DatasetSplitAssignment, DatasetSplitCounts, DatasetSplitPolicy, EventChronologyBuild,
-    EventChronologyKey, EventIndexEntry, EventMetadataChronologyInput, REPRICING_LABEL_30S,
-    SETTLEMENT_LABEL, SplitBuildError, assign_chronological_event_splits,
-    build_canonical_event_chronology,
+    DatasetArtifacts, DatasetBuildError, DatasetBuildManifest, DatasetBuildStats,
+    DatasetLabelContract, DatasetSkipCounts, DatasetSourceWindow, DatasetSplit,
+    DatasetSplitArtifactPaths, DatasetSplitAssignment, DatasetSplitCounts,
+    DatasetSplitDerivedArtifacts, DatasetSplitPolicy, EventChronologyBuild, EventChronologyKey,
+    EventIndexEntry, EventMetadataChronologyInput, EventRootDatasetBuild,
+    EventRootDatasetBuildRequest, REPRICING_LABEL_30S, SETTLEMENT_LABEL, SplitBuildError,
+    assign_chronological_event_splits, build_canonical_event_chronology,
+    build_event_root_dataset, standard_event_root_dataset_artifacts,
 };
 pub use factors::{
     aggregate_factor_metrics, build_event_summaries, build_factor_observations,

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attribution;
 pub mod backtest;
 pub mod backtesting;
+pub mod dataset;
 pub mod factors;
 pub mod factors_new;
 #[cfg(any(feature = "ml", feature = "rl"))]
@@ -9,6 +10,15 @@ pub mod replay;
 pub mod signal;
 
 pub use backtesting::{run_backtest, BacktestReport};
+pub use dataset::{
+    CANONICAL_REGIME_VERSION, ChronologyAnchor, ChronologyOrdering, DATASET_MANIFEST_VERSION,
+    DatasetArtifacts, DatasetBuildManifest, DatasetBuildStats, DatasetLabelContract,
+    DatasetSkipCounts, DatasetSourceWindow, DatasetSplit, DatasetSplitArtifactPaths,
+    DatasetSplitAssignment, DatasetSplitCounts, DatasetSplitPolicy, EventChronologyBuild,
+    EventChronologyKey, EventIndexEntry, EventMetadataChronologyInput, REPRICING_LABEL_30S,
+    SETTLEMENT_LABEL, SplitBuildError, assign_chronological_event_splits,
+    build_canonical_event_chronology,
+};
 pub use factors::{
     aggregate_factor_metrics, build_event_summaries, build_factor_observations,
     build_factor_observations_with_lob, factor_metrics, AggregatedFactorMetric, EventFactorSummary,

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -21,6 +21,11 @@ pub use dataset::{
     assign_chronological_event_splits, build_canonical_event_chronology,
     build_event_root_dataset, standard_event_root_dataset_artifacts,
 };
+#[cfg(feature = "polars-export")]
+pub use dataset::{
+    DatasetExportError, event_index_to_frame, event_summaries_to_frame,
+    export_event_root_dataset_parquet, split_assignments_to_frame,
+};
 pub use factors::{
     aggregate_factor_metrics, build_event_summaries, build_factor_observations,
     build_factor_observations_with_lob, factor_metrics, AggregatedFactorMetric, EventFactorSummary,

--- a/scripts/check_event_dataset_scope.sh
+++ b/scripts/check_event_dataset_scope.sh
@@ -31,6 +31,8 @@ failures=()
 allowed_paths=(
   "crates/ploy-research/"
   "scripts/check_event_dataset_scope.sh"
+  "scripts/check_event_dataset_verification_lane.sh"
+  "tasks/event_dataset_verification_matrix.md"
 )
 protected_prefixes=(
   "apps/ploy-backtest/"

--- a/scripts/check_event_dataset_scope.sh
+++ b/scripts/check_event_dataset_scope.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+base_ref="${1:-}"
+if [[ -z "${base_ref}" ]]; then
+  for candidate in origin/fix/backtest-realism origin/main; do
+    if git rev-parse --verify --quiet "${candidate}" >/dev/null; then
+      base_ref="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${base_ref}" ]]; then
+  echo "FAIL: could not resolve a default base ref; pass one explicitly" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+  echo "FAIL: base ref '${base_ref}' does not exist" >&2
+  exit 1
+fi
+
+range="${base_ref}...HEAD"
+changed_files="$(git diff --name-only "${range}")"
+
+failures=()
+allowed_paths=(
+  "crates/ploy-research/"
+  "scripts/check_event_dataset_scope.sh"
+)
+protected_prefixes=(
+  "apps/ploy-backtest/"
+  "apps/ploy-replay/"
+  "crates/ploy-feed-loaders/"
+  "crates/ploy-strategy-bundles/"
+  "crates/ploy-strategy-runtime/"
+)
+protected_files=(
+  ".github/workflows/optimize.yml"
+  "Cargo.toml"
+)
+
+is_allowed() {
+  local path="$1"
+  local allowed
+  for allowed in "${allowed_paths[@]}"; do
+    if [[ "${allowed}" == */ ]]; then
+      [[ "${path}" == "${allowed}"* ]] && return 0
+    else
+      [[ "${path}" == "${allowed}" ]] && return 0
+    fi
+  done
+  return 1
+}
+
+while IFS= read -r path; do
+  [[ -z "${path}" ]] && continue
+
+  local_hit=0
+  for prefix in "${protected_prefixes[@]}"; do
+    if [[ "${path}" == "${prefix}"* ]]; then
+      failures+=("protected hot-path file changed: ${path}")
+      local_hit=1
+      break
+    fi
+  done
+  if [[ "${local_hit}" -eq 1 ]]; then
+    continue
+  fi
+
+  for exact in "${protected_files[@]}"; do
+    if [[ "${path}" == "${exact}" ]]; then
+      failures+=("protected hot-path file changed: ${path}")
+      local_hit=1
+      break
+    fi
+  done
+  if [[ "${local_hit}" -eq 1 ]]; then
+    continue
+  fi
+
+  if ! is_allowed "${path}"; then
+    failures+=("event dataset slice escaped crates/ploy-research: ${path}")
+  fi
+done <<< "${changed_files}"
+
+if git diff --quiet "${range}" -- crates/ploy-strategy-bundles/examples/optimize_backtest.rs; then
+  :
+else
+  failures+=("optimize_backtest hot path changed")
+fi
+
+if git diff --quiet "${range}" -- crates/ploy-research/Cargo.toml; then
+  :
+else
+  if git diff --unified=0 "${range}" -- crates/ploy-research/Cargo.toml | grep -Eq '^\+.*polars-export *= *\[.*\]|^\+.*default *= .*polars-export|^\+.*full *= .*polars-export'; then
+    failures+=("ploy-research/Cargo.toml now routes dataset work through polars-export defaults")
+  fi
+fi
+
+if [[ "${#failures[@]}" -gt 0 ]]; then
+  echo "FAIL: event dataset scope guard rejected hot-path changes"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
+fi
+
+echo "PASS: event dataset slice stays in crates/ploy-research and leaves optimize/backtest hot paths untouched"

--- a/scripts/check_event_dataset_verification_lane.sh
+++ b/scripts/check_event_dataset_verification_lane.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+base_ref="${1:-}"
+if [[ -z "${base_ref}" ]]; then
+  for candidate in origin/fix/backtest-realism origin/main; do
+    if git rev-parse --verify --quiet "${candidate}" >/dev/null; then
+      base_ref="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${base_ref}" ]]; then
+  echo "FAIL: could not resolve a default base ref; pass one explicitly" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+  echo "FAIL: base ref '${base_ref}' does not exist" >&2
+  exit 1
+fi
+
+range="${base_ref}...HEAD"
+changed_file_list="$(mktemp)"
+trap 'rm -f "${changed_file_list}"' EXIT
+
+git diff --name-only "${range}" > "${changed_file_list}"
+
+failures=0
+while IFS= read -r path; do
+  [[ -z "${path}" ]] && continue
+
+  case "${path}" in
+    apps/ploy-backtest/*|apps/ploy-replay/*|crates/ploy-feed-loaders/*|crates/ploy-strategy-bundles/*|crates/ploy-strategy-runtime/*|.github/workflows/optimize.yml|Cargo.toml)
+      echo "FAIL: protected hot-path file changed: ${path}" >&2
+      failures=1
+      continue
+      ;;
+    crates/ploy-research/*|tasks/event_dataset_verification_matrix.md|scripts/check_event_dataset_verification_lane.sh|scripts/check_event_dataset_scope.sh)
+      ;;
+    *)
+      echo "FAIL: verification lane escaped allowed scope: ${path}" >&2
+      failures=1
+      ;;
+  esac
+done < "${changed_file_list}"
+
+if [[ "${failures}" -ne 0 ]]; then
+  echo "FAIL: event dataset verification lane detected forbidden changes" >&2
+  exit 1
+fi
+
+echo "PASS: verification lane stayed within event dataset scope and left optimize/backtest hot paths untouched"

--- a/tasks/event_dataset_verification_matrix.md
+++ b/tasks/event_dataset_verification_matrix.md
@@ -1,0 +1,133 @@
+# Event Dataset Verification Matrix
+
+Owner: `worker-1`
+Task: `8` verification lane for the event-id dataset slice
+
+## Scope
+
+This lane owns verification evidence for the event-aware dataset work under
+`crates/ploy-research` and must not widen into optimize/backtest hot-path
+changes.
+
+## Shared-file conflict watchpoints
+
+Treat these as shared/high-conflict paths and escalate before editing them from
+this verification lane:
+
+- `crates/ploy-research/src/lib.rs`
+- `crates/ploy-research/src/factors.rs`
+- `crates/ploy-research/examples/factor_research.rs`
+- `crates/ploy-research/src/dataset/**` (expected new implementation area)
+- `crates/ploy-research/Cargo.toml`
+
+Hot-path files that must stay untouched by the event-dataset slice:
+
+- `apps/ploy-backtest/**`
+- `apps/ploy-replay/**`
+- `crates/ploy-feed-loaders/**`
+- `crates/ploy-strategy-bundles/**`
+- `crates/ploy-strategy-runtime/**`
+- `.github/workflows/optimize.yml`
+- workspace `Cargo.toml`
+
+## Verification matrix
+
+| Check | Command | PASS condition |
+| --- | --- | --- |
+| Scope guard | `scripts/check_event_dataset_verification_lane.sh` | Only dataset-slice files changed; hot path untouched |
+| Research crate typecheck | `cargo check -p ploy-research --tests` | exits 0 |
+| Research crate unit tests | `cargo test -p ploy-research --lib` | exits 0 |
+| Example compile guard | `cargo test -p ploy-research --example factor_research --features db,polars-export -- --nocapture` | exits 0 if dataset work touches example/export path |
+| Dataset-focused test discovery | `cargo test -p ploy-research --lib -- --list | grep -Ei 'dataset|split|manifest|chronolog|event[_-]?summary'` | at least one dataset-oriented test name present once implementation lands |
+| Targeted dataset tests | `cargo test -p ploy-research <matched-test-name> -- --nocapture` | exits 0 for each matched dataset/split/manifest test |
+| Hot-path regression guard | `git diff --name-only <base>...HEAD -- apps/ploy-backtest apps/ploy-replay crates/ploy-feed-loaders crates/ploy-strategy-bundles crates/ploy-strategy-runtime .github/workflows/optimize.yml Cargo.toml` | no output |
+
+## Required evidence mapped from approved test spec
+
+1. **Leakage boundary**
+   - prove no `event_id` appears in more than one split
+   - prove split key is event-level, not row-level
+2. **Chronology**
+   - prove split anchor is `pm_market_metadata.end_time`
+   - prove ordering tuple is exactly `(end_time, symbol, event_id)`
+3. **Artifact contract**
+   - show event index shape
+   - show manifest shape
+   - show split output shape
+   - show event-summary output shape
+4. **Task-grain correctness**
+   - observation-level repricing label remains `future_up_ask_change_30s`
+   - event-summary-level settlement label remains `settlement_up`
+5. **Sequence/RL boundaries**
+   - no second conflicting split system for sequence prep
+   - RL remains deferred; no claim that current RL skeleton is execution-ready
+6. **Hot-path protection**
+   - optimize/backtest path remains unchanged
+
+## Completion report shape
+
+When implementation lands, report evidence in this exact order:
+
+1. `PASS/FAIL Scope guard`
+2. `PASS/FAIL cargo check -p ploy-research --tests`
+3. `PASS/FAIL cargo test -p ploy-research --lib`
+4. `PASS/FAIL dataset-focused tests`
+5. `PASS/FAIL artifact evidence`
+6. `PASS/FAIL hot-path regression guard`
+7. Blockers / shared-file conflicts
+
+## Notes
+
+- Run the example compile guard only when implementation touches
+  `examples/factor_research.rs` or the parquet/export surface.
+- If dataset work adds new binary/example entrypoints, extend this matrix rather
+  than replacing the existing checks.
+
+## Verification run: current landed dataset slice
+
+Verified slice: `16710042..59f7f775`
+Comparison base for slice-scoped guards: `e5d39f89^`
+
+### Structured evidence
+
+1. `PASS Scope guard`
+   - `scripts/check_event_dataset_verification_lane.sh e5d39f89^`
+   - Output: `PASS: verification lane stayed within event dataset scope and left optimize/backtest hot paths untouched`
+2. `PASS cargo check -p ploy-research --tests`
+   - Command exited `0`
+3. `PASS cargo test -p ploy-research --lib`
+   - Output summary: `24 passed; 0 failed`
+4. `PASS dataset-focused tests`
+   - Discovery:
+     - `cargo test -p ploy-research --lib -- --list | grep -Ei 'dataset|split|manifest|chronolog|event[_-]?summary'`
+     - Matched 7 dataset tests under `dataset::chronology`, `dataset::contracts`, and `dataset::split`
+   - Targeted run:
+     - `cargo test -p ploy-research dataset:: --lib -- --nocapture`
+     - Output summary: `7 passed; 0 failed`
+   - Supporting task-grain evidence:
+     - `cargo test -p ploy-research --lib` also passed `factors::tests::derived_artifacts_filter_to_selected_events_and_preserve_task_grains`
+5. `PASS artifact evidence`
+   - Chronology contract lives in `crates/ploy-research/src/dataset/chronology.rs`
+   - Split contract + hard-failure policy live in `crates/ploy-research/src/dataset/split.rs`
+   - Manifest / event-index contract lives in `crates/ploy-research/src/dataset/contracts.rs`
+   - Event-summary / task-grain derived-view logic lives in `crates/ploy-research/src/factors.rs`
+   - Crate exports are wired through `crates/ploy-research/src/dataset/mod.rs` and `crates/ploy-research/src/lib.rs`
+6. `PASS hot-path regression guard`
+   - `git diff --name-only e5d39f89^..HEAD -- apps/ploy-backtest apps/ploy-replay crates/ploy-feed-loaders crates/ploy-strategy-bundles crates/ploy-strategy-runtime .github/workflows/optimize.yml Cargo.toml`
+   - Output: empty
+7. `PASS modified-file lint`
+   - `bash -n scripts/check_event_dataset_verification_lane.sh`
+   - Output: empty
+
+### Conditional check status
+
+- `SKIP example compile guard`
+  - `e5d39f89^..HEAD` did not touch `crates/ploy-research/examples/factor_research.rs`
+    or the parquet/export surface, so the conditional example check was not required
+    for this landed slice.
+
+### Conflict watch result
+
+- No new shared-file conflict required intervention from the verification lane.
+- Verification evidence was recorded without editing dataset implementation files
+  after they landed.

--- a/tasks/event_dataset_verification_matrix.md
+++ b/tasks/event_dataset_verification_matrix.md
@@ -105,7 +105,8 @@ Comparison base for slice-scoped guards: `e5d39f89^`
      - `cargo test -p ploy-research dataset:: --lib -- --nocapture`
      - Output summary: `7 passed; 0 failed`
    - Supporting task-grain evidence:
-     - `cargo test -p ploy-research --lib` also passed `factors::tests::derived_artifacts_filter_to_selected_events_and_preserve_task_grains`
+     - `cargo test -p ploy-research derived_artifacts_filter_to_selected_events_and_preserve_task_grains --lib -- --nocapture`
+     - Output summary: `1 passed; 0 failed`
 5. `PASS artifact evidence`
    - Chronology contract lives in `crates/ploy-research/src/dataset/chronology.rs`
    - Split contract + hard-failure policy live in `crates/ploy-research/src/dataset/split.rs`


### PR DESCRIPTION
## Summary
- add a canonical event-root dataset contract under `crates/ploy-research/src/dataset`
- pin chronology to `pm_market_metadata.end_time` with ordering `(end_time, symbol, event_id)`
- add fixed chronological event split helpers and dataset invariants/tests
- add an in-memory event-root builder that materializes event index, split assignments, manifest stats, and train/val/test task-grain artifacts
- add a Polars-gated Parquet writer for `event_index`, `split_assignments`, train/val/test `observations`, train/val/test `event_summaries`, and `event_manifest.json`
- wire `crates/ploy-research/examples/factor_research.rs` to export the full event-root dataset with `--export-event-dataset <dir>`
- align task-grain event summaries with event-root ordering
- add scope/verification helpers and a verification matrix for the dataset slice

## What changed
- new dataset modules:
  - `crates/ploy-research/src/dataset/chronology.rs`
  - `crates/ploy-research/src/dataset/contracts.rs`
  - `crates/ploy-research/src/dataset/split.rs`
  - `crates/ploy-research/src/dataset/builder.rs`
  - `crates/ploy-research/src/dataset/export.rs`
  - `crates/ploy-research/src/dataset/mod.rs`
- re-export dataset contract, builder, and Polars export helpers from `crates/ploy-research/src/lib.rs`
- update `crates/ploy-research/src/factors.rs` to keep task-grain event summaries aligned with event-root ordering
- update `crates/ploy-research/examples/factor_research.rs` so research runs can export model-ready event-root artifacts from observed factor rows plus canonical `pm_market_metadata`
- add:
  - `scripts/check_event_dataset_scope.sh`
  - `scripts/check_event_dataset_verification_lane.sh`
  - `tasks/event_dataset_verification_matrix.md`

## CLI usage
Example shape:

```bash
cargo run -p ploy-research --example factor_research --features db,polars-export -- \
  --export-event-dataset /tmp/ploy-event-dataset
```

The export directory contains `event_manifest.json`, `event_index.parquet`, `split_assignments.parquet`, train/val/test observation Parquet files, and train/val/test event summary Parquet files.

## Why
This creates the first reusable event-aware pipeline for 5-minute binary-event ML work without touching the optimize/backtest hot path. It makes the split boundary, chronology, and durable training artifacts explicit before model training expands around ad hoc example-local behavior.

## Verification
- `rtk cargo check -p ploy-research --example factor_research --features db,polars-export`
- `rtk cargo test -p ploy-research --example factor_research --features db,polars-export -- --nocapture`
- `rtk cargo test -p ploy-research dataset:: --lib --features polars-export -- --nocapture`
- `git diff --check`
- `bash scripts/check_event_dataset_verification_lane.sh origin/main`

## Notes
- This PR still does not add model training.
- Polars export stays behind `polars-export`; no-default `ploy-research` remains lightweight.
- The runtime replay/backtest hot path remains untouched.
- Next step after merge is to generate one real dataset from DB-backed factor research output, inspect manifest/split distributions, then start a supervised baseline before DL/RL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--export-event-dataset` CLI flag to export event-root datasets to Parquet format with automatic event chronology resolution and manifest generation containing dataset statistics.

* **Documentation**
  * Added event dataset verification matrix documentation with scope boundaries and verification procedures.

* **Tests**
  * Added comprehensive unit tests for chronology resolution, dataset construction, split assignment validation, and Parquet export workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->