### PR TITLE
Keep Deribit greeks collector deployable

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -144,6 +144,7 @@ jobs:
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
           cp scripts/binance_lob_collector.py dist/scripts/binance_lob_collector.py
+          cp scripts/deribit_atm_greeks_collector.py dist/scripts/deribit_atm_greeks_collector.py
           cp scripts/report_strategy.py dist/scripts/report_strategy.py
           cp scripts/report_market_data_health.py dist/scripts/report_market_data_health.py
           cp scripts/report_dryrun_summary.py dist/scripts/report_dryrun_summary.py
@@ -159,6 +160,7 @@ jobs:
           done
           cp deployment/systemd/ploy-binance-aggtrade-collector.service dist/deployment/systemd/ploy-binance-aggtrade-collector.service
           cp deployment/systemd/ploy-binance-lob-collector.service dist/deployment/systemd/ploy-binance-lob-collector.service
+          cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
           cp deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf dist/deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf
           cp deployment/systemd/ploy-quote-collector.hardening.conf dist/deployment/systemd/ploy-quote-collector.hardening.conf
@@ -366,6 +368,7 @@ jobs:
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py
             install -m 0755 ./scripts/binance_lob_collector.py ${DEPLOY_ROOT}/scripts/binance_lob_collector.py
+            install -m 0755 ./scripts/deribit_atm_greeks_collector.py ${DEPLOY_ROOT}/scripts/deribit_atm_greeks_collector.py
             install -m 0755 ./scripts/report_strategy.py ${DEPLOY_ROOT}/scripts/report_strategy.py
             install -m 0755 ./scripts/report_market_data_health.py ${DEPLOY_ROOT}/scripts/report_market_data_health.py
             install -m 0755 ./scripts/report_dryrun_summary.py ${DEPLOY_ROOT}/scripts/report_dryrun_summary.py
@@ -383,6 +386,7 @@ jobs:
             install -d /etc/systemd/system/ploy-quote-collector.service.d
             install -m 0644 ./deployment/systemd/ploy-binance-aggtrade-collector.service /etc/systemd/system/ploy-binance-aggtrade-collector.service
             install -m 0644 ./deployment/systemd/ploy-binance-lob-collector.service /etc/systemd/system/ploy-binance-lob-collector.service
+            install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
             install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
             install -m 0644 ./deployment/systemd/ploy-quote-collector.hardening.conf /etc/systemd/system/ploy-quote-collector.service.d/hardening.conf
             systemctl daemon-reload
@@ -413,6 +417,8 @@ jobs:
             if service_exists ploy-deribit-iv-collector.service; then
               systemctl restart ploy-deribit-iv-collector.service
             fi
+            systemctl enable --now ploy-deribit-greeks-collector.service
+            systemctl restart ploy-deribit-greeks-collector.service
             if service_exists ploy-quote-collector.service; then
               systemctl enable --now ploy-quote-collector.service
               systemctl restart ploy-quote-collector.service
@@ -440,6 +446,8 @@ jobs:
             if service_exists ploy-deribit-iv-collector.service; then
               systemctl is-active --quiet ploy-deribit-iv-collector.service
             fi
+            systemctl is-active --quiet ploy-deribit-greeks-collector.service
+            require_service_guardrails ploy-deribit-greeks-collector.service
             if service_exists ployd.service; then
               systemctl is-active --quiet ployd.service
               curl -fsS http://127.0.0.1:8081/health
@@ -471,6 +479,11 @@ jobs:
                 3
             fi
             wait_for_recent_rows \
+              "SELECT EXISTS (SELECT 1 FROM deribit_atm_greeks_ticks WHERE fetched_at >= NOW() - INTERVAL '15 minutes')" \
+              "deribit_atm_greeks_ticks is not fresh after deploy" \
+              20 \
+              3
+            wait_for_recent_rows \
               "SELECT EXISTS (SELECT 1 FROM clob_trade_ticks WHERE received_at >= NOW() - INTERVAL '5 minutes')" \
               "clob_trade_ticks is not receiving PM trade prints after deploy" \
               20 \
@@ -495,6 +508,10 @@ jobs:
                 "deribit iv collector still lacks active partitions"
             fi
             assert_no_recent_logs \
+              "ploy-deribit-greeks-collector.service" \
+              "Traceback|psql failed|column \"option_type\" does not exist|column \"strike\" does not exist" \
+              "deribit greeks collector failed after deploy"
+            assert_no_recent_logs \
               "ploy-pm-trade-collector.service" \
               "no partition of relation \"clob_trade_ticks\"" \
               "pm trade collector still lacks active partitions"
@@ -508,6 +525,7 @@ jobs:
             if service_exists ploy-deribit-iv-collector.service; then
               systemctl status ploy-deribit-iv-collector.service --no-pager
             fi
+            systemctl status ploy-deribit-greeks-collector.service --no-pager
             if service_exists ployd.service; then
               systemctl status ployd.service --no-pager
             fi
@@ -525,6 +543,7 @@ jobs:
             if service_exists ploy-deribit-iv-collector.service; then
               journalctl -u ploy-deribit-iv-collector.service -n 20 --no-pager
             fi
+            journalctl -u ploy-deribit-greeks-collector.service -n 20 --no-pager
             if service_exists ployd.service; then
               journalctl -u ployd.service -n 20 --no-pager
             fi

--- a/.github/workflows/healthcheck-tango-1-1.yml
+++ b/.github/workflows/healthcheck-tango-1-1.yml
@@ -82,12 +82,14 @@ jobs:
             systemctl is-active --quiet ploy-binance-price-collector.service
             systemctl is-active --quiet ploy-binance-lob-collector.service
             systemctl is-active --quiet ploy-deribit-iv-collector.service
+            systemctl is-active --quiet ploy-deribit-greeks-collector.service
             systemctl is-active --quiet ployd.service
             systemctl is-active --quiet ploy-quote-collector.service
             if service_exists ploy-pm-trade-collector.service; then
               systemctl is-active --quiet ploy-pm-trade-collector.service
             fi
             require_service_guardrails ploy-binance-lob-collector.service
+            require_service_guardrails ploy-deribit-greeks-collector.service
             require_service_guardrails ployd.service
             require_service_guardrails ploy-quote-collector.service
             if service_exists ploy-pm-trade-collector.service; then
@@ -120,6 +122,11 @@ jobs:
               echo "deribit_iv_ticks has not advanced within the last 15 minutes" >&2
               exit 1
             fi
+            if [ "$(PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
+              "SELECT EXISTS (SELECT 1 FROM deribit_atm_greeks_ticks WHERE fetched_at >= NOW() - INTERVAL '15 minutes')")" != "t" ]; then
+              echo "deribit_atm_greeks_ticks has not advanced within the last 15 minutes" >&2
+              exit 1
+            fi
             if journalctl -u ploy-binance-price-collector.service --since '15 minutes ago' --no-pager \
               | grep -qE "uq_binance_price_ticks_symbol_second|duplicate key value"; then
               echo "binance price collector still reports duplicate-write churn" >&2
@@ -128,6 +135,11 @@ jobs:
             if journalctl -u ploy-deribit-iv-collector.service --since '15 minutes ago' --no-pager \
               | grep -qE "no partition of relation \"deribit_iv_ticks\""; then
               echo "deribit iv collector still reports missing partitions" >&2
+              exit 1
+            fi
+            if journalctl -u ploy-deribit-greeks-collector.service --since '15 minutes ago' --no-pager \
+              | grep -qE "Traceback|psql failed|column \"option_type\" does not exist|column \"strike\" does not exist"; then
+              echo "deribit greeks collector failed within the last 15 minutes" >&2
               exit 1
             fi
 
@@ -151,12 +163,17 @@ jobs:
               PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
                 "SELECT coalesce(max(fetched_at)::text, 'none') FROM deribit_iv_ticks"
             )
+            latest_deribit_greeks=$(
+              PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
+                "SELECT coalesce(max(fetched_at)::text, 'none') FROM deribit_atm_greeks_ticks"
+            )
 
             echo "postgres=$(systemctl show -P ActiveState postgresql@16-main)"
             echo "aggtrade=$(systemctl show -P ActiveState ploy-binance-aggtrade-collector.service)"
             echo "price=$(systemctl show -P ActiveState ploy-binance-price-collector.service)"
             echo "lob=$(systemctl show -P ActiveState ploy-binance-lob-collector.service)"
             echo "deribit=$(systemctl show -P ActiveState ploy-deribit-iv-collector.service)"
+            echo "deribit_greeks=$(systemctl show -P ActiveState ploy-deribit-greeks-collector.service)"
             echo "ployd=$(systemctl show -P ActiveState ployd.service)"
             echo "collector=$(systemctl show -P ActiveState ploy-quote-collector.service)"
             if service_exists ploy-pm-trade-collector.service; then
@@ -166,6 +183,7 @@ jobs:
             echo "latest_price=${latest_price}"
             echo "latest_lob=${latest_lob}"
             echo "latest_deribit=${latest_deribit}"
+            echo "latest_deribit_greeks=${latest_deribit_greeks}"
             echo "latest_signal=${latest_signal}"
           EOF
 
@@ -180,5 +198,6 @@ jobs:
             echo "- binance_price_ticks must advance within the last 10 minutes"
             echo "- binance_lob_ticks must advance within the last 15 minutes"
             echo "- deribit_iv_ticks must advance within the last 15 minutes"
+            echo "- deribit_atm_greeks_ticks must advance within the last 15 minutes"
             echo "- ployd must not log degraded persistence messages in the last 15 minutes"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deployment/systemd/ploy-deribit-greeks-collector.service
+++ b/deployment/systemd/ploy-deribit-greeks-collector.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Ploy Deribit ATM Greeks Collector
+After=postgresql.service network-online.target ploy-deribit-iv-collector.service
+Wants=network-online.target ploy-deribit-iv-collector.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ploy
+Environment=DERIBIT_GREEKS_CURRENCIES=BTC,ETH,SOL
+Environment=DERIBIT_GREEKS_POLL_SECS=30
+Environment=DERIBIT_GREEKS_HTTP_TIMEOUT_SECS=20
+ExecStart=/usr/bin/env bash -lc 'if [ -f /opt/ploy/.env ]; then set -a; . /opt/ploy/.env >/dev/null 2>&1; set +a; fi; exec /usr/bin/python3 /opt/ploy/scripts/deribit_atm_greeks_collector.py'
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+MemoryHigh=1280M
+MemoryMax=1536M
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deribit_atm_greeks_collector.py
+++ b/scripts/deribit_atm_greeks_collector.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Collect Deribit ATM option greeks into PostgreSQL.
+
+The collector reuses fresh instruments already present in deribit_iv_ticks,
+selects the nearest ATM option per configured currency, then calls Deribit's
+public get_order_book endpoint for greeks and order-book fields.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import os
+import signal
+import subprocess
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+API_BASE = os.getenv("DERIBIT_API_BASE", "https://www.deribit.com/api/v2/public")
+CURRENCIES = [
+    c.strip().upper()
+    for c in os.getenv("DERIBIT_GREEKS_CURRENCIES", "BTC,ETH,SOL").split(",")
+    if c.strip()
+]
+POLL_SECS = max(5, int(os.getenv("DERIBIT_GREEKS_POLL_SECS", "30")))
+HTTP_TIMEOUT_SECS = int(os.getenv("DERIBIT_GREEKS_HTTP_TIMEOUT_SECS", "20"))
+
+DB_URL = (
+    os.getenv("PLOY_DATABASE__URL")
+    or os.getenv("DATABASE_URL")
+    or "postgresql://postgres:postgres@localhost:5432/ploy"
+)
+PSQL_BIN = os.getenv("PSQL_BIN", "psql")
+
+RUNNING = True
+
+
+def _on_signal(signum: int, _frame: Any) -> None:
+    global RUNNING
+    RUNNING = False
+    print(f"[deribit-greeks] received signal={signum}, stopping...", flush=True)
+
+
+def _run_psql(sql: str, at_mode: bool = False) -> str:
+    cmd = [PSQL_BIN, DB_URL, "-v", "ON_ERROR_STOP=1", "-X"]
+    if at_mode:
+        cmd.extend(["-A", "-t", "-F", "\t"])
+    cmd.extend(["-c", sql])
+
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"psql failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    return proc.stdout
+
+
+def _sql_text(value: Optional[str]) -> str:
+    if value is None:
+        return "NULL"
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _sql_num(value: Optional[float]) -> str:
+    if value is None:
+        return "NULL"
+    if not math.isfinite(value):
+        return "NULL"
+    return str(value)
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(num):
+        return None
+    return num
+
+
+def ensure_table() -> None:
+    sql = """
+    CREATE TABLE IF NOT EXISTS deribit_atm_greeks_ticks (
+        id BIGSERIAL PRIMARY KEY,
+        currency TEXT NOT NULL,
+        instrument_name TEXT NOT NULL,
+        source_ts TIMESTAMPTZ NOT NULL,
+        fetched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        mark_iv NUMERIC,
+        bid_iv NUMERIC,
+        ask_iv NUMERIC,
+        delta NUMERIC,
+        gamma NUMERIC,
+        vega NUMERIC,
+        theta NUMERIC,
+        rho NUMERIC,
+        mark_price NUMERIC,
+        underlying_price NUMERIC,
+        index_price NUMERIC,
+        best_bid_price NUMERIC,
+        best_ask_price NUMERIC,
+        open_interest NUMERIC,
+        raw JSONB NOT NULL DEFAULT '{}'::jsonb,
+        UNIQUE (currency, instrument_name, source_ts)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_deribit_atm_greeks_ccy_ts
+      ON deribit_atm_greeks_ticks(currency, source_ts DESC);
+    CREATE INDEX IF NOT EXISTS idx_deribit_atm_greeks_fetched
+      ON deribit_atm_greeks_ticks(fetched_at DESC);
+    """
+    _run_psql(sql)
+
+
+def pick_atm_instruments() -> List[Tuple[str, str]]:
+    if not CURRENCIES:
+        return []
+
+    currency_values = ",".join(f"({_sql_text(currency)})" for currency in CURRENCIES)
+
+    # deribit_iv_ticks stores Deribit option metadata in instrument_name rather
+    # than separate option_type/strike columns. Bound the lateral scan to fresh
+    # rows so it stays cheap on the partitioned IV table.
+    sql = f"""
+    WITH candidates AS (
+      SELECT c.currency,
+             t.instrument_name,
+             split_part(t.instrument_name, '-', 4) AS option_type,
+             NULLIF(split_part(t.instrument_name, '-', 3), '')::numeric AS strike,
+             t.underlying_price,
+             t.creation_ts,
+             abs(NULLIF(split_part(t.instrument_name, '-', 3), '')::numeric - t.underlying_price) AS atm_distance
+      FROM (VALUES {currency_values}) AS c(currency)
+      CROSS JOIN LATERAL (
+        SELECT instrument_name, underlying_price, creation_ts, fetched_at
+        FROM deribit_iv_ticks
+        WHERE upper(currency) = c.currency
+          AND fetched_at >= NOW() - INTERVAL '10 minutes'
+          AND creation_ts IS NOT NULL
+          AND underlying_price IS NOT NULL
+          AND instrument_name ~ '^[^-]+-[0-9]{{1,2}}[A-Z]{{3}}[0-9]{{2}}-[0-9]+(\\.[0-9]+)?-[CP]$'
+        ORDER BY fetched_at DESC, creation_ts DESC
+        LIMIT 1000
+      ) t
+    ), ranked AS (
+      SELECT
+        currency,
+        instrument_name,
+        row_number() OVER (
+          PARTITION BY currency
+          ORDER BY
+            atm_distance ASC,
+            CASE WHEN option_type = 'C' THEN 0 WHEN option_type = 'P' THEN 1 ELSE 2 END,
+            creation_ts DESC,
+            instrument_name ASC
+        ) AS rn
+      FROM candidates
+    )
+    SELECT currency, instrument_name
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY currency;
+    """
+    out = _run_psql(sql, at_mode=True).strip()
+    if not out:
+        return []
+
+    pairs: List[Tuple[str, str]] = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        currency, instrument = parts[0].strip(), parts[1].strip()
+        if currency and instrument:
+            pairs.append((currency, instrument))
+    return pairs
+
+
+def fetch_order_book(instrument_name: str) -> Dict[str, Any]:
+    url = f"{API_BASE}/get_order_book"
+    resp = requests.get(
+        url,
+        params={"instrument_name": instrument_name},
+        timeout=HTTP_TIMEOUT_SECS,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError("invalid Deribit response: missing result")
+    return result
+
+
+def upsert_greeks(currency: str, instrument_name: str, result: Dict[str, Any]) -> None:
+    ts_ms = result.get("timestamp")
+    if ts_ms is None:
+        source_ts = dt.datetime.now(dt.timezone.utc)
+    else:
+        source_ts = dt.datetime.fromtimestamp(int(ts_ms) / 1000.0, tz=dt.timezone.utc)
+
+    greeks = result.get("greeks") or {}
+
+    mark_iv = _to_float(result.get("mark_iv"))
+    bid_iv = _to_float(result.get("bid_iv"))
+    ask_iv = _to_float(result.get("ask_iv"))
+
+    delta = _to_float(greeks.get("delta"))
+    gamma = _to_float(greeks.get("gamma"))
+    vega = _to_float(greeks.get("vega"))
+    theta = _to_float(greeks.get("theta"))
+    rho = _to_float(greeks.get("rho"))
+
+    mark_price = _to_float(result.get("mark_price"))
+    underlying_price = _to_float(result.get("underlying_price"))
+    index_price = _to_float(result.get("index_price"))
+    best_bid_price = _to_float(result.get("best_bid_price"))
+    best_ask_price = _to_float(result.get("best_ask_price"))
+    open_interest = _to_float(result.get("open_interest"))
+
+    raw_json = json.dumps(result, ensure_ascii=True, separators=(",", ":"))
+
+    sql = f"""
+    INSERT INTO deribit_atm_greeks_ticks (
+      currency, instrument_name, source_ts, fetched_at,
+      mark_iv, bid_iv, ask_iv,
+      delta, gamma, vega, theta, rho,
+      mark_price, underlying_price, index_price,
+      best_bid_price, best_ask_price, open_interest,
+      raw
+    ) VALUES (
+      {_sql_text(currency)}, {_sql_text(instrument_name)}, {_sql_text(source_ts.isoformat())}, NOW(),
+      {_sql_num(mark_iv)}, {_sql_num(bid_iv)}, {_sql_num(ask_iv)},
+      {_sql_num(delta)}, {_sql_num(gamma)}, {_sql_num(vega)}, {_sql_num(theta)}, {_sql_num(rho)},
+      {_sql_num(mark_price)}, {_sql_num(underlying_price)}, {_sql_num(index_price)},
+      {_sql_num(best_bid_price)}, {_sql_num(best_ask_price)}, {_sql_num(open_interest)},
+      {_sql_text(raw_json)}::jsonb
+    )
+    ON CONFLICT (currency, instrument_name, source_ts) DO UPDATE
+    SET
+      fetched_at = NOW(),
+      mark_iv = EXCLUDED.mark_iv,
+      bid_iv = EXCLUDED.bid_iv,
+      ask_iv = EXCLUDED.ask_iv,
+      delta = EXCLUDED.delta,
+      gamma = EXCLUDED.gamma,
+      vega = EXCLUDED.vega,
+      theta = EXCLUDED.theta,
+      rho = EXCLUDED.rho,
+      mark_price = EXCLUDED.mark_price,
+      underlying_price = EXCLUDED.underlying_price,
+      index_price = EXCLUDED.index_price,
+      best_bid_price = EXCLUDED.best_bid_price,
+      best_ask_price = EXCLUDED.best_ask_price,
+      open_interest = EXCLUDED.open_interest,
+      raw = EXCLUDED.raw;
+    """
+    _run_psql(sql)
+
+
+def run_once() -> Tuple[int, int]:
+    pairs = pick_atm_instruments()
+    ok = 0
+    total = 0
+
+    for currency, instrument_name in pairs:
+        total += 1
+        try:
+            result = fetch_order_book(instrument_name)
+            upsert_greeks(currency, instrument_name, result)
+            ok += 1
+        except Exception as exc:
+            print(
+                f"[deribit-greeks] currency={currency} instrument={instrument_name} error={exc}",
+                flush=True,
+            )
+
+    return ok, total
+
+
+def main() -> int:
+    ensure_table()
+    print(
+        f"[deribit-greeks] started currencies={','.join(CURRENCIES)} poll_secs={POLL_SECS}",
+        flush=True,
+    )
+
+    while RUNNING:
+        started = time.time()
+        ok, total = run_once()
+        elapsed = time.time() - started
+        print(
+            f"[deribit-greeks] cycle ok={ok}/{total} elapsed_s={elapsed:.2f}",
+            flush=True,
+        )
+
+        sleep_left = POLL_SECS - elapsed
+        if sleep_left > 0:
+            time.sleep(sleep_left)
+
+    print("[deribit-greeks] stopped", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the Deribit ATM greeks collector script to the repo with schema-compatible instrument-name parsing
- ship and install the greeks systemd unit from deploy-tango-1-1
- include greeks service and table freshness in tango healthcheck/deploy verification

## Verification
- python3 -m py_compile scripts/deribit_atm_greeks_collector.py scripts/report_market_data_health.py
- Ruby YAML load for deploy-tango-1-1.yml and healthcheck-tango-1-1.yml
- bash -n on the healthcheck remote shell body
- copied repo script to tango /tmp and verified it selects ATM instruments/fetches Deribit greeks without missing option_type/strike columns

## Notes
- actionlint is not installed in this local environment, so workflow validation used YAML parsing and shell-body syntax checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deribit ATM Greeks collector service now deployed with automatic startup, self-healing restart capabilities, and persistent background processing

* **Chores**
  * Greeks collector service integrated into deployment workflow with comprehensive post-deployment health verification
  * Health checks expanded: includes service operational status validation, data freshness verification (15-minute window), and systematic error detection via log scanning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->