### PR TITLE
Make live execution wait for real fill evidence

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -443,6 +443,13 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
                         .await
                 }
                 OrderExecutionType::FAK | OrderExecutionType::FOK => {
+                    let price = execution_price_override(
+                        request.order_type,
+                        request.side,
+                        limit_price,
+                        request.aggressive_ticks,
+                    )
+                    .unwrap_or(limit_price);
                     let amount = normalize_execution_amount(request.quantity, limit_price, side)
                         .map_err(|err| {
                             ExecutionError::Validation(format!("build amount: {err}"))
@@ -451,6 +458,7 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
                         .market_order()
                         .token_id(token_id)
                         .order_type(request.order_type.into_sdk())
+                        .price(price)
                         .amount(amount)
                         .side(side)
                         .build()
@@ -625,7 +633,7 @@ fn execution_price_override(
                 tick_size,
             ))
         }
-        OrderExecutionType::FAK | OrderExecutionType::FOK => None,
+        OrderExecutionType::FAK | OrderExecutionType::FOK => Some(limit_price),
     }
 }
 
@@ -830,12 +838,12 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
-        ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
-        PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
-        TrackedOrder, WalletSignatureType, execution_price_override, normalize_aggressive_price,
-        normalize_execution_amount, normalize_order_notional, normalize_order_quantity,
-        polymarket_signature_type_from_env, tracked_trade_fill, trade_side, unique_token_ids,
+        execution_price_override, normalize_aggressive_price, normalize_execution_amount,
+        normalize_order_notional, normalize_order_quantity, polymarket_signature_type_from_env,
+        tracked_trade_fill, trade_side, unique_token_ids, CancellationOutcome, CancellationRequest,
+        ExecutionError, ExecutionOutcome, ExecutionRequest, LiveExecutionGateway,
+        OrderExecutionType, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
+        ReplaceRequest, StaticExecutionGateway, TrackedOrder, WalletSignatureType,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -960,18 +968,18 @@ mod tests {
     }
 
     #[test]
-    fn immediate_execution_uses_orderbook_pricing_instead_of_signal_cap() {
+    fn immediate_execution_keeps_a_hard_price_bound() {
         assert_eq!(
             execution_price_override(OrderExecutionType::GTC, TradeSide::Buy, dec!(0.417075), 2),
             Some(dec!(0.44))
         );
         assert_eq!(
             execution_price_override(OrderExecutionType::FAK, TradeSide::Buy, dec!(0.417075), 2),
-            None
+            Some(dec!(0.417075))
         );
         assert_eq!(
             execution_price_override(OrderExecutionType::FOK, TradeSide::Buy, dec!(0.417075), 2),
-            None
+            Some(dec!(0.417075))
         );
     }
 
@@ -1072,22 +1080,20 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000001")
                     .expect("maker address"),
             )
-            .maker_orders(vec![
-                MakerOrder::builder()
-                    .order_id("venue-order-b")
-                    .owner(ApiKey::nil())
-                    .maker_address(
-                        Address::from_str("0x0000000000000000000000000000000000000002")
-                            .expect("second maker address"),
-                    )
-                    .matched_amount(dec!(2))
-                    .price(dec!(0.56))
-                    .fee_rate_bps(dec!(4))
-                    .asset_id(U256::from(1_u64))
-                    .outcome("YES")
-                    .side(polymarket_client_sdk::clob::types::Side::Sell)
-                    .build(),
-            ])
+            .maker_orders(vec![MakerOrder::builder()
+                .order_id("venue-order-b")
+                .owner(ApiKey::nil())
+                .maker_address(
+                    Address::from_str("0x0000000000000000000000000000000000000002")
+                        .expect("second maker address"),
+                )
+                .matched_amount(dec!(2))
+                .price(dec!(0.56))
+                .fee_rate_bps(dec!(4))
+                .asset_id(U256::from(1_u64))
+                .outcome("YES")
+                .side(polymarket_client_sdk::clob::types::Side::Sell)
+                .build()])
             .transaction_hash(B256::ZERO)
             .trader_side(TraderSide::Taker)
             .build();

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -5,6 +5,7 @@
 
 use chrono::{DateTime, Utc};
 use ploy_market_contracts::{InstrumentKind, PredictionFamily, VenueKind};
+use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::path::Path;
@@ -42,6 +43,8 @@ pub struct FullConfig {
     pub backtest_data: BacktestDataSection,
     #[serde(default)]
     pub execution: SimExecutionSection,
+    #[serde(default)]
+    pub live_execution: LiveExecutionSection,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -157,6 +160,36 @@ pub struct SimExecutionSection {
     pub default_depth_shares: u64,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct LiveExecutionSection {
+    /// Maximum permitted price movement from the strategy limit for live FAK/FOK
+    /// execution. Buy orders cap at `limit * (1 + bps/10000)`; sell orders floor
+    /// at `limit * (1 - bps/10000)`.
+    #[serde(default = "default_live_max_slippage_bps")]
+    pub max_slippage_bps: u32,
+    /// Maximum total submission attempts for an acknowledged-but-unfilled FAK
+    /// order before the runtime marks the intent terminal and lets the strategy
+    /// cool down.
+    #[serde(default = "default_live_max_attempts")]
+    pub max_attempts: u8,
+    /// Number of reconciliation passes to wait before treating an acknowledged
+    /// FAK order with no new fill as terminal/unfilled for that attempt.
+    #[serde(default = "default_live_reconcile_cycles_before_retry")]
+    pub reconcile_cycles_before_retry: u8,
+}
+
+fn default_live_max_slippage_bps() -> u32 {
+    150
+}
+
+fn default_live_max_attempts() -> u8 {
+    2
+}
+
+fn default_live_reconcile_cycles_before_retry() -> u8 {
+    2
+}
+
 fn default_spread() -> f64 {
     0.02
 }
@@ -184,6 +217,16 @@ impl Default for SimExecutionSection {
             enable_market_impact: false,
             impact_coefficient: 0.1,
             default_depth_shares: 500,
+        }
+    }
+}
+
+impl Default for LiveExecutionSection {
+    fn default() -> Self {
+        Self {
+            max_slippage_bps: default_live_max_slippage_bps(),
+            max_attempts: default_live_max_attempts(),
+            reconcile_cycles_before_retry: default_live_reconcile_cycles_before_retry(),
         }
     }
 }
@@ -269,6 +312,15 @@ impl FullConfig {
             default_depth_shares: e.default_depth_shares,
         }
     }
+
+    pub fn live_execution_policy(&self) -> crate::traits::ExecutionPolicy {
+        crate::traits::ExecutionPolicy {
+            max_slippage_bps: Decimal::from_u32(self.live_execution.max_slippage_bps)
+                .unwrap_or_default(),
+            max_attempts: self.live_execution.max_attempts.max(1),
+            reconcile_cycles_before_retry: self.live_execution.reconcile_cycles_before_retry.max(1),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -327,6 +379,7 @@ enable_market_impact = true
         assert!(config.reference_data.capture_sports_state);
         assert!(config.backtest_data.include_reference_prices);
         assert!(config.backtest_data.include_sports_state);
+        assert_eq!(config.live_execution.max_slippage_bps, 150);
         assert!(!config.backtest_data.require_official_settlement);
         assert!((config.strategy.min_edge - 0.02).abs() < 1e-10);
         assert_eq!(config.strategy.stake_usd, Decimal::new(25, 0));
@@ -389,8 +442,33 @@ mode = "dryrun"
         assert!(!config.backtest_data.include_reference_prices);
         assert!(!config.backtest_data.include_sports_state);
         assert!(!config.backtest_data.require_official_settlement);
+        assert_eq!(config.live_execution.max_attempts, 2);
+        assert_eq!(config.live_execution.reconcile_cycles_before_retry, 2);
         assert!((config.strategy.min_edge - 0.02).abs() < 1e-10);
         assert!(!config.execution.use_spread);
+    }
+
+    #[test]
+    fn parses_live_execution_policy() {
+        let config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "live"
+
+[strategy]
+
+[live_execution]
+max_slippage_bps = 75
+max_attempts = 3
+reconcile_cycles_before_retry = 2
+"#,
+        )
+        .unwrap();
+
+        let policy = config.live_execution_policy();
+        assert_eq!(policy.max_slippage_bps, Decimal::new(75, 0));
+        assert_eq!(policy.max_attempts, 3);
+        assert_eq!(policy.reconcile_cycles_before_retry, 2);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -10,12 +10,12 @@
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
-use ploy_trading::{PnlSnapshot, RiskSnapshot, TradingRuntime};
+use ploy_trading::{OrderState, PnlSnapshot, RiskSnapshot, TradingIntent, TradingRuntime};
 use rust_decimal::Decimal;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use ploy_trading::{FillRecord, IntentPurpose};
+use ploy_trading::IntentPurpose;
 use rust_decimal_macros::dec;
 
 use crate::traits::{Executor, Feed, MarketUpdate, Recorder, StrategyDecision, StrategyLogic};
@@ -57,6 +57,30 @@ pub struct RuntimeResult {
     pub elapsed_secs: f64,
 }
 
+#[derive(Debug, Clone)]
+struct PendingLiveOrder {
+    intent: TradingIntent,
+    attempts: u8,
+    reconciles_without_fill: u8,
+}
+
+fn retry_attempt_from_intent_id(intent_id: &str) -> u8 {
+    retry_suffix(intent_id).map_or(1, |(_, attempt)| attempt.max(1))
+}
+
+fn retry_root_intent_id(intent_id: &str) -> &str {
+    retry_suffix(intent_id).map_or(intent_id, |(root, _)| root)
+}
+
+fn retry_suffix(intent_id: &str) -> Option<(&str, u8)> {
+    let (root, suffix) = intent_id.rsplit_once("_retry")?;
+    if root.is_empty() || suffix.is_empty() || !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    Some((root, suffix.parse().ok()?))
+}
+
 /// Unified strategy runtime.
 ///
 /// Generic over:
@@ -91,12 +115,30 @@ where
         recorder: Box<dyn Recorder>,
         config: RuntimeConfig,
     ) -> Self {
+        Self::new_with_trading(
+            strategy,
+            feed,
+            executor,
+            recorder,
+            config,
+            TradingRuntime::default(),
+        )
+    }
+
+    pub fn new_with_trading(
+        strategy: S,
+        feed: F,
+        executor: E,
+        recorder: Box<dyn Recorder>,
+        config: RuntimeConfig,
+        trading: TradingRuntime,
+    ) -> Self {
         Self {
             strategy,
             feed,
             executor,
             recorder,
-            trading: TradingRuntime::default(),
+            trading,
             config,
         }
     }
@@ -108,6 +150,7 @@ where
         let mut intents_submitted: u64 = 0;
         let mut fills_recorded: u64 = 0;
         let mut last_eval_ts: Option<DateTime<Utc>> = None;
+        let mut pending_live_orders = self.initial_pending_live_orders();
 
         info!(
             mode = ?self.config.mode,
@@ -197,7 +240,15 @@ where
                 intents_submitted += 1;
 
                 if let Some(fill) = report.fill.as_ref() {
-                    self.trading.record_fill(fill.clone());
+                    if !self.trading.record_fill(fill.clone()) {
+                        warn!(
+                            order_id = %order_id,
+                            fill_id = %fill.fill_id,
+                            qty = %fill.quantity,
+                            "Ignoring immediate duplicate, orphan, or overfilled fill",
+                        );
+                        continue;
+                    }
                     self.recorder
                         .record_fill(&strategy_name, &intent, signal_ref, fill, &report)
                         .await;
@@ -210,50 +261,61 @@ where
                         price = %fill.price,
                         "Fill recorded",
                     );
-                } else if !report.rejected && intent.purpose == IntentPurpose::Entry {
-                    // Live mode: executor acknowledged an entry but no immediate fill.
-                    // Arm cooldown/daily counter with a synthetic fill so the
-                    // strategy doesn't re-signal for the same symbol immediately.
-                    //
-                    // Do not synthesize fills for exits: a live exit acknowledge
-                    // without a real fill must not make the strategy believe the
-                    // position is closed.
-                    let synthetic = FillRecord {
-                        fill_id: format!("synthetic_{order_id}"),
-                        order_id: order_id.clone(),
-                        token_id: intent.token_id.clone(),
-                        side: intent.side.clone(),
-                        quantity: intent.quantity,
-                        price: intent.limit_price.unwrap_or_default(),
-                        fee: Decimal::ZERO,
-                        timestamp: intent.created_at,
-                    };
-                    self.strategy.on_fill(&synthetic);
+                } else if self.config.mode == RuntimeMode::Live && !report.rejected {
+                    pending_live_orders.insert(
+                        order_id.clone(),
+                        PendingLiveOrder {
+                            intent: intent.clone(),
+                            attempts: 1,
+                            reconciles_without_fill: 0,
+                        },
+                    );
                     debug!(
                         order_id = %order_id,
                         token = %intent.token_id,
-                        "Synthetic fill for cooldown (live acknowledged)",
+                        "Live order acknowledged without fill; waiting for reconciliation",
                     );
                 }
             }
 
-            match self.executor.reconcile_fills(self.trading.orders()).await {
+            let reconcile_completed = match self
+                .executor
+                .reconcile_fills(self.trading.orders())
+                .await
+            {
                 Ok(fills) => {
                     let strategy_name = self.strategy.name().to_string();
                     for fill in fills {
+                        let Some(order_before) = self.trading.order(&fill.order_id).cloned() else {
+                            warn!(
+                                order_id = %fill.order_id,
+                                fill_id = %fill.fill_id,
+                                "Ignoring reconciled fill for unknown order",
+                            );
+                            continue;
+                        };
+                        let Some(intent) = self.trading.intent(&order_before.intent_id).cloned()
+                        else {
+                            warn!(
+                                order_id = %fill.order_id,
+                                fill_id = %fill.fill_id,
+                                intent_id = %order_before.intent_id,
+                                "Ignoring reconciled fill for unknown intent",
+                            );
+                            continue;
+                        };
                         if !self.trading.record_fill(fill.clone()) {
+                            warn!(
+                                order_id = %fill.order_id,
+                                fill_id = %fill.fill_id,
+                                qty = %fill.quantity,
+                                "Ignoring duplicate, orphan, or overfilled reconciled fill",
+                            );
                             continue;
                         }
 
-                        let Some(order) = self.trading.order(&fill.order_id).cloned() else {
-                            continue;
-                        };
-                        let Some(intent) = self.trading.intent(&order.intent_id).cloned() else {
-                            continue;
-                        };
-
                         let report = crate::traits::ExecutionReport {
-                            order_id: order
+                            order_id: order_before
                                 .venue_order_id
                                 .clone()
                                 .unwrap_or_else(|| fill.order_id.clone()),
@@ -267,8 +329,20 @@ where
                         self.recorder
                             .record_fill(&strategy_name, &intent, None, &fill, &report)
                             .await;
+                        self.recorder
+                            .record_order(&strategy_name, &intent, None, &report, &fill.order_id)
+                            .await;
                         self.strategy.on_fill(&fill);
                         fills_recorded += 1;
+                        if self
+                            .trading
+                            .order(&fill.order_id)
+                            .is_some_and(|order| order.state == OrderState::Filled)
+                        {
+                            pending_live_orders.remove(&fill.order_id);
+                        } else if let Some(pending) = pending_live_orders.get_mut(&fill.order_id) {
+                            pending.reconciles_without_fill = 0;
+                        }
                         debug!(
                             order_id = %fill.order_id,
                             token = %fill.token_id,
@@ -277,10 +351,21 @@ where
                             "Reconciled fill recorded",
                         );
                     }
+                    self.executor.last_reconcile_attempted()
                 }
                 Err(error) => {
                     warn!(error = %error, "Fill reconciliation failed");
+                    false
                 }
+            };
+
+            if reconcile_completed {
+                self.process_live_unfilled_orders(
+                    &mut pending_live_orders,
+                    &mut intents_submitted,
+                    &mut fills_recorded,
+                )
+                .await;
             }
 
             // 3. Check update limit (backtest bound).
@@ -326,6 +411,175 @@ where
         &self.trading
     }
 
+    fn initial_pending_live_orders(&self) -> BTreeMap<String, PendingLiveOrder> {
+        if self.config.mode != RuntimeMode::Live {
+            return BTreeMap::new();
+        }
+
+        self.trading
+            .orders()
+            .orders()
+            .filter(|order| {
+                order.venue_order_id.is_some()
+                    && matches!(
+                        order.state,
+                        OrderState::Acknowledged | OrderState::PartiallyFilled
+                    )
+            })
+            .filter_map(|order| {
+                let intent = self.trading.intent(&order.intent_id)?.clone();
+                Some((
+                    order.order_id.clone(),
+                    PendingLiveOrder {
+                        intent,
+                        attempts: retry_attempt_from_intent_id(&order.intent_id),
+                        reconciles_without_fill: 0,
+                    },
+                ))
+            })
+            .collect()
+    }
+
+    async fn process_live_unfilled_orders(
+        &mut self,
+        pending_live_orders: &mut BTreeMap<String, PendingLiveOrder>,
+        intents_submitted: &mut u64,
+        fills_recorded: &mut u64,
+    ) {
+        if self.config.mode != RuntimeMode::Live || pending_live_orders.is_empty() {
+            return;
+        }
+
+        let policy = self.executor.execution_policy();
+        let strategy_name = self.strategy.name().to_string();
+        let order_ids = pending_live_orders.keys().cloned().collect::<Vec<_>>();
+
+        for order_id in order_ids {
+            let Some(mut pending) = pending_live_orders.remove(&order_id) else {
+                continue;
+            };
+            let Some(order) = self.trading.order(&order_id).cloned() else {
+                continue;
+            };
+
+            if !matches!(
+                order.state,
+                OrderState::Acknowledged | OrderState::PartiallyFilled
+            ) {
+                continue;
+            }
+
+            let remaining_qty = (order.requested_qty - order.filled_qty).max(Decimal::ZERO);
+            if remaining_qty <= Decimal::ZERO {
+                continue;
+            }
+
+            pending.reconciles_without_fill += 1;
+            if pending.reconciles_without_fill < policy.reconcile_cycles_before_retry {
+                pending_live_orders.insert(order_id, pending);
+                continue;
+            }
+
+            let terminal_reason = if pending.attempts >= policy.max_attempts {
+                format!(
+                    "live order unfilled after {} attempt(s); remaining_qty={remaining_qty}",
+                    pending.attempts
+                )
+            } else {
+                format!(
+                    "live FAK attempt unfilled; retrying remaining_qty={remaining_qty} after {} attempt(s)",
+                    pending.attempts
+                )
+            };
+            self.trading.cancel_order(&order_id);
+            let terminal_report = crate::traits::ExecutionReport {
+                order_id: order
+                    .venue_order_id
+                    .clone()
+                    .unwrap_or_else(|| order_id.clone()),
+                fill: None,
+                rejected: true,
+                rejection_reason: Some(terminal_reason.clone()),
+                slippage: None,
+                market_impact: None,
+            };
+            self.recorder
+                .record_order(
+                    &strategy_name,
+                    &pending.intent,
+                    None,
+                    &terminal_report,
+                    &order_id,
+                )
+                .await;
+
+            if pending.attempts >= policy.max_attempts {
+                self.strategy.on_reject(&pending.intent, &terminal_reason);
+                warn!(order_id = %order_id, reason = %terminal_reason, "Live order terminal unfilled");
+                continue;
+            }
+
+            let retry_attempt = pending.attempts + 1;
+            let mut retry_intent = pending.intent.clone();
+            retry_intent.intent_id = format!(
+                "{}_retry{retry_attempt}",
+                retry_root_intent_id(&pending.intent.intent_id)
+            );
+            retry_intent.quantity = remaining_qty;
+            retry_intent.created_at = Utc::now();
+            let retry_order_id = Uuid::new_v4().to_string();
+            let report = self.executor.submit(&retry_intent, &retry_order_id).await;
+            self.recorder
+                .record_order(
+                    &strategy_name,
+                    &retry_intent,
+                    None,
+                    &report,
+                    &retry_order_id,
+                )
+                .await;
+
+            if report.rejected && report.fill.is_none() {
+                let reason = report.rejection_reason.as_deref().unwrap_or("unknown");
+                warn!(
+                    order_id = %retry_order_id,
+                    attempt = retry_attempt,
+                    reason = %reason,
+                    "Live retry rejected",
+                );
+                self.strategy.on_reject(&retry_intent, reason);
+                continue;
+            }
+
+            self.trading
+                .submit_intent(retry_intent.clone(), retry_order_id.clone());
+            if !report.order_id.is_empty() && report.order_id != retry_order_id {
+                self.trading
+                    .acknowledge_order(&retry_order_id, report.order_id.clone());
+            }
+            *intents_submitted += 1;
+
+            if let Some(fill) = report.fill.as_ref() {
+                if self.trading.record_fill(fill.clone()) {
+                    self.recorder
+                        .record_fill(&strategy_name, &retry_intent, None, fill, &report)
+                        .await;
+                    self.strategy.on_fill(fill);
+                    *fills_recorded += 1;
+                }
+            } else {
+                pending_live_orders.insert(
+                    retry_order_id,
+                    PendingLiveOrder {
+                        intent: retry_intent,
+                        attempts: retry_attempt,
+                        reconciles_without_fill: 0,
+                    },
+                );
+            }
+        }
+    }
+
     /// Extract timestamp from a market update (for throttling).
     fn update_ts(update: &MarketUpdate) -> Option<DateTime<Utc>> {
         match update {
@@ -358,14 +612,32 @@ mod tests {
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
-    use super::{RuntimeConfig, RuntimeMode, StrategyRuntime};
+    use super::{
+        retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig, RuntimeMode,
+        StrategyRuntime,
+    };
     use crate::traits::{
-        ExecutionReport, Executor, Feed, MarketUpdate, Recorder, SignalRecord, StrategyDecision,
-        StrategyLogic,
+        ExecutionPolicy, ExecutionReport, Executor, Feed, MarketUpdate, Recorder, SignalRecord,
+        StrategyDecision, StrategyLogic,
     };
 
     struct SingleUpdateFeed {
         next: Option<MarketUpdate>,
+    }
+
+    #[test]
+    fn retry_suffix_parsing_only_treats_numeric_suffix_as_attempt() {
+        assert_eq!(retry_attempt_from_intent_id("pm5d_BTCUSDT_UP"), 1);
+        assert_eq!(
+            retry_root_intent_id("pm5d_BTCUSDT_UP_retry"),
+            "pm5d_BTCUSDT_UP_retry"
+        );
+        assert_eq!(retry_attempt_from_intent_id("pm5d_BTCUSDT_UP_retry"), 1);
+        assert_eq!(
+            retry_root_intent_id("pm5d_BTCUSDT_UP_retry2"),
+            "pm5d_BTCUSDT_UP"
+        );
+        assert_eq!(retry_attempt_from_intent_id("pm5d_BTCUSDT_UP_retry2"), 2);
     }
 
     #[async_trait]
@@ -616,10 +888,63 @@ mod tests {
         }
     }
 
-    struct AcknowledgingExecutor;
+    #[derive(Clone)]
+    struct AcknowledgingExecutor {
+        policy: ExecutionPolicy,
+        submissions: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Default for AcknowledgingExecutor {
+        fn default() -> Self {
+            Self {
+                policy: ExecutionPolicy::default(),
+                submissions: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
 
     #[async_trait]
     impl Executor for AcknowledgingExecutor {
+        fn execution_policy(&self) -> ExecutionPolicy {
+            self.policy
+        }
+
+        async fn submit(&mut self, intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
+            self.submissions
+                .lock()
+                .unwrap()
+                .push(intent.intent_id.clone());
+            ExecutionReport {
+                order_id: "venue-order-1".into(),
+                fill: None,
+                rejected: false,
+                rejection_reason: None,
+                slippage: None,
+                market_impact: None,
+            }
+        }
+
+        async fn cancel(&mut self, _order_id: &str) -> bool {
+            true
+        }
+    }
+
+    struct SkippedReconcileExecutor;
+
+    #[async_trait]
+    impl Executor for SkippedReconcileExecutor {
+        fn execution_policy(&self) -> ExecutionPolicy {
+            ExecutionPolicy {
+                max_slippage_bps: Decimal::ZERO,
+                max_attempts: 1,
+                reconcile_cycles_before_retry: 1,
+            }
+        }
+
+        fn last_reconcile_attempted(&self) -> bool {
+            false
+        }
+
         async fn submit(&mut self, _intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
             ExecutionReport {
                 order_id: "venue-order-1".into(),
@@ -633,6 +958,13 @@ mod tests {
 
         async fn cancel(&mut self, _order_id: &str) -> bool {
             true
+        }
+
+        async fn reconcile_fills(
+            &mut self,
+            _orders: &OrderLedger,
+        ) -> Result<Vec<FillRecord>, String> {
+            Ok(Vec::new())
         }
     }
 
@@ -701,7 +1033,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn acknowledged_orders_update_runtime_order_state_with_venue_id() {
+    async fn live_ack_without_fill_is_not_treated_as_filled() {
         let now = Utc::now();
         let signal = SignalRecord {
             strategy: "pm_5m_directional".into(),
@@ -744,7 +1076,7 @@ mod tests {
                 ts: now,
             }),
         };
-        let executor = AcknowledgingExecutor;
+        let executor = AcknowledgingExecutor::default();
         let config = RuntimeConfig {
             mode: RuntimeMode::Live,
             throttle_hz: None,
@@ -757,14 +1089,291 @@ mod tests {
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
         assert_eq!(snapshot.orders.len(), 1);
-        assert_eq!(
-            snapshot.orders[0].state,
-            ploy_trading::OrderState::Acknowledged
-        );
+        assert_eq!(snapshot.orders[0].state, ploy_trading::OrderState::Canceled);
         assert_eq!(
             snapshot.orders[0].venue_order_id.as_deref(),
             Some("venue-order-1")
         );
+        assert_eq!(snapshot.fills.len(), 0);
+        assert_eq!(snapshot.risk.active_orders, 0);
+    }
+
+    #[tokio::test]
+    async fn live_ack_without_completed_reconcile_stays_pending() {
+        let now = Utc::now();
+        let signal = SignalRecord {
+            strategy: "pm_5m_directional".into(),
+            event_id: Some("evt1".into()),
+            token_id: Some("token-up".into()),
+            intent_id: Some("pm5d_BTCUSDT_UP_wait".into()),
+            symbol: "BTCUSDT".into(),
+            direction: "UP".into(),
+            p_hat: 0.71,
+            edge: 0.08,
+            entry_price: dec!(0.30),
+            decision: "enter".into(),
+            ts: now,
+        };
+        let intent = TradingIntent {
+            intent_id: "pm5d_BTCUSDT_UP_wait".into(),
+            deployment_id: String::new(),
+            market_id: "evt1".into(),
+            token_id: "token-up".into(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.30)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let strategy = RecordingStrategy {
+            emitted: false,
+            signal,
+            intent,
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: true,
+        };
+
+        let mut runtime =
+            StrategyRuntime::new(strategy, feed, SkippedReconcileExecutor, recorder, config);
+        let _ = runtime.run().await;
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+
+        assert_eq!(snapshot.orders.len(), 1);
+        assert_eq!(
+            snapshot.orders[0].state,
+            ploy_trading::OrderState::Acknowledged
+        );
+        assert_eq!(snapshot.risk.active_orders, 1);
+    }
+
+    #[tokio::test]
+    async fn live_unfilled_ack_retries_remaining_quantity_within_attempt_limit() {
+        let now = Utc::now();
+        let signal = SignalRecord {
+            strategy: "pm_5m_directional".into(),
+            event_id: Some("evt1".into()),
+            token_id: Some("token-up".into()),
+            intent_id: Some("pm5d_BTCUSDT_UP_retry".into()),
+            symbol: "BTCUSDT".into(),
+            direction: "UP".into(),
+            p_hat: 0.71,
+            edge: 0.08,
+            entry_price: dec!(0.30),
+            decision: "enter".into(),
+            ts: now,
+        };
+        let intent = TradingIntent {
+            intent_id: "pm5d_BTCUSDT_UP_retry".into(),
+            deployment_id: String::new(),
+            market_id: "evt1".into(),
+            token_id: "token-up".into(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.30)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        };
+        let submissions = Arc::new(Mutex::new(Vec::new()));
+        let executor = AcknowledgingExecutor {
+            policy: ExecutionPolicy {
+                max_slippage_bps: Decimal::ZERO,
+                max_attempts: 2,
+                reconcile_cycles_before_retry: 1,
+            },
+            submissions: submissions.clone(),
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let strategy = RecordingStrategy {
+            emitted: false,
+            signal,
+            intent,
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: true,
+        };
+
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let _ = runtime.run().await;
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+
+        assert_eq!(
+            submissions.lock().unwrap().as_slice(),
+            ["pm5d_BTCUSDT_UP_retry", "pm5d_BTCUSDT_UP_retry_retry2"]
+        );
+        assert_eq!(snapshot.orders.len(), 2);
+        assert_eq!(
+            snapshot
+                .orders
+                .iter()
+                .filter(|order| order.state == ploy_trading::OrderState::Canceled)
+                .count(),
+            1
+        );
+        assert_eq!(
+            snapshot
+                .orders
+                .iter()
+                .filter(|order| order.state == ploy_trading::OrderState::Acknowledged)
+                .count(),
+            1
+        );
+        assert_eq!(snapshot.fills.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn restored_live_ack_order_is_managed_as_pending() {
+        let now = Utc::now();
+        let mut trading = ploy_trading::TradingRuntime::default();
+        trading.submit_intent(
+            TradingIntent {
+                intent_id: "restored-intent".into(),
+                deployment_id: "example.live".into(),
+                market_id: "evt1".into(),
+                token_id: "token-up".into(),
+                side: TradeSide::Buy,
+                quantity: dec!(10),
+                limit_price: Some(dec!(0.30)),
+                purpose: IntentPurpose::Entry,
+                created_at: now,
+            },
+            "restored-order",
+        );
+        trading.acknowledge_order("restored-order", "venue-restored");
+
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: true,
+        };
+
+        let mut runtime = StrategyRuntime::new_with_trading(
+            NoopStrategy,
+            feed,
+            AcknowledgingExecutor::default(),
+            recorder,
+            config,
+            trading,
+        );
+        let _ = runtime.run().await;
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+
+        assert_eq!(snapshot.orders.len(), 1);
+        assert_eq!(snapshot.orders[0].state, ploy_trading::OrderState::Canceled);
+        assert_eq!(snapshot.fills.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn restored_live_retry_order_continues_from_existing_attempt_suffix() {
+        let now = Utc::now();
+        let mut trading = ploy_trading::TradingRuntime::default();
+        trading.submit_intent(
+            TradingIntent {
+                intent_id: "pm5d_BTCUSDT_UP_retry2".into(),
+                deployment_id: "example.live".into(),
+                market_id: "evt1".into(),
+                token_id: "token-up".into(),
+                side: TradeSide::Buy,
+                quantity: dec!(10),
+                limit_price: Some(dec!(0.30)),
+                purpose: IntentPurpose::Entry,
+                created_at: now,
+            },
+            "restored-order",
+        );
+        trading.acknowledge_order("restored-order", "venue-restored");
+
+        let submissions = Arc::new(Mutex::new(Vec::new()));
+        let executor = AcknowledgingExecutor {
+            policy: ExecutionPolicy {
+                max_slippage_bps: Decimal::ZERO,
+                max_attempts: 3,
+                reconcile_cycles_before_retry: 1,
+            },
+            submissions: submissions.clone(),
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: true,
+        };
+
+        let mut runtime = StrategyRuntime::new_with_trading(
+            NoopStrategy,
+            feed,
+            executor,
+            recorder,
+            config,
+            trading,
+        );
+        let _ = runtime.run().await;
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+
+        assert_eq!(
+            submissions.lock().unwrap().as_slice(),
+            ["pm5d_BTCUSDT_UP_retry3"]
+        );
+        assert_eq!(snapshot.orders.len(), 2);
+        assert!(snapshot
+            .orders
+            .iter()
+            .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
+                && order.state == ploy_trading::OrderState::Acknowledged));
     }
 
     #[tokio::test]
@@ -799,7 +1408,7 @@ mod tests {
             orders: Arc::new(Mutex::new(Vec::new())),
             fills: Arc::new(Mutex::new(Vec::new())),
         });
-        let executor = AcknowledgingExecutor;
+        let executor = AcknowledgingExecutor::default();
         let config = RuntimeConfig {
             mode: RuntimeMode::Live,
             throttle_hz: None,

--- a/crates/ploy-strategy-bundles/src/lib.rs
+++ b/crates/ploy-strategy-bundles/src/lib.rs
@@ -34,8 +34,8 @@ pub use strategies::ReversalStrategy;
 pub use strategies::SweepStrategy;
 pub use strategies::ThreeLayerStrategy;
 pub use traits::{
-    ExecutionReport, Executor, NullRecorder, Recorder, SignalRecord, StrategyDecision,
-    StrategyLogic,
+    ExecutionPolicy, ExecutionReport, Executor, NullRecorder, Recorder, SignalRecord,
+    StrategyDecision, StrategyLogic,
 };
 
 pub const CRATE_MARKER: &str = "ploy-strategy-bundles";

--- a/crates/ploy-strategy-bundles/src/traits.rs
+++ b/crates/ploy-strategy-bundles/src/traits.rs
@@ -31,9 +31,34 @@ pub struct ExecutionReport {
     pub market_impact: Option<Decimal>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ExecutionPolicy {
+    pub max_slippage_bps: Decimal,
+    pub max_attempts: u8,
+    pub reconcile_cycles_before_retry: u8,
+}
+
+impl Default for ExecutionPolicy {
+    fn default() -> Self {
+        Self {
+            max_slippage_bps: Decimal::ZERO,
+            max_attempts: 1,
+            reconcile_cycles_before_retry: 1,
+        }
+    }
+}
+
 /// Order executor — real exchange or execution simulator.
 #[async_trait]
 pub trait Executor: Send {
+    fn execution_policy(&self) -> ExecutionPolicy {
+        ExecutionPolicy::default()
+    }
+
+    fn last_reconcile_attempted(&self) -> bool {
+        true
+    }
+
     /// Submit a trading intent and return the execution report.
     /// `order_id` is the caller-assigned ID that must be used in the returned fill.
     async fn submit(&mut self, intent: &TradingIntent, order_id: &str) -> ExecutionReport;

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use ploy_market_data::feeds::{
     spawn_chainlink_feed, spawn_db_aggtrade_feed, spawn_db_l2_feed, spawn_db_spot_feed,
     spawn_pyth_reference_feed, spawn_spot_feed,
@@ -8,7 +9,12 @@ use ploy_market_data::sports_feed::spawn_sports_feed;
 use ploy_strategy_bundles::{
     Feed, FullConfig, LiveFeed, RecordingFeed, RuntimeMode, StrategyLogic,
 };
-use sqlx::postgres::PgPoolOptions;
+use ploy_trading::{
+    FillRecord, IntentPurpose, OrderRecord, OrderState, PnlSnapshot, TradeSide, TradingIntent,
+    TradingRuntime, TradingRuntimeSnapshot,
+};
+use rust_decimal::Decimal;
+use sqlx::{postgres::PgPoolOptions, FromRow, PgPool};
 use std::env;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -17,8 +23,9 @@ use tracing::{error, info, warn};
 #[cfg(all(feature = "live", feature = "live-execution"))]
 mod execution {
     use async_trait::async_trait;
-    use ploy_strategy_bundles::ExecutionReport;
-    use ploy_trading::{FillRecord, TradingIntent};
+    use ploy_strategy_bundles::{ExecutionPolicy, ExecutionReport};
+    use ploy_trading::{FillRecord, TradeSide, TradingIntent};
+    use rust_decimal::Decimal;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
     use tracing::{error, info};
@@ -27,18 +34,27 @@ mod execution {
     pub(super) struct LiveExecutor {
         gateway: Arc<ploy_connectivity::PolymarketExecutionGateway>,
         next_reconcile_at: Option<Instant>,
+        policy: ExecutionPolicy,
+        last_reconcile_attempted: bool,
     }
 
     impl LiveExecutor {
-        pub(super) fn new(gateway: Arc<ploy_connectivity::PolymarketExecutionGateway>) -> Self {
+        pub(super) fn new(
+            gateway: Arc<ploy_connectivity::PolymarketExecutionGateway>,
+            policy: ExecutionPolicy,
+        ) -> Self {
             Self {
                 gateway,
                 next_reconcile_at: None,
+                policy,
+                last_reconcile_attempted: false,
             }
         }
 
         fn build_request(&self, intent: &TradingIntent) -> ploy_connectivity::ExecutionRequest {
-            let limit_price = intent.limit_price.map(|price| price.round_dp(2));
+            let limit_price = intent
+                .limit_price
+                .map(|price| self.slippage_bounded_price(price, intent.side));
             let quantity = intent.quantity.trunc_with_scale(2);
             ploy_connectivity::ExecutionRequest {
                 order_id: intent.intent_id.clone(),
@@ -50,10 +66,29 @@ mod execution {
                 aggressive_ticks: 0,
             }
         }
+
+        fn slippage_bounded_price(&self, limit_price: Decimal, side: TradeSide) -> Decimal {
+            let tolerance = self.policy.max_slippage_bps / Decimal::from(10_000_u32);
+            let adjusted = match side {
+                TradeSide::Buy => limit_price * (Decimal::ONE + tolerance),
+                TradeSide::Sell => limit_price * (Decimal::ONE - tolerance),
+            };
+            adjusted
+                .clamp(Decimal::new(1, 2), Decimal::new(99, 2))
+                .round_dp(2)
+        }
     }
 
     #[async_trait]
     impl ploy_strategy_bundles::Executor for LiveExecutor {
+        fn execution_policy(&self) -> ExecutionPolicy {
+            self.policy
+        }
+
+        fn last_reconcile_attempted(&self) -> bool {
+            self.last_reconcile_attempted
+        }
+
         async fn submit(&mut self, intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
             use ploy_connectivity::{ExecutionOutcome, LiveExecutionGateway};
 
@@ -120,6 +155,7 @@ mod execution {
         ) -> Result<Vec<FillRecord>, String> {
             use ploy_connectivity::{LiveExecutionGateway, TrackedOrder};
 
+            self.last_reconcile_attempted = false;
             let now = Instant::now();
             if let Some(next_reconcile_at) = self.next_reconcile_at {
                 if now < next_reconcile_at {
@@ -156,6 +192,7 @@ mod execution {
                 .await
             {
                 Ok(Ok(fills)) => {
+                    self.last_reconcile_attempted = true;
                     self.next_reconcile_at = Some(now + Duration::from_secs(3));
                     Ok(fills)
                 }
@@ -173,7 +210,35 @@ mod execution {
 }
 
 use crate::recording::build_signal_recorder;
-use crate::{RuntimeModeConfig, database_unavailable_is_fatal};
+use crate::{database_unavailable_is_fatal, RuntimeModeConfig};
+
+#[derive(Debug, FromRow)]
+struct LiveOrderRestoreRow {
+    intent_id: String,
+    order_id: String,
+    deployment_id: String,
+    event_id: Option<String>,
+    token_id: String,
+    order_side: String,
+    quantity: Decimal,
+    limit_price: Option<Decimal>,
+    venue_order_id: Option<String>,
+    filled_quantity: Decimal,
+    status: String,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, FromRow)]
+struct LiveFillRestoreRow {
+    order_id: String,
+    fill_id: String,
+    token_id: String,
+    fill_side: String,
+    quantity: Decimal,
+    price: Decimal,
+    fee: Decimal,
+    fill_timestamp: DateTime<Utc>,
+}
 
 pub(crate) async fn run_live_or_dry_run_entry(
     config: &FullConfig,
@@ -185,6 +250,156 @@ pub(crate) async fn run_live_or_dry_run_entry(
     ploy_trading::TradingRuntimeSnapshot,
 ) {
     run_live_or_dry_run(config, symbols, strategy, runtime_config).await
+}
+
+async fn restore_active_live_trading_runtime(pool: &PgPool) -> Option<TradingRuntime> {
+    let orders = match sqlx::query_as::<_, LiveOrderRestoreRow>(
+        r#"
+        SELECT
+            intent_id,
+            order_id,
+            deployment_id,
+            event_id,
+            token_id,
+            order_side,
+            quantity,
+            limit_price,
+            venue_order_id,
+            filled_quantity,
+            status,
+            created_at
+        FROM strategy_runtime_orders
+        WHERE runtime_mode = 'live'
+          AND venue_order_id IS NOT NULL
+          AND status IN ('ACKNOWLEDGED', 'PARTIALLY_FILLED', 'acknowledged', 'partially_filled')
+        ORDER BY created_at DESC
+        LIMIT 500
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            warn!(error = %error, "Failed to restore active live orders from DB");
+            return None;
+        }
+    };
+
+    if orders.is_empty() {
+        return None;
+    }
+
+    let order_ids = orders
+        .iter()
+        .map(|order| order.order_id.clone())
+        .collect::<Vec<_>>();
+    let fills = match sqlx::query_as::<_, LiveFillRestoreRow>(
+        r#"
+        SELECT order_id, fill_id, token_id, fill_side, quantity, price, fee, fill_timestamp
+        FROM strategy_runtime_fills
+        WHERE runtime_mode = 'live'
+          AND order_id = ANY($1)
+        ORDER BY fill_timestamp ASC
+        "#,
+    )
+    .bind(&order_ids)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            warn!(error = %error, "Failed to restore live fills from DB");
+            Vec::new()
+        }
+    };
+
+    let intents = orders
+        .iter()
+        .map(|order| TradingIntent {
+            intent_id: order.intent_id.clone(),
+            deployment_id: order.deployment_id.clone(),
+            market_id: order.event_id.clone().unwrap_or_default(),
+            token_id: order.token_id.clone(),
+            side: trade_side_from_db(&order.order_side),
+            quantity: order.quantity,
+            limit_price: order.limit_price,
+            purpose: intent_purpose_from_side(&order.order_side),
+            created_at: order.created_at,
+        })
+        .collect::<Vec<_>>();
+    let order_records = orders
+        .into_iter()
+        .map(|order| OrderRecord {
+            order_id: order.order_id,
+            intent_id: order.intent_id,
+            deployment_id: order.deployment_id,
+            token_id: order.token_id,
+            requested_qty: order.quantity,
+            limit_price: order.limit_price,
+            venue_order_id: order.venue_order_id,
+            venue_order_history: Vec::new(),
+            revision: 0,
+            state: order_state_from_db(&order.status),
+            filled_qty: order.filled_quantity,
+            rejection_reason: None,
+            last_error: None,
+        })
+        .collect::<Vec<_>>();
+    let fill_records = fills
+        .into_iter()
+        .map(|fill| FillRecord {
+            fill_id: fill.fill_id,
+            order_id: fill.order_id,
+            token_id: fill.token_id,
+            side: trade_side_from_db(&fill.fill_side),
+            quantity: fill.quantity,
+            price: fill.price,
+            fee: fill.fee,
+            timestamp: fill.fill_timestamp,
+        })
+        .collect::<Vec<_>>();
+
+    info!(
+        orders = order_records.len(),
+        fills = fill_records.len(),
+        "Restored active live trading runtime from DB"
+    );
+
+    Some(TradingRuntime::restore(TradingRuntimeSnapshot {
+        intents,
+        orders: order_records,
+        fills: fill_records,
+        positions: Vec::new(),
+        pnl: PnlSnapshot::default(),
+        risk: Default::default(),
+    }))
+}
+
+fn trade_side_from_db(side: &str) -> TradeSide {
+    if side.eq_ignore_ascii_case("SELL") {
+        TradeSide::Sell
+    } else {
+        TradeSide::Buy
+    }
+}
+
+fn intent_purpose_from_side(side: &str) -> IntentPurpose {
+    if side.eq_ignore_ascii_case("SELL") {
+        IntentPurpose::Exit
+    } else {
+        IntentPurpose::Entry
+    }
+}
+
+fn order_state_from_db(status: &str) -> OrderState {
+    match status.to_ascii_uppercase().as_str() {
+        "PARTIALLY_FILLED" => OrderState::PartiallyFilled,
+        "FILLED" => OrderState::Filled,
+        "CANCELED" | "CANCELLED" => OrderState::Canceled,
+        "REJECTED" => OrderState::Rejected,
+        _ => OrderState::Acknowledged,
+    }
 }
 
 async fn run_live_or_dry_run(
@@ -291,13 +506,20 @@ async fn run_live_or_dry_run(
 
         #[cfg(feature = "live-execution")]
         {
-            let executor = build_live_executor();
-            let mut runtime = ploy_strategy_bundles::StrategyRuntime::new(
+            let executor = build_live_executor(config.live_execution_policy());
+            let trading = match db_pool.as_ref() {
+                Some(pool) => restore_active_live_trading_runtime(pool)
+                    .await
+                    .unwrap_or_default(),
+                None => TradingRuntime::default(),
+            };
+            let mut runtime = ploy_strategy_bundles::StrategyRuntime::new_with_trading(
                 strategy,
                 feed,
                 executor,
                 recorder,
                 runtime_config,
+                trading,
             );
             let result = runtime.run().await;
             let snapshot = runtime
@@ -336,7 +558,7 @@ async fn run_live_or_dry_run(
 }
 
 #[cfg(all(feature = "live", feature = "live-execution"))]
-fn build_live_executor() -> execution::LiveExecutor {
+fn build_live_executor(policy: ploy_strategy_bundles::ExecutionPolicy) -> execution::LiveExecutor {
     let gateway = Arc::new(ploy_connectivity::PolymarketExecutionGateway::from_env());
-    execution::LiveExecutor::new(gateway)
+    execution::LiveExecutor::new(gateway, policy)
 }

--- a/crates/ploy-strategy-runtime/src/recording.rs
+++ b/crates/ploy-strategy-runtime/src/recording.rs
@@ -211,8 +211,25 @@ impl RuntimeDbRecorder {
                 event_id = COALESCE(EXCLUDED.event_id, strategy_runtime_orders.event_id),
                 symbol = COALESCE(EXCLUDED.symbol, strategy_runtime_orders.symbol),
                 market_side = COALESCE(EXCLUDED.market_side, strategy_runtime_orders.market_side),
-                filled_quantity = EXCLUDED.filled_quantity,
-                avg_fill_price = COALESCE(EXCLUDED.avg_fill_price, strategy_runtime_orders.avg_fill_price),
+                filled_quantity = CASE
+                    WHEN EXCLUDED.filled_quantity > 0 THEN
+                        strategy_runtime_orders.filled_quantity + EXCLUDED.filled_quantity
+                    ELSE strategy_runtime_orders.filled_quantity
+                END,
+                avg_fill_price = CASE
+                    WHEN EXCLUDED.filled_quantity > 0 AND EXCLUDED.avg_fill_price IS NOT NULL THEN
+                        (
+                            COALESCE(
+                                strategy_runtime_orders.avg_fill_price,
+                                EXCLUDED.avg_fill_price
+                            ) * strategy_runtime_orders.filled_quantity
+                            + EXCLUDED.avg_fill_price * EXCLUDED.filled_quantity
+                        ) / NULLIF(
+                            strategy_runtime_orders.filled_quantity + EXCLUDED.filled_quantity,
+                            0
+                        )
+                    ELSE COALESCE(EXCLUDED.avg_fill_price, strategy_runtime_orders.avg_fill_price)
+                END,
                 status = EXCLUDED.status,
                 rejection_reason = COALESCE(EXCLUDED.rejection_reason, strategy_runtime_orders.rejection_reason),
                 slippage = COALESCE(EXCLUDED.slippage, strategy_runtime_orders.slippage),

--- a/crates/ploy-trading/src/orders.rs
+++ b/crates/ploy-trading/src/orders.rs
@@ -118,6 +118,10 @@ impl OrderLedger {
     pub fn reject(&mut self, order_id: &str, reason: impl Into<String>) -> Option<&OrderRecord> {
         let record = self.orders.get_mut(order_id)?;
         let reason = reason.into();
+        if matches!(record.state, OrderState::Filled) {
+            record.last_error = Some(reason);
+            return Some(record);
+        }
         record.state = OrderState::Rejected;
         record.rejection_reason = Some(reason.clone());
         record.last_error = Some(reason);
@@ -136,6 +140,9 @@ impl OrderLedger {
 
     pub fn cancel(&mut self, order_id: &str) -> Option<&OrderRecord> {
         let record = self.orders.get_mut(order_id)?;
+        if matches!(record.state, OrderState::Filled | OrderState::Rejected) {
+            return Some(record);
+        }
         record.state = OrderState::Canceled;
         record.last_error = None;
         Some(record)
@@ -143,6 +150,10 @@ impl OrderLedger {
 
     pub fn apply_fill(&mut self, fill: &FillRecord) -> Option<&OrderRecord> {
         let record = self.orders.get_mut(&fill.order_id)?;
+        let remaining_qty = (record.requested_qty - record.filled_qty).max(Decimal::ZERO);
+        if fill.quantity > remaining_qty {
+            return None;
+        }
         record.filled_qty += fill.quantity;
         record.state = if record.filled_qty >= record.requested_qty {
             OrderState::Filled
@@ -178,7 +189,22 @@ mod tests {
     use super::{OrderLedger, OrderState};
     use crate::{IntentPurpose, TradeSide, TradingIntent};
     use chrono::Utc;
+    use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
+
+    fn intent(token_id: &str) -> TradingIntent {
+        TradingIntent {
+            intent_id: format!("intent-{token_id}"),
+            deployment_id: "example.live".to_string(),
+            market_id: "market-1".to_string(),
+            token_id: token_id.to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(1),
+            limit_price: Some(dec!(0.45)),
+            purpose: IntentPurpose::Entry,
+            created_at: Utc::now(),
+        }
+    }
 
     #[test]
     fn replace_preserves_logical_order_and_tracks_revision_history() {
@@ -209,6 +235,54 @@ mod tests {
         assert_eq!(order.revision, 1);
         assert_eq!(order.requested_qty, dec!(3));
         assert_eq!(order.limit_price, Some(dec!(0.47)));
+        assert_eq!(order.state, OrderState::Acknowledged);
+    }
+
+    #[test]
+    fn terminal_filled_order_is_not_overwritten_by_cancel_or_reject() {
+        let mut ledger = OrderLedger::default();
+        ledger.insert_from_intent("order-1", &intent("token-a"));
+        ledger.acknowledge("order-1", "venue-1");
+        ledger.apply_fill(&crate::FillRecord {
+            fill_id: "fill-1".to_string(),
+            order_id: "order-1".to_string(),
+            token_id: "token-a".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(1),
+            price: dec!(0.5),
+            fee: dec!(0),
+            timestamp: Utc::now(),
+        });
+
+        ledger.cancel("order-1");
+        assert_eq!(ledger.order("order-1").unwrap().state, OrderState::Filled);
+
+        ledger.reject("order-1", "late rejection");
+        let order = ledger.order("order-1").unwrap();
+        assert_eq!(order.state, OrderState::Filled);
+        assert_eq!(order.last_error.as_deref(), Some("late rejection"));
+    }
+
+    #[test]
+    fn overfill_is_rejected() {
+        let mut ledger = OrderLedger::default();
+        ledger.insert_from_intent("order-1", &intent("token-a"));
+        ledger.acknowledge("order-1", "venue-1");
+
+        let result = ledger.apply_fill(&crate::FillRecord {
+            fill_id: "fill-1".to_string(),
+            order_id: "order-1".to_string(),
+            token_id: "token-a".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(2),
+            price: dec!(0.5),
+            fee: dec!(0),
+            timestamp: Utc::now(),
+        });
+
+        assert!(result.is_none());
+        let order = ledger.order("order-1").unwrap();
+        assert_eq!(order.filled_qty, Decimal::ZERO);
         assert_eq!(order.state, OrderState::Acknowledged);
     }
 }

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -3,7 +3,7 @@ use crate::intents::{TradeSide, TradingIntent};
 use crate::orders::OrderLedger;
 use crate::pnl::PnlSnapshot;
 use crate::positions::{PositionLedger, PositionSnapshot};
-use crate::risk::{RiskSnapshot, snapshot_from_state};
+use crate::risk::{snapshot_from_state, RiskSnapshot};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -173,7 +173,9 @@ impl TradingRuntime {
         if self.fills.contains(&fill.fill_id) {
             return false;
         }
-        self.orders.apply_fill(&fill);
+        if self.orders.apply_fill(&fill).is_none() {
+            return false;
+        }
         self.positions.apply_fill(&fill);
         self.fills.record(fill);
         self.prune_inactive_intents();
@@ -378,9 +380,24 @@ mod tests {
         });
         assert!(runtime.intent("intent-1").is_some());
 
+        runtime.submit_intent(
+            TradingIntent {
+                intent_id: "intent-exit".to_string(),
+                deployment_id: "dep-1".to_string(),
+                market_id: "market-1".to_string(),
+                token_id: "token-1".to_string(),
+                side: TradeSide::Sell,
+                quantity: dec!(1),
+                limit_price: Some(dec!(0.60)),
+                purpose: IntentPurpose::Exit,
+                created_at: Utc::now(),
+            },
+            "order-exit",
+        );
+        runtime.acknowledge_order("order-exit", "venue-exit");
         runtime.record_fill(FillRecord {
             fill_id: "fill-2".to_string(),
-            order_id: "order-1".to_string(),
+            order_id: "order-exit".to_string(),
             token_id: "token-1".to_string(),
             side: TradeSide::Sell,
             quantity: dec!(1),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Live Order Execution Management (2026-04-24)
+
+## Files
+
+- `crates/ploy-connectivity/src/lib.rs`
+- `crates/ploy-strategy-bundles/src/config.rs`
+- `crates/ploy-strategy-bundles/src/engine.rs`
+- `crates/ploy-strategy-runtime/src/live.rs`
+- `crates/ploy-strategy-runtime/src/recording.rs`
+- `crates/ploy-trading/src/orders.rs`
+
+## Tasks
+
+- [x] Add bounded live slippage controls so FAK/FOK execution cannot chase far beyond the strategy limit.
+- [x] Treat venue acknowledgement as a pending order state, not a fill, and remove synthetic live fills.
+- [x] Add live retry/terminal-unfilled handling for acknowledged FAK orders that do not produce fills after reconciliation.
+- [x] Harden order ledger transitions around cancel/reject/fill invariants.
+- [x] Restore active live venue orders from DB on startup so post-restart reconciliation can continue.
+- [x] Verify with focused Rust tests for slippage, ack-without-fill, retry, partial fill, and order-state invariants.
+
+## Review
+
+- 2026-04-24: Live FAK/FOK execution now carries a hard bounded price derived from the strategy limit plus `[live_execution].max_slippage_bps` instead of relying on orderbook-derived market pricing alone.
+- 2026-04-24: Live acknowledgements without fills remain pending/retryable orders; they no longer call `on_fill` with synthetic fills, so strategy counters/cooldowns only advance on real fills or explicit rejection.
+- 2026-04-24: Acknowledged live orders with no reconciled fill are retried for remaining quantity up to `[live_execution].max_attempts`, then marked terminal-unfilled and passed to `on_reject`.
+- 2026-04-24: Order ledger invariants now reject orphan/overfilled fills and prevent filled orders from being overwritten by later cancel/reject transitions.
+- 2026-04-24: Live startup now restores active acknowledged/partially-filled venue orders from `strategy_runtime_orders` plus their fills so reconciliation is not purely in-memory after a process restart.
+- 2026-04-24: Review hardening: unfilled live ACKs only advance after an actual reconcile attempt, retry attempts persist the previous venue order as terminal before submitting the next attempt, restored retry intent IDs continue from `_retryN` instead of compounding suffixes, and order persistence now accumulates partial fills instead of overwriting them during terminal updates.
+
 # PM5D Settlement + Strategy Audit (2026-04-12)
 
 ## Optimize Workflow Recovery (2026-04-23)


### PR DESCRIPTION
## Summary
- add bounded live FAK/FOK price policy via [live_execution]
- keep live venue ACKs pending until real fills reconcile, with retry/terminal-unfilled handling
- restore active live orders from DB and preserve cumulative partial-fill accounting

## Tests
- rtk cargo test -p ploy-trading
- rtk cargo test -p ploy-connectivity
- rtk cargo test -p ploy-strategy-bundles
- rtk cargo test -p ploy-strategy-runtime
- rtk cargo check -p ploy-strategy-runtime --features live,live-execution
- git diff --check