### PR TITLE
Keep quote repair temp table alive

### DIFF
--- a/scripts/repair_clob_quote_sizes_from_snapshots.sh
+++ b/scripts/repair_clob_quote_sizes_from_snapshots.sh
@@ -39,7 +39,7 @@ WHERE received_at >= :'start_ts'::timestamptz
   AND source = 'polymarket_ws_collector';
 
 \echo 'Materializing snapshot top-of-book levels into a temp table'
-CREATE TEMP TABLE quote_size_repair ON COMMIT DROP AS
+CREATE TEMP TABLE quote_size_repair AS
 SELECT
     s.token_id,
     s.received_at,


### PR DESCRIPTION
## Summary
- remove ON COMMIT DROP from the repair temp table because psql autocommit drops it before the index/update steps

## Verification
- bash -n scripts/repair_clob_quote_sizes_from_snapshots.sh
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database maintenance script to adjust temporary table management behavior during repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->