### PR TITLE
Preserve executable quote liquidity in replay

### DIFF
--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -511,6 +511,9 @@ async fn load_pm_quotes(
     // - UP token:   best_bid is the real price, best_ask may be NULL
     // - DOWN token: best_ask is the real price, best_bid may be NULL
     // Accept rows where EITHER bid OR ask is in the real price range (0.01, 0.99).
+    // Within each second, prefer book rows with executable size over later price-only
+    // best_bid_ask/price_change rows; otherwise LOB-aware replay sees valid prices
+    // but no executable top-of-book liquidity.
     let rows: Vec<(
         DateTime<Utc>,
         String,
@@ -532,7 +535,10 @@ async fn load_pm_quotes(
             OR
             (best_ask  IS NOT NULL AND best_ask  > 0.01 AND best_ask  < 0.99)
           )
-        ORDER BY date_trunc('second', received_at), token_id, received_at DESC
+        ORDER BY date_trunc('second', received_at), token_id,
+                 (ask_size IS NOT NULL AND ask_size > 0)::int DESC,
+                 (bid_size IS NOT NULL AND bid_size > 0)::int DESC,
+                 received_at DESC
         "#,
     )
     .bind(from)

--- a/crates/ploy-strategy-bundles/src/executor/simulated.rs
+++ b/crates/ploy-strategy-bundles/src/executor/simulated.rs
@@ -266,13 +266,18 @@ impl Executor for SimulatedExecutor {
             ..
         } = update
         {
+            let previous = self
+                .quotes
+                .get(token_id.as_ref())
+                .copied()
+                .unwrap_or_default();
             self.quotes.insert(
                 token_id.to_string(),
                 QuoteLiquidity {
                     bid: *bid,
                     ask: *ask,
-                    bid_size: *bid_size,
-                    ask_size: *ask_size,
+                    bid_size: bid_size.or(previous.bid_size),
+                    ask_size: ask_size.or(previous.ask_size),
                 },
             );
         }
@@ -517,6 +522,34 @@ mod tests {
             report.rejection_reason.as_deref(),
             Some("No executable ask liquidity")
         );
+    }
+
+    #[tokio::test]
+    async fn price_only_quote_does_not_erase_last_observed_liquidity() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.49)),
+            Some(dec!(0.50)),
+            Some(dec!(50)),
+            Some(dec!(8)),
+        ));
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.48)),
+            Some(dec!(0.50)),
+            None,
+            None,
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(25));
+
+        let report = exec.submit(&intent, "test-order-lob-price-only").await;
+        assert!(!report.rejected);
+        let fill = report.fill.expect("last known top-of-book size");
+        assert_eq!(fill.price, dec!(0.50));
+        assert_eq!(fill.quantity, dec!(8));
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
@@ -265,7 +265,8 @@ fn run_background(
         ));
     }
 
-    // PM quotes — align with database.rs: DISTINCT ON per-second per-token, trusted sources only
+    // PM quotes — align with database.rs: DISTINCT ON per-second per-token, trusted sources only.
+    // Prefer book rows with executable size over later price-only rows in the same second.
     if Path::new(&format!("{data_dir}/clob_quote_ticks")).exists() {
         parts.push(format!(
             "SELECT ts_us, source_rank, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
@@ -284,7 +285,10 @@ fn run_background(
                    AND source IN ('polymarket_ws', 'polymarket_ws_collector', 'ploy_runner_live') \
                    AND best_bid IS NOT NULL AND best_ask IS NOT NULL \
                    AND (best_bid > 0.01 AND best_bid < 0.99 OR best_ask > 0.01 AND best_ask < 0.99) \
-                 ORDER BY date_trunc('second', received_at), token_id, received_at DESC \
+                 ORDER BY date_trunc('second', received_at), token_id, \
+                          CASE WHEN ask_size IS NOT NULL AND ask_size > 0 THEN 1 ELSE 0 END DESC, \
+                          CASE WHEN bid_size IS NOT NULL AND bid_size > 0 THEN 1 ELSE 0 END DESC, \
+                          received_at DESC \
              )"
         ));
     }
@@ -1030,6 +1034,8 @@ mod tests {
         assert!(quote_section.contains("best_bid IS NOT NULL AND best_ask IS NOT NULL"));
         assert!(quote_section.contains("CAST(bid_size AS DOUBLE) AS f3"));
         assert!(quote_section.contains("CAST(ask_size AS DOUBLE) AS f4"));
+        assert!(quote_section.contains("CASE WHEN ask_size IS NOT NULL AND ask_size > 0"));
+        assert!(quote_section.contains("CASE WHEN bid_size IS NOT NULL AND bid_size > 0"));
         assert!(source.contains("pm_token_settlements"));
         assert!(source.contains("if require_official_settlement && resolved_up_won.is_none()"));
         assert!(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9181,3 +9181,23 @@ Checklist:
 
 Review:
 - 2026-04-25: Post-guard optimize run `24924887117` proved official settlement replay no longer fails silently, but all 20 TPE trials still produced zero trades. Added optimizer diagnostics so the next bounded run reports runtime intents/fills, recorded signals/orders, executor rejection reasons, and ThreeLayer gate counters such as missing candidate events, missing PM quotes, stale quotes, edge-score filtering, and entry-score filtering. This keeps the next threshold discussion evidence-driven instead of guessing from `trades=0`.
+
+## Prefer Executable PM Quotes
+
+Goal: stop price-only PM quote rows from erasing or outranking book rows that carry executable top-of-book size in LOB-aware dry-run/backtest replay.
+
+File ownership:
+- `crates/ploy-strategy-bundles/src/executor/simulated.rs`
+- `crates/ploy-strategy-bundles/src/feed/parquet_stream.rs`
+- `crates/ploy-feed-loaders/src/database.rs`
+- `tasks/todo.md`
+
+Checklist:
+- [x] Make the simulated executor preserve last observed bid/ask size when a later price-only quote arrives.
+- [x] Prefer positive ask/bid size rows during per-second quote de-duplication in Parquet streaming replay.
+- [x] Apply the same size-preference ordering to DB historical quote loading.
+- [x] Add focused regression coverage for price-only quote updates preserving executable liquidity.
+- [x] Verify formatting, focused tests, and relevant cargo checks.
+
+Review:
+- 2026-04-25: Diagnostic optimize run `24925353379` showed hundreds to thousands of entry signals per trial, but every simulated order was rejected with `No executable ask liquidity`. The replay SQL was selecting the newest quote per token/second, which can choose later price-only `best_bid_ask`/`price_change` rows over book rows with size. The simulator also overwrote known sizes with `None` when it observed price-only quotes. Fixed both paths so LOB-aware replay can use executable liquidity when the historical data contains it, while still rejecting when size was never observed.


### PR DESCRIPTION
## Summary\n- prefer PM quote rows with positive bid/ask size during per-second replay de-duplication\n- keep the last observed executable size when the simulator receives later price-only quote updates\n- document the optimizer diagnostic evidence that led to this fix\n\n## Verification\n- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/executor/simulated.rs crates/ploy-strategy-bundles/src/feed/parquet_stream.rs crates/ploy-feed-loaders/src/database.rs\n- rtk cargo test -p ploy-strategy-bundles executor::simulated::tests::price_only_quote_does_not_erase_last_observed_liquidity --lib\n- rtk cargo check -p ploy-feed-loaders\n- rtk cargo check -p ploy-strategy-bundles --features ploy-strategy-bundles/parquet-feed --example optimize_backtest\n- rtk git diff --check\n\n## Not tested\n- parquet_stream focused unit links DuckDB on this Mac and failed with local -lduckdb linker error; CI covers the DuckDB-linked lanes.