### PR TITLE
Persist executable Polymarket quote sizes

### DIFF
--- a/crates/ploy-market-data/src/collector.rs
+++ b/crates/ploy-market-data/src/collector.rs
@@ -124,24 +124,24 @@ fn is_tradeable_price(price: Decimal) -> bool {
     price > rust_decimal_macros::dec!(0.02) && price < rust_decimal_macros::dec!(0.98)
 }
 
-fn best_tradeable_bid<I>(prices: I) -> Option<Decimal>
+fn best_tradeable_bid_level<I>(levels: I) -> Option<(Decimal, Decimal)>
 where
-    I: IntoIterator<Item = Decimal>,
+    I: IntoIterator<Item = (Decimal, Decimal)>,
 {
-    prices
+    levels
         .into_iter()
-        .filter(|price| is_tradeable_price(*price))
-        .max()
+        .filter(|(price, size)| is_tradeable_price(*price) && *size > Decimal::ZERO)
+        .max_by(|left, right| left.0.cmp(&right.0))
 }
 
-fn best_tradeable_ask<I>(prices: I) -> Option<Decimal>
+fn best_tradeable_ask_level<I>(levels: I) -> Option<(Decimal, Decimal)>
 where
-    I: IntoIterator<Item = Decimal>,
+    I: IntoIterator<Item = (Decimal, Decimal)>,
 {
-    prices
+    levels
         .into_iter()
-        .filter(|price| is_tradeable_price(*price))
-        .min()
+        .filter(|(price, size)| is_tradeable_price(*price) && *size > Decimal::ZERO)
+        .min_by(|left, right| left.0.cmp(&right.0))
 }
 
 fn serialize_orderbook_levels(levels: &[OrderBookLevel]) -> String {
@@ -440,14 +440,22 @@ impl QuoteCollector {
                                     s.books_received += 1;
                                 }
 
-                                // Select the actual best tradeable prices, not just the first
-                                // non-placeholder level returned by the SDK.
-                                let real_bid =
-                                    best_tradeable_bid(book.bids.iter().map(|bid| bid.price));
-                                let real_ask =
-                                    best_tradeable_ask(book.asks.iter().map(|ask| ask.price));
+                                // Select the actual best tradeable levels, not just the first
+                                // non-placeholder level returned by the SDK. Preserve size so
+                                // LOB-aware replay can model executable top-of-book liquidity.
+                                let real_bid = best_tradeable_bid_level(
+                                    book.bids.iter().map(|bid| (bid.price, bid.size)),
+                                );
+                                let real_ask = best_tradeable_ask_level(
+                                    book.asks.iter().map(|ask| (ask.price, ask.size)),
+                                );
 
-                                let (best_bid, best_ask) = (real_bid, real_ask);
+                                let (best_bid, bid_size) = real_bid
+                                    .map(|(price, size)| (Some(price), Some(size)))
+                                    .unwrap_or((None, None));
+                                let (best_ask, ask_size) = real_ask
+                                    .map(|(price, size)| (Some(price), Some(size)))
+                                    .unwrap_or((None, None));
 
                                 // Get metadata
                                 let meta = {
@@ -464,6 +472,8 @@ impl QuoteCollector {
                                         &token_id,
                                         best_bid,
                                         best_ask,
+                                        bid_size,
+                                        ask_size,
                                     )
                                     .await
                                     {
@@ -961,6 +971,8 @@ async fn persist_book_update(
     token_id: &str,
     best_bid: Option<Decimal>,
     best_ask: Option<Decimal>,
+    bid_size: Option<Decimal>,
+    ask_size: Option<Decimal>,
 ) -> Result<PersistResult, sqlx::Error> {
     let received_at = Utc::now();
     let bids_json = serialize_orderbook_levels(&book.bids);
@@ -995,9 +1007,9 @@ async fn persist_book_update(
         sqlx::query(
             r#"
         INSERT INTO clob_quote_ticks (
-            token_id, side, best_bid, best_ask,
+            token_id, side, best_bid, best_ask, bid_size, ask_size,
             received_at, source, domain
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         ON CONFLICT DO NOTHING
         "#,
         )
@@ -1005,6 +1017,8 @@ async fn persist_book_update(
         .bind(&meta.side)
         .bind(best_bid)
         .bind(best_ask)
+        .bind(bid_size)
+        .bind(ask_size)
         .bind(received_at)
         .bind("polymarket_ws_collector")
         .bind("Crypto")
@@ -1026,7 +1040,7 @@ async fn persist_book_update(
 #[cfg(test)]
 mod tests {
     use super::{
-        best_tradeable_ask, best_tradeable_bid, book_timestamp, bridge_sdk_json,
+        best_tradeable_ask_level, best_tradeable_bid_level, book_timestamp, bridge_sdk_json,
         collector_market_data_ws_config, parse_official_market_settlements,
         serialize_orderbook_levels, snapshot_context, OfficialMarketSettlementPayload,
         OrderBookLevel, TokenMetadata,
@@ -1037,21 +1051,67 @@ mod tests {
 
     #[test]
     fn best_tradeable_bid_skips_placeholders_and_takes_highest_level() {
-        let prices = vec![dec!(0.01), dec!(0.45), dec!(0.62), dec!(0.99)];
-        assert_eq!(best_tradeable_bid(prices), Some(dec!(0.62)));
+        let levels = vec![
+            (dec!(0.01), dec!(100)),
+            (dec!(0.45), dec!(12)),
+            (dec!(0.62), dec!(4)),
+            (dec!(0.99), dec!(100)),
+        ];
+        assert_eq!(
+            best_tradeable_bid_level(levels),
+            Some((dec!(0.62), dec!(4)))
+        );
     }
 
     #[test]
     fn best_tradeable_ask_skips_placeholders_and_takes_lowest_level() {
-        let prices = vec![dec!(0.99), dec!(0.54), dec!(0.31), dec!(0.01)];
-        assert_eq!(best_tradeable_ask(prices), Some(dec!(0.31)));
+        let levels = vec![
+            (dec!(0.99), dec!(100)),
+            (dec!(0.54), dec!(12)),
+            (dec!(0.31), dec!(4)),
+            (dec!(0.01), dec!(100)),
+        ];
+        assert_eq!(
+            best_tradeable_ask_level(levels),
+            Some((dec!(0.31), dec!(4)))
+        );
     }
 
     #[test]
     fn best_tradeable_prices_return_none_when_only_placeholders_exist() {
-        let prices = vec![dec!(0.01), dec!(0.02), dec!(0.98), dec!(0.99)];
-        assert_eq!(best_tradeable_bid(prices.clone()), None);
-        assert_eq!(best_tradeable_ask(prices), None);
+        let levels = vec![
+            (dec!(0.01), dec!(100)),
+            (dec!(0.02), dec!(100)),
+            (dec!(0.98), dec!(100)),
+            (dec!(0.99), dec!(100)),
+        ];
+        assert_eq!(best_tradeable_bid_level(levels.clone()), None);
+        assert_eq!(best_tradeable_ask_level(levels), None);
+    }
+
+    #[test]
+    fn best_tradeable_levels_preserve_size() {
+        let bids = vec![
+            (dec!(0.01), dec!(100)),
+            (dec!(0.45), dec!(0)),
+            (dec!(0.52), dec!(6.25)),
+            (dec!(0.48), dec!(9.5)),
+        ];
+        let asks = vec![
+            (dec!(0.99), dec!(100)),
+            (dec!(0.44), dec!(0)),
+            (dec!(0.41), dec!(3.75)),
+            (dec!(0.49), dec!(8)),
+        ];
+
+        assert_eq!(
+            best_tradeable_bid_level(bids),
+            Some((dec!(0.52), dec!(6.25)))
+        );
+        assert_eq!(
+            best_tradeable_ask_level(asks),
+            Some((dec!(0.41), dec!(3.75)))
+        );
     }
 
     #[test]

--- a/scripts/repair_clob_quote_sizes_from_snapshots.sh
+++ b/scripts/repair_clob_quote_sizes_from_snapshots.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 YYYY-MM-DD" >&2
+  exit 64
+fi
+
+repair_date="$1"
+if [[ ! "${repair_date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "repair date must be YYYY-MM-DD: ${repair_date}" >&2
+  exit 64
+fi
+
+db_url="${DB_URL:-postgresql://postgres:postgres@localhost:5432/ploy}"
+start_ts="${repair_date}T00:00:00Z"
+end_ts="$(date -u -d "${repair_date} + 1 day" +%Y-%m-%dT00:00:00Z)"
+
+psql "${db_url}" \
+  --set=ON_ERROR_STOP=1 \
+  --set=start_ts="${start_ts}" \
+  --set=end_ts="${end_ts}" <<'SQL'
+\echo 'Repairing clob_quote_ticks bid_size/ask_size from clob_orderbook_snapshots'
+\echo 'Window:' :start_ts 'to' :end_ts
+
+WITH before_counts AS (
+    SELECT
+        count(*) AS quote_rows,
+        count(*) FILTER (WHERE ask_size IS NOT NULL AND ask_size > 0) AS ask_size_rows,
+        count(*) FILTER (WHERE bid_size IS NOT NULL AND bid_size > 0) AS bid_size_rows
+    FROM clob_quote_ticks
+    WHERE received_at >= :'start_ts'::timestamptz
+      AND received_at < :'end_ts'::timestamptz
+      AND source = 'polymarket_ws_collector'
+),
+candidates AS (
+    SELECT
+        q.id,
+        (
+            SELECT (level->>'size')::numeric
+            FROM clob_orderbook_snapshots s
+            CROSS JOIN LATERAL jsonb_array_elements(s.bids) AS level
+            WHERE s.token_id = q.token_id
+              AND s.received_at = q.received_at
+              AND q.best_bid IS NOT NULL
+              AND (level->>'price')::numeric = q.best_bid
+              AND (level->>'size')::numeric > 0
+            ORDER BY (level->>'size')::numeric DESC
+            LIMIT 1
+        ) AS repaired_bid_size,
+        (
+            SELECT (level->>'size')::numeric
+            FROM clob_orderbook_snapshots s
+            CROSS JOIN LATERAL jsonb_array_elements(s.asks) AS level
+            WHERE s.token_id = q.token_id
+              AND s.received_at = q.received_at
+              AND q.best_ask IS NOT NULL
+              AND (level->>'price')::numeric = q.best_ask
+              AND (level->>'size')::numeric > 0
+            ORDER BY (level->>'size')::numeric DESC
+            LIMIT 1
+        ) AS repaired_ask_size
+    FROM clob_quote_ticks q
+    WHERE q.received_at >= :'start_ts'::timestamptz
+      AND q.received_at < :'end_ts'::timestamptz
+      AND q.source = 'polymarket_ws_collector'
+      AND (q.bid_size IS NULL OR q.ask_size IS NULL)
+),
+updated AS (
+    UPDATE clob_quote_ticks q
+    SET
+        bid_size = COALESCE(q.bid_size, c.repaired_bid_size),
+        ask_size = COALESCE(q.ask_size, c.repaired_ask_size)
+    FROM candidates c
+    WHERE q.id = c.id
+      AND (c.repaired_bid_size IS NOT NULL OR c.repaired_ask_size IS NOT NULL)
+    RETURNING q.id
+),
+after_counts AS (
+    SELECT
+        count(*) AS quote_rows,
+        count(*) FILTER (WHERE ask_size IS NOT NULL AND ask_size > 0) AS ask_size_rows,
+        count(*) FILTER (WHERE bid_size IS NOT NULL AND bid_size > 0) AS bid_size_rows
+    FROM clob_quote_ticks
+    WHERE received_at >= :'start_ts'::timestamptz
+      AND received_at < :'end_ts'::timestamptz
+      AND source = 'polymarket_ws_collector'
+)
+SELECT
+    (SELECT quote_rows FROM before_counts) AS before_quote_rows,
+    (SELECT ask_size_rows FROM before_counts) AS before_ask_size_rows,
+    (SELECT bid_size_rows FROM before_counts) AS before_bid_size_rows,
+    (SELECT count(*) FROM updated) AS updated_rows,
+    (SELECT ask_size_rows FROM after_counts) AS after_ask_size_rows,
+    (SELECT bid_size_rows FROM after_counts) AS after_bid_size_rows;
+SQL

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# PM5D PM Quote Size Persistence Repair (2026-04-25)
+
+## Files
+
+- `crates/ploy-market-data/src/collector.rs`
+  - Owner: WebSocket quote collector persistence into `clob_quote_ticks`.
+- `scripts/repair_clob_quote_sizes_from_snapshots.sh`
+  - Owner: Tango-side historical quote-size repair from stored orderbook snapshots.
+
+## Tasks
+
+- [x] Confirm bounded optimize preflight sees quote rows but zero
+  `ask_size`/`bid_size` rows.
+- [x] Persist top-of-book sizes from collector orderbook updates into
+  `clob_quote_ticks`.
+- [x] Add a repair script that backfills old quote sizes from
+  `clob_orderbook_snapshots`.
+- [ ] Run focused local checks and land through PR/CI.
+- [ ] Repair/export the 2026-04-24 Tango Parquet partition and rerun bounded
+  optimize.
+
+## Review
+
+- 2026-04-25: Run `24926056851` failed preflight on main `eb9b00c` before
+  optimization. It found train `pm_quote` rows `778,682` and val rows `260,698`,
+  but both splits had `ask_size_rows=0` and `bid_size_rows=0`.
+- 2026-04-25: The WS collector already stores full book snapshots with level
+  sizes, but its derived `clob_quote_ticks` insert only wrote `best_bid` and
+  `best_ask`. Future collector rows now preserve the selected tradeable
+  top-of-book sizes. Historical rows can be repaired from the exact same
+  snapshot timestamp/token before re-exporting Parquet.
+
 # PM5D Optimize Quote Liquidity Preflight (2026-04-25)
 
 ## Files


### PR DESCRIPTION
## Summary
- preserve tradeable top-of-book bid/ask sizes when WS collector writes clob_quote_ticks
- update collector tests so best tradeable levels carry size, not only price
- add a bounded Tango repair script to backfill historical quote sizes from stored orderbook snapshots

## Verification
- rustfmt --edition 2021 --check crates/ploy-market-data/src/collector.rs
- rtk cargo test -p ploy-market-data 'collector::tests::best_tradeable' --lib
- rtk cargo check -p ploy-market-data
- bash -n scripts/repair_clob_quote_sizes_from_snapshots.sh
- rtk git diff --check