### PR TITLE
Make Binance replay sampling use indexed buckets

### DIFF
--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -17,16 +17,16 @@
 //! | `pm_token_settlements` | Settlement outcomes |
 
 use chrono::{DateTime, Duration, Utc};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
 
 use ploy_market_contracts::{
-    HistoricalLoadOptions, MarketUpdate, l2_updates_from_depth_totals, market_update_sort_ts,
-    normalize_token_id,
+    l2_updates_from_depth_totals, market_update_sort_ts, normalize_token_id, HistoricalLoadOptions,
+    MarketUpdate,
 };
 
 #[cfg(test)]
@@ -34,6 +34,81 @@ use serde_json::Value;
 
 /// How far before `from` to load spot prices for EWMA volatility warm-up.
 const WARMUP_MINUTES: i64 = 30;
+
+const SYNC_RECORDS_SPOT_SAMPLED_QUERY: &str = r#"
+        WITH buckets AS (
+            SELECT s.symbol, bucket_start
+            FROM unnest($1::text[]) AS s(symbol)
+            CROSS JOIN generate_series(
+                $2::timestamptz,
+                $3::timestamptz,
+                make_interval(secs => $4::int)
+            ) AS bucket_start
+        )
+        SELECT spot.timestamp, spot.symbol, spot.bn_mid_price
+        FROM buckets
+        JOIN LATERAL (
+            SELECT timestamp, symbol, bn_mid_price
+            FROM sync_records
+            WHERE symbol = buckets.symbol
+              AND timestamp >= buckets.bucket_start
+              AND timestamp < buckets.bucket_start + make_interval(secs => $4::int)
+              AND timestamp <= $3
+            ORDER BY timestamp DESC
+            LIMIT 1
+        ) AS spot ON true
+        ORDER BY spot.timestamp
+        "#;
+
+const BINANCE_PRICE_SAMPLED_QUERY: &str = r#"
+        WITH buckets AS (
+            SELECT s.symbol, bucket_start
+            FROM unnest($1::text[]) AS s(symbol)
+            CROSS JOIN generate_series(
+                $2::timestamptz,
+                $3::timestamptz,
+                make_interval(secs => $4::int)
+            ) AS bucket_start
+        )
+        SELECT spot.trade_time, spot.symbol, spot.price
+        FROM buckets
+        JOIN LATERAL (
+            SELECT trade_time, symbol, price
+            FROM binance_price_ticks
+            WHERE symbol = buckets.symbol
+              AND trade_time >= buckets.bucket_start
+              AND trade_time < buckets.bucket_start + make_interval(secs => $4::int)
+              AND trade_time <= $3
+            ORDER BY trade_time DESC
+            LIMIT 1
+        ) AS spot ON true
+        ORDER BY spot.trade_time
+        "#;
+
+const BINANCE_AGG_TRADE_SAMPLED_QUERY: &str = r#"
+        WITH buckets AS (
+            SELECT s.symbol, bucket_start
+            FROM unnest($1::text[]) AS s(symbol)
+            CROSS JOIN generate_series(
+                $2::timestamptz,
+                $3::timestamptz,
+                interval '5 seconds'
+            ) AS bucket_start
+        )
+        SELECT agg.trade_time, agg.symbol, agg.agg_trade_id, agg.price, agg.quantity, agg.is_buyer_maker
+        FROM buckets
+        JOIN LATERAL (
+            SELECT trade_time, symbol, agg_trade_id, price, quantity, is_buyer_maker
+            FROM binance_agg_trade_ticks
+            WHERE symbol = buckets.symbol
+              AND trade_time >= buckets.bucket_start
+              AND trade_time < buckets.bucket_start + interval '5 seconds'
+              AND trade_time <= $3
+            ORDER BY trade_time ASC
+            LIMIT 1
+        ) AS agg ON true
+        ORDER BY agg.trade_time
+        "#;
 
 /// Historical research backtests only trust canonical historical PM quote captures.
 ///
@@ -241,43 +316,20 @@ async fn load_spot_prices(
 ) -> Result<(), sqlx::Error> {
     let sample_secs = sample_secs.max(1) as i64;
     // Try sync_records first (has bn_mid_price)
-    let rows: Vec<(DateTime<Utc>, String, Decimal)> = sqlx::query_as(
-        r#"
-        SELECT timestamp, symbol, bn_mid_price
-        FROM (
-            SELECT DISTINCT ON (symbol, bucket)
-                   timestamp, symbol, bn_mid_price, bucket
-            FROM (
-                SELECT
-                    timestamp,
-                    symbol,
-                    bn_mid_price,
-                    to_timestamp(
-                        floor(EXTRACT(EPOCH FROM timestamp) / $4::double precision) * $4
-                    ) AS bucket
-                FROM sync_records
-                WHERE symbol = ANY($1)
-                  AND timestamp >= $2
-                  AND timestamp <= $3
-            ) ticks
-            ORDER BY symbol, bucket, timestamp DESC
-        ) sampled
-        ORDER BY timestamp
-        "#,
-    )
-    .bind(symbols)
-    .bind(from)
-    .bind(to)
-    .bind(sample_secs)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let rows: Vec<(DateTime<Utc>, String, Decimal)> =
+        sqlx::query_as(SYNC_RECORDS_SPOT_SAMPLED_QUERY)
+            .bind(symbols)
+            .bind(from)
+            .bind(to)
+            .bind(sample_secs)
+            .fetch_all(pool)
+            .await
+            .unwrap_or_default();
 
     if !rows.is_empty() {
         info!(
             count = rows.len(),
-            sample_secs,
-            "Loaded spot prices from sync_records"
+            sample_secs, "Loaded spot prices from sync_records"
         );
         for (ts, symbol, price) in rows {
             updates.push(MarketUpdate::SpotPrice {
@@ -290,42 +342,18 @@ async fn load_spot_prices(
     }
 
     // Fallback: binance_price_ticks
-    let rows: Vec<(DateTime<Utc>, String, Decimal)> = sqlx::query_as(
-        r#"
-        SELECT trade_time, symbol, price
-        FROM (
-            SELECT DISTINCT ON (symbol, bucket)
-                   trade_time, symbol, price, bucket
-            FROM (
-                SELECT
-                    trade_time,
-                    symbol,
-                    price,
-                    to_timestamp(
-                        floor(EXTRACT(EPOCH FROM trade_time) / $4::double precision) * $4
-                    ) AS bucket
-                FROM binance_price_ticks
-                WHERE symbol = ANY($1)
-                  AND trade_time >= $2
-                  AND trade_time <= $3
-            ) ticks
-            ORDER BY symbol, bucket, trade_time DESC
-        ) sampled
-        ORDER BY trade_time
-        "#,
-    )
-    .bind(symbols)
-    .bind(from)
-    .bind(to)
-    .bind(sample_secs)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let rows: Vec<(DateTime<Utc>, String, Decimal)> = sqlx::query_as(BINANCE_PRICE_SAMPLED_QUERY)
+        .bind(symbols)
+        .bind(from)
+        .bind(to)
+        .bind(sample_secs)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
 
     info!(
         count = rows.len(),
-        sample_secs,
-        "Loaded spot prices from binance_price_ticks"
+        sample_secs, "Loaded spot prices from binance_price_ticks"
     );
     for (ts, symbol, price) in rows {
         updates.push(MarketUpdate::SpotPrice {
@@ -348,25 +376,14 @@ async fn load_agg_trades(
     // Downsample to one row per 5-second bucket per symbol to avoid OOM.
     // AggTrade volume can reach millions of rows per hour; the strategy only
     // needs the signed trade imbalance signal, not tick-level granularity.
-    let rows: Vec<(DateTime<Utc>, String, i64, Decimal, Decimal, bool)> = sqlx::query_as(
-        r#"
-        SELECT DISTINCT ON (symbol, date_trunc('seconds', trade_time) - INTERVAL '1 second' * (EXTRACT(EPOCH FROM trade_time)::bigint % 5))
-               trade_time, symbol, agg_trade_id, price, quantity, is_buyer_maker
-        FROM binance_agg_trade_ticks
-        WHERE symbol = ANY($1)
-          AND trade_time >= $2
-          AND trade_time <= $3
-        ORDER BY symbol,
-                 date_trunc('seconds', trade_time) - INTERVAL '1 second' * (EXTRACT(EPOCH FROM trade_time)::bigint % 5),
-                 trade_time
-        "#,
-    )
-    .bind(symbols)
-    .bind(from)
-    .bind(to)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let rows: Vec<(DateTime<Utc>, String, i64, Decimal, Decimal, bool)> =
+        sqlx::query_as(BINANCE_AGG_TRADE_SAMPLED_QUERY)
+            .bind(symbols)
+            .bind(from)
+            .bind(to)
+            .fetch_all(pool)
+            .await
+            .unwrap_or_default();
 
     info!(
         count = rows.len(),
@@ -1130,8 +1147,40 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        EventMetadataRow, MarketUpdate, build_event_updates, l2_updates_from_book, near_depth,
+        build_event_updates, l2_updates_from_book, near_depth, EventMetadataRow, MarketUpdate,
+        BINANCE_AGG_TRADE_SAMPLED_QUERY, BINANCE_PRICE_SAMPLED_QUERY,
+        SYNC_RECORDS_SPOT_SAMPLED_QUERY,
     };
+
+    #[test]
+    fn binance_samplers_use_bucketed_index_lookups() {
+        for query in [
+            SYNC_RECORDS_SPOT_SAMPLED_QUERY,
+            BINANCE_PRICE_SAMPLED_QUERY,
+            BINANCE_AGG_TRADE_SAMPLED_QUERY,
+        ] {
+            assert!(
+                query.contains("generate_series"),
+                "sampled Binance loaders should generate bounded buckets"
+            );
+            assert!(
+                query.contains("JOIN LATERAL"),
+                "sampled Binance loaders should perform one indexable lookup per bucket"
+            );
+            assert!(
+                !query.contains("DISTINCT ON"),
+                "sampled Binance loaders must not sort full time ranges by bucket"
+            );
+            assert!(
+                !query.contains("EXTRACT(EPOCH FROM"),
+                "sampled Binance loaders should avoid computed bucket expressions over full tables"
+            );
+        }
+
+        assert!(BINANCE_PRICE_SAMPLED_QUERY.contains("trade_time >= buckets.bucket_start"));
+        assert!(BINANCE_PRICE_SAMPLED_QUERY.contains("ORDER BY trade_time DESC"));
+        assert!(BINANCE_AGG_TRADE_SAMPLED_QUERY.contains("ORDER BY trade_time ASC"));
+    }
 
     #[test]
     fn official_settlement_backfill_repairs_event_expiry_outcome() {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9969,9 +9969,32 @@ Review:
 - [x] Replace the PM book sampler full time-range scan with token/event-window indexed sampling.
 - [x] Verify the SQL shape avoids `DISTINCT ON` over the 41GB `clob_orderbook_snapshots` table.
 - [x] Run focused tests/checks.
-- [ ] Open/merge PR, then rerun Factor Review and Walk-Forward on `ploy-ci-1`.
+- [x] Open/merge PR, then rerun Factor Review and Walk-Forward on `ploy-ci-1`.
 
 ## Review
 
 - 2026-04-28: Replaced the old PM book sampler `DISTINCT ON (token_id, bucket)` time-range scan with an event-bounded lateral bucket lookup that constrains `clob_orderbook_snapshots` by `token_id` and `received_at`. Tango smoke on a 15-minute six-symbol window returned 308 sampled rows in about 2.1s and used `Index Only Scan using idx_clob_orderbook_snapshots_token_time`.
 - 2026-04-28: Verification passed: `CARGO_TARGET_DIR=/tmp/ploy-pm-book-loader-indexed rtk cargo test -p ploy-research pm_book_sampler_uses_token_window_index_lookup --lib`, `CARGO_TARGET_DIR=/tmp/ploy-pm-book-loader-indexed rtk cargo check -p ploy-research --features db --lib`, and `rtk git diff --check`. The previous slow Factor Walk-Forward V2 retry `25017670831` is cancelled, and `ploy-ci-1` has no active `factor_walk_forward_v2` worker.
+- 2026-04-28: PR #186 merged into `main` at `8a97d18`. A valid post-merge Factor Review V2 run `25021532625` checked out `8a97d18`, loaded 26,151 PM book snapshot rows, and completed in 3m22s. The follow-up Walk-Forward V2 run `25021701326` was cancelled after the next slow query surfaced in Binance spot sampling, not PM full-depth sampling.
+
+# Binance Sampled Loader Performance (2026-04-28)
+
+## Files
+
+- `crates/ploy-feed-loaders/src/database.rs`
+  - Owner: database historical spot and aggTrade sampled SQL
+- `tasks/todo.md`
+  - Owner: session tracker
+
+## Tasks
+
+- [x] Cancel the Walk-Forward run that exposed the next slow sampled query.
+- [x] Identify the active Tango query and index coverage for Binance sampled data.
+- [x] Replace `sync_records`, `binance_price_ticks`, and `binance_agg_trade_ticks` sampled scans with bucketed index lookups.
+- [x] Verify focused tests/checks and Tango `EXPLAIN ANALYZE`.
+- [ ] Open/merge PR, then rerun Factor Walk-Forward V2 on `main`.
+
+## Review
+
+- 2026-04-28: Replaced historical spot and aggTrade sampled queries that used `DISTINCT ON` plus computed bucket expressions over full time ranges. New queries generate bounded `symbols x bucket` windows and use lateral lookups against existing time/symbol indexes. AggTrade preserves the previous earliest-in-5s-bucket semantics with `ORDER BY trade_time ASC`.
+- 2026-04-28: Verification passed: `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo test -p ploy-feed-loaders binance_samplers_use_bucketed_index_lookups --lib`, `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo check -p ploy-feed-loaders --lib`, `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`, and `rtk git diff --check`. Tango `EXPLAIN ANALYZE` on a 15-minute six-symbol window completed in about 42ms for `binance_price_ticks` and 259ms for `binance_agg_trade_ticks` without the previous `BufFileRead` full-range sort pattern.


### PR DESCRIPTION
## Summary
- replace database replay spot sampling over `sync_records` / `binance_price_ticks` with bounded symbol-bucket lateral lookups
- replace aggTrade 5s downsample full-range `DISTINCT ON` scan with bounded bucket lookups while preserving earliest-in-bucket semantics
- add a regression guard against reintroducing `DISTINCT ON` / computed bucket scans in these loaders

## Verification
- `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo test -p ploy-feed-loaders binance_samplers_use_bucketed_index_lookups --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo check -p ploy-feed-loaders --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-binance-loader-indexed rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`
- `rtk git diff --check`
- Tango `EXPLAIN ANALYZE` 15-minute six-symbol smoke: `binance_price_ticks` ~42ms, `binance_agg_trade_ticks` ~259ms, no previous `BufFileRead` full-range sort pattern

## Context
PR #186 fixed PM full-depth replay. The post-merge Factor Review V2 run `25021532625` checked out `8a97d18` and completed. The follow-up Walk-Forward V2 run exposed the next full-range sampled SQL bottleneck in Binance spot sampling, so it was cancelled before retrying with this fix.

## Follow-up after merge
- rerun Factor Walk-Forward V2 on `main` / `ploy-ci-1`
