### PR TITLE
Make dry-run fills respect executable LOB liquidity

### DIFF
--- a/config/strategies/02-pm5d-threelayer.live.toml
+++ b/config/strategies/02-pm5d-threelayer.live.toml
@@ -55,6 +55,7 @@ min_fill_pct = 0.5
 enable_market_impact = true
 impact_coefficient = 0.1
 default_depth_shares = 500
+require_lob_liquidity = true
 
 [reference_data]
 capture_sports_state = false

--- a/config/strategies/02-pm5d-threelayer.unified.toml
+++ b/config/strategies/02-pm5d-threelayer.unified.toml
@@ -55,6 +55,7 @@ min_fill_pct = 0.5
 enable_market_impact = true
 impact_coefficient = 0.1
 default_depth_shares = 500
+require_lob_liquidity = true
 
 [reference_data]
 capture_sports_state = false

--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -17,16 +17,16 @@
 //! | `pm_token_settlements` | Settlement outcomes |
 
 use chrono::{DateTime, Duration, Utc};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
 
 use ploy_market_contracts::{
-    HistoricalLoadOptions, MarketUpdate, l2_updates_from_depth_totals, market_update_sort_ts,
-    normalize_token_id,
+    l2_updates_from_depth_totals, market_update_sort_ts, normalize_token_id, HistoricalLoadOptions,
+    MarketUpdate,
 };
 
 #[cfg(test)]
@@ -37,9 +37,10 @@ const WARMUP_MINUTES: i64 = 30;
 
 /// Historical research backtests only trust canonical historical PM quote captures.
 ///
-/// `ploy_runner_live` is a synthetic midpoint feed for live/dry-run operation, and
-/// the existing `polymarket_ws_collector` history before the next validated cutover
-/// is too polluted with placeholder `0.01/0.99` books to mix into research results.
+/// Older `ploy_runner_live` rows were synthetic midpoint quotes; newer rows carry
+/// filtered top-of-book sizes from REST `/book`. The existing
+/// `polymarket_ws_collector` history before the next validated cutover is too
+/// polluted with placeholder `0.01/0.99` books to mix into research results.
 /// Dry-run parity should use recorded replay mode instead of the historical DB path.
 const TRUSTED_PM_RESEARCH_QUOTE_SOURCES: &[&str] = &[
     "polymarket_ws",
@@ -984,7 +985,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        EventMetadataRow, MarketUpdate, build_event_updates, l2_updates_from_book, near_depth,
+        build_event_updates, l2_updates_from_book, near_depth, EventMetadataRow, MarketUpdate,
     };
 
     #[test]

--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -9,12 +9,13 @@ use std::time::Duration as StdDuration;
 
 use chrono::{DateTime, Timelike, Utc};
 use futures::StreamExt;
-use ploy_market_contracts::{MarketUpdate, l2_updates_from_depth_totals};
+use ploy_market_contracts::{l2_updates_from_depth_totals, MarketUpdate};
 use polymarket_client_sdk::rtds::{Client as RtdsClient, EquityPriceMessage};
 use polymarket_client_sdk::types::U256;
 use polymarket_client_sdk::ws::config::{Config as PolymarketWsConfig, ReconnectConfig};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use serde::Deserialize;
 use serde_json::Value;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
@@ -22,12 +23,13 @@ use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, error, info, warn};
 
 use crate::reference_prices::{
-    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
-    ReferencePriceSource, infer_pyth_asset_class, market_symbol_to_binance_symbol,
-    normalize_reference_symbol, pyth_symbol, upsert_reference_price,
+    infer_pyth_asset_class, market_symbol_to_binance_symbol, normalize_reference_symbol,
+    pyth_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
+    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
 };
 
 const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
+const POLYMARKET_CLOB_HTTP_ENDPOINT: &str = "https://clob.polymarket.com";
 const NEAR_DEPTH_PCT_RANGE: f64 = 0.001;
 
 fn rtds_market_data_ws_config() -> PolymarketWsConfig {
@@ -38,6 +40,67 @@ fn rtds_market_data_ws_config() -> PolymarketWsConfig {
     config.heartbeat_timeout = StdDuration::from_secs(45);
     config.reconnect = ReconnectConfig::default();
     config
+}
+
+#[derive(Debug, Deserialize)]
+struct RestBookLevel {
+    price: String,
+    size: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestBook {
+    #[serde(default)]
+    bids: Vec<RestBookLevel>,
+    #[serde(default)]
+    asks: Vec<RestBookLevel>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct BookQuote {
+    bid: Option<Decimal>,
+    ask: Option<Decimal>,
+    bid_size: Option<Decimal>,
+    ask_size: Option<Decimal>,
+}
+
+fn pm_tradeable_price(price: Decimal) -> bool {
+    price > rust_decimal_macros::dec!(0.02) && price < rust_decimal_macros::dec!(0.98)
+}
+
+fn parse_rest_book_level(level: &RestBookLevel) -> Option<(Decimal, Decimal)> {
+    let price = level.price.parse::<Decimal>().ok()?;
+    let size = level.size.parse::<Decimal>().ok()?;
+    if size <= Decimal::ZERO || !pm_tradeable_price(price) {
+        return None;
+    }
+    Some((price, size))
+}
+
+fn best_tradeable_bid_level(levels: &[RestBookLevel]) -> Option<(Decimal, Decimal)> {
+    levels
+        .iter()
+        .filter_map(parse_rest_book_level)
+        .max_by(|left, right| left.0.cmp(&right.0))
+}
+
+fn best_tradeable_ask_level(levels: &[RestBookLevel]) -> Option<(Decimal, Decimal)> {
+    levels
+        .iter()
+        .filter_map(parse_rest_book_level)
+        .min_by(|left, right| left.0.cmp(&right.0))
+}
+
+fn book_quote_from_rest(book: &RestBook) -> BookQuote {
+    let bid = best_tradeable_bid_level(&book.bids);
+    let ask = best_tradeable_ask_level(&book.asks);
+
+    BookQuote {
+        bid: bid.map(|(price, _)| price),
+        bid_size: bid.map(|(_, size)| size),
+        ask: ask.map(|(price, _)| price),
+        ask_size: ask.map(|(_, size)| size),
+    }
 }
 
 /// Spawn a task that subscribes to Binance spot prices via RTDS WebSocket
@@ -496,7 +559,7 @@ fn json_f64(value: &Value) -> Option<f64> {
 }
 
 /// Spawn a task that polls the Polymarket CLOB REST API for orderbook data
-/// and publishes `MarketUpdate::Quote` events.
+/// and publishes `MarketUpdate::Quote` events with top-of-book sizes.
 ///
 /// REST polling is more reliable than WS for the 5-min window lifecycle.
 /// Polls every 5 seconds per token batch.
@@ -520,74 +583,64 @@ pub fn spawn_quote_feed(
             for token in &token_ids {
                 let token_str = token.to_string();
 
-                // Use /midpoint API instead of /book to get the real market price.
-                // The /book endpoint returns extreme placeholder orders (bid=0.01, ask=0.99)
-                // when there is no real liquidity, which is useless for strategy evaluation.
-                // /midpoint returns the actual market consensus price.
-                let url = format!(
-                    "https://clob.polymarket.com/midpoint?token_id={}",
-                    token_str
-                );
+                let url = format!("{POLYMARKET_CLOB_HTTP_ENDPOINT}/book?token_id={token_str}");
 
                 match http.get(&url).send().await {
-                    Ok(resp) => {
-                        if let Ok(body) = resp.json::<serde_json::Value>().await {
-                            let mid = body["mid"].as_str().and_then(|p| p.parse::<Decimal>().ok());
-
-                            if let Some(mid_price) = mid {
-                                // Store mid as both bid and ask — strategy uses ask for entry.
-                                // A small synthetic spread (0.5%) is applied so bid < ask.
-                                let half_spread = mid_price * rust_decimal_macros::dec!(0.005);
-                                let bid = Some(
-                                    (mid_price - half_spread).max(rust_decimal_macros::dec!(0.01)),
+                    Ok(resp) if resp.status().is_success() => {
+                        if let Ok(book) = resp.json::<RestBook>().await {
+                            let quote = book_quote_from_rest(&book);
+                            let now = Utc::now();
+                            let update = MarketUpdate::Quote {
+                                token_id: Arc::from(token_str.as_str()),
+                                bid: quote.bid,
+                                ask: quote.ask,
+                                bid_size: quote.bid_size,
+                                ask_size: quote.ask_size,
+                                ts: now,
+                            };
+                            if tx.send(update).is_err() {
+                                warn!(
+                                    tokens = token_ids.len(),
+                                    "All receivers dropped, stopping quote poller"
                                 );
-                                let ask = Some(
-                                    (mid_price + half_spread).min(rust_decimal_macros::dec!(0.99)),
+                                return;
+                            }
+
+                            // Persist non-empty top-of-book quotes to DB for replay.
+                            if let Some(ref db) = pool {
+                                if quote.bid.is_some() || quote.ask.is_some() {
+                                    persist_quote(db, &token_str, quote, now).await;
+                                }
+                            }
+
+                            quoted_tokens += 1;
+                            if logged_quote_tokens.insert(token_str.clone()) {
+                                info!(
+                                    token = %token_str,
+                                    bid = ?quote.bid,
+                                    ask = ?quote.ask,
+                                    bid_size = ?quote.bid_size,
+                                    ask_size = ?quote.ask_size,
+                                    "First orderbook quote observed"
                                 );
-
-                                let now = Utc::now();
-                                let update = MarketUpdate::Quote {
-                                    token_id: Arc::from(token_str.as_str()),
-                                    bid,
-                                    ask,
-                                    bid_size: None,
-                                    ask_size: None,
-                                    ts: now,
-                                };
-                                if tx.send(update).is_err() {
-                                    warn!(
-                                        tokens = token_ids.len(),
-                                        "All receivers dropped, stopping quote poller"
-                                    );
-                                    return;
-                                }
-
-                                // Persist to DB for backtest replay.
-                                if let Some(ref db) = pool {
-                                    persist_quote(db, &token_str, bid, ask, now).await;
-                                }
-
-                                quoted_tokens += 1;
-                                if logged_quote_tokens.insert(token_str.clone()) {
-                                    info!(
-                                        token = %token_str,
-                                        mid = %mid_price,
-                                        bid = ?bid,
-                                        ask = ?ask,
-                                        "First midpoint quote observed"
-                                    );
-                                } else if quoted_tokens % 100 == 0 {
-                                    info!(
-                                        quotes = quoted_tokens,
-                                        tracked_tokens = logged_quote_tokens.len(),
-                                        "REST quote poller forwarded midpoint quotes"
-                                    );
-                                }
+                            } else if quoted_tokens % 100 == 0 {
+                                info!(
+                                    quotes = quoted_tokens,
+                                    tracked_tokens = logged_quote_tokens.len(),
+                                    "REST quote poller forwarded orderbook quotes"
+                                );
                             }
                         }
                     }
+                    Ok(resp) => {
+                        debug!(
+                            status = %resp.status(),
+                            token = %token_str,
+                            "REST orderbook fetch returned non-success status"
+                        );
+                    }
                     Err(e) => {
-                        debug!(error = %e, token = %token_str, "REST midpoint fetch failed");
+                        debug!(error = %e, token = %token_str, "REST orderbook fetch failed");
                     }
                 }
             }
@@ -921,20 +974,23 @@ async fn persist_spot_price(
 async fn persist_quote(
     pool: &PgPool,
     token_id: &str,
-    bid: Option<Decimal>,
-    ask: Option<Decimal>,
+    quote: BookQuote,
     received_at: DateTime<Utc>,
 ) {
     let result = sqlx::query(
         r#"
-        INSERT INTO clob_quote_ticks (token_id, best_bid, best_ask, received_at, source)
-        VALUES ($1, $2, $3, $4, 'ploy_runner_live')
+        INSERT INTO clob_quote_ticks (
+            token_id, best_bid, best_ask, bid_size, ask_size, received_at, source
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'ploy_runner_live')
         ON CONFLICT DO NOTHING
         "#,
     )
     .bind(token_id)
-    .bind(bid)
-    .bind(ask)
+    .bind(quote.bid)
+    .bind(quote.ask)
+    .bind(quote.bid_size)
+    .bind(quote.ask_size)
     .bind(received_at)
     .execute(pool)
     .await;
@@ -1052,7 +1108,10 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 
 #[cfg(test)]
 mod tests {
-    use super::{l2_updates_from_book, parse_agg_trade_msg, rtds_market_data_ws_config};
+    use super::{
+        book_quote_from_rest, l2_updates_from_book, parse_agg_trade_msg,
+        rtds_market_data_ws_config, RestBook,
+    };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;
     use rust_decimal::prelude::ToPrimitive;
@@ -1103,6 +1162,46 @@ mod tests {
                 && (ask_depth_near - 5.5).abs() < 1e-9
                 && *spread_bps == 11
         ));
+    }
+
+    #[test]
+    fn rest_book_quote_uses_tradeable_top_of_book_size() {
+        let book: RestBook = serde_json::from_value(json!({
+            "bids": [
+                {"price": "0.01", "size": "999"},
+                {"price": "0.47", "size": "12.5"},
+                {"price": "0.52", "size": "7.25"}
+            ],
+            "asks": [
+                {"price": "0.99", "size": "999"},
+                {"price": "0.54", "size": "20"},
+                {"price": "0.53", "size": "9.5"}
+            ]
+        }))
+        .unwrap();
+
+        let quote = book_quote_from_rest(&book);
+
+        assert_eq!(quote.bid, Some(dec!(0.52)));
+        assert_eq!(quote.bid_size, Some(dec!(7.25)));
+        assert_eq!(quote.ask, Some(dec!(0.53)));
+        assert_eq!(quote.ask_size, Some(dec!(9.5)));
+    }
+
+    #[test]
+    fn rest_book_quote_filters_placeholder_only_books() {
+        let book: RestBook = serde_json::from_value(json!({
+            "bids": [{"price": "0.01", "size": "999"}],
+            "asks": [{"price": "0.99", "size": "999"}]
+        }))
+        .unwrap();
+
+        let quote = book_quote_from_rest(&book);
+
+        assert_eq!(quote.bid, None);
+        assert_eq!(quote.bid_size, None);
+        assert_eq!(quote.ask, None);
+        assert_eq!(quote.ask_size, None);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -674,6 +674,7 @@ fn run_backtest(
         enable_market_impact: true,
         impact_coefficient: dec!(0.1),
         default_depth_shares: 500,
+        require_lob_liquidity: false,
     });
     let recorder = Box::new(NullRecorder);
     let runtime_config = RuntimeConfig {

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -158,6 +158,8 @@ pub struct SimExecutionSection {
     pub impact_coefficient: f64,
     #[serde(default = "default_depth_shares")]
     pub default_depth_shares: u64,
+    #[serde(default)]
+    pub require_lob_liquidity: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -217,6 +219,7 @@ impl Default for SimExecutionSection {
             enable_market_impact: false,
             impact_coefficient: 0.1,
             default_depth_shares: 500,
+            require_lob_liquidity: false,
         }
     }
 }
@@ -310,6 +313,7 @@ impl FullConfig {
             enable_market_impact: e.enable_market_impact,
             impact_coefficient: Decimal::try_from(e.impact_coefficient).unwrap_or_default(),
             default_depth_shares: e.default_depth_shares,
+            require_lob_liquidity: e.require_lob_liquidity,
         }
     }
 

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -173,6 +173,7 @@ where
 
         while let Some(update) = self.feed.next().await {
             updates_processed += 1;
+            self.executor.observe_market_update(&update);
 
             // Throttle: skip high-frequency price/quote updates if within the same time slot.
             // Event lifecycle updates (discovered/expired) always pass through.

--- a/crates/ploy-strategy-bundles/src/executor/simulated.rs
+++ b/crates/ploy-strategy-bundles/src/executor/simulated.rs
@@ -9,6 +9,8 @@
 //! Used by both backtest (`HistoricalFeed + SimulatedExecutor`) and
 //! dry-run (`LiveFeed + SimulatedExecutor`) modes.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use ploy_trading::{FillRecord, IntentPurpose, TradeSide, TradingIntent};
 use rust_decimal::Decimal;
@@ -16,7 +18,7 @@ use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::traits::{ExecutionReport, Executor};
+use crate::traits::{ExecutionReport, Executor, MarketUpdate};
 
 const MIN_BINARY_PRICE: Decimal = dec!(0.01);
 const MAX_BINARY_PRICE: Decimal = dec!(0.99);
@@ -40,6 +42,12 @@ pub struct SimulatedExecutorConfig {
     pub impact_coefficient: Decimal,
     /// Default market depth in shares when unknown.
     pub default_depth_shares: u64,
+    /// Require a fresh observed PM quote with executable size before filling.
+    ///
+    /// When enabled, BUY fills consume `ask_size` at `ask`, and SELL fills
+    /// consume `bid_size` at `bid`. This mirrors FAK-style top-of-book
+    /// execution more closely than synthetic fixed-depth fills.
+    pub require_lob_liquidity: bool,
 }
 
 impl Default for SimulatedExecutorConfig {
@@ -53,18 +61,31 @@ impl Default for SimulatedExecutorConfig {
             enable_market_impact: false,
             impact_coefficient: dec!(0.1),
             default_depth_shares: 500,
+            require_lob_liquidity: false,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct QuoteLiquidity {
+    bid: Option<Decimal>,
+    ask: Option<Decimal>,
+    bid_size: Option<Decimal>,
+    ask_size: Option<Decimal>,
 }
 
 /// Simulated executor that models realistic fills.
 pub struct SimulatedExecutor {
     config: SimulatedExecutorConfig,
+    quotes: HashMap<String, QuoteLiquidity>,
 }
 
 impl SimulatedExecutor {
     pub fn new(config: SimulatedExecutorConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            quotes: HashMap::new(),
+        }
     }
 
     fn clamp_price(price: Decimal) -> Decimal {
@@ -146,6 +167,69 @@ impl SimulatedExecutor {
         (fill_price, filled_qty, slippage, impact)
     }
 
+    fn simulate_lob_fill(
+        &self,
+        intent: &TradingIntent,
+        signal_price: Decimal,
+    ) -> Result<(Decimal, Decimal, Decimal, Decimal), String> {
+        let quote = self
+            .quotes
+            .get(&intent.token_id)
+            .ok_or_else(|| "No observed LOB quote".to_string())?;
+        let requested = intent.quantity.max(Decimal::ZERO);
+
+        match intent.side {
+            TradeSide::Buy => {
+                let ask = quote
+                    .ask
+                    .map(Self::clamp_price)
+                    .ok_or_else(|| "No executable ask quote".to_string())?;
+                let ask_size = quote
+                    .ask_size
+                    .ok_or_else(|| "No executable ask liquidity".to_string())?;
+                if ask_size <= Decimal::ZERO {
+                    return Err("No executable ask liquidity".into());
+                }
+
+                let limit = intent.limit_price.map(Self::clamp_price).unwrap_or(ask);
+                if ask > limit {
+                    return Err(format!("Best ask {ask} above limit {limit}"));
+                }
+
+                let filled_qty = requested.min(ask_size);
+                if filled_qty <= Decimal::ZERO {
+                    return Err("No liquidity".into());
+                }
+                let reference = Self::clamp_price(signal_price);
+                Ok((ask, filled_qty, ask - reference, Decimal::ZERO))
+            }
+            TradeSide::Sell => {
+                let bid = quote
+                    .bid
+                    .map(Self::clamp_price)
+                    .ok_or_else(|| "No executable bid quote".to_string())?;
+                let bid_size = quote
+                    .bid_size
+                    .ok_or_else(|| "No executable bid liquidity".to_string())?;
+                if bid_size <= Decimal::ZERO {
+                    return Err("No executable bid liquidity".into());
+                }
+
+                let limit = intent.limit_price.map(Self::clamp_price).unwrap_or(bid);
+                if bid < limit {
+                    return Err(format!("Best bid {bid} below limit {limit}"));
+                }
+
+                let filled_qty = requested.min(bid_size);
+                if filled_qty <= Decimal::ZERO {
+                    return Err("No liquidity".into());
+                }
+                let reference = Self::clamp_price(signal_price);
+                Ok((bid, filled_qty, reference - bid, Decimal::ZERO))
+            }
+        }
+    }
+
     /// Determine fill quantity given requested shares and market depth.
     fn fill_quantity(&self, requested: Decimal, depth: Decimal) -> (Decimal, bool) {
         if !self.config.enable_partial_fills || depth <= Decimal::ZERO {
@@ -172,6 +256,28 @@ impl SimulatedExecutor {
 
 #[async_trait]
 impl Executor for SimulatedExecutor {
+    fn observe_market_update(&mut self, update: &MarketUpdate) {
+        if let MarketUpdate::Quote {
+            token_id,
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            ..
+        } = update
+        {
+            self.quotes.insert(
+                token_id.to_string(),
+                QuoteLiquidity {
+                    bid: *bid,
+                    ask: *ask,
+                    bid_size: *bid_size,
+                    ask_size: *ask_size,
+                },
+            );
+        }
+    }
+
     async fn submit(&mut self, intent: &TradingIntent, order_id: &str) -> ExecutionReport {
         let signal_price = intent.limit_price.unwrap_or(dec!(0.50));
         let synthetic_mid = intent.limit_price.is_none();
@@ -180,12 +286,28 @@ impl Executor for SimulatedExecutor {
         let is_settlement = intent.purpose == IntentPurpose::Exit
             && (signal_price == Decimal::ZERO || signal_price == Decimal::ONE);
 
-        let (fill_price, filled_qty, slippage, impact) = if is_settlement {
-            (signal_price, intent.quantity, Decimal::ZERO, Decimal::ZERO)
+        let simulated = if is_settlement {
+            Ok((signal_price, intent.quantity, Decimal::ZERO, Decimal::ZERO))
+        } else if self.config.require_lob_liquidity {
+            self.simulate_lob_fill(intent, signal_price)
         } else {
-            match intent.side {
+            Ok(match intent.side {
                 TradeSide::Buy => self.simulate_buy(signal_price, intent.quantity, synthetic_mid),
                 TradeSide::Sell => self.simulate_sell(signal_price, intent.quantity, synthetic_mid),
+            })
+        };
+
+        let (fill_price, filled_qty, slippage, impact) = match simulated {
+            Ok(fill) => fill,
+            Err(reason) => {
+                return ExecutionReport {
+                    order_id: order_id.to_string(),
+                    fill: None,
+                    rejected: true,
+                    rejection_reason: Some(reason),
+                    slippage: None,
+                    market_impact: None,
+                };
             }
         };
 
@@ -252,6 +374,22 @@ mod tests {
         }
     }
 
+    fn quote_update(
+        bid: Option<Decimal>,
+        ask: Option<Decimal>,
+        bid_size: Option<Decimal>,
+        ask_size: Option<Decimal>,
+    ) -> MarketUpdate {
+        MarketUpdate::Quote {
+            token_id: "token-1".into(),
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            ts: Utc::now(),
+        }
+    }
+
     #[tokio::test]
     async fn buy_applies_quote_price_and_impact() {
         let config = SimulatedExecutorConfig {
@@ -310,6 +448,97 @@ mod tests {
         let fill = report.fill.unwrap();
         assert_eq!(fill.price, dec!(0.60));
         assert_eq!(report.slippage.unwrap(), Decimal::ZERO);
+    }
+
+    #[tokio::test]
+    async fn lob_buy_consumes_only_executable_ask_size() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.49)),
+            Some(dec!(0.50)),
+            Some(dec!(50)),
+            Some(dec!(7.5)),
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(25));
+
+        let report = exec.submit(&intent, "test-order-lob-buy").await;
+        assert!(!report.rejected);
+        let fill = report.fill.expect("partial top-of-book fill");
+        assert_eq!(fill.price, dec!(0.50));
+        assert_eq!(fill.quantity, dec!(7.5));
+    }
+
+    #[tokio::test]
+    async fn lob_buy_rejects_when_ask_is_not_crossable() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.49)),
+            Some(dec!(0.52)),
+            Some(dec!(50)),
+            Some(dec!(50)),
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(25));
+
+        let report = exec.submit(&intent, "test-order-lob-buy-reject").await;
+        assert!(report.rejected);
+        assert!(report.fill.is_none());
+        assert_eq!(
+            report.rejection_reason.as_deref(),
+            Some("Best ask 0.52 above limit 0.50")
+        );
+    }
+
+    #[tokio::test]
+    async fn lob_buy_rejects_when_size_is_missing() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.49)),
+            Some(dec!(0.50)),
+            Some(dec!(50)),
+            None,
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(25));
+
+        let report = exec.submit(&intent, "test-order-lob-no-size").await;
+        assert!(report.rejected);
+        assert_eq!(
+            report.rejection_reason.as_deref(),
+            Some("No executable ask liquidity")
+        );
+    }
+
+    #[tokio::test]
+    async fn lob_sell_consumes_only_executable_bid_size() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.54)),
+            Some(dec!(0.55)),
+            Some(dec!(6)),
+            Some(dec!(50)),
+        ));
+        let intent = test_intent(TradeSide::Sell, dec!(0.54), dec!(20));
+
+        let report = exec.submit(&intent, "test-order-lob-sell").await;
+        assert!(!report.rejected);
+        let fill = report.fill.expect("partial bid fill");
+        assert_eq!(fill.price, dec!(0.54));
+        assert_eq!(fill.quantity, dec!(6));
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/traits.rs
+++ b/crates/ploy-strategy-bundles/src/traits.rs
@@ -51,6 +51,11 @@ impl Default for ExecutionPolicy {
 /// Order executor — real exchange or execution simulator.
 #[async_trait]
 pub trait Executor: Send {
+    /// Observe a market update before decisions are submitted.
+    ///
+    /// Simulated executors can use this to keep quote/liquidity state current.
+    fn observe_market_update(&mut self, _update: &MarketUpdate) {}
+
     fn execution_policy(&self) -> ExecutionPolicy {
         ExecutionPolicy::default()
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,53 @@
+# Dry-run LOB Liquidity Parity (2026-04-25)
+
+## Files
+
+- `crates/ploy-market-data/src/feeds.rs`
+  - Owner: live/dry-run Polymarket quote feed and persisted quote sizes.
+- `crates/ploy-strategy-bundles/src/traits.rs`
+  - Owner: executor market-update observation hook.
+- `crates/ploy-strategy-bundles/src/engine.rs`
+  - Owner: forwarding every market update to the executor before throttled strategy evaluation.
+- `crates/ploy-strategy-bundles/src/executor/simulated.rs`
+  - Owner: LOB-aware dry-run fill simulation.
+- `crates/ploy-strategy-bundles/src/config.rs`
+  - Owner: TOML surface for requiring LOB liquidity.
+- `crates/ploy-strategy-bundles/examples/optimize_backtest.rs`
+  - Owner: explicit simulator config initializer compatibility.
+- `config/strategies/02-pm5d-threelayer.unified.toml`
+- `config/strategies/02-pm5d-threelayer.live.toml`
+
+## Tasks
+
+- [x] Replace dry-run midpoint-only quote generation with top-of-book quotes that include executable size.
+- [x] Let the simulated executor track latest quote liquidity per token.
+- [x] When enabled, require buy orders to consume ask liquidity and sell orders to consume bid liquidity instead of fixed synthetic depth.
+- [x] Enable the LOB-liquidity requirement for the PM5D ThreeLayer dry-run/live config pair without changing strategy parameters.
+- [x] Add focused tests for no-liquidity reject, partial top-of-book fills, quote-feed parsing, and config parsing.
+- [ ] Run focused Rust tests, open PR, and deploy through GitHub Actions after merge.
+
+## Review
+
+- 2026-04-25: Root cause confirmed: dry-run used REST `/midpoint` to synthesize
+  bid/ask with no size, and `SimulatedExecutor` filled from a fixed synthetic
+  `default_depth_shares=500` instead of observed LOB liquidity.
+- 2026-04-25: The live/dry-run quote feed now polls CLOB `/book`, filters
+  placeholder `0.01/0.99` levels, emits best bid/ask plus top-of-book size, and
+  persists non-empty sizes to `clob_quote_ticks`.
+- 2026-04-25: `SimulatedExecutor` now observes quote updates. When
+  `require_lob_liquidity=true`, BUY consumes only executable ask size at or
+  below limit and SELL consumes only executable bid size at or above limit;
+  missing size or uncrossable prices are rejected instead of filled.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-strategy-bundles --lib`,
+  `rtk cargo test -p ploy-market-data --lib`,
+  `rtk cargo test -p ploy-strategy-runtime --lib`,
+  `rustfmt --edition 2021 --check ...`, and `git diff --check`.
+- 2026-04-25: PR CI caught one explicit `SimulatedExecutorConfig`
+  initializer in `optimize_backtest`; it now opts out of LOB liquidity
+  explicitly because optimizer backtests still use the historical simulator
+  path unless their configs request LOB-aware execution.
+
 # Live Market Buy Precision Repair (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- switch live/dry-run PM quote polling from synthetic midpoint quotes to filtered CLOB /book top-of-book quotes with size
- let SimulatedExecutor observe quote updates and require executable bid/ask size when configured
- enable LOB-liquidity fill gating for the PM5D ThreeLayer dry-run/live config pair

## Tests
- rtk cargo test -p ploy-strategy-bundles --lib
- rtk cargo test -p ploy-market-data --lib
- rtk cargo test -p ploy-strategy-runtime --lib
- rustfmt --edition 2021 --check focused Rust files
- git diff --check