### PR TITLE
Scope deploy log checks after restarts

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -312,7 +312,8 @@ jobs:
               local unit="\$1"
               local pattern="\$2"
               local message="\$3"
-              if journalctl -u "\${unit}" --since "\${DEPLOY_STARTED_AT}" --no-pager | grep -E "\${pattern}"; then
+              local since="\${DEPLOY_VERIFY_SINCE:-\${DEPLOY_STARTED_AT}}"
+              if journalctl -u "\${unit}" --since "\${since}" --no-pager | grep -E "\${pattern}"; then
                 echo "\${message}" >&2
                 exit 1
               fi
@@ -431,6 +432,7 @@ jobs:
               systemctl restart ployd.service
             fi
 
+            DEPLOY_VERIFY_SINCE=\$(date -u +"%Y-%m-%dT%H:%M:%SZ")
             sleep 5
             require_postgres
             systemctl is-active --quiet ploy-binance-aggtrade-collector.service

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10068,3 +10068,6 @@ Review:
   repo-backed collector only covers from about `2026-04-28 06:33 +08` onward.
 - 2026-04-28: Adjusted `research_valid_windows` freshness warning to 6 hours,
   matching the documented 6-hour materialized-view refresh cadence.
+- 2026-04-28: Moved deploy log-failure checks to a post-restart verification
+  baseline so controlled `systemctl restart` noise from old collector processes
+  is not classified as a new deployment failure.


### PR DESCRIPTION
## Summary
- move deploy journal error checks to a post-restart baseline
- keep service active/guardrail/freshness checks after restart
- prevent controlled restart noise from the old greeks collector process from failing deploy

## Verification
- git diff --check
- ruby YAML.load_file .github/workflows/deploy-tango-1-1.yml
- Tango greeks service active/running with fresh rows after the failed deploy attempt