### PR TITLE
Prevent live order reject loops

### DIFF
--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -20,6 +20,9 @@ use rust_decimal_macros::dec;
 
 use crate::traits::{Executor, Feed, MarketUpdate, Recorder, StrategyDecision, StrategyLogic};
 
+const MIN_LIVE_RETRY_SHARES: Decimal = dec!(1.00);
+const MIN_LIVE_RETRY_NOTIONAL: Decimal = dec!(1.00);
+
 /// Operating mode for the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeMode {
@@ -79,6 +82,16 @@ fn retry_suffix(intent_id: &str) -> Option<(&str, u8)> {
     }
 
     Some((root, suffix.parse().ok()?))
+}
+
+fn live_retry_remainder_is_dust(remaining_qty: Decimal, limit_price: Option<Decimal>) -> bool {
+    if remaining_qty < MIN_LIVE_RETRY_SHARES {
+        return true;
+    }
+
+    limit_price
+        .map(|price| remaining_qty * price < MIN_LIVE_RETRY_NOTIONAL)
+        .unwrap_or(false)
 }
 
 /// Unified strategy runtime.
@@ -477,6 +490,36 @@ where
             pending.reconciles_without_fill += 1;
             if pending.reconciles_without_fill < policy.reconcile_cycles_before_retry {
                 pending_live_orders.insert(order_id, pending);
+                continue;
+            }
+
+            if live_retry_remainder_is_dust(remaining_qty, order.limit_price) {
+                let terminal_reason = format!(
+                    "live order remainder below retry threshold; remaining_qty={remaining_qty}"
+                );
+                self.trading.cancel_order(&order_id);
+                let terminal_report = crate::traits::ExecutionReport {
+                    order_id: order
+                        .venue_order_id
+                        .clone()
+                        .unwrap_or_else(|| order_id.clone()),
+                    fill: None,
+                    rejected: true,
+                    rejection_reason: Some(terminal_reason.clone()),
+                    slippage: None,
+                    market_impact: None,
+                };
+                self.recorder
+                    .record_order(
+                        &strategy_name,
+                        &pending.intent,
+                        None,
+                        &terminal_report,
+                        &order_id,
+                    )
+                    .await;
+                self.strategy.on_reject(&pending.intent, &terminal_reason);
+                warn!(order_id = %order_id, reason = %terminal_reason, "Live order terminal dust");
                 continue;
             }
 
@@ -1248,6 +1291,80 @@ mod tests {
             1
         );
         assert_eq!(snapshot.fills.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn live_unfilled_ack_does_not_retry_dust_remainder() {
+        let now = Utc::now();
+        let signal = SignalRecord {
+            strategy: "pm_5m_directional".into(),
+            event_id: Some("evt1".into()),
+            token_id: Some("token-up".into()),
+            intent_id: Some("pm5d_BTCUSDT_UP_dust".into()),
+            symbol: "BTCUSDT".into(),
+            direction: "UP".into(),
+            p_hat: 0.71,
+            edge: 0.08,
+            entry_price: dec!(0.30),
+            decision: "enter".into(),
+            ts: now,
+        };
+        let intent = TradingIntent {
+            intent_id: "pm5d_BTCUSDT_UP_dust".into(),
+            deployment_id: String::new(),
+            market_id: "evt1".into(),
+            token_id: "token-up".into(),
+            side: TradeSide::Buy,
+            quantity: dec!(0.02),
+            limit_price: Some(dec!(0.30)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        };
+        let submissions = Arc::new(Mutex::new(Vec::new()));
+        let executor = AcknowledgingExecutor {
+            policy: ExecutionPolicy {
+                max_slippage_bps: Decimal::ZERO,
+                max_attempts: 2,
+                reconcile_cycles_before_retry: 1,
+            },
+            submissions: submissions.clone(),
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let strategy = RecordingStrategy {
+            emitted: false,
+            signal,
+            intent,
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: true,
+        };
+
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let _ = runtime.run().await;
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+
+        assert_eq!(
+            submissions.lock().unwrap().as_slice(),
+            ["pm5d_BTCUSDT_UP_dust"]
+        );
+        assert_eq!(snapshot.orders.len(), 1);
+        assert_eq!(snapshot.orders[0].state, ploy_trading::OrderState::Canceled);
+        assert_eq!(snapshot.fills.len(), 0);
+        assert_eq!(snapshot.risk.active_orders, 0);
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -4,11 +4,11 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, OrderState, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use tracing::info;
+use tracing::{debug, info, warn};
 
 use super::common::event::EventWindow;
 use super::common::fees::crypto_fee_cost;
@@ -73,6 +73,9 @@ impl From<DirectionalConfig> for ThreeLayerConfig {
 const DRIFT_WINDOW_SECS: f64 = 30.0;
 const VOL_WINDOW_SECS: f64 = 120.0;
 const MIN_VOL_POINTS: usize = 5;
+const BALANCE_REJECT_PAUSE_SECS: i64 = 5 * 60;
+const INVALID_AMOUNT_REJECT_PAUSE_SECS: i64 = 5 * 60;
+const NO_LIQUIDITY_REJECT_PAUSE_SECS: i64 = 30;
 
 struct DriftTracker {
     history: VecDeque<(DateTime<Utc>, f64)>,
@@ -257,7 +260,11 @@ fn norm_cdf(x: f64) -> f64 {
     let d = 0.3989422804014327 * (-x * x / 2.0).exp();
     let p =
         d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 { 1.0 - p } else { p }
+    if x >= 0.0 {
+        1.0 - p
+    } else {
+        p
+    }
 }
 
 /// Layer 1: Direction score (0.0 – 1.0).
@@ -373,6 +380,8 @@ pub struct ThreeLayerStrategy {
     token_event: HashMap<Arc<str>, Arc<str>>,
     events: HashMap<Arc<str>, Vec<EventWindow>>,
     last_entry: HashMap<Arc<str>, DateTime<Utc>>,
+    token_reject_until: HashMap<Arc<str>, DateTime<Utc>>,
+    balance_exhausted_until: Option<DateTime<Utc>>,
     daily_trade_count: u32,
     daily_trade_date: Option<chrono::NaiveDate>,
     feed_time: Option<DateTime<Utc>>,
@@ -391,6 +400,8 @@ impl ThreeLayerStrategy {
             token_event: HashMap::new(),
             events: HashMap::new(),
             last_entry: HashMap::new(),
+            token_reject_until: HashMap::new(),
+            balance_exhausted_until: None,
             daily_trade_count: 0,
             daily_trade_date: None,
             feed_time: None,
@@ -440,6 +451,31 @@ impl ThreeLayerStrategy {
         (self.config.stake_usd / entry_price).round_dp(6)
     }
 
+    fn reject_cooldown_secs(&self) -> i64 {
+        self.config.cooldown_secs.max(1) as i64
+    }
+
+    fn balance_pause_active(&self, now: DateTime<Utc>) -> bool {
+        self.balance_exhausted_until
+            .is_some_and(|until| now < until)
+    }
+
+    fn token_reject_active(&self, token_id: &str, now: DateTime<Utc>) -> bool {
+        self.token_reject_until
+            .get(token_id)
+            .is_some_and(|until| now < *until)
+    }
+
+    fn active_order_exists(orders: &OrderLedger, token_id: &str) -> bool {
+        orders.orders().any(|o| {
+            o.token_id == token_id
+                && matches!(
+                    o.state,
+                    OrderState::Pending | OrderState::Acknowledged | OrderState::PartiallyFilled
+                )
+        })
+    }
+
     fn try_entry(
         &mut self,
         symbol: &str,
@@ -447,6 +483,10 @@ impl ThreeLayerStrategy {
         positions: &PositionLedger,
         orders: &OrderLedger,
     ) -> Option<StrategyDecision> {
+        if self.balance_pause_active(now) {
+            debug!(symbol, "Balance exhausted pause active, skipping entry");
+            return None;
+        }
         if self.daily_trade_count >= self.config.max_daily_trades {
             return None;
         }
@@ -513,15 +553,10 @@ impl ThreeLayerStrategy {
             if positions.net_qty(token_id) > Decimal::ZERO {
                 continue;
             }
-            if orders.orders().any(|o| {
-                o.token_id.as_str() == &**token_id
-                    && matches!(
-                        o.state,
-                        OrderState::Pending
-                            | OrderState::Acknowledged
-                            | OrderState::PartiallyFilled
-                    )
-            }) {
+            if Self::active_order_exists(orders, token_id) {
+                continue;
+            }
+            if self.token_reject_active(token_id, now) {
                 continue;
             }
 
@@ -637,13 +672,23 @@ impl ThreeLayerStrategy {
         now: DateTime<Utc>,
         spot: Option<f64>,
         positions: &PositionLedger,
+        orders: &OrderLedger,
     ) -> Vec<StrategyDecision> {
         let mut decisions = Vec::new();
+        if self.balance_pause_active(now) {
+            return decisions;
+        }
 
         for event in self.events.get(symbol).into_iter().flatten() {
             for (token_id, is_up) in [(&event.up_token, true), (&event.down_token, false)] {
                 let qty = positions.net_qty(token_id);
                 if qty <= Decimal::ZERO {
+                    continue;
+                }
+                if Self::active_order_exists(orders, token_id) {
+                    continue;
+                }
+                if self.token_reject_active(token_id, now) {
                     continue;
                 }
 
@@ -707,43 +752,71 @@ impl ThreeLayerStrategy {
         up_won: bool,
         now: DateTime<Utc>,
         positions: &PositionLedger,
+        orders: &OrderLedger,
     ) -> Vec<StrategyDecision> {
         let mut exits = Vec::new();
+        if self.balance_pause_active(now) {
+            return exits;
+        }
 
         if positions.net_qty(&event.up_token) > Decimal::ZERO {
-            exits.push(StrategyDecision::Exit(TradingIntent {
-                intent_id: format!("tl_settle_{}_up", event.event_id),
-                deployment_id: String::new(),
-                market_id: event.event_id.to_string(),
-                token_id: event.up_token.to_string(),
-                side: TradeSide::Sell,
-                quantity: positions.net_qty(&event.up_token),
-                limit_price: Some(if up_won {
-                    Decimal::new(1, 0)
-                } else {
-                    Decimal::ZERO
-                }),
-                purpose: IntentPurpose::Exit,
-                created_at: now,
-            }));
+            if Self::active_order_exists(orders, &event.up_token) {
+                debug!(
+                    token_id = %event.up_token,
+                    "Active order exists, skipping settlement exit"
+                );
+            } else if self.token_reject_active(&event.up_token, now) {
+                debug!(
+                    token_id = %event.up_token,
+                    "Token reject cooldown active, skipping settlement exit"
+                );
+            } else {
+                exits.push(StrategyDecision::Exit(TradingIntent {
+                    intent_id: format!("tl_settle_{}_up", event.event_id),
+                    deployment_id: String::new(),
+                    market_id: event.event_id.to_string(),
+                    token_id: event.up_token.to_string(),
+                    side: TradeSide::Sell,
+                    quantity: positions.net_qty(&event.up_token),
+                    limit_price: Some(if up_won {
+                        Decimal::new(1, 0)
+                    } else {
+                        Decimal::ZERO
+                    }),
+                    purpose: IntentPurpose::Exit,
+                    created_at: now,
+                }));
+            }
         }
 
         if positions.net_qty(&event.down_token) > Decimal::ZERO {
-            exits.push(StrategyDecision::Exit(TradingIntent {
-                intent_id: format!("tl_settle_{}_down", event.event_id),
-                deployment_id: String::new(),
-                market_id: event.event_id.to_string(),
-                token_id: event.down_token.to_string(),
-                side: TradeSide::Sell,
-                quantity: positions.net_qty(&event.down_token),
-                limit_price: Some(if up_won {
-                    Decimal::ZERO
-                } else {
-                    Decimal::new(1, 0)
-                }),
-                purpose: IntentPurpose::Exit,
-                created_at: now,
-            }));
+            if Self::active_order_exists(orders, &event.down_token) {
+                debug!(
+                    token_id = %event.down_token,
+                    "Active order exists, skipping settlement exit"
+                );
+            } else if self.token_reject_active(&event.down_token, now) {
+                debug!(
+                    token_id = %event.down_token,
+                    "Token reject cooldown active, skipping settlement exit"
+                );
+            } else {
+                exits.push(StrategyDecision::Exit(TradingIntent {
+                    intent_id: format!("tl_settle_{}_down", event.event_id),
+                    deployment_id: String::new(),
+                    market_id: event.event_id.to_string(),
+                    token_id: event.down_token.to_string(),
+                    side: TradeSide::Sell,
+                    quantity: positions.net_qty(&event.down_token),
+                    limit_price: Some(if up_won {
+                        Decimal::ZERO
+                    } else {
+                        Decimal::new(1, 0)
+                    }),
+                    purpose: IntentPurpose::Exit,
+                    created_at: now,
+                }));
+            }
         }
 
         exits
@@ -803,7 +876,7 @@ impl StrategyLogic for ThreeLayerStrategy {
                 // Check exits first
                 let spot_opt = Some(price_f64);
                 let mut decisions =
-                    self.exit_decisions_for_symbol(symbol, *ts, spot_opt, positions);
+                    self.exit_decisions_for_symbol(symbol, *ts, spot_opt, positions, orders);
 
                 // Cooldown check before entry
                 if let Some(last) = self.last_entry.get(symbol) {
@@ -825,6 +898,7 @@ impl StrategyLogic for ThreeLayerStrategy {
                 ts,
                 ..
             } => {
+                self.feed_time = Some(*ts);
                 self.quotes.insert(
                     token_id.clone(),
                     QuoteState {
@@ -838,7 +912,7 @@ impl StrategyLogic for ThreeLayerStrategy {
                     return Vec::new();
                 };
                 let spot = self.spot.get(&symbol).and_then(|p| p.to_f64());
-                self.exit_decisions_for_symbol(&symbol, *ts, spot, positions)
+                self.exit_decisions_for_symbol(&symbol, *ts, spot, positions, orders)
             }
 
             MarketUpdate::AggTrade {
@@ -983,9 +1057,9 @@ impl StrategyLogic for ThreeLayerStrategy {
                             continue;
                         }
                         if let Some(up_won) = self.resolve_up_won(event, *resolved_up_won) {
-                            decisions.extend(
-                                self.build_settlement_exits(event, up_won, *end_time, positions),
-                            );
+                            decisions.extend(self.build_settlement_exits(
+                                event, up_won, *end_time, positions, orders,
+                            ));
                             resolved_events.push(event.event_id.clone());
                         }
                     }
@@ -1013,6 +1087,49 @@ impl StrategyLogic for ThreeLayerStrategy {
         }
     }
 
+    fn on_reject(&mut self, intent: &TradingIntent, reason: &str) {
+        let now = self.now();
+        let reason_lc = reason.to_ascii_lowercase();
+        let balance_or_allowance =
+            reason_lc.contains("not enough balance") || reason_lc.contains("allowance");
+        let invalid_amount =
+            reason_lc.contains("invalid amounts") || reason_lc.contains("below retry threshold");
+        let no_liquidity = reason_lc.contains("no orders found") || reason_lc.contains("no match");
+        let cooldown_secs = if balance_or_allowance {
+            BALANCE_REJECT_PAUSE_SECS
+        } else if invalid_amount {
+            INVALID_AMOUNT_REJECT_PAUSE_SECS
+        } else if no_liquidity {
+            self.reject_cooldown_secs()
+                .max(NO_LIQUIDITY_REJECT_PAUSE_SECS)
+        } else {
+            self.reject_cooldown_secs()
+        };
+        let until = now + chrono::Duration::seconds(cooldown_secs);
+
+        if balance_or_allowance {
+            self.balance_exhausted_until = Some(until);
+        }
+
+        self.token_reject_until
+            .insert(Arc::<str>::from(intent.token_id.as_str()), until);
+
+        if intent.side == TradeSide::Buy {
+            if let Some(symbol) = self.token_symbol.get(intent.token_id.as_str()).cloned() {
+                self.last_entry.insert(symbol, now);
+            }
+        }
+
+        warn!(
+            strategy = self.name(),
+            intent_id = %intent.intent_id,
+            token_id = %intent.token_id,
+            reason = %reason,
+            cooldown_secs,
+            "Order rejected; suppressing duplicate live intents during cooldown"
+        );
+    }
+
     fn name(&self) -> &str {
         "three_layer"
     }
@@ -1021,6 +1138,7 @@ impl StrategyLogic for ThreeLayerStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn regime_from_secs_boundaries() {
@@ -1092,6 +1210,121 @@ mod tests {
             max_entry_price: 0.85,
             min_entry_score: 0.30,
         }
+    }
+
+    fn discover_test_event(strategy: &mut ThreeLayerStrategy, now: DateTime<Utc>) {
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        strategy.on_update(
+            &MarketUpdate::EventDiscovered {
+                event_id: Arc::from("evt1"),
+                symbol: Arc::from("BTCUSDT"),
+                up_token: Arc::from("token-up"),
+                down_token: Arc::from("token-down"),
+                end_time: now + chrono::Duration::seconds(300),
+                window_secs: 300,
+                price_to_beat: Some(dec!(100000)),
+                resolved_up_won: None,
+            },
+            &positions,
+            &orders,
+        );
+    }
+
+    fn position_with_token(token_id: &str, now: DateTime<Utc>) -> PositionLedger {
+        let mut positions = PositionLedger::default();
+        positions.apply_fill(&FillRecord {
+            fill_id: format!("fill-{token_id}"),
+            order_id: format!("order-{token_id}"),
+            token_id: token_id.to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            price: dec!(0.45),
+            fee: Decimal::ZERO,
+            timestamp: now,
+        });
+        positions
+    }
+
+    fn active_order_for_token(token_id: &str, now: DateTime<Utc>) -> OrderLedger {
+        let mut orders = OrderLedger::default();
+        let intent = TradingIntent {
+            intent_id: format!("intent-{token_id}"),
+            deployment_id: "three-layer-live".into(),
+            market_id: "evt1".into(),
+            token_id: token_id.to_string(),
+            side: TradeSide::Sell,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.72)),
+            purpose: IntentPurpose::Exit,
+            created_at: now,
+        };
+        orders.insert_from_intent(format!("order-{token_id}"), &intent);
+        orders.acknowledge(&format!("order-{token_id}"), format!("venue-{token_id}"));
+        orders
+    }
+
+    fn take_profit_quote(token_id: &str, ts: DateTime<Utc>) -> MarketUpdate {
+        MarketUpdate::Quote {
+            token_id: Arc::from(token_id),
+            bid: Some(dec!(0.72)),
+            ask: Some(dec!(0.75)),
+            bid_size: Some(dec!(100)),
+            ask_size: Some(dec!(100)),
+            ts,
+        }
+    }
+
+    #[test]
+    fn reject_cooldown_suppresses_duplicate_live_exit() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        discover_test_event(&mut strategy, now);
+        let positions = position_with_token("token-down", now);
+        let orders = OrderLedger::default();
+
+        let first_decisions =
+            strategy.on_update(&take_profit_quote("token-down", now), &positions, &orders);
+        let exit_intent = match first_decisions.as_slice() {
+            [StrategyDecision::Exit(intent)] => intent.clone(),
+            other => panic!("expected one take-profit exit, got {other:?}"),
+        };
+
+        strategy.on_reject(
+            &exit_intent,
+            "not enough balance / allowance: available balance is lower than order size",
+        );
+        let next_decisions = strategy.on_update(
+            &take_profit_quote("token-down", now + chrono::Duration::seconds(1)),
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            next_decisions.is_empty(),
+            "rejected token should not emit duplicate live exit"
+        );
+    }
+
+    #[test]
+    fn active_order_suppresses_duplicate_live_exit() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        discover_test_event(&mut strategy, now);
+        let positions = position_with_token("token-down", now);
+        let orders = active_order_for_token("token-down", now);
+
+        let decisions =
+            strategy.on_update(&take_profit_quote("token-down", now), &positions, &orders);
+
+        assert!(
+            decisions.is_empty(),
+            "active order should gate duplicate live exit"
+        );
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -466,6 +466,24 @@ impl ThreeLayerStrategy {
             .is_some_and(|until| now < *until)
     }
 
+    fn set_token_reject_until(&mut self, token_id: &str, until: DateTime<Utc>) {
+        self.token_reject_until
+            .entry(Arc::<str>::from(token_id))
+            .and_modify(|existing| {
+                if until > *existing {
+                    *existing = until;
+                }
+            })
+            .or_insert(until);
+    }
+
+    fn set_balance_exhausted_until(&mut self, until: DateTime<Utc>) {
+        match self.balance_exhausted_until {
+            Some(existing) if existing >= until => {}
+            _ => self.balance_exhausted_until = Some(until),
+        }
+    }
+
     fn active_order_exists(orders: &OrderLedger, token_id: &str) -> bool {
         orders.orders().any(|o| {
             o.token_id == token_id
@@ -1090,11 +1108,20 @@ impl StrategyLogic for ThreeLayerStrategy {
     fn on_reject(&mut self, intent: &TradingIntent, reason: &str) {
         let now = self.now();
         let reason_lc = reason.to_ascii_lowercase();
-        let balance_or_allowance =
-            reason_lc.contains("not enough balance") || reason_lc.contains("allowance");
+        // Reject-string provenance:
+        // - Polymarket CLOB/live executor: "not enough balance", "not enough allowance",
+        //   "no orders found to match with FAK order", "insufficient liquidity", "no match".
+        // - Venue precision/min-size rejects observed in live records: "invalid amount(s)".
+        // - Local engine dust guard: "below retry threshold".
+        let balance_or_allowance = reason_lc.contains("not enough balance")
+            || reason_lc.contains("not enough allowance")
+            || (reason_lc.contains("not enough") && reason_lc.contains("allowance"))
+            || (reason_lc.contains("insufficient") && reason_lc.contains("allowance"));
         let invalid_amount =
-            reason_lc.contains("invalid amounts") || reason_lc.contains("below retry threshold");
-        let no_liquidity = reason_lc.contains("no orders found") || reason_lc.contains("no match");
+            reason_lc.contains("invalid amount") || reason_lc.contains("below retry threshold");
+        let no_liquidity = reason_lc.contains("no orders found")
+            || reason_lc.contains("insufficient liquidity")
+            || reason_lc.contains("no match");
         let cooldown_secs = if balance_or_allowance {
             BALANCE_REJECT_PAUSE_SECS
         } else if invalid_amount {
@@ -1108,11 +1135,10 @@ impl StrategyLogic for ThreeLayerStrategy {
         let until = now + chrono::Duration::seconds(cooldown_secs);
 
         if balance_or_allowance {
-            self.balance_exhausted_until = Some(until);
+            self.set_balance_exhausted_until(until);
         }
 
-        self.token_reject_until
-            .insert(Arc::<str>::from(intent.token_id.as_str()), until);
+        self.set_token_reject_until(&intent.token_id, until);
 
         if intent.side == TradeSide::Buy {
             if let Some(symbol) = self.token_symbol.get(intent.token_id.as_str()).cloned() {
@@ -1275,6 +1301,20 @@ mod tests {
         }
     }
 
+    fn rejected_exit_intent(token_id: &str, now: DateTime<Utc>) -> TradingIntent {
+        TradingIntent {
+            intent_id: format!("reject-{token_id}"),
+            deployment_id: "three-layer-live".into(),
+            market_id: "evt1".into(),
+            token_id: token_id.to_string(),
+            side: TradeSide::Sell,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.72)),
+            purpose: IntentPurpose::Exit,
+            created_at: now,
+        }
+    }
+
     #[test]
     fn reject_cooldown_suppresses_duplicate_live_exit() {
         use chrono::TimeZone;
@@ -1305,6 +1345,94 @@ mod tests {
         assert!(
             next_decisions.is_empty(),
             "rejected token should not emit duplicate live exit"
+        );
+    }
+
+    #[test]
+    fn reject_cooldown_preserves_longer_existing_pause() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        strategy.feed_time = Some(now);
+        let intent = rejected_exit_intent("token-down", now);
+
+        strategy.on_reject(
+            &intent,
+            "not enough balance / allowance: available balance is lower than order size",
+        );
+        let first_token_until = strategy
+            .token_reject_until
+            .get("token-down")
+            .copied()
+            .expect("token cooldown");
+        let first_balance_until = strategy.balance_exhausted_until.expect("balance pause");
+
+        strategy.feed_time = Some(now + chrono::Duration::seconds(10));
+        strategy.on_reject(&intent, "no orders found to match with FAK order");
+
+        assert_eq!(
+            strategy
+                .token_reject_until
+                .get("token-down")
+                .copied()
+                .expect("token cooldown"),
+            first_token_until
+        );
+        assert_eq!(
+            strategy.balance_exhausted_until.expect("balance pause"),
+            first_balance_until
+        );
+    }
+
+    #[test]
+    fn reject_cooldown_classifies_observed_live_reasons() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        let intent = rejected_exit_intent("token-down", now);
+
+        strategy.feed_time = Some(now);
+        strategy.on_reject(&intent, "invalid amounts");
+        assert_eq!(
+            strategy
+                .token_reject_until
+                .get("token-down")
+                .copied()
+                .expect("token cooldown"),
+            now + chrono::Duration::seconds(INVALID_AMOUNT_REJECT_PAUSE_SECS)
+        );
+
+        strategy.token_reject_until.clear();
+        strategy.feed_time = Some(now);
+        strategy.on_reject(&intent, "no orders found to match with FAK order");
+        assert_eq!(
+            strategy
+                .token_reject_until
+                .get("token-down")
+                .copied()
+                .expect("token cooldown"),
+            now + chrono::Duration::seconds(NO_LIQUIDITY_REJECT_PAUSE_SECS)
+        );
+
+        strategy.token_reject_until.clear();
+        strategy.feed_time = Some(now);
+        strategy.on_reject(
+            &intent,
+            "not enough allowance: allowance is lower than order size",
+        );
+        assert_eq!(
+            strategy
+                .token_reject_until
+                .get("token-down")
+                .copied()
+                .expect("token cooldown"),
+            now + chrono::Duration::seconds(BALANCE_REJECT_PAUSE_SECS)
+        );
+        assert_eq!(
+            strategy.balance_exhausted_until.expect("balance pause"),
+            now + chrono::Duration::seconds(BALANCE_REJECT_PAUSE_SECS)
         );
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,7 +3,9 @@
 ## Files
 
 - `crates/ploy-strategy-bundles/src/engine.rs`
+  - Owner: live dust-remainder retry guard in reconciliation.
 - `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: in-flight/reject cooldown duplicate-intent gates.
 
 ## Tasks
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,31 @@
+# Live Order Duplicate Suppression (2026-04-25)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/engine.rs`
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+
+## Tasks
+
+- [x] Confirm the repeated live order pattern from Tango `strategy_runtime_orders`.
+- [x] Add a runtime dust/min-notional guard before retrying live FAK remainders.
+- [x] Add ThreeLayer rejection cooldowns for balance exhaustion, no-liquidity, and invalid-amount rejects.
+- [x] Add focused regression tests for duplicate suppression and dust handling.
+- [x] Run focused Rust tests and diff checks.
+
+## Review
+
+- 2026-04-25: Tango live records showed repeated `not enough balance / allowance`,
+  `no orders found to match with FAK order`, and dust `invalid amounts` attempts
+  for the same token/intention after live FAK acknowledgements or rejects.
+- 2026-04-25: Runtime now stops retrying sub-1-share or sub-1U live remainders,
+  and ThreeLayer now gates duplicate live intents while a token has an active
+  order or a recent venue rejection cooldown.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture`,
+  `rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/engine.rs crates/ploy-strategy-bundles/src/strategies/three_layer.rs`,
+  and `git diff --check`.
+
 # Polymarket V1 Contract Config Follow-up (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary

- stop live FAK retry loops for dust remainders below 1 share or 1U notional
- add ThreeLayer in-flight order gates for entry, exit, and settlement exits
- add rejection cooldowns for balance/allowance, invalid amount, and no-liquidity live rejects
- document the live duplicate-order diagnosis in tasks/todo.md

## Verification

- rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/engine.rs crates/ploy-strategy-bundles/src/strategies/three_layer.rs
- git diff --check

## Deployment note

Not deployed to Tango. Merge through CI first, then deploy via the existing deploy-tango-1-1 workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Orders falling below minimum thresholds during live trading are now automatically canceled instead of retried
  * Duplicate order entries and exits are suppressed using rejection-driven cooldown gates to prevent redundant placements
  * Balance exhaustion now pauses order generation to prevent invalid order attempts
  * Improved handling of rejected orders with cooldown periods based on rejection reason

<!-- end of auto-generated comment: release notes by coderabbit.ai -->