### PR TITLE
Penalize sparse snapshot optimizer winners

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -400,7 +400,7 @@ fn evaluate_snapshot_objective(
     let objective = if trades < min_trades {
         -1_000_000.0 + trades as f64
     } else {
-        sharpe + (net_pnl / 100_000.0)
+        (sharpe * sample_power_multiplier(trades, min_trades)) + (net_pnl / 100_000.0)
     };
 
     SnapshotObjectiveMetrics {
@@ -442,7 +442,15 @@ fn ratio(num: usize, den: usize) -> f64 {
 
 fn default_min_trades(train_rows: usize, val_rows: usize) -> usize {
     let base_rows = train_rows.min(val_rows);
-    (base_rows / 500).clamp(200, 2_000)
+    (base_rows / 200).clamp(500, 5_000)
+}
+
+fn sample_power_multiplier(trades: usize, min_trades: usize) -> f64 {
+    if trades < min_trades || min_trades == 0 {
+        return 0.0;
+    }
+    let full_power_trades = min_trades.saturating_mul(4).max(min_trades + 1);
+    (trades as f64 / full_power_trades as f64).min(1.0).sqrt()
 }
 
 fn write_outputs(
@@ -924,7 +932,8 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        default_min_trades, directional_score, parse_date_end, reward_risk_ratio, trade_sharpe,
+        default_min_trades, directional_score, parse_date_end, reward_risk_ratio,
+        sample_power_multiplier, trade_sharpe,
     };
 
     #[test]
@@ -958,8 +967,16 @@ mod tests {
 
     #[test]
     fn default_min_trades_scales_with_snapshot_size() {
-        assert_eq!(default_min_trades(185_158, 107_774), 215);
-        assert_eq!(default_min_trades(1_000, 1_000), 200);
-        assert_eq!(default_min_trades(2_000_000, 2_000_000), 2_000);
+        assert_eq!(default_min_trades(185_158, 107_774), 538);
+        assert_eq!(default_min_trades(1_000, 1_000), 500);
+        assert_eq!(default_min_trades(2_000_000, 2_000_000), 5_000);
+    }
+
+    #[test]
+    fn sample_power_multiplier_penalizes_threshold_hugging() {
+        assert_eq!(sample_power_multiplier(499, 500), 0.0);
+        assert!(sample_power_multiplier(500, 500) < 0.6);
+        assert_eq!(sample_power_multiplier(2_000, 500), 1.0);
+        assert_eq!(sample_power_multiplier(3_000, 500), 1.0);
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,12 +13,17 @@
 - [x] Replace the hard-coded 20-trade optimizer floor with a snapshot-size dynamic default.
 - [x] Persist min-trade source and underpowered train/validation flags in optimizer artifacts.
 - [x] Verify focused local tests/checks.
-- [ ] Open/merge PR, then rerun Optimize on `main` using snapshot run `25029217647`.
+- [x] Open/merge PR, then rerun Optimize on `main` using snapshot run `25029217647`.
+- [x] Use the 200-trial rerun to confirm sparse-threshold hugging is still rejected instead of treated as deployable.
+- [x] Strengthen the objective against threshold-hugging by raising the dynamic floor and shrinking near-floor Sharpe.
+- [ ] Verify, merge, and rerun Optimize on `main`.
 
 ## Review
 
 - 2026-04-28: Runtime-compatible contrarian support made the optimizer output usable as config keys, but the first rerun exposed a separate research validity bug: a sparse training fit with 72 trades and only 4 validation trades could still look like a completed optimization when the default trade floor was 20. The optimizer now computes a dynamic default floor from the smaller train/validation slice, records underpowered flags, and fails the run after writing artifacts if the selected result is not sample-powered.
 - 2026-04-28: Local verification passed: `CARGO_TARGET_DIR=/tmp/ploy-snapshot-min-trades-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` and `git diff --check`.
+- 2026-04-28: PR #204 merged at `285e94f9`. A corrected 50-trial optimize run `25036006982` completed with `min_trades=215`, train trades `1841`, validation trades `1814`, validation PnL `$337.53`, and validation Sharpe `0.399`. A 200-trial run `25036115888` correctly failed after artifact upload because it selected a threshold-hugging fit with train trades `222` and validation trades `103`, below the validation floor. That means the guard works, but the objective still needs a stronger sample-power penalty.
+- 2026-04-28: Raised the default dynamic trade floor to `clamp(min(train_rows, val_rows) / 200, 500, 5000)` and shrunk objective Sharpe until a trial reaches 4x the floor. Local verification passed: `CARGO_TARGET_DIR=/tmp/ploy-snapshot-sample-power-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` and `git diff --check`.
 
 # Merge Remote Dry-Run Report To Main (2026-04-28)
 


### PR DESCRIPTION
## Summary
- raise the dynamic snapshot optimizer trade floor so multi-day PM5D runs need hundreds of trades, not just ~200
- shrink Sharpe contribution for trials that barely clear the floor, reducing threshold-hugging overfit
- record the 50/200 trial rerun evidence in tasks/todo.md

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-snapshot-sample-power-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- git diff --check