### PR TITLE
Harden Rust release build hygiene

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - ploy-ci-1
+    - tango-1-1
+
+config-variables: null

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.91
           components: clippy, rustfmt
 
       - name: Install build dependencies

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Add cargo to PATH
-        run: echo "/home/runner/.cargo/bin" >> $GITHUB_PATH
+        run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -104,15 +104,17 @@ jobs:
 
       - name: Sync Parquet data from Tango-1-1
         if: ${{ github.event.inputs.data_dir != '' }}
+        env:
+          DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
           chmod 600 ~/.ssh/tango_key
-          mkdir -p ${{ github.event.inputs.data_dir }}
+          mkdir -p "${DATA_DIR}"
           rsync -az \
             -e "ssh -i ~/.ssh/tango_key -o StrictHostKeyChecking=no" \
             root@172.16.0.204:/opt/ploy/data/parquet/ \
-            ${{ github.event.inputs.data_dir }}/
+            "${DATA_DIR}/"
 
       - name: Run backtest
         env:
@@ -121,13 +123,13 @@ jobs:
           END_DATE: ${{ github.event.inputs.end_date }}
           DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
-          EXTRA_ARGS=""
+          extra_args=()
           if [ -n "$DATA_DIR" ]; then
-            EXTRA_ARGS="--data-dir $DATA_DIR"
+            extra_args=(--data-dir "$DATA_DIR")
           fi
           ./target/release/examples/run_backtest \
             --config "${CONFIG}" \
             --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --start-date "${START_DATE}" \
             --end-date "${END_DATE}" \
-            $EXTRA_ARGS
+            "${extra_args[@]}"

--- a/.github/workflows/build-push-acr.yml
+++ b/.github/workflows/build-push-acr.yml
@@ -14,6 +14,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  SCCACHE_CACHE_SIZE: 10G
+  TZ: UTC
+  LC_ALL: C
+  LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
   ACR_REGISTRY: registry.ap-northeast-1.aliyuncs.com
   ACR_NAMESPACE: ploy
@@ -30,20 +35,44 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
+      - name: Set reproducible build environment
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.91
           targets: ${{ env.PLATFORM_TARGET }}
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld
+          sudo apt-get install -y sccache || cargo install sccache --locked
+          sudo apt-get install -y mold || true
+
+      - name: Capture cache metadata
+        id: cache_meta
+        run: |
+          echo "rustc_version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: acr-build-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-
+            ${{ runner.os }}-sccache-acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
+            ${{ runner.os }}-sccache-acr-build-${{ env.PLATFORM_TARGET }}-release-
+            ${{ runner.os }}-sccache-acr-build-
+            ${{ runner.os }}-sccache-
 
       - name: Build ploy-runner
         run: |
@@ -61,9 +90,14 @@ jobs:
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
             -p ploy-research \
+            --features db,polars-export \
             --example factor_research
           strip "target/${PLATFORM_TARGET}/release/examples/run_backtest" || true
           strip "target/${PLATFORM_TARGET}/release/examples/factor_research" || true
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
       - name: Login to ACR
         if: ${{ github.event.inputs.push_images == 'true' }}
@@ -101,8 +135,10 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Build Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ploy-runner: built" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ploy-collector: built" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ploy-research: built" >> "$GITHUB_STEP_SUMMARY"
-          echo "- SHA: ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Build Summary"
+            echo "- ploy-runner: built"
+            echo "- ploy-collector: built"
+            echo "- ploy-research: built"
+            echo "- SHA: ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -7,6 +7,11 @@ on:
         description: "Git ref to deploy (branch, tag, or SHA)"
         required: true
         default: "main"
+      deploy:
+        description: "Push the built bundle to OSS and restart tango-1-1 services"
+        type: boolean
+        required: true
+        default: true
 
 concurrency:
   group: deploy-tango-1-1-${{ github.ref }}
@@ -18,6 +23,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  SCCACHE_CACHE_SIZE: 10G
+  TZ: UTC
+  LC_ALL: C
+  LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
   DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
   DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
@@ -50,15 +59,44 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
+      - name: Set reproducible build environment
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.91
           targets: ${{ env.PLATFORM_TARGET }}
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
+          sudo apt-get install -y sccache || cargo install sccache --locked
+          sudo apt-get install -y mold || true
+
+      - name: Capture cache metadata
+        id: cache_meta
+        run: |
+          echo "rustc_version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-
+            ${{ runner.os }}-sccache-deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
+            ${{ runner.os }}-sccache-deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-
+            ${{ runner.os }}-sccache-deploy-tango-1-1-
+            ${{ runner.os }}-sccache-
 
       - name: Build new-ploy-runner
         run: |
@@ -84,14 +122,19 @@ jobs:
             -p ploy-strategy-bundles --example optimize_backtest
           strip "target/${PLATFORM_TARGET}/release/examples/optimize_backtest" || true
 
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
       - name: Build deploy bundle
         run: |
+          set -euo pipefail
           rm -rf dist
           mkdir -p dist/bin dist/config/strategies dist/migrations dist/deployment/systemd dist/scripts
-          cp target/${PLATFORM_TARGET}/release/new-ployd dist/bin/ployd
-          cp target/${PLATFORM_TARGET}/release/new-ploy-runner dist/bin/ploy-runner
-          cp target/${PLATFORM_TARGET}/release/examples/factor_research dist/bin/factor-research
-          cp target/${PLATFORM_TARGET}/release/examples/optimize_backtest dist/bin/optimize-backtest
+          cp "target/${PLATFORM_TARGET}/release/new-ployd" dist/bin/ployd
+          cp "target/${PLATFORM_TARGET}/release/new-ploy-runner" dist/bin/ploy-runner
+          cp "target/${PLATFORM_TARGET}/release/examples/factor_research" dist/bin/factor-research
+          cp "target/${PLATFORM_TARGET}/release/examples/optimize_backtest" dist/bin/optimize-backtest
           cp config/strategies/02-pm5d.unified.toml dist/config/strategies/02-pm5d.unified.toml
           cp config/strategies/02-pm5d.live.toml dist/config/strategies/02-pm5d.live.toml
           cp config/strategies/02-pm5d-threelayer.unified.toml dist/config/strategies/02-pm5d-threelayer.unified.toml
@@ -112,10 +155,12 @@ jobs:
           cp deployment/systemd/ploy-binance-lob-collector.service dist/deployment/systemd/ploy-binance-lob-collector.service
           cp deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf dist/deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf
           cp deployment/systemd/ploy-quote-collector.hardening.conf dist/deployment/systemd/ploy-quote-collector.hardening.conf
-          tar -C dist -czf "${DEPLOY_BUNDLE_NAME}" .
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+            -C dist -cf - . | gzip -n > "${DEPLOY_BUNDLE_NAME}"
           sha256sum "${DEPLOY_BUNDLE_NAME}" > "${DEPLOY_BUNDLE_NAME}.sha256"
 
       - name: Validate OSS deploy secrets
+        if: ${{ inputs.deploy }}
         env:
           OSS_ACCESS_KEY_ID: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}
           OSS_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}
@@ -131,6 +176,7 @@ jobs:
           fi
 
       - name: Install ossutil
+        if: ${{ inputs.deploy }}
         run: |
           if ! command -v ossutil >/dev/null 2>&1; then
             curl -fsSL https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash
@@ -139,6 +185,7 @@ jobs:
           command -v ossutil >/dev/null 2>&1
 
       - name: Upload deploy bundle to OSS
+        if: ${{ inputs.deploy }}
         id: upload_bundle_to_oss
         env:
           OSS_ACCESS_KEY_ID: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}
@@ -164,6 +211,7 @@ jobs:
           echo "checksum_object=${checksum_object}" >> "${GITHUB_OUTPUT}"
 
       - name: Configure SSH for deploy
+        if: ${{ inputs.deploy }}
         run: |
           install -m 700 -d ~/.ssh
           printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
@@ -181,11 +229,15 @@ jobs:
           EOF
 
       - name: Prepare remote directories
+        if: ${{ inputs.deploy }}
         run: |
+          # shellcheck disable=SC2029
           ssh tango-1-1 "mkdir -p ${DEPLOY_ROOT}/bin ${DEPLOY_ROOT}/config/strategies ${DEPLOY_ROOT}/migrations ${DEPLOY_ROOT}/scripts ${DEPLOY_ROOT}/tmp"
 
       - name: Pull bundle from OSS and restart services
+        if: ${{ inputs.deploy }}
         run: |
+          # shellcheck disable=SC2087
           ssh tango-1-1 /bin/bash <<EOF
             set -euo pipefail
             DEPLOY_STARTED_AT=\$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -453,14 +505,17 @@ jobs:
           EOF
 
       - name: Deployment summary
+        if: ${{ inputs.deploy }}
         run: |
-          echo "## Deployment to tango-1-1" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Binary: \`ploy-runner\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Target: \`${{ secrets.TANGO_1_1_HOST }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Transport: \`GitHub Actions -> OSS -> ECS\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- OSS object: \`${{ steps.upload_bundle_to_oss.outputs.bundle_object }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Services: \`ployd\` (if installed), \`ploy-binance-aggtrade-collector\`, \`ploy-binance-price-collector\`, \`ploy-binance-lob-collector\`, \`ploy-deribit-iv-collector\`, \`ploy-quote-collector\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Migrations: \`${DEPLOY_MIGRATIONS}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Postgres pre/postflight: required" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Persistence guardrail: deployment fails if dry-run starts without DB-backed recorder" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deployment to tango-1-1"
+            echo "- Binary: \`ploy-runner\`"
+            echo "- Target: \`${{ secrets.TANGO_1_1_HOST }}\`"
+            echo "- Transport: \`GitHub Actions -> OSS -> ECS\`"
+            echo "- OSS object: \`${{ steps.upload_bundle_to_oss.outputs.bundle_object }}\`"
+            echo "- Services: \`ployd\` (if installed), \`ploy-binance-aggtrade-collector\`, \`ploy-binance-price-collector\`, \`ploy-binance-lob-collector\`, \`ploy-deribit-iv-collector\`, \`ploy-quote-collector\`"
+            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
+            echo "- Migrations: \`${DEPLOY_MIGRATIONS}\`"
+            echo "- Postgres pre/postflight: required"
+            echo "- Persistence guardrail: deployment fails if dry-run starts without DB-backed recorder"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -7,6 +7,11 @@ on:
         description: "Git ref to deploy (branch, tag, or SHA)"
         required: true
         default: "main"
+      deploy:
+        description: "Copy the built runner to ploy-trade-1 and restart services"
+        type: boolean
+        required: true
+        default: true
 
 concurrency:
   group: deploy-trade-1
@@ -17,6 +22,11 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  SCCACHE_CACHE_SIZE: 10G
+  TZ: UTC
+  LC_ALL: C
+  LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
   DEPLOY_HOST: ploy-trade-1
 
@@ -32,10 +42,27 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
+      - name: Set reproducible build environment
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.91
           targets: ${{ env.PLATFORM_TARGET }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
+          sudo apt-get install -y sccache || cargo install sccache --locked
+          sudo apt-get install -y mold || true
+
+      - name: Capture cache metadata
+        id: cache_meta
+        run: |
+          echo "rustc_version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -44,14 +71,23 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-trade-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
+            ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-
             ${{ runner.os }}-cargo-trade-
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-
+            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
+            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-
+            ${{ runner.os }}-sccache-deploy-trade-
+            ${{ runner.os }}-sccache-
 
       - name: Build new-ploy-runner
         run: |
@@ -59,8 +95,14 @@ jobs:
             --target "${PLATFORM_TARGET}" \
             -p new-ploy-runner
           strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
+          (cd "target/${PLATFORM_TARGET}/release" && sha256sum new-ploy-runner > new-ploy-runner.sha256)
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
       - name: Configure SSH
+        if: ${{ inputs.deploy }}
         run: |
           install -m 700 -d ~/.ssh
           printf '%s\n' '${{ secrets.PLOY_TRADE_1_SSH_KEY }}' > ~/.ssh/deploy_key
@@ -78,14 +120,17 @@ jobs:
           EOF
 
       - name: Deploy binary and configs
+        if: ${{ inputs.deploy }}
         run: |
+          RUNNER_SHA256="$(cut -d ' ' -f1 "target/${PLATFORM_TARGET}/release/new-ploy-runner.sha256")"
           scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" ploy-trade-1:/opt/ploy/bin/ploy-runner
           scp config/strategies/02-pm5d.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
           scp config/strategies/02-pm5d.live.toml ploy-trade-1:/opt/ploy/config/strategies/
           scp config/strategies/02-pm5d-threelayer.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
 
-          ssh ploy-trade-1 bash <<'REMOTE'
+          ssh ploy-trade-1 RUNNER_SHA256="${RUNNER_SHA256}" bash <<'REMOTE'
             set -euo pipefail
+            printf '%s  /opt/ploy/bin/ploy-runner\n' "${RUNNER_SHA256}" | sha256sum -c -
             chmod +x /opt/ploy/bin/ploy-runner
 
             systemctl daemon-reload
@@ -111,6 +156,7 @@ jobs:
           REMOTE
 
       - name: Verify deployment
+        if: ${{ inputs.deploy }}
         run: |
           ssh ploy-trade-1 bash <<'VERIFY'
             echo "=== Binary ==="
@@ -125,10 +171,13 @@ jobs:
           VERIFY
 
       - name: Deployment summary
+        if: ${{ inputs.deploy }}
         run: |
-          echo "## Deployment to ploy-trade-1" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Binary: \`ploy-runner\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Target: \`ploy-trade-1\` (\`${{ secrets.PLOY_TRADE_1_HOST }}\`)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Strategy configs: \`02-pm5d.unified.toml\`, \`02-pm5d.live.toml\`, \`02-pm5d-threelayer.unified.toml\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Services restarted: \`ployd\`, \`ploy-strategy-dryrun\` (if active)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Deployment to ploy-trade-1"
+            echo "- Binary: \`ploy-runner\`"
+            echo "- Target: \`ploy-trade-1\` (\`${{ secrets.PLOY_TRADE_1_HOST }}\`)"
+            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
+            echo "- Strategy configs: \`02-pm5d.unified.toml\`, \`02-pm5d.live.toml\`, \`02-pm5d-threelayer.unified.toml\`"
+            echo "- Services restarted: \`ployd\`, \`ploy-strategy-dryrun\` (if active)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/healthcheck-tango-1-1.yml
+++ b/.github/workflows/healthcheck-tango-1-1.yml
@@ -159,12 +159,14 @@ jobs:
 
       - name: Healthcheck summary
         run: |
-          echo "## tango-1-1 healthcheck" >> "$GITHUB_STEP_SUMMARY"
-          echo "- PostgreSQL must be active and queryable" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ployd, ploy-binance-aggtrade-collector, ploy-binance-price-collector, ploy-binance-lob-collector, ploy-deribit-iv-collector, and ploy-quote-collector must be active" >> "$GITHUB_STEP_SUMMARY"
-          echo "- systemd guardrails must remain configured on all checked services" >> "$GITHUB_STEP_SUMMARY"
-          echo "- binance_agg_trade_ticks must advance within the last 10 minutes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- binance_price_ticks must advance within the last 10 minutes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- binance_lob_ticks must advance within the last 15 minutes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- deribit_iv_ticks must advance within the last 15 minutes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ployd must not log degraded persistence messages in the last 15 minutes" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## tango-1-1 healthcheck"
+            echo "- PostgreSQL must be active and queryable"
+            echo "- ployd, ploy-binance-aggtrade-collector, ploy-binance-price-collector, ploy-binance-lob-collector, ploy-deribit-iv-collector, and ploy-quote-collector must be active"
+            echo "- systemd guardrails must remain configured on all checked services"
+            echo "- binance_agg_trade_ticks must advance within the last 10 minutes"
+            echo "- binance_price_ticks must advance within the last 10 minutes"
+            echo "- binance_lob_ticks must advance within the last 15 minutes"
+            echo "- deribit_iv_ticks must advance within the last 15 minutes"
+            echo "- ployd must not log degraded persistence messages in the last 15 minutes"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -104,7 +104,7 @@ jobs:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Add cargo to PATH
-        run: echo "/home/runner/.cargo/bin" >> $GITHUB_PATH
+        run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -7,6 +7,11 @@ on:
         description: "Git ref to release (branch, tag, or SHA)"
         required: true
         default: "main"
+      deploy:
+        description: "Deploy the built bundle after build verification"
+        type: boolean
+        required: true
+        default: true
 
 concurrency:
   group: release-platform-${{ github.ref }}
@@ -18,6 +23,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  SCCACHE_CACHE_SIZE: 10G
+  TZ: UTC
+  LC_ALL: C
+  LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
   DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
 
@@ -33,15 +42,44 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
+      - name: Set reproducible build environment
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.91
           targets: ${{ env.PLATFORM_TARGET }}
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld
+          sudo apt-get install -y sccache || cargo install sccache --locked
+          sudo apt-get install -y mold || true
+
+      - name: Capture cache metadata
+        id: cache_meta
+        run: |
+          echo "rustc_version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-
+            ${{ runner.os }}-sccache-release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
+            ${{ runner.os }}-sccache-release-platform-${{ env.PLATFORM_TARGET }}-release-
+            ${{ runner.os }}-sccache-release-platform-
+            ${{ runner.os }}-sccache-
 
       - name: Build platform binaries
         run: |
@@ -60,6 +98,7 @@ jobs:
 
       - name: Create platform bundle
         run: |
+          set -euo pipefail
           bundle_root="dist/platform-bundle"
           mkdir -p \
             "${bundle_root}/bin" \
@@ -77,18 +116,27 @@ jobs:
           install -m 755 scripts/drills/live_dry_run.sh "${bundle_root}/scripts/drills/live_dry_run.sh"
           install -m 644 config/deployments/example.live.dry-run.json "${bundle_root}/config/deployments/example.live.dry-run.json.sample"
           install -m 644 data/state/deployments.json.sample "${bundle_root}/data/state/deployments.json.sample"
-          tar czf dist/ploy-platform.tar.gz -C "${bundle_root}" .
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+            -C "${bundle_root}" -cf - . | gzip -n > dist/ploy-platform.tar.gz
+          (cd dist && sha256sum ploy-platform.tar.gz > ploy-platform.tar.gz.sha256)
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
       - name: Upload platform bundle
         uses: actions/upload-artifact@v4
         with:
           name: ploy-platform-bundle
-          path: dist/ploy-platform.tar.gz
+          path: |
+            dist/ploy-platform.tar.gz
+            dist/ploy-platform.tar.gz.sha256
           retention-days: 14
 
   deploy:
     name: Deploy platform bundle
     needs: build
+    if: ${{ inputs.deploy }}
     runs-on: ubuntu-latest
     environment: production
 
@@ -99,6 +147,9 @@ jobs:
           name: ploy-platform-bundle
           path: dist
 
+      - name: Verify platform bundle checksum
+        run: (cd dist && sha256sum -c ploy-platform.tar.gz.sha256)
+
       - name: Upload platform bundle to host
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -106,7 +157,7 @@ jobs:
           username: ${{ vars.EC2_USER || 'ec2-user' }}
           key: ${{ secrets.EC2_SSH_KEY }}
           fingerprint: ${{ secrets.EC2_HOST_FINGERPRINT || secrets.AWS_EC2_HOST_FINGERPRINT }}
-          source: dist/ploy-platform.tar.gz
+          source: dist/ploy-platform.tar.gz,dist/ploy-platform.tar.gz.sha256
           target: /tmp/
           strip_components: 1
 
@@ -125,6 +176,7 @@ jobs:
             WORKDIR="/tmp/ploy-platform"
             rm -rf "${WORKDIR}"
             mkdir -p "${WORKDIR}"
+            (cd /tmp && sha256sum -c ploy-platform.tar.gz.sha256)
             tar xzf /tmp/ploy-platform.tar.gz -C "${WORKDIR}"
 
             SUDO=""
@@ -163,7 +215,9 @@ jobs:
 
       - name: Deployment summary
         run: |
-          echo "## Platform Release" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Bundle: \`ployd + ployctl + ploytui\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Service: \`ployd.service\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Drill: \`/opt/ploy/scripts/drills/live_dry_run.sh\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Platform Release"
+            echo "- Bundle: \`ployd + ployctl + ploytui\`"
+            echo "- Service: \`ployd.service\`"
+            echo "- Drill: \`/opt/ploy/scripts/drills/live_dry_run.sh\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@cargo-audit
@@ -97,9 +99,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.91
           components: clippy, rustfmt
 
       - name: Install build dependencies
@@ -187,7 +189,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install build dependencies
         run: |
@@ -256,7 +260,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install build dependencies
         run: |
@@ -335,7 +341,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install build dependencies
         run: |
@@ -401,7 +409,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install build dependencies
         run: |
@@ -476,7 +486,9 @@ jobs:
             ploy-sidecar/package-lock.json
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -521,7 +533,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: Install build dependencies
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,10 +100,11 @@ rust_decimal.workspace = true
 
 [profile.release]
 lto = "thin"
-codegen-units = 4
+codegen-units = 1
 panic = "abort"
-strip = true
+strip = "symbols"
 opt-level = 2
+split-debuginfo = "packed"
 
 [profile.dev]
 debug = 1

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Runbooks:
 Default release workflow:
 
 - `.github/workflows/release-platform.yml`
+- Build-only verification: dispatch `release-platform.yml` with `deploy=false`
+  to build, package, checksum, and upload the bundle artifact without restarting
+  the remote service.
 
 Remote live-host acceptance path:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,9 @@ Guidelines for contributing to the Ploy Polymarket trading bot.
 
 ### Prerequisites
 
-- **Rust** (stable toolchain) -- install via [rustup](https://rustup.rs/)
+- **Rust** via [rustup](https://rustup.rs/). The repository pins the exact
+  toolchain in `rust-toolchain.toml`; run `rustup show active-toolchain` after
+  checkout to confirm your shell is using it.
 - **PostgreSQL 15+** -- used for event registry, position tracking, and audit logs
 - **pkg-config**, **libssl-dev**, **libpq-dev** (Linux) or equivalent (macOS: `brew install postgresql openssl`)
 - **Node.js 18+** (only if working on the NBA Swing frontend)
@@ -99,6 +101,10 @@ A separate release/deploy path can still build release artifacts, but the defaul
 The default platform deployment workflow is `.github/workflows/release-platform.yml`.
 Legacy single-binary workflows remain in `.github/workflows/`, but they are not
 the default release path for the workspace runtime.
+
+For build-only release verification without touching a remote host, dispatch
+`release-platform.yml` with `deploy=false`. The deploy workflows keep
+`deploy=true` as their default for the established operator path.
 
 ## Running Tests
 

--- a/docs/runbooks/platform-deploy.md
+++ b/docs/runbooks/platform-deploy.md
@@ -8,6 +8,10 @@ The workspace-default deploy path is:
 - Long-running systemd unit: `deployment/ployd.service`
 - Host install helper: `scripts/install-platform-service.sh`
 
+Use `deploy=false` when dispatching the workflow if you only want CI to build,
+package, checksum, and upload the platform bundle artifact without touching the
+remote host. The default `deploy=true` preserves the normal release path.
+
 This path deploys three binaries:
 
 - `/opt/ploy/bin/ployd`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.91"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Rust Release Build Hygiene (2026-04-27)
+
+## Files
+
+- `Cargo.toml`
+- `rust-toolchain.toml`
+- `.github/actionlint.yaml`
+- `.github/workflows/auto-review.yml`
+- `.github/workflows/backtest.yml`
+- `.github/workflows/test.yml`
+- `.github/workflows/release-platform.yml`
+- `.github/workflows/deploy-tango-1-1.yml`
+- `.github/workflows/deploy-trade.yml`
+- `.github/workflows/build-push-acr.yml`
+- `.github/workflows/healthcheck-tango-1-1.yml`
+- `.github/workflows/optimize.yml`
+- `docs/CONTRIBUTING.md`
+- `docs/runbooks/platform-deploy.md`
+- `README.md`
+
+## Tasks
+
+- [x] Tighten the release profile for shipped binaries without changing dev/fast iteration profiles.
+- [x] Enable release/deploy CI lanes to use the repo's `sccache` wrapper and fast linker path.
+- [x] Add deterministic build environment and artifact checksum checks where bundles/binaries are deployed.
+- [x] Verify workflow syntax and diff hygiene without running heavy local Rust builds.
+
+## Review
+
+- 2026-04-27: Release profile now keeps `thin` LTO but uses one codegen unit, symbol stripping, and packed split debuginfo for shipped binaries; dev and fast profiles remain optimized for iteration.
+- 2026-04-27: `release-platform`, `deploy-tango-1-1`, `deploy-trade`, and `build-push-acr` now install/cache `sccache`, try `mold` before falling back through the repo fast-linker, and set `SOURCE_DATE_EPOCH` from the checked-out commit time with UTC/C locale settings.
+- 2026-04-27: Platform and Tango deploy bundles now use deterministic tar/gzip flags (`--sort=name`, fixed `--mtime`, numeric owner/group, `gzip -n`) before SHA256 generation; platform upload verifies the checksum before deploy upload and again on the remote host, while direct trade deploy verifies the remote runner binary checksum after copy.
+- 2026-04-27: Release/deploy cache keys now include target, `release` profile, `rustc` version, `sccache` version for sccache caches, and `Cargo.lock` hash. This closes the main cache-hygiene gap from the original build checklist.
+- 2026-04-27: Added `rust-toolchain.toml` pinned to Rust `1.91` (currently resolves to `1.91.1` with cargo/clippy/rustfmt) and switched active GitHub workflows from implicit `dtolnay/rust-toolchain@stable` to `@master`, so CI uses the repository toolchain file instead of floating latest stable.
+- 2026-04-27: Added `deploy` workflow_dispatch inputs to platform, Tango, and trade deploy workflows. Defaults remain `true`; setting `deploy=false` gives a build/package/checksum-only verification path without restarting remote services.
+- 2026-04-27: Added `.github/actionlint.yaml` for self-hosted labels (`ploy-ci-1`, `tango-1-1`) and cleaned existing shellcheck findings in `backtest.yml`, `optimize.yml`, and `healthcheck-tango-1-1.yml` so full active-workflow `actionlint` passes.
+- 2026-04-27: Verification used full active-workflow `actionlint`, YAML parsing, `rustup show active-toolchain`, `cargo metadata --no-deps --locked`, and `git diff --check`; no heavy local Rust build was run.
+
 # Ploy Frontend Operator Cockpit (2026-04-24)
 
 ## Files


### PR DESCRIPTION
## Summary
- pin the repository Rust toolchain and release profile for deterministic CI release builds
- add sccache/cache metadata, deterministic bundle packaging, checksums, and build-only dispatch inputs
- teach actionlint about self-hosted runner labels and document the build/deploy rules

## Verification
- actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml
- YAML parse for active workflow files and actionlint config
- rustup show active-toolchain plus cargo/rustc version
- cargo metadata --no-deps --locked --format-version 1
- git diff --check
- GitHub Actions build-only: release-platform deploy=false, deploy-tango-1-1 deploy=false, deploy-trade deploy=false, build-push-acr push_images=false

## Notes
- This is a stacked PR on fix/remote-dryrun-report because the local branch stack is not based directly on origin/main.
- No remote deploy/restart path was triggered; deploy/push steps were disabled or skipped.