### PR TITLE
Add executable factor walk-forward review

### DIFF
--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -1,0 +1,157 @@
+name: Factor Walk-Forward V2
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref"
+        required: true
+        default: "main"
+      start_date:
+        description: "Review start date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-21"
+      end_date:
+        description: "Review end date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-25"
+      symbols:
+        description: "Comma-separated Binance symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT,BNBUSDT,XRPUSDT"
+      stake_usd:
+        description: "Fixed notional per candidate"
+        required: true
+        default: "15"
+      train_window_days:
+        description: "Training window length in days"
+        required: false
+        default: "2"
+      test_window_days:
+        description: "Test window length in days"
+        required: false
+        default: "1"
+      step_days:
+        description: "Rolling step length in days"
+        required: false
+        default: "1"
+      lob_sample_secs:
+        description: "Binance and PM LOB sample interval"
+        required: false
+        default: "30"
+      observation_sample_secs:
+        description: "Factor observation output interval"
+        required: false
+        default: "30"
+      max_quote_age_secs:
+        description: "Maximum PM quote age"
+        required: false
+        default: "30"
+      top_n:
+        description: "Number of factor rows to keep per test window"
+        required: false
+        default: "20"
+      min_observations:
+        description: "Minimum observations for a factor"
+        required: false
+        default: "20"
+      top_quantile:
+        description: "Train-window selected quantile"
+        required: false
+        default: "0.2"
+
+concurrency:
+  group: factor-walk-forward-v2-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  walk-forward:
+    name: Run factor walk-forward on ploy-ci-1
+    runs-on: [self-hosted, ploy-ci-1]
+    timeout-minutes: 60
+    environment: ploy-ci-1
+
+    steps:
+      - name: Repair runner workspace permissions
+        run: |
+          if [ -d "${GITHUB_WORKSPACE}" ]; then
+            sudo chown -R "$(id -un):$(id -gn)" "${GITHUB_WORKSPACE}" || true
+            sudo rm -rf "${GITHUB_WORKSPACE}/target" "${GITHUB_WORKSPACE}/.cargo-lock" || true
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Add cargo to PATH
+        run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: factor-walk-forward-v2-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build factor_walk_forward_v2
+        run: |
+          . /home/runner/.cargo/env
+          cargo build --release --locked \
+            -p ploy-research \
+            --features db \
+            --example factor_walk_forward_v2
+
+      - name: Run factor walk-forward
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/factor-walk-forward-v2
+          ./target/release/examples/factor_walk_forward_v2 \
+            --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --start-date "${{ github.event.inputs.start_date }}" \
+            --end-date "${{ github.event.inputs.end_date }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --train-window-days "${{ github.event.inputs.train_window_days }}" \
+            --test-window-days "${{ github.event.inputs.test_window_days }}" \
+            --step-days "${{ github.event.inputs.step_days }}" \
+            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
+            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
+            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --min-observations "${{ github.event.inputs.min_observations }}" \
+            --top-quantile "${{ github.event.inputs.top_quantile }}" \
+            --top-n "${{ github.event.inputs.top_n }}" \
+            | tee artifacts/factor-walk-forward-v2/report.txt
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Factor Walk-Forward V2"
+            echo ""
+            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Train/Test: ${{ github.event.inputs.train_window_days }}d / ${{ github.event.inputs.test_window_days }}d"
+            echo "- Symbols: ${{ github.event.inputs.symbols }}"
+            echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            echo ""
+            if [ -f artifacts/factor-walk-forward-v2/report.txt ]; then
+              echo '```'
+              sed -n '1,160p' artifacts/factor-walk-forward-v2/report.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: factor-walk-forward-v2-${{ github.run_id }}
+          path: artifacts/factor-walk-forward-v2/
+          retention-days: 14

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -70,6 +70,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PLOY_DB_URL: ${{ secrets.PLOY_DB_URL }}
 
 jobs:
   walk-forward:
@@ -83,7 +84,7 @@ jobs:
         run: |
           if [ -d "${GITHUB_WORKSPACE}" ]; then
             sudo chown -R "$(id -un):$(id -gn)" "${GITHUB_WORKSPACE}" || true
-            sudo rm -rf "${GITHUB_WORKSPACE}/target" "${GITHUB_WORKSPACE}/.cargo-lock" || true
+            sudo rm -f "${GITHUB_WORKSPACE}/.cargo-lock" || true
           fi
 
       - name: Checkout code
@@ -114,7 +115,7 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts/factor-walk-forward-v2
           ./target/release/examples/factor_walk_forward_v2 \
-            --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
+            --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --start-date "${{ github.event.inputs.start_date }}" \
             --end-date "${{ github.event.inputs.end_date }}" \

--- a/crates/ploy-research/Cargo.toml
+++ b/crates/ploy-research/Cargo.toml
@@ -90,3 +90,8 @@ path = "examples/event_ml_rolling_workflow.rs"
 name = "factor_review_v2"
 path = "examples/factor_review_v2.rs"
 required-features = ["db"]
+
+[[example]]
+name = "factor_walk_forward_v2"
+path = "examples/factor_walk_forward_v2.rs"
+required-features = ["db"]

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -31,7 +31,10 @@ fn parse_date_start(raw: &str) -> DateTime<Utc> {
 fn parse_date_end(raw: &str) -> DateTime<Utc> {
     let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
         .unwrap_or_else(|_| panic!("invalid date: {raw}"));
-    Utc.from_utc_datetime(&date.and_hms_opt(23, 59, 59).unwrap())
+    let next_day = date
+        .succ_opt()
+        .unwrap_or_else(|| panic!("invalid end date: {raw}"));
+    Utc.from_utc_datetime(&next_day.and_hms_opt(0, 0, 0).unwrap())
 }
 
 fn parse_timestamp(raw: &str) -> DateTime<Utc> {
@@ -44,7 +47,7 @@ where
     F: Fn(&T) -> DateTime<Utc>,
 {
     let lo = items.partition_point(|item| ts_fn(item) < start);
-    let hi = items.partition_point(|item| ts_fn(item) <= end);
+    let hi = items.partition_point(|item| ts_fn(item) < end);
     &items[lo..hi]
 }
 
@@ -123,11 +126,12 @@ async fn main() {
         .await
         .expect("database connection failed");
 
+    let history_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
     let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
     let all_updates = load_from_database_with_options(
         &pool,
         &symbols,
-        start,
+        history_start,
         end,
         &HistoricalLoadOptions {
             require_official_settlement: true,
@@ -142,7 +146,7 @@ async fn main() {
     eprintln!("updates: {}", all_updates.len());
 
     let all_lob_snapshots =
-        load_research_lob_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
+        load_research_lob_snapshots_sampled(&pool, &symbols, history_start, end, lob_sample_secs)
             .await
             .expect("bulk lob snapshot load failed");
     eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
@@ -151,14 +155,10 @@ async fn main() {
         load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
     eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
 
-    let updates_slice_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
-    let updates_slice = slice_by_time(
-        &all_updates,
-        updates_slice_start,
-        end,
-        MarketUpdate::sort_ts,
-    );
-    let lob_slice = slice_by_time(&all_lob_snapshots, start, end, |snapshot| snapshot.ts);
+    let updates_slice = slice_by_time(&all_updates, history_start, end, MarketUpdate::sort_ts);
+    let lob_slice = slice_by_time(&all_lob_snapshots, history_start, end, |snapshot| {
+        snapshot.ts
+    });
 
     let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
         updates_slice,

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -1,0 +1,184 @@
+//! factor_walk_forward_v2 — executable PM5D factor walk-forward review
+//!
+//! The training window fits each factor's direction and selected-quantile
+//! threshold. The following test window only applies that trained threshold and
+//! scores executable PnL after PM CLOB fillability.
+
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_market_contracts::MarketUpdate;
+use ploy_research::{
+    FactorObservation, FactorReviewOptions, FactorWalkForwardOptions,
+    build_factor_observations_with_lob_sampled, format_factor_walk_forward_v2_report,
+    load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
+    walk_forward_factors_v2_with_deribit,
+};
+use sqlx::postgres::PgPoolOptions;
+use std::time::Duration;
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|window| window[0] == flag)
+        .map(|window| window[1].clone())
+}
+
+fn parse_date_start(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+}
+
+fn parse_date_end(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    Utc.from_utc_datetime(&date.and_hms_opt(23, 59, 59).unwrap())
+}
+
+fn parse_timestamp(raw: &str) -> DateTime<Utc> {
+    raw.parse::<DateTime<Utc>>()
+        .unwrap_or_else(|_| panic!("invalid timestamp: {raw}"))
+}
+
+fn slice_by_time<T, F>(items: &[T], start: DateTime<Utc>, end: DateTime<Utc>, ts_fn: F) -> &[T]
+where
+    F: Fn(&T) -> DateTime<Utc>,
+{
+    let lo = items.partition_point(|item| ts_fn(item) < start);
+    let hi = items.partition_point(|item| ts_fn(item) <= end);
+    &items[lo..hi]
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let db_url = flag_value(&args, "--db-url").expect("--db-url required");
+    let start = flag_value(&args, "--start-ts")
+        .map(|raw| parse_timestamp(&raw))
+        .unwrap_or_else(|| {
+            parse_date_start(&flag_value(&args, "--start-date").expect("--start-date required"))
+        });
+    let end = flag_value(&args, "--end-ts")
+        .map(|raw| parse_timestamp(&raw))
+        .unwrap_or_else(|| {
+            parse_date_end(&flag_value(&args, "--end-date").expect("--end-date required"))
+        });
+    let symbols: Vec<String> = flag_value(&args, "--symbols")
+        .unwrap_or_else(|| "BTCUSDT".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|symbol| !symbol.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    let lob_sample_secs: i32 = flag_value(&args, "--lob-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let max_quote_age_secs: i64 = flag_value(&args, "--max-quote-age-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let observation_sample_secs: i64 = flag_value(&args, "--observation-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let review = FactorReviewOptions {
+        stake_usd: flag_value(&args, "--stake-usd")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(15.0),
+        min_observations: flag_value(&args, "--min-observations")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(20),
+        top_quantile: flag_value(&args, "--top-quantile")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(0.2),
+    };
+    let options = FactorWalkForwardOptions {
+        review,
+        train_window_days: flag_value(&args, "--train-window-days")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(2),
+        test_window_days: flag_value(&args, "--test-window-days")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(1),
+        step_days: flag_value(&args, "--step-days")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(1),
+        top_n: flag_value(&args, "--top-n")
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(20),
+    };
+
+    eprintln!(
+        "factor_walk_forward_v2: {} -> {} for {:?}, stake_usd={:.2}, train_days={}, test_days={}, observation_sample_secs={}",
+        start,
+        end,
+        symbols,
+        options.review.stake_usd,
+        options.train_window_days,
+        options.test_window_days,
+        observation_sample_secs
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(120))
+        .connect(&db_url)
+        .await
+        .expect("database connection failed");
+
+    let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
+    let all_updates = load_from_database_with_options(
+        &pool,
+        &symbols,
+        start,
+        end,
+        &HistoricalLoadOptions {
+            require_official_settlement: true,
+            include_l2: false,
+            spot_sample_secs: historical_sample_secs,
+            lob_sample_secs: historical_sample_secs,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("bulk historical load failed");
+    eprintln!("updates: {}", all_updates.len());
+
+    let all_lob_snapshots =
+        load_research_lob_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
+            .await
+            .expect("bulk lob snapshot load failed");
+    eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
+
+    let deribit_snapshots =
+        load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
+    eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
+
+    let updates_slice_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
+    let updates_slice = slice_by_time(
+        &all_updates,
+        updates_slice_start,
+        end,
+        MarketUpdate::sort_ts,
+    );
+    let lob_slice = slice_by_time(&all_lob_snapshots, start, end, |snapshot| snapshot.ts);
+
+    let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
+        updates_slice,
+        lob_slice,
+        max_quote_age_secs,
+        observation_sample_secs,
+    );
+    eprintln!("factor_observations: {}", observations.len());
+
+    if observations.is_empty() {
+        eprintln!("no observations — check date range, symbols, quote coverage, and settlements");
+        return;
+    }
+
+    let report = walk_forward_factors_v2_with_deribit(
+        &observations,
+        &deribit_snapshots,
+        start,
+        end,
+        options,
+    );
+    println!("{}", format_factor_walk_forward_v2_report(&report));
+}

--- a/crates/ploy-research/src/deribit.rs
+++ b/crates/ploy-research/src/deribit.rs
@@ -1,0 +1,227 @@
+use chrono::{DateTime, Utc};
+
+use crate::DeribitFeatureSnapshot;
+
+pub async fn load_deribit_feature_snapshots(
+    pool: &sqlx::PgPool,
+    symbols: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_secs: i64,
+) -> Vec<DeribitFeatureSnapshot> {
+    let currencies: Vec<String> = symbols
+        .iter()
+        .filter_map(|symbol| symbol_to_deribit_currency(symbol))
+        .collect();
+    if currencies.is_empty() {
+        return Vec::new();
+    }
+
+    let sample_secs = sample_secs.clamp(1, 300) as i32;
+    let mut snapshots = Vec::new();
+    let current_iv_rows: Vec<(
+        String,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        DateTime<Utc>,
+    )> = match sqlx::query_as(
+        r#"
+        WITH currencies AS (
+            SELECT unnest($1::text[]) AS currency
+        ),
+        buckets AS (
+            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
+        )
+        SELECT
+            c.currency,
+            d.mark_iv::double precision,
+            d.bid_iv::double precision,
+            d.ask_iv::double precision,
+            d.underlying_price::double precision,
+            b.bucket_ts
+        FROM currencies c
+        CROSS JOIN buckets b
+        JOIN LATERAL (
+            SELECT mark_iv, bid_iv, ask_iv, underlying_price
+            FROM deribit_iv_ticks d
+            WHERE d.currency = c.currency
+              AND d.creation_ts <= b.bucket_ts
+              AND d.creation_ts > b.bucket_ts - interval '5 minutes'
+              AND d.mark_iv IS NOT NULL
+            ORDER BY d.creation_ts DESC, d.open_interest DESC NULLS LAST
+            LIMIT 1
+        ) d ON true
+        ORDER BY b.bucket_ts
+        "#,
+    )
+    .bind(&currencies)
+    .bind(start)
+    .bind(end)
+    .bind(sample_secs)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            eprintln!("deribit iv load failed: {err}");
+            Vec::new()
+        }
+    };
+
+    for (currency, mark_iv, bid_iv, ask_iv, underlying_price, ts) in current_iv_rows {
+        snapshots.push(DeribitFeatureSnapshot {
+            symbol: deribit_currency_to_symbol(&currency),
+            ts,
+            mark_iv: mark_iv.unwrap_or(f64::NAN),
+            bid_iv: bid_iv.unwrap_or(f64::NAN),
+            ask_iv: ask_iv.unwrap_or(f64::NAN),
+            underlying_price: underlying_price.unwrap_or(f64::NAN),
+            delta: f64::NAN,
+            gamma: f64::NAN,
+            vega: f64::NAN,
+            theta: f64::NAN,
+        });
+    }
+
+    if snapshots.is_empty() {
+        let legacy_iv_rows: Vec<(String, Option<f64>, Option<f64>, DateTime<Utc>)> =
+            match sqlx::query_as(
+                r#"
+                SELECT
+                    currency,
+                    COALESCE(atm_iv, iv_close, iv_open)::double precision,
+                    iv_close::double precision,
+                    timestamp
+                FROM deribit_iv_ticks
+                WHERE currency = ANY($1)
+                  AND timestamp >= $2
+                  AND timestamp <= $3
+                ORDER BY timestamp
+                "#,
+            )
+            .bind(&currencies)
+            .bind(start)
+            .bind(end)
+            .fetch_all(pool)
+            .await
+            {
+                Ok(rows) => rows,
+                Err(err) => {
+                    eprintln!("legacy deribit iv load skipped: {err}");
+                    Vec::new()
+                }
+            };
+        for (currency, atm_iv, iv_close, ts) in legacy_iv_rows {
+            let mark_iv = atm_iv.or(iv_close).unwrap_or(f64::NAN);
+            snapshots.push(DeribitFeatureSnapshot {
+                symbol: deribit_currency_to_symbol(&currency),
+                ts,
+                mark_iv,
+                bid_iv: f64::NAN,
+                ask_iv: f64::NAN,
+                underlying_price: f64::NAN,
+                delta: f64::NAN,
+                gamma: f64::NAN,
+                vega: f64::NAN,
+                theta: f64::NAN,
+            });
+        }
+    }
+
+    let greeks_rows: Vec<(
+        String,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        DateTime<Utc>,
+    )> = match sqlx::query_as(
+        r#"
+        WITH currencies AS (
+            SELECT unnest($1::text[]) AS currency
+        ),
+        buckets AS (
+            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
+        )
+        SELECT
+            c.currency,
+            d.mark_iv::double precision,
+            d.delta::double precision,
+            d.gamma::double precision,
+            d.vega::double precision,
+            d.theta::double precision,
+            d.underlying_price::double precision,
+            b.bucket_ts
+        FROM currencies c
+        CROSS JOIN buckets b
+        JOIN LATERAL (
+            SELECT mark_iv, delta, gamma, vega, theta, underlying_price
+            FROM deribit_atm_greeks_ticks d
+            WHERE d.currency = c.currency
+              AND d.source_ts <= b.bucket_ts
+              AND d.source_ts > b.bucket_ts - interval '5 minutes'
+              AND d.mark_iv IS NOT NULL
+            ORDER BY d.source_ts DESC, d.open_interest DESC NULLS LAST
+            LIMIT 1
+        ) d ON true
+        ORDER BY b.bucket_ts
+        "#,
+    )
+    .bind(&currencies)
+    .bind(start)
+    .bind(end)
+    .bind(sample_secs)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            eprintln!("deribit greeks load failed: {err}");
+            Vec::new()
+        }
+    };
+
+    for (currency, mark_iv, delta, gamma, vega, theta, underlying_price, ts) in greeks_rows {
+        snapshots.push(DeribitFeatureSnapshot {
+            symbol: deribit_currency_to_symbol(&currency),
+            ts,
+            mark_iv: mark_iv.unwrap_or(f64::NAN),
+            bid_iv: f64::NAN,
+            ask_iv: f64::NAN,
+            underlying_price: underlying_price.unwrap_or(f64::NAN),
+            delta: delta.unwrap_or(f64::NAN),
+            gamma: gamma.unwrap_or(f64::NAN),
+            vega: vega.unwrap_or(f64::NAN),
+            theta: theta.unwrap_or(f64::NAN),
+        });
+    }
+
+    snapshots.sort_by_key(|snapshot| (snapshot.symbol.clone(), snapshot.ts));
+    snapshots
+}
+
+fn symbol_to_deribit_currency(symbol: &str) -> Option<String> {
+    let upper = symbol.trim().to_ascii_uppercase();
+    if upper.starts_with("BTC") {
+        Some("BTC".to_string())
+    } else if upper.starts_with("ETH") {
+        Some("ETH".to_string())
+    } else if upper.starts_with("SOL") {
+        Some("SOL".to_string())
+    } else {
+        None
+    }
+}
+
+fn deribit_currency_to_symbol(currency: &str) -> String {
+    match currency.trim().to_ascii_uppercase().as_str() {
+        "BTC" => "BTCUSDT".to_string(),
+        "ETH" => "ETHUSDT".to_string(),
+        "SOL" => "SOLUSDT".to_string(),
+        other => format!("{other}USDT"),
+    }
+}

--- a/crates/ploy-research/src/deribit.rs
+++ b/crates/ploy-research/src/deribit.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::DeribitFeatureSnapshot;
 
@@ -9,16 +10,31 @@ pub async fn load_deribit_feature_snapshots(
     end: DateTime<Utc>,
     sample_secs: i64,
 ) -> Vec<DeribitFeatureSnapshot> {
-    let currencies: Vec<String> = symbols
-        .iter()
-        .filter_map(|symbol| symbol_to_deribit_currency(symbol))
-        .collect();
+    let mut currency_set = BTreeSet::new();
+    let mut unsupported_symbols = Vec::new();
+    for symbol in symbols {
+        match symbol_to_deribit_currency(symbol) {
+            Some(currency) => {
+                currency_set.insert(currency);
+            }
+            None => unsupported_symbols.push(symbol.clone()),
+        }
+    }
+    if !unsupported_symbols.is_empty() {
+        tracing::warn!(
+            symbols = ?unsupported_symbols,
+            "deribit feature loader skipped unsupported symbols"
+        );
+    }
+
+    let currencies: Vec<String> = currency_set.into_iter().collect();
     if currencies.is_empty() {
+        tracing::warn!("deribit feature loader has no supported currencies");
         return Vec::new();
     }
 
     let sample_secs = sample_secs.clamp(1, 300) as i32;
-    let mut snapshots = Vec::new();
+    let mut snapshots: BTreeMap<(String, DateTime<Utc>), DeribitFeatureSnapshot> = BTreeMap::new();
     let current_iv_rows: Vec<(
         String,
         Option<f64>,
@@ -65,68 +81,95 @@ pub async fn load_deribit_feature_snapshots(
     {
         Ok(rows) => rows,
         Err(err) => {
-            eprintln!("deribit iv load failed: {err}");
+            tracing::warn!(error = %err, "deribit iv load failed");
             Vec::new()
         }
     };
 
     for (currency, mark_iv, bid_iv, ask_iv, underlying_price, ts) in current_iv_rows {
-        snapshots.push(DeribitFeatureSnapshot {
-            symbol: deribit_currency_to_symbol(&currency),
+        let symbol = deribit_currency_to_symbol(&currency);
+        merge_deribit_snapshot(
+            &mut snapshots,
+            symbol,
             ts,
-            mark_iv: mark_iv.unwrap_or(f64::NAN),
-            bid_iv: bid_iv.unwrap_or(f64::NAN),
-            ask_iv: ask_iv.unwrap_or(f64::NAN),
-            underlying_price: underlying_price.unwrap_or(f64::NAN),
-            delta: f64::NAN,
-            gamma: f64::NAN,
-            vega: f64::NAN,
-            theta: f64::NAN,
-        });
+            DeribitFeatureSnapshot {
+                symbol: String::new(),
+                ts,
+                mark_iv: mark_iv.unwrap_or(f64::NAN),
+                bid_iv: bid_iv.unwrap_or(f64::NAN),
+                ask_iv: ask_iv.unwrap_or(f64::NAN),
+                underlying_price: underlying_price.unwrap_or(f64::NAN),
+                delta: f64::NAN,
+                gamma: f64::NAN,
+                vega: f64::NAN,
+                theta: f64::NAN,
+            },
+        );
     }
 
     if snapshots.is_empty() {
         let legacy_iv_rows: Vec<(String, Option<f64>, Option<f64>, DateTime<Utc>)> =
             match sqlx::query_as(
                 r#"
+                WITH currencies AS (
+                    SELECT unnest($1::text[]) AS currency
+                ),
+                buckets AS (
+                    SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
+                )
                 SELECT
-                    currency,
-                    COALESCE(atm_iv, iv_close, iv_open)::double precision,
-                    iv_close::double precision,
-                    timestamp
-                FROM deribit_iv_ticks
-                WHERE currency = ANY($1)
-                  AND timestamp >= $2
-                  AND timestamp <= $3
-                ORDER BY timestamp
+                    c.currency,
+                    COALESCE(d.atm_iv, d.iv_close, d.iv_open)::double precision,
+                    d.iv_close::double precision,
+                    b.bucket_ts
+                FROM currencies c
+                CROSS JOIN buckets b
+                JOIN LATERAL (
+                    SELECT atm_iv, iv_close, iv_open, timestamp
+                    FROM deribit_iv_ticks d
+                    WHERE d.currency = c.currency
+                      AND d.timestamp <= b.bucket_ts
+                      AND d.timestamp > b.bucket_ts - interval '5 minutes'
+                      AND COALESCE(d.atm_iv, d.iv_close, d.iv_open) IS NOT NULL
+                    ORDER BY d.timestamp DESC
+                    LIMIT 1
+                ) d ON true
+                ORDER BY b.bucket_ts
                 "#,
             )
             .bind(&currencies)
             .bind(start)
             .bind(end)
+            .bind(sample_secs)
             .fetch_all(pool)
             .await
             {
                 Ok(rows) => rows,
                 Err(err) => {
-                    eprintln!("legacy deribit iv load skipped: {err}");
+                    tracing::warn!(error = %err, "legacy deribit iv load skipped");
                     Vec::new()
                 }
             };
         for (currency, atm_iv, iv_close, ts) in legacy_iv_rows {
             let mark_iv = atm_iv.or(iv_close).unwrap_or(f64::NAN);
-            snapshots.push(DeribitFeatureSnapshot {
-                symbol: deribit_currency_to_symbol(&currency),
+            let symbol = deribit_currency_to_symbol(&currency);
+            merge_deribit_snapshot(
+                &mut snapshots,
+                symbol,
                 ts,
-                mark_iv,
-                bid_iv: f64::NAN,
-                ask_iv: f64::NAN,
-                underlying_price: f64::NAN,
-                delta: f64::NAN,
-                gamma: f64::NAN,
-                vega: f64::NAN,
-                theta: f64::NAN,
-            });
+                DeribitFeatureSnapshot {
+                    symbol: String::new(),
+                    ts,
+                    mark_iv,
+                    bid_iv: f64::NAN,
+                    ask_iv: f64::NAN,
+                    underlying_price: f64::NAN,
+                    delta: f64::NAN,
+                    gamma: f64::NAN,
+                    vega: f64::NAN,
+                    theta: f64::NAN,
+                },
+            );
         }
     }
 
@@ -180,28 +223,66 @@ pub async fn load_deribit_feature_snapshots(
     {
         Ok(rows) => rows,
         Err(err) => {
-            eprintln!("deribit greeks load failed: {err}");
+            tracing::warn!(error = %err, "deribit greeks load failed");
             Vec::new()
         }
     };
 
     for (currency, mark_iv, delta, gamma, vega, theta, underlying_price, ts) in greeks_rows {
-        snapshots.push(DeribitFeatureSnapshot {
-            symbol: deribit_currency_to_symbol(&currency),
+        let symbol = deribit_currency_to_symbol(&currency);
+        merge_deribit_snapshot(
+            &mut snapshots,
+            symbol,
             ts,
-            mark_iv: mark_iv.unwrap_or(f64::NAN),
-            bid_iv: f64::NAN,
-            ask_iv: f64::NAN,
-            underlying_price: underlying_price.unwrap_or(f64::NAN),
-            delta: delta.unwrap_or(f64::NAN),
-            gamma: gamma.unwrap_or(f64::NAN),
-            vega: vega.unwrap_or(f64::NAN),
-            theta: theta.unwrap_or(f64::NAN),
-        });
+            DeribitFeatureSnapshot {
+                symbol: String::new(),
+                ts,
+                mark_iv: mark_iv.unwrap_or(f64::NAN),
+                bid_iv: f64::NAN,
+                ask_iv: f64::NAN,
+                underlying_price: underlying_price.unwrap_or(f64::NAN),
+                delta: delta.unwrap_or(f64::NAN),
+                gamma: gamma.unwrap_or(f64::NAN),
+                vega: vega.unwrap_or(f64::NAN),
+                theta: theta.unwrap_or(f64::NAN),
+            },
+        );
     }
 
+    let mut snapshots: Vec<_> = snapshots.into_values().collect();
     snapshots.sort_by_key(|snapshot| (snapshot.symbol.clone(), snapshot.ts));
     snapshots
+}
+
+fn merge_deribit_snapshot(
+    snapshots: &mut BTreeMap<(String, DateTime<Utc>), DeribitFeatureSnapshot>,
+    symbol: String,
+    ts: DateTime<Utc>,
+    mut incoming: DeribitFeatureSnapshot,
+) {
+    incoming.symbol = symbol.clone();
+    incoming.ts = ts;
+    snapshots
+        .entry((symbol, ts))
+        .and_modify(|existing| merge_finite_fields(existing, &incoming))
+        .or_insert(incoming);
+}
+
+fn merge_finite_fields(existing: &mut DeribitFeatureSnapshot, incoming: &DeribitFeatureSnapshot) {
+    update_if_finite(&mut existing.mark_iv, incoming.mark_iv);
+    update_if_finite(&mut existing.bid_iv, incoming.bid_iv);
+    update_if_finite(&mut existing.ask_iv, incoming.ask_iv);
+    update_if_finite(&mut existing.underlying_price, incoming.underlying_price);
+    update_if_finite(&mut existing.delta, incoming.delta);
+    update_if_finite(&mut existing.gamma, incoming.gamma);
+    update_if_finite(&mut existing.vega, incoming.vega);
+    update_if_finite(&mut existing.theta, incoming.theta);
+}
+
+fn update_if_finite(target: &mut f64, value: f64) {
+    if value.is_finite() {
+        *target = value;
+    }
 }
 
 fn symbol_to_deribit_currency(symbol: &str) -> Option<String> {

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -897,7 +897,9 @@ pub fn walk_forward_factors_v2_with_deribit(
     end: DateTime<Utc>,
     options: FactorWalkForwardOptions,
 ) -> FactorWalkForwardReport {
-    let v2_rows = build_factor_observations_v2_with_deribit(source_rows, deribit, &options.review);
+    let mut v2_rows =
+        build_factor_observations_v2_with_deribit(source_rows, deribit, &options.review);
+    v2_rows.sort_by_key(|row| row.tick_ts);
     let health = build_data_health_report(source_rows, &v2_rows);
     let train_duration = Duration::days(options.train_window_days.max(1));
     let test_duration = Duration::days(options.test_window_days.max(1));
@@ -914,14 +916,14 @@ pub fn walk_forward_factors_v2_with_deribit(
         let train_end = train_start + train_duration;
         let test_start = train_end;
         let test_end = test_start + test_duration;
-        let train_rows: Vec<&FactorObservationV2> = v2_rows
-            .iter()
-            .filter(|row| row.tick_ts >= train_start && row.tick_ts < train_end)
-            .collect();
-        let test_rows: Vec<&FactorObservationV2> = v2_rows
-            .iter()
-            .filter(|row| row.tick_ts >= test_start && row.tick_ts < test_end)
-            .collect();
+        let train_rows: Vec<&FactorObservationV2> =
+            walk_forward_time_slice(&v2_rows, train_start, train_end)
+                .iter()
+                .collect();
+        let test_rows: Vec<&FactorObservationV2> =
+            walk_forward_time_slice(&v2_rows, test_start, test_end)
+                .iter()
+                .collect();
 
         if train_rows.len() >= options.review.min_observations
             && test_rows.len() >= options.review.min_observations
@@ -1162,6 +1164,9 @@ fn fit_walk_forward_factor(
         .map(|(_, score)| *score * direction)
         .filter(|score| score.is_finite())
         .collect();
+    if directed_scores.is_empty() {
+        return None;
+    }
     directed_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
     let selected_n = ((directed_scores.len() as f64) * options.top_quantile.clamp(0.01, 1.0))
         .ceil()
@@ -1193,6 +1198,16 @@ fn is_walk_forward_candidate_descriptor(descriptor: &FactorV2Descriptor) -> bool
     // They are intentionally reviewed in the single-window report, but using
     // them as train-time selection factors would leak future PM quote movement.
     !descriptor.name.starts_with("future_exit_")
+}
+
+fn walk_forward_time_slice(
+    rows: &[FactorObservationV2],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> &[FactorObservationV2] {
+    let lo = rows.partition_point(|row| row.tick_ts < start);
+    let hi = rows.partition_point(|row| row.tick_ts < end);
+    &rows[lo..hi]
 }
 
 fn evaluate_factor_threshold(

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use ploy_operator_contracts::Regime;
 
 use crate::factors::{FactorObservation, pearson_ic, spearman_ic};
@@ -278,6 +278,81 @@ pub struct FactorReviewV2Report {
     pub options: FactorReviewOptions,
     pub health: DataHealthReport,
     pub reviews: Vec<SingleFactorReview>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactorWalkForwardOptions {
+    pub review: FactorReviewOptions,
+    pub train_window_days: i64,
+    pub test_window_days: i64,
+    pub step_days: i64,
+    pub top_n: usize,
+}
+
+impl Default for FactorWalkForwardOptions {
+    fn default() -> Self {
+        Self {
+            review: FactorReviewOptions::default(),
+            train_window_days: 2,
+            test_window_days: 1,
+            step_days: 1,
+            top_n: 20,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FactorSelectionMetrics {
+    pub n: usize,
+    pub selected_n: usize,
+    pub executable_fill_rate: f64,
+    pub rejection_rate: f64,
+    pub total_pnl_after_cost: f64,
+    pub avg_pnl_after_cost: f64,
+    pub sharpe: f64,
+    pub max_drawdown: f64,
+    pub by_symbol_positive_ratio: f64,
+    pub by_time_bucket_positive_ratio: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactorWalkForwardWindow {
+    pub window_index: usize,
+    pub train_start: DateTime<Utc>,
+    pub train_end: DateTime<Utc>,
+    pub test_start: DateTime<Utc>,
+    pub test_end: DateTime<Utc>,
+    pub factor: String,
+    pub family: FactorFamily,
+    pub layer: ThreeLayerArchive,
+    pub direction: f64,
+    pub threshold: f64,
+    pub train_settlement_rank_ic: f64,
+    pub train_executable_pnl_rank_ic: f64,
+    pub train: FactorSelectionMetrics,
+    pub test: FactorSelectionMetrics,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactorWalkForwardAggregate {
+    pub factor: String,
+    pub family: FactorFamily,
+    pub layer: ThreeLayerArchive,
+    pub windows: usize,
+    pub positive_window_ratio: f64,
+    pub total_test_pnl_after_cost: f64,
+    pub avg_test_pnl_per_window: f64,
+    pub min_test_pnl_after_cost: f64,
+    pub avg_test_fill_rate: f64,
+    pub avg_test_rejection_rate: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactorWalkForwardReport {
+    pub options: FactorWalkForwardOptions,
+    pub health: DataHealthReport,
+    pub windows: Vec<FactorWalkForwardWindow>,
+    pub aggregates: Vec<FactorWalkForwardAggregate>,
 }
 
 pub fn build_factor_observations_v2(
@@ -815,6 +890,161 @@ pub fn review_factors_v2_with_deribit(
     }
 }
 
+pub fn walk_forward_factors_v2_with_deribit(
+    source_rows: &[FactorObservation],
+    deribit: &[DeribitFeatureSnapshot],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    options: FactorWalkForwardOptions,
+) -> FactorWalkForwardReport {
+    let v2_rows = build_factor_observations_v2_with_deribit(source_rows, deribit, &options.review);
+    let health = build_data_health_report(source_rows, &v2_rows);
+    let train_duration = Duration::days(options.train_window_days.max(1));
+    let test_duration = Duration::days(options.test_window_days.max(1));
+    let step_duration = Duration::days(options.step_days.max(1));
+    let descriptors = factor_v2_descriptors();
+
+    let mut windows = Vec::new();
+    let mut train_start = start;
+    let mut window_index = 0usize;
+    while train_start + train_duration + test_duration <= end + Duration::seconds(1) {
+        let train_end = train_start + train_duration;
+        let test_start = train_end;
+        let test_end = test_start + test_duration;
+        let train_rows: Vec<&FactorObservationV2> = v2_rows
+            .iter()
+            .filter(|row| row.tick_ts >= train_start && row.tick_ts < train_end)
+            .collect();
+        let test_rows: Vec<&FactorObservationV2> = v2_rows
+            .iter()
+            .filter(|row| row.tick_ts >= test_start && row.tick_ts < test_end)
+            .collect();
+
+        if train_rows.len() >= options.review.min_observations
+            && test_rows.len() >= options.review.min_observations
+        {
+            let mut fitted: Vec<FactorWalkForwardWindow> = descriptors
+                .iter()
+                .filter_map(|descriptor| {
+                    fit_walk_forward_factor(
+                        &train_rows,
+                        &test_rows,
+                        *descriptor,
+                        &options.review,
+                        window_index,
+                        train_start,
+                        train_end,
+                        test_start,
+                        test_end,
+                    )
+                })
+                .collect();
+            fitted.sort_by(|a, b| {
+                b.test
+                    .total_pnl_after_cost
+                    .partial_cmp(&a.test.total_pnl_after_cost)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| {
+                        b.test
+                            .sharpe
+                            .partial_cmp(&a.test.sharpe)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
+            });
+            windows.extend(fitted.into_iter().take(options.top_n.max(1)));
+        }
+
+        window_index += 1;
+        train_start += step_duration;
+    }
+
+    let aggregates = aggregate_walk_forward_windows(&windows);
+    FactorWalkForwardReport {
+        options,
+        health,
+        windows,
+        aggregates,
+    }
+}
+
+pub fn format_factor_walk_forward_v2_report(report: &FactorWalkForwardReport) -> String {
+    let mut out = String::new();
+    out.push_str("=== Factor Walk-Forward V2 Data Health ===\n");
+    out.push_str(&format!(
+        "source_obs={} v2_rows={} settlement_labels={} executable_pnl_rows={} deribit_rows={}\n",
+        report.health.source_observations,
+        report.health.v2_rows,
+        report.health.settlement_label_rows,
+        report.health.executable_pnl_rows,
+        report.health.deribit_rows,
+    ));
+    out.push_str(&format!(
+        "entry_fill_rate={:.2}% rejection_rate={:.2}% exit_fill_rate={:.2}% avg_pm_lag_secs={:.2}\n",
+        report.health.entry_fill_rate() * 100.0,
+        report.health.rejection_rate() * 100.0,
+        report.health.exit_fill_rate() * 100.0,
+        report.health.avg_pm_lag_secs,
+    ));
+    out.push_str(&format!(
+        "stake_usd={:.2} train_days={} test_days={} step_days={} top_quantile={:.2}\n\n",
+        report.options.review.stake_usd,
+        report.options.train_window_days,
+        report.options.test_window_days,
+        report.options.step_days,
+        report.options.review.top_quantile,
+    ));
+
+    out.push_str("=== Walk-Forward Aggregates By Test PnL ===\n");
+    out.push_str("factor,family,layer,windows,pos_window_ratio,total_test_pnl,avg_window_pnl,min_window_pnl,avg_fill_rate,avg_reject_rate\n");
+    for aggregate in &report.aggregates {
+        out.push_str(&format!(
+            "{},{},{},{},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4}\n",
+            aggregate.factor,
+            aggregate.family.as_str(),
+            aggregate.layer.as_str(),
+            aggregate.windows,
+            aggregate.positive_window_ratio,
+            aggregate.total_test_pnl_after_cost,
+            aggregate.avg_test_pnl_per_window,
+            aggregate.min_test_pnl_after_cost,
+            aggregate.avg_test_fill_rate,
+            aggregate.avg_test_rejection_rate,
+        ));
+    }
+
+    out.push_str("\n=== Walk-Forward Windows ===\n");
+    out.push_str("window,train_start,train_end,test_start,test_end,factor,family,layer,direction,threshold,train_ic,test_ic_proxy,train_selected,train_pnl,test_selected,test_fill,test_reject,test_pnl,test_avg_pnl,test_sharpe,test_max_dd,symbol_pos,time_bucket_pos\n");
+    for window in &report.windows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{:.0},{:.8},{:.4},{:.4},{},{:.4},{},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4}\n",
+            window.window_index,
+            window.train_start,
+            window.train_end,
+            window.test_start,
+            window.test_end,
+            window.factor,
+            window.family.as_str(),
+            window.layer.as_str(),
+            window.direction,
+            window.threshold,
+            window.train_executable_pnl_rank_ic,
+            window.train_settlement_rank_ic,
+            window.train.selected_n,
+            window.train.total_pnl_after_cost,
+            window.test.selected_n,
+            window.test.executable_fill_rate,
+            window.test.rejection_rate,
+            window.test.total_pnl_after_cost,
+            window.test.avg_pnl_after_cost,
+            window.test.sharpe,
+            window.test.max_drawdown,
+            window.test.by_symbol_positive_ratio,
+            window.test.by_time_bucket_positive_ratio,
+        ));
+    }
+    out
+}
+
 pub fn format_factor_review_v2_report(report: &FactorReviewV2Report, top_n: usize) -> String {
     let mut out = String::new();
     out.push_str("=== Factor Review V2 Data Health ===\n");
@@ -869,6 +1099,193 @@ pub fn format_factor_review_v2_report(report: &FactorReviewV2Report, top_n: usiz
         ));
     }
     out
+}
+
+fn fit_walk_forward_factor(
+    train_rows: &[&FactorObservationV2],
+    test_rows: &[&FactorObservationV2],
+    descriptor: FactorV2Descriptor,
+    options: &FactorReviewOptions,
+    window_index: usize,
+    train_start: DateTime<Utc>,
+    train_end: DateTime<Utc>,
+    test_start: DateTime<Utc>,
+    test_end: DateTime<Utc>,
+) -> Option<FactorWalkForwardWindow> {
+    let scored: Vec<(&FactorObservationV2, f64)> = train_rows
+        .iter()
+        .filter_map(|row| {
+            let value = (descriptor.accessor)(row);
+            value.is_finite().then_some((*row, value))
+        })
+        .collect();
+    if scored.len() < options.min_observations {
+        return None;
+    }
+
+    let settlement_pairs: Vec<(f64, f64)> = scored
+        .iter()
+        .filter_map(|(row, score)| row.label_settlement_win.map(|label| (*score, label)))
+        .filter(|(score, label)| score.is_finite() && label.is_finite())
+        .collect();
+    let executable_pairs: Vec<(f64, f64)> = scored
+        .iter()
+        .filter_map(|(row, score)| row.label_executable_pnl_15u.map(|label| (*score, label)))
+        .filter(|(score, label)| score.is_finite() && label.is_finite())
+        .collect();
+    let train_settlement_rank_ic = pair_spearman(&settlement_pairs);
+    let train_executable_pnl_rank_ic = pair_spearman(&executable_pairs);
+    let direction = if train_executable_pnl_rank_ic.is_finite() {
+        train_executable_pnl_rank_ic.signum()
+    } else if train_settlement_rank_ic.is_finite() {
+        train_settlement_rank_ic.signum()
+    } else {
+        1.0
+    };
+    let direction = if direction.abs() <= EPS {
+        1.0
+    } else {
+        direction
+    };
+
+    let mut directed_scores: Vec<f64> = scored
+        .iter()
+        .map(|(_, score)| *score * direction)
+        .filter(|score| score.is_finite())
+        .collect();
+    directed_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let selected_n = ((directed_scores.len() as f64) * options.top_quantile.clamp(0.01, 1.0))
+        .ceil()
+        .max(1.0) as usize;
+    let threshold = directed_scores[selected_n.min(directed_scores.len()) - 1];
+
+    let train = evaluate_factor_threshold(train_rows, descriptor, direction, threshold);
+    let test = evaluate_factor_threshold(test_rows, descriptor, direction, threshold);
+    Some(FactorWalkForwardWindow {
+        window_index,
+        train_start,
+        train_end,
+        test_start,
+        test_end,
+        factor: descriptor.name.to_string(),
+        family: descriptor.family,
+        layer: descriptor.layer,
+        direction,
+        threshold,
+        train_settlement_rank_ic,
+        train_executable_pnl_rank_ic,
+        train,
+        test,
+    })
+}
+
+fn evaluate_factor_threshold(
+    rows: &[&FactorObservationV2],
+    descriptor: FactorV2Descriptor,
+    direction: f64,
+    threshold: f64,
+) -> FactorSelectionMetrics {
+    let scored_n = rows
+        .iter()
+        .filter(|row| (descriptor.accessor)(row).is_finite())
+        .count();
+    let selected: Vec<&FactorObservationV2> = rows
+        .iter()
+        .copied()
+        .filter(|row| {
+            let value = (descriptor.accessor)(row);
+            value.is_finite() && value * direction >= threshold
+        })
+        .collect();
+    let filled: Vec<&FactorObservationV2> = selected
+        .iter()
+        .copied()
+        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .collect();
+    let pnls: Vec<(DateTime<Utc>, f64)> = filled
+        .iter()
+        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
+        .filter(|(_, pnl)| pnl.is_finite())
+        .collect();
+    let pnl_values: Vec<f64> = pnls.iter().map(|(_, pnl)| *pnl).collect();
+    let total_pnl = pnl_values.iter().sum::<f64>();
+    FactorSelectionMetrics {
+        n: scored_n,
+        selected_n: selected.len(),
+        executable_fill_rate: ratio(filled.len(), selected.len()),
+        rejection_rate: ratio(
+            selected
+                .iter()
+                .filter(|row| !row.label_executable_fillable)
+                .count(),
+            selected.len(),
+        ),
+        total_pnl_after_cost: total_pnl,
+        avg_pnl_after_cost: if pnl_values.is_empty() {
+            f64::NAN
+        } else {
+            total_pnl / pnl_values.len() as f64
+        },
+        sharpe: trade_sharpe(&pnl_values),
+        max_drawdown: max_drawdown(&pnls),
+        by_symbol_positive_ratio: positive_group_ratio(&filled, |row| row.symbol.clone()),
+        by_time_bucket_positive_ratio: positive_group_ratio(&filled, |row| {
+            row.regime.as_str().to_string()
+        }),
+    }
+}
+
+fn aggregate_walk_forward_windows(
+    windows: &[FactorWalkForwardWindow],
+) -> Vec<FactorWalkForwardAggregate> {
+    let mut grouped: BTreeMap<String, Vec<&FactorWalkForwardWindow>> = BTreeMap::new();
+    for window in windows {
+        grouped
+            .entry(window.factor.clone())
+            .or_default()
+            .push(window);
+    }
+    let mut aggregates = Vec::with_capacity(grouped.len());
+    for (factor, rows) in grouped {
+        let Some(first) = rows.first() else {
+            continue;
+        };
+        let total_test_pnl_after_cost = rows
+            .iter()
+            .map(|row| row.test.total_pnl_after_cost)
+            .sum::<f64>();
+        let min_test_pnl_after_cost = rows
+            .iter()
+            .map(|row| row.test.total_pnl_after_cost)
+            .fold(f64::INFINITY, f64::min);
+        let positive_windows = rows
+            .iter()
+            .filter(|row| row.test.total_pnl_after_cost > 0.0)
+            .count();
+        aggregates.push(FactorWalkForwardAggregate {
+            factor,
+            family: first.family,
+            layer: first.layer,
+            windows: rows.len(),
+            positive_window_ratio: ratio(positive_windows, rows.len()),
+            total_test_pnl_after_cost,
+            avg_test_pnl_per_window: total_test_pnl_after_cost / rows.len() as f64,
+            min_test_pnl_after_cost,
+            avg_test_fill_rate: mean(rows.iter().map(|row| row.test.executable_fill_rate)),
+            avg_test_rejection_rate: mean(rows.iter().map(|row| row.test.rejection_rate)),
+        });
+    }
+    aggregates.sort_by(|a, b| {
+        b.total_test_pnl_after_cost
+            .partial_cmp(&a.total_test_pnl_after_cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.positive_window_ratio
+                    .partial_cmp(&a.positive_window_ratio)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+    aggregates
 }
 
 fn review_one_factor(
@@ -1767,6 +2184,56 @@ mod tests {
                 .reviews
                 .iter()
                 .any(|review| review.factor == "side_model_edge")
+        );
+    }
+
+    #[test]
+    fn walk_forward_uses_train_threshold_on_future_window() {
+        let base = Utc::now();
+        let mut observations = Vec::new();
+        for i in 0..72 {
+            let mut obs = base_obs();
+            obs.event_id = format!("event-{i}");
+            obs.tick_ts = base + chrono::Duration::hours(i);
+            obs.model_prob_up = if i % 2 == 0 { 0.78 } else { 0.22 };
+            obs.model_edge_up = obs.model_prob_up - obs.pm_up_ask - crypto_fee_cost(obs.pm_up_ask);
+            obs.settlement_up = if i % 2 == 0 { 1.0 } else { 0.0 };
+            observations.push(obs);
+        }
+
+        let report = walk_forward_factors_v2_with_deribit(
+            &observations,
+            &[],
+            base,
+            base + chrono::Duration::days(3) - chrono::Duration::seconds(1),
+            FactorWalkForwardOptions {
+                review: FactorReviewOptions {
+                    stake_usd: 15.0,
+                    min_observations: 10,
+                    top_quantile: 0.2,
+                },
+                train_window_days: 2,
+                test_window_days: 1,
+                step_days: 1,
+                top_n: 10,
+            },
+        );
+
+        assert!(!report.windows.is_empty());
+        let side_model = report
+            .windows
+            .iter()
+            .find(|window| window.factor == "side_model_prob")
+            .expect("side_model_prob window");
+        assert_eq!(side_model.window_index, 0);
+        assert!(side_model.threshold.is_finite());
+        assert!(side_model.test.selected_n > 0);
+        assert!(side_model.test.total_pnl_after_cost > 0.0);
+        assert!(
+            report
+                .aggregates
+                .iter()
+                .any(|aggregate| aggregate.factor == "side_model_prob")
         );
     }
 }

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -902,7 +902,10 @@ pub fn walk_forward_factors_v2_with_deribit(
     let train_duration = Duration::days(options.train_window_days.max(1));
     let test_duration = Duration::days(options.test_window_days.max(1));
     let step_duration = Duration::days(options.step_days.max(1));
-    let descriptors = factor_v2_descriptors();
+    let descriptors: Vec<FactorV2Descriptor> = factor_v2_descriptors()
+        .into_iter()
+        .filter(is_walk_forward_candidate_descriptor)
+        .collect();
 
     let mut windows = Vec::new();
     let mut train_start = start;
@@ -951,7 +954,7 @@ pub fn walk_forward_factors_v2_with_deribit(
                             .unwrap_or(std::cmp::Ordering::Equal)
                     })
             });
-            windows.extend(fitted.into_iter().take(options.top_n.max(1)));
+            windows.extend(fitted);
         }
 
         window_index += 1;
@@ -996,7 +999,7 @@ pub fn format_factor_walk_forward_v2_report(report: &FactorWalkForwardReport) ->
 
     out.push_str("=== Walk-Forward Aggregates By Test PnL ===\n");
     out.push_str("factor,family,layer,windows,pos_window_ratio,total_test_pnl,avg_window_pnl,min_window_pnl,avg_fill_rate,avg_reject_rate\n");
-    for aggregate in &report.aggregates {
+    for aggregate in report.aggregates.iter().take(report.options.top_n.max(1)) {
         out.push_str(&format!(
             "{},{},{},{},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4}\n",
             aggregate.factor,
@@ -1013,8 +1016,14 @@ pub fn format_factor_walk_forward_v2_report(report: &FactorWalkForwardReport) ->
     }
 
     out.push_str("\n=== Walk-Forward Windows ===\n");
-    out.push_str("window,train_start,train_end,test_start,test_end,factor,family,layer,direction,threshold,train_ic,test_ic_proxy,train_selected,train_pnl,test_selected,test_fill,test_reject,test_pnl,test_avg_pnl,test_sharpe,test_max_dd,symbol_pos,time_bucket_pos\n");
+    out.push_str("window,train_start,train_end,test_start,test_end,factor,family,layer,direction,threshold,train_pnl_rank_ic,train_settle_rank_ic,train_selected,train_pnl,test_selected,test_fill,test_reject,test_pnl,test_avg_pnl,test_sharpe,test_max_dd,symbol_pos,time_bucket_pos\n");
+    let mut displayed_by_window: BTreeMap<usize, usize> = BTreeMap::new();
     for window in &report.windows {
+        let displayed = displayed_by_window.entry(window.window_index).or_insert(0);
+        if *displayed >= report.options.top_n.max(1) {
+            continue;
+        }
+        *displayed += 1;
         out.push_str(&format!(
             "{},{},{},{},{},{},{},{},{:.0},{:.8},{:.4},{:.4},{},{:.4},{},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4},{:.4}\n",
             window.window_index,
@@ -1177,6 +1186,13 @@ fn fit_walk_forward_factor(
         train,
         test,
     })
+}
+
+fn is_walk_forward_candidate_descriptor(descriptor: &FactorV2Descriptor) -> bool {
+    // `future_exit_*` descriptors are diagnostic labels for exit feasibility.
+    // They are intentionally reviewed in the single-window report, but using
+    // them as train-time selection factors would leak future PM quote movement.
+    !descriptor.name.starts_with("future_exit_")
 }
 
 fn evaluate_factor_threshold(
@@ -2220,6 +2236,7 @@ mod tests {
         );
 
         assert!(!report.windows.is_empty());
+        assert!(report.windows.len() > report.options.top_n);
         let side_model = report
             .windows
             .iter()
@@ -2234,6 +2251,12 @@ mod tests {
                 .aggregates
                 .iter()
                 .any(|aggregate| aggregate.factor == "side_model_prob")
+        );
+        assert!(
+            report
+                .windows
+                .iter()
+                .all(|window| !window.factor.starts_with("future_exit_"))
         );
     }
 }

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -2,6 +2,8 @@ pub mod attribution;
 pub mod backtest;
 pub mod backtesting;
 pub mod dataset;
+#[cfg(feature = "db")]
+pub mod deribit;
 pub mod event_ml;
 pub mod factors;
 pub mod factors_new;
@@ -28,6 +30,8 @@ pub use dataset::{
     DatasetExportError, event_index_to_frame, event_summaries_to_frame,
     export_event_root_dataset_parquet, split_assignments_to_frame,
 };
+#[cfg(feature = "db")]
+pub use deribit::load_deribit_feature_snapshots;
 pub use event_ml::{
     ArchitectureArtifact, EVENT_ML_ARCHITECTURE_VERSION, EventMlArchitecture, LaneReadiness,
     LaneStatus, LearningLane, LearningLaneId, PhaseId, ReadinessGate, WALK_FORWARD_REPORT_VERSION,
@@ -67,10 +71,13 @@ pub use factors_new::{
 };
 pub use factors_v2::{
     DataHealthReport, DeribitFeatureSnapshot, FactorFamily, FactorObservationV2,
-    FactorReviewOptions, FactorReviewV2Report, FactorV2Descriptor, ReviewSide, SingleFactorReview,
-    ThreeLayerArchive, build_data_health_report, build_factor_observations_v2,
+    FactorReviewOptions, FactorReviewV2Report, FactorSelectionMetrics, FactorV2Descriptor,
+    FactorWalkForwardAggregate, FactorWalkForwardOptions, FactorWalkForwardReport,
+    FactorWalkForwardWindow, ReviewSide, SingleFactorReview, ThreeLayerArchive,
+    build_data_health_report, build_factor_observations_v2,
     build_factor_observations_v2_with_deribit, factor_v2_descriptors,
-    format_factor_review_v2_report, review_factors_v2, review_factors_v2_with_deribit,
+    format_factor_review_v2_report, format_factor_walk_forward_v2_report, review_factors_v2,
+    review_factors_v2_with_deribit, walk_forward_factors_v2_with_deribit,
 };
 #[cfg(feature = "rl")]
 pub use model::rl::{BinaryEventEnv, DqnAgent, Environment, ReplayBuffer};

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -829,6 +829,33 @@ evidence.
   dataset dry-run was skipped because `/tmp/ploy-event-root-5sym-150-20260424`
   was not present.
 
+# PM5D Factor Walk-Forward V2 (2026-04-26)
+
+## Files
+
+- `crates/ploy-research/src/factors_v2.rs`
+- `crates/ploy-research/src/deribit.rs`
+- `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+- `.github/workflows/factor-walk-forward-v2.yml`
+
+## Tasks
+
+- [x] Add a train-window threshold / future-window evaluation path for `FactorObservationV2`.
+- [x] Share Deribit feature loading through `ploy-research` instead of duplicating it in each example.
+- [x] Add a DB-backed `factor_walk_forward_v2` entrypoint for ploy-ci/Tango research runs.
+- [x] Add a workflow-dispatch lane for factor walk-forward artifacts.
+- [ ] Verify locally, then run a ploy-ci smoke against 2026-04-21..25.
+
+## Review
+
+- 2026-04-26: Local verification passed: `rtk cargo test -p ploy-research factors_v2 --lib`,
+  `rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`,
+  `rtk cargo check -p ploy-research --features db --example factor_review_v2`,
+  `rtk cargo check -p ploy-research --no-default-features`, workflow YAML parse,
+  `rustfmt --edition 2024 --check` on touched Rust files, and `git diff --check`.
+- 2026-04-26: ploy-ci smoke is pending after branch push because it requires the new workflow
+  on the remote branch.
+
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 
 ## Files

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -880,6 +880,13 @@ evidence.
   midnight, loaded symmetric pre-window Binance/LOB history, bounded legacy Deribit fallback
   with the same bucket sampling, merged IV/greeks snapshots by `(symbol, ts)`, and added an
   empty directed-score guard.
+- 2026-04-26: ploy-ci review-fix smoke on `26d67fc` completed with exit code 0 against Tango DB.
+  Evidence: right-open range printed as `2026-04-21 00:00:00 UTC -> 2026-04-26 00:00:00 UTC`,
+  `updates=3,307,273`, `lob snapshot rows=86,886`, `deribit_snapshots=28,726`,
+  `factor_observations=104,777`, `v2_rows=209,554`, `executable_pnl_rows=12,088`,
+  entry fill rate `5.77%`, rejection rate `94.23%`, swap stayed `0B`, and no
+  `future_exit_*` factor appeared in the walk-forward output. The ploy-ci runner was restored
+  to active afterward.
 
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -841,6 +841,8 @@ evidence.
 ## Tasks
 
 - [x] Add a train-window threshold / future-window evaluation path for `FactorObservationV2`.
+- [x] Exclude future-exit diagnostic labels from walk-forward candidate selection.
+- [x] Keep walk-forward aggregation on all candidate factors; apply `top_n` only to report display.
 - [x] Share Deribit feature loading through `ploy-research` instead of duplicating it in each example.
 - [x] Add a DB-backed `factor_walk_forward_v2` entrypoint for ploy-ci/Tango research runs.
 - [x] Add a workflow-dispatch lane for factor walk-forward artifacts.
@@ -855,6 +857,12 @@ evidence.
   `rustfmt --edition 2024 --check` on touched Rust files, and `git diff --check`.
 - 2026-04-26: ploy-ci smoke is pending after branch push because it requires the new workflow
   on the remote branch.
+- 2026-04-26: First ploy-ci manual smoke completed, but exposed that `future_exit_*` diagnostic
+  labels were being ranked as candidate factors. This is a look-ahead path for walk-forward
+  selection, so candidate selection now excludes those descriptors while single-window review
+  still reports them as exit diagnostics.
+- 2026-04-26: Walk-forward windows are no longer truncated before aggregation. `top_n` now limits
+  output display only, so aggregate metrics are not biased by post-test top performer selection.
 
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -846,7 +846,7 @@ evidence.
 - [x] Share Deribit feature loading through `ploy-research` instead of duplicating it in each example.
 - [x] Add a DB-backed `factor_walk_forward_v2` entrypoint for ploy-ci/Tango research runs.
 - [x] Add a workflow-dispatch lane for factor walk-forward artifacts.
-- [ ] Verify locally, then run a ploy-ci smoke against 2026-04-21..25.
+- [x] Verify locally, then run a ploy-ci smoke against 2026-04-21..25.
 
 ## Review
 
@@ -855,14 +855,20 @@ evidence.
   `rtk cargo check -p ploy-research --features db --example factor_review_v2`,
   `rtk cargo check -p ploy-research --no-default-features`, workflow YAML parse,
   `rustfmt --edition 2024 --check` on touched Rust files, and `git diff --check`.
-- 2026-04-26: ploy-ci smoke is pending after branch push because it requires the new workflow
-  on the remote branch.
+- 2026-04-26: ploy-ci smoke was run manually because a new workflow cannot be dispatched
+  from the default branch until it is merged.
 - 2026-04-26: First ploy-ci manual smoke completed, but exposed that `future_exit_*` diagnostic
   labels were being ranked as candidate factors. This is a look-ahead path for walk-forward
   selection, so candidate selection now excludes those descriptors while single-window review
   still reports them as exit diagnostics.
 - 2026-04-26: Walk-forward windows are no longer truncated before aggregation. `top_n` now limits
   output display only, so aggregate metrics are not biased by post-test top performer selection.
+- 2026-04-26: ploy-ci manual smoke on `c0b872c` completed with exit code 0 against Tango DB
+  (`2026-04-21..2026-04-25`, six symbols, 30s sampling, stake 15). Evidence:
+  `updates=3,273,137`, `lob snapshot rows=85,854`, `deribit_snapshots=28,642`,
+  `factor_observations=104,495`, `v2_rows=208,990`, `executable_pnl_rows=12,049`,
+  entry fill rate `5.77%`, rejection rate `94.23%`, swap stayed `0B`, and no
+  `future_exit_*` factor appeared in the walk-forward output.
 
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -834,9 +834,13 @@ evidence.
 ## Files
 
 - `crates/ploy-research/src/factors_v2.rs`
+  - Owner: solo research lane
 - `crates/ploy-research/src/deribit.rs`
+  - Owner: solo research lane
 - `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+  - Owner: solo research lane
 - `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: solo research lane
 
 ## Tasks
 
@@ -847,6 +851,8 @@ evidence.
 - [x] Add a DB-backed `factor_walk_forward_v2` entrypoint for ploy-ci/Tango research runs.
 - [x] Add a workflow-dispatch lane for factor walk-forward artifacts.
 - [x] Verify locally, then run a ploy-ci smoke against 2026-04-21..25.
+- [x] Address PR review fixes for workflow secrets, Deribit cardinality/merge behavior,
+  exclusive end-date slicing, and walk-forward empty-factor guards.
 
 ## Review
 
@@ -869,6 +875,11 @@ evidence.
   `factor_observations=104,495`, `v2_rows=208,990`, `executable_pnl_rows=12,049`,
   entry fill rate `5.77%`, rejection rate `94.23%`, swap stayed `0B`, and no
   `future_exit_*` factor appeared in the walk-forward output.
+- 2026-04-26: Code review fixes removed hardcoded workflow DB credentials in favor of
+  `PLOY_DB_URL`, preserved cargo target caching, made end-date slicing exclusive at next-day
+  midnight, loaded symmetric pre-window Binance/LOB history, bounded legacy Deribit fallback
+  with the same bucket sampling, merged IV/greeks snapshots by `(symbol, ts)`, and added an
+  empty directed-score guard.
 
 # PM5D ThreeLayer Live Readiness (2026-04-24)
 


### PR DESCRIPTION
## Summary
- add a `factor_walk_forward_v2` research entrypoint for train-window threshold fitting and next-window executable evaluation
- share Deribit snapshot loading and include Deribit-derived factors in `FactorObservationV2`
- add a workflow-dispatch lane for ploy-ci factor walk-forward artifacts
- exclude `future_exit_*` diagnostic labels from walk-forward candidate selection and keep aggregation on all candidates before display top-n

## Verification
- `rustfmt --edition 2024 --check crates/ploy-research/src/factors_v2.rs crates/ploy-research/src/deribit.rs crates/ploy-research/examples/factor_walk_forward_v2.rs`
- `git diff --check`
- `rtk cargo test -p ploy-research factors_v2 --lib`
- `rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`
- `rtk cargo check -p ploy-research --features db --example factor_review_v2`
- `rtk cargo check -p ploy-research --no-default-features`
- ploy-ci manual smoke on `c0b872c` against Tango DB, `2026-04-21..2026-04-25`, six symbols, 30s sampling, stake 15: exit code 0; `updates=3,273,137`, `lob snapshot rows=85,854`, `deribit_snapshots=28,642`, `factor_observations=104,495`, `v2_rows=208,990`, `executable_pnl_rows=12,049`, entry fill rate `5.77%`, rejection rate `94.23%`, swap `0B`, and no `future_exit_*` factor appeared in walk-forward output

## Notes
The workflow file is new, so it cannot be dispatched from `main` until this PR is merged. The manual ploy-ci smoke was used to prove the same binary path against the Tango database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Factor Walk-Forward V2 analysis engine for rolling train/test window evaluation with detailed performance metrics
  * New manually-triggered CI workflow enabling parameterized factor analysis runs with customizable date ranges, symbols, and window configurations
  * Added Deribit options data loading to enhance factor feature engineering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->