### PR TITLE
Align gap audit valid-window threshold

### DIFF
--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -292,9 +292,9 @@ def audit_research_windows(statement_timeout_seconds: int, psql_timeout_seconds:
         elif latest_lag > 12 * 3600:
             status = "critical"
             reasons.append(f"latest window lag {latest_lag}s > 12h")
-        elif latest_lag > 2 * 3600 and STATUS_ORDER[status] < STATUS_ORDER["warn"]:
+        elif latest_lag > 6 * 3600 and STATUS_ORDER[status] < STATUS_ORDER["warn"]:
             status = "warn"
-            reasons.append(f"latest window lag {latest_lag}s > 2h")
+            reasons.append(f"latest window lag {latest_lag}s > 6h")
         if not reasons:
             reasons.append("valid windows are populated and recent")
         row["status"] = status

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10057,3 +10057,5 @@ Review:
   Binance price/aggTrade/LOB across BTC/ETH/SOL/XRP/DOGE/BNB, Deribit IV, and
   `research_valid_windows`, but marked `deribit_atm_greeks` critical because the
   repo-backed collector only covers from about `2026-04-28 06:33 +08` onward.
+- 2026-04-28: Adjusted `research_valid_windows` freshness warning to 6 hours,
+  matching the documented 6-hour materialized-view refresh cadence.


### PR DESCRIPTION
## Summary
- adjust research_valid_windows warning threshold from 2h to 6h
- keep critical threshold at 12h
- record the cadence adjustment in tasks/todo.md

## Verification
- python3 -m py_compile scripts/audit_market_data_gaps.py
- git diff --check
- Tango 1h audit reports research_valid_windows as OK with latest_end=2026-04-28T06:20:00+08:00