### PR TITLE
Tune pm5d three-layer strategy parameters

### DIFF
--- a/config/strategies/02-pm5d-threelayer.unified.toml
+++ b/config/strategies/02-pm5d-threelayer.unified.toml
@@ -24,35 +24,35 @@ no_trade_zone_max = 0.55
 
 min_edge = 0.0316
 
-min_time_remaining_secs = 69
-max_time_remaining_secs = 99
-cooldown_secs = 35
+min_time_remaining_secs = 70
+max_time_remaining_secs = 125
+cooldown_secs = 119
 
 stake_usd = 15.0
 max_positions = 1000
 max_daily_trades = 1000
 allowed_window_secs = [300, 900]
 
-# Optimized parameters (TPE 200 trials, train Apr 10-13, val Apr 14-15)
-# Train: Sharpe=137.8, 239 trades, +$5,743
-# Val:   Sharpe=141.7, 1017 trades, +$25,689
+# Optimized parameters (random sampling 300 trials, train Apr 15-17, val Apr 20-21)
+# Train: Sharpe=100.296, 1858 trades, +$54,381.36
+# Val:   Sharpe=109.227, 1478 trades, +$50,649.69
 three_layer_min_entry_score = 0.25
-three_layer_min_direction_prob = 0.6297
-three_layer_min_distance_over_sigma = 0.4622
-three_layer_min_confirmation_score = 0.2472
-three_layer_min_drift_confirmation = 0.000546
-three_layer_min_edge = 0.0316
-three_layer_min_reward_risk = 1.2630
-three_layer_take_profit_ask = 0.8437
-three_layer_stop_distance_pct = 0.0152
+three_layer_min_direction_prob = 0.6478
+three_layer_min_distance_over_sigma = 0.3438
+three_layer_min_confirmation_score = 0.2921
+three_layer_min_drift_confirmation = 0.000479
+three_layer_min_edge = 0.0352
+three_layer_min_reward_risk = 0.9276
+three_layer_take_profit_ask = 0.8486
+three_layer_stop_distance_pct = 0.0113
 three_layer_max_pm_lag_secs = 15
 
 [execution]
-use_spread = true
-spread_pct = 0.08
+use_spread = false
+spread_pct = 0.02
 enable_partial_fills = false
 min_fill_pct = 0.5
-enable_market_impact = true
+enable_market_impact = false
 impact_coefficient = 0.1
 default_depth_shares = 500
 


### PR DESCRIPTION
## Summary

Isolated strategy parameter tuning that was previously an uncommitted diff sitting in the `fix/remote-dryrun-report` working tree.

## Changes

- Update pm5d three-layer strategy parameters in `config/strategies/02-pm5d-threelayer.unified.toml`

## Context

These parameter changes were mixed into the frontend cockpit working directory. Extracted to a standalone branch for independent review and merge.