### PR TITLE
Surface dry-run/live order parity in frontend

### DIFF
--- a/.github/workflows/deploy-frontend-tango-1-1.yml
+++ b/.github/workflows/deploy-frontend-tango-1-1.yml
@@ -1,0 +1,108 @@
+name: Deploy frontend to tango-1-1
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to deploy (branch, tag, or SHA)"
+        required: true
+        default: "main"
+
+concurrency:
+  group: deploy-frontend-tango-1-1-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+
+jobs:
+  build-and-deploy-frontend:
+    name: Build and deploy frontend to tango-1-1
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ploy-frontend/package-lock.json
+
+      - name: Build frontend
+        run: |
+          npm ci --prefix ploy-frontend
+          npm run contracts:check --prefix ploy-frontend
+          npm run build --prefix ploy-frontend
+          tar -C ploy-frontend/dist -czf ploy-frontend-dist.tar.gz .
+
+      - name: Configure SSH for deploy
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Prepare remote directory
+        run: |
+          ssh tango-1-1 "mkdir -p ${DEPLOY_ROOT}/tmp"
+
+      - name: Upload frontend bundle
+        run: |
+          scp ploy-frontend-dist.tar.gz tango-1-1:${DEPLOY_ROOT}/tmp/ploy-frontend-dist.tar.gz
+          scp deployment/nginx/ploy-frontend.conf tango-1-1:${DEPLOY_ROOT}/tmp/ploy-frontend.nginx
+
+      - name: Install frontend and reload nginx
+        run: |
+          ssh tango-1-1 /bin/bash <<EOF
+            set -euo pipefail
+
+            mkdir -p "${DEPLOY_ROOT}/tmp" "${DEPLOY_ROOT}/frontend.next"
+            rm -rf "${DEPLOY_ROOT}/frontend.next"
+            mkdir -p "${DEPLOY_ROOT}/frontend.next"
+            tar -C "${DEPLOY_ROOT}/frontend.next" -xzf "${DEPLOY_ROOT}/tmp/ploy-frontend-dist.tar.gz"
+
+            rm -rf "${DEPLOY_ROOT}/frontend.prev"
+            if [ -d "${DEPLOY_ROOT}/frontend" ]; then
+              mv "${DEPLOY_ROOT}/frontend" "${DEPLOY_ROOT}/frontend.prev"
+            fi
+            mv "${DEPLOY_ROOT}/frontend.next" "${DEPLOY_ROOT}/frontend"
+
+            install -m 0644 "${DEPLOY_ROOT}/tmp/ploy-frontend.nginx" /etc/nginx/sites-available/ploy-report
+            ln -sfn /etc/nginx/sites-available/ploy-report /etc/nginx/sites-enabled/ploy-report
+            nginx -t
+            systemctl reload nginx
+
+            curl -fsS http://127.0.0.1/ >/dev/null
+            curl -fsS http://127.0.0.1/parity >/dev/null
+            curl -fsS http://127.0.0.1/api/system/status >/dev/null
+          EOF
+
+      - name: Deployment summary
+        run: |
+          echo "## Frontend deployment to tango-1-1" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: \`${{ secrets.TANGO_1_1_HOST }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Root: \`${DEPLOY_ROOT}/frontend\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Nginx: \`/etc/nginx/sites-available/ploy-report\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Runtime impact: frontend static files only; no ployd restart" >> "$GITHUB_STEP_SUMMARY"

--- a/deployment/nginx/ploy-frontend.conf
+++ b/deployment/nginx/ploy-frontend.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    root /opt/ploy/frontend;
+    index index.html;
+
+    location /api/ {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+        proxy_pass http://127.0.0.1:8081/api/;
+    }
+
+    location = /reports/strategy {
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:8081/reports/strategy;
+    }
+
+    location = /reports/strategy/ {
+        return 301 /reports/strategy;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/ploy-frontend/.eslintrc.cjs
+++ b/ploy-frontend/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'src/types/operator-contracts.ts'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {

--- a/ploy-frontend/src/App.tsx
+++ b/ploy-frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/Layout';
 import { Dashboard } from '@/pages/Dashboard';
 import { TradeHistory } from '@/pages/TradeHistory';
 import { LiveMonitor } from '@/pages/LiveMonitor';
+import { LiveParity } from '@/pages/LiveParity';
 import { StrategyMonitor } from '@/pages/StrategyMonitor';
 import { SystemControl } from '@/pages/SystemControl';
 import { SecurityAudit } from '@/pages/SecurityAudit';
@@ -97,6 +98,7 @@ function App() {
             <Route index element={<Dashboard />} />
             <Route path="trades" element={<TradeHistory />} />
             <Route path="monitor" element={<LiveMonitor />} />
+            <Route path="parity" element={<LiveParity />} />
             <Route path="deployments" element={<StrategyMonitor />} />
             <Route path="monitor-strategy" element={<StrategyMonitor />} />
             <Route path="nba-swing" element={<NBASwingMonitor />} />

--- a/ploy-frontend/src/components/Layout.tsx
+++ b/ploy-frontend/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { api } from '@/services/api';
+import { LiveParityBanner } from '@/components/LiveParityBanner';
 import { useStore } from '@/store';
 import {
   LayoutDashboard,
@@ -13,6 +14,7 @@ import {
   Shield,
   TrendingUp,
   ShieldAlert,
+  GitCompare,
 } from 'lucide-react';
 
 function getErrorMessage(error: unknown, fallback: string) {
@@ -27,6 +29,7 @@ const navigation = [
   { name: '仪表盘', href: '/', icon: LayoutDashboard },
   { name: '交易历史', href: '/trades', icon: History },
   { name: '实时日志', href: '/monitor', icon: Activity },
+  { name: 'Dry/Live 对比', href: '/parity', icon: GitCompare },
   { name: '部署控制', href: '/deployments', icon: Target },
   { name: 'NBA Legacy', href: '/nba-swing', icon: TrendingUp },
   { name: 'Risk Monitor', href: '/risk', icon: ShieldAlert },
@@ -212,6 +215,7 @@ export function Layout() {
 
       {/* Main content */}
       <div className="flex-1 overflow-auto">
+        <LiveParityBanner />
         <Outlet />
       </div>
     </div>

--- a/ploy-frontend/src/components/LiveParityBanner.tsx
+++ b/ploy-frontend/src/components/LiveParityBanner.tsx
@@ -1,0 +1,43 @@
+import { AlertTriangle, ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/Badge';
+import { buildLiveParityReport } from '@/lib/liveParity';
+import { useStore } from '@/store';
+
+export function LiveParityBanner() {
+  const tradingSnapshots = useStore((state) => state.tradingSnapshots);
+  const report = buildLiveParityReport(tradingSnapshots);
+
+  if (report.alertPairs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-destructive/25 bg-destructive/10 px-6 py-3 text-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex min-w-0 items-center gap-2 font-semibold text-destructive">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>Dry-run 已下单，Live 未同步下单</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
+          {report.alertPairs.slice(0, 3).map((pair) => (
+            <Badge key={pair.key} variant="destructive">
+              {pair.key}: {pair.dryrunOnlyOrders.length}
+            </Badge>
+          ))}
+          {report.alertPairs.length > 3 && (
+            <Badge variant="outline">+{report.alertPairs.length - 3}</Badge>
+          )}
+        </div>
+        <Link
+          to="/parity"
+          className="ml-auto inline-flex items-center gap-1 font-medium text-destructive underline-offset-4 hover:underline"
+        >
+          查看对比
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ploy-frontend/src/lib/liveParity.ts
+++ b/ploy-frontend/src/lib/liveParity.ts
@@ -1,0 +1,235 @@
+import type {
+  OrderSnapshot,
+  TradingIntentSnapshot,
+  TradingStateSnapshot,
+} from '@/types/operator-contracts';
+
+type RuntimeBucket = 'dryrun' | 'live';
+
+export interface SnapshotSummary {
+  activeOrders: number;
+  fills: number;
+  grossExposure: string;
+  intents: number;
+  orders: number;
+  positions: number;
+  reservedExposure: string;
+  totalExposure: string;
+}
+
+export interface ParityOrderRow {
+  createdAt: string | null;
+  limitPrice: string | null;
+  orderId: string;
+  quantity: string;
+  side: string;
+  state: string;
+  tokenId: string;
+}
+
+export interface LiveParityPair {
+  dryrun?: TradingStateSnapshot;
+  dryrunOnlyOrders: ParityOrderRow[];
+  dryrunSummary: SnapshotSummary;
+  key: string;
+  live?: TradingStateSnapshot;
+  liveSummary: SnapshotSummary;
+  message: string;
+  status: 'idle' | 'matched' | 'alert' | 'missing_dryrun' | 'missing_live';
+}
+
+export interface LiveParityReport {
+  alertPairs: LiveParityPair[];
+  dryrunOrders: number;
+  liveOrders: number;
+  pairs: LiveParityPair[];
+  unmatchedDryrunOrders: number;
+}
+
+const EMPTY_SUMMARY: SnapshotSummary = {
+  activeOrders: 0,
+  fills: 0,
+  grossExposure: '0',
+  intents: 0,
+  orders: 0,
+  positions: 0,
+  reservedExposure: '0',
+  totalExposure: '0',
+};
+
+function runtimeBucket(snapshot: TradingStateSnapshot): RuntimeBucket | null {
+  const mode = snapshot.runtime_mode.toLowerCase();
+  const id = snapshot.deployment_id.toLowerCase();
+
+  if (mode.includes('dry')) {
+    return 'dryrun';
+  }
+
+  if (mode === 'live' || id.endsWith('.live') || id.endsWith('-live')) {
+    return 'live';
+  }
+
+  return null;
+}
+
+export function parityKey(snapshot: TradingStateSnapshot) {
+  return snapshot.deployment_id
+    .toLowerCase()
+    .replace(/([._-])(dry[-_]?run|dryrun|live)$/u, '')
+    .replace(/([._-])$/u, '');
+}
+
+function summarize(snapshot?: TradingStateSnapshot): SnapshotSummary {
+  if (!snapshot) {
+    return EMPTY_SUMMARY;
+  }
+
+  return {
+    activeOrders: snapshot.risk.active_orders,
+    fills: snapshot.fills.length,
+    grossExposure: snapshot.risk.gross_exposure,
+    intents: snapshot.intents.length,
+    orders: snapshot.orders.length,
+    positions: snapshot.positions.length,
+    reservedExposure: snapshot.risk.reserved_order_exposure,
+    totalExposure: snapshot.risk.total_gross_exposure,
+  };
+}
+
+function intentById(snapshot: TradingStateSnapshot) {
+  return new Map(snapshot.intents.map((intent) => [intent.intent_id, intent]));
+}
+
+function orderRow(
+  order: OrderSnapshot,
+  intent: TradingIntentSnapshot | undefined
+): ParityOrderRow {
+  return {
+    createdAt: intent?.created_at ?? null,
+    limitPrice: order.limit_price ?? null,
+    orderId: order.order_id,
+    quantity: order.requested_qty,
+    side: intent?.side ?? 'unknown',
+    state: order.state,
+    tokenId: order.token_id,
+  };
+}
+
+function orderCompareKey(
+  order: OrderSnapshot,
+  intent: TradingIntentSnapshot | undefined
+) {
+  return `${order.token_id}:${(intent?.side ?? 'unknown').toLowerCase()}`;
+}
+
+function dryrunOnlyOrders(dryrun?: TradingStateSnapshot, live?: TradingStateSnapshot) {
+  if (!dryrun) {
+    return [];
+  }
+
+  const dryrunIntents = intentById(dryrun);
+  const liveIntents = live ? intentById(live) : new Map<string, TradingIntentSnapshot>();
+  const liveOrderKeys = new Set(
+    (live?.orders ?? []).map((order) =>
+      orderCompareKey(order, liveIntents.get(order.intent_id))
+    )
+  );
+
+  return dryrun.orders
+    .filter(
+      (order) =>
+        !liveOrderKeys.has(orderCompareKey(order, dryrunIntents.get(order.intent_id)))
+    )
+    .map((order) => orderRow(order, dryrunIntents.get(order.intent_id)));
+}
+
+function pairMessage(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 'live'>) {
+  if (!pair.dryrun) {
+    return 'No dry-run snapshot';
+  }
+
+  if (!pair.live) {
+    return 'No live snapshot';
+  }
+
+  if (pair.dryrunOnlyOrders.length > 0) {
+    return 'Dry-run order is missing from live';
+  }
+
+  if (pair.dryrun.orders.length === 0 && pair.live.orders.length === 0) {
+    return 'No orders yet';
+  }
+
+  return 'Order paths match';
+}
+
+function pairStatus(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 'live'>) {
+  if (!pair.dryrun) {
+    return 'missing_dryrun' as const;
+  }
+
+  if (!pair.live) {
+    return pair.dryrun.orders.length > 0 ? ('alert' as const) : ('missing_live' as const);
+  }
+
+  if (pair.dryrunOnlyOrders.length > 0) {
+    return 'alert' as const;
+  }
+
+  if (pair.dryrun.orders.length === 0 && pair.live.orders.length === 0) {
+    return 'idle' as const;
+  }
+
+  return 'matched' as const;
+}
+
+export function buildLiveParityReport(
+  snapshots: TradingStateSnapshot[] = []
+): LiveParityReport {
+  const grouped = new Map<string, Partial<Record<RuntimeBucket, TradingStateSnapshot>>>();
+
+  for (const snapshot of snapshots) {
+    const bucket = runtimeBucket(snapshot);
+    if (!bucket) {
+      continue;
+    }
+
+    const key = parityKey(snapshot);
+    const current = grouped.get(key) ?? {};
+    current[bucket] = snapshot;
+    grouped.set(key, current);
+  }
+
+  const pairs = Array.from(grouped.entries())
+    .map(([key, bucket]) => {
+      const dryrun = bucket.dryrun;
+      const live = bucket.live;
+      const missingOrders = dryrunOnlyOrders(dryrun, live);
+      const pair = {
+        dryrun,
+        dryrunOnlyOrders: missingOrders,
+        dryrunSummary: summarize(dryrun),
+        key,
+        live,
+        liveSummary: summarize(live),
+      };
+
+      return {
+        ...pair,
+        message: pairMessage(pair),
+        status: pairStatus(pair),
+      };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  return {
+    alertPairs: pairs.filter((pair) => pair.status === 'alert'),
+    dryrunOrders: pairs.reduce((sum, pair) => sum + pair.dryrunSummary.orders, 0),
+    liveOrders: pairs.reduce((sum, pair) => sum + pair.liveSummary.orders, 0),
+    pairs,
+    unmatchedDryrunOrders: pairs.reduce(
+      (sum, pair) => sum + pair.dryrunOnlyOrders.length,
+      0
+    ),
+  };
+}

--- a/ploy-frontend/src/pages/LiveParity.tsx
+++ b/ploy-frontend/src/pages/LiveParity.tsx
@@ -1,0 +1,306 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  ArrowRightLeft,
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  RadioTower,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/Badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { buildLiveParityReport } from '@/lib/liveParity';
+import { formatTimestamp } from '@/lib/utils';
+import { api } from '@/services/api';
+import { ws } from '@/services/websocket';
+import { useStore } from '@/store';
+
+import type { LiveParityPair, SnapshotSummary } from '@/lib/liveParity';
+
+function integer(value: number) {
+  return new Intl.NumberFormat('zh-CN').format(value);
+}
+
+function compactDecimal(value: string) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+
+  return parsed.toLocaleString('zh-CN', {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: 0,
+  });
+}
+
+function statusVariant(pair: LiveParityPair) {
+  switch (pair.status) {
+    case 'alert':
+      return 'destructive' as const;
+    case 'matched':
+      return 'success' as const;
+    case 'missing_live':
+    case 'missing_dryrun':
+      return 'warning' as const;
+    case 'idle':
+    default:
+      return 'secondary' as const;
+  }
+}
+
+function SummaryRail({
+  label,
+  mode,
+  summary,
+}: {
+  label: string;
+  mode: 'dryrun' | 'live';
+  summary: SnapshotSummary;
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+            {mode}
+          </div>
+          <div className="mt-1 text-lg font-semibold">{label}</div>
+        </div>
+        <Badge variant={mode === 'live' ? 'default' : 'outline'}>
+          {summary.orders} orders
+        </Badge>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <Metric label="Intents" value={integer(summary.intents)} />
+        <Metric label="Active" value={integer(summary.activeOrders)} />
+        <Metric label="Fills" value={integer(summary.fills)} />
+        <Metric label="Positions" value={integer(summary.positions)} />
+        <Metric label="Reserved" value={compactDecimal(summary.reservedExposure)} />
+        <Metric label="Exposure" value={compactDecimal(summary.totalExposure)} />
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md bg-muted/60 px-3 py-2">
+      <div className="truncate text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 truncate font-mono text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function EmptyOrders() {
+  return (
+    <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+      No unmatched dry-run orders
+    </div>
+  );
+}
+
+function PairCard({ pair }: { pair: LiveParityPair }) {
+  return (
+    <Card className={pair.status === 'alert' ? 'border-destructive/45' : undefined}>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="truncate text-xl">{pair.key}</CardTitle>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <Badge variant={statusVariant(pair)}>{pair.message}</Badge>
+              <span>{pair.dryrun?.deployment_id ?? 'no dry-run'}</span>
+              <ArrowRightLeft className="h-3.5 w-3.5" />
+              <span>{pair.live?.deployment_id ?? 'no live'}</span>
+            </div>
+          </div>
+          {pair.status === 'alert' ? (
+            <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm font-semibold text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+              {pair.dryrunOnlyOrders.length} missing live
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 rounded-lg bg-success/10 px-3 py-2 text-sm font-semibold text-success">
+              <CheckCircle2 className="h-4 w-4" />
+              clear
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[1fr_auto_1fr]">
+          <SummaryRail
+            label={pair.dryrun?.deployment_id ?? 'missing'}
+            mode="dryrun"
+            summary={pair.dryrunSummary}
+          />
+          <div className="hidden items-center justify-center px-2 xl:flex">
+            <ArrowRightLeft className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <SummaryRail
+            label={pair.live?.deployment_id ?? 'missing'}
+            mode="live"
+            summary={pair.liveSummary}
+          />
+        </div>
+
+        <div className="mt-5">
+          <div className="mb-3 text-sm font-semibold">Dry-run orders without live match</div>
+          {pair.dryrunOnlyOrders.length === 0 ? (
+            <EmptyOrders />
+          ) : (
+            <div className="overflow-hidden rounded-lg border">
+              <div className="grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <div>Created</div>
+                <div>Side</div>
+                <div>State</div>
+                <div>Qty / Price</div>
+                <div>Token</div>
+              </div>
+              {pair.dryrunOnlyOrders.map((order) => (
+                <div
+                  key={order.orderId}
+                  className="grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] gap-0 border-t px-4 py-3 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{order.orderId}</div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                      {order.createdAt ? formatTimestamp(order.createdAt) : 'unknown time'}
+                    </div>
+                  </div>
+                  <div className="font-semibold">{order.side}</div>
+                  <div>{order.state}</div>
+                  <div className="font-mono text-xs">
+                    {order.quantity}
+                    <br />
+                    {order.limitPrice ?? 'market'}
+                  </div>
+                  <div className="truncate font-mono text-xs text-muted-foreground">
+                    {order.tokenId}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function LiveParity() {
+  const queryClient = useQueryClient();
+  const storeSnapshots = useStore((state) => state.tradingSnapshots);
+  const setTradingSnapshots = useStore((state) => state.setTradingSnapshots);
+
+  const { data: polledSnapshots, error, isLoading } = useQuery({
+    queryKey: ['trading', 'state'],
+    queryFn: () => api.getTradingState(),
+    refetchInterval: 10000,
+  });
+
+  useEffect(() => {
+    if (polledSnapshots) {
+      setTradingSnapshots(polledSnapshots);
+    }
+  }, [polledSnapshots, setTradingSnapshots]);
+
+  useEffect(() => {
+    const unsubscribe = ws.subscribe('trading_snapshot', (event) => {
+      if (event.type === 'trading_snapshot') {
+        queryClient.setQueryData(['trading', 'state'], event.data.trading);
+        setTradingSnapshots(event.data.trading);
+      }
+    });
+    return unsubscribe;
+  }, [queryClient, setTradingSnapshots]);
+
+  const snapshots = storeSnapshots.length > 0 ? storeSnapshots : polledSnapshots ?? [];
+  const report = buildLiveParityReport(snapshots);
+  const hasAlert = report.alertPairs.length > 0;
+
+  if (isLoading && snapshots.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error && snapshots.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center">
+          <p className="text-destructive">Failed to load trading snapshots</p>
+          <p className="mt-1 text-sm text-muted-foreground">{String(error)}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Dry-run / Live Parity</h1>
+          <p className="text-muted-foreground">
+            Side-by-side order path comparison for paired strategy deployments
+          </p>
+        </div>
+        <Badge
+          variant={hasAlert ? 'destructive' : 'success'}
+          className="flex items-center gap-2 px-3 py-1"
+        >
+          {hasAlert ? <AlertTriangle className="h-4 w-4" /> : <RadioTower className="h-4 w-4" />}
+          {hasAlert ? 'Mismatch' : 'Aligned'}
+        </Badge>
+      </div>
+
+      <div
+        className={
+          hasAlert
+            ? 'mb-6 rounded-lg border border-destructive/30 bg-destructive/10 p-4'
+            : 'mb-6 rounded-lg border border-success/25 bg-success/10 p-4'
+        }
+      >
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2 font-semibold">
+            {hasAlert ? (
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+            ) : (
+              <CheckCircle2 className="h-5 w-5 text-success" />
+            )}
+            {hasAlert
+              ? 'Dry-run has orders that live has not placed'
+              : 'No dry-run-only live order gaps detected'}
+          </div>
+          <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+            <span>{integer(report.pairs.length)} pairs</span>
+            <span>{integer(report.dryrunOrders)} dry-run orders</span>
+            <span>{integer(report.liveOrders)} live orders</span>
+            <span>{integer(report.unmatchedDryrunOrders)} missing live orders</span>
+          </div>
+        </div>
+      </div>
+
+      {report.pairs.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <CircleDashed className="mx-auto mb-4 h-12 w-12 text-muted-foreground/50" />
+            <p className="text-lg font-medium text-muted-foreground">No paired snapshots yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The parity view appears after dry-run or live trading snapshots arrive.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-5">
+          {report.pairs.map((pair) => (
+            <PairCard key={pair.key} pair={pair} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ploy-frontend/src/services/api.ts
+++ b/ploy-frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import type {
   DeploymentState,
   PlatformMetrics,
   ActiveAlert,
+  TradingStateSnapshot,
 } from '@/types';
 
 const API_BASE = '/api';
@@ -210,6 +211,10 @@ class ApiService {
 
   async getDeployments(): Promise<DeploymentSummary[]> {
     return this.fetch<DeploymentSummary[]>('/deployments');
+  }
+
+  async getTradingState(): Promise<TradingStateSnapshot[]> {
+    return this.fetch<TradingStateSnapshot[]>('/trading/state');
   }
 
   async updateDeploymentState(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Dry-run / Live Order Parity UI (2026-04-25)
+
+## Files
+
+- `ploy-frontend/src/lib/liveParity.ts`
+- `ploy-frontend/src/components/LiveParityBanner.tsx`
+- `ploy-frontend/src/pages/LiveParity.tsx`
+- `ploy-frontend/src/services/api.ts`
+- `ploy-frontend/src/App.tsx`
+- `ploy-frontend/src/components/Layout.tsx`
+
+## Tasks
+
+- [x] Add a frontend parity model that pairs dry-run and live trading snapshots by deployment family.
+- [x] Show an in-app warning when dry-run has orders and live has no matching live order.
+- [x] Add an operator page with side-by-side order, intent, fill, and exposure comparison.
+- [x] Add a frontend-only Tango deploy path that does not restart live trading services.
+- [x] Validate the TypeScript build and frontend bundle.
+
+## Review
+
+- 2026-04-25: The parity model compares dry-run and live snapshots by normalized
+  deployment family, then flags dry-run orders without a matching live token and
+  side. This covers the requested case where dry-run enters but live fails to
+  place the corresponding order.
+- 2026-04-25: Added a frontend-only GitHub Actions deploy lane for Tango. It
+  builds `ploy-frontend`, installs static files under `/opt/ploy/frontend`,
+  updates nginx, reloads nginx, and deliberately avoids restarting `ployd`.
+- 2026-04-25: Local verification passed:
+  `npm run contracts:check --prefix ploy-frontend`,
+  `npm run build --prefix ploy-frontend`, `npm run lint --prefix ploy-frontend`,
+  `git diff --check`, and YAML parse for
+  `.github/workflows/deploy-frontend-tango-1-1.yml`.
+- 2026-04-25: Dev-server smoke with a Tango API tunnel returned HTTP 200 for
+  `/parity` and `/api/trading/state` returned three snapshots:
+  `example.live.dry-run`, `pm5d.threelayer.dryrun`, and
+  `pm5d.threelayer.live`, all currently at zero orders.
+
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 
 ## Files


### PR DESCRIPTION
## Summary
- Add a Dry-run / Live Parity frontend page that pairs trading snapshots by deployment family.
- Show a global warning banner when dry-run has an order without a matching live token/side order.
- Add a frontend-only Tango deploy workflow and nginx config so UI-only changes can ship without restarting ployd.

## Verification
- `npm run contracts:check --prefix ploy-frontend`
- `npm run build --prefix ploy-frontend`
- `npm run lint --prefix ploy-frontend`
- `git diff --check`
- YAML parse for `.github/workflows/deploy-frontend-tango-1-1.yml`
- Dev-server smoke for `/parity` and `/api/trading/state` through a Tango API tunnel

## Notes
- Current Tango snapshots are all at zero orders, so the UI shows aligned state until a dry-run-only order appears.
- Frontend deploy is intentionally separate from the existing Tango deploy because live trading is running and static UI updates should not restart trading services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Dry/Live Comparison" page accessible via the sidebar, displaying real-time parity between dry-run and live trading states.
  * Introduced a banner notification alerting users to order mismatches between environments.
  * Enabled continuous monitoring with automatic updates every 10 seconds and real-time WebSocket data streaming.

* **Chores**
  * Added frontend deployment workflow and nginx configuration for production hosting.
  * Updated documentation of completed features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->