### PR TITLE
Protect PM5D optimizer replay guards

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -23,6 +23,22 @@ on:
         description: "Validation end date (YYYY-MM-DD)"
         required: true
         default: "2026-04-20"
+      train_start_ts:
+        description: "Optional train start timestamp (RFC3339); overrides train_start"
+        required: false
+        default: ""
+      train_end_ts:
+        description: "Optional train end timestamp (RFC3339); overrides train_end"
+        required: false
+        default: ""
+      val_start_ts:
+        description: "Optional validation start timestamp (RFC3339); overrides val_start"
+        required: false
+        default: ""
+      val_end_ts:
+        description: "Optional validation end timestamp (RFC3339); overrides val_end"
+        required: false
+        default: ""
       trials:
         description: "Number of optimization trials"
         required: true
@@ -195,6 +211,20 @@ jobs:
           }
           trap 'status=$?; health_summary; rm -rf "${PLOY_DUCKDB_TEMP_DIR}"; exit ${status}' EXIT
 
+          time_flags=()
+          if [ -n "${{ github.event.inputs.train_start_ts }}" ]; then
+            time_flags+=(--train-start-ts "${{ github.event.inputs.train_start_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.train_end_ts }}" ]; then
+            time_flags+=(--train-end-ts "${{ github.event.inputs.train_end_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.val_start_ts }}" ]; then
+            time_flags+=(--val-start-ts "${{ github.event.inputs.val_start_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.val_end_ts }}" ]; then
+            time_flags+=(--val-end-ts "${{ github.event.inputs.val_end_ts }}")
+          fi
+
           extra_flags=()
           if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
             extra_flags+=(--allow-large-window)
@@ -222,6 +252,7 @@ jobs:
             --max-days "${{ github.event.inputs.max_days }}" \
             --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
             --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+            "${time_flags[@]}" \
             "${extra_flags[@]}"
 
       - name: Run optimize
@@ -251,6 +282,20 @@ jobs:
           }
           trap cleanup EXIT
 
+          time_flags=()
+          if [ -n "${{ github.event.inputs.train_start_ts }}" ]; then
+            time_flags+=(--train-start-ts "${{ github.event.inputs.train_start_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.train_end_ts }}" ]; then
+            time_flags+=(--train-end-ts "${{ github.event.inputs.train_end_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.val_start_ts }}" ]; then
+            time_flags+=(--val-start-ts "${{ github.event.inputs.val_start_ts }}")
+          fi
+          if [ -n "${{ github.event.inputs.val_end_ts }}" ]; then
+            time_flags+=(--val-end-ts "${{ github.event.inputs.val_end_ts }}")
+          fi
+
           extra_flags=()
           if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
             extra_flags+=(--allow-large-window)
@@ -278,4 +323,5 @@ jobs:
             --max-days "${{ github.event.inputs.max_days }}" \
             --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
             --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+            "${time_flags[@]}" \
             "${extra_flags[@]}"

--- a/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
@@ -259,7 +259,7 @@ fn run_background(
                         'quote' AS typ, \
                         token_id AS s1, NULL AS s2, \
                         CAST(best_bid AS DOUBLE) AS f1, CAST(best_ask AS DOUBLE) AS f2, \
-                        0.0 AS f3, 0.0 AS f4, \
+                        CAST(bid_size AS DOUBLE) AS f3, CAST(ask_size AS DOUBLE) AS f4, \
                         CAST(0 AS BIGINT) AS i1, false AS b1 \
                  FROM read_parquet('{quote_glob}') \
                  WHERE received_at >= TIMESTAMPTZ '{from_str}' \
@@ -427,6 +427,8 @@ fn market_updates_from_row(row: StreamRow) -> Vec<MarketUpdate> {
             let token_id: Arc<str> = Arc::from(row.s1.unwrap_or_default());
             let bid = row.f1.and_then(|v| Decimal::try_from(v).ok());
             let ask = row.f2.and_then(|v| Decimal::try_from(v).ok());
+            let bid_size = row.f3.and_then(|v| Decimal::try_from(v).ok());
+            let ask_size = row.f4.and_then(|v| Decimal::try_from(v).ok());
             if bid.is_none() && ask.is_none() {
                 Vec::new()
             } else {
@@ -434,8 +436,8 @@ fn market_updates_from_row(row: StreamRow) -> Vec<MarketUpdate> {
                     token_id,
                     bid,
                     ask,
-                    bid_size: None,
-                    ask_size: None,
+                    bid_size,
+                    ask_size,
                     ts,
                 }]
             }
@@ -773,6 +775,38 @@ mod tests {
     }
 
     #[test]
+    fn quote_row_preserves_executable_sizes() {
+        let updates = market_updates_from_row(StreamRow {
+            ts_us: 1_000_000,
+            typ: "quote".to_string(),
+            s1: Some("token".to_string()),
+            f1: Some(0.5),
+            f2: Some(0.75),
+            f3: Some(12.0),
+            f4: Some(13.0),
+            i1: None,
+            b1: None,
+        });
+
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            MarketUpdate::Quote {
+                bid,
+                ask,
+                bid_size,
+                ask_size,
+                ..
+            } => {
+                assert_eq!(*bid, Some(dec!(0.5)));
+                assert_eq!(*ask, Some(dec!(0.75)));
+                assert_eq!(*bid_size, Some(dec!(12)));
+                assert_eq!(*ask_size, Some(dec!(13)));
+            }
+            other => panic!("expected Quote, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn sql_keeps_lob_and_aggtrade_full_cadence_but_filters_pm_quotes() {
         let source = include_str!("parquet_stream.rs");
         let agg_section = section_between(source, "// Agg trades", "// LOB");
@@ -792,6 +826,8 @@ mod tests {
             "source IN ('polymarket_ws', 'polymarket_ws_collector', 'ploy_runner_live')"
         ));
         assert!(quote_section.contains("best_bid IS NOT NULL AND best_ask IS NOT NULL"));
+        assert!(quote_section.contains("CAST(bid_size AS DOUBLE) AS f3"));
+        assert!(quote_section.contains("CAST(ask_size AS DOUBLE) AS f4"));
     }
 
     fn section_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {

--- a/scripts/check_optimize_verification_gates.sh
+++ b/scripts/check_optimize_verification_gates.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 workflow="${repo_root}/.github/workflows/optimize.yml"
 optimizer="${repo_root}/crates/ploy-strategy-bundles/examples/optimize_backtest.rs"
+stream_feed="${repo_root}/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs"
 
 failures=()
 
@@ -42,6 +43,7 @@ require_any_text() {
 
 require_file "${workflow}"
 require_file "${optimizer}"
+require_file "${stream_feed}"
 
 if [[ -f "${workflow}" ]]; then
   require_any_text "${workflow}" "preflight-only workflow gate" "run_mode" "preflight_only" "preflight-only"
@@ -51,6 +53,10 @@ if [[ -f "${workflow}" ]]; then
   require_any_text "${workflow}" "smoke max-updates control" "max_updates" "max-updates"
   require_any_text "${workflow}" "DuckDB memory guard" "duckdb_memory_limit" "duckdb-memory-limit"
   require_any_text "${workflow}" "DuckDB temp-dir isolation" "duckdb_temp_dir" "duckdb-temp-dir"
+  require_any_text "${workflow}" "timestamp train-start narrow-window control" "train_start_ts" "train-start-ts"
+  require_any_text "${workflow}" "timestamp train-end narrow-window control" "train_end_ts" "train-end-ts"
+  require_any_text "${workflow}" "timestamp validation-start narrow-window control" "val_start_ts" "val-start-ts"
+  require_any_text "${workflow}" "timestamp validation-end narrow-window control" "val_end_ts" "val-end-ts"
   require_text "${workflow}" "timeout" "optimize process timeout wrapper"
 
   if ! python3 - "${workflow}" <<'PY'
@@ -119,6 +125,13 @@ if [[ -f "${optimizer}" ]]; then
       failures+=("optimizer contains sampling language without non-canonical smoke labeling")
     fi
   fi
+fi
+
+if [[ -f "${stream_feed}" ]]; then
+  require_text "${stream_feed}" "CAST(bid_size AS DOUBLE) AS f3" "streaming PM quote bid-size replay"
+  require_text "${stream_feed}" "CAST(ask_size AS DOUBLE) AS f4" "streaming PM quote ask-size replay"
+  require_text "${stream_feed}" "bid_size," "streaming MarketUpdate quote bid-size propagation"
+  require_text "${stream_feed}" "ask_size," "streaming MarketUpdate quote ask-size propagation"
 fi
 
 if [[ "${#failures[@]}" -gt 0 ]]; then

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -80,6 +80,45 @@
   ThreeLayer thresholds/time gates. The optimize workflow passes
   `--require-lob-liquidity` in both preflight and full replay.
 
+# PM5D HFT-Style Replay Guard Repair (2026-04-25)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/feed/parquet_stream.rs`
+  - Owner: tick-preserving Parquet replay semantics and PM quote liquidity.
+- `.github/workflows/optimize.yml`
+  - Owner: bounded optimizer workflow dispatch controls for six-symbol smoke.
+- `scripts/check_optimize_verification_gates.sh`
+  - Owner: cheap local readiness guard before remote optimizer runs.
+
+## Tasks
+
+- [x] Confirm the prior tick-preserving architecture record and identify mismatches with current workflow/code.
+- [x] Preserve PM quote bid/ask sizes in `StreamingParquetFeed` so LOB-required fills can be simulated faithfully.
+- [x] Expose timestamp-window optimizer inputs so the documented narrow six-symbol smoke can run before any multi-day replay.
+- [x] Update cheap gate checks to catch missing timestamp controls and quote-size regression.
+- [x] Run lightweight verification without local heavy Parquet replay.
+
+## Review
+
+- 2026-04-25: Existing ADR/runbook already rejected LOB/aggTrade
+  downsampling, required preflight first, removed full-window Rust
+  `Vec<MarketUpdate>` materialization, and called out chunked k-way Parquet
+  merge as the next architecture if DuckDB global ordering remains too heavy.
+- 2026-04-25: Current main did not expose the documented timestamp-window
+  workflow inputs, so the narrow six-symbol smoke gate could not be dispatched.
+  The workflow now forwards optional RFC3339 timestamp overrides to both
+  preflight and optimize runs.
+- 2026-04-25: `StreamingParquetFeed` was dropping PM quote `bid_size` and
+  `ask_size`, which made `--require-lob-liquidity` replay unable to model
+  executable top-of-book liquidity. Streaming replay now preserves quote sizes
+  and has a regression test plus cheap source gate coverage.
+- 2026-04-25: The remaining architecture gap is throughput, not immediate Rust
+  heap safety: each optimization trial still reopens the Parquet stream and
+  asks DuckDB to globally order the same split. Before multi-day six-symbol
+  tuning, run the documented smoke sequence; if it remains too slow or spills
+  heavily, implement the planned chunked k-way/event-tape replay layer.
+
 # Live Price Improvement Fill Accounting (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- preserve PM quote bid/ask sizes in StreamingParquetFeed so require_lob_liquidity can model executable liquidity
- add timestamp-window optimize workflow inputs for the documented narrow six-symbol smoke gate
- extend the cheap optimize gate script and task notes to catch future regressions

## Verification
- bash -n scripts/check_optimize_verification_gates.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/optimize.yml")'\n- ./scripts/check_optimize_verification_gates.sh\n- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/feed/parquet_stream.rs\n- git diff --check\n- rtk cargo check -p ploy-strategy-bundles --features ploy-strategy-bundles/parquet-feed --example optimize_backtest\n- rtk cargo check -p ploy-strategy-bundles --features ploy-strategy-bundles/parquet-feed --tests\n\n## Not tested\n- cargo test link/run locally; this Mac lacks libduckdb for -lduckdb linking. CI/runner should validate the linked test path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimization workflow now accepts optional timestamp inputs for fine-grained control over training and validation periods.
  * Quote data now includes executable bid/ask size information for improved top-of-book liquidity modeling.

* **Tests**
  * Enhanced verification gates to validate timestamp controls and quote size data propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->