### PR TITLE
Fix live FAK fill accounting and reject cooldowns

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -755,17 +755,13 @@ fn normalize_order_quantity(quantity: Decimal) -> Decimal {
     quantity.trunc_with_scale(2)
 }
 
-fn normalize_order_notional(quantity: Decimal, limit_price: Decimal) -> Decimal {
-    (quantity * limit_price).trunc_with_scale(2)
-}
-
 fn normalize_execution_amount(
     quantity: Decimal,
-    limit_price: Decimal,
+    _limit_price: Decimal,
     side: Side,
 ) -> Result<Amount, polymarket_client_sdk::error::Error> {
     match side {
-        Side::Buy => Amount::usdc(normalize_order_notional(quantity, limit_price)),
+        Side::Buy => Amount::shares(normalize_order_quantity(quantity)),
         Side::Sell => Amount::shares(normalize_order_quantity(quantity)),
         _ => unreachable!("invalid Polymarket side"),
     }
@@ -839,11 +835,11 @@ pub fn crate_marker() -> &'static str {
 mod tests {
     use super::{
         execution_price_override, normalize_aggressive_price, normalize_execution_amount,
-        normalize_order_notional, normalize_order_quantity, polymarket_signature_type_from_env,
-        tracked_trade_fill, trade_side, unique_token_ids, CancellationOutcome, CancellationRequest,
-        ExecutionError, ExecutionOutcome, ExecutionRequest, LiveExecutionGateway,
-        OrderExecutionType, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
-        ReplaceRequest, StaticExecutionGateway, TrackedOrder, WalletSignatureType,
+        normalize_order_quantity, polymarket_signature_type_from_env, tracked_trade_fill,
+        trade_side, unique_token_ids, CancellationOutcome, CancellationRequest, ExecutionError,
+        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, OrderExecutionType,
+        PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest,
+        StaticExecutionGateway, TrackedOrder, WalletSignatureType,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -930,22 +926,14 @@ mod tests {
     }
 
     #[test]
-    fn normalize_order_notional_truncates_to_two_decimals() {
-        assert_eq!(
-            normalize_order_notional(dec!(24.467825), dec!(0.61305)),
-            dec!(15.00)
-        );
-    }
-
-    #[test]
-    fn normalize_execution_amount_uses_usdc_for_buy_and_shares_for_sell() {
+    fn normalize_execution_amount_uses_shares_for_immediate_orders() {
         let buy = normalize_execution_amount(dec!(24.467825), dec!(0.61305), Side::Buy)
             .expect("buy amount");
         let sell = normalize_execution_amount(dec!(24.467825), dec!(0.61305), Side::Sell)
             .expect("sell amount");
 
-        assert!(buy.is_usdc());
-        assert_eq!(buy.as_inner(), dec!(15.00));
+        assert!(buy.is_shares());
+        assert_eq!(buy.as_inner(), dec!(24.46));
         assert!(sell.is_shares());
         assert_eq!(sell.as_inner(), dec!(24.46));
     }

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -73,9 +73,9 @@ impl From<DirectionalConfig> for ThreeLayerConfig {
 const DRIFT_WINDOW_SECS: f64 = 30.0;
 const VOL_WINDOW_SECS: f64 = 120.0;
 const MIN_VOL_POINTS: usize = 5;
-const BALANCE_REJECT_PAUSE_SECS: i64 = 5 * 60;
-const INVALID_AMOUNT_REJECT_PAUSE_SECS: i64 = 5 * 60;
-const NO_LIQUIDITY_REJECT_PAUSE_SECS: i64 = 30;
+const ACCOUNT_BALANCE_REJECT_PAUSE_SECS: i64 = 15;
+const HARD_TOKEN_REJECT_PAUSE_SECS: i64 = 35;
+const NO_LIQUIDITY_REJECT_PAUSE_SECS: i64 = 15;
 
 struct DriftTracker {
     history: VecDeque<(DateTime<Utc>, f64)>,
@@ -1122,23 +1122,22 @@ impl StrategyLogic for ThreeLayerStrategy {
         let no_liquidity = reason_lc.contains("no orders found")
             || reason_lc.contains("insufficient liquidity")
             || reason_lc.contains("no match");
-        let cooldown_secs = if balance_or_allowance {
-            BALANCE_REJECT_PAUSE_SECS
-        } else if invalid_amount {
-            INVALID_AMOUNT_REJECT_PAUSE_SECS
+        let token_cooldown_secs = if balance_or_allowance || invalid_amount {
+            HARD_TOKEN_REJECT_PAUSE_SECS
         } else if no_liquidity {
-            self.reject_cooldown_secs()
-                .max(NO_LIQUIDITY_REJECT_PAUSE_SECS)
+            NO_LIQUIDITY_REJECT_PAUSE_SECS
         } else {
             self.reject_cooldown_secs()
         };
-        let until = now + chrono::Duration::seconds(cooldown_secs);
+        let token_until = now + chrono::Duration::seconds(token_cooldown_secs);
 
-        if balance_or_allowance {
-            self.set_balance_exhausted_until(until);
+        if balance_or_allowance && intent.side == TradeSide::Buy {
+            self.set_balance_exhausted_until(
+                now + chrono::Duration::seconds(ACCOUNT_BALANCE_REJECT_PAUSE_SECS),
+            );
         }
 
-        self.set_token_reject_until(&intent.token_id, until);
+        self.set_token_reject_until(&intent.token_id, token_until);
 
         if intent.side == TradeSide::Buy {
             if let Some(symbol) = self.token_symbol.get(intent.token_id.as_str()).cloned() {
@@ -1151,7 +1150,7 @@ impl StrategyLogic for ThreeLayerStrategy {
             intent_id = %intent.intent_id,
             token_id = %intent.token_id,
             reason = %reason,
-            cooldown_secs,
+            cooldown_secs = token_cooldown_secs,
             "Order rejected; suppressing duplicate live intents during cooldown"
         );
     }
@@ -1315,6 +1314,20 @@ mod tests {
         }
     }
 
+    fn rejected_buy_intent(token_id: &str, now: DateTime<Utc>) -> TradingIntent {
+        TradingIntent {
+            intent_id: format!("buy-reject-{token_id}"),
+            deployment_id: "three-layer-live".into(),
+            market_id: "evt1".into(),
+            token_id: token_id.to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.72)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        }
+    }
+
     #[test]
     fn reject_cooldown_suppresses_duplicate_live_exit() {
         use chrono::TimeZone;
@@ -1357,16 +1370,12 @@ mod tests {
         strategy.feed_time = Some(now);
         let intent = rejected_exit_intent("token-down", now);
 
-        strategy.on_reject(
-            &intent,
-            "not enough balance / allowance: available balance is lower than order size",
-        );
+        strategy.on_reject(&intent, "invalid amounts");
         let first_token_until = strategy
             .token_reject_until
             .get("token-down")
             .copied()
             .expect("token cooldown");
-        let first_balance_until = strategy.balance_exhausted_until.expect("balance pause");
 
         strategy.feed_time = Some(now + chrono::Duration::seconds(10));
         strategy.on_reject(&intent, "no orders found to match with FAK order");
@@ -1379,10 +1388,7 @@ mod tests {
                 .expect("token cooldown"),
             first_token_until
         );
-        assert_eq!(
-            strategy.balance_exhausted_until.expect("balance pause"),
-            first_balance_until
-        );
+        assert!(strategy.balance_exhausted_until.is_none());
     }
 
     #[test]
@@ -1401,8 +1407,9 @@ mod tests {
                 .get("token-down")
                 .copied()
                 .expect("token cooldown"),
-            now + chrono::Duration::seconds(INVALID_AMOUNT_REJECT_PAUSE_SECS)
+            now + chrono::Duration::seconds(HARD_TOKEN_REJECT_PAUSE_SECS)
         );
+        assert!(strategy.balance_exhausted_until.is_none());
 
         strategy.token_reject_until.clear();
         strategy.feed_time = Some(now);
@@ -1428,11 +1435,36 @@ mod tests {
                 .get("token-down")
                 .copied()
                 .expect("token cooldown"),
-            now + chrono::Duration::seconds(BALANCE_REJECT_PAUSE_SECS)
+            now + chrono::Duration::seconds(HARD_TOKEN_REJECT_PAUSE_SECS)
+        );
+        assert!(strategy.balance_exhausted_until.is_none());
+    }
+
+    #[test]
+    fn buy_balance_reject_uses_short_account_pause() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        let intent = rejected_buy_intent("token-up", now);
+
+        strategy.feed_time = Some(now);
+        strategy.on_reject(
+            &intent,
+            "not enough balance: available balance is lower than order size",
+        );
+
+        assert_eq!(
+            strategy
+                .token_reject_until
+                .get("token-up")
+                .copied()
+                .expect("token cooldown"),
+            now + chrono::Duration::seconds(HARD_TOKEN_REJECT_PAUSE_SECS)
         );
         assert_eq!(
             strategy.balance_exhausted_until.expect("balance pause"),
-            now + chrono::Duration::seconds(BALANCE_REJECT_PAUSE_SECS)
+            now + chrono::Duration::seconds(ACCOUNT_BALANCE_REJECT_PAUSE_SECS)
         );
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,39 @@
+# Live FAK Fill Accounting Repair (2026-04-25)
+
+## Files
+
+- `crates/ploy-connectivity/src/lib.rs`
+  - Owner: Polymarket FAK amount semantics and reconciled fill accounting.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: short event-safe rejection cooldown policy.
+
+## Tasks
+
+- [x] Confirm Tango logs show reconciled fills rejected locally as overfilled.
+- [x] Align Polymarket BUY FAK requests with local share quantity accounting.
+- [x] Shorten/remove event-killing account-level reject cooldowns.
+- [x] Add focused regression tests for BUY FAK amount semantics and cooldown policy.
+- [x] Run focused Rust tests and diff checks.
+
+## Review
+
+- 2026-04-25: Tango logs showed acknowledged BUY FAK orders receiving
+  reconciled fills with more shares than the local `requested_qty`, e.g. a
+  142.146411 share BTC order later reconciled as 173.666665 shares. The local
+  ledger rejected those as overfills, kept the order unfilled, and then retried.
+- 2026-04-25: Root cause was a unit mismatch: live BUY FAK used Polymarket
+  `Amount::usdc(quantity * limit_price)` while the local order lifecycle tracks
+  `quantity` as shares. BUY FAK now uses `Amount::shares(quantity)` so venue
+  fills and local order quantities share the same unit.
+- 2026-04-25: Rejection cooldowns are now event-safe: hard token cooldowns are
+  35 seconds, no-liquidity cooldown is 15 seconds, and account-level balance
+  pause is only 15 seconds for BUY balance/allowance rejects.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-connectivity --lib -- --nocapture`,
+  `rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture`,
+  `rustfmt --edition 2021 --check crates/ploy-connectivity/src/lib.rs crates/ploy-strategy-bundles/src/strategies/three_layer.rs`,
+  and `git diff --check`.
+
 # Live Order Duplicate Suppression (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- submit live BUY FAK/FOK requests in share units so reconciled fills cannot exceed local requested_qty due to price improvement
- shorten rejection cooldowns for 5-minute PM5D events: hard token rejects 35s, no-liquidity 15s, BUY account balance pause 15s
- document the Tango log evidence and add regression coverage

## Root cause
Tango logs showed live BUY FAK fills returning more shares than the local order requested, for example a 142.146411 share BTC order reconciled as 173.666665 shares. The ledger rejected those fills as overfills, leaving the order unfilled locally and allowing retry attempts that looked like duplicate live orders.

The execution gateway submitted BUY market orders as USDC notional (`quantity * limit_price`) while the rest of the order lifecycle treated `quantity` as shares.

## Tests
- `rtk cargo test -p ploy-connectivity --lib -- --nocapture`
- `rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture`
- `rustfmt --edition 2021 --check crates/ploy-connectivity/src/lib.rs crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
- `git diff --check`