### PR TITLE
Fix live gate status parsing

### DIFF
--- a/scripts/drills/live_dry_run.sh
+++ b/scripts/drills/live_dry_run.sh
@@ -47,6 +47,16 @@ extract_value() {
   printf '%s\n' "$line" | tr ' ' '\n' | awk -F= -v k="$key" '$1 == k { print $2 }'
 }
 
+strip_blank_lines() {
+  printf '%s\n' "$1" | tr -d '\r' | sed '/^[[:space:]]*$/d'
+}
+
+normalize_status_value() {
+  local value="$1"
+  value="${value%%@*}"
+  printf '%s\n' "$value"
+}
+
 env_has_key() {
   local key="$1"
   grep -Eq "^[[:space:]]*${key}=" "$ENV_FILE"
@@ -166,7 +176,7 @@ printf '%s\n' "${METRICS_OUTPUT}"
 printf '%s\n' "${ALERTS_OUTPUT}"
 printf '%s\n' "${AUDIT_OUTPUT}"
 
-SYSTEM_STATE="$(extract_value "${STATUS_OUTPUT}" "status")"
+SYSTEM_STATE="$(normalize_status_value "$(extract_value "${STATUS_OUTPUT}" "status")")"
 case "${SYSTEM_STATE}" in
   running)
     ;;
@@ -178,8 +188,9 @@ case "${SYSTEM_STATE}" in
     ;;
 esac
 
-if [[ "${ALERTS_OUTPUT}" != "none" ]]; then
-  if printf '%s\n' "${ALERTS_OUTPUT}" | grep -q ' critical '; then
+ALERTS_NORMALIZED="$(strip_blank_lines "${ALERTS_OUTPUT}")"
+if [[ "${ALERTS_NORMALIZED}" != "none" ]]; then
+  if printf '%s\n' "${ALERTS_NORMALIZED}" | grep -q ' critical '; then
     fail "critical alerts are active"
   fi
   warn "non-critical alerts are active"

--- a/scripts/drills/pm5d_threelayer_live_gate.sh
+++ b/scripts/drills/pm5d_threelayer_live_gate.sh
@@ -54,6 +54,10 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
 }
 
+strip_blank_lines() {
+  printf '%s\n' "$1" | tr -d '\r' | sed '/^[[:space:]]*$/d'
+}
+
 env_has_key() {
   local key="$1"
   grep -Eq "^[[:space:]]*${key}=" "$ENV_FILE"
@@ -180,8 +184,9 @@ printf '%s\n' "$STATUS_OUTPUT"
 printf '%s\n' "$ALERTS_OUTPUT"
 printf '%s\n' "$TRADING_OUTPUT"
 
-if [[ "$ALERTS_OUTPUT" != "none" ]]; then
-  if printf '%s\n' "$ALERTS_OUTPUT" | grep -q ' critical '; then
+ALERTS_NORMALIZED="$(strip_blank_lines "$ALERTS_OUTPUT")"
+if [[ "$ALERTS_NORMALIZED" != "none" ]]; then
+  if printf '%s\n' "$ALERTS_NORMALIZED" | grep -q ' critical '; then
     fail "critical alerts are active"
   fi
   warn "non-critical alerts are active"
@@ -270,7 +275,10 @@ APPLY_OUTPUT="$("$PLOYCTL" deployments apply "$MANIFEST")"
 printf '%s\n' "$APPLY_OUTPUT"
 INSPECT_OUTPUT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
 printf '%s\n' "$INSPECT_OUTPUT"
-printf '%s\n' "$INSPECT_OUTPUT" | grep -q 'desired=Paused' || fail "live deployment was not applied as paused"
+case "$INSPECT_OUTPUT" in
+  *"desired=Paused"*) ;;
+  *) fail "live deployment was not applied as paused" ;;
+esac
 
 if [[ "$GO_LIVE" -ne 1 ]]; then
   log_step "result"
@@ -287,7 +295,10 @@ RESUME_OUTPUT="$("$PLOYCTL" deployments resume "$DEPLOYMENT_ID")"
 printf '%s\n' "$RESUME_OUTPUT"
 FINAL_INSPECT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
 printf '%s\n' "$FINAL_INSPECT"
-printf '%s\n' "$FINAL_INSPECT" | grep -q 'desired=Running' || fail "live deployment did not enter desired=Running"
+case "$FINAL_INSPECT" in
+  *"desired=Running"*) ;;
+  *) fail "live deployment did not enter desired=Running" ;;
+esac
 
 log_step "result"
 printf 'LIVE: %s resume command accepted. Watch ployctl trading status and worker logs immediately.\n' "$DEPLOYMENT_ID"


### PR DESCRIPTION
## Summary
- Accept ployctl daemon status values with an address suffix such as `running@127.0.0.1:8081`.
- Normalize blank-line-only alert output before deciding whether alerts are active.
- Replace pipefail-sensitive grep assertions with shell pattern checks for paused/resumed deployment state.

## Verification
- `bash -n scripts/drills/live_dry_run.sh scripts/drills/pm5d_threelayer_live_gate.sh`
- Mocked live gate with `status=running@127.0.0.1:8081` and `desired=Paused`
- Mocked live_dry_run drill with `status=running@127.0.0.1:8081` and blank-line alerts
- `git diff --check`