### PR TITLE
Accept live buy fills improved by price

### DIFF
--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -52,42 +52,39 @@ mod execution {
         }
 
         fn build_request(&self, intent: &TradingIntent) -> ploy_connectivity::ExecutionRequest {
-            let limit_price = intent
-                .limit_price
-                .map(|price| self.slippage_bounded_price(price, intent.side));
             let quantity = intent.quantity.trunc_with_scale(2);
             ploy_connectivity::ExecutionRequest {
                 order_id: intent.intent_id.clone(),
                 token_id: intent.token_id.clone(),
                 side: intent.side,
                 quantity,
-                limit_price,
+                limit_price: intent.limit_price,
                 order_type: ploy_connectivity::OrderExecutionType::FAK,
                 aggressive_ticks: 0,
             }
         }
 
-        fn prepared_quantity(&self, intent: &TradingIntent) -> Decimal {
+        fn prepared_quantity_and_price(
+            &self,
+            intent: &TradingIntent,
+        ) -> (Decimal, Option<Decimal>) {
             let normalized_quantity = intent.quantity.trunc_with_scale(2);
+            let Some(limit_price) = intent.limit_price else {
+                return (normalized_quantity, None);
+            };
+
+            let execution_price = self.slippage_bounded_price(limit_price, intent.side);
             if intent.side != TradeSide::Buy {
-                return normalized_quantity;
+                return (normalized_quantity, Some(execution_price));
             }
 
-            let Some(limit_price) = intent.limit_price else {
-                return normalized_quantity;
-            };
             if limit_price <= Decimal::ZERO || normalized_quantity <= Decimal::ZERO {
-                return normalized_quantity;
+                return (normalized_quantity, Some(execution_price));
             }
 
             let target_notional = (intent.quantity * limit_price).trunc_with_scale(6);
             if target_notional <= Decimal::ZERO {
-                return normalized_quantity;
-            }
-
-            let execution_price = self.slippage_bounded_price(limit_price, intent.side);
-            if execution_price <= Decimal::ZERO {
-                return normalized_quantity;
+                return (normalized_quantity, Some(execution_price));
             }
 
             let capped_quantity = (target_notional / execution_price).trunc_with_scale(2);
@@ -104,7 +101,7 @@ mod execution {
                 );
             }
 
-            prepared_quantity
+            (prepared_quantity, Some(execution_price))
         }
 
         fn slippage_bounded_price(&self, limit_price: Decimal, side: TradeSide) -> Decimal {
@@ -131,7 +128,9 @@ mod execution {
 
         fn prepare_intent(&self, intent: &TradingIntent) -> TradingIntent {
             let mut prepared = intent.clone();
-            prepared.quantity = self.prepared_quantity(intent);
+            let (quantity, limit_price) = self.prepared_quantity_and_price(intent);
+            prepared.quantity = quantity;
+            prepared.limit_price = limit_price;
             prepared
         }
 
@@ -295,6 +294,7 @@ mod execution {
             let request = executor.build_request(&prepared);
             let execution_price = request.limit_price.expect("bounded live price");
 
+            assert_eq!(prepared.limit_price, Some(Decimal::new(11, 2)));
             assert_eq!(execution_price, Decimal::new(11, 2));
             assert_eq!(prepared.quantity, Decimal::new(13_636, 2));
             assert_eq!(request.quantity, Decimal::new(13_636, 2));
@@ -309,6 +309,7 @@ mod execution {
             let prepared = executor.prepare_intent(&intent);
             let request = executor.build_request(&prepared);
 
+            assert_eq!(prepared.limit_price, Some(Decimal::new(10, 2)));
             assert_eq!(request.limit_price, Some(Decimal::new(10, 2)));
             assert_eq!(prepared.quantity, Decimal::new(15_000, 2));
             assert_eq!(request.quantity, Decimal::new(15_000, 2));

--- a/crates/ploy-trading/src/orders.rs
+++ b/crates/ploy-trading/src/orders.rs
@@ -154,12 +154,13 @@ impl OrderLedger {
         if fill.quantity > remaining_qty {
             return None;
         }
-        record.filled_qty += fill.quantity;
-        record.state = if record.filled_qty >= record.requested_qty {
-            OrderState::Filled
-        } else {
-            OrderState::PartiallyFilled
-        };
+        apply_fill_to_record(record, fill.quantity);
+        Some(record)
+    }
+
+    pub fn apply_price_improved_buy_fill(&mut self, fill: &FillRecord) -> Option<&OrderRecord> {
+        let record = self.orders.get_mut(&fill.order_id)?;
+        apply_fill_to_record(record, fill.quantity);
         Some(record)
     }
 
@@ -182,6 +183,15 @@ impl OrderLedger {
     pub fn orders(&self) -> impl Iterator<Item = &OrderRecord> {
         self.orders.values()
     }
+}
+
+fn apply_fill_to_record(record: &mut OrderRecord, quantity: Decimal) {
+    record.filled_qty += quantity;
+    record.state = if record.filled_qty >= record.requested_qty {
+        OrderState::Filled
+    } else {
+        OrderState::PartiallyFilled
+    };
 }
 
 #[cfg(test)]

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -174,12 +174,51 @@ impl TradingRuntime {
             return false;
         }
         if self.orders.apply_fill(&fill).is_none() {
-            return false;
+            if !self.buy_fill_is_price_improved_overfill(&fill) {
+                return false;
+            }
+            if self.orders.apply_price_improved_buy_fill(&fill).is_none() {
+                return false;
+            }
         }
         self.positions.apply_fill(&fill);
         self.fills.record(fill);
         self.prune_inactive_intents();
         true
+    }
+
+    fn buy_fill_is_price_improved_overfill(&self, fill: &FillRecord) -> bool {
+        if fill.side != TradeSide::Buy {
+            return false;
+        }
+
+        let Some(order) = self.orders.order(&fill.order_id) else {
+            return false;
+        };
+        let Some(limit_price) = order.limit_price else {
+            return false;
+        };
+        let Some(intent) = self.intent(&order.intent_id) else {
+            return false;
+        };
+        if intent.side != TradeSide::Buy {
+            return false;
+        }
+
+        let requested_notional = order.requested_qty.max(Decimal::ZERO) * limit_price;
+        let recorded_notional: Decimal = self
+            .fills
+            .all()
+            .iter()
+            .filter(|existing| existing.order_id == fill.order_id)
+            .map(|existing| {
+                existing.quantity.max(Decimal::ZERO) * existing.price.max(Decimal::ZERO)
+            })
+            .sum();
+        let fill_notional = fill.quantity.max(Decimal::ZERO) * fill.price.max(Decimal::ZERO);
+        let remaining_notional = (requested_notional - recorded_notional).max(Decimal::ZERO);
+
+        fill_notional <= remaining_notional + Decimal::new(2, 2)
     }
 
     pub fn last_fill_time(&self) -> Option<DateTime<Utc>> {
@@ -407,6 +446,81 @@ mod tests {
         });
         assert!(runtime.intent("intent-1").is_none());
         assert!(runtime.snapshot(&BTreeMap::new()).intents.is_empty());
+    }
+
+    #[test]
+    fn price_improved_buy_fill_can_exceed_requested_shares_within_notional_cap() {
+        let mut runtime = TradingRuntime::default();
+        runtime.submit_intent(
+            TradingIntent {
+                intent_id: "intent-buy".to_string(),
+                deployment_id: "dep-1".to_string(),
+                market_id: "market-1".to_string(),
+                token_id: "token-1".to_string(),
+                side: TradeSide::Buy,
+                quantity: dec!(28.30),
+                limit_price: Some(dec!(0.53)),
+                purpose: IntentPurpose::Entry,
+                created_at: Utc::now(),
+            },
+            "order-buy",
+        );
+        runtime.acknowledge_order("order-buy", "venue-buy");
+
+        let recorded = runtime.record_fill(FillRecord {
+            fill_id: "fill-buy".to_string(),
+            order_id: "order-buy".to_string(),
+            token_id: "token-1".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(31.466665),
+            price: dec!(0.4767),
+            fee: dec!(0.12),
+            timestamp: Utc::now(),
+        });
+
+        assert!(recorded);
+        let order = runtime.order("order-buy").expect("order");
+        assert_eq!(order.state, OrderState::Filled);
+        assert_eq!(order.filled_qty, dec!(31.466665));
+        let snapshot = runtime.snapshot(&BTreeMap::new());
+        assert_eq!(snapshot.fills.len(), 1);
+        assert_eq!(snapshot.positions[0].net_qty, dec!(31.466665));
+    }
+
+    #[test]
+    fn price_improved_buy_overfill_still_rejects_above_notional_cap() {
+        let mut runtime = TradingRuntime::default();
+        runtime.submit_intent(
+            TradingIntent {
+                intent_id: "intent-buy".to_string(),
+                deployment_id: "dep-1".to_string(),
+                market_id: "market-1".to_string(),
+                token_id: "token-1".to_string(),
+                side: TradeSide::Buy,
+                quantity: dec!(28.30),
+                limit_price: Some(dec!(0.53)),
+                purpose: IntentPurpose::Entry,
+                created_at: Utc::now(),
+            },
+            "order-buy",
+        );
+        runtime.acknowledge_order("order-buy", "venue-buy");
+
+        let recorded = runtime.record_fill(FillRecord {
+            fill_id: "fill-buy".to_string(),
+            order_id: "order-buy".to_string(),
+            token_id: "token-1".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(40),
+            price: dec!(0.53),
+            fee: Decimal::ZERO,
+            timestamp: Utc::now(),
+        });
+
+        assert!(!recorded);
+        let order = runtime.order("order-buy").expect("order");
+        assert_eq!(order.state, OrderState::Acknowledged);
+        assert_eq!(order.filled_qty, Decimal::ZERO);
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,51 @@
+# Live Price Improvement Fill Accounting (2026-04-25)
+
+## Files
+
+- `crates/ploy-strategy-runtime/src/live.rs`
+  - Owner: live execution price recorded in prepared intents.
+- `crates/ploy-trading/src/runtime.rs`
+  - Owner: accepting BUY fills that exceed share quantity only because of
+    venue price improvement while staying inside signed notional.
+- `crates/ploy-trading/src/orders.rs`
+  - Owner: explicit overfill acceptance path used by the runtime.
+
+## Tasks
+
+- [x] Confirm whether multiple live strategies are running.
+- [x] Reconcile Polymarket wallet trades against local runtime orders.
+- [x] Identify why DOGE accumulated about 30U.
+- [x] Record live BUY orders with the actual slippage-bounded signing price.
+- [x] Accept price-improved BUY fills by notional instead of rejecting them as share overfills.
+- [x] Add regression tests for the DOGE-style overfill/retry failure.
+- [x] Run focused Rust tests and static checks.
+- [ ] Land through PR/CI, deploy Tango, and verify no further duplicate live BUY retry.
+
+## Review
+
+- 2026-04-25: Tango systemd has one `ployd` and no separate live strategy
+  service. Recent DB rows have only `runtime_mode=live, strategy_id=three_layer`.
+- 2026-04-25: Polymarket user activity shows DOGE Down had two live BUY trades
+  for the 10:05PM-10:10PM ET market: about 15.00U and 14.72U. The local DB
+  marked both corresponding orders as rejected because reconciled fills were
+  treated as overfilled and ignored.
+- 2026-04-25: Root cause is live BUY price improvement. The signed order has a
+  USDC notional cap, but if the venue fills at a better price, the returned
+  shares can exceed local `requested_qty`. The runtime rejects that fill by
+  share count, then retries the remaining quantity, creating duplicate live
+  buys.
+- 2026-04-25: The runtime now records live prepared orders at the actual
+  slippage-bounded signing price. BUY fills that exceed requested shares are
+  accepted only when their actual notional stays inside the remaining order
+  notional plus a small cent-rounding tolerance, then the order is marked filled
+  so FAK retry stops.
+- 2026-04-25: Verification passed:
+  `rtk cargo test -p ploy-trading --lib`,
+  `rtk cargo test -p ploy-strategy-runtime --features live,live-execution --lib`,
+  `rtk cargo test -p ploy-strategy-bundles --lib runtime_records_prepared_intent_quantity`,
+  `rustfmt --edition 2021 --check crates/ploy-strategy-runtime/src/live.rs crates/ploy-trading/src/runtime.rs crates/ploy-trading/src/orders.rs`,
+  and `git diff --check`.
+
 # Live Buy Notional Cap (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- record prepared live orders at the actual slippage-bounded signing price
- accept BUY fills that exceed requested shares only when actual fill notional stays inside the order notional cap
- stop FAK retry after those price-improved fills are recorded, preventing duplicate live BUY exposure

## Evidence
- Polymarket activity showed DOGE Down 10:05PM-10:10PM ET had two live BUY trades around 15.00U and 14.72U
- Tango logs showed both reconciled fills were ignored as overfilled, then the runtime retried

## Tests
- rtk cargo test -p ploy-trading --lib -- --nocapture
- rtk cargo test -p ploy-strategy-runtime --features live,live-execution --lib -- --nocapture
- rtk cargo test -p ploy-strategy-bundles --lib runtime_records_prepared_intent_quantity -- --nocapture
- rustfmt --edition 2021 --check crates/ploy-strategy-runtime/src/live.rs crates/ploy-trading/src/runtime.rs crates/ploy-trading/src/orders.rs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buy orders now support price-improved fills that exceed the requested quantity when the total notional value remains within acceptable bounds and tolerance limits.

* **Refactor**
  * Restructured fill handling and order state management logic for improved code reuse and consistency across different fill scenarios.

* **Documentation**
  * Added comprehensive task documentation for the live price improvement fill accounting implementation, current status, and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->