### PR TITLE
Gate event ML escalation on walk-forward evidence

### DIFF
--- a/crates/ploy-research/Cargo.toml
+++ b/crates/ploy-research/Cargo.toml
@@ -72,3 +72,7 @@ required-features = ["polars-export"]
 [[example]]
 name = "event_ml_architecture"
 path = "examples/event_ml_architecture.rs"
+
+[[example]]
+name = "event_ml_walk_forward"
+path = "examples/event_ml_walk_forward.rs"

--- a/crates/ploy-research/examples/event_ml_walk_forward.rs
+++ b/crates/ploy-research/examples/event_ml_walk_forward.rs
@@ -1,0 +1,152 @@
+use std::env;
+use std::fs::{self, File};
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use ploy_research::{build_walk_forward_report, walk_forward_report_markdown, WalkForwardConfig};
+
+fn main() -> Result<()> {
+    let config = Config::parse(env::args().skip(1))?;
+    let output_dir = config.output_dir.clone().unwrap_or_else(|| {
+        config
+            .run_dirs
+            .first()
+            .expect("run_dirs is validated")
+            .join("walk_forward")
+    });
+    fs::create_dir_all(&output_dir)
+        .with_context(|| format!("create output dir {}", output_dir.display()))?;
+
+    let report = build_walk_forward_report(&WalkForwardConfig {
+        run_dirs: config.run_dirs,
+        min_windows: config.min_windows,
+        min_test_trades_per_window: config.min_test_trades_per_window,
+    })?;
+    let markdown = walk_forward_report_markdown(&report);
+
+    let json_path = output_dir.join("walk_forward_report.json");
+    let markdown_path = output_dir.join("walk_forward_report.md");
+    let json_file =
+        File::create(&json_path).with_context(|| format!("create {}", json_path.display()))?;
+    serde_json::to_writer_pretty(json_file, &report)
+        .with_context(|| format!("write {}", json_path.display()))?;
+    fs::write(&markdown_path, markdown)
+        .with_context(|| format!("write {}", markdown_path.display()))?;
+
+    eprintln!("artifact_walk_forward_report={}", json_path.display());
+    eprintln!(
+        "artifact_walk_forward_report_md={}",
+        markdown_path.display()
+    );
+    eprintln!("walk_forward_status={}", report.readiness.status.as_str());
+    eprintln!(
+        "walk_forward_ready_for_dl_rl={}",
+        report.readiness.ready_for_dl_rl
+    );
+    if !report.readiness.missing_gate_ids.is_empty() {
+        eprintln!(
+            "walk_forward_missing_gates={}",
+            report.readiness.missing_gate_ids.join(",")
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct Config {
+    run_dirs: Vec<PathBuf>,
+    output_dir: Option<PathBuf>,
+    min_windows: usize,
+    min_test_trades_per_window: usize,
+}
+
+impl Config {
+    fn parse<I>(args: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let args = args.into_iter().collect::<Vec<_>>();
+        if has_flag(&args, "--help") || has_flag(&args, "-h") {
+            print_help();
+            std::process::exit(0);
+        }
+
+        let mut run_dirs = flag_values(&args, "--run-dir")
+            .into_iter()
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+        if let Some(csv) = flag_value(&args, "--run-dirs") {
+            run_dirs.extend(
+                csv.split(',')
+                    .map(str::trim)
+                    .filter(|item| !item.is_empty())
+                    .map(PathBuf::from),
+            );
+        }
+        if run_dirs.is_empty() {
+            bail!("--run-dir <workflow-run-dir> is required");
+        }
+
+        let output_dir = flag_value(&args, "--output-dir").map(PathBuf::from);
+        let min_windows = parse_usize_flag(&args, "--min-windows", 3)?;
+        let min_test_trades_per_window =
+            parse_usize_flag(&args, "--min-test-trades-per-window", 1)?;
+        if min_windows == 0 {
+            bail!("--min-windows must be positive");
+        }
+
+        Ok(Config {
+            run_dirs,
+            output_dir,
+            min_windows,
+            min_test_trades_per_window,
+        })
+    }
+}
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|pair| pair[0] == flag)
+        .map(|pair| pair[1].clone())
+}
+
+fn flag_values(args: &[String], flag: &str) -> Vec<String> {
+    args.windows(2)
+        .filter(|pair| pair[0] == flag)
+        .map(|pair| pair[1].clone())
+        .collect()
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn parse_usize_flag(args: &[String], flag: &str, default: usize) -> Result<usize> {
+    flag_value(args, flag)
+        .map(|raw| {
+            raw.parse::<usize>()
+                .with_context(|| format!("invalid {flag}: {raw}"))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(default))
+}
+
+fn print_help() {
+    println!(
+        r#"Event ML walk-forward gate artifact writer
+
+Usage:
+  cargo run -p ploy-research --example event_ml_walk_forward -- \
+    --run-dir <workflow-run-dir> [--run-dir <workflow-run-dir> ...]
+
+Options:
+  --run-dir <dir>                    Workflow run directory containing workflow_report.json
+                                     and hyperparameter/hyperparameter_search.json.
+  --run-dirs <csv>                   Additional comma-separated workflow run directories.
+  --output-dir <dir>                 Output artifact directory. Default: <first-run-dir>/walk_forward.
+  --min-windows <n>                  Minimum windows required for DL/RL readiness. Default: 3.
+  --min-test-trades-per-window <n>   Minimum test trades per window. Default: 1.
+  -h, --help                         Show this help.
+"#
+    );
+}

--- a/crates/ploy-research/examples/event_ml_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_workflow.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,6 +14,7 @@ enum Phase {
     Attribution,
     Baseline,
     Hyperparameter,
+    WalkForward,
 }
 
 impl Phase {
@@ -23,6 +24,7 @@ impl Phase {
             Phase::Attribution => Some("event_factor_attribution"),
             Phase::Baseline => Some("event_dataset_baseline"),
             Phase::Hyperparameter => None,
+            Phase::WalkForward => None,
         }
     }
 
@@ -32,6 +34,7 @@ impl Phase {
             Phase::Attribution => "AutoML-style factor attribution",
             Phase::Baseline => "fixed supervised baseline",
             Phase::Hyperparameter => "bounded logistic hyperparameter search",
+            Phase::WalkForward => "walk-forward executable-price gate",
         }
     }
 }
@@ -43,6 +46,7 @@ impl fmt::Display for Phase {
             Phase::Attribution => "attribution",
             Phase::Baseline => "baseline",
             Phase::Hyperparameter => "hyperparameter",
+            Phase::WalkForward => "walk_forward",
         })
     }
 }
@@ -60,6 +64,8 @@ struct Config {
     search_min_edge: Vec<f64>,
     search_learning_rate: Vec<f64>,
     search_epochs: usize,
+    walk_forward_min_windows: usize,
+    walk_forward_min_test_trades: usize,
     phases: Vec<Phase>,
     dry_run: bool,
 }
@@ -131,6 +137,17 @@ struct BaselineMetric {
     pnl: f64,
 }
 
+#[derive(Debug, Deserialize)]
+struct WalkForwardGateArtifact {
+    readiness: WalkForwardReadinessArtifact,
+}
+
+#[derive(Debug, Deserialize)]
+struct WalkForwardReadinessArtifact {
+    ready_for_dl_rl: bool,
+    status: String,
+}
+
 fn main() -> Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
     if has_flag(&args, "--help") || has_flag(&args, "-h") {
@@ -156,9 +173,7 @@ fn main() -> Result<()> {
     eprintln!();
     eprintln!("workflow_status=completed");
     eprintln!("workflow_run_dir={}", state.run_dir.display());
-    eprintln!(
-        "next_gates=model_family_selection -> hyperparameter_search -> walk_forward_backtest -> DL/RL only if justified"
-    );
+    eprintln!("next_gates=walk_forward_backtest -> DL/RL only if justified -> dry_run_handoff");
     Ok(())
 }
 
@@ -181,6 +196,7 @@ fn parse_config(args: &[String]) -> Result<Config> {
                 Phase::Attribution,
                 Phase::Baseline,
                 Phase::Hyperparameter,
+                Phase::WalkForward,
             ]
         });
     let dry_run = has_flag(args, "--dry-run");
@@ -188,6 +204,8 @@ fn parse_config(args: &[String]) -> Result<Config> {
     let search_min_edge = parse_f64_list_flag(args, "--search-min-edge", &[0.0, 0.02, 0.05])?;
     let search_learning_rate = parse_f64_list_flag(args, "--search-learning-rate", &[0.03, 0.05])?;
     let search_epochs = parse_usize_flag(args, "--search-epochs", 500)?;
+    let walk_forward_min_windows = parse_usize_flag(args, "--walk-forward-min-windows", 3)?;
+    let walk_forward_min_test_trades = parse_usize_flag(args, "--walk-forward-min-test-trades", 1)?;
 
     if entry_secs < 0 {
         bail!("--entry-secs must be non-negative");
@@ -210,6 +228,9 @@ fn parse_config(args: &[String]) -> Result<Config> {
     {
         bail!("--search-learning-rate values must be in [0, 1)");
     }
+    if walk_forward_min_windows == 0 {
+        bail!("--walk-forward-min-windows must be positive");
+    }
 
     Ok(Config {
         dataset,
@@ -223,6 +244,8 @@ fn parse_config(args: &[String]) -> Result<Config> {
         search_min_edge,
         search_learning_rate,
         search_epochs,
+        walk_forward_min_windows,
+        walk_forward_min_test_trades,
         phases,
         dry_run,
     })
@@ -296,6 +319,9 @@ fn parse_phases(raw: &str) -> Result<Vec<Phase>> {
             "attribution" | "factor-attribution" | "automl" => Phase::Attribution,
             "baseline" | "fixed-baseline" => Phase::Baseline,
             "hyperparameter" | "hyperparameter-search" | "search" => Phase::Hyperparameter,
+            "walk-forward" | "walk_forward" | "backtest" | "walk-forward-backtest" => {
+                Phase::WalkForward
+            }
             other => bail!("unknown workflow phase: {other}"),
         };
         phases.push(phase);
@@ -347,6 +373,9 @@ fn run_phase(phase: Phase, config: &Config, state: &mut WorkflowState) -> Result
     if phase == Phase::Hyperparameter {
         return run_hyperparameter_phase(config, state);
     }
+    if phase == Phase::WalkForward {
+        return run_walk_forward_phase(config, state);
+    }
 
     let args = phase_args(phase, config, state);
     let example = phase
@@ -393,6 +422,75 @@ fn run_phase(phase: Phase, config: &Config, state: &mut WorkflowState) -> Result
         label: phase.label(),
         command,
         status: "passed".to_string(),
+    });
+    Ok(())
+}
+
+fn run_walk_forward_phase(config: &Config, state: &mut WorkflowState) -> Result<()> {
+    let workflow_report = state.run_dir.join("workflow_report.json");
+    if !workflow_report.exists() && !config.dry_run {
+        write_workflow_report(config, state)?;
+    }
+    let output_dir = state.run_dir.join("walk_forward");
+    let args = vec![
+        "--run-dir".to_string(),
+        state.run_dir.display().to_string(),
+        "--output-dir".to_string(),
+        output_dir.display().to_string(),
+        "--min-windows".to_string(),
+        config.walk_forward_min_windows.to_string(),
+        "--min-test-trades-per-window".to_string(),
+        config.walk_forward_min_test_trades.to_string(),
+    ];
+    let command = shell_command_without_features("event_ml_walk_forward", &args);
+    eprintln!();
+    eprintln!(
+        "--- phase={} label=\"{}\" ---",
+        Phase::WalkForward,
+        Phase::WalkForward.label()
+    );
+    eprintln!("command={command}");
+
+    if config.dry_run {
+        state.records.push(PhaseRecord {
+            phase: Phase::WalkForward.to_string(),
+            label: Phase::WalkForward.label(),
+            command,
+            status: "dry_run".to_string(),
+        });
+        return Ok(());
+    }
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "ploy-research",
+            "--example",
+            "event_ml_walk_forward",
+            "--",
+        ])
+        .args(&args)
+        .status()
+        .context("spawn walk-forward gate phase")?;
+    if !status.success() {
+        bail!("walk-forward gate failed with status {status}");
+    }
+
+    let report_path = output_dir.join("walk_forward_report.json");
+    let report_file =
+        File::open(&report_path).with_context(|| format!("open {}", report_path.display()))?;
+    let report: WalkForwardGateArtifact = serde_json::from_reader(report_file)
+        .with_context(|| format!("parse {}", report_path.display()))?;
+    eprintln!(
+        "walk_forward_readiness={} ready_for_dl_rl={}",
+        report.readiness.status, report.readiness.ready_for_dl_rl
+    );
+    state.records.push(PhaseRecord {
+        phase: Phase::WalkForward.to_string(),
+        label: Phase::WalkForward.label(),
+        command,
+        status: report.readiness.status,
     });
     Ok(())
 }
@@ -682,7 +780,7 @@ fn phase_args(phase: Phase, config: &Config, state: &WorkflowState) -> Vec<Strin
             args.push("--min-edge".to_string());
             args.push(config.min_edge.to_string());
         }
-        Phase::Hyperparameter => {}
+        Phase::Hyperparameter | Phase::WalkForward => {}
     }
 
     let features = match phase {
@@ -719,11 +817,10 @@ fn write_workflow_report(config: &Config, state: &WorkflowState) -> Result<()> {
         .map(split_features)
         .unwrap_or_default();
     let next_gates = [
-        "model_family_selection",
-        "hyperparameter_search",
         "walk_forward_backtest",
         "dl_gate_if_justified",
         "rl_gate_if_justified",
+        "dry_run_handoff",
     ];
     let report = WorkflowReport {
         dataset: &config.dataset,
@@ -821,6 +918,20 @@ fn shell_command(example: &str, args: &[String]) -> String {
     parts.join(" ")
 }
 
+fn shell_command_without_features(example: &str, args: &[String]) -> String {
+    let mut parts = vec![
+        "cargo".to_string(),
+        "run".to_string(),
+        "-p".to_string(),
+        "ploy-research".to_string(),
+        "--example".to_string(),
+        example.to_string(),
+        "--".to_string(),
+    ];
+    parts.extend(args.iter().map(|arg| shell_quote(arg)));
+    parts.join(" ")
+}
+
 fn shell_quote(value: &str) -> String {
     if value
         .chars()
@@ -849,12 +960,16 @@ Options:
   --min-edge <value>       Baseline trading edge threshold. Default: 0.0.
   --features <csv>         Override default feature list.
   --output-dir <dir>       Workflow artifact directory. Default: <dataset>/workflow_runs/event_ml_<timestamp>.
-  --phases <csv>           coverage,attribution,baseline,hyperparameter. Default: all four.
+  --phases <csv>           coverage,attribution,baseline,hyperparameter,walk-forward. Default: all five.
   --search-l2 <csv>        Logistic L2 values for bounded search. Default: 0,0.001,0.01.
   --search-min-edge <csv>  Min-edge values for bounded search. Default: 0,0.02,0.05.
   --search-learning-rate <csv>
                            Learning rates for bounded search. Default: 0.03,0.05.
   --search-epochs <n>      Epochs for bounded search candidates. Default: 500.
+  --walk-forward-min-windows <n>
+                           Minimum windows required before DL/RL readiness. Default: 3.
+  --walk-forward-min-test-trades <n>
+                           Minimum test trades per walk-forward window. Default: 1.
   --dry-run                Print commands without running phases.
 "
     );
@@ -880,7 +995,8 @@ mod tests {
                 Phase::Coverage,
                 Phase::Attribution,
                 Phase::Baseline,
-                Phase::Hyperparameter
+                Phase::Hyperparameter,
+                Phase::WalkForward,
             ]
         );
         assert_eq!(config.entry_secs, 60);
@@ -893,7 +1009,7 @@ mod tests {
             "--dataset",
             "/tmp/events",
             "--phases",
-            "coverage,automl,fixed-baseline,search",
+            "coverage,automl,fixed-baseline,search,walk-forward",
             "--dry-run",
         ]))
         .unwrap();
@@ -904,7 +1020,8 @@ mod tests {
                 Phase::Coverage,
                 Phase::Attribution,
                 Phase::Baseline,
-                Phase::Hyperparameter
+                Phase::Hyperparameter,
+                Phase::WalkForward,
             ]
         );
         assert!(config.dry_run);
@@ -929,16 +1046,12 @@ mod tests {
         };
         let phase_args = phase_args(Phase::Coverage, &config, &state);
 
-        assert!(
-            phase_args
-                .windows(2)
-                .any(|pair| pair == ["--tolerances", "15"])
-        );
-        assert!(
-            !phase_args
-                .windows(2)
-                .any(|pair| pair == ["--tolerance-secs", "15"])
-        );
+        assert!(phase_args
+            .windows(2)
+            .any(|pair| pair == ["--tolerances", "15"]));
+        assert!(!phase_args
+            .windows(2)
+            .any(|pair| pair == ["--tolerance-secs", "15"]));
     }
 
     #[test]
@@ -967,10 +1080,8 @@ mod tests {
 
         let phase_args = phase_args(Phase::Baseline, &config, &state);
 
-        assert!(
-            phase_args
-                .windows(2)
-                .any(|pair| pair == ["--features", "fair_prob_up,model_edge_up"])
-        );
+        assert!(phase_args
+            .windows(2)
+            .any(|pair| pair == ["--features", "fair_prob_up,model_edge_up"]));
     }
 }

--- a/crates/ploy-research/src/event_ml/mod.rs
+++ b/crates/ploy-research/src/event_ml/mod.rs
@@ -1,6 +1,14 @@
+pub mod walk_forward;
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
+
+pub use walk_forward::{
+    build_walk_forward_report, walk_forward_report_markdown, WalkForwardAggregate,
+    WalkForwardConfig, WalkForwardGate, WalkForwardGateStatus, WalkForwardMetric,
+    WalkForwardReadiness, WalkForwardReport, WalkForwardWindow, WALK_FORWARD_REPORT_VERSION,
+};
 
 pub const EVENT_ML_ARCHITECTURE_VERSION: &str = "event-ml-architecture.v1";
 

--- a/crates/ploy-research/src/event_ml/walk_forward.rs
+++ b/crates/ploy-research/src/event_ml/walk_forward.rs
@@ -1,0 +1,557 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+pub const WALK_FORWARD_REPORT_VERSION: &str = "event-ml-walk-forward.v1";
+
+#[derive(Debug, Clone)]
+pub struct WalkForwardConfig {
+    pub run_dirs: Vec<PathBuf>,
+    pub min_windows: usize,
+    pub min_test_trades_per_window: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WalkForwardReport {
+    pub version: String,
+    pub selection_rule: String,
+    pub readiness: WalkForwardReadiness,
+    pub gates: Vec<WalkForwardGate>,
+    pub aggregate: WalkForwardAggregate,
+    pub windows: Vec<WalkForwardWindow>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WalkForwardReadiness {
+    pub ready_for_dl_rl: bool,
+    pub status: WalkForwardGateStatus,
+    pub missing_gate_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WalkForwardGateStatus {
+    Ready,
+    Blocked,
+}
+
+impl WalkForwardGateStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            WalkForwardGateStatus::Ready => "ready",
+            WalkForwardGateStatus::Blocked => "blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WalkForwardGate {
+    pub id: String,
+    pub passed: bool,
+    pub evidence: String,
+    pub stop_if_missing: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WalkForwardAggregate {
+    pub window_count: usize,
+    pub total_test_trades: usize,
+    pub total_test_cost: f64,
+    pub total_test_pnl: f64,
+    pub total_test_roi: f64,
+    pub weighted_avg_entry: f64,
+    pub mean_test_logloss: f64,
+    pub mean_test_pnl: f64,
+    pub positive_test_windows: usize,
+    pub validation_test_direction_agreement: usize,
+    pub max_window_drawdown: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WalkForwardWindow {
+    pub id: usize,
+    pub run_dir: String,
+    pub dataset: String,
+    pub entry_secs: i64,
+    pub tolerance_secs: i64,
+    pub candidate_id: usize,
+    pub feature_count: usize,
+    pub baseline_metrics_path: String,
+    pub validation: WalkForwardMetric,
+    pub test: WalkForwardMetric,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WalkForwardMetric {
+    pub trades: usize,
+    pub wins: usize,
+    pub win_rate: f64,
+    pub pnl: f64,
+    pub cost: f64,
+    pub roi: f64,
+    pub avg_entry: f64,
+    pub logloss: f64,
+    pub auc: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowReportArtifact {
+    dataset: String,
+    entry_secs: i64,
+    tolerance_secs: i64,
+    governed_features: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HyperparameterSearchArtifact {
+    selection_rule: String,
+    best_candidate: Option<HyperparameterCandidateArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HyperparameterCandidateArtifact {
+    id: usize,
+    output_json: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineArtifact {
+    metrics: Vec<BaselineMetricArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineMetricArtifact {
+    split: String,
+    logloss: f64,
+    auc: Option<f64>,
+    trades: usize,
+    wins: usize,
+    pnl: f64,
+    cost: f64,
+    roi: f64,
+    avg_entry: f64,
+}
+
+pub fn build_walk_forward_report(config: &WalkForwardConfig) -> Result<WalkForwardReport> {
+    if config.run_dirs.is_empty() {
+        bail!("walk-forward requires at least one workflow run dir");
+    }
+    if config.min_windows == 0 {
+        bail!("min_windows must be positive");
+    }
+
+    let mut windows = Vec::new();
+    let mut selection_rules = Vec::new();
+    for (index, run_dir) in config.run_dirs.iter().enumerate() {
+        let loaded = load_window(index + 1, run_dir)?;
+        if !selection_rules.contains(&loaded.selection_rule) {
+            selection_rules.push(loaded.selection_rule);
+        }
+        windows.push(loaded.window);
+    }
+
+    let aggregate = aggregate_windows(&windows);
+    let gates = readiness_gates(config, &windows, &aggregate);
+    let missing_gate_ids = gates
+        .iter()
+        .filter(|gate| !gate.passed)
+        .map(|gate| gate.id.clone())
+        .collect::<Vec<_>>();
+    let status = if missing_gate_ids.is_empty() {
+        WalkForwardGateStatus::Ready
+    } else {
+        WalkForwardGateStatus::Blocked
+    };
+
+    Ok(WalkForwardReport {
+        version: WALK_FORWARD_REPORT_VERSION.to_string(),
+        selection_rule: selection_rules.join(" | "),
+        readiness: WalkForwardReadiness {
+            ready_for_dl_rl: status == WalkForwardGateStatus::Ready,
+            status,
+            missing_gate_ids,
+        },
+        gates,
+        aggregate,
+        windows,
+        notes: vec![
+            "This report gates DL/RL readiness; it is not a live-edge approval.".to_string(),
+            "Hyperparameter candidates are assumed to have been selected by validation metrics only."
+                .to_string(),
+            "Max drawdown is computed across window-level test PnL until trade-level equity curves are available."
+                .to_string(),
+        ],
+    })
+}
+
+pub fn walk_forward_report_markdown(report: &WalkForwardReport) -> String {
+    let mut out = String::new();
+    out.push_str("# Event ML Walk-Forward Gate\n\n");
+    out.push_str(&format!("Version: `{}`\n\n", report.version));
+    out.push_str(&format!(
+        "Readiness: `{}`\n\n",
+        report.readiness.status.as_str()
+    ));
+    if !report.readiness.missing_gate_ids.is_empty() {
+        out.push_str("Missing gates:\n\n");
+        for gate_id in &report.readiness.missing_gate_ids {
+            out.push_str(&format!("- `{gate_id}`\n"));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Aggregate\n\n");
+    out.push_str(&format!("- windows: `{}`\n", report.aggregate.window_count));
+    out.push_str(&format!(
+        "- test trades: `{}`\n",
+        report.aggregate.total_test_trades
+    ));
+    out.push_str(&format!(
+        "- test PnL: `{:.4}`\n",
+        report.aggregate.total_test_pnl
+    ));
+    out.push_str(&format!(
+        "- test ROI: `{:.4}`\n",
+        report.aggregate.total_test_roi
+    ));
+    out.push_str(&format!(
+        "- weighted avg entry: `{:.4}`\n",
+        report.aggregate.weighted_avg_entry
+    ));
+    out.push_str(&format!(
+        "- max window drawdown: `{:.4}`\n\n",
+        report.aggregate.max_window_drawdown
+    ));
+
+    out.push_str("## Gates\n\n");
+    out.push_str("| gate | passed | evidence |\n");
+    out.push_str("| --- | --- | --- |\n");
+    for gate in &report.gates {
+        out.push_str(&format!(
+            "| `{}` | `{}` | {} |\n",
+            gate.id, gate.passed, gate.evidence
+        ));
+    }
+
+    out.push_str("\n## Windows\n\n");
+    out.push_str("| id | dataset | candidate | features | val_pnl | test_pnl | test_trades | test_roi | avg_entry |\n");
+    out.push_str("| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for window in &report.windows {
+        out.push_str(&format!(
+            "| {} | `{}` | {} | {} | {:.4} | {:.4} | {} | {:.4} | {:.4} |\n",
+            window.id,
+            window.dataset,
+            window.candidate_id,
+            window.feature_count,
+            window.validation.pnl,
+            window.test.pnl,
+            window.test.trades,
+            window.test.roi,
+            window.test.avg_entry
+        ));
+    }
+
+    out.push_str("\n## Notes\n\n");
+    for note in &report.notes {
+        out.push_str(&format!("- {note}\n"));
+    }
+
+    out
+}
+
+struct LoadedWindow {
+    selection_rule: String,
+    window: WalkForwardWindow,
+}
+
+fn load_window(id: usize, run_dir: &Path) -> Result<LoadedWindow> {
+    let workflow_path = run_dir.join("workflow_report.json");
+    let workflow: WorkflowReportArtifact = read_json(&workflow_path)?;
+
+    let search_path = run_dir
+        .join("hyperparameter")
+        .join("hyperparameter_search.json");
+    let search: HyperparameterSearchArtifact = read_json(&search_path)?;
+    let candidate = search
+        .best_candidate
+        .context("hyperparameter_search.json missing best_candidate")?;
+
+    let baseline_path = resolve_candidate_path(run_dir, &candidate.output_json);
+    let baseline: BaselineArtifact = read_json(&baseline_path)?;
+    let validation = metric_for_split(&baseline, "val")?;
+    let test = metric_for_split(&baseline, "test")?;
+
+    Ok(LoadedWindow {
+        selection_rule: search.selection_rule,
+        window: WalkForwardWindow {
+            id,
+            run_dir: run_dir.display().to_string(),
+            dataset: workflow.dataset,
+            entry_secs: workflow.entry_secs,
+            tolerance_secs: workflow.tolerance_secs,
+            candidate_id: candidate.id,
+            feature_count: workflow.governed_features.len(),
+            baseline_metrics_path: baseline_path.display().to_string(),
+            validation,
+            test,
+        },
+    })
+}
+
+fn read_json<T>(path: &Path) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    serde_json::from_reader(file).with_context(|| format!("parse {}", path.display()))
+}
+
+fn resolve_candidate_path(run_dir: &Path, raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        run_dir.join(path)
+    }
+}
+
+fn metric_for_split(artifact: &BaselineArtifact, split: &str) -> Result<WalkForwardMetric> {
+    let metric = artifact
+        .metrics
+        .iter()
+        .find(|metric| metric.split == split)
+        .with_context(|| format!("baseline artifact missing {split} metric"))?;
+    let win_rate = if metric.trades > 0 {
+        metric.wins as f64 / metric.trades as f64
+    } else {
+        0.0
+    };
+    Ok(WalkForwardMetric {
+        trades: metric.trades,
+        wins: metric.wins,
+        win_rate,
+        pnl: metric.pnl,
+        cost: metric.cost,
+        roi: metric.roi,
+        avg_entry: metric.avg_entry,
+        logloss: metric.logloss,
+        auc: metric.auc,
+    })
+}
+
+fn aggregate_windows(windows: &[WalkForwardWindow]) -> WalkForwardAggregate {
+    let window_count = windows.len();
+    let total_test_trades = windows.iter().map(|window| window.test.trades).sum();
+    let total_test_cost = windows.iter().map(|window| window.test.cost).sum();
+    let total_test_pnl = windows.iter().map(|window| window.test.pnl).sum();
+    let total_test_roi = if total_test_cost > 0.0 {
+        total_test_pnl / total_test_cost
+    } else {
+        0.0
+    };
+    let weighted_avg_entry = weighted_avg_entry(windows, total_test_trades);
+    let mean_test_logloss = mean_by_window(windows, |window| window.test.logloss);
+    let mean_test_pnl = mean_by_window(windows, |window| window.test.pnl);
+    let positive_test_windows = windows
+        .iter()
+        .filter(|window| window.test.pnl > 0.0)
+        .count();
+    let validation_test_direction_agreement = windows
+        .iter()
+        .filter(|window| same_direction(window.validation.pnl, window.test.pnl))
+        .count();
+    let max_window_drawdown = max_drawdown(windows);
+
+    WalkForwardAggregate {
+        window_count,
+        total_test_trades,
+        total_test_cost,
+        total_test_pnl,
+        total_test_roi,
+        weighted_avg_entry,
+        mean_test_logloss,
+        mean_test_pnl,
+        positive_test_windows,
+        validation_test_direction_agreement,
+        max_window_drawdown,
+    }
+}
+
+fn weighted_avg_entry(windows: &[WalkForwardWindow], total_trades: usize) -> f64 {
+    if total_trades == 0 {
+        return 0.0;
+    }
+    windows
+        .iter()
+        .map(|window| window.test.avg_entry * window.test.trades as f64)
+        .sum::<f64>()
+        / total_trades as f64
+}
+
+fn mean_by_window<F>(windows: &[WalkForwardWindow], metric: F) -> f64
+where
+    F: Fn(&WalkForwardWindow) -> f64,
+{
+    if windows.is_empty() {
+        return 0.0;
+    }
+    windows.iter().map(metric).sum::<f64>() / windows.len() as f64
+}
+
+fn same_direction(left: f64, right: f64) -> bool {
+    (left >= 0.0 && right >= 0.0) || (left <= 0.0 && right <= 0.0)
+}
+
+fn max_drawdown(windows: &[WalkForwardWindow]) -> f64 {
+    let mut equity = 0.0;
+    let mut peak = 0.0;
+    let mut drawdown: f64 = 0.0;
+    for window in windows {
+        equity += window.test.pnl;
+        peak = f64::max(peak, equity);
+        drawdown = drawdown.max(peak - equity);
+    }
+    drawdown
+}
+
+fn readiness_gates(
+    config: &WalkForwardConfig,
+    windows: &[WalkForwardWindow],
+    aggregate: &WalkForwardAggregate,
+) -> Vec<WalkForwardGate> {
+    vec![
+        WalkForwardGate {
+            id: "min_walk_forward_windows".to_string(),
+            passed: windows.len() >= config.min_windows,
+            evidence: format!(
+                "windows={} min_required={}",
+                windows.len(),
+                config.min_windows
+            ),
+            stop_if_missing: "collect more event-root windows before DL/RL".to_string(),
+        },
+        WalkForwardGate {
+            id: "test_trades_present".to_string(),
+            passed: windows
+                .iter()
+                .all(|window| window.test.trades >= config.min_test_trades_per_window),
+            evidence: format!(
+                "min_test_trades_per_window={} total_test_trades={}",
+                config.min_test_trades_per_window, aggregate.total_test_trades
+            ),
+            stop_if_missing: "fix tradable coverage before model escalation".to_string(),
+        },
+        WalkForwardGate {
+            id: "executable_entry_accounting".to_string(),
+            passed: windows.iter().all(|window| {
+                window.test.cost > 0.0 && window.test.avg_entry > 0.0 && window.test.avg_entry < 1.0
+            }),
+            evidence: format!(
+                "total_cost={:.4} weighted_avg_entry={:.4}",
+                aggregate.total_test_cost, aggregate.weighted_avg_entry
+            ),
+            stop_if_missing: "do not claim executable strategy quality".to_string(),
+        },
+        WalkForwardGate {
+            id: "window_drawdown_reported".to_string(),
+            passed: aggregate.max_window_drawdown.is_finite(),
+            evidence: format!("max_window_drawdown={:.4}", aggregate.max_window_drawdown),
+            stop_if_missing: "add drawdown evidence before dry-run handoff".to_string(),
+        },
+        WalkForwardGate {
+            id: "validation_test_direction_reported".to_string(),
+            passed: true,
+            evidence: format!(
+                "agreement_windows={} of {}",
+                aggregate.validation_test_direction_agreement, aggregate.window_count
+            ),
+            stop_if_missing: "report validation/test drift before model-family escalation"
+                .to_string(),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window(
+        id: usize,
+        val_pnl: f64,
+        test_pnl: f64,
+        trades: usize,
+        avg_entry: f64,
+    ) -> WalkForwardWindow {
+        WalkForwardWindow {
+            id,
+            run_dir: format!("/tmp/run-{id}"),
+            dataset: format!("dataset-{id}"),
+            entry_secs: 60,
+            tolerance_secs: 30,
+            candidate_id: 1,
+            feature_count: 8,
+            baseline_metrics_path: format!("/tmp/run-{id}/baseline_metrics.json"),
+            validation: WalkForwardMetric {
+                trades,
+                wins: trades / 2,
+                win_rate: 0.5,
+                pnl: val_pnl,
+                cost: trades as f64 * avg_entry,
+                roi: 0.0,
+                avg_entry,
+                logloss: 0.5,
+                auc: Some(0.6),
+            },
+            test: WalkForwardMetric {
+                trades,
+                wins: trades / 2,
+                win_rate: 0.5,
+                pnl: test_pnl,
+                cost: trades as f64 * avg_entry,
+                roi: if trades > 0 {
+                    test_pnl / (trades as f64 * avg_entry)
+                } else {
+                    0.0
+                },
+                avg_entry,
+                logloss: 0.6,
+                auc: Some(0.55),
+            },
+        }
+    }
+
+    #[test]
+    fn aggregate_reports_window_level_drawdown() {
+        let windows = vec![
+            window(1, 1.0, 2.0, 10, 0.4),
+            window(2, 1.0, -3.0, 10, 0.5),
+            window(3, 1.0, 1.0, 10, 0.5),
+        ];
+
+        let aggregate = aggregate_windows(&windows);
+
+        assert_eq!(aggregate.window_count, 3);
+        assert_eq!(aggregate.total_test_trades, 30);
+        assert!((aggregate.total_test_pnl - 0.0).abs() < 1e-9);
+        assert!((aggregate.max_window_drawdown - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_window_is_blocked_by_min_window_gate() {
+        let config = WalkForwardConfig {
+            run_dirs: vec![PathBuf::from("/tmp/run-1")],
+            min_windows: 3,
+            min_test_trades_per_window: 1,
+        };
+        let windows = vec![window(1, 1.0, 1.0, 5, 0.4)];
+        let aggregate = aggregate_windows(&windows);
+        let gates = readiness_gates(&config, &windows, &aggregate);
+
+        assert!(gates
+            .iter()
+            .any(|gate| gate.id == "min_walk_forward_windows" && !gate.passed));
+    }
+}

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -28,9 +28,12 @@ pub use dataset::{
     export_event_root_dataset_parquet, split_assignments_to_frame,
 };
 pub use event_ml::{
-    canonical_event_ml_architecture, event_ml_architecture_markdown, gate_matrix,
-    ArchitectureArtifact, EventMlArchitecture, LaneReadiness, LaneStatus, LearningLane,
-    LearningLaneId, PhaseId, ReadinessGate, WorkflowPhase, EVENT_ML_ARCHITECTURE_VERSION,
+    build_walk_forward_report, canonical_event_ml_architecture, event_ml_architecture_markdown,
+    gate_matrix, walk_forward_report_markdown, ArchitectureArtifact, EventMlArchitecture,
+    LaneReadiness, LaneStatus, LearningLane, LearningLaneId, PhaseId, ReadinessGate,
+    WalkForwardAggregate, WalkForwardConfig, WalkForwardGate, WalkForwardGateStatus,
+    WalkForwardMetric, WalkForwardReadiness, WalkForwardReport, WalkForwardWindow, WorkflowPhase,
+    EVENT_ML_ARCHITECTURE_VERSION, WALK_FORWARD_REPORT_VERSION,
 };
 pub use factors::{
     aggregate_factor_metrics, build_event_summaries, build_factor_observations,

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -97,6 +97,7 @@ The runner executes:
 2. `event_factor_attribution`
 3. `event_dataset_baseline`
 4. bounded logistic hyperparameter search using `event_dataset_baseline`
+5. `event_ml_walk_forward`
 
 It stops on the first failed phase. The attribution phase writes
 `factor_attributions.json`, `feature_whitelist.txt`, and
@@ -105,13 +106,16 @@ phase consumes that whitelist automatically. The runner also writes
 `workflow_report.json` and `workflow_report.md` into the run directory.
 The hyperparameter phase writes candidate-level `baseline_metrics.json` files
 plus `hyperparameter_search.json` and `hyperparameter_search.md`.
+The walk-forward phase writes `walk_forward_report.json` and
+`walk_forward_report.md`. With only one workflow run, the report is expected to
+mark DL/RL readiness as `blocked`; that is a useful gate, not a runner failure.
 
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.
 
 Use `--dry-run` to print the commands without running them, or
-`--phases coverage,attribution,baseline,hyperparameter` to run a subset in
-canonical order.
+`--phases coverage,attribution,baseline,hyperparameter,walk-forward` to run a
+subset in canonical order.
 
 ## Phase 1 - Coverage Diagnostics
 
@@ -363,6 +367,39 @@ Stop gate:
 ## Phase 7 - Walk-Forward And Backtest
 
 Goal: prove the result is not a single split artifact.
+
+Executable gate command for one or more completed workflow run directories:
+
+```bash
+rtk cargo run -p ploy-research --example event_ml_walk_forward -- \
+  --run-dir /tmp/ploy-event-ml-run-1 \
+  --run-dir /tmp/ploy-event-ml-run-2 \
+  --run-dir /tmp/ploy-event-ml-run-3 \
+  --output-dir /tmp/ploy-event-ml-walk-forward
+```
+
+The gate consumes:
+
+- `workflow_report.json`
+- `hyperparameter/hyperparameter_search.json`
+- the selected candidate's `baseline_metrics.json`
+
+The gate writes:
+
+- `walk_forward_report.json`
+- `walk_forward_report.md`
+
+Default readiness gates:
+
+- at least `3` workflow windows
+- each window has at least one test trade
+- executable entry accounting is present: cost, ROI, and average entry
+- window-level drawdown is reported
+- validation/test direction agreement is reported
+
+The workflow runner calls this gate automatically for its current run. A
+single-run report should remain `blocked` for DL/RL because it lacks rolling
+window evidence.
 
 Required once enough history exists:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8382,3 +8382,28 @@ Checklist:
 
 Review:
 - 2026-04-24: Added `event_ml` as a pure Rust architecture contract for the event-root ML foundation. The contract defines canonical phases, supervised/DL/RL/dry-run lanes, required artifacts, stop rules, and lane-specific readiness gates. DL and RL remain gated lanes: DL requires stable walk-forward evidence plus enough multi-day history and a no-future-row state contract; RL requires decision-time-only state, explicit action space, binary payout reward parity, quote/latency assumptions, and bankroll accounting before environment training. Added `event_ml_architecture`, a no-Polars example that writes `event_ml_architecture.json`, `event_ml_architecture.md`, and `event_ml_gate_matrix.json` for agents and reviewers before new model-family work starts.
+
+## Event ML Walk-Forward Gate
+
+Goal: add the executable-price walk-forward gate that blocks DL/RL until multiple workflow windows produce OOS accounting evidence.
+
+File ownership:
+- `crates/ploy-research/src/event_ml/walk_forward.rs`
+- `crates/ploy-research/src/event_ml/mod.rs`
+- `crates/ploy-research/src/lib.rs`
+- `crates/ploy-research/examples/event_ml_walk_forward.rs`
+- `crates/ploy-research/examples/event_ml_workflow.rs`
+- `crates/ploy-research/Cargo.toml`
+- `docs/runbooks/event-ml-automl-workflow.md`
+- `tasks/todo.md`
+
+Checklist:
+- [x] Add a pure Rust walk-forward report builder that consumes completed workflow run artifacts.
+- [x] Add a cargo-run example that writes `walk_forward_report.json` and `walk_forward_report.md`.
+- [x] Aggregate test PnL, ROI, average entry, trade count, validation/test agreement, and window-level drawdown.
+- [x] Mark single-window evidence as `blocked` for DL/RL instead of treating it as ready.
+- [x] Wire the gate into `event_ml_workflow` after bounded hyperparameter search.
+- [x] Update runbook and skill guidance.
+
+Review:
+- 2026-04-24: Added `event_ml_walk_forward` plus `event_ml::walk_forward` to consume `workflow_report.json`, `hyperparameter/hyperparameter_search.json`, and the selected candidate's `baseline_metrics.json`. The report aggregates OOS test trades, PnL, ROI, weighted average entry, validation/test direction agreement, and window-level drawdown. The workflow runner now includes `walk_forward` after hyperparameter search and records readiness as `ready` or `blocked`; a single run is expected to be blocked by the `min_walk_forward_windows` gate, preserving the DL/RL deferral boundary.


### PR DESCRIPTION
## Summary
- add a pure Rust walk-forward report builder under event_ml
- add event_ml_walk_forward example that writes walk_forward_report.json/md
- aggregate OOS test trades, PnL, ROI, average entry, validation/test direction agreement, and window-level drawdown
- wire the gate into event_ml_workflow after bounded hyperparameter search
- mark single-window evidence as blocked for DL/RL instead of ready
- update runbook, skill guidance, and task tracker

## Verification
- `rtk cargo check -p ploy-research`
- `rtk cargo check -p ploy-research --example event_ml_walk_forward`
- `rtk cargo check -p ploy-research --example event_ml_workflow --features polars-export`
- `rtk cargo test -p ploy-research --lib -- --nocapture`
- `rtk cargo test -p ploy-research --example event_ml_workflow --features polars-export -- --nocapture`
- `rtk cargo run -p ploy-research --example event_ml_workflow --features polars-export -- --dataset /tmp/ploy-event-root-5sym-150-20260424 --entry-secs 60 --tolerance-secs 30 --top-n 8 --output-dir /tmp/ploy-event-ml-walk-forward-gate --search-l2 0,0.001 --search-min-edge 0 --search-learning-rate 0.05`

## Real dataset smoke evidence
- five workflow phases ran: coverage, attribution, baseline, hyperparameter, walk_forward
- walk-forward report wrote `/tmp/ploy-event-ml-walk-forward-gate/walk_forward/walk_forward_report.json`
- readiness was `blocked`, with missing gate `min_walk_forward_windows`
- single-window OOS accounting reported 23 test trades, test PnL 1.90485, ROI 0.13514, weighted avg entry 0.61283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added walk-forward analysis capability for event ML workflows, generating readiness reports in JSON and Markdown formats.
  * Introduced a new CLI tool for running walk-forward backtests with configurable minimum windows and trade thresholds.
  * Integrated walk-forward phase into the event ML workflow with automated readiness gate evaluation.

* **Documentation**
  * Updated workflow documentation with walk-forward phase details and gate specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->