### PR TITLE
Cap live sells to venue balance and surface parity fill gaps

### DIFF
--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -2,9 +2,9 @@ use alloy::signers::local::PrivateKeySigner;
 use ploy_trading::{FillRecord, TradeSide};
 use polymarket_client_sdk::auth::state::Authenticated;
 use polymarket_client_sdk::auth::{Normal, Signer};
-use polymarket_client_sdk::clob::types::request::TradesRequest;
+use polymarket_client_sdk::clob::types::request::{BalanceAllowanceRequest, TradesRequest};
 use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
-use polymarket_client_sdk::clob::types::{Amount, OrderType, Side, SignatureType};
+use polymarket_client_sdk::clob::types::{Amount, AssetType, OrderType, Side, SignatureType};
 use polymarket_client_sdk::clob::{Client, Config};
 use polymarket_client_sdk::types::{Address, U256};
 use polymarket_client_sdk::{POLYGON, PRIVATE_KEY_VAR};
@@ -422,6 +422,11 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
 
         let result = self.runtime.block_on(async {
             let side = polymarket_side(request.side);
+            let quantity = if request.side == TradeSide::Sell {
+                sell_quantity_capped_to_balance(&client, token_id, request.quantity).await?
+            } else {
+                request.quantity
+            };
             let order = match request.order_type {
                 OrderExecutionType::GTC => {
                     let price = execution_price_override(
@@ -431,7 +436,7 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
                         request.aggressive_ticks,
                     )
                     .expect("GTC orders must keep an explicit price");
-                    let normalized_quantity = normalize_order_quantity(request.quantity);
+                    let normalized_quantity = normalize_order_quantity(quantity);
                     client
                         .limit_order()
                         .token_id(token_id)
@@ -450,8 +455,8 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
                         request.aggressive_ticks,
                     )
                     .unwrap_or(limit_price);
-                    let amount = normalize_execution_amount(request.quantity, limit_price, side)
-                        .map_err(|err| {
+                    let amount =
+                        normalize_execution_amount(quantity, limit_price, side).map_err(|err| {
                             ExecutionError::Validation(format!("build amount: {err}"))
                         })?;
                     client
@@ -733,6 +738,43 @@ async fn load_trades_for_token(
     Ok(trades)
 }
 
+async fn sell_quantity_capped_to_balance(
+    client: &Client<Authenticated<Normal>>,
+    token_id: U256,
+    requested_quantity: Decimal,
+) -> Result<Decimal, ExecutionError> {
+    let response = client
+        .balance_allowance(
+            BalanceAllowanceRequest::builder()
+                .asset_type(AssetType::Conditional)
+                .token_id(token_id)
+                .build(),
+        )
+        .await
+        .map_err(|err| {
+            ExecutionError::Transport(format!("load conditional token balance: {err}"))
+        })?;
+
+    cap_sell_quantity_to_balance(requested_quantity, response.balance)
+}
+
+fn cap_sell_quantity_to_balance(
+    requested_quantity: Decimal,
+    available_balance: Decimal,
+) -> Result<Decimal, ExecutionError> {
+    let requested = normalize_market_order_quantity(requested_quantity.max(Decimal::ZERO));
+    let available = normalize_market_order_quantity(available_balance.max(Decimal::ZERO));
+    let effective = requested.min(available);
+
+    if effective <= Decimal::ZERO {
+        return Err(ExecutionError::Validation(format!(
+            "sell rejected before submit: no sellable conditional-token balance; requested={requested}, available={available}"
+        )));
+    }
+
+    Ok(effective)
+}
+
 fn normalize_aggressive_price(
     limit_price: Decimal,
     side: TradeSide,
@@ -838,8 +880,8 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        execution_price_override, normalize_aggressive_price, normalize_execution_amount,
-        normalize_market_order_quantity, normalize_order_quantity,
+        cap_sell_quantity_to_balance, execution_price_override, normalize_aggressive_price,
+        normalize_execution_amount, normalize_market_order_quantity, normalize_order_quantity,
         polymarket_signature_type_from_env, tracked_trade_fill, trade_side, unique_token_ids,
         CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
         ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
@@ -852,6 +894,7 @@ mod tests {
     use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
     use polymarket_client_sdk::clob::types::{Side, TradeStatusType, TraderSide};
     use polymarket_client_sdk::types::{Address, B256, U256};
+    use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use std::str::FromStr;
 
@@ -953,6 +996,25 @@ mod tests {
         assert_eq!(buy.as_inner(), dec!(24.4678));
         assert!(sell.is_shares());
         assert_eq!(sell.as_inner(), dec!(24.4678));
+    }
+
+    #[test]
+    fn sell_quantity_is_capped_to_conditional_token_balance() {
+        let capped =
+            cap_sell_quantity_to_balance(dec!(5), dec!(4.881280)).expect("available balance");
+
+        assert_eq!(capped, dec!(4.8812));
+    }
+
+    #[test]
+    fn sell_quantity_rejects_when_conditional_token_balance_is_zero() {
+        let error = cap_sell_quantity_to_balance(dec!(5), Decimal::ZERO)
+            .expect_err("zero balance should reject");
+
+        assert!(matches!(error, ExecutionError::Validation(_)));
+        assert!(error
+            .to_string()
+            .contains("no sellable conditional-token balance"));
     }
 
     #[test]

--- a/ploy-frontend/src/components/LiveParityBanner.tsx
+++ b/ploy-frontend/src/components/LiveParityBanner.tsx
@@ -18,12 +18,12 @@ export function LiveParityBanner() {
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex min-w-0 items-center gap-2 font-semibold text-destructive">
           <AlertTriangle className="h-4 w-4 shrink-0" />
-          <span>Dry-run 已下单，Live 未同步下单</span>
+          <span>Dry-run / Live 订单或成交不一致</span>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
           {report.alertPairs.slice(0, 3).map((pair) => (
             <Badge key={pair.key} variant="destructive">
-              {pair.key}: {pair.dryrunOnlyOrders.length}
+              {pair.key}: {pair.dryrunOnlyOrders.length + pair.executionMismatches.length}
             </Badge>
           ))}
           {report.alertPairs.length > 3 && (

--- a/ploy-frontend/src/lib/liveParity.ts
+++ b/ploy-frontend/src/lib/liveParity.ts
@@ -19,20 +19,34 @@ export interface SnapshotSummary {
 
 export interface ParityOrderRow {
   createdAt: string | null;
+  eventId: string;
+  filledQty: string;
   limitPrice: string | null;
   orderId: string;
+  purpose: string;
   quantity: string;
+  rejectionReason: string | null;
   side: string;
   state: string;
   tokenId: string;
+}
+
+export interface ParityExecutionMismatch {
+  dryrun: ParityOrderRow;
+  key: string;
+  live?: ParityOrderRow;
+  liveFilledQty: string;
+  message: string;
 }
 
 export interface LiveParityPair {
   dryrun?: TradingStateSnapshot;
   dryrunOnlyOrders: ParityOrderRow[];
   dryrunSummary: SnapshotSummary;
+  executionMismatches: ParityExecutionMismatch[];
   key: string;
   live?: TradingStateSnapshot;
+  liveOnlyOrders: ParityOrderRow[];
   liveSummary: SnapshotSummary;
   message: string;
   status: 'idle' | 'matched' | 'alert' | 'missing_dryrun' | 'missing_live';
@@ -41,6 +55,7 @@ export interface LiveParityPair {
 export interface LiveParityReport {
   alertPairs: LiveParityPair[];
   dryrunOrders: number;
+  executionMismatches: number;
   liveOrders: number;
   pairs: LiveParityPair[];
   unmatchedDryrunOrders: number;
@@ -106,44 +121,115 @@ function orderRow(
 ): ParityOrderRow {
   return {
     createdAt: intent?.created_at ?? null,
+    eventId: intent?.market_id ?? '',
+    filledQty: order.filled_qty,
     limitPrice: order.limit_price ?? null,
     orderId: order.order_id,
+    purpose: intent?.purpose ?? 'unknown',
     quantity: order.requested_qty,
+    rejectionReason: order.rejection_reason ?? order.last_error ?? null,
     side: intent?.side ?? 'unknown',
     state: order.state,
     tokenId: order.token_id,
   };
 }
 
-function orderCompareKey(
-  order: OrderSnapshot,
-  intent: TradingIntentSnapshot | undefined
-) {
-  return `${order.token_id}:${(intent?.side ?? 'unknown').toLowerCase()}`;
+function rowCompareKey(row: ParityOrderRow) {
+  return [
+    row.eventId || 'unknown-event',
+    row.tokenId,
+    row.side.toLowerCase(),
+    row.purpose.toLowerCase(),
+  ].join(':');
 }
 
-function dryrunOnlyOrders(dryrun?: TradingStateSnapshot, live?: TradingStateSnapshot) {
-  if (!dryrun) {
+function orderRows(snapshot?: TradingStateSnapshot) {
+  if (!snapshot) {
     return [];
   }
 
-  const dryrunIntents = intentById(dryrun);
-  const liveIntents = live ? intentById(live) : new Map<string, TradingIntentSnapshot>();
-  const liveOrderKeys = new Set(
-    (live?.orders ?? []).map((order) =>
-      orderCompareKey(order, liveIntents.get(order.intent_id))
-    )
-  );
-
-  return dryrun.orders
-    .filter(
-      (order) =>
-        !liveOrderKeys.has(orderCompareKey(order, dryrunIntents.get(order.intent_id)))
-    )
-    .map((order) => orderRow(order, dryrunIntents.get(order.intent_id)));
+  const intents = intentById(snapshot);
+  return snapshot.orders.map((order) => orderRow(order, intents.get(order.intent_id)));
 }
 
-function pairMessage(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 'live'>) {
+function aggregateFilledByKey(rows: ParityOrderRow[]) {
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const filled = Number(row.filledQty);
+    totals.set(rowCompareKey(row), (totals.get(rowCompareKey(row)) ?? 0) + (Number.isFinite(filled) ? filled : 0));
+  }
+  return totals;
+}
+
+function firstRowByKey(rows: ParityOrderRow[]) {
+  const map = new Map<string, ParityOrderRow>();
+  for (const row of rows) {
+    const key = rowCompareKey(row);
+    if (!map.has(key)) {
+      map.set(key, row);
+    }
+  }
+  return map;
+}
+
+function formatQuantity(value: number) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+
+  return value.toFixed(4).replace(/\.?0+$/u, '');
+}
+
+function dryrunOnlyOrders(dryrun?: TradingStateSnapshot, live?: TradingStateSnapshot) {
+  const dryRows = orderRows(dryrun);
+  const liveKeys = new Set(orderRows(live).map(rowCompareKey));
+
+  return dryRows.filter((row) => !liveKeys.has(rowCompareKey(row)));
+}
+
+function liveOnlyOrders(dryrun?: TradingStateSnapshot, live?: TradingStateSnapshot) {
+  const dryKeys = new Set(orderRows(dryrun).map(rowCompareKey));
+  return orderRows(live).filter((row) => !dryKeys.has(rowCompareKey(row)));
+}
+
+function executionMismatches(dryrun?: TradingStateSnapshot, live?: TradingStateSnapshot) {
+  const dryRows = orderRows(dryrun);
+  const liveRows = orderRows(live);
+  const liveFilled = aggregateFilledByKey(liveRows);
+  const liveFirst = firstRowByKey(liveRows);
+
+  return dryRows.flatMap((dryrunRow) => {
+    const key = rowCompareKey(dryrunRow);
+    const dryrunFilled = Number(dryrunRow.filledQty);
+    const liveFilledQty = liveFilled.get(key) ?? 0;
+    const dryrunHasFill = Number.isFinite(dryrunFilled) && dryrunFilled > 0;
+    const liveIsShort = dryrunHasFill && liveFilledQty + 0.0001 < dryrunFilled;
+
+    if (!liveIsShort) {
+      return [];
+    }
+
+    return [
+      {
+        dryrun: dryrunRow,
+        key,
+        live: liveFirst.get(key),
+        liveFilledQty: formatQuantity(liveFilledQty),
+        message:
+          liveFilledQty > 0
+            ? 'Live partial fill is below dry-run fill'
+            : 'Dry-run filled but live has no fill',
+      },
+    ];
+  });
+}
+
+function pairMessage(
+  pair: Pick<
+    LiveParityPair,
+    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live'
+  >
+) {
   if (!pair.dryrun) {
     return 'No dry-run snapshot';
   }
@@ -156,6 +242,10 @@ function pairMessage(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 
     return 'Dry-run order is missing from live';
   }
 
+  if (pair.executionMismatches.length > 0) {
+    return 'Live execution differs from dry-run';
+  }
+
   if (pair.dryrun.orders.length === 0 && pair.live.orders.length === 0) {
     return 'No orders yet';
   }
@@ -163,7 +253,12 @@ function pairMessage(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 
   return 'Order paths match';
 }
 
-function pairStatus(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | 'live'>) {
+function pairStatus(
+  pair: Pick<
+    LiveParityPair,
+    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live'
+  >
+) {
   if (!pair.dryrun) {
     return 'missing_dryrun' as const;
   }
@@ -173,6 +268,10 @@ function pairStatus(pair: Pick<LiveParityPair, 'dryrun' | 'dryrunOnlyOrders' | '
   }
 
   if (pair.dryrunOnlyOrders.length > 0) {
+    return 'alert' as const;
+  }
+
+  if (pair.executionMismatches.length > 0) {
     return 'alert' as const;
   }
 
@@ -205,12 +304,16 @@ export function buildLiveParityReport(
       const dryrun = bucket.dryrun;
       const live = bucket.live;
       const missingOrders = dryrunOnlyOrders(dryrun, live);
+      const liveOnly = liveOnlyOrders(dryrun, live);
+      const mismatches = executionMismatches(dryrun, live);
       const pair = {
         dryrun,
         dryrunOnlyOrders: missingOrders,
         dryrunSummary: summarize(dryrun),
+        executionMismatches: mismatches,
         key,
         live,
+        liveOnlyOrders: liveOnly,
         liveSummary: summarize(live),
       };
 
@@ -225,6 +328,10 @@ export function buildLiveParityReport(
   return {
     alertPairs: pairs.filter((pair) => pair.status === 'alert'),
     dryrunOrders: pairs.reduce((sum, pair) => sum + pair.dryrunSummary.orders, 0),
+    executionMismatches: pairs.reduce(
+      (sum, pair) => sum + pair.executionMismatches.length,
+      0
+    ),
     liveOrders: pairs.reduce((sum, pair) => sum + pair.liveSummary.orders, 0),
     pairs,
     unmatchedDryrunOrders: pairs.reduce(

--- a/ploy-frontend/src/pages/LiveParity.tsx
+++ b/ploy-frontend/src/pages/LiveParity.tsx
@@ -101,7 +101,17 @@ function EmptyOrders() {
   );
 }
 
+function EmptyMismatches() {
+  return (
+    <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+      No dry-run/live fill mismatch
+    </div>
+  );
+}
+
 function PairCard({ pair }: { pair: LiveParityPair }) {
+  const alertCount = pair.dryrunOnlyOrders.length + pair.executionMismatches.length;
+
   return (
     <Card className={pair.status === 'alert' ? 'border-destructive/45' : undefined}>
       <CardHeader>
@@ -118,7 +128,7 @@ function PairCard({ pair }: { pair: LiveParityPair }) {
           {pair.status === 'alert' ? (
             <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm font-semibold text-destructive">
               <AlertTriangle className="h-4 w-4" />
-              {pair.dryrunOnlyOrders.length} missing live
+              {alertCount} parity gaps
             </div>
           ) : (
             <div className="flex items-center gap-2 rounded-lg bg-success/10 px-3 py-2 text-sm font-semibold text-success">
@@ -156,7 +166,7 @@ function PairCard({ pair }: { pair: LiveParityPair }) {
                 <div>Side</div>
                 <div>State</div>
                 <div>Qty / Price</div>
-                <div>Token</div>
+                <div>Event / Token</div>
               </div>
               {pair.dryrunOnlyOrders.map((order) => (
                 <div
@@ -177,7 +187,49 @@ function PairCard({ pair }: { pair: LiveParityPair }) {
                     {order.limitPrice ?? 'market'}
                   </div>
                   <div className="truncate font-mono text-xs text-muted-foreground">
+                    {order.eventId}
+                    <br />
                     {order.tokenId}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-5">
+          <div className="mb-3 text-sm font-semibold">Dry-run filled more than live</div>
+          {pair.executionMismatches.length === 0 ? (
+            <EmptyMismatches />
+          ) : (
+            <div className="overflow-hidden rounded-lg border">
+              <div className="grid grid-cols-[minmax(180px,1fr)_110px_110px_130px_minmax(160px,1fr)] bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <div>Event / Side</div>
+                <div>Dry fill</div>
+                <div>Live fill</div>
+                <div>Live state</div>
+                <div>Reason</div>
+              </div>
+              {pair.executionMismatches.map((mismatch) => (
+                <div
+                  key={mismatch.key}
+                  className="grid grid-cols-[minmax(180px,1fr)_110px_110px_130px_minmax(160px,1fr)] gap-0 border-t px-4 py-3 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">
+                      {mismatch.dryrun.eventId} {mismatch.dryrun.side}
+                    </div>
+                    <div className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                      {mismatch.dryrun.tokenId}
+                    </div>
+                  </div>
+                  <div className="font-mono text-xs">{mismatch.dryrun.filledQty}</div>
+                  <div className="font-mono text-xs">{mismatch.liveFilledQty}</div>
+                  <div>{mismatch.live?.state ?? 'missing'}</div>
+                  <div className="min-w-0">
+                    <div className="truncate text-xs text-muted-foreground">
+                      {mismatch.live?.rejectionReason ?? mismatch.message}
+                    </div>
                   </div>
                 </div>
               ))}
@@ -280,6 +332,7 @@ export function LiveParity() {
             <span>{integer(report.dryrunOrders)} dry-run orders</span>
             <span>{integer(report.liveOrders)} live orders</span>
             <span>{integer(report.unmatchedDryrunOrders)} missing live orders</span>
+            <span>{integer(report.executionMismatches)} fill mismatches</span>
           </div>
         </div>
       </div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,50 @@
+# Live Sell Balance Cap And Fee-Aware Fill Accounting (2026-04-25)
+
+## Files
+
+- `crates/ploy-connectivity/src/lib.rs`
+  - Owner: live Polymarket order sizing, conditional-token balance preflight,
+    and reconciled fill quantity/fee accounting.
+
+## Tasks
+
+- [x] Confirm recent live BUY notional still targets about the configured 15U stake.
+- [x] Confirm live SELL rejections are caused by local gross position exceeding
+  CLOB conditional-token balance after buy-side fees.
+- [x] Cap live SELL quantity to CLOB-reported sellable token balance before signing.
+- [ ] Record BUY taker fills as net received shares after protocol fee.
+- [x] Upgrade the frontend parity alert to flag fill quantity mismatches, not
+  only missing live orders.
+- [x] Add focused regression tests and local verification.
+- [ ] Land through PR/CI, deploy Tango, and verify post-deploy parity records.
+
+## Review
+
+- 2026-04-25: Recent live BUY requests still show `quantity * limit_price`
+  around 15U, so the entry stake path is not multiplying order size.
+- 2026-04-25: Live exits are over-sizing: examples include local SELL
+  `5.0000` when CLOB balance was `4.8812`, and local SELL `9.7400` when CLOB
+  balance was `9.56828`.
+- 2026-04-25: Root cause is twofold: BUY fills are recorded with gross trade
+  size even though taker buy fees reduce received shares, and SELL submit does
+  not preflight the actual conditional-token balance before signing.
+- 2026-04-25: Live SELL submit now queries CLOB `balance-allowance` for the
+  conditional token and caps the signed order quantity to the venue-reported
+  sellable balance, preventing the observed 5.0000-vs-4.8812 and
+  9.7400-vs-9.56828 over-sells.
+- 2026-04-25: Frontend parity now compares by event/token/side/purpose and
+  alerts when dry-run filled more than live, so partial fills and live rejects
+  are visible instead of being hidden by the presence of any live order.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-connectivity --lib -- --nocapture`,
+  `npm run build`, `npm run lint`,
+  `rustfmt --edition 2021 --check crates/ploy-connectivity/src/lib.rs`, and
+  `git diff --check`.
+- 2026-04-25: Remaining risk: gross BUY fill accounting still records the
+  venue trade size rather than net received shares. SELL balance cap prevents
+  bad live exits now; a follow-up should reconcile net token quantity directly
+  into positions/PnL.
+
 # Dry-run LOB Liquidity Parity (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- cap live Polymarket SELL quantity to CLOB-reported conditional-token balance before signing
- make the dry-run/live parity UI compare by event/token/side/purpose and alert on fill quantity gaps
- document the observed live divergence and remaining gross BUY fill-accounting follow-up

## Evidence
- Recent live BUY notional remained about 15U, but exits attempted to sell 5.0000 when CLOB reported 4.8812 and 9.7400 when CLOB reported 9.56828.
- Dry-run/live entry signals were often similar, but dry-run full fills and live FAK partial/reject paths made later orders and fills diverge.

## Tests
- rtk cargo test -p ploy-connectivity --lib -- --nocapture
- npm run build
- npm run lint
- rustfmt --edition 2021 --check crates/ploy-connectivity/src/lib.rs
- git diff --check

## Not tested
- Post-deploy live SELL against CLOB; requires merge and Tango deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sell orders are now capped to the user's available balance to prevent oversizing.
  * Live Parity monitoring enhanced to detect execution fill discrepancies between dry-run and live orders.

* **New Features**
  * Live Parity UI now displays detailed alerts and metrics for fill mismatches in order executions.

* **Documentation**
  * Updated task tracking for recent improvements and pending work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->