### PR TITLE
Automate market data gap audits

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -1,0 +1,251 @@
+name: Market Data Gap Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_full_audit:
+        description: "Run the full retained-window audit"
+        type: boolean
+        required: true
+        default: true
+      full_lookback_hours:
+        description: "Full audit lookback window in hours"
+        required: true
+        default: "168"
+      bucket_minutes:
+        description: "Coverage bucket size in minutes"
+        required: true
+        default: "5"
+      symbols:
+        description: "Comma-separated Binance symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT"
+      fail_on:
+        description: "Gate threshold"
+        type: choice
+        required: true
+        default: "critical"
+        options:
+          - critical
+          - warn
+          - never
+  schedule:
+    - cron: "*/30 * * * *"
+    - cron: "17 */6 * * *"
+
+concurrency:
+  group: market-data-gap-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+  DEFAULT_SYMBOLS: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT
+
+jobs:
+  audit:
+    name: Audit Tango market-data gaps
+    runs-on: [self-hosted, tango-1-1]
+    timeout-minutes: 20
+    environment: tango-1-1
+
+    steps:
+      - name: Ensure SSH client
+        run: |
+          set -euo pipefail
+          if command -v ssh >/dev/null 2>&1; then
+            ssh -V
+            exit 0
+          fi
+
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update
+            apt-get install -y openssh-client
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y openssh-client
+          else
+            echo "ssh client is missing and passwordless sudo is unavailable on this runner" >&2
+            exit 1
+          fi
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Resolve audit scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
+          INPUT_RUN_FULL: ${{ inputs.run_full_audit }}
+          INPUT_LOOKBACK_HOURS: ${{ inputs.full_lookback_hours }}
+          INPUT_BUCKET_MINUTES: ${{ inputs.bucket_minutes }}
+          INPUT_SYMBOLS: ${{ inputs.symbols }}
+          INPUT_FAIL_ON: ${{ inputs.fail_on }}
+        run: |
+          set -euo pipefail
+
+          run_full="false"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            run_full="${INPUT_RUN_FULL:-true}"
+          elif [ "${EVENT_SCHEDULE}" = "17 */6 * * *" ]; then
+            run_full="true"
+          fi
+
+          lookback_hours="${INPUT_LOOKBACK_HOURS:-168}"
+          bucket_minutes="${INPUT_BUCKET_MINUTES:-5}"
+          symbols="${INPUT_SYMBOLS:-${DEFAULT_SYMBOLS}}"
+          fail_on="${INPUT_FAIL_ON:-critical}"
+
+          case "${run_full}" in
+            true|false) ;;
+            *) echo "invalid run_full value: ${run_full}" >&2; exit 1 ;;
+          esac
+          case "${fail_on}" in
+            critical|warn|never) ;;
+            *) echo "invalid fail_on value: ${fail_on}" >&2; exit 1 ;;
+          esac
+
+          echo "run_full=${run_full}" >> "$GITHUB_OUTPUT"
+          echo "lookback_hours=${lookback_hours}" >> "$GITHUB_OUTPUT"
+          echo "bucket_minutes=${bucket_minutes}" >> "$GITHUB_OUTPUT"
+          echo "symbols=${symbols}" >> "$GITHUB_OUTPUT"
+          echo "fail_on=${fail_on}" >> "$GITHUB_OUTPUT"
+
+      - name: Run remote gap audits
+        env:
+          RUN_FULL: ${{ steps.scope.outputs.run_full }}
+          FULL_LOOKBACK_HOURS: ${{ steps.scope.outputs.lookback_hours }}
+          BUCKET_MINUTES: ${{ steps.scope.outputs.bucket_minutes }}
+          SYMBOLS: ${{ steps.scope.outputs.symbols }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/market-data-gap-audit
+
+          run_remote_audit() {
+            local audit_kind="$1"
+            local lookback_hours="$2"
+            local remote_dir="${DEPLOY_ROOT}/reports/market-data-gap-audit"
+            local remote_file="${remote_dir}/${audit_kind}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+            local local_file="artifacts/market-data-gap-audit/${audit_kind}.json"
+
+            ssh tango-1-1 \
+              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
+          set -euo pipefail
+          mkdir -p "$(dirname "${REMOTE_FILE}")"
+          test -x "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py"
+          "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py" \
+            --lookback-hours "${LOOKBACK_HOURS}" \
+            --bucket-minutes "${BUCKET_MINUTES}" \
+            --symbols "${SYMBOLS}" \
+            --statement-timeout-seconds 20 \
+            --psql-timeout-seconds 30 \
+            --format json \
+            --fail-on never > "${REMOTE_FILE}"
+          cp "${REMOTE_FILE}" "${DEPLOY_ROOT}/reports/market-data-gap-audit/${AUDIT_KIND}-latest.json"
+          EOF
+
+            scp "tango-1-1:${remote_file}" "${local_file}"
+          }
+
+          run_remote_audit quick 1
+          if [ "${RUN_FULL}" = "true" ]; then
+            run_remote_audit full "${FULL_LOOKBACK_HOURS}"
+          fi
+
+      - name: Summarize and enforce audit gate
+        id: gate
+        env:
+          FAIL_ON: ${{ steps.scope.outputs.fail_on }}
+          RUN_FULL: ${{ steps.scope.outputs.run_full }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import glob
+          import json
+          import os
+          import sys
+
+          status_order = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
+          fail_on = os.environ["FAIL_ON"]
+          paths = sorted(glob.glob("artifacts/market-data-gap-audit/*.json"))
+          reports = []
+          for path in paths:
+              with open(path, encoding="utf-8") as fh:
+                  payload = json.load(fh)
+              reports.append((os.path.basename(path).removesuffix(".json"), path, payload))
+
+          if not reports:
+              raise SystemExit("no audit reports were produced")
+
+          worst = "ok"
+          lines = [
+              "## Market Data Gap Audit",
+              "",
+              f"- Gate: `{fail_on}`",
+              f"- Full audit requested: `{os.environ['RUN_FULL']}`",
+              "",
+              "| Audit | Overall | Lookback | Bucket | Non-OK sources |",
+              "| --- | --- | ---: | ---: | --- |",
+          ]
+          for name, _path, payload in reports:
+              status = payload.get("overall_status", "unknown")
+              if status_order.get(status, 2) > status_order[worst]:
+                  worst = status
+              non_ok = []
+              for item in payload.get("gap_audits", []) + payload.get("window_audits", []):
+                  item_status = item.get("status", "unknown")
+                  if item_status != "ok":
+                      source = item.get("source_id", "unknown")
+                      reason = "; ".join(item.get("reasons") or [])
+                      non_ok.append(f"`{source}` {item_status}: {reason}")
+              lines.append(
+                  f"| {name} | `{status}` | {payload.get('lookback_hours', 'n/a')}h "
+                  f"| {payload.get('bucket_minutes', 'n/a')}m | "
+                  f"{'<br>'.join(non_ok) if non_ok else 'none'} |"
+              )
+
+          should_fail = False
+          if fail_on == "critical" and worst in {"critical", "unknown"}:
+              should_fail = True
+          elif fail_on == "warn" and worst in {"warn", "unknown", "critical"}:
+              should_fail = True
+
+          lines.extend(["", f"Overall gate status: `{worst}`"])
+          summary = "\n".join(lines) + "\n"
+          with open("artifacts/market-data-gap-audit/summary.md", "w", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"overall_status={worst}\n")
+
+          if should_fail:
+              print(summary)
+              raise SystemExit(f"market data audit gate failed: {worst}")
+          PY
+
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: market-data-gap-audit-${{ github.run_id }}
+          path: artifacts/market-data-gap-audit/
+          retention-days: 14

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10162,3 +10162,33 @@ Review:
 - 2026-04-28: Added `three_layer_alpha_contrarian` and `three_layer_cex_contrarian` as default-off config fields. Alpha contrarian mode fades the model-favored side and rewards lower model edge; CEX contrarian mode inverts the confirmation bonus. Existing live/dry-run behavior is unchanged unless these fields are explicitly enabled.
 - 2026-04-28: Local verification passed with `CARGO_TARGET_DIR=/tmp/ploy-three-layer-contrarian-test cargo check -p ploy-strategy-bundles --tests --examples`, `CARGO_TARGET_DIR=/tmp/ploy-three-layer-contrarian-test rtk cargo test -p ploy-strategy-bundles three_layer --lib`, `CARGO_TARGET_DIR=/tmp/ploy-three-layer-contrarian-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features`, and `git diff --check`.
 - 2026-04-28: PR #203 CI passed after adding the new fields to example and integration-test `DirectionalConfig` fixtures.
+
+# Market Data Gap Audit Automation (2026-04-28)
+
+## Files
+
+- `.github/workflows/market-data-gap-audit.yml`
+  - Owner: scheduled/manual Tango market-data gap gate.
+- `tasks/todo.md`
+  - Owner: session tracker.
+
+## Tasks
+
+- [x] Add a scheduled workflow that runs the deployed gap-audit script on Tango.
+- [x] Run quick 1-hour audits every 30 minutes and full retained-window audits every 6 hours.
+- [x] Save JSON reports as GitHub artifacts and stable Tango latest files.
+- [x] Fail the workflow on critical/unknown audit results by default.
+- [ ] Verify workflow YAML and run the workflow from `main`.
+
+## Review
+
+- 2026-04-28: Added `market-data-gap-audit.yml` with manual dispatch plus two
+  schedules: every 30 minutes for a 1-hour quick audit, and every 6 hours for
+  quick + retained-window audit. Reports are written under
+  `/opt/ploy/reports/market-data-gap-audit/` on Tango, copied back as GitHub
+  artifacts, and summarized in the workflow step summary.
+- 2026-04-28: Static verification passed with `git diff --check`, Ruby YAML
+  parse, and `bash -n` over every embedded workflow shell step. A direct Tango
+  quick-audit smoke produced JSON with 21 gap audits plus one window audit; it
+  returned `warn` because `research_valid_windows` has exceeded the 6-hour
+  warning threshold, not because live collectors stopped.


### PR DESCRIPTION
## Summary
- add a scheduled/manual Tango market-data gap audit workflow
- run quick 1h audits every 30 minutes and full retained-window audits every 6 hours
- publish JSON reports under /opt/ploy/reports/market-data-gap-audit, upload GitHub artifacts, and gate on critical/unknown by default

## Verification
- git diff --check
- ruby YAML parse for .github/workflows/market-data-gap-audit.yml
- bash -n over every embedded workflow shell step
- direct Tango quick-audit smoke produced JSON with 21 gap audits + 1 window audit; overall_status=warn because research_valid_windows exceeded the 6h warning threshold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated market data gap audit workflow with scheduled and on-demand execution options.
  * Generates audit reports and conditionally alerts based on configurable severity thresholds.

* **Documentation**
  * Updated project tracking to document audit workflow implementation progress and deployment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->