### PR TITLE
Make optimizer consume immutable research snapshots

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -1,4 +1,4 @@
-name: Optimize three_layer params (tick-preserving)
+name: Optimize three_layer params (snapshot-backed)
 
 on:
   workflow_dispatch:
@@ -110,7 +110,7 @@ env:
 
 jobs:
   build:
-    name: Build optimize_backtest binary
+    name: Build optimize runner
     runs-on: [self-hosted, ploy-ci-1]
     timeout-minutes: 45
     environment: ploy-ci-1
@@ -136,21 +136,30 @@ jobs:
         with:
           cache-on-failure: true
           cache-targets: "true"
-          key: optimize-${{ hashFiles('crates/ploy-strategy-bundles/**', 'Cargo.lock') }}
+          key: optimize-${{ hashFiles('crates/ploy-strategy-bundles/**', 'crates/ploy-research/**', 'Cargo.lock') }}
 
-      - name: Build optimize_backtest
+      - name: Build optimize runner
         run: |
           . /home/runner/.cargo/env
-          cargo build --release --locked \
-            -p ploy-strategy-bundles \
-            --features ploy-strategy-bundles/parquet-feed \
-            --example optimize_backtest
+          mkdir -p artifacts/optimize-bin
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ]; then
+            cargo build --release --locked \
+              -p ploy-research \
+              --example three_layer_snapshot_optimize
+            cp target/release/examples/three_layer_snapshot_optimize artifacts/optimize-bin/optimize-runner
+          else
+            cargo build --release --locked \
+              -p ploy-strategy-bundles \
+              --features ploy-strategy-bundles/parquet-feed \
+              --example optimize_backtest
+            cp target/release/examples/optimize_backtest artifacts/optimize-bin/optimize-runner
+          fi
 
-      - name: Upload optimize_backtest binary
+      - name: Upload optimize runner
         uses: actions/upload-artifact@v7
         with:
-          name: optimize_backtest-${{ github.sha }}
-          path: target/release/examples/optimize_backtest
+          name: optimize-runner-${{ github.sha }}
+          path: artifacts/optimize-bin/optimize-runner
           retention-days: 1
 
   optimize:
@@ -173,14 +182,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
-      - name: Download optimize_backtest binary
+      - name: Download optimize runner
         uses: actions/download-artifact@v8
         with:
-          name: optimize_backtest-${{ github.sha }}
+          name: optimize-runner-${{ github.sha }}
           path: target/release/examples
 
       - name: Make binary executable
-        run: chmod +x target/release/examples/optimize_backtest
+        run: chmod +x target/release/examples/optimize-runner
 
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
@@ -192,7 +201,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Sync Parquet data from Tango-1-1
-        if: ${{ github.event.inputs.snapshot_run_id != '' || github.event.inputs.allow_live_parquet_debug == 'true' }}
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.allow_live_parquet_debug == 'true' }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
@@ -256,6 +265,7 @@ jobs:
           cat artifacts/optimize/snapshot-provenance.txt >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Preflight Parquet manifest
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
         run: |
           set -euo pipefail
           . /home/runner/.cargo/env
@@ -294,13 +304,11 @@ jobs:
           if [ -n "${{ github.event.inputs.max_updates }}" ]; then
             extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
           fi
-          if [ -f artifacts/research-snapshot/manifest.json ]; then
-            extra_flags+=(--snapshot-dir artifacts/research-snapshot)
-          elif [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+          if [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
-          ./target/release/examples/optimize_backtest \
+          ./target/release/examples/optimize-runner \
             --preflight-only \
             --strategy-variant three_layer \
             --config config/strategies/02-pm5d-threelayer.unified.toml \
@@ -370,33 +378,46 @@ jobs:
           if [ -n "${{ github.event.inputs.max_updates }}" ]; then
             extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
           fi
-          if [ -f artifacts/research-snapshot/manifest.json ]; then
-            extra_flags+=(--snapshot-dir artifacts/research-snapshot)
-          elif [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+          if [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
-          timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
-          ./target/release/examples/optimize_backtest \
-            --strategy-variant three_layer \
-            --config config/strategies/02-pm5d-threelayer.unified.toml \
-            --data-dir "${{ github.event.inputs.data_dir }}" \
-            --train-start "${{ github.event.inputs.train_start }}" \
-            --train-end "${{ github.event.inputs.train_end }}" \
-            --val-start "${{ github.event.inputs.val_start }}" \
-            --val-end "${{ github.event.inputs.val_end }}" \
-            --symbols "${{ github.event.inputs.symbols }}" \
-            --trials "${{ github.event.inputs.trials }}" \
-            --require-official-settlement \
-            --require-lob-liquidity \
-            --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
-            --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
-            --max-symbols "${{ github.event.inputs.max_symbols }}" \
-            --max-days "${{ github.event.inputs.max_days }}" \
-            --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
-            --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
-            "${time_flags[@]}" \
-            "${extra_flags[@]}"
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
+            ./target/release/examples/optimize-runner \
+              --snapshot-dir artifacts/research-snapshot \
+              --train-start "${{ github.event.inputs.train_start }}" \
+              --train-end "${{ github.event.inputs.train_end }}" \
+              --val-start "${{ github.event.inputs.val_start }}" \
+              --val-end "${{ github.event.inputs.val_end }}" \
+              --symbols "${{ github.event.inputs.symbols }}" \
+              --trials "${{ github.event.inputs.trials }}" \
+              --stake-usd 15 \
+              --output-dir artifacts/optimize \
+              "${time_flags[@]}"
+          else
+            timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
+            ./target/release/examples/optimize-runner \
+              --strategy-variant three_layer \
+              --config config/strategies/02-pm5d-threelayer.unified.toml \
+              --data-dir "${{ github.event.inputs.data_dir }}" \
+              --train-start "${{ github.event.inputs.train_start }}" \
+              --train-end "${{ github.event.inputs.train_end }}" \
+              --val-start "${{ github.event.inputs.val_start }}" \
+              --val-end "${{ github.event.inputs.val_end }}" \
+              --symbols "${{ github.event.inputs.symbols }}" \
+              --trials "${{ github.event.inputs.trials }}" \
+              --require-official-settlement \
+              --require-lob-liquidity \
+              --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
+              --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
+              --max-symbols "${{ github.event.inputs.max_symbols }}" \
+              --max-days "${{ github.event.inputs.max_days }}" \
+              --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
+              --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+              "${time_flags[@]}" \
+              "${extra_flags[@]}"
+          fi
 
       - name: Upload optimize provenance
         if: ${{ always() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5377,6 +5377,7 @@ dependencies = [
  "burn",
  "burn-ndarray",
  "chrono",
+ "optimizer",
  "ploy-feed-loaders",
  "ploy-market-contracts",
  "ploy-operator-contracts",

--- a/crates/ploy-research/Cargo.toml
+++ b/crates/ploy-research/Cargo.toml
@@ -35,6 +35,7 @@ uuid.workspace = true
 anyhow = "1"
 burn = { version = "0.17", default-features = false, features = ["ndarray", "autodiff", "std"], optional = true }
 burn-ndarray = { version = "0.17", optional = true }
+optimizer.workspace = true
 
 [dev-dependencies]
 rust_decimal_macros.workspace = true
@@ -104,6 +105,10 @@ required-features = ["db"]
 [[example]]
 name = "research_snapshot_parity"
 path = "examples/research_snapshot_parity.rs"
+
+[[example]]
+name = "three_layer_snapshot_optimize"
+path = "examples/three_layer_snapshot_optimize.rs"
 
 [[example]]
 name = "collector_data_utilization"

--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -1,0 +1,814 @@
+//! three_layer_snapshot_optimize - PM5D three-layer optimizer over an immutable research snapshot.
+//!
+//! This runner is the canonical optimizer path for multi-day research. It loads a
+//! compiled `ResearchSnapshot`, expands side-aware `FactorObservationV2` rows,
+//! and optimizes gates against official-settlement executable PM CLOB labels
+//! without replaying raw tick Parquet for every trial.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use optimizer::prelude::*;
+use ploy_research::{
+    build_data_health_report, build_factor_observations_v2_with_deribit_and_pm_books,
+    load_research_snapshot, FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest,
+};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct SnapshotThreeLayerParams {
+    min_direction_prob: f64,
+    min_distance_over_sigma: f64,
+    min_confirmation_score: f64,
+    min_drift_confirmation: f64,
+    min_edge: f64,
+    min_reward_risk: f64,
+    min_entry_score: f64,
+    cooldown_secs: i64,
+    min_time_remaining_secs: i64,
+    max_time_remaining_secs: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SnapshotObjectiveMetrics {
+    candidates: usize,
+    selected: usize,
+    trades: usize,
+    rejected_duplicate: usize,
+    rejected_cooldown: usize,
+    rejected_non_executable: usize,
+    net_pnl: f64,
+    avg_pnl: f64,
+    sharpe: f64,
+    objective: f64,
+    fill_rate: f64,
+    win_rate: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct OptimizeSummary<'a> {
+    snapshot_schema: &'a str,
+    snapshot_hash: &'a str,
+    snapshot_generated_at: DateTime<Utc>,
+    symbols: &'a [String],
+    train_start: DateTime<Utc>,
+    train_end: DateTime<Utc>,
+    val_start: DateTime<Utc>,
+    val_end: DateTime<Utc>,
+    trials: usize,
+    stake_usd: f64,
+    train_rows: usize,
+    val_rows: usize,
+    best_params: SnapshotThreeLayerParams,
+    train_metrics: SnapshotObjectiveMetrics,
+    val_metrics: SnapshotObjectiveMetrics,
+}
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|window| window[0] == flag)
+        .map(|window| window[1].clone())
+}
+
+fn parse_date_start(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+}
+
+fn parse_date_end(raw: &str) -> DateTime<Utc> {
+    let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .unwrap_or_else(|_| panic!("invalid date: {raw}"));
+    let next_day = date
+        .succ_opt()
+        .unwrap_or_else(|| panic!("invalid end date: {raw}"));
+    Utc.from_utc_datetime(&next_day.and_hms_opt(0, 0, 0).unwrap())
+}
+
+fn parse_timestamp(raw: &str) -> DateTime<Utc> {
+    raw.parse::<DateTime<Utc>>()
+        .unwrap_or_else(|_| panic!("invalid timestamp: {raw}"))
+}
+
+fn parse_window(args: &[String], date_flag: &str, ts_flag: &str, is_end: bool) -> DateTime<Utc> {
+    if let Some(raw) = flag_value(args, ts_flag) {
+        return parse_timestamp(&raw);
+    }
+    let raw = flag_value(args, date_flag).unwrap_or_else(|| panic!("{date_flag} required"));
+    if is_end {
+        parse_date_end(&raw)
+    } else {
+        parse_date_start(&raw)
+    }
+}
+
+fn slice_by_time(
+    rows: &[FactorObservationV2],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> &[FactorObservationV2] {
+    let lo = rows.partition_point(|row| row.tick_ts < start);
+    let hi = rows.partition_point(|row| row.tick_ts < end);
+    &rows[lo..hi]
+}
+
+fn validate_snapshot_scope(
+    manifest: &ResearchSnapshotManifest,
+    symbols: &[String],
+    train_start: DateTime<Utc>,
+    train_end: DateTime<Utc>,
+    val_start: DateTime<Utc>,
+    val_end: DateTime<Utc>,
+    stake_usd: f64,
+) -> Result<()> {
+    if !manifest.immutable_input {
+        anyhow::bail!("snapshot manifest is not immutable_input=true");
+    }
+    if manifest
+        .snapshot_hash
+        .as_deref()
+        .unwrap_or_default()
+        .is_empty()
+    {
+        anyhow::bail!("snapshot manifest is missing snapshot_hash");
+    }
+    if !manifest.require_official_settlement {
+        anyhow::bail!("snapshot was not compiled with require_official_settlement=true");
+    }
+    if (manifest.stake_usd - stake_usd).abs() > 1e-9 {
+        anyhow::bail!(
+            "snapshot stake_usd {} does not match optimizer stake_usd {}",
+            manifest.stake_usd,
+            stake_usd
+        );
+    }
+
+    let snapshot_symbols: HashSet<&str> = manifest.symbols.iter().map(String::as_str).collect();
+    let missing: Vec<&str> = symbols
+        .iter()
+        .map(String::as_str)
+        .filter(|symbol| !snapshot_symbols.contains(symbol))
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "snapshot symbols {:?} do not cover requested symbols {:?}; missing {:?}",
+            manifest.symbols,
+            symbols,
+            missing
+        );
+    }
+
+    let requested_start = train_start.min(val_start);
+    let requested_end = train_end.max(val_end);
+    if manifest.start > requested_start || manifest.end < requested_end {
+        anyhow::bail!(
+            "snapshot window {} -> {} does not cover optimizer window {} -> {}",
+            manifest.start,
+            manifest.end,
+            requested_start,
+            requested_end
+        );
+    }
+
+    Ok(())
+}
+
+fn finite_or_zero(value: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
+}
+
+fn crypto_fee_cost(entry_price: f64) -> f64 {
+    0.02 * entry_price * (1.0 - entry_price)
+}
+
+fn reward_risk_ratio(entry_price: f64) -> f64 {
+    if !entry_price.is_finite() || entry_price <= 0.0 || entry_price >= 1.0 {
+        return f64::NAN;
+    }
+    let fee = crypto_fee_cost(entry_price);
+    let reward = 1.0 - entry_price - fee;
+    let risk = entry_price + fee;
+    if risk <= 0.0 {
+        f64::NAN
+    } else {
+        reward / risk
+    }
+}
+
+fn confirmation_score(row: &FactorObservationV2) -> f64 {
+    let side = row.side.multiplier();
+    let continuation = finite_or_zero(row.cex_continuation_score_side).clamp(-1.0, 1.0);
+    let obi = finite_or_zero(row.obi_10 * side).clamp(-1.0, 1.0);
+    let depth = finite_or_zero(row.depth_imbalance * side).clamp(-1.0, 1.0);
+    let microprice = finite_or_zero(row.microprice_offset_bps * side / 10.0).clamp(-1.0, 1.0);
+    0.45 * continuation + 0.25 * obi + 0.15 * depth + 0.15 * microprice
+}
+
+fn three_layer_entry_score(row: &FactorObservationV2, edge: f64, confirmation: f64) -> f64 {
+    let direction_score = ((row.side_model_prob - 0.5) / 0.5).clamp(0.0, 1.0);
+    let edge_score = (edge / 0.12).clamp(0.0, 1.0);
+    let confirmation_score = confirmation.clamp(-0.25, 0.35);
+    0.50 * direction_score + 0.35 * edge_score + 0.15 * confirmation_score
+}
+
+fn executable_pnl(row: &FactorObservationV2) -> Option<f64> {
+    row.label_full_depth_executable_pnl_15u
+        .or(row.label_executable_pnl_15u)
+        .filter(|pnl| pnl.is_finite())
+}
+
+fn entry_fillable(row: &FactorObservationV2) -> bool {
+    row.label_full_depth_entry_fillable || row.label_executable_fillable
+}
+
+fn row_passes_gates(row: &FactorObservationV2, params: &SnapshotThreeLayerParams) -> bool {
+    if row.time_remaining_secs < params.min_time_remaining_secs
+        || row.time_remaining_secs > params.max_time_remaining_secs
+    {
+        return false;
+    }
+    if !row.entry_ask.is_finite() || row.entry_ask < 0.10 || row.entry_ask > 0.85 {
+        return false;
+    }
+    if !row.pm_lag_secs.is_finite() || row.pm_lag_secs < 0.0 || row.pm_lag_secs > 15.0 {
+        return false;
+    }
+    if !row.side_model_prob.is_finite() || row.side_model_prob < params.min_direction_prob {
+        return false;
+    }
+    if !row.side_distance_over_sigma.is_finite()
+        || row.side_distance_over_sigma < params.min_distance_over_sigma
+    {
+        return false;
+    }
+
+    let drift_side = row.drift_30s * row.side.multiplier();
+    if !drift_side.is_finite() || drift_side < params.min_drift_confirmation {
+        return false;
+    }
+
+    let edge = if row.side_model_edge.is_finite() {
+        row.side_model_edge
+    } else {
+        row.side_model_prob - row.entry_ask - crypto_fee_cost(row.entry_ask)
+    };
+    if !edge.is_finite() || edge < params.min_edge {
+        return false;
+    }
+    let reward_risk = reward_risk_ratio(row.entry_ask);
+    if !reward_risk.is_finite() || reward_risk < params.min_reward_risk {
+        return false;
+    }
+    let confirmation = confirmation_score(row);
+    if confirmation < params.min_confirmation_score {
+        return false;
+    }
+    three_layer_entry_score(row, edge, confirmation) >= params.min_entry_score
+}
+
+fn evaluate_snapshot_objective(
+    rows: &[FactorObservationV2],
+    params: &SnapshotThreeLayerParams,
+    min_trades: usize,
+) -> SnapshotObjectiveMetrics {
+    let mut last_trade_by_symbol: HashMap<String, DateTime<Utc>> = HashMap::new();
+    let mut traded_event_sides: HashSet<String> = HashSet::new();
+    let mut pnls = Vec::new();
+    let mut candidates = 0usize;
+    let mut selected = 0usize;
+    let mut rejected_duplicate = 0usize;
+    let mut rejected_cooldown = 0usize;
+    let mut rejected_non_executable = 0usize;
+
+    for row in rows {
+        if !row_passes_gates(row, params) {
+            continue;
+        }
+        candidates += 1;
+
+        let event_side_key = format!("{}:{}", row.event_id, row.side.as_str());
+        if traded_event_sides.contains(&event_side_key) {
+            rejected_duplicate += 1;
+            continue;
+        }
+        if let Some(last_ts) = last_trade_by_symbol.get(&row.symbol) {
+            if (row.tick_ts - *last_ts).num_seconds() < params.cooldown_secs {
+                rejected_cooldown += 1;
+                continue;
+            }
+        }
+
+        selected += 1;
+        if !entry_fillable(row) {
+            rejected_non_executable += 1;
+            continue;
+        }
+        let Some(pnl) = executable_pnl(row) else {
+            rejected_non_executable += 1;
+            continue;
+        };
+
+        pnls.push(pnl);
+        traded_event_sides.insert(event_side_key);
+        last_trade_by_symbol.insert(row.symbol.clone(), row.tick_ts);
+    }
+
+    let trades = pnls.len();
+    let net_pnl = pnls.iter().sum::<f64>();
+    let avg_pnl = if trades == 0 {
+        f64::NAN
+    } else {
+        net_pnl / trades as f64
+    };
+    let sharpe = trade_sharpe(&pnls);
+    let fill_rate = ratio(trades, selected);
+    let win_rate = if trades == 0 {
+        f64::NAN
+    } else {
+        ratio(pnls.iter().filter(|pnl| **pnl > 0.0).count(), trades)
+    };
+    let objective = if trades < min_trades {
+        -1_000_000.0 + trades as f64
+    } else {
+        sharpe + (net_pnl / 100_000.0)
+    };
+
+    SnapshotObjectiveMetrics {
+        candidates,
+        selected,
+        trades,
+        rejected_duplicate,
+        rejected_cooldown,
+        rejected_non_executable,
+        net_pnl,
+        avg_pnl,
+        sharpe,
+        objective,
+        fill_rate,
+        win_rate,
+    }
+}
+
+fn trade_sharpe(pnls: &[f64]) -> f64 {
+    if pnls.is_empty() {
+        return -100.0;
+    }
+    let mean = pnls.iter().sum::<f64>() / pnls.len() as f64;
+    let variance = pnls.iter().map(|pnl| (pnl - mean).powi(2)).sum::<f64>() / pnls.len() as f64;
+    let std = variance.sqrt();
+    if std <= 1e-9 {
+        return mean.signum() * (pnls.len() as f64).sqrt();
+    }
+    mean / std * (pnls.len() as f64).sqrt()
+}
+
+fn ratio(num: usize, den: usize) -> f64 {
+    if den == 0 {
+        0.0
+    } else {
+        num as f64 / den as f64
+    }
+}
+
+fn write_outputs(
+    output_dir: Option<PathBuf>,
+    summary: &OptimizeSummary<'_>,
+    trials: &[optimizer::sampler::CompletedTrial<f64>],
+) -> Result<()> {
+    let Some(output_dir) = output_dir else {
+        return Ok(());
+    };
+    fs::create_dir_all(&output_dir)
+        .with_context(|| format!("create output dir {}", output_dir.display()))?;
+
+    let summary_json =
+        serde_json::to_string_pretty(summary).context("serialize snapshot optimizer summary")?;
+    fs::write(
+        output_dir.join("three-layer-snapshot-optimize-summary.json"),
+        summary_json,
+    )
+    .context("write snapshot optimizer summary")?;
+
+    let params = summary.best_params;
+    let config = format!(
+        "# PM5D three-layer snapshot optimizer output\n\
+         # snapshot_hash = {}\n\
+         # validation_sharpe = {:.6}\n\
+         # validation_pnl = {:.6}\n\
+         # validation_trades = {}\n\
+         three_layer_min_direction_prob = {:.6}\n\
+         three_layer_min_distance_over_sigma = {:.6}\n\
+         three_layer_min_confirmation_score = {:.6}\n\
+         three_layer_min_drift_confirmation = {:.8}\n\
+         three_layer_min_edge = {:.6}\n\
+         three_layer_min_reward_risk = {:.6}\n\
+         three_layer_min_entry_score = {:.6}\n\
+         cooldown_secs = {}\n\
+         min_time_remaining_secs = {}\n\
+         max_time_remaining_secs = {}\n\
+         # three_layer_take_profit_ask and three_layer_stop_distance_pct are not optimized here.\n",
+        summary.snapshot_hash,
+        summary.val_metrics.sharpe,
+        summary.val_metrics.net_pnl,
+        summary.val_metrics.trades,
+        params.min_direction_prob,
+        params.min_distance_over_sigma,
+        params.min_confirmation_score,
+        params.min_drift_confirmation,
+        params.min_edge,
+        params.min_reward_risk,
+        params.min_entry_score,
+        params.cooldown_secs,
+        params.min_time_remaining_secs,
+        params.max_time_remaining_secs,
+    );
+    fs::write(
+        output_dir.join("three-layer-snapshot-best-params.toml"),
+        config,
+    )
+    .context("write snapshot optimizer best params")?;
+
+    let mut top_trials = trials.to_vec();
+    top_trials.sort_by(|lhs, rhs| {
+        rhs.value
+            .partial_cmp(&lhs.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let top_text = top_trials
+        .iter()
+        .take(20)
+        .map(|trial| format!("trial={} objective={:.6}", trial.id, trial.value))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        output_dir.join("three-layer-snapshot-top-trials.txt"),
+        top_text,
+    )
+    .context("write snapshot optimizer top trials")?;
+    Ok(())
+}
+
+fn print_metrics(label: &str, metrics: &SnapshotObjectiveMetrics) {
+    eprintln!(
+        "{label}: objective={:.3} sharpe={:.3} pnl=${:.2} trades={} candidates={} selected={} fill_rate={:.2}% win_rate={:.2}% non_exec={} dup={} cooldown={}",
+        metrics.objective,
+        metrics.sharpe,
+        metrics.net_pnl,
+        metrics.trades,
+        metrics.candidates,
+        metrics.selected,
+        metrics.fill_rate * 100.0,
+        metrics.win_rate * 100.0,
+        metrics.rejected_non_executable,
+        metrics.rejected_duplicate,
+        metrics.rejected_cooldown,
+    );
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().collect::<Vec<_>>();
+    let snapshot_dir = PathBuf::from(flag_value(&args, "--snapshot-dir").unwrap_or_else(|| {
+        eprintln!("ERROR: --snapshot-dir is required for three_layer_snapshot_optimize");
+        std::process::exit(2);
+    }));
+    let train_start = parse_window(&args, "--train-start", "--train-start-ts", false);
+    let train_end = parse_window(&args, "--train-end", "--train-end-ts", true);
+    let val_start = parse_window(&args, "--val-start", "--val-start-ts", false);
+    let val_end = parse_window(&args, "--val-end", "--val-end-ts", true);
+    let symbols = flag_value(&args, "--symbols")
+        .unwrap_or_else(|| "BTCUSDT,ETHUSDT".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|symbol| !symbol.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let n_trials = flag_value(&args, "--trials")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(50usize);
+    let stake_usd = flag_value(&args, "--stake-usd")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(15.0);
+    let min_trades = flag_value(&args, "--min-trades")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(20usize);
+    let output_dir = flag_value(&args, "--output-dir").map(PathBuf::from);
+
+    let started = Instant::now();
+    let snapshot = load_research_snapshot(&snapshot_dir)
+        .with_context(|| format!("load research snapshot {}", snapshot_dir.display()))?;
+    validate_snapshot_scope(
+        &snapshot.manifest,
+        &symbols,
+        train_start,
+        train_end,
+        val_start,
+        val_end,
+        stake_usd,
+    )?;
+    let snapshot_hash = snapshot
+        .manifest
+        .snapshot_hash
+        .as_deref()
+        .unwrap_or("<missing>");
+
+    eprintln!("=== PM5D Three-Layer Snapshot Optimization ===");
+    eprintln!(
+        "Research snapshot: schema={} hash={} generated_at={}",
+        snapshot.manifest.schema_version, snapshot_hash, snapshot.manifest.generated_at
+    );
+    eprintln!(
+        "Snapshot rows: observations={} deribit={} pm_books={} load_ms={}",
+        snapshot.observations.len(),
+        snapshot.deribit_snapshots.len(),
+        snapshot.pm_book_snapshots.len(),
+        started.elapsed().as_millis()
+    );
+    eprintln!(
+        "Train: {} -> {}  Val: {} -> {}  Symbols: {:?}",
+        train_start, train_end, val_start, val_end, symbols
+    );
+    eprintln!(
+        "Trials: {n_trials}  Algorithm: TPE  Stake: ${stake_usd:.2}  Min trades: {min_trades}"
+    );
+    eprintln!(
+        "Objective labels: official settlement + executable PM CLOB full-depth/top-book fillability"
+    );
+    eprintln!(
+        "Note: stop-loss/take-profit path exits are not optimized in this observation-level runner."
+    );
+
+    let review_options = FactorReviewOptions {
+        stake_usd,
+        min_observations: min_trades,
+        top_quantile: 0.2,
+    };
+    let mut v2_rows = build_factor_observations_v2_with_deribit_and_pm_books(
+        &snapshot.observations,
+        &snapshot.deribit_snapshots,
+        &snapshot.pm_book_snapshots,
+        &review_options,
+    );
+    let symbol_set = symbols.iter().map(String::as_str).collect::<HashSet<_>>();
+    v2_rows.retain(|row| symbol_set.contains(row.symbol.as_str()));
+    v2_rows.sort_by_key(|row| row.tick_ts);
+
+    let health = build_data_health_report(&snapshot.observations, &v2_rows);
+    eprintln!(
+        "Data health: source_obs={} v2_rows={} executable_pnl_rows={} full_depth_pnl_rows={} entry_fill_rate={:.2}% full_depth_entry_fill_rate={:.2}%",
+        health.source_observations,
+        health.v2_rows,
+        health.executable_pnl_rows,
+        health.full_depth_executable_pnl_rows,
+        health.entry_fill_rate() * 100.0,
+        health.full_depth_entry_fill_rate() * 100.0,
+    );
+
+    let train_rows = slice_by_time(&v2_rows, train_start, train_end).to_vec();
+    let val_rows = slice_by_time(&v2_rows, val_start, val_end).to_vec();
+    if train_rows.len() < min_trades {
+        anyhow::bail!(
+            "training slice has only {} rows; need at least {}",
+            train_rows.len(),
+            min_trades
+        );
+    }
+    if val_rows.len() < min_trades {
+        anyhow::bail!(
+            "validation slice has only {} rows; need at least {}",
+            val_rows.len(),
+            min_trades
+        );
+    }
+    eprintln!(
+        "Slice rows: train={} validation={}",
+        train_rows.len(),
+        val_rows.len()
+    );
+
+    let train_rows = Arc::new(train_rows);
+    let study: Study<f64> = Study::maximize(TpeSampler::new());
+    let p_min_direction_prob = FloatParam::new(0.52, 0.70).name("three_layer_min_direction_prob");
+    let p_min_distance_over_sigma =
+        FloatParam::new(0.10, 0.60).name("three_layer_min_distance_over_sigma");
+    let p_min_confirmation_score =
+        FloatParam::new(0.05, 0.30).name("three_layer_min_confirmation_score");
+    let p_min_drift_confirmation =
+        FloatParam::new(0.0001, 0.001).name("three_layer_min_drift_confirmation");
+    let p_min_edge = FloatParam::new(0.02, 0.06).name("three_layer_min_edge");
+    let p_min_reward_risk = FloatParam::new(0.8, 2.0).name("three_layer_min_reward_risk");
+    let p_min_entry_score = FloatParam::new(0.10, 0.40).name("three_layer_min_entry_score");
+    let p_cooldown_secs = IntParam::new(15, 60).name("cooldown_secs");
+    let p_min_time_remaining_secs = IntParam::new(30, 120).name("min_time_remaining_secs");
+    let p_max_time_span_secs = IntParam::new(30, 120).name("three_layer_time_span_secs");
+
+    {
+        let train_rows = Arc::clone(&train_rows);
+        let p_min_direction_prob_c = p_min_direction_prob.clone();
+        let p_min_distance_over_sigma_c = p_min_distance_over_sigma.clone();
+        let p_min_confirmation_score_c = p_min_confirmation_score.clone();
+        let p_min_drift_confirmation_c = p_min_drift_confirmation.clone();
+        let p_min_edge_c = p_min_edge.clone();
+        let p_min_reward_risk_c = p_min_reward_risk.clone();
+        let p_min_entry_score_c = p_min_entry_score.clone();
+        let p_cooldown_secs_c = p_cooldown_secs.clone();
+        let p_min_time_remaining_secs_c = p_min_time_remaining_secs.clone();
+        let p_max_time_span_secs_c = p_max_time_span_secs.clone();
+
+        study
+            .optimize(n_trials, move |trial: &mut Trial| {
+                let min_time_remaining_secs = p_min_time_remaining_secs_c.suggest(trial)?;
+                let params = SnapshotThreeLayerParams {
+                    min_direction_prob: p_min_direction_prob_c.suggest(trial)?,
+                    min_distance_over_sigma: p_min_distance_over_sigma_c.suggest(trial)?,
+                    min_confirmation_score: p_min_confirmation_score_c.suggest(trial)?,
+                    min_drift_confirmation: p_min_drift_confirmation_c.suggest(trial)?,
+                    min_edge: p_min_edge_c.suggest(trial)?,
+                    min_reward_risk: p_min_reward_risk_c.suggest(trial)?,
+                    min_entry_score: p_min_entry_score_c.suggest(trial)?,
+                    cooldown_secs: p_cooldown_secs_c.suggest(trial)?,
+                    min_time_remaining_secs,
+                    max_time_remaining_secs: min_time_remaining_secs
+                        + p_max_time_span_secs_c.suggest(trial)?,
+                };
+
+                let metrics = evaluate_snapshot_objective(&train_rows, &params, min_trades);
+                eprintln!(
+                    "  Trial {:>3}: source=snapshot-observation objective={:>9.3} sharpe={:>7.3} pnl=${:>8.2} trades={:>4} selected={:>5} fill={:>5.1}% | dir_prob={:.3} dist_sigma={:.3} conf={:.3} drift={:.5} edge={:.3} rr={:.2} score={:.3} cd={}s time={}..{}",
+                    trial.id(),
+                    metrics.objective,
+                    metrics.sharpe,
+                    metrics.net_pnl,
+                    metrics.trades,
+                    metrics.selected,
+                    metrics.fill_rate * 100.0,
+                    params.min_direction_prob,
+                    params.min_distance_over_sigma,
+                    params.min_confirmation_score,
+                    params.min_drift_confirmation,
+                    params.min_edge,
+                    params.min_reward_risk,
+                    params.min_entry_score,
+                    params.cooldown_secs,
+                    params.min_time_remaining_secs,
+                    params.max_time_remaining_secs,
+                );
+                Ok::<f64, Error>(metrics.objective)
+            })
+            .context("snapshot TPE optimization failed")?;
+    }
+
+    let best = study
+        .best_trial()
+        .context("no completed optimizer trials")?;
+    let best_min_time_remaining_secs = best.get(&p_min_time_remaining_secs).unwrap_or(30);
+    let best_params = SnapshotThreeLayerParams {
+        min_direction_prob: best.get(&p_min_direction_prob).unwrap_or(0.52),
+        min_distance_over_sigma: best.get(&p_min_distance_over_sigma).unwrap_or(0.10),
+        min_confirmation_score: best.get(&p_min_confirmation_score).unwrap_or(0.05),
+        min_drift_confirmation: best.get(&p_min_drift_confirmation).unwrap_or(0.0001),
+        min_edge: best.get(&p_min_edge).unwrap_or(0.02),
+        min_reward_risk: best.get(&p_min_reward_risk).unwrap_or(0.8),
+        min_entry_score: best.get(&p_min_entry_score).unwrap_or(0.10),
+        cooldown_secs: best.get(&p_cooldown_secs).unwrap_or(15),
+        min_time_remaining_secs: best_min_time_remaining_secs,
+        max_time_remaining_secs: best_min_time_remaining_secs
+            + best.get(&p_max_time_span_secs).unwrap_or(60),
+    };
+
+    let train_metrics = evaluate_snapshot_objective(&train_rows, &best_params, min_trades);
+    let val_metrics = evaluate_snapshot_objective(&val_rows, &best_params, min_trades);
+
+    eprintln!("\n=== Best Parameters (Training) ===");
+    eprintln!("Objective:                       {:.3}", best.value);
+    eprintln!(
+        "three_layer_min_direction_prob = {:.6}",
+        best_params.min_direction_prob
+    );
+    eprintln!(
+        "three_layer_min_distance_over_sigma = {:.6}",
+        best_params.min_distance_over_sigma
+    );
+    eprintln!(
+        "three_layer_min_confirmation_score = {:.6}",
+        best_params.min_confirmation_score
+    );
+    eprintln!(
+        "three_layer_min_drift_confirmation = {:.8}",
+        best_params.min_drift_confirmation
+    );
+    eprintln!("three_layer_min_edge = {:.6}", best_params.min_edge);
+    eprintln!(
+        "three_layer_min_reward_risk = {:.6}",
+        best_params.min_reward_risk
+    );
+    eprintln!(
+        "three_layer_min_entry_score = {:.6}",
+        best_params.min_entry_score
+    );
+    eprintln!("cooldown_secs = {}", best_params.cooldown_secs);
+    eprintln!(
+        "min_time_remaining_secs = {}",
+        best_params.min_time_remaining_secs
+    );
+    eprintln!(
+        "max_time_remaining_secs = {}",
+        best_params.max_time_remaining_secs
+    );
+    eprintln!("\n=== Snapshot Objective Metrics ===");
+    print_metrics("Train", &train_metrics);
+    print_metrics("Validation", &val_metrics);
+
+    eprintln!("\n=== Config Snippet ===");
+    eprintln!("# Paste into [strategy] only after walk-forward and dry-run/live parity review.");
+    eprintln!(
+        "three_layer_min_direction_prob = {:.6}",
+        best_params.min_direction_prob
+    );
+    eprintln!(
+        "three_layer_min_distance_over_sigma = {:.6}",
+        best_params.min_distance_over_sigma
+    );
+    eprintln!(
+        "three_layer_min_confirmation_score = {:.6}",
+        best_params.min_confirmation_score
+    );
+    eprintln!(
+        "three_layer_min_drift_confirmation = {:.8}",
+        best_params.min_drift_confirmation
+    );
+    eprintln!("three_layer_min_edge = {:.6}", best_params.min_edge);
+    eprintln!(
+        "three_layer_min_reward_risk = {:.6}",
+        best_params.min_reward_risk
+    );
+    eprintln!(
+        "three_layer_min_entry_score = {:.6}",
+        best_params.min_entry_score
+    );
+    eprintln!("cooldown_secs = {}", best_params.cooldown_secs);
+    eprintln!(
+        "min_time_remaining_secs = {}",
+        best_params.min_time_remaining_secs
+    );
+    eprintln!(
+        "max_time_remaining_secs = {}",
+        best_params.max_time_remaining_secs
+    );
+    eprintln!("# stop-loss/take-profit path exits require a future path replay label.");
+
+    let trials = study.trials();
+    let summary = OptimizeSummary {
+        snapshot_schema: &snapshot.manifest.schema_version,
+        snapshot_hash,
+        snapshot_generated_at: snapshot.manifest.generated_at,
+        symbols: &symbols,
+        train_start,
+        train_end,
+        val_start,
+        val_end,
+        trials: n_trials,
+        stake_usd,
+        train_rows: train_rows.len(),
+        val_rows: val_rows.len(),
+        best_params,
+        train_metrics,
+        val_metrics,
+    };
+    write_outputs(output_dir, &summary, &trials)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_date_end, reward_risk_ratio, trade_sharpe};
+
+    #[test]
+    fn date_end_is_exclusive_next_day() {
+        assert_eq!(
+            parse_date_end("2026-04-27").to_rfc3339(),
+            "2026-04-28T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn reward_risk_rejects_invalid_prices() {
+        assert!(reward_risk_ratio(0.0).is_nan());
+        assert!(reward_risk_ratio(1.0).is_nan());
+        assert!(reward_risk_ratio(0.25).is_finite());
+    }
+
+    #[test]
+    fn trade_sharpe_penalizes_empty_trials() {
+        assert_eq!(trade_sharpe(&[]), -100.0);
+        assert!(trade_sharpe(&[1.0, 2.0, 3.0]).is_finite());
+    }
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10071,3 +10071,30 @@ Review:
 - 2026-04-28: Moved deploy log-failure checks to a post-restart verification
   baseline so controlled `systemctl restart` noise from old collector processes
   is not classified as a new deployment failure.
+
+# Snapshot Observation Optimizer Completion (2026-04-28)
+
+## Files
+
+- `crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
+  - Owner: canonical PM5D three-layer optimizer over immutable research snapshot observations.
+- `crates/ploy-research/Cargo.toml`
+  - Owner: expose the snapshot optimizer example and optimizer crate dependency.
+- `.github/workflows/optimize.yml`
+  - Owner: choose snapshot-observation optimization for canonical runs and raw Parquet replay only for explicit debug.
+- `tasks/todo.md`
+  - Owner: session tracker and completion review.
+
+## Tasks
+
+- [x] Add a TPE/Bayesian three-layer optimizer that consumes `ResearchSnapshot` and `FactorObservationV2` rows.
+- [x] Enforce snapshot immutability, hash, symbol subset, official settlement, stake, and time-window coverage before optimization.
+- [x] Score only executable/fillable PM CLOB labels so non-fillable dry-run signals cannot dominate the objective.
+- [x] Keep raw tick-preserving Parquet optimizer replay as an explicit debug path, not the canonical snapshot path.
+- [x] Verify locally with targeted compile/tests and workflow YAML parsing.
+- [ ] Push PR, merge after CI, and rerun Optimize using snapshot run `25029217647`.
+
+## Review
+
+- 2026-04-28: Added `three_layer_snapshot_optimize`, a snapshot-observation TPE runner that validates immutable official-settlement snapshot scope, expands side-aware `FactorObservationV2`, dedupes one trade per event side, applies a per-symbol cooldown, and scores only executable full-depth/top-book PM CLOB labels.
+- 2026-04-28: Updated `optimize.yml` so canonical runs with `snapshot_run_id` build and run the snapshot optimizer, while raw Parquet sync/preflight/replay remains only for explicit non-snapshot debug mode.


### PR DESCRIPTION
## Summary
- add a snapshot-observation TPE runner for PM5D three-layer params over FactorObservationV2
- validate immutable official-settlement snapshot scope before optimization
- make optimize.yml use the snapshot runner for canonical snapshot_run_id runs and keep raw Parquet replay as explicit debug only

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-snapshot-observation-optimize-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/optimize.yml")'
- git diff --check

## Notes
- Snapshot objective optimizes executable settlement PnL and fillability gates. It intentionally does not optimize stop-loss/take-profit path exits; those need a future path replay label before promotion.