### PR TITLE
Stabilize paused worker restart test

### DIFF
--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -194,6 +194,8 @@ mod tests {
     use rust_decimal_macros::dec;
     use std::fs;
     use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration as StdDuration;
 
     fn test_working_directory() -> PathBuf {
         let unique = std::time::SystemTime::now()
@@ -358,14 +360,29 @@ mod tests {
         });
 
         tick_workers(&mut control_plane, &mut supervisor, &config);
-        supervisor.pause("example.paper");
+        let paused = supervisor.pause("example.paper").expect("paused worker");
+        assert_eq!(paused.observed_state, ObservedState::Paused);
 
-        tick_workers(&mut control_plane, &mut supervisor, &config);
+        let restarted = (0..20).any(|_| {
+            tick_workers(&mut control_plane, &mut supervisor, &config);
+            let Some(status) = supervisor.status("example.paper") else {
+                return false;
+            };
+            if matches!(
+                status.observed_state,
+                ObservedState::Starting | ObservedState::Running
+            ) && status.pid.is_some()
+            {
+                return true;
+            }
+            thread::sleep(StdDuration::from_millis(10));
+            false
+        });
+
         let status = supervisor.status("example.paper").expect("status");
-        assert!(matches!(
-            status.observed_state,
-            ObservedState::Starting | ObservedState::Running
-        ));
-        assert!(status.pid.is_some());
+        assert!(
+            restarted,
+            "worker did not restart from paused state; final status={status:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Change the paused-worker restart test to assert eventual restart instead of a single-tick process timing state
- Keep production worker restart logic unchanged
- Add a clearer failure message with the final worker status

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-worker-tick-flake rtk cargo test -p ploy-platform-runtime running_desired_state_restarts_paused_worker --lib -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-worker-tick-flake rtk cargo test -p ploy-platform-runtime --lib
- rtk git diff --check

## Context
The main run after #195 saw one flaky failure in worker_tick::tests::running_desired_state_restarts_paused_worker. The rerun passed, and #195 did not touch this Rust code. The daemon tick loop retries Running deployments, so the test should verify convergence rather than a single instantaneous supervisor state.