### PR TITLE
Keep live buys inside configured stake

### DIFF
--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -228,6 +228,7 @@ where
                     self.recorder.record_signal(signal).await;
                 }
 
+                let intent = self.executor.prepare_intent(&intent);
                 let order_id = Uuid::new_v4().to_string();
 
                 let report = self.executor.submit(&intent, &order_id).await;
@@ -571,6 +572,7 @@ where
             );
             retry_intent.quantity = remaining_qty;
             retry_intent.created_at = Utc::now();
+            let retry_intent = self.executor.prepare_intent(&retry_intent);
             let retry_order_id = Uuid::new_v4().to_string();
             let report = self.executor.submit(&retry_intent, &retry_order_id).await;
             self.recorder
@@ -973,6 +975,37 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct PreparingExecutor {
+        prepared_quantity: Decimal,
+        submissions: Arc<Mutex<Vec<Decimal>>>,
+    }
+
+    #[async_trait]
+    impl Executor for PreparingExecutor {
+        fn prepare_intent(&self, intent: &TradingIntent) -> TradingIntent {
+            let mut prepared = intent.clone();
+            prepared.quantity = self.prepared_quantity;
+            prepared
+        }
+
+        async fn submit(&mut self, intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
+            self.submissions.lock().unwrap().push(intent.quantity);
+            ExecutionReport {
+                order_id: "venue-order-prepared".into(),
+                fill: None,
+                rejected: false,
+                rejection_reason: None,
+                slippage: None,
+                market_impact: None,
+            }
+        }
+
+        async fn cancel(&mut self, _order_id: &str) -> bool {
+            true
+        }
+    }
+
     struct SkippedReconcileExecutor;
 
     #[async_trait]
@@ -1074,6 +1107,72 @@ mod tests {
         assert_eq!(result.fills_recorded, 1);
         assert_eq!(order_store.lock().unwrap().len(), 1);
         assert_eq!(fill_store.lock().unwrap().as_slice(), ["fill-1"]);
+    }
+
+    #[tokio::test]
+    async fn runtime_records_prepared_intent_quantity() {
+        let now = Utc::now();
+        let signal = SignalRecord {
+            strategy: "pm_5m_directional".into(),
+            event_id: Some("evt1".into()),
+            token_id: Some("token-up".into()),
+            intent_id: Some("pm5d_BTCUSDT_UP_prepared".into()),
+            symbol: "BTCUSDT".into(),
+            direction: "UP".into(),
+            p_hat: 0.71,
+            edge: 0.08,
+            entry_price: dec!(0.30),
+            decision: "enter".into(),
+            ts: now,
+        };
+        let intent = TradingIntent {
+            intent_id: "pm5d_BTCUSDT_UP_prepared".into(),
+            deployment_id: String::new(),
+            market_id: "evt1".into(),
+            token_id: "token-up".into(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.30)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        };
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: Arc::new(Mutex::new(Vec::new())),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let strategy = RecordingStrategy {
+            emitted: false,
+            signal,
+            intent,
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let submissions = Arc::new(Mutex::new(Vec::new()));
+        let executor = PreparingExecutor {
+            prepared_quantity: dec!(7.50),
+            submissions: submissions.clone(),
+        };
+        let config = RuntimeConfig {
+            mode: RuntimeMode::Live,
+            throttle_hz: None,
+            max_updates: Some(1),
+            skip_settlement_exits: false,
+        };
+
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let result = runtime.run().await;
+
+        assert_eq!(result.intents_submitted, 1);
+        assert_eq!(submissions.lock().unwrap().as_slice(), [dec!(7.50)]);
+        let orders = runtime.trading().orders().orders().collect::<Vec<_>>();
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0].requested_qty, dec!(7.50));
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/traits.rs
+++ b/crates/ploy-strategy-bundles/src/traits.rs
@@ -64,6 +64,15 @@ pub trait Executor: Send {
         true
     }
 
+    /// Normalize an intent immediately before submission.
+    ///
+    /// Live executors use this to align the runtime's requested quantity with
+    /// venue-specific signing constraints. Simulated executors should keep the
+    /// strategy intent unchanged.
+    fn prepare_intent(&self, intent: &TradingIntent) -> TradingIntent {
+        intent.clone()
+    }
+
     /// Submit a trading intent and return the execution report.
     /// `order_id` is the caller-assigned ID that must be used in the returned fill.
     async fn submit(&mut self, intent: &TradingIntent, order_id: &str) -> ExecutionReport;

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -28,7 +28,7 @@ mod execution {
     use rust_decimal::Decimal;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
-    use tracing::{error, info};
+    use tracing::{debug, error, info};
 
     #[derive(Clone)]
     pub(super) struct LiveExecutor {
@@ -67,6 +67,46 @@ mod execution {
             }
         }
 
+        fn prepared_quantity(&self, intent: &TradingIntent) -> Decimal {
+            let normalized_quantity = intent.quantity.trunc_with_scale(2);
+            if intent.side != TradeSide::Buy {
+                return normalized_quantity;
+            }
+
+            let Some(limit_price) = intent.limit_price else {
+                return normalized_quantity;
+            };
+            if limit_price <= Decimal::ZERO || normalized_quantity <= Decimal::ZERO {
+                return normalized_quantity;
+            }
+
+            let target_notional = (intent.quantity * limit_price).trunc_with_scale(6);
+            if target_notional <= Decimal::ZERO {
+                return normalized_quantity;
+            }
+
+            let execution_price = self.slippage_bounded_price(limit_price, intent.side);
+            if execution_price <= Decimal::ZERO {
+                return normalized_quantity;
+            }
+
+            let capped_quantity = (target_notional / execution_price).trunc_with_scale(2);
+            let prepared_quantity = normalized_quantity.min(capped_quantity);
+            if prepared_quantity < normalized_quantity {
+                debug!(
+                    intent_id = %intent.intent_id,
+                    original_quantity = %intent.quantity,
+                    prepared_quantity = %prepared_quantity,
+                    limit_price = %limit_price,
+                    execution_price = %execution_price,
+                    target_notional = %target_notional,
+                    "Capped live BUY quantity to strategy notional"
+                );
+            }
+
+            prepared_quantity
+        }
+
         fn slippage_bounded_price(&self, limit_price: Decimal, side: TradeSide) -> Decimal {
             let tolerance = self.policy.max_slippage_bps / Decimal::from(10_000_u32);
             let adjusted = match side {
@@ -87,6 +127,12 @@ mod execution {
 
         fn last_reconcile_attempted(&self) -> bool {
             self.last_reconcile_attempted
+        }
+
+        fn prepare_intent(&self, intent: &TradingIntent) -> TradingIntent {
+            let mut prepared = intent.clone();
+            prepared.quantity = self.prepared_quantity(intent);
+            prepared
         }
 
         async fn submit(&mut self, intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
@@ -205,6 +251,67 @@ mod execution {
                     Err(format!("reconcile task failed: {error}"))
                 }
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use chrono::Utc;
+        use ploy_strategy_bundles::Executor;
+        use ploy_trading::IntentPurpose;
+
+        fn test_executor(max_slippage_bps: Decimal) -> LiveExecutor {
+            LiveExecutor::new(
+                Arc::new(ploy_connectivity::PolymarketExecutionGateway::from_env()),
+                ExecutionPolicy {
+                    max_slippage_bps,
+                    max_attempts: 2,
+                    reconcile_cycles_before_retry: 2,
+                },
+            )
+        }
+
+        fn buy_intent(quantity: Decimal, limit_price: Decimal) -> TradingIntent {
+            TradingIntent {
+                intent_id: "intent-buy".into(),
+                deployment_id: "deployment".into(),
+                market_id: "event".into(),
+                token_id: "token".into(),
+                side: TradeSide::Buy,
+                quantity,
+                limit_price: Some(limit_price),
+                purpose: IntentPurpose::Entry,
+                created_at: Utc::now(),
+            }
+        }
+
+        #[test]
+        fn prepare_intent_caps_buy_quantity_to_slippage_bounded_notional() {
+            let executor = test_executor(Decimal::new(150, 0));
+            let intent = buy_intent(Decimal::new(142_857_143, 6), Decimal::new(105, 3));
+
+            let prepared = executor.prepare_intent(&intent);
+            let request = executor.build_request(&prepared);
+            let execution_price = request.limit_price.expect("bounded live price");
+
+            assert_eq!(execution_price, Decimal::new(11, 2));
+            assert_eq!(prepared.quantity, Decimal::new(13_636, 2));
+            assert_eq!(request.quantity, Decimal::new(13_636, 2));
+            assert!(prepared.quantity * execution_price <= Decimal::new(1_500, 2));
+        }
+
+        #[test]
+        fn prepare_intent_keeps_buy_quantity_when_slippage_price_does_not_raise_notional() {
+            let executor = test_executor(Decimal::new(150, 0));
+            let intent = buy_intent(Decimal::new(150, 0), Decimal::new(10, 2));
+
+            let prepared = executor.prepare_intent(&intent);
+            let request = executor.build_request(&prepared);
+
+            assert_eq!(request.limit_price, Some(Decimal::new(10, 2)));
+            assert_eq!(prepared.quantity, Decimal::new(15_000, 2));
+            assert_eq!(request.quantity, Decimal::new(15_000, 2));
         }
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
+# Live Buy Notional Cap (2026-04-25)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/traits.rs`
+  - Owner: executor hook for pre-submit intent normalization.
+- `crates/ploy-strategy-bundles/src/engine.rs`
+  - Owner: using normalized intents for order recording and retry accounting.
+- `crates/ploy-strategy-runtime/src/live.rs`
+  - Owner: live BUY quantity cap under slippage-bounded execution price.
+
+## Tasks
+
+- [x] Confirm current live config still targets `stake_usd = 15.0`.
+- [x] Cap live BUY requested shares so `shares * slippage_bounded_price <= target_notional`.
+- [x] Ensure runtime requested quantity uses the capped quantity to prevent retry over-buying.
+- [x] Add regression tests for low-price BUY amount cap.
+- [x] Run focused Rust tests and static checks.
+- [ ] Land through PR/CI, deploy Tango, and verify post-deploy state.
+
+## Review
+
+- 2026-04-25: Current config targets `stake_usd = 15.0`, but live BUY orders
+  derive shares from the strategy entry price and then sign at a
+  slippage-bounded rounded price. That makes 15U a strategy target, not a hard
+  live signing cap.
+- 2026-04-25: Live execution now prepares BUY intents before submission by
+  capping requested shares to the target notional divided by the
+  slippage-bounded execution price. The strategy runtime records this prepared
+  quantity, so later FAK reconciliation retries cannot chase the original,
+  larger share count and exceed the 15U target.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-strategy-bundles --lib`,
+  `rtk cargo test -p ploy-strategy-runtime --features live,live-execution --lib`,
+  `rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/traits.rs crates/ploy-strategy-bundles/src/engine.rs crates/ploy-strategy-runtime/src/live.rs`,
+  and `git diff --check`.
+
 # Live Sell Balance Cap And Fee-Aware Fill Accounting (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- cap live BUY requested shares against the slippage-bounded execution price so worst-price notional stays inside the strategy target
- add an executor prepare hook so runtime requested_qty matches the quantity actually signed live
- add regression coverage for runtime quantity preparation and low-price live BUY caps

## Tests
- rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture
- rtk cargo test -p ploy-strategy-runtime --features live,live-execution --lib -- --nocapture
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/traits.rs crates/ploy-strategy-bundles/src/engine.rs crates/ploy-strategy-runtime/src/live.rs
- git diff --check