### PR TITLE
Keep event ML evidence builds off ploy-ci

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -10,11 +10,11 @@ on:
       start_date:
         description: "Dataset start date (YYYY-MM-DD)"
         required: true
-        default: "2026-04-24"
+        default: "2026-04-09"
       end_date:
         description: "Dataset end date (YYYY-MM-DD)"
         required: true
-        default: "2026-04-25"
+        default: "2026-04-11"
       symbols:
         description: "Comma-separated Binance symbols"
         required: true
@@ -76,12 +76,78 @@ permissions:
   contents: read
 
 env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: never
+  RUST_BACKTRACE: "1"
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_JOBS: "1"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_DEV_OPT_LEVEL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+  POLARS_MAX_THREADS: "2"
 
 jobs:
+  build-event-ml-examples:
+    name: Build event ML examples on GitHub-hosted runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: event-ml-rolling-build-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build event ML examples
+        run: |
+          set -euo pipefail
+          cargo build --locked -j1 \
+            -p ploy-research \
+            --features db,polars-export \
+            --example factor_research
+          cargo build --locked -j1 \
+            -p ploy-research \
+            --features polars-export \
+            --example event_dataset_rolling_windows \
+            --example event_ml_rolling_workflow \
+            --example event_ml_workflow \
+            --example event_dataset_coverage \
+            --example event_factor_attribution \
+            --example event_dataset_baseline \
+            --example event_ml_walk_forward
+
+      - name: Package event ML examples
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/event-ml-bin
+          cp \
+            target/debug/examples/factor_research \
+            target/debug/examples/event_dataset_rolling_windows \
+            target/debug/examples/event_ml_rolling_workflow \
+            target/debug/examples/event_ml_workflow \
+            target/debug/examples/event_dataset_coverage \
+            target/debug/examples/event_factor_attribution \
+            target/debug/examples/event_dataset_baseline \
+            target/debug/examples/event_ml_walk_forward \
+            artifacts/event-ml-bin/
+          tar -C artifacts -czf event-ml-example-binaries.tar.gz event-ml-bin
+
+      - name: Upload event ML example binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-ml-example-binaries-${{ github.run_id }}
+          path: event-ml-example-binaries.tar.gz
+          retention-days: 3
+
   event-ml:
     name: Generate event ML rolling evidence on ploy-ci-1
+    needs: build-event-ml-examples
     runs-on: [self-hosted, ploy-ci-1]
     timeout-minutes: 150
     environment: ploy-ci-1
@@ -102,28 +168,18 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
+      - name: Download event ML example binaries
+        uses: actions/download-artifact@v4
         with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: event-ml-rolling-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+          name: event-ml-example-binaries-${{ github.run_id }}
 
-      - name: Build event ML examples
+      - name: Unpack event ML example binaries
         run: |
           set -euo pipefail
-          . /home/runner/.cargo/env
-          cargo build --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_research \
-            --example event_dataset_rolling_windows \
-            --example event_ml_rolling_workflow \
-            --example event_ml_workflow \
-            --example event_dataset_coverage \
-            --example event_factor_attribution \
-            --example event_dataset_baseline \
-            --example event_ml_walk_forward
+          rm -rf artifacts/event-ml-bin
+          mkdir -p artifacts
+          tar -xzf event-ml-example-binaries.tar.gz -C artifacts
+          chmod +x artifacts/event-ml-bin/*
 
       - name: Export large event-root dataset
         run: |
@@ -132,10 +188,7 @@ jobs:
           rm -rf artifacts/event-ml
           mkdir -p artifacts/event-ml/source_event_root artifacts/event-ml/reports
 
-          cargo run --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_research -- \
+          artifacts/event-ml-bin/factor_research \
             --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --start-date "${{ github.event.inputs.start_date }}" \
@@ -152,10 +205,7 @@ jobs:
           set -euo pipefail
           . /home/runner/.cargo/env
 
-          cargo run --locked \
-            -p ploy-research \
-            --features polars-export \
-            --example event_dataset_rolling_windows -- \
+          artifacts/event-ml-bin/event_dataset_rolling_windows \
             --dataset artifacts/event-ml/source_event_root \
             --window-events "${{ github.event.inputs.child_window_events }}" \
             --output-root artifacts/event-ml/rolling_datasets \
@@ -168,10 +218,7 @@ jobs:
           . /home/runner/.cargo/env
 
           DATASETS="$(paste -sd, artifacts/event-ml/rolling_datasets/rolling_datasets.txt)"
-          cargo run --locked \
-            -p ploy-research \
-            --features polars-export \
-            --example event_ml_rolling_workflow -- \
+          artifacts/event-ml-bin/event_ml_rolling_workflow \
             --datasets "${DATASETS}" \
             --output-root artifacts/event-ml/rolling_workflow \
             --entry-secs "${{ github.event.inputs.entry_secs }}" \

--- a/crates/ploy-research/examples/event_ml_rolling_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_rolling_workflow.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
             .output_root
             .join(format!("window_{window_id:03}_event_ml"));
         let command_args = event_ml_workflow_args(&config, dataset, &output_dir, &prior_run_dirs);
-        let command = shell_command("event_ml_workflow", &command_args, true);
+        let command = event_ml_workflow_command_string(&command_args);
 
         eprintln!();
         eprintln!("--- rolling_window={window_id} ---");
@@ -40,18 +40,7 @@ fn main() -> Result<()> {
         } else {
             fs::create_dir_all(&output_dir)
                 .with_context(|| format!("create output dir {}", output_dir.display()))?;
-            let status = Command::new("cargo")
-                .args([
-                    "run",
-                    "-p",
-                    "ploy-research",
-                    "--example",
-                    "event_ml_workflow",
-                    "--features",
-                    "polars-export",
-                    "--",
-                ])
-                .args(&command_args)
+            let status = event_ml_workflow_command(&command_args)
                 .status()
                 .with_context(|| format!("spawn rolling window {window_id}"))?;
             ensure_success(window_id, status)?;
@@ -394,6 +383,50 @@ fn shell_command(example: &str, args: &[String], polars_export: bool) -> String 
     parts.push("--".to_string());
     parts.extend(args.iter().map(|arg| shell_quote(arg)));
     parts.join(" ")
+}
+
+fn event_ml_workflow_command(args: &[String]) -> Command {
+    if let Some(binary) = sibling_example_binary("event_ml_workflow") {
+        let mut command = Command::new(binary);
+        command.args(args);
+        command
+    } else {
+        let mut command = Command::new("cargo");
+        command.args([
+            "run",
+            "-p",
+            "ploy-research",
+            "--example",
+            "event_ml_workflow",
+            "--features",
+            "polars-export",
+            "--",
+        ]);
+        command.args(args);
+        command
+    }
+}
+
+fn event_ml_workflow_command_string(args: &[String]) -> String {
+    if let Some(binary) = sibling_example_binary("event_ml_workflow") {
+        let mut parts = vec![shell_quote(&binary.display().to_string())];
+        parts.extend(args.iter().map(|arg| shell_quote(arg)));
+        parts.join(" ")
+    } else {
+        shell_command("event_ml_workflow", args, true)
+    }
+}
+
+fn sibling_example_binary(example: &str) -> Option<PathBuf> {
+    let current = env::current_exe().ok()?;
+    let dir = current.parent()?;
+    let binary_name = if cfg!(windows) {
+        format!("{example}.exe")
+    } else {
+        example.to_string()
+    };
+    let candidate = dir.join(binary_name);
+    candidate.is_file().then_some(candidate)
 }
 
 fn shell_quote(value: &str) -> String {

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -190,26 +190,34 @@ database-backed research on a local machine:
 ```bash
 gh workflow run event-ml-rolling-evidence.yml \
   -f git_ref=main \
-  -f start_date=2026-04-24 \
-  -f end_date=2026-04-25 \
+  -f start_date=2026-04-09 \
+  -f end_date=2026-04-11 \
   -f symbols=BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT,BNBUSDT,XRPUSDT \
   -f source_windows=450 \
   -f child_window_events=150 \
   -f run_workflow=true
 ```
 
-The workflow runs on `ploy-ci-1`, reads the remote research database at
-`172.16.0.204`, and performs:
+The workflow compiles the Polars-heavy Rust examples on a GitHub-hosted
+`ubuntu-latest` runner, then runs only the downloaded binaries on `ploy-ci-1`.
+The evidence job reads the remote research database at `172.16.0.204` and
+performs:
 
 1. `factor_research --export-event-dataset`
 2. `event_dataset_rolling_windows`
 3. `event_ml_rolling_workflow`
 
-It uploads a compact report artifact by default and deliberately avoids
-uploading raw Parquet datasets unless `upload_parquet_datasets=true` is passed.
+This keeps heavy Rust compilation off `ploy-ci-1`; that host is only the
+database-adjacent execution surface. The workflow uploads a compact report
+artifact by default and deliberately avoids uploading raw Parquet datasets
+unless `upload_parquet_datasets=true` is passed.
 Keep the default `source_windows=450` / `child_window_events=150` shape for the
 first full run because it should produce three distinct child datasets while
 keeping each child comfortably above the 134-event split-policy floor.
+The default date window is intentionally a matview-backed smoke range; moving
+to a newer range is valid, but expect the run to fall back to raw discovery and
+take materially longer unless `research_valid_windows` has been refreshed for
+that range.
 
 ## Phase 1 - Coverage Diagnostics
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -769,6 +769,10 @@ can still discover valid event windows.
 - [x] Fall back to raw valid-window discovery when the materialized view returns
   zero rows.
 - [x] Verify the factor research example still builds.
+- [x] Harden the rolling evidence workflow default window and Polars build
+  settings for `ploy-ci-1`.
+- [x] Move Polars-heavy example compilation off `ploy-ci-1`; the self-hosted
+  runner should download binaries and only execute DB-adjacent evidence.
 - [ ] Re-run the GitHub rolling evidence workflow from `main`.
 
 ## Review
@@ -782,6 +786,16 @@ can still discover valid event windows.
   --features db,polars-export --example factor_research` and
   `rtk git diff --check`. The example still emits pre-existing unused-variable
   warnings unrelated to this fix.
+- 2026-04-26: The workflow default range now uses the matview-backed
+  `2026-04-09 -> 2026-04-11` window, which remote DB evidence showed has enough
+  valid 5-minute events for a `450/150` rolling smoke. Cargo/Polars builds are
+  pinned to single-job, no incremental, no dev debuginfo settings to reduce
+  runner memory and session-kill exposure before scaling the evidence job.
+- 2026-04-26: Remote retries showed `ploy-ci-1` is not a reliable Rust compile
+  surface for heavy Polars examples when other research jobs or session cleanup
+  are active. The workflow now builds the event ML example binaries on
+  GitHub-hosted `ubuntu-latest`, uploads them as an artifact, and makes
+  `ploy-ci-1` run only the downloaded binaries against the private DB.
 
 # Event Dataset Rolling Window Splitter (2026-04-25)
 


### PR DESCRIPTION
## Summary
- Build the heavy event ML/Polars examples on GitHub-hosted Ubuntu and upload them as binaries.
- Make the ploy-ci-1 evidence job download and execute binaries only, keeping it focused on private DB access.
- Teach event_ml_rolling_workflow to prefer a sibling event_ml_workflow binary before falling back to cargo run.
- Switch the default evidence window to the matview-backed 2026-04-09 -> 2026-04-11 smoke range.

## Verification
- ruby YAML parse for .github/workflows/event-ml-rolling-evidence.yml
- rustfmt --check crates/ploy-research/examples/event_ml_rolling_workflow.rs
- rtk git diff --check on touched files

## Not Tested
- Full workflow_dispatch evidence run after this change; that should run from this PR branch before merge.