### PR TITLE
Avoid duplicate LOB scans in factor review

### DIFF
--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -17,16 +17,16 @@
 //! | `pm_token_settlements` | Settlement outcomes |
 
 use chrono::{DateTime, Duration, Utc};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
 
 use ploy_market_contracts::{
-    l2_updates_from_depth_totals, market_update_sort_ts, normalize_token_id, HistoricalLoadOptions,
-    MarketUpdate,
+    HistoricalLoadOptions, MarketUpdate, l2_updates_from_depth_totals, market_update_sort_ts,
+    normalize_token_id,
 };
 
 #[cfg(test)]
@@ -154,16 +154,22 @@ pub async fn load_from_database_with_options(
         load_pm_quotes_from_snapshots(pool, &token_map, from, to, &mut updates).await?;
     }
 
-    // 4. L2 orderbook from binance_lob_ticks
-    load_l2_data(
-        pool,
-        symbols,
-        from,
-        to,
-        options.lob_sample_secs,
-        &mut updates,
-    )
-    .await?;
+    // 4. L2 orderbook from binance_lob_ticks.
+    //
+    // Some research consumers load richer LOB snapshots separately and do not
+    // need these generic updates. Keep the default enabled for strategy replay,
+    // but allow research jobs to avoid scanning the large LOB table twice.
+    if options.include_l2 {
+        load_l2_data(
+            pool,
+            symbols,
+            from,
+            to,
+            options.lob_sample_secs,
+            &mut updates,
+        )
+        .await?;
+    }
 
     if options.include_reference_prices {
         let reference_symbols = options.normalized_reference_symbols();
@@ -991,7 +997,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        build_event_updates, l2_updates_from_book, near_depth, EventMetadataRow, MarketUpdate,
+        EventMetadataRow, MarketUpdate, build_event_updates, l2_updates_from_book, near_depth,
     };
 
     #[test]

--- a/crates/ploy-market-contracts/src/feed.rs
+++ b/crates/ploy-market-contracts/src/feed.rs
@@ -9,6 +9,11 @@ pub struct HistoricalLoadOptions {
     pub reference_symbols: Vec<String>,
     pub include_sports_state: bool,
     pub require_official_settlement: bool,
+    /// Include `binance_lob_ticks` as generic L2 market updates.
+    ///
+    /// Research jobs that load richer LOB snapshots separately can disable this
+    /// to avoid scanning the same large table twice.
+    pub include_l2: bool,
     /// Downsample `binance_lob_ticks` to one snapshot per N seconds per symbol.
     /// Defaults to 30 (one row per 30-second bucket). Set to 1 to disable downsampling.
     pub lob_sample_secs: u32,
@@ -21,6 +26,7 @@ impl Default for HistoricalLoadOptions {
             reference_symbols: Vec::new(),
             include_sports_state: false,
             require_official_settlement: false,
+            include_l2: true,
             lob_sample_secs: 30,
         }
     }

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -119,6 +119,7 @@ async fn main() {
         end,
         &HistoricalLoadOptions {
             require_official_settlement: true,
+            include_l2: false,
             ..Default::default()
         },
     )

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -13,12 +13,12 @@
 //! If no --db-url is given, uses synthetic market data.
 
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    config::FullConfig, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
-    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
-    StrategyLogic, StrategyRuntime, ThreeLayerStrategy,
+    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
+    RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
+    StrategyRuntime, ThreeLayerStrategy, config::FullConfig,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -202,6 +202,7 @@ fn main() {
                     .reference_symbols(&config.reference_data),
                 include_sports_state: config.backtest_data.include_sports_state,
                 require_official_settlement: config.backtest_data.require_official_settlement,
+                include_l2: true,
                 lob_sample_secs: 30,
             };
             (strategy_variant, config.strategy, sim, rt, backtest_options)

--- a/crates/ploy-strategy-runtime/src/backtest.rs
+++ b/crates/ploy-strategy-runtime/src/backtest.rs
@@ -77,6 +77,7 @@ async fn run_backtest(
             .reference_symbols(&config.reference_data),
         include_sports_state: config.backtest_data.include_sports_state,
         require_official_settlement: config.backtest_data.require_official_settlement,
+        include_l2: true,
         lob_sample_secs: 30,
     };
 


### PR DESCRIPTION
## Summary
- add an include_l2 flag to HistoricalLoadOptions with the existing default behavior preserved
- skip generic L2 MarketUpdate loading in factor_review_v2 because it loads richer research LOB snapshots separately
- keep runtime/backtest config callers explicit with include_l2=true

## Verification
- rtk cargo check -p ploy-research --features db --example factor_review_v2
- rtk cargo check -p ploy-feed-loaders -p ploy-strategy-runtime -p ploy-strategy-bundles --examples
- rtk cargo test -p ploy-research factors_v2 --lib
- rtk git diff --check

## Context
The first Factor Review V2 run stalled in Postgres DataFileRead on the generic binance_lob_ticks L2 load. That data path is redundant for factor_review_v2 because the review later loads ResearchLobSnapshot rows with PM5D-specific depth/microprice fields.