### PR TITLE
Upgrade GitHub Actions off Node 20 runtime

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -49,7 +49,7 @@ jobs:
           shared-key: auto-review
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-auto-review-${{ hashFiles('**/Cargo.lock') }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create or update auto-review comment
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           FMT_STATUS: ${{ steps.fmt.outputs.status }}
           CLIPPY_STATUS: ${{ steps.clippy.outputs.status }}

--- a/.github/workflows/backtest-ack.yml
+++ b/.github/workflows/backtest-ack.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -74,7 +74,7 @@ jobs:
             --example run_backtest
 
       - name: Upload run_backtest binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: run_backtest-${{ github.sha }}
           path: target/release/examples/run_backtest
@@ -89,12 +89,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Download run_backtest binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: run_backtest-${{ github.sha }}
           path: target/release/examples

--- a/.github/workflows/build-push-acr.yml
+++ b/.github/workflows/build-push-acr.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -63,7 +63,7 @@ jobs:
           shared-key: acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-acr-build-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/deploy-ack.yml
+++ b/.github/workflows/deploy-ack.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3

--- a/.github/workflows/deploy-frontend-tango-1-1.yml
+++ b/.github/workflows/deploy-frontend-tango-1-1.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -88,7 +88,7 @@ jobs:
           shared-key: deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-deploy-tango-1-1-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -65,7 +65,7 @@ jobs:
           echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-cargo-trade-
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -95,7 +95,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload compact report bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: event-ml-rolling-reports-${{ github.run_id }}
           path: artifacts/event-ml-report-bundle/
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload Parquet datasets
         if: ${{ github.event.inputs.upload_parquet_datasets == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: event-ml-rolling-datasets-${{ github.run_id }}
           path: |

--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: factor-review-v2-${{ github.run_id }}
           path: artifacts/factor-review-v2/

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: factor-walk-forward-v2-${{ github.run_id }}
           path: artifacts/factor-walk-forward-v2/

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -115,7 +115,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -138,7 +138,7 @@ jobs:
             --example optimize_backtest
 
       - name: Upload optimize_backtest binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: optimize_backtest-${{ github.sha }}
           path: target/release/examples/optimize_backtest
@@ -160,12 +160,12 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Download optimize_backtest binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: optimize_backtest-${{ github.sha }}
           path: target/release/examples

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
@@ -70,7 +70,7 @@ jobs:
           shared-key: release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-release-platform-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
@@ -125,7 +125,7 @@ jobs:
         run: sccache --show-stats || true
 
       - name: Upload platform bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ploy-platform-bundle
           path: |
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Download platform bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ploy-platform-bundle
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -96,7 +96,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -116,7 +116,7 @@ jobs:
           shared-key: rust-control-plane-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-control-${{ hashFiles('**/Cargo.lock') }}
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 18
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -205,7 +205,7 @@ jobs:
           shared-key: rust-runner-lean-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-runner-lean-${{ hashFiles('**/Cargo.lock') }}
@@ -257,7 +257,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -276,7 +276,7 @@ jobs:
           shared-key: rust-runner-live-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-runner-live-${{ hashFiles('**/Cargo.lock') }}
@@ -338,7 +338,7 @@ jobs:
     timeout-minutes: 18
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -357,7 +357,7 @@ jobs:
           shared-key: rust-market-data-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-market-data-${{ hashFiles('**/Cargo.lock') }}
@@ -406,7 +406,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -425,7 +425,7 @@ jobs:
           shared-key: rust-research-heavy-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-research-heavy-${{ hashFiles('**/Cargo.lock') }}
@@ -474,10 +474,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -530,7 +530,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -549,7 +549,7 @@ jobs:
           shared-key: rust-integration-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-integration-${{ hashFiles('**/Cargo.lock') }}
@@ -611,7 +611,7 @@ jobs:
     if: ${{ failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Create or update CI failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = "Main CI failed";

--- a/crates/ploy-platform-runtime/src/bootstrap.rs
+++ b/crates/ploy-platform-runtime/src/bootstrap.rs
@@ -46,6 +46,19 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    fn test_working_directory() -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "ploy-platform-bootstrap-workdir-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create test working directory");
+        path
+    }
+
     fn test_runner_binary() -> PathBuf {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -71,7 +84,7 @@ mod tests {
             worker_heartbeat_stale_after_ms: 15_000,
             runner_binary: test_runner_binary(),
             strategy_config_root: PathBuf::from("config/strategies"),
-            working_directory: std::env::current_dir().expect("cwd"),
+            working_directory: test_working_directory(),
         }
     }
 
@@ -80,6 +93,7 @@ mod tests {
         let mut registry = DeploymentRegistry::default();
         let mut supervisor = WorkerSupervisor::default();
         let mut trading = BTreeMap::<String, TradingRuntime>::new();
+        let config = config();
 
         apply_loaded_registry_state(
             vec![DeploymentRecord {
@@ -95,7 +109,7 @@ mod tests {
             &mut registry,
             &mut supervisor,
             &mut trading,
-            &config(),
+            &config,
         );
 
         assert!(registry.get("example.paper").is_some());
@@ -108,6 +122,7 @@ mod tests {
         let mut registry = DeploymentRegistry::default();
         let mut supervisor = WorkerSupervisor::default();
         let mut trading = BTreeMap::<String, TradingRuntime>::new();
+        let config = config();
 
         let records = vec![DeploymentRecord {
             deployment_id: "example.paper".to_string(),
@@ -125,7 +140,7 @@ mod tests {
             &mut registry,
             &mut supervisor,
             &mut trading,
-            &config(),
+            &config,
         );
         let first_pid = supervisor
             .status("example.paper")
@@ -137,7 +152,7 @@ mod tests {
             &mut registry,
             &mut supervisor,
             &mut trading,
-            &config(),
+            &config,
         );
         let second_pid = supervisor
             .status("example.paper")

--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -195,6 +195,19 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    fn test_working_directory() -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "ploy-platform-runtime-workdir-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create test working directory");
+        path
+    }
+
     fn test_runner_binary() -> PathBuf {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -220,7 +233,7 @@ mod tests {
             worker_heartbeat_stale_after_ms: 15_000,
             runner_binary: test_runner_binary(),
             strategy_config_root: PathBuf::from("config/strategies"),
-            working_directory: std::env::current_dir().expect("cwd"),
+            working_directory: test_working_directory(),
         }
     }
 
@@ -228,6 +241,7 @@ mod tests {
     fn tick_boots_running_workers_and_updates_status() {
         let mut control_plane = ControlPlane::default();
         let mut supervisor = WorkerSupervisor::default();
+        let config = config();
         control_plane.deployments.upsert(DeploymentRecord {
             deployment_id: "example.paper".to_string(),
             bundle_id: "example".to_string(),
@@ -239,7 +253,7 @@ mod tests {
             observed_state: ObservedState::Starting,
         });
 
-        tick_workers(&mut control_plane, &mut supervisor, &config());
+        tick_workers(&mut control_plane, &mut supervisor, &config);
         assert!(supervisor.status("example.paper").is_some());
     }
 
@@ -270,6 +284,7 @@ mod tests {
 
     #[test]
     fn build_launch_spec_resolves_strategy_config_path_and_dry_run_flag() {
+        let config = config();
         let spec = super::build_worker_launch_spec(
             &DeploymentRecord {
                 deployment_id: "pm5d.v2.paper".to_string(),
@@ -281,7 +296,7 @@ mod tests {
                 desired_state: DesiredState::Running,
                 observed_state: ObservedState::Starting,
             },
-            &config(),
+            &config,
         );
 
         assert!(spec
@@ -299,6 +314,7 @@ mod tests {
     fn repeated_ticks_do_not_respawn_running_worker() {
         let mut control_plane = ControlPlane::default();
         let mut supervisor = WorkerSupervisor::default();
+        let config = config();
         control_plane.deployments.upsert(DeploymentRecord {
             deployment_id: "example.paper".to_string(),
             bundle_id: "example".to_string(),
@@ -310,13 +326,13 @@ mod tests {
             observed_state: ObservedState::Starting,
         });
 
-        tick_workers(&mut control_plane, &mut supervisor, &config());
+        tick_workers(&mut control_plane, &mut supervisor, &config);
         let first_pid = supervisor
             .status("example.paper")
             .and_then(|status| status.pid)
             .expect("first pid");
 
-        tick_workers(&mut control_plane, &mut supervisor, &config());
+        tick_workers(&mut control_plane, &mut supervisor, &config);
         let second_pid = supervisor
             .status("example.paper")
             .and_then(|status| status.pid)
@@ -329,6 +345,7 @@ mod tests {
     fn running_desired_state_restarts_paused_worker() {
         let mut control_plane = ControlPlane::default();
         let mut supervisor = WorkerSupervisor::default();
+        let config = config();
         control_plane.deployments.upsert(DeploymentRecord {
             deployment_id: "example.paper".to_string(),
             bundle_id: "example".to_string(),
@@ -340,10 +357,10 @@ mod tests {
             observed_state: ObservedState::Starting,
         });
 
-        tick_workers(&mut control_plane, &mut supervisor, &config());
+        tick_workers(&mut control_plane, &mut supervisor, &config);
         supervisor.pause("example.paper");
 
-        tick_workers(&mut control_plane, &mut supervisor, &config());
+        tick_workers(&mut control_plane, &mut supervisor, &config);
         let status = supervisor.status("example.paper").expect("status");
         assert!(matches!(
             status.observed_state,


### PR DESCRIPTION
## Summary
- upgrade first-party GitHub Actions used by workflows to current Node 24-compatible majors
- keep deploy/build scripts and conditions unchanged

## Verification
- /Users/proerror/go/bin/actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml\n- git diff --check\n\n## Notes\n- This is intended to remove GitHub Actions Node 20 deprecation warnings across the workflow set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across CI/CD workflows, including checkout, caching, artifact handling, Node.js setup, and scripting tools to their latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->