### PR TITLE
Use PM full-depth books in factor execution labels

### DIFF
--- a/crates/ploy-research/examples/collector_data_utilization.rs
+++ b/crates/ploy-research/examples/collector_data_utilization.rs
@@ -12,13 +12,14 @@
 //!     --end-date 2026-04-26
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    build_data_health_report, build_factor_observations_v2_with_deribit,
+    FactorObservation, FactorReviewOptions, build_data_health_report,
+    build_factor_observations_v2_with_deribit_and_pm_books,
     build_factor_observations_with_lob_sampled, factor_v2_descriptors,
-    load_deribit_feature_snapshots, load_research_lob_snapshots_sampled, FactorObservation,
-    FactorReviewOptions,
+    load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
+    load_research_pm_book_snapshots_sampled,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::collections::BTreeSet;
@@ -514,6 +515,15 @@ async fn main() {
         load_research_lob_snapshots_sampled(&pool, &symbols, history_start, end, lob_sample_secs)
             .await
             .expect("lob snapshot load failed");
+    let pm_book_snapshots = load_research_pm_book_snapshots_sampled(
+        &pool,
+        &symbols,
+        history_start,
+        end,
+        lob_sample_secs,
+    )
+    .await
+    .expect("PM book snapshot load failed");
     let deribit_snapshots =
         load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
     let updates_slice = slice_by_time(&updates, history_start, end, MarketUpdate::sort_ts);
@@ -528,9 +538,10 @@ async fn main() {
         stake_usd,
         ..Default::default()
     };
-    let v2_rows = build_factor_observations_v2_with_deribit(
+    let v2_rows = build_factor_observations_v2_with_deribit_and_pm_books(
         &observations,
         &deribit_snapshots,
+        &pm_book_snapshots,
         &review_options,
     );
     let health = build_data_health_report(&observations, &v2_rows);
@@ -579,7 +590,7 @@ async fn main() {
 
     println!("\n=== Factor V2 Data Health ===");
     println!(
-        "source_obs={},v2_rows={},settlement_labels={},entry_quote_rows={},entry_size_rows={},entry_fill_rate={:.4},exit_fill_rate={:.4},executable_pnl_rows={},deribit_rows={},avg_pm_lag_secs={:.2}",
+        "source_obs={},v2_rows={},settlement_labels={},entry_quote_rows={},entry_size_rows={},entry_fill_rate={:.4},exit_fill_rate={:.4},full_depth_entry_fill_rate={:.4},full_depth_exit_fill_rate={:.4},executable_pnl_rows={},full_depth_executable_pnl_rows={},deribit_rows={},avg_pm_lag_secs={:.2},avg_entry_sweep_slip_bps={:.2},avg_exit_sweep_slip_bps={:.2}",
         health.source_observations,
         health.v2_rows,
         health.settlement_label_rows,
@@ -587,9 +598,14 @@ async fn main() {
         health.entry_size_rows,
         health.entry_fill_rate(),
         health.exit_fill_rate(),
+        health.full_depth_entry_fill_rate(),
+        health.full_depth_exit_fill_rate(),
         health.executable_pnl_rows,
+        health.full_depth_executable_pnl_rows,
         health.deribit_rows,
-        health.avg_pm_lag_secs
+        health.avg_pm_lag_secs,
+        health.avg_entry_sweep_slippage_bps,
+        health.avg_exit_sweep_slippage_bps
     );
 
     println!("\n=== Factor Descriptor Coverage ===");
@@ -616,9 +632,19 @@ async fn main() {
 
     println!("\n=== Known Utilization Gaps ===");
     println!("gap,status,next_action");
-    println!("pm_full_depth,partial,wire clob_orderbook_snapshots multi-level depth/shape factors after freshness stays stable");
-    println!("pm_trade_prints,collector_added_factor_pending,deploy collect-pm-trades and then wire trade imbalance/burst factors into Factor V2");
-    println!("deribit_greeks,conditional,only promote delta/gamma/vega/theta when deribit_atm_greeks_ticks has fresh source_ts in-window");
-    println!("reference_prices,not_used,keep out of PM5D crypto factor review unless adding Chainlink/Pyth cross-source lag features");
-    println!("binance_klines,not_used,current continuation features are rebuilt point-in-time from spot/aggTrade streams");
+    println!(
+        "pm_full_depth,used_for_sweep_labels,compare top-of-book live parity labels against full-depth sweep labels before changing live order aggressiveness"
+    );
+    println!(
+        "pm_trade_prints,collector_added_factor_pending,deploy collect-pm-trades and then wire trade imbalance/burst factors into Factor V2"
+    );
+    println!(
+        "deribit_greeks,conditional,only promote delta/gamma/vega/theta when deribit_atm_greeks_ticks has fresh source_ts in-window"
+    );
+    println!(
+        "reference_prices,not_used,keep out of PM5D crypto factor review unless adding Chainlink/Pyth cross-source lag features"
+    );
+    println!(
+        "binance_klines,not_used,current continuation features are rebuilt point-in-time from spot/aggTrade streams"
+    );
 }

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -22,7 +22,8 @@ use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
     DeribitFeatureSnapshot, FactorObservation, FactorReviewOptions,
     build_factor_observations_with_lob_sampled, format_factor_review_v2_report,
-    load_research_lob_snapshots_sampled, review_factors_v2_with_deribit,
+    load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
+    review_factors_v2_with_deribit_and_pm_books,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -140,6 +141,12 @@ async fn main() {
             .expect("bulk lob snapshot load failed");
     eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
 
+    let all_pm_book_snapshots =
+        load_research_pm_book_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
+            .await
+            .expect("bulk PM book snapshot load failed");
+    eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
+
     let deribit_snapshots =
         load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
     eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
@@ -166,7 +173,12 @@ async fn main() {
         return;
     }
 
-    let report = review_factors_v2_with_deribit(&observations, &deribit_snapshots, options);
+    let report = review_factors_v2_with_deribit_and_pm_books(
+        &observations,
+        &deribit_snapshots,
+        &all_pm_book_snapshots,
+        options,
+    );
     println!("{}", format_factor_review_v2_report(&report, top_n));
 }
 

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -18,9 +18,9 @@ use ploy_research::{
     format_meta_label_walk_forward_v1_report, format_trade_formation_v1_report,
     liquidity_gate_v1_with_deribit, liquidity_gated_alpha_v1_with_deribit,
     load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
-    review_fillability_v1_with_deribit, review_trade_formation_v1_with_deribit,
-    walk_forward_factor_combo_v1_with_deribit, walk_forward_factors_v2_with_deribit,
-    walk_forward_meta_label_v1_with_deribit,
+    load_research_pm_book_snapshots_sampled, review_fillability_v1_with_deribit,
+    review_trade_formation_v1_with_deribit, walk_forward_factor_combo_v1_with_deribit,
+    walk_forward_factors_v2_with_deribit_and_pm_books, walk_forward_meta_label_v1_with_deribit,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -162,6 +162,17 @@ async fn main() {
             .expect("bulk lob snapshot load failed");
     eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
 
+    let all_pm_book_snapshots = load_research_pm_book_snapshots_sampled(
+        &pool,
+        &symbols,
+        history_start,
+        end,
+        lob_sample_secs,
+    )
+    .await
+    .expect("bulk PM book snapshot load failed");
+    eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
+
     let deribit_snapshots =
         load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
     eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
@@ -184,9 +195,10 @@ async fn main() {
         return;
     }
 
-    let report = walk_forward_factors_v2_with_deribit(
+    let report = walk_forward_factors_v2_with_deribit_and_pm_books(
         &observations,
         &deribit_snapshots,
+        &all_pm_book_snapshots,
         start,
         end,
         options.clone(),

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -198,6 +198,22 @@ pub struct ResearchLobSnapshot {
     pub ask_depth_inner: f64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResearchPmBookLevel {
+    pub price: f64,
+    pub size: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResearchPmBookSnapshot {
+    pub event_id: String,
+    pub token_id: String,
+    pub side: String,
+    pub ts: DateTime<Utc>,
+    pub bids: Vec<ResearchPmBookLevel>,
+    pub asks: Vec<ResearchPmBookLevel>,
+}
+
 #[derive(Clone, Default)]
 struct EventState {
     event_id: String,
@@ -766,6 +782,109 @@ pub async fn load_research_lob_snapshots_sampled(
             },
         )
         .collect())
+}
+
+#[cfg(feature = "db")]
+pub async fn load_research_pm_book_snapshots_sampled(
+    pool: &PgPool,
+    symbols: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_every_secs: i32,
+) -> Result<Vec<ResearchPmBookSnapshot>, sqlx::Error> {
+    let sample_every_secs = sample_every_secs.max(1);
+    let rows: Vec<(String, String, String, DateTime<Utc>, Value, Value)> = sqlx::query_as(
+        r#"
+        WITH token_map AS (
+            SELECT DISTINCT
+                m.market_slug,
+                trim(both '"' from token.value::text) AS token_id,
+                CASE token.ordinality WHEN 1 THEN 'UP' ELSE 'DOWN' END AS side
+            FROM pm_market_metadata m
+            CROSS JOIN LATERAL jsonb_array_elements(
+                (m.raw_market->'markets'->0->>'clobTokenIds')::jsonb
+            ) WITH ORDINALITY AS token(value, ordinality)
+            WHERE m.symbol = ANY($1)
+              AND m.end_time >= $2
+              AND m.start_time <= $3
+              AND m.raw_market->'markets'->0->'clobTokenIds' IS NOT NULL
+        ),
+        sampled AS (
+            SELECT DISTINCT ON (o.token_id, bucket)
+                t.market_slug,
+                t.token_id,
+                t.side,
+                o.received_at,
+                o.bids,
+                o.asks,
+                bucket
+            FROM (
+                SELECT
+                    token_id,
+                    received_at,
+                    bids,
+                    asks,
+                    to_timestamp(
+                        floor(EXTRACT(EPOCH FROM received_at) / $4::double precision) * $4
+                    ) AS bucket
+                FROM clob_orderbook_snapshots
+                WHERE received_at >= $2
+                  AND received_at <= $3
+            ) o
+            JOIN token_map t ON t.token_id = o.token_id
+            ORDER BY o.token_id, bucket, o.received_at DESC
+        )
+        SELECT market_slug, token_id, side, received_at, bids, asks
+        FROM sampled
+        ORDER BY received_at
+        "#,
+    )
+    .bind(symbols)
+    .bind(start)
+    .bind(end)
+    .bind(sample_every_secs)
+    .fetch_all(pool)
+    .await?;
+
+    eprintln!(
+        "pm book snapshot rows: {} (sample_every_secs={})",
+        rows.len(),
+        sample_every_secs
+    );
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(event_id, token_id, side, ts, bids, asks)| ResearchPmBookSnapshot {
+                event_id,
+                token_id,
+                side,
+                ts,
+                bids: book_levels_from_json(&bids, true),
+                asks: book_levels_from_json(&asks, false),
+            },
+        )
+        .collect())
+}
+
+#[cfg(feature = "db")]
+fn book_levels_from_json(levels: &Value, descending: bool) -> Vec<ResearchPmBookLevel> {
+    let mut out = levels
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(parse_depth_level)
+        .filter(|(price, size)| {
+            price.is_finite() && *price > 0.01 && *price < 0.99 && size.is_finite() && *size > 0.0
+        })
+        .map(|(price, size)| ResearchPmBookLevel { price, size })
+        .collect::<Vec<_>>();
+    if descending {
+        out.sort_by(|a, b| b.price.total_cmp(&a.price));
+    } else {
+        out.sort_by(|a, b| a.price.total_cmp(&b.price));
+    }
+    out
 }
 
 #[cfg(feature = "db")]
@@ -1675,11 +1794,7 @@ pub fn aggregate_factor_metrics(windows: &[Vec<FactorMetric>]) -> Vec<Aggregated
                     let std = (vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>()
                         / vals.len() as f64)
                         .sqrt();
-                    if std <= 1e-9 {
-                        None
-                    } else {
-                        Some(mean / std)
-                    }
+                    if std <= 1e-9 { None } else { Some(mean / std) }
                 }
             };
             AggregatedFactorMetric {
@@ -2146,11 +2261,7 @@ pub(crate) fn bucket_icir(bucketed: &[(i64, f64, f64)], min_points: usize) -> Op
                 return None;
             }
             let ic = spearman_ic(&xs, &ys);
-            if ic.is_finite() {
-                Some(ic)
-            } else {
-                None
-            }
+            if ic.is_finite() { Some(ic) } else { None }
         })
         .collect();
 
@@ -2191,9 +2302,8 @@ pub fn export_observations_parquet(
 #[cfg(test)]
 mod tests {
     use super::{
-        attach_future_pm_labels, build_factor_observations_with_lob,
+        FactorObservation, LabelField, attach_future_pm_labels, build_factor_observations_with_lob,
         build_task_grain_derived_artifacts_for_event_ids, pearson_ic, spearman_ic,
-        FactorObservation, LabelField,
     };
     use chrono::{TimeZone, Utc};
     use ploy_market_contracts::MarketUpdate;

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -3,10 +3,11 @@ use std::collections::{BTreeMap, HashMap};
 use chrono::{DateTime, Duration, Utc};
 use ploy_operator_contracts::Regime;
 
-use crate::factors::{FactorObservation, pearson_ic, spearman_ic};
+use crate::factors::{FactorObservation, ResearchPmBookSnapshot, pearson_ic, spearman_ic};
 
 const DEFAULT_STAKE_USD: f64 = 15.0;
 const DEFAULT_TOP_QUANTILE: f64 = 0.2;
+const PM_BOOK_MAX_AGE_SECS: i64 = 30;
 const EPS: f64 = 1e-9;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,8 +202,17 @@ pub struct FactorObservationV2 {
     pub exit_liquidity_usd: f64,
     pub liquidity_shortfall_usd: f64,
     pub slippage_to_fill_15u_bps: f64,
+    pub entry_sweep_avg_price_15u: f64,
+    pub exit_sweep_avg_price_15u: f64,
+    pub entry_sweep_shares_15u: f64,
+    pub exit_sweep_shares_15u: f64,
+    pub entry_sweep_levels_15u: f64,
+    pub exit_sweep_levels_15u: f64,
+    pub entry_sweep_slippage_bps: f64,
+    pub exit_sweep_slippage_bps: f64,
     pub roundtrip_cost_usd: f64,
     pub roundtrip_pnl_now_15u: Option<f64>,
+    pub roundtrip_pnl_now_full_depth_15u: Option<f64>,
 
     pub portfolio_stake_usd: f64,
     pub portfolio_event_exposure_usd: f64,
@@ -212,8 +222,11 @@ pub struct FactorObservationV2 {
 
     pub label_settlement_win: Option<f64>,
     pub label_executable_pnl_15u: Option<f64>,
+    pub label_full_depth_executable_pnl_15u: Option<f64>,
     pub label_executable_fillable: bool,
     pub label_exit_fillable: bool,
+    pub label_full_depth_entry_fillable: bool,
+    pub label_full_depth_exit_fillable: bool,
     pub label_future_exit_bid_change_30s: Option<f64>,
     pub label_future_exit_bid_change_60s: Option<f64>,
     pub label_future_exit_pnl_30s: Option<f64>,
@@ -239,11 +252,16 @@ pub struct DataHealthReport {
     pub exit_size_rows: usize,
     pub entry_fillable_rows: usize,
     pub exit_fillable_rows: usize,
+    pub entry_full_depth_fillable_rows: usize,
+    pub exit_full_depth_fillable_rows: usize,
     pub executable_pnl_rows: usize,
+    pub full_depth_executable_pnl_rows: usize,
     pub deribit_rows: usize,
     pub avg_pm_lag_secs: f64,
     pub avg_entry_capacity_ratio: f64,
     pub avg_exit_capacity_ratio: f64,
+    pub avg_entry_sweep_slippage_bps: f64,
+    pub avg_exit_sweep_slippage_bps: f64,
 }
 
 impl DataHealthReport {
@@ -257,6 +275,14 @@ impl DataHealthReport {
 
     pub fn rejection_rate(&self) -> f64 {
         1.0 - self.entry_fill_rate()
+    }
+
+    pub fn full_depth_entry_fill_rate(&self) -> f64 {
+        ratio(self.entry_full_depth_fillable_rows, self.v2_rows)
+    }
+
+    pub fn full_depth_exit_fill_rate(&self) -> f64 {
+        ratio(self.exit_full_depth_fillable_rows, self.v2_rows)
     }
 }
 
@@ -800,11 +826,23 @@ pub fn build_factor_observations_v2_with_deribit(
     deribit: &[DeribitFeatureSnapshot],
     options: &FactorReviewOptions,
 ) -> Vec<FactorObservationV2> {
+    build_factor_observations_v2_with_deribit_and_pm_books(rows, deribit, &[], options)
+}
+
+pub fn build_factor_observations_v2_with_deribit_and_pm_books(
+    rows: &[FactorObservation],
+    deribit: &[DeribitFeatureSnapshot],
+    pm_books: &[ResearchPmBookSnapshot],
+    options: &FactorReviewOptions,
+) -> Vec<FactorObservationV2> {
     let stake_usd = options.stake_usd;
+    let book_index = build_pm_book_index(pm_books);
     let mut out = Vec::with_capacity(rows.len() * 2);
     for row in rows {
-        out.push(side_row(row, ReviewSide::Up, stake_usd));
-        out.push(side_row(row, ReviewSide::Down, stake_usd));
+        let up_book = latest_pm_book(&book_index, &row.event_id, ReviewSide::Up, row.tick_ts);
+        let down_book = latest_pm_book(&book_index, &row.event_id, ReviewSide::Down, row.tick_ts);
+        out.push(side_row(row, ReviewSide::Up, stake_usd, up_book));
+        out.push(side_row(row, ReviewSide::Down, stake_usd, down_book));
     }
     enrich_rolling_features(&mut out, deribit);
     out
@@ -1051,6 +1089,42 @@ pub fn factor_v2_descriptors() -> Vec<FactorV2Descriptor> {
             FactorFamily::PmLiquidity,
             ThreeLayerArchive::PmExecutableLiquidityRiskGate,
             |r| r.exit_bid_size,
+        ),
+        descriptor(
+            "entry_sweep_slippage_bps",
+            FactorFamily::Execution,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| r.entry_sweep_slippage_bps,
+        ),
+        descriptor(
+            "exit_sweep_slippage_bps",
+            FactorFamily::Execution,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| r.exit_sweep_slippage_bps,
+        ),
+        descriptor(
+            "entry_sweep_levels_15u",
+            FactorFamily::PmLiquidity,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| r.entry_sweep_levels_15u,
+        ),
+        descriptor(
+            "exit_sweep_levels_15u",
+            FactorFamily::PmLiquidity,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| r.exit_sweep_levels_15u,
+        ),
+        descriptor(
+            "entry_full_depth_fillable_15u",
+            FactorFamily::Execution,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| bool_num(r.label_full_depth_entry_fillable),
+        ),
+        descriptor(
+            "exit_full_depth_fillable_15u",
+            FactorFamily::Execution,
+            ThreeLayerArchive::PmExecutableLiquidityRiskGate,
+            |r| bool_num(r.label_full_depth_exit_fillable),
         ),
         descriptor(
             "up_down_ask_sum",
@@ -1333,13 +1407,30 @@ pub fn build_data_health_report(
             .filter(|row| row.label_executable_fillable)
             .count(),
         exit_fillable_rows: v2_rows.iter().filter(|row| row.label_exit_fillable).count(),
+        entry_full_depth_fillable_rows: v2_rows
+            .iter()
+            .filter(|row| row.label_full_depth_entry_fillable)
+            .count(),
+        exit_full_depth_fillable_rows: v2_rows
+            .iter()
+            .filter(|row| row.label_full_depth_exit_fillable)
+            .count(),
         executable_pnl_rows: v2_rows
             .iter()
             .filter(|row| row.label_executable_pnl_15u.is_some_and(f64::is_finite))
             .count(),
+        full_depth_executable_pnl_rows: v2_rows
+            .iter()
+            .filter(|row| {
+                row.label_full_depth_executable_pnl_15u
+                    .is_some_and(f64::is_finite)
+            })
+            .count(),
         avg_pm_lag_secs: mean(v2_rows.iter().map(|row| row.pm_lag_secs)),
         avg_entry_capacity_ratio: mean(v2_rows.iter().map(|row| row.entry_capacity_ratio)),
         avg_exit_capacity_ratio: mean(v2_rows.iter().map(|row| row.exit_capacity_ratio)),
+        avg_entry_sweep_slippage_bps: mean(v2_rows.iter().map(|row| row.entry_sweep_slippage_bps)),
+        avg_exit_sweep_slippage_bps: mean(v2_rows.iter().map(|row| row.exit_sweep_slippage_bps)),
         deribit_rows: v2_rows
             .iter()
             .filter(|row| row.deribit_mark_iv.is_finite())
@@ -1360,6 +1451,21 @@ pub fn review_factors_v2_with_deribit(
     options: FactorReviewOptions,
 ) -> FactorReviewV2Report {
     let v2_rows = build_factor_observations_v2_with_deribit(source_rows, deribit, &options);
+    review_factor_rows(source_rows, &v2_rows, options)
+}
+
+pub fn review_factors_v2_with_deribit_and_pm_books(
+    source_rows: &[FactorObservation],
+    deribit: &[DeribitFeatureSnapshot],
+    pm_books: &[ResearchPmBookSnapshot],
+    options: FactorReviewOptions,
+) -> FactorReviewV2Report {
+    let v2_rows = build_factor_observations_v2_with_deribit_and_pm_books(
+        source_rows,
+        deribit,
+        pm_books,
+        &options,
+    );
     review_factor_rows(source_rows, &v2_rows, options)
 }
 
@@ -1423,6 +1529,23 @@ pub fn walk_forward_factors_v2_with_deribit(
 ) -> FactorWalkForwardReport {
     let mut v2_rows =
         build_factor_observations_v2_with_deribit(source_rows, deribit, &options.review);
+    walk_forward_factor_rows(source_rows, &mut v2_rows, start, end, options)
+}
+
+pub fn walk_forward_factors_v2_with_deribit_and_pm_books(
+    source_rows: &[FactorObservation],
+    deribit: &[DeribitFeatureSnapshot],
+    pm_books: &[ResearchPmBookSnapshot],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    options: FactorWalkForwardOptions,
+) -> FactorWalkForwardReport {
+    let mut v2_rows = build_factor_observations_v2_with_deribit_and_pm_books(
+        source_rows,
+        deribit,
+        pm_books,
+        &options.review,
+    );
     walk_forward_factor_rows(source_rows, &mut v2_rows, start, end, options)
 }
 
@@ -2597,6 +2720,14 @@ pub fn format_factor_review_v2_report(report: &FactorReviewV2Report, top_n: usiz
         report.health.avg_pm_lag_secs,
     ));
     out.push_str(&format!(
+        "full_depth_entry_fill_rate={:.2}% full_depth_exit_fill_rate={:.2}% full_depth_pnl_rows={} avg_entry_sweep_slip_bps={:.2} avg_exit_sweep_slip_bps={:.2}\n",
+        report.health.full_depth_entry_fill_rate() * 100.0,
+        report.health.full_depth_exit_fill_rate() * 100.0,
+        report.health.full_depth_executable_pnl_rows,
+        report.health.avg_entry_sweep_slippage_bps,
+        report.health.avg_exit_sweep_slippage_bps,
+    ));
+    out.push_str(&format!(
         "stake_usd={:.2} top_quantile={:.2} min_observations={}\n\n",
         report.options.stake_usd, report.options.top_quantile, report.options.min_observations,
     ));
@@ -2827,7 +2958,22 @@ fn trade_formation_path(row: &FactorObservationV2) -> String {
 }
 
 fn executable_pnl(row: &FactorObservationV2) -> Option<f64> {
-    row.label_executable_pnl_15u.filter(|pnl| pnl.is_finite())
+    row.label_full_depth_executable_pnl_15u
+        .or(row.label_executable_pnl_15u)
+        .filter(|pnl| pnl.is_finite())
+}
+
+fn entry_fillable(row: &FactorObservationV2) -> bool {
+    row.label_full_depth_entry_fillable || row.label_executable_fillable
+}
+
+fn exit_fillable(row: &FactorObservationV2) -> bool {
+    row.label_full_depth_exit_fillable || row.label_exit_fillable
+}
+
+fn roundtrip_fillable(row: &FactorObservationV2) -> bool {
+    (row.label_full_depth_entry_fillable && row.label_full_depth_exit_fillable)
+        || (row.label_executable_fillable && row.label_exit_fillable)
 }
 
 fn direction_bin(row: &FactorObservationV2) -> &'static str {
@@ -3048,19 +3194,12 @@ fn build_fillability_bucket_row(
     total_rows: usize,
     options: &FillabilityReviewOptions,
 ) -> FillabilityBucketRow {
-    let entry_filled = rows
-        .iter()
-        .filter(|row| row.label_executable_fillable)
-        .count();
-    let exit_filled = rows.iter().filter(|row| row.label_exit_fillable).count();
-    let roundtrip_filled = rows
-        .iter()
-        .filter(|row| row.label_executable_fillable && row.label_exit_fillable)
-        .count();
+    let entry_filled = rows.iter().filter(|row| entry_fillable(row)).count();
+    let exit_filled = rows.iter().filter(|row| exit_fillable(row)).count();
+    let roundtrip_filled = rows.iter().filter(|row| roundtrip_fillable(row)).count();
     let executable_pnls = rows
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u)
-        .filter(|pnl| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row))
         .collect::<Vec<_>>();
     let total_executable_pnl_after_cost = executable_pnls.iter().sum::<f64>();
     let entry_fill_rate = ratio(entry_filled, rows.len());
@@ -3165,12 +3304,11 @@ fn selection_metrics_for_rows(
     let filled = selected
         .iter()
         .copied()
-        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .filter(|row| executable_pnl(row).is_some())
         .collect::<Vec<_>>();
     let pnls = filled
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
-        .filter(|(_, pnl)| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row).map(|pnl| (row.tick_ts, pnl)))
         .collect::<Vec<_>>();
     let pnl_values = pnls.iter().map(|(_, pnl)| *pnl).collect::<Vec<_>>();
     let total_pnl = pnl_values.iter().sum::<f64>();
@@ -3179,10 +3317,7 @@ fn selection_metrics_for_rows(
         selected_n: selected.len(),
         executable_fill_rate: ratio(filled.len(), selected.len()),
         rejection_rate: ratio(
-            selected
-                .iter()
-                .filter(|row| !row.label_executable_fillable)
-                .count(),
+            selected.iter().filter(|row| !entry_fillable(row)).count(),
             selected.len(),
         ),
         total_pnl_after_cost: total_pnl,
@@ -3409,7 +3544,7 @@ fn fit_combo_component(
     }
     let executable_pairs: Vec<(f64, f64)> = scored
         .iter()
-        .filter_map(|(row, score)| row.label_executable_pnl_15u.map(|label| (*score, label)))
+        .filter_map(|(row, score)| executable_pnl(row).map(|label| (*score, label)))
         .filter(|(score, label)| score.is_finite() && label.is_finite())
         .collect();
     if executable_pairs.len() < min_observations {
@@ -3460,12 +3595,11 @@ fn evaluate_combo_v1_threshold(
     let filled: Vec<&FactorObservationV2> = selected
         .iter()
         .copied()
-        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .filter(|row| executable_pnl(row).is_some())
         .collect();
     let pnls: Vec<(DateTime<Utc>, f64)> = filled
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
-        .filter(|(_, pnl)| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row).map(|pnl| (row.tick_ts, pnl)))
         .collect();
     let pnl_values: Vec<f64> = pnls.iter().map(|(_, pnl)| *pnl).collect();
     let total_pnl = pnl_values.iter().sum::<f64>();
@@ -3474,10 +3608,7 @@ fn evaluate_combo_v1_threshold(
         selected_n: selected.len(),
         executable_fill_rate: ratio(filled.len(), selected.len()),
         rejection_rate: ratio(
-            selected
-                .iter()
-                .filter(|row| !row.label_executable_fillable)
-                .count(),
+            selected.iter().filter(|row| !entry_fillable(row)).count(),
             selected.len(),
         ),
         total_pnl_after_cost: total_pnl,
@@ -3576,12 +3707,11 @@ fn evaluate_meta_label_rule(
     let filled = selected
         .iter()
         .copied()
-        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .filter(|row| executable_pnl(row).is_some())
         .collect::<Vec<_>>();
     let pnls = filled
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
-        .filter(|(_, pnl)| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row).map(|pnl| (row.tick_ts, pnl)))
         .collect::<Vec<_>>();
     let pnl_values = pnls.iter().map(|(_, pnl)| *pnl).collect::<Vec<_>>();
     let total_pnl = pnl_values.iter().sum::<f64>();
@@ -3591,10 +3721,7 @@ fn evaluate_meta_label_rule(
         selected_n: selected.len(),
         executable_fill_rate: ratio(filled.len(), selected.len()),
         rejection_rate: ratio(
-            selected
-                .iter()
-                .filter(|row| !row.label_executable_fillable)
-                .count(),
+            selected.iter().filter(|row| !entry_fillable(row)).count(),
             selected.len(),
         ),
         total_pnl_after_cost: total_pnl,
@@ -3789,7 +3916,7 @@ fn fit_walk_forward_factor(
         .collect();
     let executable_pairs: Vec<(f64, f64)> = scored
         .iter()
-        .filter_map(|(row, score)| row.label_executable_pnl_15u.map(|label| (*score, label)))
+        .filter_map(|(row, score)| executable_pnl(row).map(|label| (*score, label)))
         .filter(|(score, label)| score.is_finite() && label.is_finite())
         .collect();
     let train_settlement_rank_ic = pair_spearman(&settlement_pairs);
@@ -3890,12 +4017,11 @@ fn evaluate_factor_threshold(
     let filled: Vec<&FactorObservationV2> = selected
         .iter()
         .copied()
-        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .filter(|row| executable_pnl(row).is_some())
         .collect();
     let pnls: Vec<(DateTime<Utc>, f64)> = filled
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
-        .filter(|(_, pnl)| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row).map(|pnl| (row.tick_ts, pnl)))
         .collect();
     let pnl_values: Vec<f64> = pnls.iter().map(|(_, pnl)| *pnl).collect();
     let total_pnl = pnl_values.iter().sum::<f64>();
@@ -3904,10 +4030,7 @@ fn evaluate_factor_threshold(
         selected_n: selected.len(),
         executable_fill_rate: ratio(filled.len(), selected.len()),
         rejection_rate: ratio(
-            selected
-                .iter()
-                .filter(|row| !row.label_executable_fillable)
-                .count(),
+            selected.iter().filter(|row| !entry_fillable(row)).count(),
             selected.len(),
         ),
         total_pnl_after_cost: total_pnl,
@@ -4002,11 +4125,7 @@ fn review_one_factor(
         .collect();
     let executable_pairs: Vec<(f64, f64)> = scored
         .iter()
-        .filter_map(|(idx, score)| {
-            rows[*idx]
-                .label_executable_pnl_15u
-                .map(|label| (*score, label))
-        })
+        .filter_map(|(idx, score)| executable_pnl(&rows[*idx]).map(|label| (*score, label)))
         .filter(|(score, label)| score.is_finite() && label.is_finite())
         .collect();
 
@@ -4044,12 +4163,11 @@ fn review_one_factor(
     let filled: Vec<&FactorObservationV2> = selected
         .iter()
         .copied()
-        .filter(|row| row.label_executable_pnl_15u.is_some())
+        .filter(|row| executable_pnl(row).is_some())
         .collect();
     let pnls: Vec<(DateTime<Utc>, f64)> = filled
         .iter()
-        .filter_map(|row| row.label_executable_pnl_15u.map(|pnl| (row.tick_ts, pnl)))
-        .filter(|(_, pnl)| pnl.is_finite())
+        .filter_map(|row| executable_pnl(row).map(|pnl| (row.tick_ts, pnl)))
         .collect();
     let pnl_values: Vec<f64> = pnls.iter().map(|(_, pnl)| *pnl).collect();
     let total_pnl = pnl_values.iter().sum::<f64>();
@@ -4066,10 +4184,7 @@ fn review_one_factor(
         executable_pnl_rank_ic,
         selected_n: selected.len(),
         selected_rejection_rate: ratio(
-            selected
-                .iter()
-                .filter(|row| !row.label_executable_fillable)
-                .count(),
+            selected.iter().filter(|row| !entry_fillable(row)).count(),
             selected.len(),
         ),
         selected_executable_fill_rate: ratio(filled.len(), selected.len()),
@@ -4089,7 +4204,150 @@ fn review_one_factor(
     })
 }
 
-fn side_row(row: &FactorObservation, side: ReviewSide, stake_usd: f64) -> FactorObservationV2 {
+type PmBookIndex<'a> = HashMap<(String, String), Vec<&'a ResearchPmBookSnapshot>>;
+
+#[derive(Debug, Clone, Copy)]
+struct SweepFill {
+    fillable: bool,
+    avg_price: f64,
+    shares: f64,
+    levels_used: f64,
+    slippage_bps: f64,
+}
+
+impl Default for SweepFill {
+    fn default() -> Self {
+        Self {
+            fillable: false,
+            avg_price: f64::NAN,
+            shares: f64::NAN,
+            levels_used: f64::NAN,
+            slippage_bps: f64::NAN,
+        }
+    }
+}
+
+fn build_pm_book_index(pm_books: &[ResearchPmBookSnapshot]) -> PmBookIndex<'_> {
+    let mut index: PmBookIndex<'_> = HashMap::new();
+    for book in pm_books {
+        index
+            .entry((book.event_id.clone(), book.side.to_ascii_uppercase()))
+            .or_default()
+            .push(book);
+    }
+    for books in index.values_mut() {
+        books.sort_by_key(|book| book.ts);
+    }
+    index
+}
+
+fn latest_pm_book<'a>(
+    index: &'a PmBookIndex<'a>,
+    event_id: &str,
+    side: ReviewSide,
+    tick_ts: DateTime<Utc>,
+) -> Option<&'a ResearchPmBookSnapshot> {
+    let key = (event_id.to_string(), book_side_key(side).to_string());
+    let books = index.get(&key)?;
+    let pos = books.partition_point(|book| book.ts <= tick_ts);
+    let book = *books.get(pos.checked_sub(1)?)?;
+    let age_secs = (tick_ts - book.ts).num_seconds();
+    (age_secs >= 0 && age_secs <= PM_BOOK_MAX_AGE_SECS).then_some(book)
+}
+
+fn book_side_key(side: ReviewSide) -> &'static str {
+    match side {
+        ReviewSide::Up => "UP",
+        ReviewSide::Down => "DOWN",
+    }
+}
+
+fn sweep_buy_to_stake(
+    levels: &[crate::factors::ResearchPmBookLevel],
+    reference_price: f64,
+    stake_usd: f64,
+) -> SweepFill {
+    if !valid_price(reference_price) || !stake_usd.is_finite() || stake_usd <= 0.0 {
+        return SweepFill::default();
+    }
+    let mut remaining = stake_usd;
+    let mut spent = 0.0;
+    let mut shares = 0.0;
+    let mut levels_used = 0.0;
+    for level in levels
+        .iter()
+        .filter(|level| valid_price(level.price) && level.size.is_finite() && level.size > 0.0)
+    {
+        if remaining <= EPS {
+            break;
+        }
+        let level_notional = level.price * level.size;
+        let take_notional = remaining.min(level_notional);
+        if take_notional <= EPS {
+            continue;
+        }
+        spent += take_notional;
+        shares += take_notional / level.price;
+        remaining -= take_notional;
+        levels_used += 1.0;
+    }
+    if remaining > EPS || shares <= EPS {
+        return SweepFill::default();
+    }
+    let avg_price = spent / shares;
+    SweepFill {
+        fillable: true,
+        avg_price,
+        shares,
+        levels_used,
+        slippage_bps: ((avg_price - reference_price).max(0.0) / reference_price) * 10_000.0,
+    }
+}
+
+fn sweep_sell_shares(
+    levels: &[crate::factors::ResearchPmBookLevel],
+    reference_price: f64,
+    shares_to_sell: f64,
+) -> SweepFill {
+    if !valid_price(reference_price) || !shares_to_sell.is_finite() || shares_to_sell <= 0.0 {
+        return SweepFill::default();
+    }
+    let mut remaining = shares_to_sell;
+    let mut proceeds = 0.0;
+    let mut sold = 0.0;
+    let mut levels_used = 0.0;
+    for level in levels
+        .iter()
+        .filter(|level| valid_price(level.price) && level.size.is_finite() && level.size > 0.0)
+    {
+        if remaining <= EPS {
+            break;
+        }
+        let take_shares = remaining.min(level.size);
+        proceeds += take_shares * level.price;
+        sold += take_shares;
+        remaining -= take_shares;
+        levels_used += 1.0;
+    }
+    if remaining > EPS || sold <= EPS {
+        return SweepFill::default();
+    }
+    let avg_price = proceeds / sold;
+    SweepFill {
+        fillable: true,
+        avg_price,
+        shares: sold,
+        levels_used,
+        slippage_bps: ((reference_price - avg_price).max(0.0) / reference_price) * 10_000.0,
+    }
+}
+
+fn side_row(
+    row: &FactorObservation,
+    side: ReviewSide,
+    stake_usd: f64,
+    pm_book: Option<&ResearchPmBookSnapshot>,
+) -> FactorObservationV2 {
     let (
         side_model_prob,
         side_fair_prob,
@@ -4190,12 +4448,39 @@ fn side_row(row: &FactorObservation, side: ReviewSide, stake_usd: f64) -> Factor
     } else {
         f64::NAN
     };
-    let slippage_to_fill_15u_bps = if entry_fillable { 0.0 } else { f64::NAN };
+    let entry_sweep = pm_book
+        .map(|book| sweep_buy_to_stake(&book.asks, entry_ask, stake_usd))
+        .unwrap_or_default();
+    let exit_sweep = if entry_sweep.fillable {
+        pm_book
+            .map(|book| sweep_sell_shares(&book.bids, exit_bid, entry_sweep.shares))
+            .unwrap_or_default()
+    } else {
+        SweepFill::default()
+    };
+    let slippage_to_fill_15u_bps = if entry_sweep.fillable {
+        entry_sweep.slippage_bps
+    } else if entry_fillable {
+        0.0
+    } else {
+        f64::NAN
+    };
     let roundtrip_pnl_now_15u = if entry_fillable && exit_fillable && valid_price(exit_bid) {
         Some(entry_shares * exit_bid - stake_usd - entry_fee_usd)
     } else {
         None
     };
+    let full_depth_entry_fee_usd = if entry_sweep.fillable && valid_price(entry_sweep.avg_price) {
+        entry_sweep.shares * crypto_fee_cost(entry_sweep.avg_price)
+    } else {
+        f64::NAN
+    };
+    let roundtrip_pnl_now_full_depth_15u =
+        if entry_sweep.fillable && exit_sweep.fillable && full_depth_entry_fee_usd.is_finite() {
+            Some(entry_sweep.shares * exit_sweep.avg_price - stake_usd - full_depth_entry_fee_usd)
+        } else {
+            None
+        };
     let roundtrip_cost_usd = if let Some(pnl) = roundtrip_pnl_now_15u {
         -pnl
     } else if valid_price(entry_ask) && valid_price(exit_bid) && entry_shares.is_finite() {
@@ -4208,6 +4493,18 @@ fn side_row(row: &FactorObservation, side: ReviewSide, stake_usd: f64) -> Factor
             stake_usd * (1.0 / entry_ask - 1.0) - stake_usd * fee_per_share / entry_ask
         } else {
             -stake_usd - stake_usd * fee_per_share / entry_ask
+        })
+    } else {
+        None
+    };
+    let full_depth_executable_pnl = if entry_sweep.fillable
+        && settlement_win.is_finite()
+        && full_depth_entry_fee_usd.is_finite()
+    {
+        Some(if settlement_win >= 0.5 {
+            entry_sweep.shares - stake_usd - full_depth_entry_fee_usd
+        } else {
+            -stake_usd - full_depth_entry_fee_usd
         })
     } else {
         None
@@ -4332,8 +4629,17 @@ fn side_row(row: &FactorObservation, side: ReviewSide, stake_usd: f64) -> Factor
         exit_liquidity_usd,
         liquidity_shortfall_usd,
         slippage_to_fill_15u_bps,
+        entry_sweep_avg_price_15u: entry_sweep.avg_price,
+        exit_sweep_avg_price_15u: exit_sweep.avg_price,
+        entry_sweep_shares_15u: entry_sweep.shares,
+        exit_sweep_shares_15u: exit_sweep.shares,
+        entry_sweep_levels_15u: entry_sweep.levels_used,
+        exit_sweep_levels_15u: exit_sweep.levels_used,
+        entry_sweep_slippage_bps: entry_sweep.slippage_bps,
+        exit_sweep_slippage_bps: exit_sweep.slippage_bps,
         roundtrip_cost_usd,
         roundtrip_pnl_now_15u,
+        roundtrip_pnl_now_full_depth_15u,
         portfolio_stake_usd: stake_usd,
         portfolio_event_exposure_usd: stake_usd,
         same_event_observation_count: f64::NAN,
@@ -4341,8 +4647,11 @@ fn side_row(row: &FactorObservation, side: ReviewSide, stake_usd: f64) -> Factor
         side_is_up: bool_num(side == ReviewSide::Up),
         label_settlement_win: settlement_win.is_finite().then_some(settlement_win),
         label_executable_pnl_15u: executable_pnl,
+        label_full_depth_executable_pnl_15u: full_depth_executable_pnl,
         label_executable_fillable: entry_fillable,
         label_exit_fillable: exit_fillable,
+        label_full_depth_entry_fillable: entry_sweep.fillable,
+        label_full_depth_exit_fillable: exit_sweep.fillable,
         label_future_exit_bid_change_30s: None,
         label_future_exit_bid_change_60s: None,
         label_future_exit_pnl_30s: None,
@@ -4756,10 +5065,8 @@ where
 {
     let mut groups: BTreeMap<String, f64> = BTreeMap::new();
     for row in rows {
-        if let Some(pnl) = row.label_executable_pnl_15u {
-            if pnl.is_finite() {
-                *groups.entry(key_fn(row)).or_default() += pnl;
-            }
+        if let Some(pnl) = executable_pnl(row) {
+            *groups.entry(key_fn(row)).or_default() += pnl;
         }
     }
     if groups.is_empty() {
@@ -4963,6 +5270,50 @@ mod tests {
         assert_eq!(health.entry_fillable_rows, 0);
         assert_eq!(health.executable_pnl_rows, 0);
         assert!((health.rejection_rate() - 1.0).abs() < EPS);
+    }
+
+    #[test]
+    fn full_depth_sweep_labels_cross_multiple_pm_levels_without_changing_top_book_label() {
+        let mut obs = base_obs();
+        obs.pm_up_ask_size = 10.0;
+        obs.pm_down_ask_size = 10.0;
+        let ts = obs.tick_ts;
+        let books = vec![ResearchPmBookSnapshot {
+            event_id: "evt".into(),
+            token_id: "up-token".into(),
+            side: "UP".into(),
+            ts,
+            bids: vec![crate::factors::ResearchPmBookLevel {
+                price: 0.49,
+                size: 40.0,
+            }],
+            asks: vec![
+                crate::factors::ResearchPmBookLevel {
+                    price: 0.50,
+                    size: 10.0,
+                },
+                crate::factors::ResearchPmBookLevel {
+                    price: 0.51,
+                    size: 25.0,
+                },
+            ],
+        }];
+
+        let rows = build_factor_observations_v2_with_deribit_and_pm_books(
+            &[obs],
+            &[],
+            &books,
+            &FactorReviewOptions::default(),
+        );
+        let up = rows.iter().find(|row| row.side == ReviewSide::Up).unwrap();
+
+        assert!(!up.label_executable_fillable);
+        assert!(up.label_full_depth_entry_fillable);
+        assert!(up.label_full_depth_exit_fillable);
+        assert!(up.label_executable_pnl_15u.is_none());
+        assert!(up.label_full_depth_executable_pnl_15u.unwrap() > 0.0);
+        assert_eq!(up.entry_sweep_levels_15u, 2.0);
+        assert!(up.entry_sweep_slippage_bps > 0.0);
     }
 
     #[test]
@@ -5351,11 +5702,16 @@ mod tests {
                 exit_size_rows: 0,
                 entry_fillable_rows: 0,
                 exit_fillable_rows: 0,
+                entry_full_depth_fillable_rows: 0,
+                exit_full_depth_fillable_rows: 0,
                 executable_pnl_rows: 0,
+                full_depth_executable_pnl_rows: 0,
                 deribit_rows: 0,
                 avg_pm_lag_secs: f64::NAN,
                 avg_entry_capacity_ratio: f64::NAN,
                 avg_exit_capacity_ratio: f64::NAN,
+                avg_entry_sweep_slippage_bps: f64::NAN,
+                avg_exit_sweep_slippage_bps: f64::NAN,
             },
             windows: vec![FactorWalkForwardWindow {
                 window_index: 0,
@@ -5449,11 +5805,16 @@ mod tests {
                 exit_size_rows: 0,
                 entry_fillable_rows: 0,
                 exit_fillable_rows: 0,
+                entry_full_depth_fillable_rows: 0,
+                exit_full_depth_fillable_rows: 0,
                 executable_pnl_rows: 0,
+                full_depth_executable_pnl_rows: 0,
                 deribit_rows: 0,
                 avg_pm_lag_secs: f64::NAN,
                 avg_entry_capacity_ratio: f64::NAN,
                 avg_exit_capacity_ratio: f64::NAN,
+                avg_entry_sweep_slippage_bps: f64::NAN,
+                avg_exit_sweep_slippage_bps: f64::NAN,
             },
             windows,
             aggregates: Vec::new(),

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -42,14 +42,17 @@ pub use event_ml::{
 };
 pub use factors::{
     AggregatedFactorMetric, EventFactorSummary, FactorMetric, FactorObservation,
-    ResearchLobSnapshot, aggregate_factor_metrics, build_event_summaries,
-    build_factor_observations, build_factor_observations_with_lob,
+    ResearchLobSnapshot, ResearchPmBookLevel, ResearchPmBookSnapshot, aggregate_factor_metrics,
+    build_event_summaries, build_factor_observations, build_factor_observations_with_lob,
     build_factor_observations_with_lob_sampled, factor_metrics,
 };
 #[cfg(feature = "polars-export")]
 pub use factors::{export_observations_parquet, observations_to_frame};
 #[cfg(feature = "db")]
-pub use factors::{load_research_lob_snapshots, load_research_lob_snapshots_sampled};
+pub use factors::{
+    load_research_lob_snapshots, load_research_lob_snapshots_sampled,
+    load_research_pm_book_snapshots_sampled,
+};
 pub use replay::replay_fills;
 
 pub const CRATE_MARKER: &str = "ploy-research";
@@ -82,15 +85,17 @@ pub use factors_v2::{
     MetaLabelWalkForwardWindow, ReviewSide, SingleFactorReview, ThreeLayerArchive,
     TradeFormationPathRow, TradeFormationReviewOptions, TradeFormationReviewReport,
     TradeFormationRuleRow, build_data_health_report, build_factor_observations_v2,
-    build_factor_observations_v2_with_deribit, build_factor_stability_report,
+    build_factor_observations_v2_with_deribit,
+    build_factor_observations_v2_with_deribit_and_pm_books, build_factor_stability_report,
     factor_v2_descriptors, format_factor_combo_v1_report, format_factor_review_v2_report,
     format_factor_stability_report, format_factor_walk_forward_v2_report,
     format_fillability_review_v1_report, format_liquidity_gate_v1_report,
     format_liquidity_gated_alpha_v1_report, format_meta_label_walk_forward_v1_report,
     format_trade_formation_v1_report, liquidity_gate_v1_with_deribit,
     liquidity_gated_alpha_v1_with_deribit, review_factors_v2, review_factors_v2_with_deribit,
-    review_fillability_v1_with_deribit, review_trade_formation_v1_with_deribit,
-    walk_forward_factor_combo_v1_with_deribit, walk_forward_factors_v2_with_deribit,
+    review_factors_v2_with_deribit_and_pm_books, review_fillability_v1_with_deribit,
+    review_trade_formation_v1_with_deribit, walk_forward_factor_combo_v1_with_deribit,
+    walk_forward_factors_v2_with_deribit, walk_forward_factors_v2_with_deribit_and_pm_books,
     walk_forward_meta_label_v1_with_deribit,
 };
 #[cfg(feature = "rl")]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9785,3 +9785,34 @@ Review:
 - 2026-04-27: Added `collector_data_utilization`, a DB-backed research report that separates collector freshness from Factor V2 utilization. A small Tango read-only window (`2026-04-27T09:45:00Z..10:05:00Z`) reported fresh Binance spot/aggTrade/LOB, fresh PM quotes/snapshots, fresh Deribit IV, zero current `clob_trade_ticks`, and stale/unusable Deribit Greeks.
 - 2026-04-27: Fixed base factor observation generation so a fresh DOWN quote can produce an observation even when the UP ask is stale; stale side values are now represented as `NaN` instead of dropping the whole event.
 - 2026-04-27: Added `collect-pm-trades`, which reads active crypto market `conditionId` from `pm_market_catalog`, polls Polymarket Data API `/trades`, and persists de-duplicated prints to `clob_trade_ticks`. Added `ploy-pm-trade-collector.service` and deploy/healthcheck wiring so the service can start after the next main deploy.
+
+# PM5D Full-Depth Execution Labels (2026-04-27)
+
+## Files
+
+- `crates/ploy-research/src/factors.rs`
+  - Owner: DB-backed PM full-depth snapshot loader
+- `crates/ploy-research/src/factors_v2.rs`
+  - Owner: Factor V2 full-depth sweep labels and descriptors
+- `crates/ploy-research/examples/factor_review_v2.rs`
+  - Owner: single-factor review CLI wiring
+- `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+  - Owner: walk-forward CLI wiring
+- `crates/ploy-research/examples/collector_data_utilization.rs`
+  - Owner: data-utilization report wiring
+- `crates/ploy-research/src/lib.rs`
+  - Owner: public research API exports
+
+## Tasks
+
+- [x] Load point-in-time PM full-depth books from `clob_orderbook_snapshots` with bucket sampling and token/event side mapping.
+- [x] Add Factor V2 full-depth 15U sweep metrics: fillability, levels used, average fill price, entry/exit slippage, and full-depth executable PnL.
+- [x] Keep existing top-of-book executable labels as the live-parity baseline while making factor review and walk-forward prefer full-depth executable PnL when PM book data is present.
+- [x] Wire full-depth books into `factor_review_v2`, `factor_walk_forward_v2`, and `collector_data_utilization`.
+- [x] Add regression coverage for multi-level fillability that is rejected by top-of-book but fillable by full-depth sweep.
+- [x] Verify targeted lib tests, full `ploy-research` lib tests, DB example compile checks, and diff hygiene.
+
+## Review
+
+- 2026-04-27: Factor V2 now distinguishes live-parity top-of-book fillability from full-depth sweep fillability. Factor review and walk-forward use full-depth executable PnL when available, while still preserving the top-of-book labels for live-parity comparison.
+- 2026-04-27: Verification passed: `rtk cargo test -p ploy-research factors_v2 --lib`, `rtk cargo test -p ploy-research --lib`, `rtk cargo check -p ploy-research --features db --example factor_review_v2 --example factor_walk_forward_v2 --example collector_data_utilization`, and `rtk git diff --check`.


### PR DESCRIPTION
## Summary
- Load sampled point-in-time PM full-depth books from clob_orderbook_snapshots for research.
- Add Factor V2 15U full-depth sweep metrics: fillability, levels used, average fill price, slippage, and full-depth executable PnL.
- Wire factor_review_v2, factor_walk_forward_v2, and collector_data_utilization to prefer full-depth executable PnL when book data exists while preserving top-of-book live-parity labels.

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-execution rtk cargo test -p ploy-research --lib
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-execution rtk cargo check -p ploy-research --features db --example factor_review_v2 --example factor_walk_forward_v2 --example collector_data_utilization
- rtk git diff --check