### PR TITLE
Fail fast on empty official settlement replay

### DIFF
--- a/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
@@ -622,6 +622,8 @@ fn load_events_vec(
         );
     }
 
+    let discovered_event_rows = event_rows.len();
+    let mut resolved_event_rows = 0usize;
     let mut events = Vec::new();
     for row in event_rows {
         let resolved_up_won = resolve_up_won_from_settlements(
@@ -632,6 +634,9 @@ fn load_events_vec(
         );
         if require_official_settlement && resolved_up_won.is_none() {
             continue;
+        }
+        if resolved_up_won.is_some() {
+            resolved_event_rows += 1;
         }
 
         let up_token: Arc<str> = Arc::from(row.up_token);
@@ -673,6 +678,15 @@ fn load_events_vec(
                 resolved_up_won,
             },
         ));
+    }
+
+    if require_official_settlement && discovered_event_rows > 0 && resolved_event_rows == 0 {
+        return Err(format!(
+            "official settlement required but no PM event metadata rows matched settlement payouts \
+             (event_rows={discovered_event_rows}, settlement_prices={})",
+            settlement_prices.len()
+        )
+        .into());
     }
 
     events.sort_by(|(left_ts, left), (right_ts, right)| {
@@ -1018,6 +1032,9 @@ mod tests {
         assert!(quote_section.contains("CAST(ask_size AS DOUBLE) AS f4"));
         assert!(source.contains("pm_token_settlements"));
         assert!(source.contains("if require_official_settlement && resolved_up_won.is_none()"));
+        assert!(
+            source.contains("official settlement required but no PM event metadata rows matched")
+        );
     }
 
     fn section_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# PM5D Official Settlement Empty Replay Guard (2026-04-25)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/feed/parquet_stream.rs`
+  - Owner: official-only Parquet replay failure semantics when settlements do not match event metadata.
+
+## Tasks
+
+- [x] Confirm bounded TPE optimize still produces zero trades under official-only replay.
+- [x] Add a hard error when PM event metadata exists but no event rows match official settlement payouts.
+- [ ] Run focused verification and land through PR/CI.
+- [ ] Rerun bounded optimize to distinguish settlement mismatch from genuine no-signal behavior.
+
+## Review
+
+- 2026-04-25: Bounded 6-symbol TPE optimize run `24924570651` processed
+  2,304 train PM event rows and 8,278,373 train updates, but all 20 trials and
+  validation produced zero trades. That can be legitimate only if the strategy
+  has no signals; it should not also cover a silent official-settlement join
+  miss.
+- 2026-04-25: Parquet streaming replay now fails fast when
+  `require_official_settlement=true`, PM event metadata rows exist, and none of
+  them resolve against `pm_token_settlements`. This turns a broken official
+  replay source into an explicit error instead of a misleading zero-trade study.
+
 # PM5D ThreeLayer TPE Optimizer Alignment (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- add a fail-fast guard for official-only Parquet replay when PM event metadata exists but zero events match settlement payouts
- prevent misleading zero-trade optimizer runs caused by missing/mismatched pm_token_settlements
- record the bounded TPE run evidence in tasks/todo.md

## Verification
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
- bash -n scripts/check_optimize_verification_gates.sh && ./scripts/check_optimize_verification_gates.sh
- rtk git diff --check
- rtk cargo check -p ploy-strategy-bundles --features ploy-strategy-bundles/parquet-feed --tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation during data import to detect when event metadata exists but cannot resolve official settlements, returning clear error messages instead of producing incomplete data sets.

* **Documentation**
  * Updated documentation to describe the new settlement validation guardrail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->