### PR TITLE
Stage PM5D ThreeLayer live deployment

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -85,18 +85,21 @@ jobs:
       - name: Build deploy bundle
         run: |
           rm -rf dist
-          mkdir -p dist/bin dist/config/strategies dist/migrations dist/deployment/systemd dist/scripts
+          mkdir -p dist/bin dist/config/strategies dist/config/deployments dist/migrations dist/deployment/systemd dist/scripts dist/scripts/drills
           cp target/${PLATFORM_TARGET}/release/new-ploy-runner dist/bin/ploy-runner
           cp target/${PLATFORM_TARGET}/release/examples/factor_research dist/bin/factor-research
           cp target/${PLATFORM_TARGET}/release/examples/optimize_backtest dist/bin/optimize-backtest
           cp config/strategies/02-pm5d.unified.toml dist/config/strategies/02-pm5d.unified.toml
           cp config/strategies/02-pm5d.live.toml dist/config/strategies/02-pm5d.live.toml
           cp config/strategies/02-pm5d-threelayer.unified.toml dist/config/strategies/02-pm5d-threelayer.unified.toml
+          cp config/strategies/02-pm5d-threelayer.live.toml dist/config/strategies/02-pm5d-threelayer.live.toml
+          cp config/deployments/*.json dist/config/deployments/
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
           cp scripts/binance_lob_collector.py dist/scripts/binance_lob_collector.py
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
+          cp scripts/drills/*.sh dist/scripts/drills/
           for migration in ${DEPLOY_MIGRATIONS}; do
             migration="$(printf '%s' "${migration}" | xargs)"
             [ -n "${migration}" ] || continue
@@ -176,7 +179,7 @@ jobs:
 
       - name: Prepare remote directories
         run: |
-          ssh tango-1-1 "mkdir -p ${DEPLOY_ROOT}/bin ${DEPLOY_ROOT}/config/strategies ${DEPLOY_ROOT}/migrations ${DEPLOY_ROOT}/scripts ${DEPLOY_ROOT}/tmp"
+          ssh tango-1-1 "mkdir -p ${DEPLOY_ROOT}/bin ${DEPLOY_ROOT}/config/strategies ${DEPLOY_ROOT}/config/deployments ${DEPLOY_ROOT}/migrations ${DEPLOY_ROOT}/scripts ${DEPLOY_ROOT}/scripts/drills ${DEPLOY_ROOT}/tmp"
 
       - name: Pull bundle from OSS and restart services
         run: |
@@ -295,11 +298,14 @@ jobs:
             install -m 0644 ./config/strategies/02-pm5d.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.unified.toml
             install -m 0644 ./config/strategies/02-pm5d.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.live.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml
+            install -m 0644 ./config/strategies/02-pm5d-threelayer.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.live.toml
+            install -m 0644 ./config/deployments/*.json ${DEPLOY_ROOT}/config/deployments/
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py
             install -m 0755 ./scripts/binance_lob_collector.py ${DEPLOY_ROOT}/scripts/binance_lob_collector.py
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
+            install -m 0755 ./scripts/drills/*.sh ${DEPLOY_ROOT}/scripts/drills/
             for migration in ${DEPLOY_MIGRATIONS}; do
               migration="$(printf '%s' "\${migration}" | xargs)"
               [ -n "\${migration}" ] || continue

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -83,6 +83,7 @@ jobs:
           scp config/strategies/02-pm5d.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
           scp config/strategies/02-pm5d.live.toml ploy-trade-1:/opt/ploy/config/strategies/
           scp config/strategies/02-pm5d-threelayer.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
+          scp config/strategies/02-pm5d-threelayer.live.toml ploy-trade-1:/opt/ploy/config/strategies/
 
           ssh ploy-trade-1 bash <<'REMOTE'
             set -euo pipefail

--- a/config/deployments/pm5d.threelayer.live.json
+++ b/config/deployments/pm5d.threelayer.live.json
@@ -1,0 +1,8 @@
+{
+  "deployment_id": "pm5d.threelayer.live",
+  "bundle_id": "02-pm5d-threelayer.live",
+  "account_id": "acct-pm5d-dryrun",
+  "max_gross_exposure": "5.00",
+  "runtime_mode": "live",
+  "desired_state": "paused"
+}

--- a/config/strategies/02-pm5d-threelayer.live.toml
+++ b/config/strategies/02-pm5d-threelayer.live.toml
@@ -1,0 +1,64 @@
+# Three-layer scoring strategy - live config
+# Mirrors 02-pm5d-threelayer.unified.toml; only [runtime].mode differs.
+#
+# Scoring model: direction(50%) + edge(35%) + confirmation bonus(15%)
+# Entry when total_score > min_entry_score
+# OBI uses 5s EWMA smoothing for 10 Hz LOB data
+
+[runtime]
+strategy_variant = "three_layer"
+mode = "live"
+throttle_hz = 10
+
+[strategy]
+symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT", "BNBUSDT"]
+
+vol_floor = 0.001
+min_probability = 0.51
+min_z_score = 0.20
+
+min_entry_price = 0.10
+max_entry_price = 0.85
+no_trade_zone_min = 0.45
+no_trade_zone_max = 0.55
+
+min_edge = 0.0316
+
+min_time_remaining_secs = 69
+max_time_remaining_secs = 99
+cooldown_secs = 35
+
+stake_usd = 15.0
+max_positions = 1000
+max_daily_trades = 1000
+allowed_window_secs = [300, 900]
+
+# Optimized parameters (TPE 200 trials, train Apr 10-13, val Apr 14-15)
+# Train: Sharpe=137.8, 239 trades, +$5,743
+# Val:   Sharpe=141.7, 1017 trades, +$25,689
+three_layer_min_entry_score = 0.25
+three_layer_min_direction_prob = 0.6297
+three_layer_min_distance_over_sigma = 0.4622
+three_layer_min_confirmation_score = 0.2472
+three_layer_min_drift_confirmation = 0.000546
+three_layer_min_edge = 0.0316
+three_layer_min_reward_risk = 1.2630
+three_layer_take_profit_ask = 0.8437
+three_layer_stop_distance_pct = 0.0152
+three_layer_max_pm_lag_secs = 15
+
+[execution]
+use_spread = true
+spread_pct = 0.08
+enable_partial_fills = false
+min_fill_pct = 0.5
+enable_market_impact = true
+impact_coefficient = 0.1
+default_depth_shares = 500
+
+[reference_data]
+capture_sports_state = false
+
+[backtest_data]
+include_reference_prices = false
+include_sports_state = false

--- a/config/strategies/REGISTRY.md
+++ b/config/strategies/REGISTRY.md
@@ -86,6 +86,7 @@ numeric ID used as filename prefix.
 | File | Format | Notes |
 |------|--------|-------|
 | `02-pm5d-threelayer.unified.toml` | **UNIFIED** | Three-gate entry filter on top of directional |
+| `02-pm5d-threelayer.live.toml` | **UNIFIED** | Live twin of unified dry-run config; only `[runtime].mode` differs |
 
 ### S03 — Pattern Memory
 | File | Format | Notes |

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -592,10 +592,11 @@ venue = "sportsbook"
 
     #[test]
     fn roadmap_config_family_parses() {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let config_dir = manifest_dir.join("../../config/strategies");
+        let config_dir = strategy_config_dir();
 
         for file in [
+            "02-pm5d-threelayer.unified.toml",
+            "02-pm5d-threelayer.live.toml",
             "02-pm5d.v1-dryrun.toml",
             "02-pm5d.v1-live.toml",
             "02-pm5d.v2-dryrun.toml",
@@ -618,5 +619,43 @@ venue = "sportsbook"
                 "{file} should resolve to a runtime variant"
             );
         }
+    }
+
+    #[test]
+    fn threelayer_live_config_matches_dryrun_except_runtime_mode() {
+        let config_dir = strategy_config_dir();
+        let dryrun_path = config_dir.join("02-pm5d-threelayer.unified.toml");
+        let live_path = config_dir.join("02-pm5d-threelayer.live.toml");
+
+        let dryrun_body = std::fs::read_to_string(&dryrun_path).unwrap();
+        let live_body = std::fs::read_to_string(&live_path).unwrap();
+        let mut dryrun: toml::Value = toml::from_str(&dryrun_body).unwrap();
+        let live: toml::Value = toml::from_str(&live_body).unwrap();
+
+        assert_eq!(
+            dryrun
+                .get("runtime")
+                .and_then(|runtime| runtime.get("mode"))
+                .and_then(toml::Value::as_str),
+            Some("dryrun")
+        );
+        assert_eq!(
+            live.get("runtime")
+                .and_then(|runtime| runtime.get("mode"))
+                .and_then(toml::Value::as_str),
+            Some("live")
+        );
+
+        dryrun
+            .get_mut("runtime")
+            .and_then(toml::Value::as_table_mut)
+            .unwrap()
+            .insert("mode".to_string(), toml::Value::String("live".to_string()));
+        assert_eq!(dryrun, live);
+    }
+
+    fn strategy_config_dir() -> PathBuf {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest_dir.join("../../config/strategies")
     }
 }

--- a/docs/runbooks/live-deployment-checklist.md
+++ b/docs/runbooks/live-deployment-checklist.md
@@ -88,6 +88,24 @@ manually reviewed:
 - `ployctl trading status`
 - the most recent audit log entries
 
+## PM5D ThreeLayer Live Gate
+
+For the current PM5D ThreeLayer setup, stage the live deployment in paused mode:
+
+```bash
+/opt/ploy/scripts/drills/pm5d_threelayer_live_gate.sh
+```
+
+This verifies `02-pm5d-threelayer.live.toml` against the dry-run config, applies
+`pm5d.threelayer.live` with `desired_state=paused`, and stops before any live
+orders can be placed.
+
+Only after explicit operator approval, run:
+
+```bash
+/opt/ploy/scripts/drills/pm5d_threelayer_live_gate.sh --go-live
+```
+
 ## Not Covered By This Checklist
 
 This checklist does not:

--- a/scripts/drills/live_dry_run.sh
+++ b/scripts/drills/live_dry_run.sh
@@ -62,6 +62,17 @@ env_has_any_key() {
   return 1
 }
 
+first_env_value() {
+  local key
+  for key in "$@"; do
+    if env_has_key "$key"; then
+      grep -E "^[[:space:]]*${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- | tr -d '[:space:]'
+      return 0
+    fi
+  done
+  return 1
+}
+
 require_env_key() {
   local key="$1"
   env_has_key "$key" || fail "required env key missing from ${ENV_FILE}: ${key}"
@@ -189,12 +200,20 @@ require_any_env_key "operator credential" \
 if ! env_has_key "PLOY_OPERATOR_TOKEN" && ! env_has_key "PLOY_API_OPERATOR_TOKEN"; then
   warn "operator token not configured; dry-run will rely on admin credentials"
 fi
-require_env_key "POLYMARKET_PRIVATE_KEY"
-if env_has_key "POLY_SIGNATURE_TYPE"; then
-  SIGNATURE_TYPE="$(grep -E '^[[:space:]]*POLY_SIGNATURE_TYPE=' "${ENV_FILE}" | tail -n 1 | cut -d= -f2- | tr -d '[:space:]')"
+require_any_env_key "Polymarket private key" "POLYMARKET_PRIVATE_KEY" "PRIVATE_KEY"
+SIGNATURE_TYPE="$(first_env_value "POLY_SIGNATURE_TYPE" "POLYMARKET_SIGNATURE_TYPE" || true)"
+FUNDER_PRESENT=0
+if env_has_any_key "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"; then
+  FUNDER_PRESENT=1
+fi
+if [[ -n "${SIGNATURE_TYPE}" ]]; then
   if [[ "${SIGNATURE_TYPE}" == "proxy" || "${SIGNATURE_TYPE}" == "gnosis_safe" ]]; then
-    require_env_key "POLY_FUNDER"
+    require_any_env_key "proxy funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
+  elif [[ "${SIGNATURE_TYPE}" != "eoa" ]]; then
+    fail "unsupported POLY_SIGNATURE_TYPE: ${SIGNATURE_TYPE}"
   fi
+elif [[ "${FUNDER_PRESENT}" -eq 1 ]]; then
+  warn "POLY_SIGNATURE_TYPE is not explicit; current SDK defaults to proxy when a funder is present"
 fi
 [[ -f "${STATE_ROOT}/deployments.json" ]] || fail "missing deployments state file: ${STATE_ROOT}/deployments.json"
 [[ -f "${RUNTIME_ROOT}/system-status.json" ]] || fail "missing system status snapshot: ${RUNTIME_ROOT}/system-status.json"

--- a/scripts/drills/pm5d_threelayer_live_gate.sh
+++ b/scripts/drills/pm5d_threelayer_live_gate.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST_ROOT="/opt/ploy"
+ADDR="http://127.0.0.1:8081"
+MANIFEST=""
+DRYRUN_CONFIG=""
+LIVE_CONFIG=""
+DEPLOYMENT_ID=""
+GO_LIVE=0
+RUN_DRY_RUN_DRILL=1
+WARNINGS=0
+
+usage() {
+  cat <<'EOF'
+Usage: pm5d_threelayer_live_gate.sh [--go-live] [--host-root /opt/ploy] [--addr http://127.0.0.1:8081]
+
+Prepares the PM5D ThreeLayer live deployment on a Tango host.
+
+Default behavior:
+  - verify daemon, env, manifest, and live/dry-run config parity
+  - run the existing paper live-dry-run drill when available
+  - apply pm5d.threelayer.live with desired_state=paused
+  - stop before placing any live orders
+
+With --go-live:
+  - perform the same checks
+  - apply the paused live manifest
+  - resume pm5d.threelayer.live
+
+The script never edits /opt/ploy/.env and never changes strategy parameters.
+EOF
+}
+
+log_step() {
+  printf '\n[%s] %s\n' "step" "$1"
+}
+
+note() {
+  printf '[info] %s\n' "$1"
+}
+
+warn() {
+  printf '[warn] %s\n' "$1"
+  WARNINGS=$((WARNINGS + 1))
+}
+
+fail() {
+  printf '[fail] %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+env_has_key() {
+  local key="$1"
+  grep -Eq "^[[:space:]]*${key}=" "$ENV_FILE"
+}
+
+env_has_any_key() {
+  local key
+  for key in "$@"; do
+    if env_has_key "$key"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+require_env_key() {
+  local key="$1"
+  env_has_key "$key" || fail "required env key missing from ${ENV_FILE}: ${key}"
+}
+
+require_any_env_key() {
+  local label="$1"
+  shift
+  env_has_any_key "$@" || fail "required ${label} missing from ${ENV_FILE}: one of [$*]"
+}
+
+first_env_value() {
+  local key
+  for key in "$@"; do
+    if env_has_key "$key"; then
+      grep -E "^[[:space:]]*${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2- | tr -d '[:space:]'
+      return 0
+    fi
+  done
+  return 1
+}
+
+source_env_file() {
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+}
+
+extract_manifest_field() {
+  local field="$1"
+  python3 - "$MANIFEST" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    value = json.load(handle)[sys.argv[2]]
+print(value)
+PY
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --go-live)
+      GO_LIVE=1
+      shift
+      ;;
+    --host-root)
+      HOST_ROOT="$2"
+      shift 2
+      ;;
+    --addr)
+      ADDR="$2"
+      shift 2
+      ;;
+    --manifest)
+      MANIFEST="$2"
+      shift 2
+      ;;
+    --dryrun-config)
+      DRYRUN_CONFIG="$2"
+      shift 2
+      ;;
+    --live-config)
+      LIVE_CONFIG="$2"
+      shift 2
+      ;;
+    --skip-dry-run-drill)
+      RUN_DRY_RUN_DRILL=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+PLOYCTL="${HOST_ROOT}/bin/ployctl"
+ENV_FILE="${HOST_ROOT}/.env"
+MANIFEST="${MANIFEST:-${HOST_ROOT}/config/deployments/pm5d.threelayer.live.json}"
+DRYRUN_CONFIG="${DRYRUN_CONFIG:-${HOST_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml}"
+LIVE_CONFIG="${LIVE_CONFIG:-${HOST_ROOT}/config/strategies/02-pm5d-threelayer.live.toml}"
+
+require_command systemctl
+require_command curl
+require_command python3
+[[ -x "$PLOYCTL" ]] || fail "missing ployctl binary: $PLOYCTL"
+[[ -f "$ENV_FILE" ]] || fail "missing env file: $ENV_FILE"
+[[ -f "$MANIFEST" ]] || fail "missing live manifest: $MANIFEST"
+[[ -f "$DRYRUN_CONFIG" ]] || fail "missing dry-run config: $DRYRUN_CONFIG"
+[[ -f "$LIVE_CONFIG" ]] || fail "missing live config: $LIVE_CONFIG"
+
+DEPLOYMENT_ID="${DEPLOYMENT_ID:-$(extract_manifest_field deployment_id)}"
+[[ -n "$DEPLOYMENT_ID" ]] || fail "deployment id could not be determined"
+
+source_env_file
+
+log_step "daemon baseline"
+[[ "$(systemctl is-active ployd)" == "active" ]] || fail "ployd.service is not active"
+curl -fsS "${ADDR}/health" >/dev/null
+STATUS_OUTPUT="$("$PLOYCTL" system status)"
+ALERTS_OUTPUT="$("$PLOYCTL" system alerts)"
+TRADING_OUTPUT="$("$PLOYCTL" trading status)"
+printf '%s\n' "$STATUS_OUTPUT"
+printf '%s\n' "$ALERTS_OUTPUT"
+printf '%s\n' "$TRADING_OUTPUT"
+
+if [[ "$ALERTS_OUTPUT" != "none" ]]; then
+  if printf '%s\n' "$ALERTS_OUTPUT" | grep -q ' critical '; then
+    fail "critical alerts are active"
+  fi
+  warn "non-critical alerts are active"
+fi
+
+log_step "credential presence"
+require_any_env_key "Polymarket private key" "POLYMARKET_PRIVATE_KEY" "PRIVATE_KEY"
+SIGNATURE_TYPE="$(first_env_value "POLY_SIGNATURE_TYPE" "POLYMARKET_SIGNATURE_TYPE" || true)"
+FUNDER_PRESENT=0
+if env_has_any_key "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"; then
+  FUNDER_PRESENT=1
+fi
+case "$SIGNATURE_TYPE" in
+  proxy|gnosis_safe)
+    require_any_env_key "proxy funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
+    ;;
+  eoa)
+    ;;
+  "")
+    if [[ "$FUNDER_PRESENT" -eq 1 ]]; then
+      warn "POLY_SIGNATURE_TYPE is not explicit; current SDK defaults to proxy when a funder is present"
+    else
+      warn "POLY_SIGNATURE_TYPE and funder are absent; current SDK defaults to eoa"
+    fi
+    ;;
+  *)
+    fail "unsupported POLY_SIGNATURE_TYPE: $SIGNATURE_TYPE"
+    ;;
+esac
+
+log_step "manifest and config parity"
+python3 - "$MANIFEST" "$DRYRUN_CONFIG" "$LIVE_CONFIG" "$GO_LIVE" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+manifest_path = pathlib.Path(sys.argv[1])
+dryrun_path = pathlib.Path(sys.argv[2])
+live_path = pathlib.Path(sys.argv[3])
+go_live = sys.argv[4] == "1"
+
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+if manifest.get("deployment_id") != "pm5d.threelayer.live":
+    raise SystemExit("manifest deployment_id must be pm5d.threelayer.live")
+if manifest.get("bundle_id") != "02-pm5d-threelayer.live":
+    raise SystemExit("manifest bundle_id must be 02-pm5d-threelayer.live")
+if manifest.get("runtime_mode") != "live":
+    raise SystemExit("manifest runtime_mode must be live")
+if manifest.get("desired_state") != "paused":
+    raise SystemExit("manifest desired_state must stay paused; --go-live resumes explicitly")
+
+dryrun = dryrun_path.read_text(encoding="utf-8")
+live = live_path.read_text(encoding="utf-8")
+if not re.search(r'(?m)^mode = "dryrun"$', dryrun):
+    raise SystemExit("dry-run config must contain mode = \"dryrun\"")
+if not re.search(r'(?m)^mode = "live"$', live):
+    raise SystemExit("live config must contain mode = \"live\"")
+
+def material_config(text):
+    return "\n".join(
+        line.rstrip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+normalized = re.sub(r'(?m)^mode = "dryrun"$', 'mode = "live"', dryrun, count=1)
+if material_config(normalized) != material_config(live):
+    raise SystemExit("live config must match dry-run config exactly except [runtime].mode")
+
+if go_live:
+    print("manifest/config gate: go-live requested")
+else:
+    print("manifest/config gate: paused apply only")
+PY
+
+if [[ "$RUN_DRY_RUN_DRILL" -eq 1 && -x "${HOST_ROOT}/scripts/drills/live_dry_run.sh" ]]; then
+  log_step "paper live-host drill"
+  "${HOST_ROOT}/scripts/drills/live_dry_run.sh"
+elif [[ "$RUN_DRY_RUN_DRILL" -eq 1 ]]; then
+  warn "paper drill script not found or not executable; skipping ${HOST_ROOT}/scripts/drills/live_dry_run.sh"
+fi
+
+log_step "apply paused live deployment"
+APPLY_OUTPUT="$("$PLOYCTL" deployments apply "$MANIFEST")"
+printf '%s\n' "$APPLY_OUTPUT"
+INSPECT_OUTPUT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
+printf '%s\n' "$INSPECT_OUTPUT"
+printf '%s\n' "$INSPECT_OUTPUT" | grep -q 'desired=Paused' || fail "live deployment was not applied as paused"
+
+if [[ "$GO_LIVE" -ne 1 ]]; then
+  log_step "result"
+  if [[ "$WARNINGS" -gt 0 ]]; then
+    printf 'READY-WITH-WARNINGS: %s is staged paused; review warnings before --go-live.\n' "$DEPLOYMENT_ID"
+  else
+    printf 'READY: %s is staged paused. Run with --go-live only after manual live approval.\n' "$DEPLOYMENT_ID"
+  fi
+  exit 0
+fi
+
+log_step "resume live deployment"
+RESUME_OUTPUT="$("$PLOYCTL" deployments resume "$DEPLOYMENT_ID")"
+printf '%s\n' "$RESUME_OUTPUT"
+FINAL_INSPECT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
+printf '%s\n' "$FINAL_INSPECT"
+printf '%s\n' "$FINAL_INSPECT" | grep -q 'desired=Running' || fail "live deployment did not enter desired=Running"
+
+log_step "result"
+printf 'LIVE: %s resume command accepted. Watch ployctl trading status and worker logs immediately.\n' "$DEPLOYMENT_ID"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# PM5D ThreeLayer Live Readiness (2026-04-24)
+
+## Files
+
+- `config/strategies/02-pm5d-threelayer.live.toml`
+- `config/deployments/pm5d.threelayer.live.json`
+- `scripts/drills/live_dry_run.sh`
+- `scripts/drills/pm5d_threelayer_live_gate.sh`
+- `.github/workflows/deploy-tango-1-1.yml`
+- `crates/ploy-strategy-bundles/src/config.rs`
+
+## Tasks
+
+- [x] Mirror the current `pm5d.threelayer.dryrun` strategy settings into a live-only config with only `[runtime].mode` changed.
+- [x] Add a paused live deployment manifest so applying it cannot start real orders until an explicit resume.
+- [x] Add a Tango-side live gate script that runs readiness checks and requires an explicit `--go-live` before resume.
+- [x] Ensure the Tango deploy workflow ships the live config, manifests, and drill scripts.
+- [x] Verify config parity and manifest parsing with targeted tests/checks.
+
+## Review
+
+- 2026-04-24: Remote registry read on `tango-1-1` showed current `pm5d.threelayer.dryrun` as `bundle_id=02-pm5d-threelayer.unified`, `account_id=acct-pm5d-dryrun`, `max_gross_exposure=5.00`, `runtime_mode=dryrun`, `desired_state=running`; live manifest mirrors those non-live fields and stays paused.
+- 2026-04-24: Local verification passed: `bash -n scripts/drills/live_dry_run.sh`, `bash -n scripts/drills/pm5d_threelayer_live_gate.sh`, JSON manifest parse, live/dry-run config parity check, workflow YAML parse, `git diff --check` for touched files, `rtk cargo test -p ploy-strategy-bundles threelayer_live_config_matches_dryrun_except_runtime_mode --lib`, and `rtk cargo test -p ploy-strategy-bundles roadmap_config_family_parses --lib`.
+- 2026-04-24: `cargo fmt --check --package ploy-strategy-bundles` still reports unrelated existing formatting drift in strategy/feed/test files outside this live-readiness slice.
+
 # Live Order Execution Management (2026-04-24)
 
 ## Files


### PR DESCRIPTION
## Summary
- add a ThreeLayer live config that mirrors the dry-run config except for runtime mode
- add a paused live deployment manifest and Tango live gate script
- ship live configs/manifests/drill scripts through deploy workflows

## Verification
- bash -n scripts/drills/live_dry_run.sh
- bash -n scripts/drills/pm5d_threelayer_live_gate.sh
- JSON manifest parse and live/dry-run parity script
- workflow YAML parse
- git diff --check
- rtk cargo test -p ploy-strategy-bundles threelayer_live_config_matches_dryrun_except_runtime_mode --lib
- rtk cargo test -p ploy-strategy-bundles roadmap_config_family_parses --lib

## Not Tested
- Full cargo fmt: existing unrelated ploy-strategy-bundles files fail fmt --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PM5D three-layer live trading strategy configuration is now available with paused startup mode for operator safety.
  * Deployment workflow enhanced to package and install strategy configurations and validation tools.

* **Documentation**
  * Added operator runbook with step-by-step procedures for PM5D three-layer live strategy deployment and activation.

* **Chores**
  * Added pre-deployment validation script for health checks and configuration consistency verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->