### PR TITLE
Capture ployctl output in live gate scripts

### DIFF
--- a/scripts/drills/live_dry_run.sh
+++ b/scripts/drills/live_dry_run.sh
@@ -41,6 +41,14 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
 }
 
+ployctl_capture() {
+  "$PLOYCTL" "$@" 2>&1
+}
+
+ployctl_quiet() {
+  "$PLOYCTL" "$@" >/dev/null 2>&1
+}
+
 extract_value() {
   local line="$1"
   local key="$2"
@@ -104,7 +112,7 @@ source_env_file() {
 cleanup() {
   if [[ "$DRILL_APPLIED" -eq 1 ]]; then
     note "stopping drill deployment ${DEPLOYMENT_ID}"
-    "$PLOYCTL" deployments stop "$DEPLOYMENT_ID" >/dev/null 2>&1 || true
+    ployctl_quiet deployments stop "$DEPLOYMENT_ID" || true
   fi
 }
 
@@ -167,10 +175,10 @@ source_env_file
 log_step "daemon baseline"
 [[ "$(systemctl is-active ployd)" == "active" ]] || fail "ployd.service is not active"
 curl -fsS "${ADDR}/health" >/dev/null
-STATUS_OUTPUT="$("${PLOYCTL}" system status)"
-METRICS_OUTPUT="$("${PLOYCTL}" system metrics)"
-ALERTS_OUTPUT="$("${PLOYCTL}" system alerts)"
-AUDIT_OUTPUT="$("${PLOYCTL}" system audit)"
+STATUS_OUTPUT="$(ployctl_capture system status)"
+METRICS_OUTPUT="$(ployctl_capture system metrics)"
+ALERTS_OUTPUT="$(ployctl_capture system alerts)"
+AUDIT_OUTPUT="$(ployctl_capture system audit)"
 printf '%s\n' "${STATUS_OUTPUT}"
 printf '%s\n' "${METRICS_OUTPUT}"
 printf '%s\n' "${ALERTS_OUTPUT}"
@@ -233,21 +241,21 @@ fi
 [[ -f "${RUNTIME_ROOT}/audit-log.jsonl" ]] || fail "missing audit log: ${RUNTIME_ROOT}/audit-log.jsonl"
 
 log_step "paper deployment drill"
-APPLY_OUTPUT="$("${PLOYCTL}" deployments apply "${MANIFEST}")"
+APPLY_OUTPUT="$(ployctl_capture deployments apply "${MANIFEST}")"
 DRILL_APPLIED=1
 printf '%s\n' "${APPLY_OUTPUT}"
-INSPECT_OUTPUT="$("${PLOYCTL}" deployments inspect "${DEPLOYMENT_ID}")"
+INSPECT_OUTPUT="$(ployctl_capture deployments inspect "${DEPLOYMENT_ID}")"
 printf '%s\n' "${INSPECT_OUTPUT}"
-"${PLOYCTL}" deployments pause "${DEPLOYMENT_ID}" >/dev/null
-"${PLOYCTL}" deployments resume "${DEPLOYMENT_ID}" >/dev/null
-"${PLOYCTL}" deployments stop "${DEPLOYMENT_ID}" >/dev/null
+ployctl_quiet deployments pause "${DEPLOYMENT_ID}"
+ployctl_quiet deployments resume "${DEPLOYMENT_ID}"
+ployctl_quiet deployments stop "${DEPLOYMENT_ID}"
 DRILL_APPLIED=0
 
-FINAL_INSPECT="$("${PLOYCTL}" deployments inspect "${DEPLOYMENT_ID}")"
+FINAL_INSPECT="$(ployctl_capture deployments inspect "${DEPLOYMENT_ID}")"
 printf '%s\n' "${FINAL_INSPECT}"
 
 log_step "trading readiness"
-TRADING_OUTPUT="$("${PLOYCTL}" trading status)"
+TRADING_OUTPUT="$(ployctl_capture trading status)"
 printf '%s\n' "${TRADING_OUTPUT}"
 
 LIVE_RECONCILE_FAILURES="$(extract_value "${STATUS_OUTPUT}" "live_reconcile_failures")"

--- a/scripts/drills/pm5d_threelayer_live_gate.sh
+++ b/scripts/drills/pm5d_threelayer_live_gate.sh
@@ -54,6 +54,10 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
 }
 
+ployctl_capture() {
+  "$PLOYCTL" "$@" 2>&1
+}
+
 strip_blank_lines() {
   printf '%s\n' "$1" | tr -d '\r' | sed '/^[[:space:]]*$/d'
 }
@@ -177,9 +181,9 @@ source_env_file
 log_step "daemon baseline"
 [[ "$(systemctl is-active ployd)" == "active" ]] || fail "ployd.service is not active"
 curl -fsS "${ADDR}/health" >/dev/null
-STATUS_OUTPUT="$("$PLOYCTL" system status)"
-ALERTS_OUTPUT="$("$PLOYCTL" system alerts)"
-TRADING_OUTPUT="$("$PLOYCTL" trading status)"
+STATUS_OUTPUT="$(ployctl_capture system status)"
+ALERTS_OUTPUT="$(ployctl_capture system alerts)"
+TRADING_OUTPUT="$(ployctl_capture trading status)"
 printf '%s\n' "$STATUS_OUTPUT"
 printf '%s\n' "$ALERTS_OUTPUT"
 printf '%s\n' "$TRADING_OUTPUT"
@@ -271,9 +275,9 @@ elif [[ "$RUN_DRY_RUN_DRILL" -eq 1 ]]; then
 fi
 
 log_step "apply paused live deployment"
-APPLY_OUTPUT="$("$PLOYCTL" deployments apply "$MANIFEST")"
+APPLY_OUTPUT="$(ployctl_capture deployments apply "$MANIFEST")"
 printf '%s\n' "$APPLY_OUTPUT"
-INSPECT_OUTPUT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
+INSPECT_OUTPUT="$(ployctl_capture deployments inspect "$DEPLOYMENT_ID")"
 printf '%s\n' "$INSPECT_OUTPUT"
 case "$INSPECT_OUTPUT" in
   *"desired=Paused"*) ;;
@@ -291,9 +295,9 @@ if [[ "$GO_LIVE" -ne 1 ]]; then
 fi
 
 log_step "resume live deployment"
-RESUME_OUTPUT="$("$PLOYCTL" deployments resume "$DEPLOYMENT_ID")"
+RESUME_OUTPUT="$(ployctl_capture deployments resume "$DEPLOYMENT_ID")"
 printf '%s\n' "$RESUME_OUTPUT"
-FINAL_INSPECT="$("$PLOYCTL" deployments inspect "$DEPLOYMENT_ID")"
+FINAL_INSPECT="$(ployctl_capture deployments inspect "$DEPLOYMENT_ID")"
 printf '%s\n' "$FINAL_INSPECT"
 case "$FINAL_INSPECT" in
   *"desired=Running"*) ;;


### PR DESCRIPTION
## Summary
- Capture ployctl output from stderr for readiness decisions.
- Keep cleanup/control calls quiet across both stdout and stderr.
- Preserve paused-by-default live gate behavior.

## Verification
- `bash -n scripts/drills/live_dry_run.sh scripts/drills/pm5d_threelayer_live_gate.sh`
- Mocked pm5d live gate with ployctl output only on stderr, `status=running@127.0.0.1:8081`, blank-line alerts, and `desired=Paused`
- Mocked live_dry_run with ployctl output only on stderr and the same status/alerts shape
- `git diff --check`