### PR TITLE
Explain zero-trade optimizer runs

### DIFF
--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -37,6 +37,7 @@
 //! When using --data-dir without explicit --val-start/--val-end, the last 40%
 //! of the train range is used as validation (train covers first 60%).
 
+use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_feed_loaders::{
@@ -44,15 +45,15 @@ use ploy_feed_loaders::{
 };
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    DirectionalStrategy, Feed, FullConfig, HistoricalFeed, MarketUpdate, NullRecorder,
-    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
-    StrategyLogic, StrategyRuntime, ThreeLayerStrategy,
+    DirectionalStrategy, ExecutionReport, Feed, FullConfig, HistoricalFeed, MarketUpdate, Recorder,
+    ReversalStrategy, RuntimeConfig, RuntimeMode, SignalRecord, SimulatedExecutor,
+    SimulatedExecutorConfig, StrategyLogic, StrategyRuntime, ThreeLayerStrategy,
 };
-use ploy_trading::TradeSide;
+use ploy_trading::{FillRecord, TradeSide, TradingIntent};
 use rust_decimal_macros::dec;
 use sqlx::postgres::PgPoolOptions;
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 const DEFAULT_THREE_LAYER_CONFIG: &str = "config/strategies/02-pm5d-threelayer.unified.toml";
 
@@ -661,6 +662,120 @@ struct BacktestOutcome {
     sharpe: f64,
     updates_processed: u64,
     elapsed_secs: f64,
+    intents_submitted: u64,
+    fills_recorded: u64,
+    diagnostics: BacktestDiagnostics,
+}
+
+#[derive(Debug, Clone, Default)]
+struct BacktestDiagnostics {
+    signals_recorded: u64,
+    orders_recorded: u64,
+    orders_rejected: u64,
+    fills_recorded_by_recorder: u64,
+    rejection_reasons: BTreeMap<String, u64>,
+    strategy: Vec<(String, u64)>,
+}
+
+impl BacktestDiagnostics {
+    fn summary(&self) -> String {
+        let mut parts = vec![
+            format!("signals={}", self.signals_recorded),
+            format!("orders={}", self.orders_recorded),
+            format!("order_rejects={}", self.orders_rejected),
+            format!("recorder_fills={}", self.fills_recorded_by_recorder),
+        ];
+
+        let strategy = top_counts(&self.strategy, 8);
+        if !strategy.is_empty() {
+            parts.push(format!("strategy=[{}]", strategy));
+        }
+
+        let rejection_reasons = self
+            .rejection_reasons
+            .iter()
+            .map(|(key, value)| (key.clone(), *value))
+            .collect::<Vec<_>>();
+        let rejections = top_counts(&rejection_reasons, 4);
+        if !rejections.is_empty() {
+            parts.push(format!("rejects=[{}]", rejections));
+        }
+
+        parts.join(" ")
+    }
+}
+
+fn top_counts(counts: &[(String, u64)], limit: usize) -> String {
+    let mut ordered = counts
+        .iter()
+        .filter(|(_, value)| *value > 0)
+        .cloned()
+        .collect::<Vec<_>>();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ordered
+        .into_iter()
+        .take(limit)
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn print_backtest_diagnostics(label: &str, outcome: &BacktestOutcome) {
+    if outcome.trade_count > 0 && outcome.diagnostics.orders_rejected == 0 {
+        return;
+    }
+
+    eprintln!(
+        "      diag {label}: runtime_intents={} runtime_fills={} {}",
+        outcome.intents_submitted,
+        outcome.fills_recorded,
+        outcome.diagnostics.summary(),
+    );
+}
+
+struct DiagnosticRecorder {
+    diagnostics: Arc<Mutex<BacktestDiagnostics>>,
+}
+
+#[async_trait]
+impl Recorder for DiagnosticRecorder {
+    async fn record_signal(&mut self, _signal: &SignalRecord) {
+        self.diagnostics.lock().unwrap().signals_recorded += 1;
+    }
+
+    async fn record_order(
+        &mut self,
+        _strategy: &str,
+        _intent: &TradingIntent,
+        _signal: Option<&SignalRecord>,
+        report: &ExecutionReport,
+        _order_id: &str,
+    ) {
+        let mut diagnostics = self.diagnostics.lock().unwrap();
+        diagnostics.orders_recorded += 1;
+        if report.rejected {
+            diagnostics.orders_rejected += 1;
+            let reason = report
+                .rejection_reason
+                .as_deref()
+                .unwrap_or("unknown")
+                .to_string();
+            *diagnostics.rejection_reasons.entry(reason).or_insert(0) += 1;
+        }
+    }
+
+    async fn record_fill(
+        &mut self,
+        _strategy: &str,
+        _intent: &TradingIntent,
+        _signal: Option<&SignalRecord>,
+        _fill: &FillRecord,
+        _report: &ExecutionReport,
+    ) {
+        self.diagnostics.lock().unwrap().fills_recorded_by_recorder += 1;
+    }
+
+    async fn flush(&mut self) {}
 }
 
 fn source_hint(source: &ReplaySource) -> String {
@@ -686,7 +801,10 @@ fn run_backtest(
     let strategy = build_strategy(strategy_variant, config);
     let feed = source.open()?;
     let executor = SimulatedExecutor::new(executor_config.clone());
-    let recorder = Box::new(NullRecorder);
+    let diagnostics = Arc::new(Mutex::new(BacktestDiagnostics::default()));
+    let recorder = Box::new(DiagnosticRecorder {
+        diagnostics: Arc::clone(&diagnostics),
+    });
     let runtime_config = RuntimeConfig {
         mode: RuntimeMode::Backtest,
         throttle_hz: None,
@@ -696,6 +814,8 @@ fn run_backtest(
 
     let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, runtime_config);
     let result = rt.block_on(runtime.run());
+    let mut diagnostics = diagnostics.lock().unwrap().clone();
+    diagnostics.strategy = result.strategy_diagnostics.clone();
 
     let snapshot = runtime.trading().snapshot(&BTreeMap::new());
     let cashflow = snapshot.fill_cashflow_summary();
@@ -750,6 +870,9 @@ fn run_backtest(
         sharpe,
         updates_processed: result.updates_processed,
         elapsed_secs: result.elapsed_secs,
+        intents_submitted: result.intents_submitted,
+        fills_recorded: result.fills_recorded,
+        diagnostics,
     })
 }
 
@@ -1220,6 +1343,7 @@ fn main() {
                     params.max_ask_for_reversal,
                     params.max_pm_lag_secs,
                 );
+                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
 
                 Ok::<f64, Error>(score)
             })
@@ -1295,6 +1419,7 @@ fn main() {
         eprintln!("Val Trades:  {}", val_outcome.trade_count);
         eprintln!("Val Updates: {}", val_outcome.updates_processed);
         eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
+        print_backtest_diagnostics("validation", &val_outcome);
 
         eprintln!("\n=== Config Snippet ===");
         eprintln!(
@@ -1455,6 +1580,7 @@ fn main() {
                     params.stop_distance_pct,
                     params.cooldown_secs,
                 );
+                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
 
                 Ok::<f64, Error>(score)
             })
@@ -1497,6 +1623,7 @@ fn main() {
         eprintln!("Val Trades:  {}", val_outcome.trade_count);
         eprintln!("Val Updates: {}", val_outcome.updates_processed);
         eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
+        print_backtest_diagnostics("validation", &val_outcome);
 
         eprintln!("\n=== Best Config (TOML) ===");
         eprintln!("# Paste into [strategy] section of your config file");
@@ -1610,6 +1737,7 @@ fn main() {
                     max_entry,
                     cooldown
                 );
+                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
 
                 Ok(outcome.sharpe)
             })
@@ -1656,6 +1784,7 @@ fn main() {
         eprintln!("Val Trades:  {}", val_outcome.trade_count);
         eprintln!("Val Updates: {}", val_outcome.updates_processed);
         eprintln!("Val Elapsed: {:.1}s", val_outcome.elapsed_secs);
+        print_backtest_diagnostics("validation", &val_outcome);
 
         eprintln!("\n=== Config Snippet ===");
         eprintln!("min_probability = {best_min_prob:.4}");

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -58,6 +58,7 @@ pub struct RuntimeResult {
     pub pnl: PnlSnapshot,
     pub risk: RiskSnapshot,
     pub elapsed_secs: f64,
+    pub strategy_diagnostics: Vec<(String, u64)>,
 }
 
 #[derive(Debug, Clone)]
@@ -406,6 +407,7 @@ where
             pnl: snapshot.pnl,
             risk: snapshot.risk,
             elapsed_secs: elapsed,
+            strategy_diagnostics: self.strategy.diagnostics(),
         };
 
         info!(

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -385,6 +385,7 @@ pub struct ThreeLayerStrategy {
     daily_trade_count: u32,
     daily_trade_date: Option<chrono::NaiveDate>,
     feed_time: Option<DateTime<Utc>>,
+    diagnostics: HashMap<&'static str, u64>,
 }
 
 impl ThreeLayerStrategy {
@@ -405,7 +406,16 @@ impl ThreeLayerStrategy {
             daily_trade_count: 0,
             daily_trade_date: None,
             feed_time: None,
+            diagnostics: HashMap::new(),
         }
+    }
+
+    fn bump(&mut self, key: &'static str) {
+        self.bump_by(key, 1);
+    }
+
+    fn bump_by(&mut self, key: &'static str, value: u64) {
+        *self.diagnostics.entry(key).or_insert(0) += value;
     }
 
     fn now(&self) -> DateTime<Utc> {
@@ -501,40 +511,61 @@ impl ThreeLayerStrategy {
         positions: &PositionLedger,
         orders: &OrderLedger,
     ) -> Option<StrategyDecision> {
+        self.bump("entry_evaluations");
         if self.balance_pause_active(now) {
+            self.bump("skip_balance_pause");
             debug!(symbol, "Balance exhausted pause active, skipping entry");
             return None;
         }
         if self.daily_trade_count >= self.config.max_daily_trades {
+            self.bump("skip_max_daily_trades");
             return None;
         }
         if positions.positions().count() >= self.config.max_positions {
+            self.bump("skip_max_positions");
             return None;
         }
 
-        let spot_price = (*self.spot.get(symbol)?).to_f64()?;
+        let Some(spot_price) = self.spot.get(symbol).and_then(|price| price.to_f64()) else {
+            self.bump("skip_no_spot");
+            return None;
+        };
         if spot_price <= 0.0 {
+            self.bump("skip_bad_spot");
             return None;
         }
 
         // Cooldown check
         if let Some(last) = self.last_entry.get(symbol) {
             if (now - *last).num_seconds() < self.config.cooldown_secs as i64 {
+                self.bump("skip_symbol_cooldown");
                 return None;
             }
         }
 
         let candidates = self.candidate_events(symbol, now);
+        if candidates.is_empty() {
+            self.bump("skip_no_candidate_events");
+        } else {
+            self.bump_by("candidate_events", candidates.len() as u64);
+        }
         for event in &candidates {
             let time_remaining = (event.end_time - now).num_seconds();
-            let price_to_beat = event.price_to_beat?.to_f64()?;
+            let Some(price_to_beat) = event.price_to_beat.and_then(|price| price.to_f64()) else {
+                self.bump("skip_no_price_to_beat");
+                continue;
+            };
             if price_to_beat <= 0.0 {
+                self.bump("skip_bad_price_to_beat");
                 continue;
             }
 
             let regime = Regime::from_secs(time_remaining);
 
-            let drift_tracker = self.drift.get_mut(symbol)?;
+            let Some(drift_tracker) = self.drift.get_mut(symbol) else {
+                self.bump("skip_no_drift_tracker");
+                return None;
+            };
             let sigma_h = drift_tracker.sigma_horizon(time_remaining as f64);
             let drift_30s = drift_tracker.drift_30s();
 
@@ -551,14 +582,17 @@ impl ThreeLayerStrategy {
                 .unwrap_or(0.0);
 
             // Layer 1: Direction score
-            let (direction_sign, effective_p, direction_score) = evaluate_direction_score(
+            let Some((direction_sign, effective_p, direction_score)) = evaluate_direction_score(
                 distance_over_sigma,
                 sigma_h,
                 cum_mprice_drift_5m,
                 drift_30s,
                 regime,
                 &self.config,
-            )?;
+            ) else {
+                self.bump("skip_direction_score");
+                continue;
+            };
 
             let betting_up = direction_sign > 0.0;
             let (token_id, direction) = if betting_up {
@@ -569,20 +603,30 @@ impl ThreeLayerStrategy {
 
             // Skip if already positioned or have active order on this token
             if positions.net_qty(token_id) > Decimal::ZERO {
+                self.bump("skip_existing_position");
                 continue;
             }
             if Self::active_order_exists(orders, token_id) {
+                self.bump("skip_active_order");
                 continue;
             }
             if self.token_reject_active(token_id, now) {
+                self.bump("skip_token_reject_cooldown");
                 continue;
             }
 
             // Check quote freshness
-            let quote = self.quotes.get(token_id)?;
-            let ask = quote.ask?.to_f64()?;
+            let Some(quote) = self.quotes.get(token_id) else {
+                self.bump("skip_no_pm_quote");
+                continue;
+            };
+            let Some(ask) = quote.ask.and_then(|price| price.to_f64()) else {
+                self.bump("skip_no_pm_ask");
+                continue;
+            };
             let quote_age = (now - quote.ts).num_seconds();
             if quote_age > self.config.max_pm_lag_secs as i64 {
+                self.bump("skip_stale_pm_quote");
                 continue;
             }
 
@@ -598,14 +642,19 @@ impl ThreeLayerStrategy {
             );
 
             // Layer 3: Edge score
-            let (entry_price_f, edge, _rr, edge_score) =
-                evaluate_edge_score(effective_p, ask, regime, &self.config)?;
+            let Some((entry_price_f, edge, _rr, edge_score)) =
+                evaluate_edge_score(effective_p, ask, regime, &self.config)
+            else {
+                self.bump("skip_edge_score");
+                continue;
+            };
 
             // Composite scoring model
             let total_score =
                 direction_score * 0.50 + edge_score * 0.35 + confirmation_bonus * 0.15;
 
             if total_score < self.config.min_entry_score {
+                self.bump("skip_entry_score");
                 info!(
                     strategy = "three_layer",
                     symbol = %symbol,
@@ -621,9 +670,13 @@ impl ThreeLayerStrategy {
                 continue;
             }
 
-            let entry_price = Decimal::try_from(entry_price_f).ok()?;
+            let Some(entry_price) = Decimal::try_from(entry_price_f).ok() else {
+                self.bump("skip_bad_entry_price");
+                continue;
+            };
             let quantity = self.entry_quantity(entry_price);
             if quantity <= Decimal::ZERO {
+                self.bump("skip_zero_quantity");
                 continue;
             }
 
@@ -676,6 +729,7 @@ impl ThreeLayerStrategy {
                 "entry signal"
             );
 
+            self.bump("entry_signals");
             return Some(StrategyDecision::Enter {
                 intent,
                 signal: Some(signal),
@@ -1151,6 +1205,16 @@ impl StrategyLogic for ThreeLayerStrategy {
     fn name(&self) -> &str {
         "three_layer"
     }
+
+    fn diagnostics(&self) -> Vec<(String, u64)> {
+        let mut diagnostics = self
+            .diagnostics
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), *value))
+            .collect::<Vec<_>>();
+        diagnostics.sort_by(|a, b| a.0.cmp(&b.0));
+        diagnostics
+    }
 }
 
 #[cfg(test)]
@@ -1203,6 +1267,30 @@ mod tests {
             tracker.push(t, price);
         }
         assert!(tracker.drift_30s() > 0.0);
+    }
+
+    #[test]
+    fn diagnostics_count_entry_gate_reasons() {
+        use chrono::TimeZone;
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &PositionLedger::default(),
+            &OrderLedger::default(),
+        );
+
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("entry_evaluations"), Some(&1));
+        assert_eq!(diagnostics.get("skip_no_candidate_events"), Some(&1));
     }
 
     fn test_config() -> ThreeLayerConfig {

--- a/crates/ploy-strategy-bundles/src/traits.rs
+++ b/crates/ploy-strategy-bundles/src/traits.rs
@@ -129,6 +129,11 @@ pub trait StrategyLogic: Send {
 
     /// Strategy name for logging and metrics.
     fn name(&self) -> &str;
+
+    /// Optional strategy-specific counters for backtest/optimizer diagnostics.
+    fn diagnostics(&self) -> Vec<(String, u64)> {
+        Vec::new()
+    }
 }
 
 /// Blanket impl so `Box<dyn StrategyLogic>` can be used as a generic `S: StrategyLogic`.
@@ -152,6 +157,10 @@ impl StrategyLogic for Box<dyn StrategyLogic> {
 
     fn name(&self) -> &str {
         (**self).name()
+    }
+
+    fn diagnostics(&self) -> Vec<(String, u64)> {
+        (**self).diagnostics()
     }
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9160,3 +9160,24 @@ Checklist:
 
 Review:
 - 2026-04-25: Changed the market scanner so tracked crypto events are not expired with locally inferred Chainlink/Pyth/Binance outcomes when database persistence is enabled. The scanner now waits for `pm_token_settlements` to identify the official winning token, and startup recovery maps that winning token back to whether the UP token won before emitting `EventExpired`. This prevents dry-run from booking settlement exits at 1.00 before Polymarket's official outcome arrives.
+
+## Optimizer No-Trade Diagnostics
+
+Goal: make zero-trade PM5D optimization runs explain whether they had no signals, execution rejections, or strategy gate filtering before changing strategy thresholds.
+
+File ownership:
+- `crates/ploy-strategy-bundles/src/traits.rs`
+- `crates/ploy-strategy-bundles/src/engine.rs`
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+- `crates/ploy-strategy-bundles/examples/optimize_backtest.rs`
+- `tasks/todo.md`
+
+Checklist:
+- [x] Expose optional strategy diagnostics through the unified runtime result.
+- [x] Add ThreeLayer entry-gate counters without changing entry/exit decisions.
+- [x] Replace optimizer `NullRecorder` with a diagnostic recorder that counts signals, orders, fills, and rejection reasons.
+- [x] Print compact diagnostics for zero-trade or rejected-order trials and validation.
+- [x] Verify with formatting, focused cargo check, and a ThreeLayer diagnostics unit test.
+
+Review:
+- 2026-04-25: Post-guard optimize run `24924887117` proved official settlement replay no longer fails silently, but all 20 TPE trials still produced zero trades. Added optimizer diagnostics so the next bounded run reports runtime intents/fills, recorded signals/orders, executor rejection reasons, and ThreeLayer gate counters such as missing candidate events, missing PM quotes, stale quotes, edge-score filtering, and entry-score filtering. This keeps the next threshold discussion evidence-driven instead of guessing from `trades=0`.


### PR DESCRIPTION
## Summary\n- add runtime/strategy diagnostic counters for PM5D optimizer backtests\n- count ThreeLayer entry-gate skip reasons without changing trading decisions\n- replace optimizer NullRecorder with a diagnostic recorder for signals, orders, fills, and rejection reasons\n\n## Verification\n- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/traits.rs crates/ploy-strategy-bundles/src/engine.rs crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-strategy-bundles/examples/optimize_backtest.rs\n- rtk cargo check -p ploy-strategy-bundles --features ploy-strategy-bundles/parquet-feed --example optimize_backtest\n- rtk cargo test -p ploy-strategy-bundles strategies::three_layer::tests::diagnostics_count_entry_gate_reasons --lib\n- rtk git diff --check