### PR TITLE
Fix live market buy amount precision

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -755,14 +755,18 @@ fn normalize_order_quantity(quantity: Decimal) -> Decimal {
     quantity.trunc_with_scale(2)
 }
 
+fn normalize_market_order_quantity(quantity: Decimal) -> Decimal {
+    quantity.trunc_with_scale(4)
+}
+
 fn normalize_execution_amount(
     quantity: Decimal,
     _limit_price: Decimal,
     side: Side,
 ) -> Result<Amount, polymarket_client_sdk::error::Error> {
     match side {
-        Side::Buy => Amount::shares(normalize_order_quantity(quantity)),
-        Side::Sell => Amount::shares(normalize_order_quantity(quantity)),
+        Side::Buy => Amount::shares(normalize_market_order_quantity(quantity)),
+        Side::Sell => Amount::shares(normalize_market_order_quantity(quantity)),
         _ => unreachable!("invalid Polymarket side"),
     }
 }
@@ -835,11 +839,12 @@ pub fn crate_marker() -> &'static str {
 mod tests {
     use super::{
         execution_price_override, normalize_aggressive_price, normalize_execution_amount,
-        normalize_order_quantity, polymarket_signature_type_from_env, tracked_trade_fill,
-        trade_side, unique_token_ids, CancellationOutcome, CancellationRequest, ExecutionError,
-        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, OrderExecutionType,
-        PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest,
-        StaticExecutionGateway, TrackedOrder, WalletSignatureType,
+        normalize_market_order_quantity, normalize_order_quantity,
+        polymarket_signature_type_from_env, tracked_trade_fill, trade_side, unique_token_ids,
+        CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
+        ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
+        PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
+        TrackedOrder, WalletSignatureType,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -926,6 +931,18 @@ mod tests {
     }
 
     #[test]
+    fn normalize_market_order_quantity_truncates_to_market_taker_scale() {
+        assert_eq!(
+            normalize_market_order_quantity(dec!(24.467825)),
+            dec!(24.4678)
+        );
+        assert_eq!(
+            normalize_market_order_quantity(dec!(17.663163)),
+            dec!(17.6631)
+        );
+    }
+
+    #[test]
     fn normalize_execution_amount_uses_shares_for_immediate_orders() {
         let buy = normalize_execution_amount(dec!(24.467825), dec!(0.61305), Side::Buy)
             .expect("buy amount");
@@ -933,9 +950,9 @@ mod tests {
             .expect("sell amount");
 
         assert!(buy.is_shares());
-        assert_eq!(buy.as_inner(), dec!(24.46));
+        assert_eq!(buy.as_inner(), dec!(24.4678));
         assert!(sell.is_shares());
-        assert_eq!(sell.as_inner(), dec!(24.46));
+        assert_eq!(sell.as_inner(), dec!(24.4678));
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Live Market Buy Precision Repair (2026-04-25)
+
+## Files
+
+- `vendor/polymarket-client-sdk/src/clob/order_builder.rs`
+  - Owner: venue precision encoding for market order maker/taker amounts.
+- `vendor/polymarket-client-sdk/src/clob/types/mod.rs`
+  - Owner: market share amount precision validation.
+- `vendor/polymarket-client-sdk/tests/order.rs`
+  - Owner: SDK market order precision regressions.
+- `crates/ploy-connectivity/src/lib.rs`
+  - Owner: live FAK/FOK amount normalization passed into the SDK.
+
+## Tasks
+
+- [x] Confirm Tango had live signals and dry-run orders after deploy.
+- [x] Confirm live orders were rejected by CLOB amount precision, not missing signals.
+- [x] Encode market BUY maker USDC at cent precision and taker shares at four decimals.
+- [x] Keep limit order lot-size normalization unchanged.
+- [x] Run focused SDK and connectivity tests.
+
+## Review
+
+- 2026-04-25: Tango logs showed `entry signal` for dry-run and live, with live
+  rejects from Polymarket: `invalid amounts, the market buy orders maker amount
+  supports a max accuracy of 2 decimals, taker amount a max of 4 decimals`.
+- 2026-04-25: DB evidence in the latest 30-minute window showed dry-run orders
+  filled while matching live BUY intents were rejected, e.g. BNBUSDT at 08:03
+  and BNBUSDT/BTCUSDT at 08:08 CST.
+- 2026-04-25: The SDK now quantizes market order USDC maker amounts to cents
+  and share taker amounts to four decimals. `ploy-connectivity` now preserves
+  four decimals for FAK/FOK share amounts while leaving limit-order quantity at
+  two decimals.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-connectivity --lib -- --nocapture`,
+  `cargo test -p polymarket-client-sdk --features clob --lib -- --nocapture`,
+  and `cargo test -p polymarket-client-sdk --features clob --test order -- --nocapture`.
+
 # Live FAK Fill Accounting Repair (2026-04-25)
 
 ## Files

--- a/vendor/polymarket-client-sdk/src/clob/order_builder.rs
+++ b/vendor/polymarket-client-sdk/src/clob/order_builder.rs
@@ -6,21 +6,27 @@ use chrono::{DateTime, Utc};
 use rand::Rng as _;
 use rust_decimal::prelude::ToPrimitive as _;
 
-use crate::Result;
-use crate::auth::Kind as AuthKind;
 use crate::auth::state::Authenticated;
-use crate::clob::Client;
+use crate::auth::Kind as AuthKind;
 use crate::clob::types::request::OrderBookSummaryRequest;
 use crate::clob::types::{
     Amount, AmountInner, Order, OrderType, Side, SignableOrder, SignatureType,
 };
+use crate::clob::Client;
 use crate::error::Error;
 use crate::types::{Address, Decimal};
+use crate::Result;
 
 pub(crate) const USDC_DECIMALS: u32 = 6;
 
 /// Maximum number of decimal places for `size`
 pub(crate) const LOT_SIZE_SCALE: u32 = 2;
+
+/// Polymarket market BUY orders reject maker USDC beyond cents.
+pub(crate) const MARKET_USDC_DECIMALS: u32 = 2;
+
+/// Polymarket market orders allow taker share precision up to four decimals.
+pub(crate) const MARKET_SHARE_DECIMALS: u32 = 4;
 
 /// Placeholder type for compile-time checks on limit order builders
 #[non_exhaustive]
@@ -416,20 +422,23 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
         let (taker_amount, maker_amount) = match (side, amount.0) {
             // Spend USDC to buy shares
             (Side::Buy, AmountInner::Usdc(_)) => {
-                let shares = (raw_amount / price).trunc_with_scale(decimals + LOT_SIZE_SCALE);
-                (shares, raw_amount)
+                let usdc = raw_amount.trunc_with_scale(MARKET_USDC_DECIMALS);
+                let shares = (usdc / price).trunc_with_scale(MARKET_SHARE_DECIMALS);
+                (shares, usdc)
             }
 
             // Buy N shares: use cutoff `price` derived from ask depth
             (Side::Buy, AmountInner::Shares(_)) => {
-                let usdc = (raw_amount * price).trunc_with_scale(decimals + LOT_SIZE_SCALE);
-                (raw_amount, usdc)
+                let shares = raw_amount.trunc_with_scale(MARKET_SHARE_DECIMALS);
+                let usdc = ceil_with_scale(shares * price, MARKET_USDC_DECIMALS);
+                (shares, usdc)
             }
 
             // Sell N shares for USDC
             (Side::Sell, AmountInner::Shares(_)) => {
-                let usdc = (raw_amount * price).trunc_with_scale(decimals + LOT_SIZE_SCALE);
-                (usdc, raw_amount)
+                let shares = raw_amount.trunc_with_scale(MARKET_SHARE_DECIMALS);
+                let usdc = (shares * price).trunc_with_scale(MARKET_USDC_DECIMALS);
+                (usdc, shares)
             }
 
             (Side::Sell, AmountInner::Usdc(_)) => {
@@ -477,6 +486,11 @@ fn to_fixed_u128(d: Decimal) -> u128 {
         .mantissa()
         .to_u128()
         .expect("The `build` call in `OrderBuilder<S, OrderKind, K>` ensures that only positive values are being multiplied/divided")
+}
+
+fn ceil_with_scale(d: Decimal, scale: u32) -> Decimal {
+    let factor = Decimal::from(10_u64.pow(scale));
+    (d * factor).ceil() / factor
 }
 
 /// Mask the salt to be <= 2^53 - 1, as the backend parses as an IEEE 754.

--- a/vendor/polymarket-client-sdk/src/clob/types/mod.rs
+++ b/vendor/polymarket-client-sdk/src/clob/types/mod.rs
@@ -5,16 +5,16 @@ use alloy::primitives::{Signature, U256};
 use bon::Builder;
 use rust_decimal_macros::dec;
 use serde::ser::{Error as _, SerializeStruct as _};
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::Serialize_repr;
-use serde_with::{DisplayFromStr, serde_as};
+use serde_with::{serde_as, DisplayFromStr};
 use strum_macros::Display;
 
-use crate::Result;
 use crate::auth::ApiKey;
-use crate::clob::order_builder::{LOT_SIZE_SCALE, USDC_DECIMALS};
+use crate::clob::order_builder::{MARKET_SHARE_DECIMALS, USDC_DECIMALS};
 use crate::error::Error;
 use crate::types::Decimal;
+use crate::Result;
 
 pub mod request;
 pub mod response;
@@ -192,9 +192,9 @@ impl Amount {
 
     pub fn shares(value: Decimal) -> Result<Amount> {
         let normalized = value.normalize();
-        if normalized.scale() > LOT_SIZE_SCALE {
+        if normalized.scale() > MARKET_SHARE_DECIMALS {
             return Err(Error::validation(format!(
-                "Unable to build Amount with {} decimal points, must be <= {LOT_SIZE_SCALE}",
+                "Unable to build Amount with {} decimal points, must be <= {MARKET_SHARE_DECIMALS}",
                 normalized.scale()
             )));
         }
@@ -598,12 +598,10 @@ mod tests {
     fn non_standard_decimal_to_tick_size_should_fail() {
         let result = TickSize::try_from(Decimal::ONE);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Unknown tick size: 1")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown tick size: 1"));
     }
 
     #[test]
@@ -616,19 +614,25 @@ mod tests {
         assert!(shares.is_shares());
         assert_eq!(shares.as_inner(), Decimal::ONE_HUNDRED);
 
+        let fractional_shares = Amount::shares(dec!(0.2345))?;
+        assert!(fractional_shares.is_shares());
+        assert_eq!(fractional_shares.as_inner(), dec!(0.2345));
+
         Ok(())
     }
 
     #[test]
     fn improper_shares_lot_size_should_fail() {
-        let Err(err) = Amount::shares(dec!(0.23400)) else {
+        let Err(err) = Amount::shares(dec!(0.23456)) else {
             panic!()
         };
 
         let message = err.downcast_ref::<Validation>().unwrap();
         assert_eq!(
             message.reason,
-            format!("Unable to build Amount with 3 decimal points, must be <= {LOT_SIZE_SCALE}")
+            format!(
+                "Unable to build Amount with 5 decimal points, must be <= {MARKET_SHARE_DECIMALS}"
+            )
         );
     }
 

--- a/vendor/polymarket-client-sdk/tests/order.rs
+++ b/vendor/polymarket-client-sdk/tests/order.rs
@@ -13,21 +13,21 @@ use chrono::{DateTime, Utc};
 use httpmock::MockServer;
 use polymarket_client_sdk::clob::types::response::OrderSummary;
 use polymarket_client_sdk::clob::types::{Amount, OrderType, Side, SignatureType, TickSize};
-use polymarket_client_sdk::types::{Address, Decimal, address};
+use polymarket_client_sdk::types::{address, Address, Decimal};
 use reqwest::StatusCode;
 use rust_decimal_macros::dec;
 
 use crate::common::{
-    USDC_DECIMALS, create_authenticated, ensure_requirements, to_decimal, token_1, token_2,
+    create_authenticated, ensure_requirements, to_decimal, token_1, token_2, USDC_DECIMALS,
 };
 
 /// Tests for the lifecycle of a [`Client`] as it moves from [`Unauthenticated`] to [`Authenticated`]
 mod lifecycle {
-    use alloy::signers::Signer as _;
     use alloy::signers::local::LocalSigner;
-    use polymarket_client_sdk::POLYGON;
+    use alloy::signers::Signer as _;
     use polymarket_client_sdk::clob::{Client, Config};
     use polymarket_client_sdk::error::Validation;
+    use polymarket_client_sdk::POLYGON;
     use serde_json::json;
 
     use super::*;
@@ -382,7 +382,7 @@ mod lifecycle {
     /// explicit funder.
     #[tokio::test]
     async fn funder_auto_derived_from_signer_for_proxy_types() -> anyhow::Result<()> {
-        use polymarket_client_sdk::{POLYGON, derive_proxy_wallet, derive_safe_wallet};
+        use polymarket_client_sdk::{derive_proxy_wallet, derive_safe_wallet, POLYGON};
 
         let server = MockServer::start();
         let signer = LocalSigner::from_str(PRIVATE_KEY)?.with_chain_id(Some(POLYGON));
@@ -2058,7 +2058,7 @@ mod market {
             assert_eq!(signable_order.order.taker, Address::ZERO);
             assert_eq!(signable_order.order.tokenId, token_1());
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
-            assert_eq!(signable_order.order.takerAmount, U256::from(1_785_714_280));
+            assert_eq!(signable_order.order.takerAmount, U256::from(1_785_714_200));
             assert_eq!(signable_order.order.expiration, U256::from(0));
             assert_eq!(signable_order.order.nonce, U256::from(123));
             assert_eq!(signable_order.order.feeRateBps, U256::ZERO);
@@ -2109,7 +2109,7 @@ mod market {
             assert_eq!(signable_order.order.makerAmount, U256::from(100_000_000));
             assert_eq!(
                 signable_order.order.takerAmount,
-                U256::from(17_857_142_857_u64)
+                U256::from(17_857_142_800_u64)
             );
             assert_eq!(signable_order.order.expiration, U256::from(0));
             assert_eq!(signable_order.order.nonce, U256::from(123));
@@ -2149,8 +2149,8 @@ mod market {
         }
 
         #[tokio::test]
-        async fn market_buy_with_shares_fok_should_fail_on_insufficient_liquidity()
-        -> anyhow::Result<()> {
+        async fn market_buy_with_shares_fok_should_fail_on_insufficient_liquidity(
+        ) -> anyhow::Result<()> {
             let server = MockServer::start();
             let client = create_authenticated(&server).await?;
 
@@ -2187,8 +2187,8 @@ mod market {
         }
 
         #[tokio::test]
-        async fn market_buy_with_shares_should_succeed_and_encode_maker_as_usdc()
-        -> anyhow::Result<()> {
+        async fn market_buy_with_shares_should_succeed_and_encode_maker_as_usdc(
+        ) -> anyhow::Result<()> {
             let server = MockServer::start();
             let client = create_authenticated(&server).await?;
 
@@ -2259,6 +2259,36 @@ mod market {
             // maker = USDC, taker = shares
             assert_eq!(signable_order.order.makerAmount, U256::from(125_000_000)); // 250 * 0.5 = 125
             assert_eq!(signable_order.order.takerAmount, U256::from(250_000_000));
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn market_buy_with_share_amount_quantizes_to_venue_precision() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements_for_market_price(
+                &server,
+                token_1(),
+                &[],
+                &[OrderSummary::builder()
+                    .price(dec!(0.7))
+                    .size(dec!(50))
+                    .build()],
+            );
+
+            let signable_order = client
+                .market_order()
+                .token_id(token_1())
+                .amount(Amount::shares(dec!(21.4285))?)
+                .side(Side::Buy)
+                .price(dec!(0.7))
+                .order_type(OrderType::FOK)
+                .build()
+                .await?;
+
+            assert_eq!(signable_order.order.makerAmount, U256::from(15_000_000));
+            assert_eq!(signable_order.order.takerAmount, U256::from(21_428_500));
             Ok(())
         }
     }


### PR DESCRIPTION
## Summary
- encode market-order USDC legs at cent precision and share legs at four decimals
- keep live BUY FAK/FOK in share units to avoid overfill/retry accounting regressions
- preserve limit-order lot-size normalization at two decimals

## Evidence
Tango produced live/dry-run entry signals after the previous deploy. Dry-run filled, while live BUY market orders were rejected by Polymarket with:

`invalid amounts, the market buy orders maker amount supports a max accuracy of 2 decimals, taker amount a max of 4 decimals`

Examples from 2026-04-25 CST:
- 08:03 BNBUSDT dry-run FILLED, live REJECTED
- 08:08 BNBUSDT dry-run FILLED, live REJECTED
- 08:08 BTCUSDT dry-run FILLED, live REJECTED

## Tests
- `rtk cargo test -p ploy-connectivity --lib -- --nocapture`
- `cargo test -p polymarket-client-sdk --features clob --lib -- --nocapture`
- `cargo test -p polymarket-client-sdk --features clob --test order -- --nocapture`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced market order amount precision by properly quantizing share quantities to 4 decimal places and USDC amounts to 2 decimal places, resolving platform rejection issues
  * Updated share amount validation to support higher decimal precision in order submissions

* **Documentation**
  * Added documentation tracking market order precision improvements and fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->