### PR TITLE
Sample factor observations for review runs

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -26,7 +26,11 @@ on:
       lob_sample_secs:
         description: "Binance LOB sample interval"
         required: false
-        default: "5"
+        default: "30"
+      observation_sample_secs:
+        description: "Factor observation output interval"
+        required: false
+        default: "30"
       max_quote_age_secs:
         description: "Maximum PM quote age"
         required: false
@@ -104,6 +108,7 @@ jobs:
             --end-date "${{ github.event.inputs.end_date }}" \
             --stake-usd "${{ github.event.inputs.stake_usd }}" \
             --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
+            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
             --min-observations "${{ github.event.inputs.min_observations }}" \
             --top-quantile "${{ github.event.inputs.top_quantile }}" \

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -12,6 +12,7 @@
 //!     --end-date 2026-04-24 \
 //!     --stake-usd 15 \
 //!     [--lob-sample-secs 5] \
+//!     [--observation-sample-secs 30] \
 //!     [--max-quote-age-secs 30] \
 //!     [--top-n 20]
 
@@ -20,7 +21,7 @@ use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
     DeribitFeatureSnapshot, FactorObservation, FactorReviewOptions,
-    build_factor_observations_with_lob, format_factor_review_v2_report,
+    build_factor_observations_with_lob_sampled, format_factor_review_v2_report,
     load_research_lob_snapshots_sampled, review_factors_v2_with_deribit,
 };
 use sqlx::postgres::PgPoolOptions;
@@ -85,6 +86,9 @@ async fn main() {
     let max_quote_age_secs: i64 = flag_value(&args, "--max-quote-age-secs")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(30);
+    let observation_sample_secs: i64 = flag_value(&args, "--observation-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
     let top_n: usize = flag_value(&args, "--top-n")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(20);
@@ -101,8 +105,8 @@ async fn main() {
     };
 
     eprintln!(
-        "factor_review_v2: {} -> {} for {:?}, stake_usd={:.2}",
-        start, end, symbols, options.stake_usd
+        "factor_review_v2: {} -> {} for {:?}, stake_usd={:.2}, observation_sample_secs={}",
+        start, end, symbols, options.stake_usd, observation_sample_secs
     );
 
     let pool = PgPoolOptions::new()
@@ -145,8 +149,12 @@ async fn main() {
     );
     let lob_slice = slice_by_time(&all_lob_snapshots, start, end, |snapshot| snapshot.ts);
 
-    let observations: Vec<FactorObservation> =
-        build_factor_observations_with_lob(updates_slice, lob_slice, max_quote_age_secs);
+    let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
+        updates_slice,
+        lob_slice,
+        max_quote_age_secs,
+        observation_sample_secs,
+    );
     eprintln!("factor_observations: {}", observations.len());
 
     if observations.is_empty() {

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -601,6 +601,16 @@ pub fn build_factor_observations_with_lob(
     lob_snapshots: &[ResearchLobSnapshot],
     max_quote_age_secs: i64,
 ) -> Vec<FactorObservation> {
+    build_factor_observations_with_lob_sampled(updates, lob_snapshots, max_quote_age_secs, 0)
+}
+
+pub fn build_factor_observations_with_lob_sampled(
+    updates: &[MarketUpdate],
+    lob_snapshots: &[ResearchLobSnapshot],
+    max_quote_age_secs: i64,
+    observation_sample_secs: i64,
+) -> Vec<FactorObservation> {
+    let observation_sample_secs = observation_sample_secs.max(0);
     let mut final_outcomes: HashMap<String, bool> = HashMap::new();
     for update in updates {
         match update {
@@ -633,6 +643,7 @@ pub fn build_factor_observations_with_lob(
     let mut lob_by_symbol: HashMap<String, Vec<&ResearchLobSnapshot>> = HashMap::new();
     let mut lob_flow: HashMap<String, LobFlowAccumulator> = HashMap::new();
     let mut trade_flow: HashMap<String, TradeFlowAccumulator> = HashMap::new();
+    let mut last_observation_bucket: HashMap<String, i64> = HashMap::new();
     let mut rows = Vec::new();
 
     for snapshot in lob_snapshots {
@@ -851,6 +862,14 @@ pub fn build_factor_observations_with_lob(
                             },
                         );
                     }
+                }
+
+                if observation_sample_secs > 1 {
+                    let bucket = ts.timestamp() / observation_sample_secs;
+                    if last_observation_bucket.get(&sym).copied() == Some(bucket) {
+                        continue;
+                    }
+                    last_observation_bucket.insert(sym.clone(), bucket);
                 }
 
                 let Some(event_ids) = events_by_symbol.get(&sym) else {

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -39,7 +39,8 @@ pub use event_ml::{
 pub use factors::{
     AggregatedFactorMetric, EventFactorSummary, FactorMetric, FactorObservation,
     ResearchLobSnapshot, aggregate_factor_metrics, build_event_summaries,
-    build_factor_observations, build_factor_observations_with_lob, factor_metrics,
+    build_factor_observations, build_factor_observations_with_lob,
+    build_factor_observations_with_lob_sampled, factor_metrics,
 };
 #[cfg(feature = "polars-export")]
 pub use factors::{export_observations_parquet, observations_to_frame};


### PR DESCRIPTION
## Summary
- add observation-level sampling for factor review runs
- keep all market updates feeding state, but emit candidate rows once per symbol/time bucket
- expose `--observation-sample-secs` and default the workflow to 30s LOB + 30s observation sampling

## Verification
- rtk cargo check -p ploy-research --features db --example factor_review_v2
- rtk cargo test -p ploy-research factor_observations_only_include_active_event_window --lib
- rtk cargo test -p ploy-research factors_v2 --lib
- ruby YAML parse for factor-review-v2 workflow
- rtk git diff --check

## Context
After #170, six symbols / one day / 30s LOB still produced 8,224,956 factor observations and OOMed before ranking. This bounds the review output rows while preserving full-state feature updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable observation sampling interval parameter (default: 30 seconds) to control market observation frequency via CLI and workflow inputs
  * Extended observation collection with improved sampling capabilities

* **Chores**
  * Updated default market data sampling interval from 5 to 30 seconds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->