### PR TITLE
Add a bounded event ML hyperparameter gate

### DIFF
--- a/crates/ploy-research/examples/event_dataset_baseline.rs
+++ b/crates/ploy-research/examples/event_dataset_baseline.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, bail};
 use ploy_research::DatasetBuildManifest;
 use polars::io::parquet::read::ParquetReader;
 use polars::prelude::*;
+use serde::Serialize;
 
 const DEFAULT_FEATURES: &[&str] = &[
     "signed_distance_to_beat",
@@ -45,6 +46,7 @@ struct Config {
     epochs: usize,
     learning_rate: f64,
     l2: f64,
+    output_json: Option<PathBuf>,
     features: Vec<String>,
 }
 
@@ -97,6 +99,46 @@ struct Metrics {
     avg_entry: f64,
 }
 
+#[derive(Debug, Serialize)]
+struct BaselineArtifact<'a> {
+    dataset: String,
+    entry_secs: i64,
+    tolerance_secs: i64,
+    min_edge: f64,
+    epochs: usize,
+    learning_rate: f64,
+    l2: f64,
+    features: &'a [String],
+    metrics: Vec<MetricArtifact>,
+    top_weights: Vec<ModelWeight<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetricArtifact {
+    split: &'static str,
+    source_rows: usize,
+    samples: usize,
+    positives: usize,
+    avg_time_remaining_secs: f64,
+    accuracy: f64,
+    logloss: f64,
+    brier: f64,
+    auc: Option<f64>,
+    avg_probability: f64,
+    trades: usize,
+    wins: usize,
+    pnl: f64,
+    cost: f64,
+    roi: f64,
+    avg_entry: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct ModelWeight<'a> {
+    feature: &'a str,
+    weight: f64,
+}
+
 fn main() -> Result<()> {
     let config = parse_config()?;
     let manifest = read_manifest(&config.dataset_root)?;
@@ -147,6 +189,14 @@ fn main() -> Result<()> {
         [&train_metrics, &val_metrics, &test_metrics],
         &model,
     );
+    if let Some(path) = &config.output_json {
+        write_artifact(
+            path,
+            &config,
+            [&train_metrics, &val_metrics, &test_metrics],
+            &model,
+        )?;
+    }
 
     Ok(())
 }
@@ -164,6 +214,7 @@ fn parse_config() -> Result<Config> {
     let epochs = parse_usize_flag(&args, "--epochs", 500)?;
     let learning_rate = parse_f64_flag(&args, "--learning-rate", 0.05)?;
     let l2 = parse_f64_flag(&args, "--l2", 1e-3)?;
+    let output_json = flag_value(&args, "--output-json").map(PathBuf::from);
     let features = flag_value(&args, "--features")
         .map(|raw| {
             raw.split(',')
@@ -201,6 +252,7 @@ fn parse_config() -> Result<Config> {
         epochs,
         learning_rate,
         l2,
+        output_json,
         features,
     })
 }
@@ -742,6 +794,83 @@ fn print_report(
     );
 }
 
+fn write_artifact(
+    path: &Path,
+    config: &Config,
+    metrics: [&Metrics; 3],
+    model: &LogisticModel,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create output dir {}", parent.display()))?;
+    }
+    let artifact = BaselineArtifact {
+        dataset: config.dataset_root.display().to_string(),
+        entry_secs: config.entry_secs,
+        tolerance_secs: config.tolerance_secs,
+        min_edge: config.min_edge,
+        epochs: config.epochs,
+        learning_rate: config.learning_rate,
+        l2: config.l2,
+        features: &config.features,
+        metrics: metrics.into_iter().map(metric_artifact).collect(),
+        top_weights: top_weights(&config.features, model, 12),
+    };
+    let file = File::create(path).with_context(|| format!("create {}", path.display()))?;
+    serde_json::to_writer_pretty(file, &artifact)
+        .with_context(|| format!("write {}", path.display()))?;
+    eprintln!("artifact_baseline_metrics={}", path.display());
+    Ok(())
+}
+
+fn metric_artifact(metric: &Metrics) -> MetricArtifact {
+    MetricArtifact {
+        split: metric.split,
+        source_rows: metric.source_rows,
+        samples: metric.samples,
+        positives: metric.positives,
+        avg_time_remaining_secs: metric.avg_time_remaining_secs,
+        accuracy: metric.accuracy,
+        logloss: metric.logloss,
+        brier: metric.brier,
+        auc: metric.auc.is_finite().then_some(metric.auc),
+        avg_probability: metric.avg_probability,
+        trades: metric.trades,
+        wins: metric.wins,
+        pnl: metric.pnl,
+        cost: metric.cost,
+        roi: if metric.cost > 0.0 {
+            metric.pnl / metric.cost
+        } else {
+            0.0
+        },
+        avg_entry: metric.avg_entry,
+    }
+}
+
+fn top_weights<'a>(
+    features: &'a [String],
+    model: &LogisticModel,
+    limit: usize,
+) -> Vec<ModelWeight<'a>> {
+    let mut weighted_features = features
+        .iter()
+        .zip(&model.weights)
+        .map(|(feature, weight)| (feature.as_str(), *weight))
+        .collect::<Vec<_>>();
+    weighted_features.sort_by(|(_, left), (_, right)| {
+        right
+            .abs()
+            .partial_cmp(&left.abs())
+            .unwrap_or(Ordering::Equal)
+    });
+    weighted_features
+        .into_iter()
+        .take(limit)
+        .map(|(feature, weight)| ModelWeight { feature, weight })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -804,5 +933,31 @@ mod tests {
         let auc = auc_pairwise(&scored);
 
         assert!((auc - 0.875).abs() < 1e-9);
+    }
+
+    #[test]
+    fn metric_artifact_reports_roi_as_fraction() {
+        let metric = Metrics {
+            split: "test",
+            source_rows: 1,
+            samples: 1,
+            positives: 1,
+            avg_time_remaining_secs: 60.0,
+            accuracy: 1.0,
+            logloss: 0.1,
+            brier: 0.1,
+            auc: f64::NAN,
+            avg_probability: 0.7,
+            trades: 1,
+            wins: 1,
+            pnl: 0.25,
+            cost: 0.5,
+            avg_entry: 0.5,
+        };
+
+        let artifact = metric_artifact(&metric);
+
+        assert_eq!(artifact.auc, None);
+        assert_eq!(artifact.roi, 0.5);
     }
 }

--- a/crates/ploy-research/examples/event_ml_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_workflow.rs
@@ -6,21 +6,23 @@ use std::process::{Command, ExitStatus};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Phase {
     Coverage,
     Attribution,
     Baseline,
+    Hyperparameter,
 }
 
 impl Phase {
-    fn example(self) -> &'static str {
+    fn example(self) -> Option<&'static str> {
         match self {
-            Phase::Coverage => "event_dataset_coverage",
-            Phase::Attribution => "event_factor_attribution",
-            Phase::Baseline => "event_dataset_baseline",
+            Phase::Coverage => Some("event_dataset_coverage"),
+            Phase::Attribution => Some("event_factor_attribution"),
+            Phase::Baseline => Some("event_dataset_baseline"),
+            Phase::Hyperparameter => None,
         }
     }
 
@@ -29,6 +31,7 @@ impl Phase {
             Phase::Coverage => "coverage diagnostics",
             Phase::Attribution => "AutoML-style factor attribution",
             Phase::Baseline => "fixed supervised baseline",
+            Phase::Hyperparameter => "bounded logistic hyperparameter search",
         }
     }
 }
@@ -39,6 +42,7 @@ impl fmt::Display for Phase {
             Phase::Coverage => "coverage",
             Phase::Attribution => "attribution",
             Phase::Baseline => "baseline",
+            Phase::Hyperparameter => "hyperparameter",
         })
     }
 }
@@ -52,6 +56,10 @@ struct Config {
     min_edge: f64,
     features: Option<String>,
     output_dir: Option<PathBuf>,
+    search_l2: Vec<f64>,
+    search_min_edge: Vec<f64>,
+    search_learning_rate: Vec<f64>,
+    search_epochs: usize,
     phases: Vec<Phase>,
     dry_run: bool,
 }
@@ -82,6 +90,45 @@ struct PhaseRecord {
     label: &'static str,
     command: String,
     status: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HyperparameterSearchReport {
+    selection_rule: &'static str,
+    candidates: Vec<CandidateRecord>,
+    best_candidate: Option<CandidateRecord>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CandidateRecord {
+    id: usize,
+    l2: f64,
+    min_edge: f64,
+    learning_rate: f64,
+    epochs: usize,
+    output_json: String,
+    val_pnl: f64,
+    val_logloss: f64,
+    val_auc: Option<f64>,
+    val_trades: usize,
+    test_pnl: f64,
+    test_logloss: f64,
+    test_auc: Option<f64>,
+    test_trades: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineArtifact {
+    metrics: Vec<BaselineMetric>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineMetric {
+    split: String,
+    logloss: f64,
+    auc: Option<f64>,
+    trades: usize,
+    pnl: f64,
 }
 
 fn main() -> Result<()> {
@@ -128,8 +175,19 @@ fn parse_config(args: &[String]) -> Result<Config> {
     let phases = flag_value(args, "--phases")
         .map(|raw| parse_phases(&raw))
         .transpose()?
-        .unwrap_or_else(|| vec![Phase::Coverage, Phase::Attribution, Phase::Baseline]);
+        .unwrap_or_else(|| {
+            vec![
+                Phase::Coverage,
+                Phase::Attribution,
+                Phase::Baseline,
+                Phase::Hyperparameter,
+            ]
+        });
     let dry_run = has_flag(args, "--dry-run");
+    let search_l2 = parse_f64_list_flag(args, "--search-l2", &[0.0, 0.001, 0.01])?;
+    let search_min_edge = parse_f64_list_flag(args, "--search-min-edge", &[0.0, 0.02, 0.05])?;
+    let search_learning_rate = parse_f64_list_flag(args, "--search-learning-rate", &[0.03, 0.05])?;
+    let search_epochs = parse_usize_flag(args, "--search-epochs", 500)?;
 
     if entry_secs < 0 {
         bail!("--entry-secs must be non-negative");
@@ -140,6 +198,18 @@ fn parse_config(args: &[String]) -> Result<Config> {
     if top_n == 0 {
         bail!("--top-n must be positive");
     }
+    if search_l2.iter().any(|value| *value < 0.0) {
+        bail!("--search-l2 values must be non-negative");
+    }
+    if search_min_edge.iter().any(|value| *value < 0.0) {
+        bail!("--search-min-edge values must be non-negative");
+    }
+    if search_learning_rate
+        .iter()
+        .any(|value| !(0.0..1.0).contains(value))
+    {
+        bail!("--search-learning-rate values must be in [0, 1)");
+    }
 
     Ok(Config {
         dataset,
@@ -149,6 +219,10 @@ fn parse_config(args: &[String]) -> Result<Config> {
         min_edge,
         features,
         output_dir,
+        search_l2,
+        search_min_edge,
+        search_learning_rate,
+        search_epochs,
         phases,
         dry_run,
     })
@@ -194,6 +268,22 @@ fn parse_f64_flag(args: &[String], flag: &str, default: f64) -> Result<f64> {
         .map(|value| value.unwrap_or(default))
 }
 
+fn parse_f64_list_flag(args: &[String], flag: &str, default: &[f64]) -> Result<Vec<f64>> {
+    flag_value(args, flag)
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(|item| {
+                    item.parse::<f64>()
+                        .with_context(|| format!("invalid {flag}: {item}"))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()
+        .map(|value| value.unwrap_or_else(|| default.to_vec()))
+}
+
 fn parse_phases(raw: &str) -> Result<Vec<Phase>> {
     let mut phases = Vec::new();
     for item in raw
@@ -205,6 +295,7 @@ fn parse_phases(raw: &str) -> Result<Vec<Phase>> {
             "coverage" => Phase::Coverage,
             "attribution" | "factor-attribution" | "automl" => Phase::Attribution,
             "baseline" | "fixed-baseline" => Phase::Baseline,
+            "hyperparameter" | "hyperparameter-search" | "search" => Phase::Hyperparameter,
             other => bail!("unknown workflow phase: {other}"),
         };
         phases.push(phase);
@@ -240,7 +331,7 @@ fn print_workflow_header(config: &Config, state: &WorkflowState) {
         config.dry_run
     );
     eprintln!(
-        "order=coverage -> AutoML factor attribution -> governed feature set -> fixed baseline -> model family -> hyperparameter search -> walk-forward/backtest -> DL/RL gates"
+        "order=coverage -> AutoML factor attribution -> governed feature set -> fixed baseline -> bounded hyperparameter search -> walk-forward/backtest -> DL/RL gates"
     );
 }
 
@@ -253,8 +344,15 @@ fn format_phases(phases: &[Phase]) -> String {
 }
 
 fn run_phase(phase: Phase, config: &Config, state: &mut WorkflowState) -> Result<()> {
+    if phase == Phase::Hyperparameter {
+        return run_hyperparameter_phase(config, state);
+    }
+
     let args = phase_args(phase, config, state);
-    let command = shell_command(phase.example(), &args);
+    let example = phase
+        .example()
+        .expect("non-hyperparameter phase must have an example");
+    let command = shell_command(example, &args);
     eprintln!();
     eprintln!("--- phase={} label=\"{}\" ---", phase, phase.label());
     eprintln!("command={command}");
@@ -270,7 +368,7 @@ fn run_phase(phase: Phase, config: &Config, state: &mut WorkflowState) -> Result
     }
 
     let status = Command::new("cargo")
-        .args(["run", "-p", "ploy-research", "--example", phase.example()])
+        .args(["run", "-p", "ploy-research", "--example", example])
         .args(["--features", "polars-export", "--"])
         .args(&args)
         .status()
@@ -297,6 +395,262 @@ fn run_phase(phase: Phase, config: &Config, state: &mut WorkflowState) -> Result
         status: "passed".to_string(),
     });
     Ok(())
+}
+
+fn run_hyperparameter_phase(config: &Config, state: &mut WorkflowState) -> Result<()> {
+    let command = format!(
+        "bounded logistic search l2={} min_edge={} learning_rate={} epochs={}",
+        format_f64_list(&config.search_l2),
+        format_f64_list(&config.search_min_edge),
+        format_f64_list(&config.search_learning_rate),
+        config.search_epochs
+    );
+    eprintln!();
+    eprintln!(
+        "--- phase={} label=\"{}\" ---",
+        Phase::Hyperparameter,
+        Phase::Hyperparameter.label()
+    );
+    eprintln!("command={command}");
+
+    if config.dry_run {
+        state.records.push(PhaseRecord {
+            phase: Phase::Hyperparameter.to_string(),
+            label: Phase::Hyperparameter.label(),
+            command,
+            status: "dry_run".to_string(),
+        });
+        return Ok(());
+    }
+
+    let features = state.governed_features.as_deref().context(
+        "hyperparameter phase requires governed features from attribution or --features",
+    )?;
+    let output_dir = state.run_dir.join("hyperparameter");
+    fs::create_dir_all(&output_dir).with_context(|| format!("create {}", output_dir.display()))?;
+
+    let mut candidates = Vec::new();
+    let mut candidate_id = 0usize;
+    for l2 in &config.search_l2 {
+        for min_edge in &config.search_min_edge {
+            for learning_rate in &config.search_learning_rate {
+                candidate_id += 1;
+                let candidate_dir = output_dir.join(format!("candidate_{candidate_id:03}"));
+                let output_json = candidate_dir.join("baseline_metrics.json");
+                let args = baseline_candidate_args(
+                    config,
+                    features,
+                    *l2,
+                    *min_edge,
+                    *learning_rate,
+                    config.search_epochs,
+                    &output_json,
+                );
+                let candidate_command = shell_command("event_dataset_baseline", &args);
+                eprintln!("candidate_id={candidate_id} command={candidate_command}");
+                let status = Command::new("cargo")
+                    .args([
+                        "run",
+                        "-p",
+                        "ploy-research",
+                        "--example",
+                        "event_dataset_baseline",
+                    ])
+                    .args(["--features", "polars-export", "--"])
+                    .args(&args)
+                    .status()
+                    .with_context(|| format!("spawn hyperparameter candidate {candidate_id}"))?;
+                if !status.success() {
+                    bail!("hyperparameter candidate {candidate_id} failed with status {status}");
+                }
+                candidates.push(read_candidate_record(
+                    candidate_id,
+                    *l2,
+                    *min_edge,
+                    *learning_rate,
+                    config.search_epochs,
+                    &output_json,
+                )?);
+            }
+        }
+    }
+
+    let best_candidate = candidates.iter().cloned().max_by(compare_candidates);
+    write_hyperparameter_report(&output_dir, &candidates, best_candidate.clone())?;
+    if let Some(best) = &best_candidate {
+        eprintln!(
+            "hyperparameter_best id={} val_pnl={:.4} val_logloss={:.4} test_pnl={:.4}",
+            best.id, best.val_pnl, best.val_logloss, best.test_pnl
+        );
+    }
+    state.records.push(PhaseRecord {
+        phase: Phase::Hyperparameter.to_string(),
+        label: Phase::Hyperparameter.label(),
+        command,
+        status: "passed".to_string(),
+    });
+    Ok(())
+}
+
+fn format_f64_list(values: &[f64]) -> String {
+    values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn baseline_candidate_args(
+    config: &Config,
+    features: &str,
+    l2: f64,
+    min_edge: f64,
+    learning_rate: f64,
+    epochs: usize,
+    output_json: &Path,
+) -> Vec<String> {
+    vec![
+        "--dataset".to_string(),
+        config.dataset.clone(),
+        "--entry-secs".to_string(),
+        config.entry_secs.to_string(),
+        "--tolerance-secs".to_string(),
+        config.tolerance_secs.to_string(),
+        "--min-edge".to_string(),
+        min_edge.to_string(),
+        "--epochs".to_string(),
+        epochs.to_string(),
+        "--learning-rate".to_string(),
+        learning_rate.to_string(),
+        "--l2".to_string(),
+        l2.to_string(),
+        "--features".to_string(),
+        features.to_string(),
+        "--output-json".to_string(),
+        output_json.display().to_string(),
+    ]
+}
+
+fn read_candidate_record(
+    id: usize,
+    l2: f64,
+    min_edge: f64,
+    learning_rate: f64,
+    epochs: usize,
+    output_json: &Path,
+) -> Result<CandidateRecord> {
+    let file =
+        File::open(output_json).with_context(|| format!("open {}", output_json.display()))?;
+    let artifact: BaselineArtifact = serde_json::from_reader(file)
+        .with_context(|| format!("parse {}", output_json.display()))?;
+    let val = metric_for_split(&artifact, "val")?;
+    let test = metric_for_split(&artifact, "test")?;
+    Ok(CandidateRecord {
+        id,
+        l2,
+        min_edge,
+        learning_rate,
+        epochs,
+        output_json: output_json.display().to_string(),
+        val_pnl: val.pnl,
+        val_logloss: val.logloss,
+        val_auc: val.auc,
+        val_trades: val.trades,
+        test_pnl: test.pnl,
+        test_logloss: test.logloss,
+        test_auc: test.auc,
+        test_trades: test.trades,
+    })
+}
+
+fn metric_for_split<'a>(artifact: &'a BaselineArtifact, split: &str) -> Result<&'a BaselineMetric> {
+    artifact
+        .metrics
+        .iter()
+        .find(|metric| metric.split == split)
+        .with_context(|| format!("missing {split} metric in baseline artifact"))
+}
+
+fn compare_candidates(left: &CandidateRecord, right: &CandidateRecord) -> std::cmp::Ordering {
+    left.val_pnl
+        .partial_cmp(&right.val_pnl)
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| {
+            right
+                .val_logloss
+                .partial_cmp(&left.val_logloss)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+}
+
+fn write_hyperparameter_report(
+    output_dir: &Path,
+    candidates: &[CandidateRecord],
+    best_candidate: Option<CandidateRecord>,
+) -> Result<()> {
+    let report = HyperparameterSearchReport {
+        selection_rule: "maximize validation PnL; break ties by lower validation logloss; test metrics are recorded but not used for selection",
+        candidates: candidates.to_vec(),
+        best_candidate,
+    };
+    let json_path = output_dir.join("hyperparameter_search.json");
+    let json_file =
+        File::create(&json_path).with_context(|| format!("create {}", json_path.display()))?;
+    serde_json::to_writer_pretty(json_file, &report)
+        .with_context(|| format!("write {}", json_path.display()))?;
+
+    let markdown_path = output_dir.join("hyperparameter_search.md");
+    let mut markdown_file = File::create(&markdown_path)
+        .with_context(|| format!("create {}", markdown_path.display()))?;
+    writeln!(markdown_file, "# Event Hyperparameter Search")?;
+    writeln!(markdown_file)?;
+    writeln!(
+        markdown_file,
+        "Selection rule: maximize validation PnL; break ties by lower validation logloss. Test metrics are recorded but not used for selection."
+    )?;
+    writeln!(markdown_file)?;
+    writeln!(
+        markdown_file,
+        "| id | l2 | min_edge | lr | epochs | val_pnl | val_logloss | val_auc | test_pnl | test_logloss | test_auc |"
+    )?;
+    writeln!(
+        markdown_file,
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    )?;
+    for candidate in candidates {
+        writeln!(
+            markdown_file,
+            "| {} | {} | {} | {} | {} | {:.4} | {:.4} | {} | {:.4} | {:.4} | {} |",
+            candidate.id,
+            candidate.l2,
+            candidate.min_edge,
+            candidate.learning_rate,
+            candidate.epochs,
+            candidate.val_pnl,
+            candidate.val_logloss,
+            format_optional(candidate.val_auc),
+            candidate.test_pnl,
+            candidate.test_logloss,
+            format_optional(candidate.test_auc)
+        )?;
+    }
+    if let Some(best) = &report.best_candidate {
+        writeln!(markdown_file)?;
+        writeln!(
+            markdown_file,
+            "Best candidate: `{}` with validation PnL `{:.4}` and test PnL `{:.4}`.",
+            best.id, best.val_pnl, best.test_pnl
+        )?;
+    }
+
+    eprintln!("artifact_hyperparameter_search={}", json_path.display());
+    Ok(())
+}
+
+fn format_optional(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{value:.4}"))
+        .unwrap_or_else(|| "null".to_string())
 }
 
 fn phase_args(phase: Phase, config: &Config, state: &WorkflowState) -> Vec<String> {
@@ -328,6 +682,7 @@ fn phase_args(phase: Phase, config: &Config, state: &WorkflowState) -> Vec<Strin
             args.push("--min-edge".to_string());
             args.push(config.min_edge.to_string());
         }
+        Phase::Hyperparameter => {}
     }
 
     let features = match phase {
@@ -494,7 +849,12 @@ Options:
   --min-edge <value>       Baseline trading edge threshold. Default: 0.0.
   --features <csv>         Override default feature list.
   --output-dir <dir>       Workflow artifact directory. Default: <dataset>/workflow_runs/event_ml_<timestamp>.
-  --phases <csv>           coverage,attribution,baseline. Default: all three.
+  --phases <csv>           coverage,attribution,baseline,hyperparameter. Default: all four.
+  --search-l2 <csv>        Logistic L2 values for bounded search. Default: 0,0.001,0.01.
+  --search-min-edge <csv>  Min-edge values for bounded search. Default: 0,0.02,0.05.
+  --search-learning-rate <csv>
+                           Learning rates for bounded search. Default: 0.03,0.05.
+  --search-epochs <n>      Epochs for bounded search candidates. Default: 500.
   --dry-run                Print commands without running phases.
 "
     );
@@ -516,7 +876,12 @@ mod tests {
 
         assert_eq!(
             config.phases,
-            vec![Phase::Coverage, Phase::Attribution, Phase::Baseline]
+            vec![
+                Phase::Coverage,
+                Phase::Attribution,
+                Phase::Baseline,
+                Phase::Hyperparameter
+            ]
         );
         assert_eq!(config.entry_secs, 60);
         assert_eq!(config.tolerance_secs, 30);
@@ -528,14 +893,19 @@ mod tests {
             "--dataset",
             "/tmp/events",
             "--phases",
-            "coverage,automl,fixed-baseline",
+            "coverage,automl,fixed-baseline,search",
             "--dry-run",
         ]))
         .unwrap();
 
         assert_eq!(
             config.phases,
-            vec![Phase::Coverage, Phase::Attribution, Phase::Baseline]
+            vec![
+                Phase::Coverage,
+                Phase::Attribution,
+                Phase::Baseline,
+                Phase::Hyperparameter
+            ]
         );
         assert!(config.dry_run);
     }

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -68,18 +68,22 @@ The runner executes:
 1. `event_dataset_coverage`
 2. `event_factor_attribution`
 3. `event_dataset_baseline`
+4. bounded logistic hyperparameter search using `event_dataset_baseline`
 
 It stops on the first failed phase. The attribution phase writes
 `factor_attributions.json`, `feature_whitelist.txt`, and
 `feature_whitelist.md`; if the user did not pass `--features`, the baseline
 phase consumes that whitelist automatically. The runner also writes
 `workflow_report.json` and `workflow_report.md` into the run directory.
+The hyperparameter phase writes candidate-level `baseline_metrics.json` files
+plus `hyperparameter_search.json` and `hyperparameter_search.md`.
 
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.
 
 Use `--dry-run` to print the commands without running them, or
-`--phases coverage,attribution,baseline` to run a subset in canonical order.
+`--phases coverage,attribution,baseline,hyperparameter` to run a subset in
+canonical order.
 
 ## Phase 1 - Coverage Diagnostics
 
@@ -290,6 +294,31 @@ Examples of acceptable search spaces:
 - calibration threshold
 - entry threshold
 - small ensemble weights
+
+The current executable runner supports a bounded logistic search:
+
+```bash
+rtk cargo run -p ploy-research --example event_ml_workflow \
+  --features polars-export -- \
+  --dataset /tmp/ploy-event-root-5sym-150-20260424 \
+  --entry-secs 60 \
+  --tolerance-secs 30 \
+  --search-l2 0,0.001,0.01 \
+  --search-min-edge 0,0.02,0.05 \
+  --search-learning-rate 0.03,0.05
+```
+
+Selection rule:
+
+- maximize validation PnL
+- break ties with lower validation logloss
+- record test metrics, but never use test metrics for selection
+
+Artifacts:
+
+- `hyperparameter/candidate_*/baseline_metrics.json`
+- `hyperparameter/hyperparameter_search.json`
+- `hyperparameter/hyperparameter_search.md`
 
 Examples to avoid early:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8310,6 +8310,7 @@ Goal: turn the agreed research sequence into a reusable workflow so future ML, D
 File ownership:
 - `docs/runbooks/event-ml-automl-workflow.md`
 - `crates/ploy-research/examples/event_ml_workflow.rs`
+- `crates/ploy-research/examples/event_dataset_baseline.rs`
 - `crates/ploy-research/Cargo.toml`
 - `AGENTS.md`
 - `CLAUDE.md`
@@ -8323,8 +8324,10 @@ Checklist:
 - [x] Add an agent-triggerable skill and repo instructions so future agents route event ML work through this workflow.
 - [x] Add an executable `event_ml_workflow` runner for ordered coverage, attribution, and fixed-baseline execution.
 - [x] Close the first executable loop by writing workflow artifacts, attribution artifacts, and a governed feature whitelist that is consumed by the baseline phase.
+- [x] Add a bounded logistic hyperparameter-search gate that records candidate metrics and selects only on validation results.
 
 Review:
 - 2026-04-24: Added `docs/runbooks/event-ml-automl-workflow.md` as the reusable event ML research workflow. The workflow codifies the sequence `coverage diagnostics -> AutoML-style factor attribution -> governed feature set -> fixed baseline -> model family selection -> hyperparameter search -> walk-forward/executable-price backtest -> DL/RL gates -> dry-run handoff`. It explicitly treats AutoML as factor discovery/governance and hyperparameter search as later model-family tuning, with event-held-out splits, train-only normalization, one-event-one-trade accounting, and stop gates against validation overfit.
 - 2026-04-24: Added the local `event-ml-automl-workflow` skill under `~/.codex/skills/` and mirrored the trigger rule into `AGENTS.md` / `CLAUDE.md` so future agents route event ML, AutoML attribution, hyperparameter-search, and DL/RL requests through the workflow. Added `event_ml_workflow`, a Polars-gated runner that executes coverage diagnostics, AutoML-style attribution, and the fixed supervised baseline in order and stops on the first failed phase. The runner supports `--dry-run` and phase selection for focused execution.
 - 2026-04-24: Extended `event_factor_attribution` with `--output-dir` artifacts: `factor_attributions.json`, `feature_whitelist.txt`, and `feature_whitelist.md`. Extended `event_ml_workflow` to create a run directory, write `workflow_report.json` / `workflow_report.md`, and feed the AutoML-generated `feature_whitelist.txt` into the baseline phase when no explicit `--features` override is provided. This closes the first loop from data coverage to factor governance to fixed baseline with persisted evidence.
+- 2026-04-24: Extended `event_dataset_baseline` with `--output-json` so baseline metrics can be consumed by downstream workflow phases. Extended `event_ml_workflow` with a bounded logistic `hyperparameter` phase over `--search-l2`, `--search-min-edge`, `--search-learning-rate`, and `--search-epochs`. The phase writes candidate `baseline_metrics.json` files plus `hyperparameter_search.json` / `.md`, selects by validation PnL with validation logloss tie-break, and records test metrics without using them for selection.


### PR DESCRIPTION
## Summary
- add --output-json to event_dataset_baseline so workflow phases can consume structured split metrics
- add a bounded logistic hyperparameter phase to event_ml_workflow
- write candidate baseline_metrics.json files plus hyperparameter_search.json/md
- select only on validation PnL with validation logloss tie-break; record test metrics without using them for selection
- update workflow docs and task tracker

## Verification
- `rtk cargo check -p ploy-research --example event_dataset_baseline --features polars-export`
- `rtk cargo test -p ploy-research --example event_dataset_baseline --features polars-export -- --nocapture`
- `rtk cargo check -p ploy-research --example event_ml_workflow --features polars-export`
- `rtk cargo test -p ploy-research --example event_ml_workflow --features polars-export -- --nocapture`
- `rtk cargo run -p ploy-research --example event_ml_workflow --features polars-export -- --dataset /tmp/ploy-event-root-5sym-150-20260424 --entry-secs 60 --tolerance-secs 30 --top-n 8 --output-dir /tmp/ploy-event-ml-hyper-gate --search-l2 0,0.001 --search-min-edge 0 --search-learning-rate 0.05`

## Evidence from real dataset run
- four workflow phases passed: coverage, attribution, baseline, hyperparameter
- generated `/tmp/ploy-event-ml-hyper-gate/hyperparameter/hyperparameter_search.json`
- best candidate was selected from validation metrics only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Baseline evaluation results can now be exported to JSON format via optional flag
  * Added hyperparameter search workflow phase with configurable search parameters for model optimization
  * Automated candidate selection based on validation metrics with tie-breaking logic; generates JSON and Markdown reports

* **Documentation**
  * Updated workflow documentation to include new hyperparameter search phase, parameters, and artifact outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->