### PR TITLE
Fix PM5D official-settlement accounting

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -36,6 +36,7 @@ env:
     035_binance_agg_trade_ticks.sql
     036_research_valid_windows_matview.sql
     037_research_time_conditioned_factor_metrics.sql
+    038_track_record_official_residual_settlement.sql
 
 jobs:
   build-and-deploy:
@@ -99,6 +100,7 @@ jobs:
           cp scripts/binance_lob_collector.py dist/scripts/binance_lob_collector.py
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
+          cp scripts/repair_strategy_track_record_official_settlement.sql dist/scripts/repair_strategy_track_record_official_settlement.sql
           cp scripts/drills/*.sh dist/scripts/drills/
           for migration in ${DEPLOY_MIGRATIONS}; do
             migration="$(printf '%s' "${migration}" | xargs)"
@@ -305,6 +307,7 @@ jobs:
             install -m 0755 ./scripts/binance_lob_collector.py ${DEPLOY_ROOT}/scripts/binance_lob_collector.py
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
+            install -m 0644 ./scripts/repair_strategy_track_record_official_settlement.sql ${DEPLOY_ROOT}/scripts/repair_strategy_track_record_official_settlement.sql
             install -m 0755 ./scripts/drills/*.sh ${DEPLOY_ROOT}/scripts/drills/
             for migration in ${DEPLOY_MIGRATIONS}; do
               migration="$(printf '%s' "\${migration}" | xargs)"

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -213,6 +213,7 @@ jobs:
             --val-end "${{ github.event.inputs.val_end }}" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --trials "${{ github.event.inputs.trials }}" \
+            --require-official-settlement \
             --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
             --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
             --max-symbols "${{ github.event.inputs.max_symbols }}" \
@@ -266,6 +267,7 @@ jobs:
             --val-end "${{ github.event.inputs.val_end }}" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --trials "${{ github.event.inputs.trials }}" \
+            --require-official-settlement \
             --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
             --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
             --max-symbols "${{ github.event.inputs.max_symbols }}" \

--- a/config/strategies/02-pm5d-threelayer.live.toml
+++ b/config/strategies/02-pm5d-threelayer.live.toml
@@ -63,3 +63,4 @@ capture_sports_state = false
 [backtest_data]
 include_reference_prices = false
 include_sports_state = false
+require_official_settlement = true

--- a/config/strategies/02-pm5d-threelayer.unified.toml
+++ b/config/strategies/02-pm5d-threelayer.unified.toml
@@ -63,3 +63,4 @@ capture_sports_state = false
 [backtest_data]
 include_reference_prices = false
 include_sports_state = false
+require_official_settlement = true

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -658,6 +658,23 @@ venue = "sportsbook"
         assert_eq!(dryrun, live);
     }
 
+    #[test]
+    fn threelayer_configs_require_official_settlement_for_backtests() {
+        let config_dir = strategy_config_dir();
+
+        for file in [
+            "02-pm5d-threelayer.unified.toml",
+            "02-pm5d-threelayer.live.toml",
+        ] {
+            let path = config_dir.join(file);
+            let config = FullConfig::from_file(path.to_str().unwrap()).unwrap();
+            assert!(
+                config.backtest_data.require_official_settlement,
+                "{file} must not optimize against spot-fallback settlement"
+            );
+        }
+    }
+
     fn strategy_config_dir() -> PathBuf {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         manifest_dir.join("../../config/strategies")

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -693,9 +693,6 @@ impl ThreeLayerStrategy {
         orders: &OrderLedger,
     ) -> Vec<StrategyDecision> {
         let mut decisions = Vec::new();
-        if self.balance_pause_active(now) {
-            return decisions;
-        }
 
         for event in self.events.get(symbol).into_iter().flatten() {
             for (token_id, is_up) in [(&event.up_token, true), (&event.down_token, false)] {
@@ -714,23 +711,22 @@ impl ThreeLayerStrategy {
                     continue;
                 };
 
-                // Take profit
-                if let Some(quote) = self.quotes.get(token_id) {
-                    if let Some(ask) = quote.ask.and_then(|v| v.to_f64()) {
-                        if ask >= self.config.take_profit_ask {
-                            decisions.push(StrategyDecision::Exit(TradingIntent {
-                                intent_id: format!("tl_tp_{}_{}", token_id, now.timestamp_millis()),
-                                deployment_id: String::new(),
-                                market_id: event.event_id.to_string(),
-                                token_id: token_id.to_string(),
-                                side: TradeSide::Sell,
-                                quantity: qty,
-                                limit_price: Some(exit_bid),
-                                purpose: IntentPurpose::Exit,
-                                created_at: now,
-                            }));
-                            continue;
-                        }
+                // Take profit must be executable: SELL can only hit the bid.
+                // The config field keeps its historical name for TOML compatibility.
+                if let Some(bid) = exit_bid.to_f64() {
+                    if bid >= self.config.take_profit_ask {
+                        decisions.push(StrategyDecision::Exit(TradingIntent {
+                            intent_id: format!("tl_tp_{}_{}", token_id, now.timestamp_millis()),
+                            deployment_id: String::new(),
+                            market_id: event.event_id.to_string(),
+                            token_id: token_id.to_string(),
+                            side: TradeSide::Sell,
+                            quantity: qty,
+                            limit_price: Some(exit_bid),
+                            purpose: IntentPurpose::Exit,
+                            created_at: now,
+                        }));
+                        continue;
                     }
                 }
 
@@ -773,9 +769,6 @@ impl ThreeLayerStrategy {
         orders: &OrderLedger,
     ) -> Vec<StrategyDecision> {
         let mut exits = Vec::new();
-        if self.balance_pause_active(now) {
-            return exits;
-        }
 
         if positions.net_qty(&event.up_token) > Decimal::ZERO {
             if Self::active_order_exists(orders, &event.up_token) {
@@ -1485,6 +1478,98 @@ mod tests {
             decisions.is_empty(),
             "active order should gate duplicate live exit"
         );
+    }
+
+    #[test]
+    fn take_profit_requires_executable_bid_not_ask_only() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        discover_test_event(&mut strategy, now);
+        let positions = position_with_token("token-down", now);
+        let orders = OrderLedger::default();
+
+        let decisions = strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-down"),
+                bid: Some(dec!(0.62)),
+                ask: Some(dec!(0.75)),
+                bid_size: Some(dec!(100)),
+                ask_size: Some(dec!(100)),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            decisions.is_empty(),
+            "a high ask alone is not an executable take-profit sell"
+        );
+    }
+
+    #[test]
+    fn balance_pause_blocks_entries_but_not_take_profit_exit() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        discover_test_event(&mut strategy, now);
+        strategy.balance_exhausted_until = Some(now + chrono::Duration::seconds(15));
+        let positions = position_with_token("token-down", now);
+        let orders = OrderLedger::default();
+
+        let decisions =
+            strategy.on_update(&take_profit_quote("token-down", now), &positions, &orders);
+
+        assert_eq!(
+            decisions.len(),
+            1,
+            "risk exits must not wait for buy balance cooldown"
+        );
+        match &decisions[0] {
+            StrategyDecision::Exit(intent) => {
+                assert_eq!(intent.token_id, "token-down");
+                assert_eq!(intent.limit_price, Some(dec!(0.72)));
+            }
+            other => panic!("expected take-profit exit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn balance_pause_does_not_block_official_settlement_exit() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        discover_test_event(&mut strategy, now);
+        strategy.balance_exhausted_until = Some(now + chrono::Duration::seconds(15));
+        let positions = position_with_token("token-down", now);
+        let orders = OrderLedger::default();
+
+        let decisions = strategy.on_update(
+            &MarketUpdate::EventExpired {
+                event_id: Arc::from("evt1"),
+                end_time: now,
+                resolved_up_won: Some(false),
+            },
+            &positions,
+            &orders,
+        );
+
+        assert_eq!(
+            decisions.len(),
+            1,
+            "settlement exits must ignore entry cooldowns"
+        );
+        match &decisions[0] {
+            StrategyDecision::Exit(intent) => {
+                assert_eq!(intent.token_id, "token-down");
+                assert_eq!(intent.limit_price, Some(Decimal::new(1, 0)));
+            }
+            other => panic!("expected settlement exit, got {other:?}"),
+        }
     }
 
     #[test]

--- a/migrations/038_track_record_official_residual_settlement.sql
+++ b/migrations/038_track_record_official_residual_settlement.sql
@@ -1,0 +1,235 @@
+-- Migration: 038_track_record_official_residual_settlement
+-- Description: Account for official settlement on residual positions even when
+--              live mode skipped synthetic settle_* exits.
+
+DROP VIEW IF EXISTS strategy_runtime_daily_track_record;
+DROP VIEW IF EXISTS strategy_runtime_event_track_record;
+
+CREATE VIEW strategy_runtime_event_track_record AS
+WITH settlement_prices AS (
+    SELECT
+        token_id,
+        CASE
+            WHEN settled_price >= 0.99 THEN 1.0::NUMERIC
+            WHEN settled_price <= 0.01 THEN 0.0::NUMERIC
+            ELSE settled_price
+        END AS official_price,
+        resolved_at,
+        fetched_at
+    FROM pm_token_settlements
+    WHERE resolved = true
+      AND settled_price IS NOT NULL
+),
+normalized_fills AS (
+    SELECT
+        f.runtime_mode,
+        f.strategy_id,
+        f.deployment_id,
+        COALESCE(NULLIF(f.event_id, ''), f.intent_id) AS trade_key,
+        f.event_id,
+        f.intent_id,
+        f.symbol,
+        f.token_id,
+        f.market_side,
+        f.fill_side,
+        f.quantity,
+        f.price AS recorded_price,
+        sp.official_price AS official_settlement_price,
+        COALESCE(sp.resolved_at, sp.fetched_at) AS official_settlement_at,
+        f.fill_side = 'SELL' AND f.intent_id LIKE '%settle_%' AS is_settlement_exit,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE '%settle_%'
+                AND sp.official_price IS NOT NULL
+            THEN sp.official_price
+            ELSE f.price
+        END AS effective_price,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE '%settle_%'
+                AND sp.official_price IS NOT NULL
+                AND ABS(f.price - sp.official_price) > 0.00000001::NUMERIC
+            THEN true
+            ELSE false
+        END AS settlement_exit_corrected,
+        f.fee,
+        f.fill_timestamp
+    FROM strategy_runtime_fills f
+    LEFT JOIN settlement_prices sp ON sp.token_id = f.token_id
+),
+aggregated AS (
+    SELECT
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        MAX(event_id) AS event_id,
+        MIN(intent_id) AS intent_id,
+        MAX(symbol) AS symbol,
+        MAX(token_id) AS token_id,
+        MAX(market_side) AS market_side,
+        BOOL_OR(settlement_exit_corrected) AS settlement_exit_corrected,
+        MAX(official_settlement_price) AS official_settlement_price,
+        MAX(official_settlement_at) AS official_settlement_at,
+        MIN(fill_timestamp) AS first_fill_at,
+        MAX(fill_timestamp) AS last_fill_at,
+        MIN(fill_timestamp) FILTER (WHERE fill_side = 'BUY') AS opened_at,
+        MAX(fill_timestamp) FILTER (WHERE fill_side = 'SELL') AS recorded_closed_at,
+        COUNT(*) AS fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'BUY') AS buy_fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'SELL') AS sell_fill_count,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'BUY'), 0::NUMERIC) AS buy_quantity,
+        COALESCE(
+            SUM(quantity) FILTER (WHERE fill_side = 'SELL' AND NOT is_settlement_exit),
+            0::NUMERIC
+        ) AS market_sell_quantity,
+        COALESCE(
+            SUM(quantity) FILTER (WHERE fill_side = 'SELL' AND is_settlement_exit),
+            0::NUMERIC
+        ) AS settlement_exit_quantity,
+        COALESCE(
+            SUM(quantity * recorded_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS recorded_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'BUY'),
+            0::NUMERIC
+        ) AS buy_notional,
+        COALESCE(
+            SUM(quantity * effective_price)
+                FILTER (WHERE fill_side = 'SELL' AND NOT is_settlement_exit),
+            0::NUMERIC
+        ) AS market_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price)
+                FILTER (WHERE fill_side = 'SELL' AND is_settlement_exit),
+            0::NUMERIC
+        ) AS settlement_exit_notional,
+        COALESCE(SUM(fee), 0::NUMERIC) AS total_fee
+    FROM normalized_fills
+    GROUP BY runtime_mode, strategy_id, deployment_id, trade_key
+),
+computed AS (
+    SELECT
+        a.*,
+        CASE
+            WHEN a.official_settlement_price IS NOT NULL
+             AND a.buy_quantity > a.market_sell_quantity + a.settlement_exit_quantity
+            THEN a.buy_quantity - a.market_sell_quantity - a.settlement_exit_quantity
+            ELSE 0::NUMERIC
+        END AS official_residual_quantity
+    FROM aggregated a
+)
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    trade_key,
+    event_id,
+    intent_id,
+    symbol,
+    token_id,
+    market_side,
+    first_fill_at,
+    last_fill_at,
+    opened_at,
+    CASE
+        WHEN official_residual_quantity > 0 THEN COALESCE(official_settlement_at, recorded_closed_at)
+        ELSE recorded_closed_at
+    END AS closed_at,
+    fill_count,
+    buy_fill_count,
+    sell_fill_count,
+    buy_quantity,
+    market_sell_quantity + settlement_exit_quantity + official_residual_quantity AS sell_quantity,
+    market_sell_quantity + settlement_exit_quantity AS recorded_sell_quantity,
+    settlement_exit_quantity,
+    official_residual_quantity,
+    buy_notional,
+    market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+        AS sell_notional,
+    recorded_sell_notional,
+    total_fee,
+    CASE
+        WHEN buy_quantity > 0 THEN buy_notional / buy_quantity
+        ELSE NULL
+    END AS avg_entry_price,
+    CASE
+        WHEN market_sell_quantity + settlement_exit_quantity > 0
+        THEN recorded_sell_notional / (market_sell_quantity + settlement_exit_quantity)
+        ELSE NULL
+    END AS recorded_exit_price,
+    CASE
+        WHEN settlement_exit_quantity > 0 OR official_residual_quantity > 0
+        THEN official_settlement_price
+        ELSE NULL
+    END AS official_exit_price,
+    CASE
+        WHEN market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        THEN (
+            market_sell_notional
+            + settlement_exit_notional
+            + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+        ) / (market_sell_quantity + settlement_exit_quantity + official_residual_quantity)
+        ELSE NULL
+    END AS avg_exit_price,
+    settlement_exit_corrected OR official_residual_quantity > 0 AS settlement_corrected,
+    buy_quantity > 0
+        AND market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        AND ABS(buy_quantity - (
+            market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        )) <= 0.00000001::NUMERIC AS is_confirmed,
+    (
+        market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+    ) - buy_notional AS gross_pnl,
+    (
+        market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+    ) - buy_notional - total_fee AS net_pnl,
+    buy_quantity > 0
+        AND market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        AND ABS(buy_quantity - (
+            market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        )) <= 0.00000001::NUMERIC AS is_closed,
+    CASE
+        WHEN buy_quantity > market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        THEN buy_quantity - market_sell_quantity - settlement_exit_quantity - official_residual_quantity
+        ELSE 0::NUMERIC
+    END AS open_quantity
+FROM computed;
+
+CREATE VIEW strategy_runtime_daily_track_record AS
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date AS trading_day_cst,
+    COUNT(*) AS trade_count,
+    COUNT(*) FILTER (WHERE is_closed) AS closed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed) AS confirmed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND settlement_corrected) AS corrected_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl > 0) AS winning_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl < 0) AS losing_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl > 0) AS winning_trade_count_all,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl < 0) AS losing_trade_count_all,
+    COALESCE(SUM(buy_notional), 0::NUMERIC) AS total_buy_notional,
+    COALESCE(SUM(sell_notional), 0::NUMERIC) AS total_sell_notional,
+    COALESCE(SUM(recorded_sell_notional), 0::NUMERIC) AS total_recorded_sell_notional,
+    COALESCE(SUM(total_fee), 0::NUMERIC) AS total_fee,
+    COALESCE(SUM(gross_pnl), 0::NUMERIC) AS gross_pnl,
+    COALESCE(SUM(net_pnl), 0::NUMERIC) AS net_pnl,
+    COALESCE(AVG(net_pnl), 0::NUMERIC) AS avg_net_pnl,
+    COALESCE(SUM(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_net_pnl,
+    COALESCE(AVG(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_avg_net_pnl,
+    COALESCE(SUM(open_quantity), 0::NUMERIC) AS residual_open_quantity
+FROM strategy_runtime_event_track_record
+GROUP BY
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date;

--- a/scripts/repair_strategy_track_record_official_settlement.sql
+++ b/scripts/repair_strategy_track_record_official_settlement.sql
@@ -1,0 +1,22 @@
+-- Rebuild strategy-runtime track-record views so historical dry-run/live rows
+-- use official Polymarket settlement for expiry payouts.
+--
+-- Usage from repo root on the DB host:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/repair_strategy_track_record_official_settlement.sql
+
+CREATE TABLE IF NOT EXISTS strategy_track_record_view_backups (
+    backup_id BIGSERIAL PRIMARY KEY,
+    backed_up_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    view_name TEXT NOT NULL,
+    view_definition TEXT
+);
+
+INSERT INTO strategy_track_record_view_backups (view_name, view_definition)
+SELECT view_name, pg_get_viewdef(('public.' || view_name)::regclass, true)
+FROM (VALUES
+    ('strategy_runtime_event_track_record'),
+    ('strategy_runtime_daily_track_record')
+) AS v(view_name)
+WHERE to_regclass('public.' || view_name) IS NOT NULL;
+
+\ir ../migrations/038_track_record_official_residual_settlement.sql

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,55 @@
+# Official Settlement Dry-run Repair (2026-04-25)
+
+## Files
+
+- `migrations/*strategy_runtime_track_record*`
+  - Owner: dry-run/live track-record accounting with official settlement.
+- `config/strategies/02-pm5d-threelayer.unified.toml`
+  - Owner: PM5D ThreeLayer optimization/backtest settlement requirements.
+- `.github/workflows/optimize.yml`
+  - Owner: remote optimizer invocation defaults.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: ThreeLayer take-profit/stop-loss exit behavior and duplicate exit gating.
+- `scripts/repair_strategy_track_record_official_settlement.sql`
+  - Owner: Tango-side read/write data repair query with backup-first usage.
+
+## Tasks
+
+- [x] Confirm current track-record views, reporting consumers, and optimizer settlement gates.
+- [x] Make dry-run/live event track-record PnL ignore fake settlement prices and prefer official settlement for all settled events.
+- [x] Force PM5D ThreeLayer backtest/parameter optimization to require official settlement.
+- [x] Wire ThreeLayer quote/spot exits to existing take-profit/stop-loss parameters without creating duplicate exits.
+- [x] Run the Tango-safe repair SQL script backup-first and verify current dry-run data.
+- [ ] Run focused checks, land through PR/CI, deploy Tango, and verify post-deploy reports.
+
+## Review
+
+- 2026-04-25: Current track-record views only corrected recorded `settle_*`
+  fills, so live rows that skip synthetic settlement exits still showed large
+  residual positions and dry-run/live PnL could be read under the old recorded
+  sell notional. Added migration `038` so closed event records include official
+  Polymarket settlement payout for any residual quantity after real market
+  sells, while unresolved events remain open instead of being guessed.
+- 2026-04-25: Tango repair script backed up the existing event/daily view
+  definitions into `strategy_track_record_view_backups` and rebuilt both views.
+  Today's dry-run daily PnL changed from the old `+923.1492` raw view to
+  `-224.4960` official-corrected; live changed from `-327.4798` to `-19.7882`.
+  Three new 12:08 CST positions remain open because their tokens have no
+  official settlement rows yet.
+- 2026-04-25: PM5D ThreeLayer config and optimize workflow now require official
+  settlement for backtest/parameter optimization, so stop-loss/take-profit
+  tuning should be rerun against official settlements before changing stop
+  thresholds.
+- 2026-04-25: ThreeLayer take-profit exits now require executable bid >= the
+  configured threshold; a high ask alone no longer triggers a sell. Balance
+  exhaustion pauses still block new entries, but no longer block take-profit or
+  official settlement exits.
+- 2026-04-25: Verification passed: `rtk cargo test -p ploy-strategy-bundles
+  --lib -- --nocapture`, `rustfmt --edition 2021 --check
+  crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+  crates/ploy-strategy-bundles/src/config.rs`, `git diff --check`, and YAML
+  parse for `optimize.yml` plus `deploy-tango-1-1.yml`.
+
 # Live Price Improvement Fill Accounting (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- rebuild strategy runtime track-record views so official settlement closes residual live/dry-run quantities and unresolved events remain open
- require official settlement in PM5D ThreeLayer configs and optimize workflow
- require executable bid for ThreeLayer take-profit exits and allow risk exits during entry balance pauses

## Verification
- rtk cargo test -p ploy-strategy-bundles --lib -- --nocapture
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-strategy-bundles/src/config.rs
- git diff --check
- YAML parse for .github/workflows/optimize.yml and .github/workflows/deploy-tango-1-1.yml
- Tango psql repair backed up old views and rebuilt track-record views; today dry-run changed from +923.1492 to -224.4960 official-corrected

## Not tested
- Full optimize run with the new official-settlement gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Official settlement data is now required for strategy optimization and backtesting.
  * Refined take-profit behavior to use bid pricing instead of ask pricing.

* **Bug Fixes**
  * Fixed track-record calculations to properly account for official settlement on residual positions.
  * Corrected exit logic to allow exits during account balance cooldown periods.

* **Chores**
  * Added migration and repair scripts for official settlement tracking updates.
  * Updated deployment workflows to include settlement migration and repair processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->