### PR TITLE
Fix PM trade collector partition repair during deploy

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -100,6 +100,7 @@ jobs:
           cp scripts/binance_lob_collector.py dist/scripts/binance_lob_collector.py
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
+          cp scripts/fix_clob_trade_partitions.sql dist/scripts/fix_clob_trade_partitions.sql
           cp scripts/repair_strategy_track_record_official_settlement.sql dist/scripts/repair_strategy_track_record_official_settlement.sql
           cp scripts/drills/*.sh dist/scripts/drills/
           for migration in ${DEPLOY_MIGRATIONS}; do
@@ -308,6 +309,7 @@ jobs:
             install -m 0755 ./scripts/binance_lob_collector.py ${DEPLOY_ROOT}/scripts/binance_lob_collector.py
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
+            install -m 0644 ./scripts/fix_clob_trade_partitions.sql ${DEPLOY_ROOT}/scripts/fix_clob_trade_partitions.sql
             install -m 0644 ./scripts/repair_strategy_track_record_official_settlement.sql ${DEPLOY_ROOT}/scripts/repair_strategy_track_record_official_settlement.sql
             install -m 0755 ./scripts/drills/*.sh ${DEPLOY_ROOT}/scripts/drills/
             for migration in ${DEPLOY_MIGRATIONS}; do
@@ -335,6 +337,7 @@ jobs:
             done
             PGPASSWORD=postgres psql -U postgres -d ploy -v ON_ERROR_STOP=1 -f ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             PGPASSWORD=postgres psql -U postgres -d ploy -v ON_ERROR_STOP=1 -f ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
+            PGPASSWORD=postgres psql -U postgres -d ploy -v ON_ERROR_STOP=1 -f ${DEPLOY_ROOT}/scripts/fix_clob_trade_partitions.sql
 
             require_postgres
 
@@ -429,6 +432,10 @@ jobs:
                 "no partition of relation \"deribit_iv_ticks\"" \
                 "deribit iv collector still lacks active partitions"
             fi
+            assert_no_recent_logs \
+              "ploy-pm-trade-collector.service" \
+              "no partition of relation \"clob_trade_ticks\"" \
+              "pm trade collector still lacks active partitions"
 
             # Check service status
             systemctl status ploy-binance-aggtrade-collector.service --no-pager

--- a/scripts/fix_clob_trade_partitions.sql
+++ b/scripts/fix_clob_trade_partitions.sql
@@ -1,0 +1,52 @@
+-- Ensure clob_trade_ticks has current and near-future daily partitions.
+-- Run safely multiple times.
+
+DO $$
+DECLARE
+    partition_day date;
+    start_day date := current_date - 7;
+    end_day date := current_date + 14;
+    partition_name text;
+    range_start text;
+    range_end text;
+BEGIN
+    partition_day := start_day;
+    WHILE partition_day <= end_day LOOP
+        partition_name := format(
+            'clob_trade_ticks_new_%s',
+            to_char(partition_day, 'YYYYMMDD')
+        );
+        range_start := format('%s 00:00:00+08', partition_day);
+        range_end := format('%s 00:00:00+08', partition_day + 1);
+
+        BEGIN
+            EXECUTE format(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF clob_trade_ticks FOR VALUES FROM (%L) TO (%L);',
+                partition_name,
+                range_start,
+                range_end
+            );
+        EXCEPTION
+            WHEN duplicate_table THEN
+                NULL;
+            WHEN OTHERS THEN
+                IF position('would overlap partition' in SQLERRM) > 0 THEN
+                    NULL;
+                ELSE
+                    RAISE;
+                END IF;
+        END;
+
+        partition_day := partition_day + 1;
+    END LOOP;
+END
+$$;
+
+SELECT
+    child.relname AS partition_name,
+    pg_get_expr(child.relpartbound, child.oid) AS partition_expression
+FROM pg_inherits
+JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+WHERE parent.relname = 'clob_trade_ticks'
+ORDER BY child.relname;


### PR DESCRIPTION
## Summary\n- add an idempotent clob_trade_ticks daily partition repair script\n- ship and run it during tango-1-1 deploy before restarting the PM trade collector\n- fail deploy explicitly if PM trade logs still show missing clob_trade_ticks partitions\n\n## Verification\n- rtk git diff --check\n- ruby Psych parsed .github/workflows/deploy-tango-1-1.yml\n\n## Context\nThe previous deploy reached Tango and started ploy-pm-trade-collector, but inserts failed because clob_trade_ticks had no current received_at partition. Tango was hotfixed manually; this PR makes the repair repeatable for future deploys and date rollovers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database reliability by implementing automatic partition management for trade data storage
  * Added deployment validation to detect and prevent partition-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->