### PR TITLE
Make PM5D research consume immutable snapshots

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -47,6 +47,22 @@ on:
         description: "Selected quantile for execution metrics"
         required: false
         default: "0.2"
+      snapshot_run_id:
+        description: "Optional Research Snapshot workflow run id to consume"
+        required: false
+        default: ""
+      compile_snapshot:
+        description: "Compile a fresh snapshot before review when snapshot_run_id is empty"
+        required: false
+        default: "true"
+      allow_direct_db_debug:
+        description: "Allow non-canonical direct DB review when no snapshot is present"
+        required: false
+        default: "false"
+      optimizer_data_dir:
+        description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
+        required: false
+        default: "/tmp/ploy-parquet"
 
 concurrency:
   group: factor-review-v2-${{ github.ref }}
@@ -54,10 +70,12 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PLOY_DB_URL: ${{ secrets.PLOY_DB_URL }}
 
 jobs:
   review:
@@ -89,20 +107,59 @@ jobs:
           cache-targets: "true"
           key: factor-review-v2-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
-      - name: Build factor_review_v2
+      - name: Build factor review and snapshot compiler
         run: |
           . /home/runner/.cargo/env
           cargo build --release --locked \
             -p ploy-research \
-            --features db \
-            --example factor_review_v2
+            --features db,polars-export \
+            --example factor_review_v2 \
+            --example research_snapshot_compile
+
+      - name: Download research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
+          path: artifacts/research-snapshot
+          run-id: ${{ github.event.inputs.snapshot_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Compile research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          ./target/release/examples/research_snapshot_compile \
+            --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --start-date "${{ github.event.inputs.start_date }}" \
+            --end-date "${{ github.event.inputs.end_date }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
+            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
+            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --output-dir artifacts/research-snapshot \
+            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            2>&1 | tee artifacts/research-snapshot/compile.log
 
       - name: Run factor review
         run: |
           set -euo pipefail
           mkdir -p artifacts/factor-review-v2
+          source_args=()
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            source_args=(--snapshot-dir artifacts/research-snapshot)
+            echo "canonical_result=snapshot" | tee artifacts/factor-review-v2/source.txt
+          elif [ "${{ github.event.inputs.allow_direct_db_debug }}" = "true" ]; then
+            source_args=(--db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" --allow-direct-db-debug)
+            echo "canonical_result=no direct_db_debug=true" | tee artifacts/factor-review-v2/source.txt
+          else
+            echo "ERROR: no research snapshot is present; set compile_snapshot=true, pass snapshot_run_id, or explicitly set allow_direct_db_debug=true" >&2
+            exit 2
+          fi
           ./target/release/examples/factor_review_v2 \
-            --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
+            "${source_args[@]}" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --start-date "${{ github.event.inputs.start_date }}" \
             --end-date "${{ github.event.inputs.end_date }}" \
@@ -124,7 +181,15 @@ jobs:
             echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            if [ -f artifacts/factor-review-v2/source.txt ]; then
+              echo "- Source: $(cat artifacts/factor-review-v2/source.txt)"
+            fi
             echo ""
+            if [ -f artifacts/research-snapshot/quality.md ]; then
+              echo "### Snapshot Quality"
+              cat artifacts/research-snapshot/quality.md
+              echo ""
+            fi
             if [ -f artifacts/factor-review-v2/report.txt ]; then
               echo '```'
               sed -n '1,120p' artifacts/factor-review-v2/report.txt
@@ -137,5 +202,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: factor-review-v2-${{ github.run_id }}
-          path: artifacts/factor-review-v2/
+          path: |
+            artifacts/factor-review-v2/
+            artifacts/research-snapshot/
           retention-days: 14

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -63,6 +63,22 @@ on:
         description: "Optional comma-separated factor-name substrings"
         required: false
         default: ""
+      snapshot_run_id:
+        description: "Optional Research Snapshot workflow run id to consume"
+        required: false
+        default: ""
+      compile_snapshot:
+        description: "Compile a fresh snapshot before walk-forward when snapshot_run_id is empty"
+        required: false
+        default: "true"
+      allow_direct_db_debug:
+        description: "Allow non-canonical direct DB walk-forward when no snapshot is present"
+        required: false
+        default: "false"
+      optimizer_data_dir:
+        description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
+        required: false
+        default: "/tmp/ploy-parquet"
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.factor_name_filter || 'all' }}
@@ -70,6 +86,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -106,20 +123,59 @@ jobs:
           cache-targets: "true"
           key: factor-walk-forward-v2-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
-      - name: Build factor_walk_forward_v2
+      - name: Build factor walk-forward and snapshot compiler
         run: |
           . /home/runner/.cargo/env
           cargo build --release --locked \
             -p ploy-research \
-            --features db \
-            --example factor_walk_forward_v2
+            --features db,polars-export \
+            --example factor_walk_forward_v2 \
+            --example research_snapshot_compile
+
+      - name: Download research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
+          path: artifacts/research-snapshot
+          run-id: ${{ github.event.inputs.snapshot_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Compile research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          ./target/release/examples/research_snapshot_compile \
+            --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --start-date "${{ github.event.inputs.start_date }}" \
+            --end-date "${{ github.event.inputs.end_date }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
+            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
+            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --output-dir artifacts/research-snapshot \
+            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            2>&1 | tee artifacts/research-snapshot/compile.log
 
       - name: Run factor walk-forward
         run: |
           set -euo pipefail
           mkdir -p artifacts/factor-walk-forward-v2
+          source_args=()
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            source_args=(--snapshot-dir artifacts/research-snapshot)
+            echo "canonical_result=snapshot" | tee artifacts/factor-walk-forward-v2/source.txt
+          elif [ "${{ github.event.inputs.allow_direct_db_debug }}" = "true" ]; then
+            source_args=(--db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" --allow-direct-db-debug)
+            echo "canonical_result=no direct_db_debug=true" | tee artifacts/factor-walk-forward-v2/source.txt
+          else
+            echo "ERROR: no research snapshot is present; set compile_snapshot=true, pass snapshot_run_id, or explicitly set allow_direct_db_debug=true" >&2
+            exit 2
+          fi
           args=(
-            --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}"
+            "${source_args[@]}"
             --symbols "${{ github.event.inputs.symbols }}"
             --start-date "${{ github.event.inputs.start_date }}"
             --end-date "${{ github.event.inputs.end_date }}"
@@ -151,7 +207,15 @@ jobs:
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
             echo "- Factor filter: ${{ github.event.inputs.factor_name_filter || '<none>' }}"
+            if [ -f artifacts/factor-walk-forward-v2/source.txt ]; then
+              echo "- Source: $(cat artifacts/factor-walk-forward-v2/source.txt)"
+            fi
             echo ""
+            if [ -f artifacts/research-snapshot/quality.md ]; then
+              echo "### Snapshot Quality"
+              cat artifacts/research-snapshot/quality.md
+              echo ""
+            fi
             if [ -f artifacts/factor-walk-forward-v2/report.txt ]; then
               echo '```'
               sed -n '1,160p' artifacts/factor-walk-forward-v2/report.txt
@@ -164,5 +228,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: factor-walk-forward-v2-${{ github.run_id }}
-          path: artifacts/factor-walk-forward-v2/
+          path: |
+            artifacts/factor-walk-forward-v2/
+            artifacts/research-snapshot/
           retention-days: 14

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -87,6 +87,14 @@ on:
         description: "Process timeout for optimize_backtest"
         required: false
         default: "90"
+      snapshot_run_id:
+        description: "Research Snapshot workflow run id; required for canonical optimizer runs"
+        required: false
+        default: ""
+      allow_live_parquet_debug:
+        description: "Allow non-canonical direct live parquet optimization without snapshot manifest"
+        required: false
+        default: "false"
 
 concurrency:
   group: optimize-${{ github.ref }}
@@ -94,6 +102,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -173,7 +182,17 @@ jobs:
       - name: Make binary executable
         run: chmod +x target/release/examples/optimize_backtest
 
+      - name: Download research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
+          path: artifacts/research-snapshot
+          run-id: ${{ github.event.inputs.snapshot_run_id }}
+          github-token: ${{ github.token }}
+
       - name: Sync Parquet data from Tango-1-1
+        if: ${{ github.event.inputs.allow_live_parquet_debug == 'true' }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
@@ -192,6 +211,30 @@ jobs:
           echo "PLOY_DUCKDB_TEMP_DIR=${DUCKDB_TEMP_DIR}" >> "${GITHUB_ENV}"
           echo "PLOY_DUCKDB_MEMORY_LIMIT=${{ github.event.inputs.duckdb_memory_limit }}" >> "${GITHUB_ENV}"
           echo "DuckDB spill directory: ${DUCKDB_TEMP_DIR}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Publish snapshot provenance
+        if: ${{ hashFiles('artifacts/research-snapshot/manifest.json') != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/optimize
+          node <<'NODE' > artifacts/optimize/snapshot-provenance.txt
+          const fs = require('fs');
+          const manifest = JSON.parse(fs.readFileSync('artifacts/research-snapshot/manifest.json', 'utf8'));
+          const lines = [
+            '# Research Snapshot Provenance',
+            `schema_version=${manifest.schema_version ?? ''}`,
+            `snapshot_hash=${manifest.snapshot_hash ?? ''}`,
+            `generated_at=${manifest.generated_at ?? ''}`,
+            `git_sha=${manifest.git_sha ?? ''}`,
+            `symbols=${(manifest.symbols ?? []).join(',')}`,
+            `start=${manifest.start ?? ''}`,
+            `end=${manifest.end ?? ''}`,
+            `immutable_input=${manifest.immutable_input ?? ''}`,
+            `optimizer_data_dir=${manifest.optimizer_data_dir ?? ''}`,
+          ];
+          console.log(lines.join('\n'));
+          NODE
+          cat artifacts/optimize/snapshot-provenance.txt >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Preflight Parquet manifest
         run: |
@@ -231,6 +274,11 @@ jobs:
           fi
           if [ -n "${{ github.event.inputs.max_updates }}" ]; then
             extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
+          fi
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            extra_flags+=(--snapshot-dir artifacts/research-snapshot)
+          elif [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+            extra_flags+=(--allow-live-parquet-debug)
           fi
 
           ./target/release/examples/optimize_backtest \
@@ -303,6 +351,11 @@ jobs:
           if [ -n "${{ github.event.inputs.max_updates }}" ]; then
             extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
           fi
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            extra_flags+=(--snapshot-dir artifacts/research-snapshot)
+          elif [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+            extra_flags+=(--allow-live-parquet-debug)
+          fi
 
           timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
           ./target/release/examples/optimize_backtest \
@@ -325,3 +378,12 @@ jobs:
             --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
             "${time_flags[@]}" \
             "${extra_flags[@]}"
+
+      - name: Upload optimize provenance
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: optimize-provenance-${{ github.run_id }}
+          path: artifacts/optimize
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -1,0 +1,138 @@
+name: Research Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref"
+        required: true
+        default: "main"
+      start_date:
+        description: "Snapshot start date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-21"
+      end_date:
+        description: "Snapshot end date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-25"
+      symbols:
+        description: "Comma-separated Binance symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT,BNBUSDT,XRPUSDT"
+      stake_usd:
+        description: "Fixed notional used by executable labels"
+        required: true
+        default: "15"
+      lob_sample_secs:
+        description: "Binance and PM LOB sample interval"
+        required: false
+        default: "30"
+      observation_sample_secs:
+        description: "Factor observation output interval"
+        required: false
+        default: "30"
+      max_quote_age_secs:
+        description: "Maximum PM quote age"
+        required: false
+        default: "30"
+      optimizer_data_dir:
+        description: "Immutable parquet-feed dir used by optimize_backtest"
+        required: true
+        default: "/tmp/ploy-parquet"
+
+concurrency:
+  group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  PLOY_DB_URL: ${{ secrets.PLOY_DB_URL }}
+
+jobs:
+  compile:
+    name: Compile research snapshot on ploy-ci-1
+    runs-on: [self-hosted, ploy-ci-1]
+    timeout-minutes: 45
+    environment: ploy-ci-1
+
+    steps:
+      - name: Repair runner workspace permissions
+        run: |
+          if [ -d "${GITHUB_WORKSPACE}" ]; then
+            sudo chown -R "$(id -un):$(id -gn)" "${GITHUB_WORKSPACE}" || true
+            sudo rm -f "${GITHUB_WORKSPACE}/.cargo-lock" || true
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Add cargo to PATH
+        run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: research-snapshot-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build research_snapshot_compile
+        run: |
+          . /home/runner/.cargo/env
+          cargo build --release --locked \
+            -p ploy-research \
+            --features db,polars-export \
+            --example research_snapshot_compile
+
+      - name: Compile snapshot
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          ./target/release/examples/research_snapshot_compile \
+            --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --start-date "${{ github.event.inputs.start_date }}" \
+            --end-date "${{ github.event.inputs.end_date }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
+            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
+            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --output-dir artifacts/research-snapshot \
+            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            2>&1 | tee artifacts/research-snapshot/compile.log
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Research Snapshot"
+            echo ""
+            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Symbols: ${{ github.event.inputs.symbols }}"
+            echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            echo ""
+            if [ -f artifacts/research-snapshot/quality.md ]; then
+              cat artifacts/research-snapshot/quality.md
+            fi
+            if [ -f artifacts/research-snapshot/compile.log ]; then
+              echo ""
+              echo "## Compile Log"
+              echo '```'
+              tail -120 artifacts/research-snapshot/compile.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload research snapshot artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: research-snapshot-${{ github.run_id }}
+          path: artifacts/research-snapshot/
+          retention-days: 14

--- a/crates/ploy-research/Cargo.toml
+++ b/crates/ploy-research/Cargo.toml
@@ -97,6 +97,15 @@ path = "examples/factor_walk_forward_v2.rs"
 required-features = ["db"]
 
 [[example]]
+name = "research_snapshot_compile"
+path = "examples/research_snapshot_compile.rs"
+required-features = ["db"]
+
+[[example]]
+name = "research_snapshot_parity"
+path = "examples/research_snapshot_parity.rs"
+
+[[example]]
 name = "collector_data_utilization"
 path = "examples/collector_data_utilization.rs"
 required-features = ["db"]

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -17,13 +17,14 @@
 //!     [--top-n 20]
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    DeribitFeatureSnapshot, FactorObservation, FactorReviewOptions,
     build_factor_observations_with_lob_sampled, format_factor_review_v2_report,
-    load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
-    review_factors_v2_with_deribit_and_pm_books,
+    load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
+    load_research_pm_book_snapshots_sampled, load_research_snapshot,
+    review_factors_v2_with_deribit_and_pm_books, validate_snapshot_request, FactorObservation,
+    FactorReviewOptions, ResearchSnapshotRequest,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -32,6 +33,10 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2)
         .find(|window| window[0] == flag)
         .map(|window| window[1].clone())
+}
+
+fn flag_present(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
 }
 
 fn parse_date_start(raw: &str) -> DateTime<Utc> {
@@ -43,7 +48,10 @@ fn parse_date_start(raw: &str) -> DateTime<Utc> {
 fn parse_date_end(raw: &str) -> DateTime<Utc> {
     let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
         .unwrap_or_else(|_| panic!("invalid date: {raw}"));
-    Utc.from_utc_datetime(&date.and_hms_opt(23, 59, 59).unwrap())
+    let next_day = date
+        .succ_opt()
+        .unwrap_or_else(|| panic!("invalid end date: {raw}"));
+    Utc.from_utc_datetime(&next_day.and_hms_opt(0, 0, 0).unwrap())
 }
 
 fn parse_timestamp(raw: &str) -> DateTime<Utc> {
@@ -63,7 +71,7 @@ where
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let db_url = flag_value(&args, "--db-url").expect("--db-url required");
+    let db_url = flag_value(&args, "--db-url");
     let start = flag_value(&args, "--start-ts")
         .map(|raw| parse_timestamp(&raw))
         .unwrap_or_else(|| {
@@ -110,63 +118,172 @@ async fn main() {
         start, end, symbols, options.stake_usd, observation_sample_secs
     );
 
-    let pool = PgPoolOptions::new()
-        .max_connections(1)
-        .acquire_timeout(Duration::from_secs(120))
-        .connect(&db_url)
+    let snapshot_dir = flag_value(&args, "--snapshot-dir");
+    let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
+    if snapshot_dir.is_some() && db_url.is_some() {
+        eprintln!("ERROR: --snapshot-dir cannot be combined with --db-url");
+        std::process::exit(2);
+    }
+    let mut snapshot_provenance: Option<String> = None;
+    let (observations, deribit_snapshots, all_pm_book_snapshots): (
+        Vec<FactorObservation>,
+        Vec<_>,
+        Vec<_>,
+    ) = if let Some(snapshot_dir) = snapshot_dir {
+        let started = std::time::Instant::now();
+        let snapshot =
+            load_research_snapshot(&snapshot_dir).expect("load research snapshot failed");
+        validate_snapshot_request(
+            &snapshot.manifest,
+            ResearchSnapshotRequest {
+                symbols: &symbols,
+                start,
+                end,
+                lob_sample_secs,
+                observation_sample_secs,
+                max_quote_age_secs,
+                stake_usd: options.stake_usd,
+                require_official_settlement: true,
+            },
+        )
+        .expect("snapshot does not match requested review inputs");
+        let snapshot_hash = snapshot
+            .manifest
+            .snapshot_hash
+            .as_deref()
+            .unwrap_or("<missing>");
+        eprintln!(
+            "snapshot: schema={} hash={} generated_at={} observations={} deribit={} pm_books={} load_ms={}",
+            snapshot.manifest.schema_version,
+            snapshot_hash,
+            snapshot.manifest.generated_at,
+            snapshot.observations.len(),
+            snapshot.deribit_snapshots.len(),
+            snapshot.pm_book_snapshots.len(),
+            started.elapsed().as_millis()
+        );
+        snapshot_provenance = Some(format!(
+            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\n",
+            snapshot.manifest.schema_version,
+            snapshot_hash,
+            snapshot.manifest.generated_at,
+            snapshot
+                .manifest
+                .optimizer_data_dir
+                .as_deref()
+                .unwrap_or("<missing>")
+        ));
+        (
+            snapshot.observations,
+            snapshot.deribit_snapshots,
+            snapshot.pm_book_snapshots,
+        )
+    } else {
+        if !allow_direct_db_debug {
+            eprintln!(
+                "ERROR: direct DB factor review is non-canonical; pass --snapshot-dir or explicit --allow-direct-db-debug"
+            );
+            std::process::exit(2);
+        }
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_secs(120))
+            .connect(
+                db_url
+                    .as_deref()
+                    .expect("--db-url required without --snapshot-dir"),
+            )
+            .await
+            .expect("database connection failed");
+
+        let mut phase_timings = Vec::new();
+        let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
+        let started = std::time::Instant::now();
+        let all_updates = load_from_database_with_options(
+            &pool,
+            &symbols,
+            start,
+            end,
+            &HistoricalLoadOptions {
+                require_official_settlement: true,
+                include_l2: false,
+                spot_sample_secs: historical_sample_secs,
+                lob_sample_secs: historical_sample_secs,
+                ..Default::default()
+            },
+        )
         .await
-        .expect("database connection failed");
+        .expect("bulk historical load failed");
+        phase_timings.push((
+            "historical_updates",
+            started.elapsed().as_millis(),
+            all_updates.len(),
+        ));
+        eprintln!("updates: {}", all_updates.len());
 
-    let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
-    let all_updates = load_from_database_with_options(
-        &pool,
-        &symbols,
-        start,
-        end,
-        &HistoricalLoadOptions {
-            require_official_settlement: true,
-            include_l2: false,
-            spot_sample_secs: historical_sample_secs,
-            lob_sample_secs: historical_sample_secs,
-            ..Default::default()
-        },
-    )
-    .await
-    .expect("bulk historical load failed");
-    eprintln!("updates: {}", all_updates.len());
+        let started = std::time::Instant::now();
+        let all_lob_snapshots =
+            load_research_lob_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
+                .await
+                .expect("bulk lob snapshot load failed");
+        phase_timings.push((
+            "cex_lob_snapshots",
+            started.elapsed().as_millis(),
+            all_lob_snapshots.len(),
+        ));
+        eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
 
-    let all_lob_snapshots =
-        load_research_lob_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
-            .await
-            .expect("bulk lob snapshot load failed");
-    eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
+        let started = std::time::Instant::now();
+        let all_pm_book_snapshots =
+            load_research_pm_book_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
+                .await
+                .expect("bulk PM book snapshot load failed");
+        phase_timings.push((
+            "pm_book_snapshots",
+            started.elapsed().as_millis(),
+            all_pm_book_snapshots.len(),
+        ));
+        eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
 
-    let all_pm_book_snapshots =
-        load_research_pm_book_snapshots_sampled(&pool, &symbols, start, end, lob_sample_secs)
-            .await
-            .expect("bulk PM book snapshot load failed");
-    eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
+        let started = std::time::Instant::now();
+        let deribit_snapshots =
+            load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs)
+                .await;
+        phase_timings.push((
+            "deribit_snapshots",
+            started.elapsed().as_millis(),
+            deribit_snapshots.len(),
+        ));
+        eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
 
-    let deribit_snapshots =
-        load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
-    eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
+        let updates_slice_start =
+            start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
+        let updates_slice = slice_by_time(
+            &all_updates,
+            updates_slice_start,
+            end,
+            MarketUpdate::sort_ts,
+        );
+        let lob_slice = slice_by_time(&all_lob_snapshots, start, end, |snapshot| snapshot.ts);
 
-    let updates_slice_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
-    let updates_slice = slice_by_time(
-        &all_updates,
-        updates_slice_start,
-        end,
-        MarketUpdate::sort_ts,
-    );
-    let lob_slice = slice_by_time(&all_lob_snapshots, start, end, |snapshot| snapshot.ts);
-
-    let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
-        updates_slice,
-        lob_slice,
-        max_quote_age_secs,
-        observation_sample_secs,
-    );
-    eprintln!("factor_observations: {}", observations.len());
+        let started = std::time::Instant::now();
+        let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
+            updates_slice,
+            lob_slice,
+            max_quote_age_secs,
+            observation_sample_secs,
+        );
+        phase_timings.push((
+            "factor_observations",
+            started.elapsed().as_millis(),
+            observations.len(),
+        ));
+        for (phase, elapsed_ms, rows) in phase_timings {
+            eprintln!("phase {phase:<24} {elapsed_ms:>8} ms rows={rows}");
+        }
+        eprintln!("factor_observations: {}", observations.len());
+        (observations, deribit_snapshots, all_pm_book_snapshots)
+    };
 
     if observations.is_empty() {
         eprintln!("no observations — check date range, symbols, quote coverage, and settlements");
@@ -179,229 +296,8 @@ async fn main() {
         &all_pm_book_snapshots,
         options,
     );
+    if let Some(snapshot_provenance) = snapshot_provenance {
+        println!("{snapshot_provenance}");
+    }
     println!("{}", format_factor_review_v2_report(&report, top_n));
-}
-
-async fn load_deribit_feature_snapshots(
-    pool: &sqlx::PgPool,
-    symbols: &[String],
-    start: DateTime<Utc>,
-    end: DateTime<Utc>,
-    sample_secs: i64,
-) -> Vec<DeribitFeatureSnapshot> {
-    let currencies: Vec<String> = symbols
-        .iter()
-        .filter_map(|symbol| symbol_to_deribit_currency(symbol))
-        .collect();
-    if currencies.is_empty() {
-        return Vec::new();
-    }
-
-    let sample_secs = sample_secs.clamp(1, 300) as i32;
-    let mut snapshots = Vec::new();
-    let current_iv_rows: Vec<(
-        String,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        DateTime<Utc>,
-    )> = match sqlx::query_as(
-        r#"
-        WITH currencies AS (
-            SELECT unnest($1::text[]) AS currency
-        ),
-        buckets AS (
-            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
-        )
-        SELECT
-            c.currency,
-            d.mark_iv::double precision,
-            d.bid_iv::double precision,
-            d.ask_iv::double precision,
-            d.underlying_price::double precision,
-            b.bucket_ts
-        FROM currencies c
-        CROSS JOIN buckets b
-        JOIN LATERAL (
-            SELECT mark_iv, bid_iv, ask_iv, underlying_price
-            FROM deribit_iv_ticks d
-            WHERE d.currency = c.currency
-              AND d.creation_ts <= b.bucket_ts
-              AND d.creation_ts > b.bucket_ts - interval '5 minutes'
-              AND d.mark_iv IS NOT NULL
-            ORDER BY d.creation_ts DESC, d.open_interest DESC NULLS LAST
-            LIMIT 1
-        ) d ON true
-        ORDER BY b.bucket_ts
-        "#,
-    )
-    .bind(&currencies)
-    .bind(start)
-    .bind(end)
-    .bind(sample_secs)
-    .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
-        Err(err) => {
-            eprintln!("deribit iv load failed: {err}");
-            Vec::new()
-        }
-    };
-
-    for (currency, mark_iv, bid_iv, ask_iv, underlying_price, ts) in current_iv_rows {
-        snapshots.push(DeribitFeatureSnapshot {
-            symbol: deribit_currency_to_symbol(&currency),
-            ts,
-            mark_iv: mark_iv.unwrap_or(f64::NAN),
-            bid_iv: bid_iv.unwrap_or(f64::NAN),
-            ask_iv: ask_iv.unwrap_or(f64::NAN),
-            underlying_price: underlying_price.unwrap_or(f64::NAN),
-            delta: f64::NAN,
-            gamma: f64::NAN,
-            vega: f64::NAN,
-            theta: f64::NAN,
-        });
-    }
-
-    if snapshots.is_empty() {
-        let legacy_iv_rows: Vec<(String, Option<f64>, Option<f64>, DateTime<Utc>)> =
-            match sqlx::query_as(
-                r#"
-                SELECT
-                    currency,
-                    COALESCE(atm_iv, iv_close, iv_open)::double precision,
-                    iv_close::double precision,
-                    timestamp
-                FROM deribit_iv_ticks
-                WHERE currency = ANY($1)
-                  AND timestamp >= $2
-                  AND timestamp <= $3
-                ORDER BY timestamp
-                "#,
-            )
-            .bind(&currencies)
-            .bind(start)
-            .bind(end)
-            .fetch_all(pool)
-            .await
-            {
-                Ok(rows) => rows,
-                Err(err) => {
-                    eprintln!("legacy deribit iv load skipped: {err}");
-                    Vec::new()
-                }
-            };
-        for (currency, atm_iv, iv_close, ts) in legacy_iv_rows {
-            let mark_iv = atm_iv.or(iv_close).unwrap_or(f64::NAN);
-            snapshots.push(DeribitFeatureSnapshot {
-                symbol: deribit_currency_to_symbol(&currency),
-                ts,
-                mark_iv,
-                bid_iv: f64::NAN,
-                ask_iv: f64::NAN,
-                underlying_price: f64::NAN,
-                delta: f64::NAN,
-                gamma: f64::NAN,
-                vega: f64::NAN,
-                theta: f64::NAN,
-            });
-        }
-    }
-
-    let greeks_rows: Vec<(
-        String,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        DateTime<Utc>,
-    )> = match sqlx::query_as(
-        r#"
-        WITH currencies AS (
-            SELECT unnest($1::text[]) AS currency
-        ),
-        buckets AS (
-            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
-        )
-        SELECT
-            c.currency,
-            d.mark_iv::double precision,
-            d.delta::double precision,
-            d.gamma::double precision,
-            d.vega::double precision,
-            d.theta::double precision,
-            d.underlying_price::double precision,
-            b.bucket_ts
-        FROM currencies c
-        CROSS JOIN buckets b
-        JOIN LATERAL (
-            SELECT mark_iv, delta, gamma, vega, theta, underlying_price
-            FROM deribit_atm_greeks_ticks d
-            WHERE d.currency = c.currency
-              AND d.source_ts <= b.bucket_ts
-              AND d.source_ts > b.bucket_ts - interval '5 minutes'
-              AND d.mark_iv IS NOT NULL
-            ORDER BY d.source_ts DESC, d.open_interest DESC NULLS LAST
-            LIMIT 1
-        ) d ON true
-        ORDER BY b.bucket_ts
-        "#,
-    )
-    .bind(&currencies)
-    .bind(start)
-    .bind(end)
-    .bind(sample_secs)
-    .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
-        Err(err) => {
-            eprintln!("deribit greeks load failed: {err}");
-            Vec::new()
-        }
-    };
-
-    for (currency, mark_iv, delta, gamma, vega, theta, underlying_price, ts) in greeks_rows {
-        snapshots.push(DeribitFeatureSnapshot {
-            symbol: deribit_currency_to_symbol(&currency),
-            ts,
-            mark_iv: mark_iv.unwrap_or(f64::NAN),
-            bid_iv: f64::NAN,
-            ask_iv: f64::NAN,
-            underlying_price: underlying_price.unwrap_or(f64::NAN),
-            delta: delta.unwrap_or(f64::NAN),
-            gamma: gamma.unwrap_or(f64::NAN),
-            vega: vega.unwrap_or(f64::NAN),
-            theta: theta.unwrap_or(f64::NAN),
-        });
-    }
-
-    snapshots.sort_by_key(|snapshot| (snapshot.symbol.clone(), snapshot.ts));
-    snapshots
-}
-
-fn symbol_to_deribit_currency(symbol: &str) -> Option<String> {
-    let upper = symbol.trim().to_ascii_uppercase();
-    if upper.starts_with("BTC") {
-        Some("BTC".to_string())
-    } else if upper.starts_with("ETH") {
-        Some("ETH".to_string())
-    } else if upper.starts_with("SOL") {
-        Some("SOL".to_string())
-    } else {
-        None
-    }
-}
-
-fn deribit_currency_to_symbol(currency: &str) -> String {
-    match currency.trim().to_ascii_uppercase().as_str() {
-        "BTC" => "BTCUSDT".to_string(),
-        "ETH" => "ETHUSDT".to_string(),
-        "SOL" => "SOLUSDT".to_string(),
-        other => format!("{other}USDT"),
-    }
 }

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -5,12 +5,9 @@
 //! scores executable PnL after PM CLOB fillability.
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
-    FactorWalkForwardOptions, FillabilityReviewOptions, LiquidityGateV1Options,
-    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, TradeFormationReviewOptions,
     build_factor_observations_with_lob_sampled, build_factor_stability_report,
     format_factor_combo_v1_report, format_factor_stability_report,
     format_factor_walk_forward_v2_report, format_fillability_review_v1_report,
@@ -18,9 +15,14 @@ use ploy_research::{
     format_meta_label_walk_forward_v1_report, format_trade_formation_v1_report,
     liquidity_gate_v1_with_deribit, liquidity_gated_alpha_v1_with_deribit,
     load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
-    load_research_pm_book_snapshots_sampled, review_fillability_v1_with_deribit,
-    review_trade_formation_v1_with_deribit, walk_forward_factor_combo_v1_with_deribit,
+    load_research_pm_book_snapshots_sampled, load_research_snapshot,
+    review_fillability_v1_with_deribit, review_trade_formation_v1_with_deribit,
+    validate_snapshot_request, walk_forward_factor_combo_v1_with_deribit,
     walk_forward_factors_v2_with_deribit_and_pm_books, walk_forward_meta_label_v1_with_deribit,
+    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
+    FactorWalkForwardOptions, FillabilityReviewOptions, LiquidityGateV1Options,
+    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, ResearchSnapshotRequest,
+    TradeFormationReviewOptions,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -29,6 +31,10 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2)
         .find(|window| window[0] == flag)
         .map(|window| window[1].clone())
+}
+
+fn flag_present(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
 }
 
 fn parse_date_start(raw: &str) -> DateTime<Utc> {
@@ -63,7 +69,7 @@ where
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let db_url = flag_value(&args, "--db-url").expect("--db-url required");
+    let db_url = flag_value(&args, "--db-url");
     let start = flag_value(&args, "--start-ts")
         .map(|raw| parse_timestamp(&raw))
         .unwrap_or_else(|| {
@@ -130,65 +136,178 @@ async fn main() {
         options.factor_name_filter.as_deref().unwrap_or("<none>")
     );
 
-    let pool = PgPoolOptions::new()
-        .max_connections(1)
-        .acquire_timeout(Duration::from_secs(120))
-        .connect(&db_url)
-        .await
-        .expect("database connection failed");
-
-    let history_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
-    let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
-    let all_updates = load_from_database_with_options(
-        &pool,
-        &symbols,
-        history_start,
-        end,
-        &HistoricalLoadOptions {
-            require_official_settlement: true,
-            include_l2: false,
-            spot_sample_secs: historical_sample_secs,
-            lob_sample_secs: historical_sample_secs,
-            ..Default::default()
-        },
-    )
-    .await
-    .expect("bulk historical load failed");
-    eprintln!("updates: {}", all_updates.len());
-
-    let all_lob_snapshots =
-        load_research_lob_snapshots_sampled(&pool, &symbols, history_start, end, lob_sample_secs)
+    let snapshot_dir = flag_value(&args, "--snapshot-dir");
+    let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
+    if snapshot_dir.is_some() && db_url.is_some() {
+        eprintln!("ERROR: --snapshot-dir cannot be combined with --db-url");
+        std::process::exit(2);
+    }
+    let mut snapshot_provenance: Option<String> = None;
+    let (observations, deribit_snapshots, all_pm_book_snapshots): (
+        Vec<FactorObservation>,
+        Vec<_>,
+        Vec<_>,
+    ) = if let Some(snapshot_dir) = snapshot_dir {
+        let started = std::time::Instant::now();
+        let snapshot =
+            load_research_snapshot(&snapshot_dir).expect("load research snapshot failed");
+        validate_snapshot_request(
+            &snapshot.manifest,
+            ResearchSnapshotRequest {
+                symbols: &symbols,
+                start,
+                end,
+                lob_sample_secs,
+                observation_sample_secs,
+                max_quote_age_secs,
+                stake_usd: options.review.stake_usd,
+                require_official_settlement: true,
+            },
+        )
+        .expect("snapshot does not match requested walk-forward inputs");
+        let snapshot_hash = snapshot
+            .manifest
+            .snapshot_hash
+            .as_deref()
+            .unwrap_or("<missing>");
+        eprintln!(
+            "snapshot: schema={} hash={} generated_at={} observations={} deribit={} pm_books={} load_ms={}",
+            snapshot.manifest.schema_version,
+            snapshot_hash,
+            snapshot.manifest.generated_at,
+            snapshot.observations.len(),
+            snapshot.deribit_snapshots.len(),
+            snapshot.pm_book_snapshots.len(),
+            started.elapsed().as_millis()
+        );
+        snapshot_provenance = Some(format!(
+            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\n",
+            snapshot.manifest.schema_version,
+            snapshot_hash,
+            snapshot.manifest.generated_at,
+            snapshot
+                .manifest
+                .optimizer_data_dir
+                .as_deref()
+                .unwrap_or("<missing>")
+        ));
+        (
+            snapshot.observations,
+            snapshot.deribit_snapshots,
+            snapshot.pm_book_snapshots,
+        )
+    } else {
+        if !allow_direct_db_debug {
+            eprintln!(
+                "ERROR: direct DB factor walk-forward is non-canonical; pass --snapshot-dir or explicit --allow-direct-db-debug"
+            );
+            std::process::exit(2);
+        }
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_secs(120))
+            .connect(
+                db_url
+                    .as_deref()
+                    .expect("--db-url required without --snapshot-dir"),
+            )
             .await
-            .expect("bulk lob snapshot load failed");
-    eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
+            .expect("database connection failed");
 
-    let all_pm_book_snapshots = load_research_pm_book_snapshots_sampled(
-        &pool,
-        &symbols,
-        history_start,
-        end,
-        lob_sample_secs,
-    )
-    .await
-    .expect("bulk PM book snapshot load failed");
-    eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
+        let mut phase_timings = Vec::new();
+        let history_start = start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
+        let historical_sample_secs = u32::try_from(lob_sample_secs.max(1)).unwrap_or(1);
+        let started = std::time::Instant::now();
+        let all_updates = load_from_database_with_options(
+            &pool,
+            &symbols,
+            history_start,
+            end,
+            &HistoricalLoadOptions {
+                require_official_settlement: true,
+                include_l2: false,
+                spot_sample_secs: historical_sample_secs,
+                lob_sample_secs: historical_sample_secs,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("bulk historical load failed");
+        phase_timings.push((
+            "historical_updates",
+            started.elapsed().as_millis(),
+            all_updates.len(),
+        ));
+        eprintln!("updates: {}", all_updates.len());
 
-    let deribit_snapshots =
-        load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs).await;
-    eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
+        let started = std::time::Instant::now();
+        let all_lob_snapshots = load_research_lob_snapshots_sampled(
+            &pool,
+            &symbols,
+            history_start,
+            end,
+            lob_sample_secs,
+        )
+        .await
+        .expect("bulk lob snapshot load failed");
+        phase_timings.push((
+            "cex_lob_snapshots",
+            started.elapsed().as_millis(),
+            all_lob_snapshots.len(),
+        ));
+        eprintln!("lob_snapshots: {}", all_lob_snapshots.len());
 
-    let updates_slice = slice_by_time(&all_updates, history_start, end, MarketUpdate::sort_ts);
-    let lob_slice = slice_by_time(&all_lob_snapshots, history_start, end, |snapshot| {
-        snapshot.ts
-    });
+        let started = std::time::Instant::now();
+        let all_pm_book_snapshots = load_research_pm_book_snapshots_sampled(
+            &pool,
+            &symbols,
+            history_start,
+            end,
+            lob_sample_secs,
+        )
+        .await
+        .expect("bulk PM book snapshot load failed");
+        phase_timings.push((
+            "pm_book_snapshots",
+            started.elapsed().as_millis(),
+            all_pm_book_snapshots.len(),
+        ));
+        eprintln!("pm_book_snapshots: {}", all_pm_book_snapshots.len());
 
-    let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
-        updates_slice,
-        lob_slice,
-        max_quote_age_secs,
-        observation_sample_secs,
-    );
-    eprintln!("factor_observations: {}", observations.len());
+        let started = std::time::Instant::now();
+        let deribit_snapshots =
+            load_deribit_feature_snapshots(&pool, &symbols, start, end, observation_sample_secs)
+                .await;
+        phase_timings.push((
+            "deribit_snapshots",
+            started.elapsed().as_millis(),
+            deribit_snapshots.len(),
+        ));
+        eprintln!("deribit_snapshots: {}", deribit_snapshots.len());
+
+        let updates_slice = slice_by_time(&all_updates, history_start, end, MarketUpdate::sort_ts);
+        let lob_slice = slice_by_time(&all_lob_snapshots, history_start, end, |snapshot| {
+            snapshot.ts
+        });
+
+        let started = std::time::Instant::now();
+        let observations: Vec<FactorObservation> = build_factor_observations_with_lob_sampled(
+            updates_slice,
+            lob_slice,
+            max_quote_age_secs,
+            observation_sample_secs,
+        );
+        phase_timings.push((
+            "factor_observations",
+            started.elapsed().as_millis(),
+            observations.len(),
+        ));
+        for (phase, elapsed_ms, rows) in phase_timings {
+            eprintln!("phase {phase:<24} {elapsed_ms:>8} ms rows={rows}");
+        }
+        eprintln!("factor_observations: {}", observations.len());
+        (observations, deribit_snapshots, all_pm_book_snapshots)
+    };
 
     if observations.is_empty() {
         eprintln!("no observations — check date range, symbols, quote coverage, and settlements");
@@ -203,6 +322,9 @@ async fn main() {
         end,
         options.clone(),
     );
+    if let Some(snapshot_provenance) = snapshot_provenance {
+        println!("{snapshot_provenance}");
+    }
     println!("{}", format_factor_walk_forward_v2_report(&report));
     let fillability_report = review_fillability_v1_with_deribit(
         &observations,

--- a/crates/ploy-research/examples/research_snapshot_compile.rs
+++ b/crates/ploy-research/examples/research_snapshot_compile.rs
@@ -1,0 +1,137 @@
+//! Compile a point-in-time research snapshot from Tango PostgreSQL raw tables.
+//!
+//! This binary is the boundary between collector storage and repeated research
+//! scoring. Factor review, walk-forward, and optimizer jobs should consume the
+//! resulting immutable snapshot artifacts instead of rebuilding raw joins.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use ploy_research::{
+    ResearchSnapshotBuildOptions, build_research_snapshot_from_database, write_research_snapshot,
+};
+use sqlx::postgres::PgPoolOptions;
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|window| window[0] == flag)
+        .map(|window| window[1].clone())
+}
+
+fn flag_present(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn parse_date_start(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+}
+
+fn parse_date_end(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    let next_day = date
+        .succ_opt()
+        .unwrap_or_else(|| panic!("invalid end date: {raw}"));
+    Utc.from_utc_datetime(&next_day.and_hms_opt(0, 0, 0).unwrap())
+}
+
+fn parse_timestamp(raw: &str) -> DateTime<Utc> {
+    raw.parse::<DateTime<Utc>>()
+        .unwrap_or_else(|_| panic!("invalid timestamp: {raw}"))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let db_url = flag_value(&args, "--db-url").expect("--db-url required");
+    let output_dir =
+        PathBuf::from(flag_value(&args, "--output-dir").expect("--output-dir required"));
+    let start = flag_value(&args, "--start-ts")
+        .map(|raw| parse_timestamp(&raw))
+        .unwrap_or_else(|| {
+            parse_date_start(&flag_value(&args, "--start-date").expect("--start-date required"))
+        });
+    let end = flag_value(&args, "--end-ts")
+        .map(|raw| parse_timestamp(&raw))
+        .unwrap_or_else(|| {
+            parse_date_end(&flag_value(&args, "--end-date").expect("--end-date required"))
+        });
+    let symbols: Vec<String> = flag_value(&args, "--symbols")
+        .unwrap_or_else(|| "BTCUSDT".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|symbol| !symbol.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    let lob_sample_secs: i32 = flag_value(&args, "--lob-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let max_quote_age_secs: i64 = flag_value(&args, "--max-quote-age-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let observation_sample_secs: i64 = flag_value(&args, "--observation-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(30);
+    let stake_usd = flag_value(&args, "--stake-usd")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(15.0);
+    let require_official_settlement = !flag_present(&args, "--allow-missing-official-settlement");
+    let optimizer_data_dir =
+        flag_value(&args, "--optimizer-data-dir").expect("--optimizer-data-dir required");
+
+    eprintln!(
+        "research_snapshot_compile: {} -> {} for {:?}, stake_usd={:.2}, output={}",
+        start,
+        end,
+        symbols,
+        stake_usd,
+        output_dir.display()
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(120))
+        .connect(&db_url)
+        .await?;
+
+    let snapshot = build_research_snapshot_from_database(
+        &pool,
+        ResearchSnapshotBuildOptions {
+            symbols,
+            start,
+            end,
+            lob_sample_secs,
+            observation_sample_secs,
+            max_quote_age_secs,
+            stake_usd,
+            require_official_settlement,
+            optimizer_data_dir: Some(optimizer_data_dir),
+            git_sha: std::env::var("GITHUB_SHA").ok(),
+        },
+    )
+    .await?;
+    let manifest = write_research_snapshot(&output_dir, snapshot)?;
+
+    eprintln!("research snapshot written: {}", output_dir.display());
+    eprintln!(
+        "rows: observations={} deribit={} pm_books={}",
+        manifest.row_counts.observations,
+        manifest.row_counts.deribit_snapshots,
+        manifest.row_counts.pm_book_snapshots
+    );
+    for timing in &manifest.phase_timings {
+        eprintln!(
+            "phase {:<24} {:>8} ms rows={}",
+            timing.phase,
+            timing.elapsed_ms,
+            timing
+                .rows
+                .map(|rows| rows.to_string())
+                .unwrap_or_else(|| "n/a".to_string())
+        );
+    }
+    Ok(())
+}

--- a/crates/ploy-research/examples/research_snapshot_parity.rs
+++ b/crates/ploy-research/examples/research_snapshot_parity.rs
@@ -1,0 +1,459 @@
+//! Compare a research snapshot with dry-run and live trading-state snapshots.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs::File;
+use std::io::BufReader;
+
+use ploy_operator_contracts::{TradingIntentSnapshot, TradingStateSnapshot};
+use ploy_research::load_research_snapshot;
+use serde::Serialize;
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|window| window[0] == flag)
+        .map(|window| window[1].clone())
+}
+
+fn flag_present(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+struct ParityKey {
+    event_id: String,
+    token_id: String,
+    side: String,
+    purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OrderParityRow {
+    key: ParityKey,
+    order_id: String,
+    state: String,
+    requested_qty: String,
+    filled_qty: String,
+    rejection_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotRuntimeParityReport {
+    snapshot_schema: String,
+    snapshot_hash: String,
+    snapshot_generated_at: String,
+    snapshot_observations: usize,
+    snapshot_events: usize,
+    dryrun_orders: usize,
+    live_orders: usize,
+    dryrun_only_orders: Vec<OrderParityRow>,
+    live_only_orders: Vec<OrderParityRow>,
+    live_fill_shortfalls: Vec<LiveFillShortfall>,
+    order_record_mismatches: Vec<OrderRecordMismatch>,
+    live_order_events_not_in_snapshot: Vec<String>,
+    dryrun_order_events_not_in_snapshot: Vec<String>,
+}
+
+impl SnapshotRuntimeParityReport {
+    fn has_blocking_mismatch(&self) -> bool {
+        !self.dryrun_only_orders.is_empty()
+            || !self.live_only_orders.is_empty()
+            || !self.live_fill_shortfalls.is_empty()
+            || !self.order_record_mismatches.is_empty()
+            || !self.live_order_events_not_in_snapshot.is_empty()
+            || !self.dryrun_order_events_not_in_snapshot.is_empty()
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct LiveFillShortfall {
+    key: ParityKey,
+    dryrun_filled_qty: String,
+    live_filled_qty: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OrderRecordMismatch {
+    key: ParityKey,
+    field: String,
+    dryrun_value: String,
+    live_value: String,
+}
+
+#[derive(Debug, Default)]
+struct OrderKeySummary {
+    order_count: usize,
+    requested_qty: f64,
+    filled_qty: f64,
+    state_counts: BTreeMap<String, usize>,
+    rejection_reason_counts: BTreeMap<String, usize>,
+}
+
+fn read_state(path: &str) -> anyhow::Result<TradingStateSnapshot> {
+    let file = File::open(path)?;
+    Ok(serde_json::from_reader(BufReader::new(file))?)
+}
+
+fn order_rows(snapshot: &TradingStateSnapshot) -> Vec<OrderParityRow> {
+    let intents: HashMap<&str, &TradingIntentSnapshot> = snapshot
+        .intents
+        .iter()
+        .map(|intent| (intent.intent_id.as_str(), intent))
+        .collect();
+
+    snapshot
+        .orders
+        .iter()
+        .filter_map(|order| {
+            let intent = intents.get(order.intent_id.as_str())?;
+            Some(OrderParityRow {
+                key: ParityKey {
+                    event_id: intent.market_id.clone(),
+                    token_id: order.token_id.clone(),
+                    side: intent.side.to_ascii_lowercase(),
+                    purpose: format!("{:?}", intent.purpose).to_ascii_lowercase(),
+                },
+                order_id: order.order_id.clone(),
+                state: order.state.clone(),
+                requested_qty: order.requested_qty.to_string(),
+                filled_qty: order.filled_qty.to_string(),
+                rejection_reason: order
+                    .rejection_reason
+                    .clone()
+                    .or_else(|| order.last_error.clone()),
+            })
+        })
+        .collect()
+}
+
+fn filled_by_key(rows: &[OrderParityRow]) -> BTreeMap<ParityKey, f64> {
+    let mut out = BTreeMap::new();
+    for row in rows {
+        let qty = quantity(&row.filled_qty);
+        *out.entry(row.key.clone()).or_insert(0.0) += qty;
+    }
+    out
+}
+
+fn quantity(raw: &str) -> f64 {
+    raw.parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite())
+        .unwrap_or(0.0)
+}
+
+fn bump_count(counts: &mut BTreeMap<String, usize>, value: impl Into<String>) {
+    *counts.entry(value.into()).or_insert(0) += 1;
+}
+
+fn order_summaries_by_key(rows: &[OrderParityRow]) -> BTreeMap<ParityKey, OrderKeySummary> {
+    let mut summaries: BTreeMap<ParityKey, OrderKeySummary> = BTreeMap::new();
+    for row in rows {
+        let summary = summaries.entry(row.key.clone()).or_default();
+        summary.order_count += 1;
+        summary.requested_qty += quantity(&row.requested_qty);
+        summary.filled_qty += quantity(&row.filled_qty);
+        bump_count(&mut summary.state_counts, row.state.clone());
+        bump_count(
+            &mut summary.rejection_reason_counts,
+            row.rejection_reason
+                .clone()
+                .unwrap_or_else(|| "<none>".to_string()),
+        );
+    }
+    summaries
+}
+
+fn format_counts(counts: &BTreeMap<String, usize>) -> String {
+    counts
+        .iter()
+        .map(|(value, count)| format!("{value}:{count}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn push_mismatch(
+    mismatches: &mut Vec<OrderRecordMismatch>,
+    key: &ParityKey,
+    field: &str,
+    dryrun_value: impl Into<String>,
+    live_value: impl Into<String>,
+) {
+    mismatches.push(OrderRecordMismatch {
+        key: key.clone(),
+        field: field.to_string(),
+        dryrun_value: dryrun_value.into(),
+        live_value: live_value.into(),
+    });
+}
+
+fn order_record_mismatches(
+    dryrun_rows: &[OrderParityRow],
+    live_rows: &[OrderParityRow],
+) -> Vec<OrderRecordMismatch> {
+    const EPSILON: f64 = 0.0001;
+
+    let dryrun = order_summaries_by_key(dryrun_rows);
+    let live = order_summaries_by_key(live_rows);
+    let keys = dryrun
+        .keys()
+        .chain(live.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut mismatches = Vec::new();
+
+    for key in keys {
+        let Some(dryrun_summary) = dryrun.get(&key) else {
+            continue;
+        };
+        let Some(live_summary) = live.get(&key) else {
+            continue;
+        };
+
+        if dryrun_summary.order_count != live_summary.order_count {
+            push_mismatch(
+                &mut mismatches,
+                &key,
+                "order_count",
+                dryrun_summary.order_count.to_string(),
+                live_summary.order_count.to_string(),
+            );
+        }
+        if dryrun_summary.state_counts != live_summary.state_counts {
+            push_mismatch(
+                &mut mismatches,
+                &key,
+                "state_counts",
+                format_counts(&dryrun_summary.state_counts),
+                format_counts(&live_summary.state_counts),
+            );
+        }
+        if (dryrun_summary.requested_qty - live_summary.requested_qty).abs() > EPSILON {
+            push_mismatch(
+                &mut mismatches,
+                &key,
+                "requested_qty",
+                format!("{:.8}", dryrun_summary.requested_qty),
+                format!("{:.8}", live_summary.requested_qty),
+            );
+        }
+        if (dryrun_summary.filled_qty - live_summary.filled_qty).abs() > EPSILON {
+            push_mismatch(
+                &mut mismatches,
+                &key,
+                "filled_qty",
+                format!("{:.8}", dryrun_summary.filled_qty),
+                format!("{:.8}", live_summary.filled_qty),
+            );
+        }
+        if dryrun_summary.rejection_reason_counts != live_summary.rejection_reason_counts {
+            push_mismatch(
+                &mut mismatches,
+                &key,
+                "rejection_reason_counts",
+                format_counts(&dryrun_summary.rejection_reason_counts),
+                format_counts(&live_summary.rejection_reason_counts),
+            );
+        }
+    }
+
+    mismatches
+}
+
+fn build_report_from_rows(
+    snapshot_schema: String,
+    snapshot_hash: String,
+    snapshot_generated_at: String,
+    snapshot_observations: usize,
+    snapshot_events: BTreeSet<String>,
+    dryrun_rows: Vec<OrderParityRow>,
+    live_rows: Vec<OrderParityRow>,
+) -> SnapshotRuntimeParityReport {
+    let dry_keys: BTreeSet<_> = dryrun_rows.iter().map(|row| row.key.clone()).collect();
+    let live_keys: BTreeSet<_> = live_rows.iter().map(|row| row.key.clone()).collect();
+    let live_filled = filled_by_key(&live_rows);
+    let dry_filled = filled_by_key(&dryrun_rows);
+    let order_record_mismatches = order_record_mismatches(&dryrun_rows, &live_rows);
+
+    let dryrun_only_orders = dryrun_rows
+        .iter()
+        .filter(|row| !live_keys.contains(&row.key))
+        .cloned()
+        .collect::<Vec<_>>();
+    let live_only_orders = live_rows
+        .iter()
+        .filter(|row| !dry_keys.contains(&row.key))
+        .cloned()
+        .collect::<Vec<_>>();
+    let live_fill_shortfalls = dry_filled
+        .iter()
+        .filter_map(|(key, dry_qty)| {
+            let live_qty = live_filled.get(key).copied().unwrap_or(0.0);
+            if *dry_qty > 0.0 && live_qty + 0.0001 < *dry_qty {
+                Some(LiveFillShortfall {
+                    key: key.clone(),
+                    dryrun_filled_qty: format!("{dry_qty:.8}"),
+                    live_filled_qty: format!("{live_qty:.8}"),
+                })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let dryrun_order_events_not_in_snapshot = dryrun_rows
+        .iter()
+        .map(|row| row.key.event_id.clone())
+        .filter(|event_id| !snapshot_events.contains(event_id))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let live_order_events_not_in_snapshot = live_rows
+        .iter()
+        .map(|row| row.key.event_id.clone())
+        .filter(|event_id| !snapshot_events.contains(event_id))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    SnapshotRuntimeParityReport {
+        snapshot_schema,
+        snapshot_hash,
+        snapshot_generated_at,
+        snapshot_observations,
+        snapshot_events: snapshot_events.len(),
+        dryrun_orders: dryrun_rows.len(),
+        live_orders: live_rows.len(),
+        dryrun_only_orders,
+        live_only_orders,
+        live_fill_shortfalls,
+        order_record_mismatches,
+        live_order_events_not_in_snapshot,
+        dryrun_order_events_not_in_snapshot,
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let snapshot_dir = flag_value(&args, "--snapshot-dir").expect("--snapshot-dir required");
+    let dryrun_state = flag_value(&args, "--dryrun-state").expect("--dryrun-state required");
+    let live_state = flag_value(&args, "--live-state").expect("--live-state required");
+    let fail_on_mismatch = flag_present(&args, "--fail-on-mismatch");
+
+    let snapshot = load_research_snapshot(snapshot_dir)?;
+    let dryrun = read_state(&dryrun_state)?;
+    let live = read_state(&live_state)?;
+
+    let snapshot_events: BTreeSet<String> = snapshot
+        .observations
+        .iter()
+        .map(|row| row.event_id.clone())
+        .collect();
+    let report = build_report_from_rows(
+        snapshot.manifest.schema_version,
+        snapshot
+            .manifest
+            .snapshot_hash
+            .unwrap_or_else(|| "<missing>".to_string()),
+        snapshot.manifest.generated_at.to_rfc3339(),
+        snapshot.observations.len(),
+        snapshot_events,
+        order_rows(&dryrun),
+        order_rows(&live),
+    );
+
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    if fail_on_mismatch && report.has_blocking_mismatch() {
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(event_id: &str, token_id: &str, side: &str, filled_qty: &str) -> OrderParityRow {
+        OrderParityRow {
+            key: ParityKey {
+                event_id: event_id.to_string(),
+                token_id: token_id.to_string(),
+                side: side.to_string(),
+                purpose: "entry".to_string(),
+            },
+            order_id: format!("{event_id}-{token_id}-{side}"),
+            state: "filled".to_string(),
+            requested_qty: "10".to_string(),
+            filled_qty: filled_qty.to_string(),
+            rejection_reason: None,
+        }
+    }
+
+    #[test]
+    fn parity_report_flags_live_fill_shortfall() {
+        let report = build_report_from_rows(
+            "research_snapshot_v1".to_string(),
+            "hash-1".to_string(),
+            "2026-04-28T00:00:00Z".to_string(),
+            1,
+            BTreeSet::from(["event-1".to_string()]),
+            vec![row("event-1", "token-up", "buy", "10")],
+            vec![row("event-1", "token-up", "buy", "4")],
+        );
+        assert_eq!(report.live_fill_shortfalls.len(), 1);
+        assert!(report
+            .order_record_mismatches
+            .iter()
+            .any(|row| row.field == "filled_qty"));
+        assert!(report.has_blocking_mismatch());
+    }
+
+    #[test]
+    fn parity_report_flags_orders_outside_snapshot_events() {
+        let report = build_report_from_rows(
+            "research_snapshot_v1".to_string(),
+            "hash-1".to_string(),
+            "2026-04-28T00:00:00Z".to_string(),
+            1,
+            BTreeSet::from(["event-1".to_string()]),
+            vec![row("event-2", "token-up", "buy", "0")],
+            vec![row("event-2", "token-up", "buy", "0")],
+        );
+        assert_eq!(report.dryrun_order_events_not_in_snapshot, vec!["event-2"]);
+        assert_eq!(report.live_order_events_not_in_snapshot, vec!["event-2"]);
+        assert!(report.has_blocking_mismatch());
+    }
+
+    #[test]
+    fn parity_report_flags_same_key_record_differences() {
+        let mut dryrun = row("event-1", "token-up", "buy", "4");
+        dryrun.requested_qty = "10".to_string();
+        dryrun.state = "filled".to_string();
+        dryrun.rejection_reason = None;
+
+        let mut live = row("event-1", "token-up", "buy", "8");
+        live.requested_qty = "12".to_string();
+        live.state = "rejected".to_string();
+        live.rejection_reason = Some("not enough balance".to_string());
+
+        let report = build_report_from_rows(
+            "research_snapshot_v1".to_string(),
+            "hash-1".to_string(),
+            "2026-04-28T00:00:00Z".to_string(),
+            1,
+            BTreeSet::from(["event-1".to_string()]),
+            vec![dryrun],
+            vec![live],
+        );
+        let fields = report
+            .order_record_mismatches
+            .iter()
+            .map(|row| row.field.as_str())
+            .collect::<BTreeSet<_>>();
+        assert!(fields.contains("state_counts"));
+        assert!(fields.contains("requested_qty"));
+        assert!(fields.contains("filled_qty"));
+        assert!(fields.contains("rejection_reason_counts"));
+        assert!(report.live_fill_shortfalls.is_empty());
+        assert!(report.has_blocking_mismatch());
+    }
+}

--- a/crates/ploy-research/src/deribit.rs
+++ b/crates/ploy-research/src/deribit.rs
@@ -1,7 +1,13 @@
 use chrono::{DateTime, Utc};
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
 
-use crate::DeribitFeatureSnapshot;
+use crate::{DeribitFeatureSnapshot, ResearchSnapshotPhaseTiming};
+
+pub struct DeribitFeatureLoadResult {
+    pub snapshots: Vec<DeribitFeatureSnapshot>,
+    pub phase_timings: Vec<ResearchSnapshotPhaseTiming>,
+}
 
 pub async fn load_deribit_feature_snapshots(
     pool: &sqlx::PgPool,
@@ -10,6 +16,19 @@ pub async fn load_deribit_feature_snapshots(
     end: DateTime<Utc>,
     sample_secs: i64,
 ) -> Vec<DeribitFeatureSnapshot> {
+    load_deribit_feature_snapshots_with_timings(pool, symbols, start, end, sample_secs)
+        .await
+        .snapshots
+}
+
+pub async fn load_deribit_feature_snapshots_with_timings(
+    pool: &sqlx::PgPool,
+    symbols: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_secs: i64,
+) -> DeribitFeatureLoadResult {
+    let mut phase_timings = Vec::new();
     let mut currency_set = BTreeSet::new();
     let mut unsupported_symbols = Vec::new();
     for symbol in symbols {
@@ -30,11 +49,248 @@ pub async fn load_deribit_feature_snapshots(
     let currencies: Vec<String> = currency_set.into_iter().collect();
     if currencies.is_empty() {
         tracing::warn!("deribit feature loader has no supported currencies");
-        return Vec::new();
+        return DeribitFeatureLoadResult {
+            snapshots: Vec::new(),
+            phase_timings,
+        };
     }
 
     let sample_secs = sample_secs.clamp(1, 300) as i32;
     let mut snapshots: BTreeMap<(String, DateTime<Utc>), DeribitFeatureSnapshot> = BTreeMap::new();
+
+    let started = Instant::now();
+    if relation_exists(pool, "strategy_data.deribit_atm_greeks_snapshots_cache").await {
+        let started = Instant::now();
+        let cache_rows = load_deribit_cache_rows(pool, &currencies, start, end, sample_secs).await;
+        let elapsed_ms = started.elapsed().as_millis();
+        tracing::info!(
+            rows = cache_rows.len(),
+            elapsed_ms,
+            "deribit cache snapshot phase complete"
+        );
+        phase_timings.push(deribit_phase_timing(
+            "deribit_cache_snapshots",
+            elapsed_ms,
+            Some(cache_rows.len()),
+        ));
+        merge_deribit_rows(&mut snapshots, cache_rows);
+    } else {
+        phase_timings.push(deribit_phase_timing(
+            "deribit_cache_snapshots",
+            started.elapsed().as_millis(),
+            Some(0),
+        ));
+        tracing::info!("deribit cache relation not present; using live ATM Greeks table");
+    }
+
+    let started = Instant::now();
+    let greeks_rows =
+        load_deribit_atm_greeks_rows(pool, &currencies, start, end, sample_secs).await;
+    let elapsed_ms = started.elapsed().as_millis();
+    tracing::info!(
+        rows = greeks_rows.len(),
+        elapsed_ms,
+        "deribit ATM Greeks phase complete"
+    );
+    phase_timings.push(deribit_phase_timing(
+        "deribit_atm_greeks",
+        elapsed_ms,
+        Some(greeks_rows.len()),
+    ));
+    merge_deribit_rows(&mut snapshots, greeks_rows);
+
+    if snapshots.is_empty() {
+        tracing::warn!(
+            "deribit ATM/cache loaders returned no rows; raw IV fallback is disabled by default"
+        );
+    }
+
+    if snapshots.is_empty() && raw_iv_fallback_enabled() {
+        let started = Instant::now();
+        let current_iv_rows =
+            load_deribit_raw_iv_rows(pool, &currencies, start, end, sample_secs).await;
+        let elapsed_ms = started.elapsed().as_millis();
+        tracing::warn!(
+            rows = current_iv_rows.len(),
+            elapsed_ms,
+            "deribit raw IV fallback phase complete"
+        );
+        phase_timings.push(deribit_phase_timing(
+            "deribit_raw_iv_fallback",
+            elapsed_ms,
+            Some(current_iv_rows.len()),
+        ));
+        merge_deribit_rows(&mut snapshots, current_iv_rows);
+    }
+
+    let mut snapshots: Vec<_> = snapshots.into_values().collect();
+    snapshots.sort_by_key(|snapshot| (snapshot.symbol.clone(), snapshot.ts));
+    DeribitFeatureLoadResult {
+        snapshots,
+        phase_timings,
+    }
+}
+
+fn deribit_phase_timing(
+    phase: &str,
+    elapsed_ms: u128,
+    rows: Option<usize>,
+) -> ResearchSnapshotPhaseTiming {
+    ResearchSnapshotPhaseTiming {
+        phase: phase.to_string(),
+        elapsed_ms,
+        rows,
+    }
+}
+
+type DeribitRow = (
+    String,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    DateTime<Utc>,
+);
+
+async fn relation_exists(pool: &sqlx::PgPool, relation: &str) -> bool {
+    sqlx::query_scalar::<_, Option<String>>("SELECT to_regclass($1)::text")
+        .bind(relation)
+        .fetch_one(pool)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+fn raw_iv_fallback_enabled() -> bool {
+    std::env::var("PLOY_RESEARCH_DERIBIT_RAW_IV_FALLBACK")
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+async fn load_deribit_cache_rows(
+    pool: &sqlx::PgPool,
+    currencies: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_secs: i32,
+) -> Vec<DeribitRow> {
+    match sqlx::query_as(
+        r#"
+        WITH currencies AS (
+            SELECT unnest($1::text[]) AS currency
+        ),
+        buckets AS (
+            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
+        )
+        SELECT
+            c.currency,
+            d.mark_iv::double precision,
+            d.bid_iv::double precision,
+            d.ask_iv::double precision,
+            d.underlying_price::double precision,
+            d.delta::double precision,
+            d.gamma::double precision,
+            d.vega::double precision,
+            d.theta::double precision,
+            b.bucket_ts
+        FROM currencies c
+        CROSS JOIN buckets b
+        JOIN LATERAL (
+            SELECT mark_iv, bid_iv, ask_iv, underlying_price, delta, gamma, vega, theta, source_ts
+            FROM strategy_data.deribit_atm_greeks_snapshots_cache d
+            WHERE d.currency = c.currency
+              AND d.source_ts <= b.bucket_ts
+              AND d.source_ts > b.bucket_ts - interval '5 minutes'
+              AND d.mark_iv IS NOT NULL
+            ORDER BY d.source_ts DESC
+            LIMIT 1
+        ) d ON true
+        ORDER BY b.bucket_ts
+        "#,
+    )
+    .bind(currencies)
+    .bind(start)
+    .bind(end)
+    .bind(sample_secs)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!(error = %err, "deribit cache load failed");
+            Vec::new()
+        }
+    }
+}
+
+async fn load_deribit_atm_greeks_rows(
+    pool: &sqlx::PgPool,
+    currencies: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_secs: i32,
+) -> Vec<DeribitRow> {
+    match sqlx::query_as(
+        r#"
+        WITH currencies AS (
+            SELECT unnest($1::text[]) AS currency
+        ),
+        buckets AS (
+            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
+        )
+        SELECT
+            c.currency,
+            d.mark_iv::double precision,
+            d.bid_iv::double precision,
+            d.ask_iv::double precision,
+            d.underlying_price::double precision,
+            d.delta::double precision,
+            d.gamma::double precision,
+            d.vega::double precision,
+            d.theta::double precision,
+            b.bucket_ts
+        FROM currencies c
+        CROSS JOIN buckets b
+        JOIN LATERAL (
+            SELECT mark_iv, bid_iv, ask_iv, underlying_price, delta, gamma, vega, theta
+            FROM deribit_atm_greeks_ticks d
+            WHERE d.currency = c.currency
+              AND d.source_ts <= b.bucket_ts
+              AND d.source_ts > b.bucket_ts - interval '5 minutes'
+              AND d.mark_iv IS NOT NULL
+            ORDER BY d.source_ts DESC, d.open_interest DESC NULLS LAST
+            LIMIT 1
+        ) d ON true
+        ORDER BY b.bucket_ts
+        "#,
+    )
+    .bind(currencies)
+    .bind(start)
+    .bind(end)
+    .bind(sample_secs)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!(error = %err, "deribit ATM Greeks load failed");
+            Vec::new()
+        }
+    }
+}
+
+async fn load_deribit_raw_iv_rows(
+    pool: &sqlx::PgPool,
+    currencies: &[String],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    sample_secs: i32,
+) -> Vec<DeribitRow> {
     let current_iv_rows: Vec<(
         String,
         Option<f64>,
@@ -72,7 +328,7 @@ pub async fn load_deribit_feature_snapshots(
         ORDER BY b.bucket_ts
         "#,
     )
-    .bind(&currencies)
+    .bind(currencies)
     .bind(start)
     .bind(end)
     .bind(sample_secs)
@@ -86,10 +342,36 @@ pub async fn load_deribit_feature_snapshots(
         }
     };
 
-    for (currency, mark_iv, bid_iv, ask_iv, underlying_price, ts) in current_iv_rows {
+    current_iv_rows
+        .into_iter()
+        .map(
+            |(currency, mark_iv, bid_iv, ask_iv, underlying_price, ts)| {
+                (
+                    currency,
+                    mark_iv,
+                    bid_iv,
+                    ask_iv,
+                    underlying_price,
+                    None,
+                    None,
+                    None,
+                    None,
+                    ts,
+                )
+            },
+        )
+        .collect()
+}
+
+fn merge_deribit_rows(
+    snapshots: &mut BTreeMap<(String, DateTime<Utc>), DeribitFeatureSnapshot>,
+    rows: Vec<DeribitRow>,
+) {
+    for (currency, mark_iv, bid_iv, ask_iv, underlying_price, delta, gamma, vega, theta, ts) in rows
+    {
         let symbol = deribit_currency_to_symbol(&currency);
         merge_deribit_snapshot(
-            &mut snapshots,
+            snapshots,
             symbol,
             ts,
             DeribitFeatureSnapshot {
@@ -99,148 +381,6 @@ pub async fn load_deribit_feature_snapshots(
                 bid_iv: bid_iv.unwrap_or(f64::NAN),
                 ask_iv: ask_iv.unwrap_or(f64::NAN),
                 underlying_price: underlying_price.unwrap_or(f64::NAN),
-                delta: f64::NAN,
-                gamma: f64::NAN,
-                vega: f64::NAN,
-                theta: f64::NAN,
-            },
-        );
-    }
-
-    if snapshots.is_empty() {
-        let legacy_iv_rows: Vec<(String, Option<f64>, Option<f64>, DateTime<Utc>)> =
-            match sqlx::query_as(
-                r#"
-                WITH currencies AS (
-                    SELECT unnest($1::text[]) AS currency
-                ),
-                buckets AS (
-                    SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
-                )
-                SELECT
-                    c.currency,
-                    COALESCE(d.atm_iv, d.iv_close, d.iv_open)::double precision,
-                    d.iv_close::double precision,
-                    b.bucket_ts
-                FROM currencies c
-                CROSS JOIN buckets b
-                JOIN LATERAL (
-                    SELECT atm_iv, iv_close, iv_open, timestamp
-                    FROM deribit_iv_ticks d
-                    WHERE d.currency = c.currency
-                      AND d.timestamp <= b.bucket_ts
-                      AND d.timestamp > b.bucket_ts - interval '5 minutes'
-                      AND COALESCE(d.atm_iv, d.iv_close, d.iv_open) IS NOT NULL
-                    ORDER BY d.timestamp DESC
-                    LIMIT 1
-                ) d ON true
-                ORDER BY b.bucket_ts
-                "#,
-            )
-            .bind(&currencies)
-            .bind(start)
-            .bind(end)
-            .bind(sample_secs)
-            .fetch_all(pool)
-            .await
-            {
-                Ok(rows) => rows,
-                Err(err) => {
-                    tracing::warn!(error = %err, "legacy deribit iv load skipped");
-                    Vec::new()
-                }
-            };
-        for (currency, atm_iv, iv_close, ts) in legacy_iv_rows {
-            let mark_iv = atm_iv.or(iv_close).unwrap_or(f64::NAN);
-            let symbol = deribit_currency_to_symbol(&currency);
-            merge_deribit_snapshot(
-                &mut snapshots,
-                symbol,
-                ts,
-                DeribitFeatureSnapshot {
-                    symbol: String::new(),
-                    ts,
-                    mark_iv,
-                    bid_iv: f64::NAN,
-                    ask_iv: f64::NAN,
-                    underlying_price: f64::NAN,
-                    delta: f64::NAN,
-                    gamma: f64::NAN,
-                    vega: f64::NAN,
-                    theta: f64::NAN,
-                },
-            );
-        }
-    }
-
-    let greeks_rows: Vec<(
-        String,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        DateTime<Utc>,
-    )> = match sqlx::query_as(
-        r#"
-        WITH currencies AS (
-            SELECT unnest($1::text[]) AS currency
-        ),
-        buckets AS (
-            SELECT generate_series($2::timestamptz, $3::timestamptz, make_interval(secs => $4::int)) AS bucket_ts
-        )
-        SELECT
-            c.currency,
-            d.mark_iv::double precision,
-            d.delta::double precision,
-            d.gamma::double precision,
-            d.vega::double precision,
-            d.theta::double precision,
-            d.underlying_price::double precision,
-            b.bucket_ts
-        FROM currencies c
-        CROSS JOIN buckets b
-        JOIN LATERAL (
-            SELECT mark_iv, delta, gamma, vega, theta, underlying_price
-            FROM deribit_atm_greeks_ticks d
-            WHERE d.currency = c.currency
-              AND d.source_ts <= b.bucket_ts
-              AND d.source_ts > b.bucket_ts - interval '5 minutes'
-              AND d.mark_iv IS NOT NULL
-            ORDER BY d.source_ts DESC, d.open_interest DESC NULLS LAST
-            LIMIT 1
-        ) d ON true
-        ORDER BY b.bucket_ts
-        "#,
-    )
-    .bind(&currencies)
-    .bind(start)
-    .bind(end)
-    .bind(sample_secs)
-    .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
-        Err(err) => {
-            tracing::warn!(error = %err, "deribit greeks load failed");
-            Vec::new()
-        }
-    };
-
-    for (currency, mark_iv, delta, gamma, vega, theta, underlying_price, ts) in greeks_rows {
-        let symbol = deribit_currency_to_symbol(&currency);
-        merge_deribit_snapshot(
-            &mut snapshots,
-            symbol,
-            ts,
-            DeribitFeatureSnapshot {
-                symbol: String::new(),
-                ts,
-                mark_iv: mark_iv.unwrap_or(f64::NAN),
-                bid_iv: f64::NAN,
-                ask_iv: f64::NAN,
-                underlying_price: underlying_price.unwrap_or(f64::NAN),
                 delta: delta.unwrap_or(f64::NAN),
                 gamma: gamma.unwrap_or(f64::NAN),
                 vega: vega.unwrap_or(f64::NAN),
@@ -248,10 +388,6 @@ pub async fn load_deribit_feature_snapshots(
             },
         );
     }
-
-    let mut snapshots: Vec<_> = snapshots.into_values().collect();
-    snapshots.sort_by_key(|snapshot| (snapshot.symbol.clone(), snapshot.ts));
-    snapshots
 }
 
 fn merge_deribit_snapshot(

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -5,6 +5,7 @@ use ploy_market_contracts::MarketUpdate;
 #[cfg(feature = "polars-export")]
 use polars::prelude::*;
 use rust_decimal::prelude::ToPrimitive;
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "db")]
 use serde_json::Value;
 #[cfg(feature = "db")]
@@ -69,7 +70,7 @@ const PM_BOOK_SAMPLED_QUERY: &str = r#"
         ORDER BY received_at
         "#;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FactorObservation {
     pub event_id: String,
     pub symbol: String,
@@ -236,7 +237,7 @@ pub struct AggregatedFactorMetric {
     pub icir: Option<f64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResearchLobSnapshot {
     pub symbol: String,
     pub ts: DateTime<Utc>,
@@ -254,13 +255,13 @@ pub struct ResearchLobSnapshot {
     pub ask_depth_inner: f64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ResearchPmBookLevel {
     pub price: f64,
     pub size: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResearchPmBookSnapshot {
     pub event_id: String,
     pub token_id: String,

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use chrono::{DateTime, Duration, Utc};
 use ploy_operator_contracts::Regime;
+use serde::{Deserialize, Serialize};
 
 use crate::factors::{pearson_ic, spearman_ic, FactorObservation, ResearchPmBookSnapshot};
 
@@ -10,7 +11,7 @@ const DEFAULT_TOP_QUANTILE: f64 = 0.2;
 const PM_BOOK_MAX_AGE_SECS: i64 = 30;
 const EPS: f64 = 1e-9;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FactorFamily {
     Alpha,
     CexLob,
@@ -41,7 +42,7 @@ impl FactorFamily {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ThreeLayerArchive {
     DirectionProbabilityEdge,
     CexMicrostructureConfirmation,
@@ -62,7 +63,7 @@ impl ThreeLayerArchive {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReviewSide {
     Up,
     Down,
@@ -101,7 +102,7 @@ impl Default for FactorReviewOptions {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeribitFeatureSnapshot {
     pub symbol: String,
     pub ts: DateTime<Utc>,
@@ -115,7 +116,7 @@ pub struct DeribitFeatureSnapshot {
     pub theta: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FactorObservationV2 {
     pub event_id: String,
     pub symbol: String,

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -11,6 +11,7 @@ pub mod factors_v2;
 #[cfg(any(feature = "ml", feature = "rl"))]
 pub mod model;
 pub mod replay;
+pub mod research_snapshot;
 pub mod signal;
 
 pub use backtesting::{BacktestReport, run_backtest};
@@ -31,7 +32,10 @@ pub use dataset::{
     export_event_root_dataset_parquet, split_assignments_to_frame,
 };
 #[cfg(feature = "db")]
-pub use deribit::load_deribit_feature_snapshots;
+pub use deribit::{
+    load_deribit_feature_snapshots, load_deribit_feature_snapshots_with_timings,
+    DeribitFeatureLoadResult,
+};
 pub use event_ml::{
     ArchitectureArtifact, EVENT_ML_ARCHITECTURE_VERSION, EventMlArchitecture, LaneReadiness,
     LaneStatus, LearningLane, LearningLaneId, PhaseId, ReadinessGate, WALK_FORWARD_REPORT_VERSION,
@@ -54,6 +58,13 @@ pub use factors::{
     load_research_pm_book_snapshots_sampled,
 };
 pub use replay::replay_fills;
+#[cfg(feature = "db")]
+pub use research_snapshot::{build_research_snapshot_from_database, ResearchSnapshotBuildOptions};
+pub use research_snapshot::{
+    load_research_snapshot, validate_snapshot_request, write_research_snapshot, ResearchSnapshot,
+    ResearchSnapshotArtifacts, ResearchSnapshotManifest, ResearchSnapshotPhaseTiming,
+    ResearchSnapshotRequest, ResearchSnapshotRowCounts, RESEARCH_SNAPSHOT_SCHEMA_VERSION,
+};
 
 pub const CRATE_MARKER: &str = "ploy-research";
 

--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -1,0 +1,603 @@
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+#[cfg(feature = "db")]
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{DeribitFeatureSnapshot, FactorObservation, ResearchPmBookSnapshot};
+
+pub const RESEARCH_SNAPSHOT_SCHEMA_VERSION: &str = "research_snapshot_v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResearchSnapshotArtifacts {
+    pub observations_json: String,
+    pub deribit_snapshots_json: String,
+    pub pm_book_snapshots_json: String,
+    pub quality_markdown: String,
+    pub query_timings_json: String,
+    pub observations_parquet: Option<String>,
+}
+
+impl Default for ResearchSnapshotArtifacts {
+    fn default() -> Self {
+        Self {
+            observations_json: "observations.json".to_string(),
+            deribit_snapshots_json: "deribit_snapshots.json".to_string(),
+            pm_book_snapshots_json: "pm_book_snapshots.json".to_string(),
+            quality_markdown: "quality.md".to_string(),
+            query_timings_json: "query_timings.json".to_string(),
+            observations_parquet: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResearchSnapshotRowCounts {
+    pub observations: usize,
+    pub deribit_snapshots: usize,
+    pub pm_book_snapshots: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResearchSnapshotPhaseTiming {
+    pub phase: String,
+    pub elapsed_ms: u128,
+    pub rows: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResearchSnapshotManifest {
+    pub schema_version: String,
+    pub snapshot_hash: Option<String>,
+    pub generated_at: DateTime<Utc>,
+    pub git_sha: Option<String>,
+    pub symbols: Vec<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub history_start: DateTime<Utc>,
+    pub lob_sample_secs: i32,
+    pub observation_sample_secs: i64,
+    pub max_quote_age_secs: i64,
+    pub stake_usd: f64,
+    pub require_official_settlement: bool,
+    pub immutable_input: bool,
+    pub source_kind: String,
+    pub optimizer_data_dir: Option<String>,
+    pub artifacts: ResearchSnapshotArtifacts,
+    pub row_counts: ResearchSnapshotRowCounts,
+    pub phase_timings: Vec<ResearchSnapshotPhaseTiming>,
+    pub quality_flags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResearchSnapshot {
+    pub manifest: ResearchSnapshotManifest,
+    pub observations: Vec<FactorObservation>,
+    pub deribit_snapshots: Vec<DeribitFeatureSnapshot>,
+    pub pm_book_snapshots: Vec<ResearchPmBookSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ResearchSnapshotRequest<'a> {
+    pub symbols: &'a [String],
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub lob_sample_secs: i32,
+    pub observation_sample_secs: i64,
+    pub max_quote_age_secs: i64,
+    pub stake_usd: f64,
+    pub require_official_settlement: bool,
+}
+
+pub fn load_research_snapshot(snapshot_dir: impl AsRef<Path>) -> Result<ResearchSnapshot> {
+    let snapshot_dir = snapshot_dir.as_ref();
+    let manifest: ResearchSnapshotManifest =
+        read_json(snapshot_dir.join("manifest.json")).context("read research snapshot manifest")?;
+
+    if manifest.schema_version != RESEARCH_SNAPSHOT_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported research snapshot schema {}; expected {}",
+            manifest.schema_version,
+            RESEARCH_SNAPSHOT_SCHEMA_VERSION
+        );
+    }
+
+    let observations = read_json(snapshot_dir.join(&manifest.artifacts.observations_json))
+        .context("read snapshot observations")?;
+    let deribit_snapshots =
+        read_json(snapshot_dir.join(&manifest.artifacts.deribit_snapshots_json))
+            .context("read snapshot Deribit rows")?;
+    let pm_book_snapshots =
+        read_json(snapshot_dir.join(&manifest.artifacts.pm_book_snapshots_json))
+            .context("read snapshot PM book rows")?;
+
+    Ok(ResearchSnapshot {
+        manifest,
+        observations,
+        deribit_snapshots,
+        pm_book_snapshots,
+    })
+}
+
+pub fn write_research_snapshot(
+    snapshot_dir: impl AsRef<Path>,
+    mut snapshot: ResearchSnapshot,
+) -> Result<ResearchSnapshotManifest> {
+    if snapshot.manifest.optimizer_data_dir.is_none() {
+        anyhow::bail!("research snapshot manifest requires optimizer_data_dir");
+    }
+
+    let snapshot_dir = snapshot_dir.as_ref();
+    fs::create_dir_all(snapshot_dir)
+        .with_context(|| format!("create snapshot dir {}", snapshot_dir.display()))?;
+
+    snapshot.manifest.row_counts = ResearchSnapshotRowCounts {
+        observations: snapshot.observations.len(),
+        deribit_snapshots: snapshot.deribit_snapshots.len(),
+        pm_book_snapshots: snapshot.pm_book_snapshots.len(),
+    };
+
+    write_json(
+        snapshot_dir.join(&snapshot.manifest.artifacts.observations_json),
+        &snapshot.observations,
+    )?;
+    write_json(
+        snapshot_dir.join(&snapshot.manifest.artifacts.deribit_snapshots_json),
+        &snapshot.deribit_snapshots,
+    )?;
+    write_json(
+        snapshot_dir.join(&snapshot.manifest.artifacts.pm_book_snapshots_json),
+        &snapshot.pm_book_snapshots,
+    )?;
+
+    #[cfg(feature = "polars-export")]
+    {
+        let parquet_name = "observations.parquet";
+        crate::export_observations_parquet(
+            &snapshot.observations,
+            &snapshot_dir.join(parquet_name),
+        )
+        .context("write snapshot observations parquet")?;
+        snapshot.manifest.artifacts.observations_parquet = Some(parquet_name.to_string());
+    }
+
+    snapshot.manifest.snapshot_hash =
+        Some(compute_snapshot_hash(snapshot_dir, &snapshot.manifest)?);
+
+    write_json(
+        snapshot_dir.join(&snapshot.manifest.artifacts.query_timings_json),
+        &snapshot.manifest.phase_timings,
+    )?;
+    write_quality_markdown(
+        &snapshot_dir.join(&snapshot.manifest.artifacts.quality_markdown),
+        &snapshot.manifest,
+    )?;
+    write_json(snapshot_dir.join("manifest.json"), &snapshot.manifest)?;
+
+    Ok(snapshot.manifest)
+}
+
+pub fn validate_snapshot_request(
+    manifest: &ResearchSnapshotManifest,
+    request: ResearchSnapshotRequest<'_>,
+) -> Result<()> {
+    let mut requested_symbols = request.symbols.to_vec();
+    requested_symbols.sort();
+    let mut snapshot_symbols = manifest.symbols.clone();
+    snapshot_symbols.sort();
+    if requested_symbols != snapshot_symbols {
+        anyhow::bail!(
+            "snapshot symbols {:?} do not match requested symbols {:?}",
+            snapshot_symbols,
+            requested_symbols
+        );
+    }
+    if manifest.start != request.start || manifest.end != request.end {
+        anyhow::bail!(
+            "snapshot window {} -> {} does not match requested window {} -> {}",
+            manifest.start,
+            manifest.end,
+            request.start,
+            request.end
+        );
+    }
+    if manifest.lob_sample_secs != request.lob_sample_secs {
+        anyhow::bail!(
+            "snapshot lob_sample_secs {} does not match requested {}",
+            manifest.lob_sample_secs,
+            request.lob_sample_secs
+        );
+    }
+    if manifest.observation_sample_secs != request.observation_sample_secs {
+        anyhow::bail!(
+            "snapshot observation_sample_secs {} does not match requested {}",
+            manifest.observation_sample_secs,
+            request.observation_sample_secs
+        );
+    }
+    if manifest.max_quote_age_secs != request.max_quote_age_secs {
+        anyhow::bail!(
+            "snapshot max_quote_age_secs {} does not match requested {}",
+            manifest.max_quote_age_secs,
+            request.max_quote_age_secs
+        );
+    }
+    if (manifest.stake_usd - request.stake_usd).abs() > 1e-9 {
+        anyhow::bail!(
+            "snapshot stake_usd {} does not match requested {}",
+            manifest.stake_usd,
+            request.stake_usd
+        );
+    }
+    if manifest.require_official_settlement != request.require_official_settlement {
+        anyhow::bail!(
+            "snapshot require_official_settlement {} does not match requested {}",
+            manifest.require_official_settlement,
+            request.require_official_settlement
+        );
+    }
+    if !manifest.immutable_input {
+        anyhow::bail!("snapshot manifest is not marked immutable_input=true");
+    }
+    if manifest
+        .snapshot_hash
+        .as_deref()
+        .unwrap_or_default()
+        .is_empty()
+    {
+        anyhow::bail!("snapshot manifest is missing snapshot_hash");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "db")]
+pub struct ResearchSnapshotBuildOptions {
+    pub symbols: Vec<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub lob_sample_secs: i32,
+    pub observation_sample_secs: i64,
+    pub max_quote_age_secs: i64,
+    pub stake_usd: f64,
+    pub require_official_settlement: bool,
+    pub optimizer_data_dir: Option<String>,
+    pub git_sha: Option<String>,
+}
+
+#[cfg(feature = "db")]
+pub async fn build_research_snapshot_from_database(
+    pool: &sqlx::PgPool,
+    options: ResearchSnapshotBuildOptions,
+) -> Result<ResearchSnapshot> {
+    use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+    use ploy_market_contracts::MarketUpdate;
+
+    use crate::{
+        build_factor_observations_with_lob_sampled, load_deribit_feature_snapshots_with_timings,
+        load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
+    };
+
+    let mut phase_timings = Vec::new();
+    let history_start = options.start - chrono::Duration::hours(1) - chrono::Duration::seconds(300);
+    let historical_sample_secs = u32::try_from(options.lob_sample_secs.max(1)).unwrap_or(1);
+
+    let started = Instant::now();
+    let all_updates = load_from_database_with_options(
+        pool,
+        &options.symbols,
+        history_start,
+        options.end,
+        &HistoricalLoadOptions {
+            require_official_settlement: options.require_official_settlement,
+            include_l2: false,
+            spot_sample_secs: historical_sample_secs,
+            lob_sample_secs: historical_sample_secs,
+            ..Default::default()
+        },
+    )
+    .await
+    .context("load historical market updates")?;
+    phase_timings.push(ResearchSnapshotPhaseTiming {
+        phase: "historical_updates".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+        rows: Some(all_updates.len()),
+    });
+
+    let started = Instant::now();
+    let all_lob_snapshots = load_research_lob_snapshots_sampled(
+        pool,
+        &options.symbols,
+        history_start,
+        options.end,
+        options.lob_sample_secs,
+    )
+    .await
+    .context("load CEX LOB snapshots")?;
+    phase_timings.push(ResearchSnapshotPhaseTiming {
+        phase: "cex_lob_snapshots".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+        rows: Some(all_lob_snapshots.len()),
+    });
+
+    let started = Instant::now();
+    let all_pm_book_snapshots = load_research_pm_book_snapshots_sampled(
+        pool,
+        &options.symbols,
+        history_start,
+        options.end,
+        options.lob_sample_secs,
+    )
+    .await
+    .context("load PM book snapshots")?;
+    phase_timings.push(ResearchSnapshotPhaseTiming {
+        phase: "pm_book_snapshots".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+        rows: Some(all_pm_book_snapshots.len()),
+    });
+
+    let started = Instant::now();
+    let deribit_result = load_deribit_feature_snapshots_with_timings(
+        pool,
+        &options.symbols,
+        options.start,
+        options.end,
+        options.observation_sample_secs,
+    )
+    .await;
+    let deribit_snapshots = deribit_result.snapshots;
+    phase_timings.extend(deribit_result.phase_timings);
+    phase_timings.push(ResearchSnapshotPhaseTiming {
+        phase: "deribit_snapshots".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+        rows: Some(deribit_snapshots.len()),
+    });
+
+    let started = Instant::now();
+    let updates_slice = slice_by_time(
+        &all_updates,
+        history_start,
+        options.end,
+        MarketUpdate::sort_ts,
+    );
+    let lob_slice = slice_by_time(&all_lob_snapshots, history_start, options.end, |snapshot| {
+        snapshot.ts
+    });
+    let observations = build_factor_observations_with_lob_sampled(
+        updates_slice,
+        lob_slice,
+        options.max_quote_age_secs,
+        options.observation_sample_secs,
+    );
+    phase_timings.push(ResearchSnapshotPhaseTiming {
+        phase: "factor_observations".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+        rows: Some(observations.len()),
+    });
+
+    let mut quality_flags = Vec::new();
+    if observations.is_empty() {
+        quality_flags.push("no_factor_observations".to_string());
+    }
+    if deribit_snapshots.is_empty() {
+        quality_flags.push("no_deribit_snapshots".to_string());
+    }
+    if all_pm_book_snapshots.is_empty() {
+        quality_flags.push("no_pm_book_snapshots".to_string());
+    }
+
+    Ok(ResearchSnapshot {
+        manifest: ResearchSnapshotManifest {
+            schema_version: RESEARCH_SNAPSHOT_SCHEMA_VERSION.to_string(),
+            snapshot_hash: None,
+            generated_at: Utc::now(),
+            git_sha: options.git_sha,
+            symbols: options.symbols,
+            start: options.start,
+            end: options.end,
+            history_start,
+            lob_sample_secs: options.lob_sample_secs,
+            observation_sample_secs: options.observation_sample_secs,
+            max_quote_age_secs: options.max_quote_age_secs,
+            stake_usd: options.stake_usd,
+            require_official_settlement: options.require_official_settlement,
+            immutable_input: true,
+            source_kind: "tango_postgres_compiled_snapshot".to_string(),
+            optimizer_data_dir: options.optimizer_data_dir,
+            artifacts: ResearchSnapshotArtifacts::default(),
+            row_counts: ResearchSnapshotRowCounts {
+                observations: observations.len(),
+                deribit_snapshots: deribit_snapshots.len(),
+                pm_book_snapshots: all_pm_book_snapshots.len(),
+            },
+            phase_timings,
+            quality_flags,
+        },
+        observations,
+        deribit_snapshots,
+        pm_book_snapshots: all_pm_book_snapshots,
+    })
+}
+
+#[cfg(feature = "db")]
+fn slice_by_time<T, F>(items: &[T], start: DateTime<Utc>, end: DateTime<Utc>, ts_fn: F) -> &[T]
+where
+    F: Fn(&T) -> DateTime<Utc>,
+{
+    let lo = items.partition_point(|item| ts_fn(item) < start);
+    let hi = items.partition_point(|item| ts_fn(item) < end);
+    &items[lo..hi]
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> Result<T> {
+    let file = File::open(&path).with_context(|| format!("open {}", path.display()))?;
+    serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("parse {}", path.display()))
+}
+
+fn write_json<T: Serialize>(path: PathBuf, value: &T) -> Result<()> {
+    let file = File::create(&path).with_context(|| format!("create {}", path.display()))?;
+    serde_json::to_writer_pretty(file, value).with_context(|| format!("write {}", path.display()))
+}
+
+fn compute_snapshot_hash(
+    snapshot_dir: &Path,
+    manifest: &ResearchSnapshotManifest,
+) -> Result<String> {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn update(hash: &mut u64, bytes: &[u8]) {
+        for byte in bytes {
+            *hash ^= u64::from(*byte);
+            *hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+
+    let mut hash = FNV_OFFSET;
+    update(&mut hash, RESEARCH_SNAPSHOT_SCHEMA_VERSION.as_bytes());
+    update(&mut hash, manifest.start.to_rfc3339().as_bytes());
+    update(&mut hash, manifest.end.to_rfc3339().as_bytes());
+    update(&mut hash, manifest.symbols.join(",").as_bytes());
+    update(&mut hash, manifest.stake_usd.to_string().as_bytes());
+    for artifact in [
+        &manifest.artifacts.observations_json,
+        &manifest.artifacts.deribit_snapshots_json,
+        &manifest.artifacts.pm_book_snapshots_json,
+    ] {
+        update(&mut hash, artifact.as_bytes());
+        let bytes = fs::read(snapshot_dir.join(artifact))
+            .with_context(|| format!("read snapshot artifact {artifact} for hashing"))?;
+        update(&mut hash, &bytes);
+    }
+    Ok(format!("{hash:016x}"))
+}
+
+fn write_quality_markdown(path: &Path, manifest: &ResearchSnapshotManifest) -> Result<()> {
+    let mut body = String::new();
+    body.push_str("# Research Snapshot Quality\n\n");
+    body.push_str(&format!("- Schema: `{}`\n", manifest.schema_version));
+    body.push_str(&format!(
+        "- Snapshot hash: `{}`\n",
+        manifest.snapshot_hash.as_deref().unwrap_or("<missing>")
+    ));
+    body.push_str(&format!("- Generated at: `{}`\n", manifest.generated_at));
+    body.push_str(&format!(
+        "- Window: `{}` -> `{}`\n",
+        manifest.start, manifest.end
+    ));
+    body.push_str(&format!("- Symbols: `{}`\n", manifest.symbols.join(",")));
+    body.push_str(&format!(
+        "- Immutable input: `{}`\n",
+        manifest.immutable_input
+    ));
+    body.push_str(&format!("- Source kind: `{}`\n", manifest.source_kind));
+    body.push_str(&format!(
+        "- Optimizer data dir: `{}`\n",
+        manifest
+            .optimizer_data_dir
+            .as_deref()
+            .unwrap_or("<missing>")
+    ));
+    body.push_str(&format!(
+        "- Rows: observations={}, deribit={}, pm_books={}\n",
+        manifest.row_counts.observations,
+        manifest.row_counts.deribit_snapshots,
+        manifest.row_counts.pm_book_snapshots
+    ));
+    body.push_str(&format!(
+        "- Official settlement required: `{}`\n",
+        manifest.require_official_settlement
+    ));
+    body.push_str("\n## Phase Timings\n\n");
+    for timing in &manifest.phase_timings {
+        body.push_str(&format!(
+            "- `{}`: {} ms, rows={}\n",
+            timing.phase,
+            timing.elapsed_ms,
+            timing
+                .rows
+                .map(|rows| rows.to_string())
+                .unwrap_or_else(|| "n/a".to_string())
+        ));
+    }
+    if !manifest.quality_flags.is_empty() {
+        body.push_str("\n## Quality Flags\n\n");
+        for flag in &manifest.quality_flags {
+            body.push_str(&format!("- `{flag}`\n"));
+        }
+    }
+    fs::write(path, body).with_context(|| format!("write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_and_load_empty_snapshot_roundtrips_manifest() {
+        let root = std::env::temp_dir().join(format!(
+            "ploy-research-snapshot-test-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let snapshot = ResearchSnapshot {
+            manifest: ResearchSnapshotManifest {
+                schema_version: RESEARCH_SNAPSHOT_SCHEMA_VERSION.to_string(),
+                snapshot_hash: None,
+                generated_at: Utc::now(),
+                git_sha: Some("test-sha".to_string()),
+                symbols: vec!["BTCUSDT".to_string()],
+                start: Utc::now(),
+                end: Utc::now(),
+                history_start: Utc::now(),
+                lob_sample_secs: 30,
+                observation_sample_secs: 30,
+                max_quote_age_secs: 30,
+                stake_usd: 15.0,
+                require_official_settlement: true,
+                immutable_input: true,
+                source_kind: "unit_test".to_string(),
+                optimizer_data_dir: Some("/tmp/immutable-parquet".to_string()),
+                artifacts: ResearchSnapshotArtifacts::default(),
+                row_counts: ResearchSnapshotRowCounts::default(),
+                phase_timings: vec![ResearchSnapshotPhaseTiming {
+                    phase: "unit".to_string(),
+                    elapsed_ms: 1,
+                    rows: Some(0),
+                }],
+                quality_flags: vec![],
+            },
+            observations: vec![],
+            deribit_snapshots: vec![],
+            pm_book_snapshots: vec![],
+        };
+
+        let written = write_research_snapshot(&root, snapshot).expect("write snapshot");
+        let loaded = load_research_snapshot(&root).expect("load snapshot");
+        assert_eq!(written.schema_version, RESEARCH_SNAPSHOT_SCHEMA_VERSION);
+        assert!(written.snapshot_hash.is_some());
+        assert_eq!(loaded.manifest.git_sha.as_deref(), Some("test-sha"));
+        validate_snapshot_request(
+            &loaded.manifest,
+            ResearchSnapshotRequest {
+                symbols: &["BTCUSDT".to_string()],
+                start: loaded.manifest.start,
+                end: loaded.manifest.end,
+                lob_sample_secs: loaded.manifest.lob_sample_secs,
+                observation_sample_secs: loaded.manifest.observation_sample_secs,
+                max_quote_age_secs: loaded.manifest.max_quote_age_secs,
+                stake_usd: loaded.manifest.stake_usd,
+                require_official_settlement: loaded.manifest.require_official_settlement,
+            },
+        )
+        .expect("snapshot request validation");
+        assert_eq!(loaded.manifest.row_counts.observations, 0);
+        assert!(root.join("quality.md").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -51,11 +51,19 @@ use ploy_strategy_bundles::{
 };
 use ploy_trading::{FillRecord, TradeSide, TradingIntent};
 use rust_decimal_macros::dec;
+use serde::Deserialize;
 use sqlx::postgres::PgPoolOptions;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
 const DEFAULT_THREE_LAYER_CONFIG: &str = "config/strategies/02-pm5d-threelayer.unified.toml";
+
+#[derive(Debug, Clone)]
+struct SnapshotProvenance {
+    hash: String,
+    generated_at: DateTime<Utc>,
+    optimizer_data_dir: String,
+}
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
@@ -108,6 +116,24 @@ fn display_bytes(bytes: u64) -> String {
     } else {
         format!("{bytes} B")
     }
+}
+
+fn load_research_snapshot_manifest(path: &str) -> ResearchSnapshotManifestProbe {
+    let manifest_path = std::path::Path::new(path).join("manifest.json");
+    let file = std::fs::File::open(&manifest_path).unwrap_or_else(|error| {
+        eprintln!(
+            "ERROR: failed to open research snapshot manifest {}: {error}",
+            manifest_path.display()
+        );
+        std::process::exit(2);
+    });
+    serde_json::from_reader(file).unwrap_or_else(|error| {
+        eprintln!(
+            "ERROR: failed to parse research snapshot manifest {}: {error}",
+            manifest_path.display()
+        );
+        std::process::exit(2);
+    })
 }
 
 fn algorithm_label(_strategy_variant: &str) -> &'static str {
@@ -178,6 +204,18 @@ impl SplitPreflight {
 #[derive(Debug, Default)]
 struct PreflightManifest {
     splits: Vec<SplitPreflight>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResearchSnapshotManifestProbe {
+    schema_version: String,
+    snapshot_hash: Option<String>,
+    generated_at: DateTime<Utc>,
+    symbols: Vec<String>,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    immutable_input: bool,
+    optimizer_data_dir: Option<String>,
 }
 
 impl PreflightManifest {
@@ -601,6 +639,35 @@ fn canonical_strategy_variant(raw: &str) -> String {
         }
         other => other.to_string(),
     }
+}
+
+fn validate_snapshot_optimizer_scope(
+    manifest: &ResearchSnapshotManifestProbe,
+    symbols: &[String],
+    train_from: DateTime<Utc>,
+    train_to: DateTime<Utc>,
+    val_from: DateTime<Utc>,
+    val_to: DateTime<Utc>,
+) -> std::result::Result<(), String> {
+    let mut requested_symbols = symbols.to_vec();
+    requested_symbols.sort();
+    let mut snapshot_symbols = manifest.symbols.clone();
+    snapshot_symbols.sort();
+    if snapshot_symbols != requested_symbols {
+        return Err(format!(
+            "snapshot symbols {:?} do not match requested symbols {:?}",
+            snapshot_symbols, requested_symbols
+        ));
+    }
+    let requested_start = train_from.min(val_from);
+    let requested_end = train_to.max(val_to);
+    if manifest.start > requested_start || manifest.end < requested_end {
+        return Err(format!(
+            "snapshot window {} -> {} does not cover optimizer window {} -> {}",
+            manifest.start, manifest.end, requested_start, requested_end
+        ));
+    }
+    Ok(())
 }
 
 fn build_strategy(strategy_variant: &str, config: DirectionalConfig) -> Box<dyn StrategyLogic> {
@@ -1114,7 +1181,85 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     let db_url = flag_value(&args, "--db-url");
-    let data_dir = flag_value(&args, "--data-dir");
+    let mut data_dir = flag_value(&args, "--data-dir");
+    let snapshot_dir = flag_value(&args, "--snapshot-dir");
+    let allow_live_parquet_debug = flag_present(&args, "--allow-live-parquet-debug");
+    let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
+    let mut snapshot_manifest = None;
+
+    if let Some(ref snapshot_dir) = snapshot_dir {
+        if db_url.is_some() {
+            eprintln!("ERROR: --snapshot-dir cannot be combined with --db-url");
+            std::process::exit(2);
+        }
+        let manifest = load_research_snapshot_manifest(snapshot_dir);
+        if !manifest.immutable_input {
+            eprintln!("ERROR: research snapshot manifest is not marked immutable_input=true");
+            std::process::exit(2);
+        }
+        if manifest.schema_version != "research_snapshot_v1" {
+            eprintln!(
+                "ERROR: unsupported research snapshot schema {}; expected research_snapshot_v1",
+                manifest.schema_version
+            );
+            std::process::exit(2);
+        }
+        if manifest
+            .snapshot_hash
+            .as_deref()
+            .unwrap_or_default()
+            .is_empty()
+        {
+            eprintln!("ERROR: research snapshot manifest is missing snapshot_hash");
+            std::process::exit(2);
+        }
+        match (&data_dir, &manifest.optimizer_data_dir) {
+            (None, Some(snapshot_data_dir)) => {
+                data_dir = Some(snapshot_data_dir.clone());
+            }
+            (Some(actual), Some(expected)) if actual != expected => {
+                eprintln!(
+                    "ERROR: --data-dir {actual} does not match snapshot optimizer_data_dir {expected}"
+                );
+                std::process::exit(2);
+            }
+            (Some(_), None) => {
+                eprintln!(
+                    "ERROR: research snapshot manifest does not declare optimizer_data_dir; \
+                     refusing to optimize against an unpinned parquet source"
+                );
+                std::process::exit(2);
+            }
+            (None, None) => {}
+            _ => {}
+        }
+        if data_dir.is_none() {
+            eprintln!(
+                "ERROR: research snapshot manifest must declare optimizer_data_dir for canonical optimization"
+            );
+            std::process::exit(2);
+        }
+        snapshot_manifest = Some(manifest);
+    } else {
+        if db_url.is_some() && !allow_direct_db_debug {
+            eprintln!(
+                "ERROR: direct DB optimizer replay is non-canonical; pass --snapshot-dir or explicit --allow-direct-db-debug"
+            );
+            std::process::exit(2);
+        }
+        if data_dir.is_some() && !allow_live_parquet_debug {
+            eprintln!(
+                "ERROR: live Parquet optimizer replay is non-canonical; pass --snapshot-dir or explicit --allow-live-parquet-debug"
+            );
+            std::process::exit(2);
+        }
+        if data_dir.is_none() && db_url.is_none() {
+            eprintln!(
+                "ERROR: optimizer canonical mode requires --snapshot-dir; debug modes require --data-dir/--allow-live-parquet-debug or --db-url/--allow-direct-db-debug"
+            );
+            std::process::exit(2);
+        }
+    }
 
     if db_url.is_none() && data_dir.is_none() {
         eprintln!("ERROR: either --db-url or --data-dir is required");
@@ -1257,6 +1402,30 @@ fn main() {
         .as_deref()
         .map(parse_timestamp)
         .unwrap_or_else(|| parse_date_end(&val_end));
+
+    let _snapshot_provenance = snapshot_manifest.as_ref().map(|manifest| {
+        if let Err(error) = validate_snapshot_optimizer_scope(
+            manifest, &symbols, train_from, train_to, val_from, val_to,
+        ) {
+            eprintln!("ERROR: research snapshot does not match optimizer request: {error}");
+            std::process::exit(2);
+        }
+        let provenance = SnapshotProvenance {
+            hash: manifest.snapshot_hash.clone().unwrap_or_default(),
+            generated_at: manifest.generated_at,
+            optimizer_data_dir: manifest.optimizer_data_dir.clone().unwrap_or_default(),
+        };
+        let line = format!(
+            "Research snapshot: schema={} hash={} generated_at={} optimizer_data_dir={}",
+            manifest.schema_version,
+            provenance.hash,
+            provenance.generated_at,
+            provenance.optimizer_data_dir
+        );
+        eprintln!("{line}");
+        println!("{line}");
+        provenance
+    });
 
     let (train_source, val_source) = if let Some(ref dir) = data_dir {
         let manifest =

--- a/ploy-frontend/src/components/LiveParityBanner.tsx
+++ b/ploy-frontend/src/components/LiveParityBanner.tsx
@@ -23,7 +23,10 @@ export function LiveParityBanner() {
         <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
           {report.alertPairs.slice(0, 3).map((pair) => (
             <Badge key={pair.key} variant="destructive">
-              {pair.key}: {pair.dryrunOnlyOrders.length + pair.executionMismatches.length}
+              {pair.key}:{' '}
+              {pair.dryrunOnlyOrders.length +
+                pair.liveOnlyOrders.length +
+                pair.executionMismatches.length}
             </Badge>
           ))}
           {report.alertPairs.length > 3 && (

--- a/ploy-frontend/src/lib/liveParity.ts
+++ b/ploy-frontend/src/lib/liveParity.ts
@@ -56,6 +56,7 @@ export interface LiveParityReport {
   alertPairs: LiveParityPair[];
   dryrunOrders: number;
   executionMismatches: number;
+  liveOnlyOrders: number;
   liveOrders: number;
   pairs: LiveParityPair[];
   unmatchedDryrunOrders: number;
@@ -76,7 +77,12 @@ function runtimeBucket(snapshot: TradingStateSnapshot): RuntimeBucket | null {
   const mode = snapshot.runtime_mode.toLowerCase();
   const id = snapshot.deployment_id.toLowerCase();
 
-  if (mode.includes('dry')) {
+  if (
+    mode.includes('dry') ||
+    mode === 'paper' ||
+    mode.includes('paper') ||
+    mode.includes('sim')
+  ) {
     return 'dryrun';
   }
 
@@ -227,7 +233,7 @@ function executionMismatches(dryrun?: TradingStateSnapshot, live?: TradingStateS
 function pairMessage(
   pair: Pick<
     LiveParityPair,
-    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live'
+    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live' | 'liveOnlyOrders'
   >
 ) {
   if (!pair.dryrun) {
@@ -240,6 +246,10 @@ function pairMessage(
 
   if (pair.dryrunOnlyOrders.length > 0) {
     return 'Dry-run order is missing from live';
+  }
+
+  if (pair.liveOnlyOrders.length > 0) {
+    return 'Live has order not seen in dry-run';
   }
 
   if (pair.executionMismatches.length > 0) {
@@ -256,7 +266,7 @@ function pairMessage(
 function pairStatus(
   pair: Pick<
     LiveParityPair,
-    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live'
+    'dryrun' | 'dryrunOnlyOrders' | 'executionMismatches' | 'live' | 'liveOnlyOrders'
   >
 ) {
   if (!pair.dryrun) {
@@ -268,6 +278,10 @@ function pairStatus(
   }
 
   if (pair.dryrunOnlyOrders.length > 0) {
+    return 'alert' as const;
+  }
+
+  if (pair.liveOnlyOrders.length > 0) {
     return 'alert' as const;
   }
 
@@ -332,6 +346,7 @@ export function buildLiveParityReport(
       (sum, pair) => sum + pair.executionMismatches.length,
       0
     ),
+    liveOnlyOrders: pairs.reduce((sum, pair) => sum + pair.liveOnlyOrders.length, 0),
     liveOrders: pairs.reduce((sum, pair) => sum + pair.liveSummary.orders, 0),
     pairs,
     unmatchedDryrunOrders: pairs.reduce(

--- a/ploy-frontend/src/pages/LiveParity.tsx
+++ b/ploy-frontend/src/pages/LiveParity.tsx
@@ -17,7 +17,7 @@ import { api } from '@/services/api';
 import { ws } from '@/services/websocket';
 import { useStore } from '@/store';
 
-import type { LiveParityPair, SnapshotSummary } from '@/lib/liveParity';
+import type { LiveParityPair, ParityOrderRow, SnapshotSummary } from '@/lib/liveParity';
 
 function integer(value: number) {
   return new Intl.NumberFormat('zh-CN').format(value);
@@ -96,7 +96,64 @@ function Metric({ label, value }: { label: string; value: string }) {
 function EmptyOrders() {
   return (
     <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
-      No unmatched dry-run orders
+      No unmatched orders
+    </div>
+  );
+}
+
+function OrderGapTable({
+  accent = 'neutral',
+  orders,
+}: {
+  accent?: 'destructive' | 'neutral';
+  orders: ParityOrderRow[];
+}) {
+  if (orders.length === 0) {
+    return <EmptyOrders />;
+  }
+
+  const headerClass =
+    accent === 'destructive'
+      ? 'bg-destructive/10 text-destructive'
+      : 'bg-muted text-muted-foreground';
+  const borderClass = accent === 'destructive' ? 'border border-destructive/30' : 'border';
+
+  return (
+    <div className={`overflow-hidden rounded-lg ${borderClass}`}>
+      <div
+        className={`grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] px-4 py-2 text-xs font-semibold uppercase tracking-wide ${headerClass}`}
+      >
+        <div>Created</div>
+        <div>Side</div>
+        <div>State</div>
+        <div>Qty / Price</div>
+        <div>Event / Token</div>
+      </div>
+      {orders.map((order) => (
+        <div
+          key={order.orderId}
+          className="grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] gap-0 border-t px-4 py-3 text-sm"
+        >
+          <div className="min-w-0">
+            <div className="truncate font-medium">{order.orderId}</div>
+            <div className="mt-1 truncate text-xs text-muted-foreground">
+              {order.createdAt ? formatTimestamp(order.createdAt) : 'unknown time'}
+            </div>
+          </div>
+          <div className="font-semibold">{order.side}</div>
+          <div>{order.state}</div>
+          <div className="font-mono text-xs">
+            {order.quantity}
+            <br />
+            {order.limitPrice ?? 'market'}
+          </div>
+          <div className="truncate font-mono text-xs text-muted-foreground">
+            {order.eventId}
+            <br />
+            {order.tokenId}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -110,7 +167,10 @@ function EmptyMismatches() {
 }
 
 function PairCard({ pair }: { pair: LiveParityPair }) {
-  const alertCount = pair.dryrunOnlyOrders.length + pair.executionMismatches.length;
+  const alertCount =
+    pair.dryrunOnlyOrders.length +
+    pair.liveOnlyOrders.length +
+    pair.executionMismatches.length;
 
   return (
     <Card className={pair.status === 'alert' ? 'border-destructive/45' : undefined}>
@@ -157,44 +217,12 @@ function PairCard({ pair }: { pair: LiveParityPair }) {
 
         <div className="mt-5">
           <div className="mb-3 text-sm font-semibold">Dry-run orders without live match</div>
-          {pair.dryrunOnlyOrders.length === 0 ? (
-            <EmptyOrders />
-          ) : (
-            <div className="overflow-hidden rounded-lg border">
-              <div className="grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] bg-muted px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                <div>Created</div>
-                <div>Side</div>
-                <div>State</div>
-                <div>Qty / Price</div>
-                <div>Event / Token</div>
-              </div>
-              {pair.dryrunOnlyOrders.map((order) => (
-                <div
-                  key={order.orderId}
-                  className="grid grid-cols-[minmax(180px,1fr)_100px_100px_120px_minmax(120px,1fr)] gap-0 border-t px-4 py-3 text-sm"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate font-medium">{order.orderId}</div>
-                    <div className="mt-1 truncate text-xs text-muted-foreground">
-                      {order.createdAt ? formatTimestamp(order.createdAt) : 'unknown time'}
-                    </div>
-                  </div>
-                  <div className="font-semibold">{order.side}</div>
-                  <div>{order.state}</div>
-                  <div className="font-mono text-xs">
-                    {order.quantity}
-                    <br />
-                    {order.limitPrice ?? 'market'}
-                  </div>
-                  <div className="truncate font-mono text-xs text-muted-foreground">
-                    {order.eventId}
-                    <br />
-                    {order.tokenId}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          <OrderGapTable orders={pair.dryrunOnlyOrders} />
+        </div>
+
+        <div className="mt-5">
+          <div className="mb-3 text-sm font-semibold">Live orders without dry-run match</div>
+          <OrderGapTable accent="destructive" orders={pair.liveOnlyOrders} />
         </div>
 
         <div className="mt-5">
@@ -324,14 +352,15 @@ export function LiveParity() {
               <CheckCircle2 className="h-5 w-5 text-success" />
             )}
             {hasAlert
-              ? 'Dry-run has orders that live has not placed'
-              : 'No dry-run-only live order gaps detected'}
+              ? 'Dry-run and live order paths are not aligned'
+              : 'No dry-run/live order or fill gaps detected'}
           </div>
           <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
             <span>{integer(report.pairs.length)} pairs</span>
             <span>{integer(report.dryrunOrders)} dry-run orders</span>
             <span>{integer(report.liveOrders)} live orders</span>
             <span>{integer(report.unmatchedDryrunOrders)} missing live orders</span>
+            <span>{integer(report.liveOnlyOrders)} live-only orders</span>
             <span>{integer(report.executionMismatches)} fill mismatches</span>
           </div>
         </div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10016,13 +10016,22 @@ Review:
 - [x] Define snapshot compiler and snapshot-backed walk-forward runtime boundaries.
 - [x] Define Deribit ATM/cache-first redesign.
 - [x] Define workflow, performance budget, correctness gates, and migration phases.
-- [ ] Implement Phase 1: Deribit ATM/cache-first loader and phase timing output.
-- [ ] Implement Phase 2: `research_snapshot_compile` and snapshot artifact workflow.
-- [ ] Implement Phase 3: snapshot-backed Factor Review and Walk-Forward workflows.
+- [x] Implement Phase 1: Deribit ATM/cache-first loader and phase timing output.
+- [x] Implement Phase 2: `research_snapshot_compile` and snapshot artifact workflow.
+- [x] Implement Phase 3: snapshot-backed Factor Review and Walk-Forward workflows.
+- [x] Implement Phase 4: optimizer immutable snapshot gate.
+- [x] Implement Phase 5: snapshot/dry-run/live parity hook.
 
 ## Review
 
 - 2026-04-28: Added a full redesign proposal that moves canonical research from direct raw PostgreSQL replay to immutable snapshot-backed replay. Tango remains the raw collector source of truth; `ploy-ci-1` compiles reusable Parquet/Arrow tapes and runs factor review/walk-forward from those artifacts.
+- 2026-04-28: Implemented the first snapshot-backed research path. Deribit now uses `strategy_data.deribit_atm_greeks_snapshots_cache` then `deribit_atm_greeks_ticks`; raw `deribit_iv_ticks` bucket fallback is disabled unless `PLOY_RESEARCH_DERIBIT_RAW_IV_FALLBACK=1`. Added `research_snapshot_compile`, snapshot manifest/quality/timing artifacts, snapshot loading for Factor Review V2 and Walk-Forward V2, a `research-snapshot.yml` workflow, snapshot-first review/walk-forward workflows, an optimizer `--snapshot-dir` gate, and a `research_snapshot_parity` CLI for snapshot/dry-run/live trading-state comparison.
+- 2026-04-28: Verification passed locally with targeted checks: `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-check rtk cargo check -p ploy-research --features db --example factor_review_v2 --example factor_walk_forward_v2 --example research_snapshot_compile`; `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-parity-check rtk cargo check -p ploy-research --example research_snapshot_parity`; `CARGO_TARGET_DIR=/tmp/ploy-optimize-snapshot-check rtk cargo check -p ploy-strategy-bundles --features parquet-feed --example optimize_backtest`; `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-test rtk cargo test -p ploy-research write_and_load_empty_snapshot_roundtrips_manifest --lib`; `npm ci && npm run build` in `ploy-frontend`; Ruby YAML parse for touched workflows; and `rtk git diff --check`.
+- 2026-04-28: Architect review rejected the first implementation because snapshot provenance and workflow gates were too soft. Fixed by requiring `optimizer_data_dir` in the snapshot workflow, preventing review/walk-forward workflows from silently falling back to DB unless `allow_direct_db_debug=true`, adding snapshot input validation and `snapshot_hash`, requiring that hash in optimizer canonical mode, and adding parity `--fail-on-mismatch` plus example tests for fill shortfall and out-of-snapshot event detection.
+- 2026-04-28: Second architect review found two remaining contract holes. Fixed by making `research_snapshot_compile` require `--optimizer-data-dir`, making `write_research_snapshot` reject manifests without that pin, passing it from all built-in snapshot-producing workflows, and making `optimize_backtest` reject `--snapshot-dir` combined with `--db-url` so canonical optimization cannot fall back to DB replay.
+- 2026-04-28: Third architect review found hidden non-canonical paths and weak runtime parity. Fixed by making Factor Review and Walk-Forward binaries reject direct DB unless `--allow-direct-db-debug` is explicit, validating snapshot stake/sample/quote/settlement/immutability parameters, splitting optimizer live-Parquet and direct-DB debug gates, treating live-only frontend orders as alerts, and comparing same-key dry-run/live order state, requested quantity, filled quantity, and rejection reasons in `research_snapshot_parity`.
+- 2026-04-28: Fourth architect review found two remaining evidence gaps. Fixed by rendering live-only orders in the frontend parity page and banner counts, and by persisting Deribit cache/ATM/raw-fallback phase timings into the research snapshot manifest/quality artifacts instead of relying only on tracing logs.
+- 2026-04-28: Ralph deslop pass stayed bounded to changed files. It removed duplicated frontend parity order-table markup, restored noisy `lib.rs` export reordering to the existing style, and kept the snapshot diff focused on required serialization/manifest changes.
 
 # Market Data Gap Audit (2026-04-28)
 


### PR DESCRIPTION
## Summary
- add `research_snapshot_compile` and a dedicated Research Snapshot workflow for immutable PM5D research artifacts
- route Factor Review / Walk-Forward through snapshot inputs by default, with explicit direct-DB debug gates
- require optimizer snapshot provenance and add snapshot/dry-run/live parity checks, including live-only and same-key order record mismatches
- surface live-only order parity alerts in the frontend page and banner

## Verification
- `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-check rtk cargo check -p ploy-research --features db,polars-export --example factor_review_v2 --example factor_walk_forward_v2 --example research_snapshot_compile`
- `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-parity-check rtk cargo test -p ploy-research --example research_snapshot_parity`
- `CARGO_TARGET_DIR=/tmp/ploy-optimize-snapshot-check rtk cargo check -p ploy-strategy-bundles --features parquet-feed --example optimize_backtest`
- `CARGO_TARGET_DIR=/tmp/ploy-research-snapshot-test rtk cargo test -p ploy-research write_and_load_empty_snapshot_roundtrips_manifest --lib`
- `npm run build` in `ploy-frontend`
- Ruby YAML parse for touched workflows
- `rtk git diff --check`

## Notes
- Full ploy-ci snapshot compilation against Tango data and optimize workflow dispatch are intentionally left to CI/workflow runs, not local DB commands.
