### PR TITLE
Accept prior event ML runs for rolling gates

### DIFF
--- a/crates/ploy-research/examples/event_ml_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_workflow.rs
@@ -66,6 +66,7 @@ struct Config {
     search_epochs: usize,
     walk_forward_min_windows: usize,
     walk_forward_min_test_trades: usize,
+    walk_forward_extra_run_dirs: Vec<PathBuf>,
     phases: Vec<Phase>,
     dry_run: bool,
 }
@@ -206,6 +207,7 @@ fn parse_config(args: &[String]) -> Result<Config> {
     let search_epochs = parse_usize_flag(args, "--search-epochs", 500)?;
     let walk_forward_min_windows = parse_usize_flag(args, "--walk-forward-min-windows", 3)?;
     let walk_forward_min_test_trades = parse_usize_flag(args, "--walk-forward-min-test-trades", 1)?;
+    let walk_forward_extra_run_dirs = parse_walk_forward_extra_run_dirs(args);
 
     if entry_secs < 0 {
         bail!("--entry-secs must be non-negative");
@@ -246,6 +248,7 @@ fn parse_config(args: &[String]) -> Result<Config> {
         search_epochs,
         walk_forward_min_windows,
         walk_forward_min_test_trades,
+        walk_forward_extra_run_dirs,
         phases,
         dry_run,
     })
@@ -255,6 +258,13 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2)
         .find(|pair| pair[0] == flag)
         .map(|pair| pair[1].clone())
+}
+
+fn flag_values(args: &[String], flag: &str) -> Vec<String> {
+    args.windows(2)
+        .filter(|pair| pair[0] == flag)
+        .map(|pair| pair[1].clone())
+        .collect()
 }
 
 fn has_flag(args: &[String], flag: &str) -> bool {
@@ -307,6 +317,22 @@ fn parse_f64_list_flag(args: &[String], flag: &str, default: &[f64]) -> Result<V
         .map(|value| value.unwrap_or_else(|| default.to_vec()))
 }
 
+fn parse_walk_forward_extra_run_dirs(args: &[String]) -> Vec<PathBuf> {
+    let mut run_dirs = flag_values(args, "--walk-forward-run-dir")
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    if let Some(raw) = flag_value(args, "--walk-forward-run-dirs") {
+        run_dirs.extend(
+            raw.split(',')
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(PathBuf::from),
+        );
+    }
+    run_dirs
+}
+
 fn parse_phases(raw: &str) -> Result<Vec<Phase>> {
     let mut phases = Vec::new();
     for item in raw
@@ -355,6 +381,10 @@ fn print_workflow_header(config: &Config, state: &WorkflowState) {
         config.tolerance_secs,
         format_phases(&config.phases),
         config.dry_run
+    );
+    eprintln!(
+        "walk_forward_extra_run_dirs={}",
+        config.walk_forward_extra_run_dirs.len()
     );
     eprintln!(
         "order=coverage -> AutoML factor attribution -> governed feature set -> fixed baseline -> bounded hyperparameter search -> walk-forward/backtest -> DL/RL gates"
@@ -432,7 +462,7 @@ fn run_walk_forward_phase(config: &Config, state: &mut WorkflowState) -> Result<
         write_workflow_report(config, state)?;
     }
     let output_dir = state.run_dir.join("walk_forward");
-    let args = vec![
+    let mut args = vec![
         "--run-dir".to_string(),
         state.run_dir.display().to_string(),
         "--output-dir".to_string(),
@@ -442,6 +472,10 @@ fn run_walk_forward_phase(config: &Config, state: &mut WorkflowState) -> Result<
         "--min-test-trades-per-window".to_string(),
         config.walk_forward_min_test_trades.to_string(),
     ];
+    for run_dir in &config.walk_forward_extra_run_dirs {
+        args.push("--run-dir".to_string());
+        args.push(run_dir.display().to_string());
+    }
     let command = shell_command_without_features("event_ml_walk_forward", &args);
     eprintln!();
     eprintln!(
@@ -970,6 +1004,11 @@ Options:
                            Minimum windows required before DL/RL readiness. Default: 3.
   --walk-forward-min-test-trades <n>
                            Minimum test trades per walk-forward window. Default: 1.
+  --walk-forward-run-dir <dir>
+                           Add a completed workflow run dir to the walk-forward gate.
+                           Repeat for rolling windows from prior datasets.
+  --walk-forward-run-dirs <csv>
+                           Add comma-separated completed workflow run dirs.
   --dry-run                Print commands without running phases.
 "
     );
@@ -1010,6 +1049,10 @@ mod tests {
             "/tmp/events",
             "--phases",
             "coverage,automl,fixed-baseline,search,walk-forward",
+            "--walk-forward-run-dir",
+            "/tmp/run-a",
+            "--walk-forward-run-dirs",
+            "/tmp/run-b,/tmp/run-c",
             "--dry-run",
         ]))
         .unwrap();
@@ -1025,6 +1068,14 @@ mod tests {
             ]
         );
         assert!(config.dry_run);
+        assert_eq!(
+            config.walk_forward_extra_run_dirs,
+            vec![
+                PathBuf::from("/tmp/run-a"),
+                PathBuf::from("/tmp/run-b"),
+                PathBuf::from("/tmp/run-c")
+            ]
+        );
     }
 
     #[test]

--- a/crates/ploy-research/src/event_ml/walk_forward.rs
+++ b/crates/ploy-research/src/event_ml/walk_forward.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -142,6 +143,7 @@ pub fn build_walk_forward_report(config: &WalkForwardConfig) -> Result<WalkForwa
     if config.min_windows == 0 {
         bail!("min_windows must be positive");
     }
+    ensure_unique_run_dirs(&config.run_dirs)?;
 
     let mut windows = Vec::new();
     let mut selection_rules = Vec::new();
@@ -434,6 +436,17 @@ fn readiness_gates(
             stop_if_missing: "collect more event-root windows before DL/RL".to_string(),
         },
         WalkForwardGate {
+            id: "unique_dataset_windows".to_string(),
+            passed: unique_dataset_count(windows) >= config.min_windows,
+            evidence: format!(
+                "unique_datasets={} min_required={}",
+                unique_dataset_count(windows),
+                config.min_windows
+            ),
+            stop_if_missing:
+                "run distinct rolling event-root datasets instead of reusing one split".to_string(),
+        },
+        WalkForwardGate {
             id: "test_trades_present".to_string(),
             passed: windows
                 .iter()
@@ -472,6 +485,25 @@ fn readiness_gates(
                 .to_string(),
         },
     ]
+}
+
+fn ensure_unique_run_dirs(run_dirs: &[PathBuf]) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for run_dir in run_dirs {
+        let key = run_dir.display().to_string();
+        if !seen.insert(key.clone()) {
+            bail!("duplicate walk-forward run dir: {key}");
+        }
+    }
+    Ok(())
+}
+
+fn unique_dataset_count(windows: &[WalkForwardWindow]) -> usize {
+    windows
+        .iter()
+        .map(|window| window.dataset.as_str())
+        .collect::<BTreeSet<_>>()
+        .len()
 }
 
 #[cfg(test)]
@@ -553,5 +585,42 @@ mod tests {
         assert!(gates
             .iter()
             .any(|gate| gate.id == "min_walk_forward_windows" && !gate.passed));
+    }
+
+    #[test]
+    fn duplicate_dataset_windows_do_not_satisfy_rolling_gate() {
+        let config = WalkForwardConfig {
+            run_dirs: vec![
+                PathBuf::from("/tmp/run-1"),
+                PathBuf::from("/tmp/run-2"),
+                PathBuf::from("/tmp/run-3"),
+            ],
+            min_windows: 3,
+            min_test_trades_per_window: 1,
+        };
+        let mut windows = vec![
+            window(1, 1.0, 1.0, 5, 0.4),
+            window(2, 1.0, 1.0, 5, 0.4),
+            window(3, 1.0, 1.0, 5, 0.4),
+        ];
+        for window in &mut windows {
+            window.dataset = "same-dataset".to_string();
+        }
+        let aggregate = aggregate_windows(&windows);
+        let gates = readiness_gates(&config, &windows, &aggregate);
+
+        assert!(gates
+            .iter()
+            .any(|gate| gate.id == "unique_dataset_windows" && !gate.passed));
+    }
+
+    #[test]
+    fn duplicate_run_dirs_are_rejected() {
+        let error =
+            ensure_unique_run_dirs(&[PathBuf::from("/tmp/run-1"), PathBuf::from("/tmp/run-1")])
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("duplicate walk-forward run dir"));
     }
 }

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -117,6 +117,23 @@ Use `--dry-run` to print the commands without running them, or
 `--phases coverage,attribution,baseline,hyperparameter,walk-forward` to run a
 subset in canonical order.
 
+When you already have completed workflow runs from prior rolling event-root
+datasets, pass them into the current run so the final gate evaluates multiple
+windows:
+
+```bash
+rtk cargo run -p ploy-research --example event_ml_workflow \
+  --features polars-export -- \
+  --dataset /tmp/ploy-event-root-window-3 \
+  --output-dir /tmp/ploy-event-ml-window-3 \
+  --walk-forward-run-dir /tmp/ploy-event-ml-window-1 \
+  --walk-forward-run-dir /tmp/ploy-event-ml-window-2
+```
+
+The current run is always included as one window. The extra run directories
+must point at distinct completed workflow runs; repeated run dirs or repeated
+dataset windows are treated as blocked evidence, not rolling validation.
+
 ## Phase 1 - Coverage Diagnostics
 
 Goal: decide whether the dataset is ready for ML, or whether feature coverage
@@ -392,6 +409,7 @@ The gate writes:
 Default readiness gates:
 
 - at least `3` workflow windows
+- at least `3` distinct event-root dataset windows
 - each window has at least one test trade
 - executable entry accounting is present: cost, ROI, and average entry
 - window-level drawdown is reported

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8407,3 +8407,23 @@ Checklist:
 
 Review:
 - 2026-04-24: Added `event_ml_walk_forward` plus `event_ml::walk_forward` to consume `workflow_report.json`, `hyperparameter/hyperparameter_search.json`, and the selected candidate's `baseline_metrics.json`. The report aggregates OOS test trades, PnL, ROI, weighted average entry, validation/test direction agreement, and window-level drawdown. The workflow runner now includes `walk_forward` after hyperparameter search and records readiness as `ready` or `blocked`; a single run is expected to be blocked by the `min_walk_forward_windows` gate, preserving the DL/RL deferral boundary.
+
+## Event ML Rolling Window Inputs
+
+Goal: let the workflow runner evaluate current and prior completed rolling windows together without letting duplicate runs fake DL/RL readiness.
+
+File ownership:
+- `crates/ploy-research/examples/event_ml_workflow.rs`
+- `crates/ploy-research/src/event_ml/walk_forward.rs`
+- `docs/runbooks/event-ml-automl-workflow.md`
+- `tasks/todo.md`
+
+Checklist:
+- [x] Add `--walk-forward-run-dir` and `--walk-forward-run-dirs` to `event_ml_workflow`.
+- [x] Include the current workflow run plus supplied prior runs in the walk-forward gate.
+- [x] Reject duplicate run dirs in the walk-forward builder.
+- [x] Block readiness when the windows do not come from distinct event-root datasets.
+- [x] Update runbook and skill guidance so agents do not duplicate a single run to pass the gate.
+
+Review:
+- 2026-04-24: Extended `event_ml_workflow` so a current workflow run can aggregate prior completed rolling windows with `--walk-forward-run-dir` or `--walk-forward-run-dirs`. The walk-forward builder now rejects duplicate run dirs and adds `unique_dataset_windows`, requiring distinct event-root dataset windows before DL/RL readiness can pass. This makes the next data job explicit: produce separate event-root workflow runs, then aggregate them through the gate.


### PR DESCRIPTION
## Summary
- add --walk-forward-run-dir and --walk-forward-run-dirs to event_ml_workflow
- include the current workflow run plus supplied prior runs in the walk-forward gate
- reject duplicate walk-forward run dirs
- add a unique_dataset_windows readiness gate so duplicated copies of one dataset cannot satisfy rolling evidence
- update runbook and task tracker for rolling workflow input usage

## Verification
- `rtk cargo check -p ploy-research --example event_ml_workflow --features polars-export`
- `rtk cargo check -p ploy-research --example event_ml_walk_forward`
- `rtk cargo test -p ploy-research --lib -- --nocapture`
- `rtk cargo test -p ploy-research event_ml::walk_forward --lib -- --nocapture`
- `rtk cargo test -p ploy-research --example event_ml_workflow --features polars-export -- --nocapture`
- copied the same workflow artifact into three dirs and verified walk-forward stayed `blocked` with missing gate `unique_dataset_windows`

## Notes
- This does not fabricate rolling evidence from the single 150-event smoke dataset.
- The next data step is to produce distinct event-root workflow runs, then pass prior run dirs into the current workflow.