### PR TITLE
Restore Polymarket V1 order compatibility for live trading

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Polymarket V1 Live Order Compatibility (2026-04-25)
+
+## Files
+
+- `vendor/polymarket-client-sdk/src/clob/client.rs`
+- `vendor/polymarket-client-sdk/src/clob/types/mod.rs`
+- `vendor/polymarket-client-sdk/src/clob/order_builder.rs`
+- `vendor/polymarket-client-sdk/examples/clob/authenticated.rs`
+- `vendor/polymarket-client-sdk/tests/clob.rs`
+- `vendor/polymarket-client-sdk/tests/order.rs`
+
+## Tasks
+
+- [x] Confirm live rejection reason against Tango logs and strategy runtime order history.
+- [x] Restore current production CLOB V1 order signing/body fields before Polymarket V2 cutover.
+- [x] Verify focused SDK/order tests and workspace checks without running heavy local workloads.
+- [ ] Prepare PR/CI deployment path for Tango, with no Rust build on the live host.
+
+## Review
+
+- 2026-04-25: Tango `ployd` logs and `strategy_runtime_orders` agree on
+  the failure mode: dry-run entries were recorded as `FILLED`, while live
+  entries were `REJECTED` by `POST /order` with
+  `error parsing fee rate bps () to int64`.
+- 2026-04-25: The vendored Rust CLOB SDK had already moved to V2 order signing
+  (`version = "2"`, `timestamp`, `metadata`, `builder`) even though
+  Polymarket production cutover is not until 2026-04-28. Restored the current
+  production V1 order fields (`taker`, `expiration`, `nonce`, `feeRateBps`)
+  and EIP-712 domain version.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p polymarket-client-sdk --features clob --test clob`,
+  `rtk cargo test -p polymarket-client-sdk --features clob --test order`,
+  `rtk cargo test -p ploy-connectivity`, `git diff --check`, and
+  `git diff --cached --check`.
+- 2026-04-25: `cargo fmt --check --package polymarket-client-sdk --package
+  ploy-connectivity` still reports unrelated pre-existing rustfmt drift in
+  `vendor/polymarket-client-sdk/src/rtds/*` and broader vendored SDK test files.
+
 # Dry-run / Live Order Parity UI (2026-04-25)
 
 ## Files

--- a/vendor/polymarket-client-sdk/examples/clob/authenticated.rs
+++ b/vendor/polymarket-client-sdk/examples/clob/authenticated.rs
@@ -101,7 +101,8 @@ async fn main() -> anyhow::Result<()> {
     let limit_order = client
         .limit_order()
         .token_id(token_id)
-        .order_type(OrderType::GTC)
+        .order_type(OrderType::GTD)
+        .expiration(Utc::now() + TimeDelta::days(2))
         .price(dec!(0.5))
         .size(Decimal::ONE_HUNDRED)
         .side(Side::Buy)

--- a/vendor/polymarket-client-sdk/src/clob/client.rs
+++ b/vendor/polymarket-client-sdk/src/clob/client.rs
@@ -61,7 +61,7 @@ use crate::{
 };
 
 const ORDER_NAME: Option<Cow<'static, str>> = Some(Cow::Borrowed("Polymarket CTF Exchange"));
-const VERSION: Option<Cow<'static, str>> = Some(Cow::Borrowed("2"));
+const VERSION: Option<Cow<'static, str>> = Some(Cow::Borrowed("1"));
 
 const TERMINAL_CURSOR: &str = "LTE="; // base64("-1")
 
@@ -2116,6 +2116,9 @@ impl<K: Kind> Client<Authenticated<K>> {
             size: None,
             amount: None,
             side: None,
+            nonce: None,
+            expiration: None,
+            taker: None,
             order_type: None,
             post_only: Some(false),
             client: Client {

--- a/vendor/polymarket-client-sdk/src/clob/order_builder.rs
+++ b/vendor/polymarket-client-sdk/src/clob/order_builder.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use alloy::primitives::U256;
+use chrono::{DateTime, Utc};
 use rand::Rng as _;
 use rust_decimal::prelude::ToPrimitive as _;
 
@@ -43,6 +44,9 @@ pub struct OrderBuilder<OrderKind, K: AuthKind> {
     pub(crate) size: Option<Decimal>,
     pub(crate) amount: Option<Amount>,
     pub(crate) side: Option<Side>,
+    pub(crate) nonce: Option<u64>,
+    pub(crate) expiration: Option<DateTime<Utc>>,
+    pub(crate) taker: Option<Address>,
     pub(crate) order_type: Option<OrderType>,
     pub(crate) post_only: Option<bool>,
     pub(crate) funder: Option<Address>,
@@ -61,6 +65,25 @@ impl<OrderKind, K: AuthKind> OrderBuilder<OrderKind, K> {
     #[must_use]
     pub fn side(mut self, side: Side) -> Self {
         self.side = Some(side);
+        self
+    }
+
+    /// Sets the nonce for this builder.
+    #[must_use]
+    pub fn nonce(mut self, nonce: u64) -> Self {
+        self.nonce = Some(nonce);
+        self
+    }
+
+    #[must_use]
+    pub fn expiration(mut self, expiration: DateTime<Utc>) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    #[must_use]
+    pub fn taker(mut self, taker: Address) -> Self {
+        self.taker = Some(taker);
         self
     }
 
@@ -123,6 +146,7 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             )));
         }
 
+        let fee_rate = self.client.fee_rate_bps(token_id).await?;
         let minimum_tick_size = self
             .client
             .tick_size(token_id)
@@ -166,8 +190,17 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             )));
         }
 
+        let nonce = self.nonce.unwrap_or(0);
+        let expiration = self.expiration.unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+        let taker = self.taker.unwrap_or(Address::ZERO);
         let order_type = self.order_type.unwrap_or(OrderType::GTC);
         let post_only = Some(self.post_only.unwrap_or(false));
+
+        if !matches!(order_type, OrderType::GTD) && expiration > DateTime::<Utc>::UNIX_EPOCH {
+            return Err(Error::validation(
+                "Only GTD orders may have a non-zero expiration",
+            ));
+        }
 
         if post_only == Some(true) && !matches!(order_type, OrderType::GTC | OrderType::GTD) {
             return Err(Error::validation(
@@ -198,22 +231,20 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
 
         let salt = to_ieee_754_int((self.salt_generator)());
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock before UNIX epoch")
-            .as_millis() as u64;
-
         let order = Order {
             salt: U256::from(salt),
             maker: self.funder.unwrap_or(self.signer),
+            taker,
             tokenId: token_id,
             makerAmount: U256::from(to_fixed_u128(maker_amount)),
             takerAmount: U256::from(to_fixed_u128(taker_amount)),
             side: side as u8,
+            feeRateBps: U256::from(fee_rate.base_fee),
+            nonce: U256::from(nonce),
             signer: self.signer,
-            timestamp,
-            metadata: alloy::primitives::B256::ZERO,
-            builder: Address::ZERO,
+            expiration: U256::from(expiration.timestamp().to_u64().ok_or(Error::validation(
+                format!("Unable to represent expiration {expiration} as a u64"),
+            ))?),
             signatureType: self.signature_type as u8,
         };
 
@@ -331,6 +362,9 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             .amount
             .ok_or_else(|| Error::validation("Unable to build Order due to missing amount"))?;
 
+        let nonce = self.nonce.unwrap_or(0);
+        let taker = self.taker.unwrap_or(Address::ZERO);
+
         let order_type = self.order_type.clone().unwrap_or(OrderType::FAK);
         let post_only = self.post_only;
         if post_only == Some(true) {
@@ -349,6 +383,7 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             .await?
             .minimum_tick_size
             .as_decimal();
+        let fee_rate = self.client.fee_rate_bps(token_id).await?;
 
         let decimals = minimum_tick_size.scale();
 
@@ -408,22 +443,18 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
 
         let salt = to_ieee_754_int((self.salt_generator)());
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock before UNIX epoch")
-            .as_millis() as u64;
-
         let order = Order {
             salt: U256::from(salt),
             maker: self.funder.unwrap_or(self.signer),
+            taker,
             tokenId: token_id,
             makerAmount: U256::from(to_fixed_u128(maker_amount)),
             takerAmount: U256::from(to_fixed_u128(taker_amount)),
             side: side as u8,
+            feeRateBps: U256::from(fee_rate.base_fee),
+            nonce: U256::from(nonce),
             signer: self.signer,
-            timestamp,
-            metadata: alloy::primitives::B256::ZERO,
-            builder: Address::ZERO,
+            expiration: U256::ZERO,
             signatureType: self.signature_type as u8,
         };
 

--- a/vendor/polymarket-client-sdk/src/clob/types/mod.rs
+++ b/vendor/polymarket-client-sdk/src/clob/types/mod.rs
@@ -436,15 +436,19 @@ sol! {
         uint256 salt;
         address maker;
         address signer;
+        address taker;
         #[serde_as(as = "DisplayFromStr")]
         uint256 tokenId;
         #[serde_as(as = "DisplayFromStr")]
         uint256 makerAmount;
         #[serde_as(as = "DisplayFromStr")]
         uint256 takerAmount;
-        uint64  timestamp;
-        bytes32 metadata;
-        address builder;
+        #[serde_as(as = "DisplayFromStr")]
+        uint256 expiration;
+        #[serde_as(as = "DisplayFromStr")]
+        uint256 nonce;
+        #[serde_as(as = "DisplayFromStr")]
+        uint256 feeRateBps;
         uint8   side;
         uint8   signatureType;
     }
@@ -488,6 +492,7 @@ struct OrderWithSignature<'order> {
     salt: &'order U256,
     maker: &'order alloy::primitives::Address,
     signer: &'order alloy::primitives::Address,
+    taker: &'order alloy::primitives::Address,
     #[serde_as(as = "DisplayFromStr")]
     #[serde(rename = "tokenId")]
     token_id: &'order U256,
@@ -497,9 +502,13 @@ struct OrderWithSignature<'order> {
     #[serde_as(as = "DisplayFromStr")]
     #[serde(rename = "takerAmount")]
     taker_amount: &'order U256,
-    timestamp: u64,
-    metadata: &'order alloy::primitives::B256,
-    builder: &'order alloy::primitives::Address,
+    #[serde_as(as = "DisplayFromStr")]
+    expiration: &'order U256,
+    #[serde_as(as = "DisplayFromStr")]
+    nonce: &'order U256,
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(rename = "feeRateBps")]
+    fee_rate_bps: &'order U256,
     /// Side serialized as "BUY"/"SELL" string (CLOB API requirement)
     side: Side,
     #[serde(rename = "signatureType")]
@@ -522,12 +531,13 @@ impl Serialize for SignedOrder {
             salt: &self.order.salt,
             maker: &self.order.maker,
             signer: &self.order.signer,
+            taker: &self.order.taker,
             token_id: &self.order.tokenId,
             maker_amount: &self.order.makerAmount,
             taker_amount: &self.order.takerAmount,
-            timestamp: self.order.timestamp,
-            metadata: &self.order.metadata,
-            builder: &self.order.builder,
+            expiration: &self.order.expiration,
+            nonce: &self.order.nonce,
+            fee_rate_bps: &self.order.feeRateBps,
             side,
             signature_type: self.order.signatureType,
             signature: self.signature.to_string(),

--- a/vendor/polymarket-client-sdk/tests/clob.rs
+++ b/vendor/polymarket-client-sdk/tests/clob.rs
@@ -1521,30 +1521,48 @@ mod authenticated {
             TickSize::Thousandth
         );
 
+        let taker = address!("0xf7fB45986800e2D259BAa25B56466bd02dA37a44");
         let signable_order = client
             .limit_order()
             .token_id(token_1())
             .price(dec!(0.512))
             .size(Decimal::ONE_HUNDRED)
             .side(Side::Buy)
+            .taker(taker)
+            .nonce(2)
             .build()
             .await?;
 
         let signed_order = client.sign(&signer, signable_order.clone()).await?;
 
-        // V2 orders include a dynamic timestamp, so the EIP-712 signature is
-        // non-deterministic across runs. Verify structural fields instead.
+        let expected = SignedOrder::builder()
+            .owner(API_KEY)
+            .order(signable_order.order)
+            .order_type(OrderType::GTC)
+            .post_only(false)
+            .signature(Signature::new(
+                U256::from_str(
+                    "67621163334702490495692752203603653486415606176046333203031895577746637168458",
+                )?,
+                U256::from_str(
+                    "22834656493077213792711278309014544874769388094209721364243931615451754929648",
+                )?,
+                false,
+            ))
+            .build();
+
+        assert_eq!(signed_order.order.taker, taker);
         assert_eq!(signed_order.order.maker, funder);
         assert_ne!(signed_order.order.maker, client.address());
         assert_eq!(signed_order.order.signatureType, SignatureType::Proxy as u8);
+        assert_eq!(signed_order.order.nonce, U256::from(2));
         assert_eq!(signed_order.order.salt, U256::from(1));
-        assert_eq!(signed_order.order, signable_order.order);
-        assert_eq!(signed_order.order_type, OrderType::GTC);
-        assert_eq!(signed_order.post_only, Some(false));
         assert_eq!(
             client.address(),
             address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266")
         );
+
+        assert_eq!(signed_order, expected);
         mock.assert();
         mock2.assert_calls(2);
 
@@ -1563,7 +1581,26 @@ mod authenticated {
                 .path("/order")
                 .header(POLY_ADDRESS, client.address().to_string().to_lowercase())
                 .header(POLY_API_KEY, API_KEY)
-                .header(POLY_PASSPHRASE, PASSPHRASE);
+                .header(POLY_PASSPHRASE, PASSPHRASE)
+                .json_body(json!({
+                    "order": {
+                        "expiration": "0",
+                        "feeRateBps": "0",
+                        "maker": Address::ZERO,
+                        "makerAmount": "0",
+                        "nonce": "0",
+                        "salt": 0,
+                        "side": Side::Buy,
+                        "signature": "0x9cb96251af741b3cc6b103bd5d1b47567cdb28563bb5a7038b2d3d612b7cd37772910f79d88ad281fa28d253793472db8c12283f1a8e0f4677338da4c39343161c",
+                        "signatureType": 0,
+                        "signer": Address::ZERO,
+                        "taker": Address::ZERO,
+                        "takerAmount": "0",
+                        "tokenId": "0"
+                    },
+                    "orderType": "FOK",
+                    "owner": "00000000-0000-0000-0000-000000000000"
+                }));
             then.status(StatusCode::OK).json_body(json!({
                 "error_msg": "",
                 "makingAmount": "",

--- a/vendor/polymarket-client-sdk/tests/order.rs
+++ b/vendor/polymarket-client-sdk/tests/order.rs
@@ -9,6 +9,7 @@ mod common;
 use std::str::FromStr as _;
 
 use alloy::primitives::U256;
+use chrono::{DateTime, Utc};
 use httpmock::MockServer;
 use polymarket_client_sdk::clob::types::response::OrderSummary;
 use polymarket_client_sdk::clob::types::{Amount, OrderType, Side, SignatureType, TickSize};
@@ -45,6 +46,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -58,6 +60,8 @@ mod lifecycle {
             .build()
             .await?;
 
+        assert_eq!(signable_order.order.nonce, U256::from(1));
+        assert_eq!(signable_order_2.order.nonce, U256::ZERO);
         assert_ne!(signable_order, signable_order_2);
 
         Ok(())
@@ -93,6 +97,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -145,6 +150,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -168,6 +174,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -214,6 +221,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -223,6 +231,7 @@ mod lifecycle {
             signable_order.order.signatureType,
             SignatureType::Proxy as u8
         );
+        assert_eq!(signable_order.order.nonce, U256::from(1));
         assert_eq!(signable_order.order.side, Side::Buy as u8);
         assert_ne!(signable_order.order.maker, signable_order.order.signer);
 
@@ -233,6 +242,7 @@ mod lifecycle {
             .token_id(token_2())
             .size(Decimal::TEN)
             .price(dec!(0.2))
+            .nonce(2)
             .side(Side::Sell)
             .build()
             .await?;
@@ -243,6 +253,7 @@ mod lifecycle {
             signable_order.order.signatureType,
             SignatureType::Proxy as u8
         );
+        assert_eq!(signable_order.order.nonce, U256::from(2));
         assert_eq!(signable_order.order.side, Side::Sell as u8);
         assert_ne!(signable_order.order.maker, signable_order.order.signer);
 
@@ -283,6 +294,7 @@ mod lifecycle {
             .token_id(token_1())
             .size(Decimal::ONE_HUNDRED)
             .price(dec!(0.1))
+            .nonce(1)
             .side(Side::Buy)
             .build()
             .await?;
@@ -292,6 +304,7 @@ mod lifecycle {
             signable_order.order.signatureType,
             SignatureType::Proxy as u8
         );
+        assert_eq!(signable_order.order.nonce, U256::from(1));
         assert_eq!(signable_order.order.side, Side::Buy as u8);
         assert_ne!(signable_order.order.maker, signable_order.order.signer);
 
@@ -308,6 +321,7 @@ mod lifecycle {
             .token_id(token_2())
             .size(Decimal::TEN)
             .price(dec!(0.2))
+            .nonce(2)
             .side(Side::Sell)
             .build()
             .await?;
@@ -315,6 +329,7 @@ mod lifecycle {
         // Funder and signature type propagate from setting on the auth builder
         assert_eq!(signable_order.order.maker, signer.address());
         assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
+        assert_eq!(signable_order.order.nonce, U256::from(2));
         assert_eq!(signable_order.order.side, Side::Sell as u8);
         assert_eq!(signable_order.order.maker, signable_order.order.signer);
 
@@ -556,6 +571,31 @@ mod limit {
     use super::*;
 
     #[tokio::test]
+    async fn should_fail_on_expiration_for_gtc() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::Tenth);
+
+        let err = client
+            .limit_order()
+            .token_id(token_1())
+            .price(dec!(0.5))
+            .size(dec!(21.04))
+            .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+            .build()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(msg, "Only GTD orders may have a non-zero expiration");
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn should_fail_on_post_only_for_non_gtc_gtd() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;
@@ -592,6 +632,8 @@ mod limit {
             .token_id(token_1())
             .size(dec!(21.04))
             .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
             .build()
             .await
             .unwrap_err();
@@ -604,6 +646,8 @@ mod limit {
             .token_id(token_1())
             .price(dec!(0.5))
             .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
             .build()
             .await
             .unwrap_err();
@@ -627,6 +671,8 @@ mod limit {
             .price(dec!(0.005))
             .size(dec!(21.04))
             .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
             .build()
             .await
             .unwrap_err();
@@ -653,6 +699,8 @@ mod limit {
             .price(dec!(-0.5))
             .size(dec!(21.04))
             .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
             .build()
             .await
             .unwrap_err();
@@ -666,6 +714,8 @@ mod limit {
             .price(dec!(0.5))
             .size(dec!(-21.04))
             .side(Side::Buy)
+            .nonce(123)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
             .build()
             .await
             .unwrap_err();
@@ -693,6 +743,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Buy)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -704,8 +756,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(10_520_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -726,6 +783,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Buy)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -737,8 +796,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(11_782_400));
+            assert_eq!(signable_order.order.takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -759,6 +823,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Buy)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -770,8 +836,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(1_178_240));
+            assert_eq!(signable_order.order.takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -792,6 +863,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Buy)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -803,8 +876,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(117_824));
+            assert_eq!(signable_order.order.takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -828,6 +906,7 @@ mod limit {
                 .await?;
 
             assert_eq!(signable_order.order.makerAmount, U256::from(3_600_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(15_000_000));
 
             Ok(())
         }
@@ -849,6 +928,7 @@ mod limit {
                 .await?;
 
             assert_eq!(signable_order.order.makerAmount, U256::from(82_820_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(101_000_000));
 
             Ok(())
         }
@@ -925,6 +1005,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Sell)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -936,8 +1018,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(10_520_000));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -958,6 +1045,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Sell)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -969,8 +1058,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(11_782_400));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -991,6 +1085,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Sell)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1002,8 +1098,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(1_178_240));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1024,6 +1125,8 @@ mod limit {
                 .size(dec!(21.04))
                 .side(Side::Sell)
                 .order_type(OrderType::GTD)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1035,8 +1138,13 @@ mod limit {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(117_824));
+            assert_eq!(signable_order.order.expiration, U256::from(50000));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1060,6 +1168,7 @@ mod limit {
                 .await?;
 
             assert_eq!(signable_order.order.makerAmount, U256::from(15_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(3_600_000));
 
             Ok(())
         }
@@ -1081,6 +1190,7 @@ mod limit {
                 .await?;
 
             assert_eq!(signable_order.order.makerAmount, U256::from(101_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(82_820_000));
 
             Ok(())
         }
@@ -1132,6 +1242,7 @@ mod limit {
                 signable_order.order.makerAmount,
                 U256::from(2_435_890_000_u64)
             );
+            assert_eq!(signable_order.order.takerAmount, U256::from(949_997_100));
 
             Ok(())
         }
@@ -1153,6 +1264,7 @@ mod limit {
                 .await?;
 
             assert_eq!(signable_order.order.makerAmount, U256::from(19_100_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(8_213_000));
 
             Ok(())
         }
@@ -1181,8 +1293,13 @@ mod limit {
             .await?;
 
         assert_eq!(signable_order.order.maker, client.address());
+        assert_eq!(signable_order.order.taker, Address::ZERO);
         assert_eq!(signable_order.order.tokenId, token_1());
         assert_eq!(signable_order.order.makerAmount, U256::from(51_200_000));
+        assert_eq!(signable_order.order.takerAmount, U256::from(100_000_000));
+        assert_eq!(signable_order.order.expiration, U256::ZERO);
+        assert_eq!(signable_order.order.nonce, U256::ZERO);
+        assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
         assert_eq!(signable_order.order.side, Side::Buy as u8);
         assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1196,8 +1313,13 @@ mod limit {
             .await?;
 
         assert_eq!(signable_order.order.maker, client.address());
+        assert_eq!(signable_order.order.taker, Address::ZERO);
         assert_eq!(signable_order.order.tokenId, token_2());
         assert_eq!(signable_order.order.makerAmount, U256::from(9_999_600));
+        assert_eq!(signable_order.order.takerAmount, U256::from(12_820_000));
+        assert_eq!(signable_order.order.expiration, U256::ZERO);
+        assert_eq!(signable_order.order.nonce, U256::ZERO);
+        assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
         assert_eq!(signable_order.order.side, Side::Buy as u8);
         assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1379,6 +1501,7 @@ mod market {
 
                 assert_eq!(signable_order.order.maker, client.address());
                 assert_eq!(signable_order.order.signer, client.address());
+                assert_eq!(signable_order.order.taker, Address::ZERO);
                 assert_eq!(
                     signable_order.order.tokenId,
                     U256::from_str(
@@ -1386,6 +1509,10 @@ mod market {
                     )?
                 );
                 assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000)); // 100 USDC
+                assert_eq!(signable_order.order.takerAmount, U256::from(200_000_000)); // 200 `token_1()` tokens
+                assert_eq!(signable_order.order.expiration, U256::ZERO);
+                assert_eq!(signable_order.order.nonce, U256::ZERO);
+                assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
                 assert_eq!(signable_order.order.side, Side::Buy as u8);
                 assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1596,6 +1723,7 @@ mod market {
 
                 assert_eq!(signable_order.order.maker, client.address());
                 assert_eq!(signable_order.order.signer, client.address());
+                assert_eq!(signable_order.order.taker, Address::ZERO);
                 assert_eq!(
                     signable_order.order.tokenId,
                     U256::from_str(
@@ -1603,6 +1731,10 @@ mod market {
                     )?
                 );
                 assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000)); // 100 USDC
+                assert_eq!(signable_order.order.takerAmount, U256::from(200_000_000)); // 200 `token_1()` tokens
+                assert_eq!(signable_order.order.expiration, U256::ZERO);
+                assert_eq!(signable_order.order.nonce, U256::ZERO);
+                assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
                 assert_eq!(signable_order.order.side, Side::Buy as u8);
                 assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1812,6 +1944,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
                 .side(Side::Buy)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1823,8 +1957,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(200_000_000));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1853,6 +1992,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
                 .side(Side::Buy)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1865,8 +2006,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(178_571_400));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1895,6 +2041,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
                 .side(Side::Buy)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1907,8 +2055,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(1_785_714_280));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -1937,6 +2090,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
                 .side(Side::Buy)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -1949,12 +2104,16 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
             assert_eq!(
                 signable_order.order.takerAmount,
                 U256::from(17_857_142_857_u64)
             );
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Buy as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2061,6 +2220,7 @@ mod market {
 
             // maker = USDC, taker = shares
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000)); // 250 * 0.4 = 100
+            assert_eq!(signable_order.order.takerAmount, U256::from(250_000_000));
             Ok(())
         }
 
@@ -2098,6 +2258,7 @@ mod market {
 
             // maker = USDC, taker = shares
             assert_eq!(signable_order.order.makerAmount, U256::from(125_000_000)); // 250 * 0.5 = 125
+            assert_eq!(signable_order.order.takerAmount, U256::from(250_000_000));
             Ok(())
         }
     }
@@ -2216,6 +2377,7 @@ mod market {
 
                 assert_eq!(signable_order.order.maker, client.address());
                 assert_eq!(signable_order.order.signer, client.address());
+                assert_eq!(signable_order.order.taker, Address::ZERO);
                 assert_eq!(
                     signable_order.order.tokenId,
                     U256::from_str(
@@ -2224,6 +2386,9 @@ mod market {
                 );
                 assert_eq!(maker_amount, U256::from(100_000_000)); // 100 `token_1()` tokens
                 assert_eq!(taker_amount, U256::from(50_000_000)); // 50 USDC
+                assert_eq!(signable_order.order.expiration, U256::ZERO);
+                assert_eq!(signable_order.order.nonce, U256::ZERO);
+                assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
                 assert_eq!(signable_order.order.side, Side::Sell as u8);
                 assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2480,6 +2645,7 @@ mod market {
 
                 assert_eq!(signable_order.order.maker, client.address());
                 assert_eq!(signable_order.order.signer, client.address());
+                assert_eq!(signable_order.order.taker, Address::ZERO);
                 assert_eq!(
                     signable_order.order.tokenId,
                     U256::from_str(
@@ -2487,6 +2653,10 @@ mod market {
                     )?
                 );
                 assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000)); // 100 USDC
+                assert_eq!(signable_order.order.takerAmount, U256::from(40_000_000)); // 40 `token_1()` tokens
+                assert_eq!(signable_order.order.expiration, U256::ZERO);
+                assert_eq!(signable_order.order.nonce, U256::ZERO);
+                assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
                 assert_eq!(signable_order.order.side, Side::Sell as u8);
                 assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2741,6 +2911,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::shares(Decimal::ONE_HUNDRED)?)
                 .side(Side::Sell)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -2752,8 +2924,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(50_000_000));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2782,6 +2959,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::shares(Decimal::ONE_HUNDRED)?)
                 .side(Side::Sell)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -2794,8 +2973,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(56_000_000));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2824,6 +3008,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::shares(Decimal::ONE_HUNDRED)?)
                 .side(Side::Sell)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -2836,8 +3022,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(5_600_000));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 
@@ -2866,6 +3057,8 @@ mod market {
                 .token_id(token_1())
                 .amount(Amount::shares(Decimal::ONE_HUNDRED)?)
                 .side(Side::Sell)
+                .nonce(123)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
                 .build()
                 .await?;
 
@@ -2878,8 +3071,13 @@ mod market {
 
             assert_eq!(signable_order.order.maker, client.address());
             assert_eq!(signable_order.order.signer, client.address());
+            assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(560_000));
+            assert_eq!(signable_order.order.expiration, U256::from(0));
+            assert_eq!(signable_order.order.nonce, U256::from(123));
+            assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
             assert_eq!(signable_order.order.side, Side::Sell as u8);
             assert_eq!(signable_order.order.signatureType, SignatureType::Eoa as u8);
 


### PR DESCRIPTION
## Summary
- restore V1 CLOB EIP-712/order fields (`taker`, `expiration`, `nonce`, `feeRateBps`) for current production `clob.polymarket.com`
- keep live execution compatible before Polymarket production V2 cutover
- restore SDK tests that assert V1 signed order body shape

## Why
Tango live attempts are reaching `POST /order` but are rejected with `error parsing fee rate bps () to int64`. The vendored Rust SDK had already moved to V2 order fields, while production cutover is announced for 2026-04-28.

## Verification
- `rtk cargo test -p polymarket-client-sdk --features clob --test clob`
- `rtk cargo test -p polymarket-client-sdk --features clob --test order`
- `rtk cargo test -p ploy-connectivity`
- `git diff --check`
- `git diff --cached --check`

## Notes
`cargo fmt --check --package polymarket-client-sdk --package ploy-connectivity` still reports unrelated pre-existing vendored SDK rustfmt drift in RTDS/test files.