### PR TITLE
Fall back from empty research window matviews

### DIFF
--- a/crates/ploy-research/examples/factor_research.rs
+++ b/crates/ploy-research/examples/factor_research.rs
@@ -204,12 +204,19 @@ async fn discover_valid_windows(
     .fetch_all(pool)
     .await;
 
-    if let Ok(rows) = matview_result {
-        eprintln!("discover_valid_windows: used matview ({} rows)", rows.len());
-        return rows;
+    match matview_result {
+        Ok(rows) if !rows.is_empty() => {
+            eprintln!("discover_valid_windows: used matview ({} rows)", rows.len());
+            return rows;
+        }
+        Ok(_) => {
+            eprintln!("discover_valid_windows: matview returned 0 rows, using raw query");
+        }
+        Err(error) => {
+            eprintln!("discover_valid_windows: matview not available ({error}), using raw query");
+        }
     }
 
-    eprintln!("discover_valid_windows: matview not available, using raw query");
     sqlx::query_as(
         r#"
         SELECT

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -714,6 +714,36 @@ windows, and publish reports as artifacts.
   `factor_research` example still emits existing unused-variable warnings
   unrelated to this workflow.
 
+# Event ML Window Discovery Fallback (2026-04-26)
+
+Goal: prevent the CI evidence workflow from treating an existing but empty
+`research_valid_windows` materialized view as authoritative when raw metadata
+can still discover valid event windows.
+
+## Files
+
+- `crates/ploy-research/examples/factor_research.rs`
+- `tasks/todo.md`
+
+## Tasks
+
+- [x] Fall back to raw valid-window discovery when the materialized view returns
+  zero rows.
+- [x] Verify the factor research example still builds.
+- [ ] Re-run the GitHub rolling evidence workflow from `main`.
+
+## Review
+
+- 2026-04-26: The first `event-ml-rolling-evidence.yml` run reached the remote
+  DB but failed during export because `research_valid_windows` existed and
+  returned zero rows for the requested range, which made the event-root builder
+  see `0` unique events. The discovery path now only trusts matview results when
+  they are non-empty; an empty matview falls back to the existing raw query.
+- 2026-04-26: Local verification passed: `rtk cargo check -p ploy-research
+  --features db,polars-export --example factor_research` and
+  `rtk git diff --check`. The example still emits pre-existing unused-variable
+  warnings unrelated to this fix.
+
 # Event Dataset Rolling Window Splitter (2026-04-25)
 
 Goal: turn one larger event-root dataset into multiple chronological, non-overlapping


### PR DESCRIPTION
## Summary
- keep the research_valid_windows fast path only when it returns non-empty rows
- fall back to the existing raw metadata/settlement/LOB discovery query when the materialized view exists but is empty
- record the failed rolling evidence run and fallback fix in tasks/todo.md

## Verification
- rtk cargo check -p ploy-research --features db,polars-export --example factor_research
- rtk git diff --check

## Remote evidence context
The first Event ML rolling evidence run reached the remote DB but failed because the materialized view returned 0 rows and blocked raw discovery: https://github.com/proerror77/ploy/actions/runs/24939828257