### PR TITLE
Scope research workflows to required data

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -63,6 +63,33 @@ on:
         description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
         required: false
         default: "/tmp/ploy-parquet"
+      data_profile:
+        description: "Project data requirements profile for fresh snapshots"
+        type: choice
+        required: true
+        default: "pm5d-execution"
+        options:
+          - pm5d-execution
+          - pm5d-vol
+          - all
+          - custom
+      custom_required_sources:
+        description: "Comma-separated sources when data_profile=custom"
+        required: false
+        default: ""
+      audit_lookback_hours:
+        description: "Market-data audit lookback in hours"
+        required: false
+        default: "168"
+      data_gate:
+        description: "Fail threshold for required-source audit"
+        type: choice
+        required: true
+        default: "never"
+        options:
+          - critical
+          - warn
+          - never
 
 concurrency:
   group: factor-review-v2-${{ github.ref }}
@@ -100,6 +127,122 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Ensure psql client
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        run: |
+          set -euo pipefail
+          if command -v psql >/dev/null 2>&1; then
+            psql --version
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          else
+            echo "psql client is required for scoped data audits" >&2
+            exit 1
+          fi
+
+      - name: Resolve data requirements
+        id: data_scope
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        env:
+          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
+          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
+        run: |
+          set -euo pipefail
+          case "${DATA_PROFILE}" in
+            pm5d-execution)
+              required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="false"
+              ;;
+            pm5d-vol)
+              required_sources="polymarket_quotes,polymarket_orderbooks,deribit_iv,deribit_atm_greeks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="true"
+              ;;
+            all)
+              required_sources="all"
+              include_deribit="true"
+              ;;
+            custom)
+              required_sources="${CUSTOM_REQUIRED_SOURCES}"
+              if [ -z "${required_sources}" ]; then
+                echo "custom_required_sources is required when data_profile=custom" >&2
+                exit 2
+              fi
+              include_deribit="false"
+              case ",${required_sources}," in
+                *deribit*|*,all,*|*,pm5d-vol,*) include_deribit="true" ;;
+              esac
+              ;;
+            *)
+              echo "unsupported data_profile=${DATA_PROFILE}" >&2
+              exit 2
+              ;;
+          esac
+          echo "required_sources=${required_sources}" >> "${GITHUB_OUTPUT}"
+          echo "include_deribit=${include_deribit}" >> "${GITHUB_OUTPUT}"
+
+      - name: Audit required market data
+        id: data_audit
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        env:
+          REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
+          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
+          DATA_GATE: ${{ github.event.inputs.data_gate }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            scripts/audit_market_data_gaps.py \
+              --lookback-hours "${AUDIT_LOOKBACK_HOURS}" \
+              --bucket-minutes 5 \
+              --symbols "${{ github.event.inputs.symbols }}" \
+              --required-sources "${REQUIRED_SOURCES}" \
+              --statement-timeout-seconds 20 \
+              --psql-timeout-seconds 30 \
+              --format json \
+              --fail-on never > artifacts/research-snapshot/data-gap-audit.json
+          python3 <<'PY'
+          import json
+          import os
+
+          status_order = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
+          gate = os.environ["DATA_GATE"]
+          with open("artifacts/research-snapshot/data-gap-audit.json", encoding="utf-8") as fh:
+              payload = json.load(fh)
+          status = payload.get("overall_status", "unknown")
+          lines = [
+              "# Scoped Data Audit",
+              "",
+              f"- Gate: `{gate}`",
+              f"- Overall: `{status}`",
+              f"- Required sources: `{','.join(payload.get('required_sources') or [])}`",
+              f"- Lookback: `{payload.get('lookback_hours')}h`",
+              "",
+              "| Source | Status | Reasons |",
+              "| --- | --- | --- |",
+          ]
+          for item in payload.get("gap_audits", []) + payload.get("window_audits", []):
+              lines.append(
+                  f"| `{item.get('source_id')}` | `{item.get('status', 'unknown')}` | "
+                  f"{'; '.join(item.get('reasons') or [])} |"
+              )
+          summary = "\n".join(lines) + "\n"
+          with open("artifacts/research-snapshot/data-gap-audit.md", "w", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"overall_status={status}\n")
+          should_fail = (
+              (gate == "critical" and status in {"critical", "unknown"})
+              or (gate == "warn" and status_order.get(status, 2) >= status_order["warn"])
+          )
+          if should_fail:
+              raise SystemExit(f"scoped data audit gate failed: {status}")
+          PY
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -129,6 +272,10 @@ jobs:
         if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         run: |
           set -euo pipefail
+          deribit_args=()
+          if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
+            deribit_args+=(--skip-deribit)
+          fi
           mkdir -p artifacts/research-snapshot
           ./target/release/examples/research_snapshot_compile \
             --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
@@ -141,6 +288,10 @@ jobs:
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
             --output-dir artifacts/research-snapshot \
             --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
+            --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
+            --data-audit-report data-gap-audit.json \
+            "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
 
       - name: Run factor review
@@ -183,6 +334,10 @@ jobs:
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
             if [ -f artifacts/factor-review-v2/source.txt ]; then
               echo "- Source: $(cat artifacts/factor-review-v2/source.txt)"
+            fi
+            if [ -f artifacts/research-snapshot/data-gap-audit.md ]; then
+              echo ""
+              cat artifacts/research-snapshot/data-gap-audit.md
             fi
             echo ""
             if [ -f artifacts/research-snapshot/quality.md ]; then

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -79,6 +79,33 @@ on:
         description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
         required: false
         default: "/tmp/ploy-parquet"
+      data_profile:
+        description: "Project data requirements profile for fresh snapshots"
+        type: choice
+        required: true
+        default: "pm5d-execution"
+        options:
+          - pm5d-execution
+          - pm5d-vol
+          - all
+          - custom
+      custom_required_sources:
+        description: "Comma-separated sources when data_profile=custom"
+        required: false
+        default: ""
+      audit_lookback_hours:
+        description: "Market-data audit lookback in hours"
+        required: false
+        default: "168"
+      data_gate:
+        description: "Fail threshold for required-source audit"
+        type: choice
+        required: true
+        default: "never"
+        options:
+          - critical
+          - warn
+          - never
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.factor_name_filter || 'all' }}
@@ -116,6 +143,122 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Ensure psql client
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        run: |
+          set -euo pipefail
+          if command -v psql >/dev/null 2>&1; then
+            psql --version
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          else
+            echo "psql client is required for scoped data audits" >&2
+            exit 1
+          fi
+
+      - name: Resolve data requirements
+        id: data_scope
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        env:
+          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
+          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
+        run: |
+          set -euo pipefail
+          case "${DATA_PROFILE}" in
+            pm5d-execution)
+              required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="false"
+              ;;
+            pm5d-vol)
+              required_sources="polymarket_quotes,polymarket_orderbooks,deribit_iv,deribit_atm_greeks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="true"
+              ;;
+            all)
+              required_sources="all"
+              include_deribit="true"
+              ;;
+            custom)
+              required_sources="${CUSTOM_REQUIRED_SOURCES}"
+              if [ -z "${required_sources}" ]; then
+                echo "custom_required_sources is required when data_profile=custom" >&2
+                exit 2
+              fi
+              include_deribit="false"
+              case ",${required_sources}," in
+                *deribit*|*,all,*|*,pm5d-vol,*) include_deribit="true" ;;
+              esac
+              ;;
+            *)
+              echo "unsupported data_profile=${DATA_PROFILE}" >&2
+              exit 2
+              ;;
+          esac
+          echo "required_sources=${required_sources}" >> "${GITHUB_OUTPUT}"
+          echo "include_deribit=${include_deribit}" >> "${GITHUB_OUTPUT}"
+
+      - name: Audit required market data
+        id: data_audit
+        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+        env:
+          REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
+          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
+          DATA_GATE: ${{ github.event.inputs.data_gate }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            scripts/audit_market_data_gaps.py \
+              --lookback-hours "${AUDIT_LOOKBACK_HOURS}" \
+              --bucket-minutes 5 \
+              --symbols "${{ github.event.inputs.symbols }}" \
+              --required-sources "${REQUIRED_SOURCES}" \
+              --statement-timeout-seconds 20 \
+              --psql-timeout-seconds 30 \
+              --format json \
+              --fail-on never > artifacts/research-snapshot/data-gap-audit.json
+          python3 <<'PY'
+          import json
+          import os
+
+          status_order = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
+          gate = os.environ["DATA_GATE"]
+          with open("artifacts/research-snapshot/data-gap-audit.json", encoding="utf-8") as fh:
+              payload = json.load(fh)
+          status = payload.get("overall_status", "unknown")
+          lines = [
+              "# Scoped Data Audit",
+              "",
+              f"- Gate: `{gate}`",
+              f"- Overall: `{status}`",
+              f"- Required sources: `{','.join(payload.get('required_sources') or [])}`",
+              f"- Lookback: `{payload.get('lookback_hours')}h`",
+              "",
+              "| Source | Status | Reasons |",
+              "| --- | --- | --- |",
+          ]
+          for item in payload.get("gap_audits", []) + payload.get("window_audits", []):
+              lines.append(
+                  f"| `{item.get('source_id')}` | `{item.get('status', 'unknown')}` | "
+                  f"{'; '.join(item.get('reasons') or [])} |"
+              )
+          summary = "\n".join(lines) + "\n"
+          with open("artifacts/research-snapshot/data-gap-audit.md", "w", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"overall_status={status}\n")
+          should_fail = (
+              (gate == "critical" and status in {"critical", "unknown"})
+              or (gate == "warn" and status_order.get(status, 2) >= status_order["warn"])
+          )
+          if should_fail:
+              raise SystemExit(f"scoped data audit gate failed: {status}")
+          PY
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -145,6 +288,10 @@ jobs:
         if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         run: |
           set -euo pipefail
+          deribit_args=()
+          if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
+            deribit_args+=(--skip-deribit)
+          fi
           mkdir -p artifacts/research-snapshot
           ./target/release/examples/research_snapshot_compile \
             --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
@@ -157,6 +304,10 @@ jobs:
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
             --output-dir artifacts/research-snapshot \
             --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
+            --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
+            --data-audit-report data-gap-audit.json \
+            "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
 
       - name: Run factor walk-forward
@@ -209,6 +360,10 @@ jobs:
             echo "- Factor filter: ${{ github.event.inputs.factor_name_filter || '<none>' }}"
             if [ -f artifacts/factor-walk-forward-v2/source.txt ]; then
               echo "- Source: $(cat artifacts/factor-walk-forward-v2/source.txt)"
+            fi
+            if [ -f artifacts/research-snapshot/data-gap-audit.md ]; then
+              echo ""
+              cat artifacts/research-snapshot/data-gap-audit.md
             fi
             echo ""
             if [ -f artifacts/research-snapshot/quality.md ]; then

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -252,6 +252,10 @@ jobs:
               f"end={value('end')}",
               f"immutable_input={value('immutable_input')}",
               f"optimizer_data_dir={value('optimizer_data_dir')}",
+              f"data_requirements={value('data_requirements')}",
+              f"data_audit_status={value('data_audit_status')}",
+              f"data_audit_report={value('data_audit_report')}",
+              f"include_deribit={value('include_deribit')}",
           ]
           print("\n".join(str(line) for line in lines))
           PY

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -39,6 +39,33 @@ on:
         description: "Immutable parquet-feed dir used by optimize_backtest"
         required: true
         default: "/tmp/ploy-parquet"
+      data_profile:
+        description: "Project data requirements profile"
+        type: choice
+        required: true
+        default: "pm5d-execution"
+        options:
+          - pm5d-execution
+          - pm5d-vol
+          - all
+          - custom
+      custom_required_sources:
+        description: "Comma-separated sources when data_profile=custom"
+        required: false
+        default: ""
+      audit_lookback_hours:
+        description: "Market-data audit lookback in hours"
+        required: false
+        default: "168"
+      data_gate:
+        description: "Fail threshold for required-source audit"
+        type: choice
+        required: true
+        default: "never"
+        options:
+          - critical
+          - warn
+          - never
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -75,6 +102,119 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Ensure psql client
+        run: |
+          set -euo pipefail
+          if command -v psql >/dev/null 2>&1; then
+            psql --version
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          else
+            echo "psql client is required for scoped data audits" >&2
+            exit 1
+          fi
+
+      - name: Resolve data requirements
+        id: data_scope
+        env:
+          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
+          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
+        run: |
+          set -euo pipefail
+          case "${DATA_PROFILE}" in
+            pm5d-execution)
+              required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="false"
+              ;;
+            pm5d-vol)
+              required_sources="polymarket_quotes,polymarket_orderbooks,deribit_iv,deribit_atm_greeks,binance_price,binance_agg_trades,binance_lob"
+              include_deribit="true"
+              ;;
+            all)
+              required_sources="all"
+              include_deribit="true"
+              ;;
+            custom)
+              required_sources="${CUSTOM_REQUIRED_SOURCES}"
+              if [ -z "${required_sources}" ]; then
+                echo "custom_required_sources is required when data_profile=custom" >&2
+                exit 2
+              fi
+              include_deribit="false"
+              case ",${required_sources}," in
+                *deribit*|*,all,*|*,pm5d-vol,*) include_deribit="true" ;;
+              esac
+              ;;
+            *)
+              echo "unsupported data_profile=${DATA_PROFILE}" >&2
+              exit 2
+              ;;
+          esac
+          echo "required_sources=${required_sources}" >> "${GITHUB_OUTPUT}"
+          echo "include_deribit=${include_deribit}" >> "${GITHUB_OUTPUT}"
+
+      - name: Audit required market data
+        id: data_audit
+        env:
+          REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
+          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
+          DATA_GATE: ${{ github.event.inputs.data_gate }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/research-snapshot
+          PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
+            scripts/audit_market_data_gaps.py \
+              --lookback-hours "${AUDIT_LOOKBACK_HOURS}" \
+              --bucket-minutes 5 \
+              --symbols "${{ github.event.inputs.symbols }}" \
+              --required-sources "${REQUIRED_SOURCES}" \
+              --statement-timeout-seconds 20 \
+              --psql-timeout-seconds 30 \
+              --format json \
+              --fail-on never > artifacts/research-snapshot/data-gap-audit.json
+          python3 <<'PY'
+          import json
+          import os
+
+          status_order = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
+          gate = os.environ["DATA_GATE"]
+          with open("artifacts/research-snapshot/data-gap-audit.json", encoding="utf-8") as fh:
+              payload = json.load(fh)
+          status = payload.get("overall_status", "unknown")
+          lines = [
+              "# Scoped Data Audit",
+              "",
+              f"- Gate: `{gate}`",
+              f"- Overall: `{status}`",
+              f"- Required sources: `{','.join(payload.get('required_sources') or [])}`",
+              f"- Lookback: `{payload.get('lookback_hours')}h`",
+              "",
+              "| Source | Status | Reasons |",
+              "| --- | --- | --- |",
+          ]
+          for item in payload.get("gap_audits", []) + payload.get("window_audits", []):
+              lines.append(
+                  f"| `{item.get('source_id')}` | `{item.get('status', 'unknown')}` | "
+                  f"{'; '.join(item.get('reasons') or [])} |"
+              )
+          summary = "\n".join(lines) + "\n"
+          with open("artifacts/research-snapshot/data-gap-audit.md", "w", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write(summary)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"overall_status={status}\n")
+          should_fail = (
+              (gate == "critical" and status in {"critical", "unknown"})
+              or (gate == "warn" and status_order.get(status, 2) >= status_order["warn"])
+          )
+          if should_fail:
+              raise SystemExit(f"scoped data audit gate failed: {status}")
+          PY
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -93,6 +233,10 @@ jobs:
       - name: Compile snapshot
         run: |
           set -euo pipefail
+          deribit_args=()
+          if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
+            deribit_args+=(--skip-deribit)
+          fi
           mkdir -p artifacts/research-snapshot
           ./target/release/examples/research_snapshot_compile \
             --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
@@ -105,6 +249,10 @@ jobs:
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
             --output-dir artifacts/research-snapshot \
             --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
+            --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
+            --data-audit-report data-gap-audit.json \
+            "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
 
       - name: Publish summary
@@ -116,7 +264,14 @@ jobs:
             echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            echo "- Data profile: ${{ github.event.inputs.data_profile }}"
+            echo "- Data requirements: ${{ steps.data_scope.outputs.required_sources }}"
+            echo "- Include Deribit: ${{ steps.data_scope.outputs.include_deribit }}"
             echo ""
+            if [ -f artifacts/research-snapshot/data-gap-audit.md ]; then
+              cat artifacts/research-snapshot/data-gap-audit.md
+              echo ""
+            fi
             if [ -f artifacts/research-snapshot/quality.md ]; then
               cat artifacts/research-snapshot/quality.md
             fi

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -17,14 +17,14 @@
 //!     [--top-n 20]
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
+    FactorObservation, FactorReviewOptions, ResearchSnapshotRequest,
     build_factor_observations_with_lob_sampled, format_factor_review_v2_report,
     load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
     load_research_pm_book_snapshots_sampled, load_research_snapshot,
-    review_factors_v2_with_deribit_and_pm_books, validate_snapshot_request, FactorObservation,
-    FactorReviewOptions, ResearchSnapshotRequest,
+    review_factors_v2_with_deribit_and_pm_books, validate_snapshot_request,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -163,7 +163,7 @@ async fn main() {
             started.elapsed().as_millis()
         );
         snapshot_provenance = Some(format!(
-            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\n",
+            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\nsnapshot_data_requirements={}\nsnapshot_data_audit_status={}\nsnapshot_data_audit_report={}\nsnapshot_include_deribit={}\n",
             snapshot.manifest.schema_version,
             snapshot_hash,
             snapshot.manifest.generated_at,
@@ -171,7 +171,23 @@ async fn main() {
                 .manifest
                 .optimizer_data_dir
                 .as_deref()
-                .unwrap_or("<missing>")
+                .unwrap_or("<missing>"),
+            if snapshot.manifest.data_requirements.is_empty() {
+                "<unspecified>".to_string()
+            } else {
+                snapshot.manifest.data_requirements.join(",")
+            },
+            snapshot
+                .manifest
+                .data_audit_status
+                .as_deref()
+                .unwrap_or("<not-recorded>"),
+            snapshot
+                .manifest
+                .data_audit_report
+                .as_deref()
+                .unwrap_or("<not-recorded>"),
+            snapshot.manifest.include_deribit
         ));
         (
             snapshot.observations,

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -5,11 +5,14 @@
 //! scores executable PnL after PM CLOB fillability.
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    build_factor_observations_with_lob_sampled, build_factor_stability_report,
-    format_factor_combo_v1_report, format_factor_stability_report,
+    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
+    FactorWalkForwardOptions, FillabilityReviewOptions, LiquidityGateV1Options,
+    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, ResearchSnapshotRequest,
+    TradeFormationReviewOptions, build_factor_observations_with_lob_sampled,
+    build_factor_stability_report, format_factor_combo_v1_report, format_factor_stability_report,
     format_factor_walk_forward_v2_report, format_fillability_review_v1_report,
     format_liquidity_gate_v1_report, format_liquidity_gated_alpha_v1_report,
     format_meta_label_walk_forward_v1_report, format_trade_formation_v1_report,
@@ -19,10 +22,6 @@ use ploy_research::{
     review_fillability_v1_with_deribit, review_trade_formation_v1_with_deribit,
     validate_snapshot_request, walk_forward_factor_combo_v1_with_deribit,
     walk_forward_factors_v2_with_deribit_and_pm_books, walk_forward_meta_label_v1_with_deribit,
-    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
-    FactorWalkForwardOptions, FillabilityReviewOptions, LiquidityGateV1Options,
-    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, ResearchSnapshotRequest,
-    TradeFormationReviewOptions,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -181,7 +180,7 @@ async fn main() {
             started.elapsed().as_millis()
         );
         snapshot_provenance = Some(format!(
-            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\n",
+            "# Snapshot\nsnapshot_schema={}\nsnapshot_hash={}\nsnapshot_generated_at={}\nsnapshot_optimizer_data_dir={}\nsnapshot_data_requirements={}\nsnapshot_data_audit_status={}\nsnapshot_data_audit_report={}\nsnapshot_include_deribit={}\n",
             snapshot.manifest.schema_version,
             snapshot_hash,
             snapshot.manifest.generated_at,
@@ -189,7 +188,23 @@ async fn main() {
                 .manifest
                 .optimizer_data_dir
                 .as_deref()
-                .unwrap_or("<missing>")
+                .unwrap_or("<missing>"),
+            if snapshot.manifest.data_requirements.is_empty() {
+                "<unspecified>".to_string()
+            } else {
+                snapshot.manifest.data_requirements.join(",")
+            },
+            snapshot
+                .manifest
+                .data_audit_status
+                .as_deref()
+                .unwrap_or("<not-recorded>"),
+            snapshot
+                .manifest
+                .data_audit_report
+                .as_deref()
+                .unwrap_or("<not-recorded>"),
+            snapshot.manifest.include_deribit
         ));
         (
             snapshot.observations,

--- a/crates/ploy-research/examples/research_snapshot_compile.rs
+++ b/crates/ploy-research/examples/research_snapshot_compile.rs
@@ -23,6 +23,15 @@ fn flag_present(args: &[String], flag: &str) -> bool {
     args.iter().any(|arg| arg == flag)
 }
 
+fn parse_csv(raw: Option<String>, default: &str) -> Vec<String> {
+    raw.unwrap_or_else(|| default.to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 fn parse_date_start(raw: &str) -> DateTime<Utc> {
     let date = NaiveDate::parse_from_str(raw, "%Y-%m-%d")
         .unwrap_or_else(|_| panic!("invalid date: {raw}"));
@@ -59,13 +68,7 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| {
             parse_date_end(&flag_value(&args, "--end-date").expect("--end-date required"))
         });
-    let symbols: Vec<String> = flag_value(&args, "--symbols")
-        .unwrap_or_else(|| "BTCUSDT".to_string())
-        .split(',')
-        .map(str::trim)
-        .filter(|symbol| !symbol.is_empty())
-        .map(ToOwned::to_owned)
-        .collect();
+    let symbols: Vec<String> = parse_csv(flag_value(&args, "--symbols"), "BTCUSDT");
     let lob_sample_secs: i32 = flag_value(&args, "--lob-sample-secs")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(30);
@@ -81,14 +84,20 @@ async fn main() -> anyhow::Result<()> {
     let require_official_settlement = !flag_present(&args, "--allow-missing-official-settlement");
     let optimizer_data_dir =
         flag_value(&args, "--optimizer-data-dir").expect("--optimizer-data-dir required");
+    let data_requirements = parse_csv(flag_value(&args, "--data-requirements"), "all");
+    let data_audit_status = flag_value(&args, "--data-audit-status");
+    let data_audit_report = flag_value(&args, "--data-audit-report");
+    let include_deribit = !flag_present(&args, "--skip-deribit");
 
     eprintln!(
-        "research_snapshot_compile: {} -> {} for {:?}, stake_usd={:.2}, output={}",
+        "research_snapshot_compile: {} -> {} for {:?}, stake_usd={:.2}, output={}, data_requirements={}, include_deribit={}",
         start,
         end,
         symbols,
         stake_usd,
-        output_dir.display()
+        output_dir.display(),
+        data_requirements.join(","),
+        include_deribit
     );
 
     let pool = PgPoolOptions::new()
@@ -110,6 +119,10 @@ async fn main() -> anyhow::Result<()> {
             require_official_settlement,
             optimizer_data_dir: Some(optimizer_data_dir),
             git_sha: std::env::var("GITHUB_SHA").ok(),
+            data_requirements,
+            data_audit_status,
+            data_audit_report,
+            include_deribit,
         },
     )
     .await?;

--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -15,8 +15,8 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_research::{
-    build_data_health_report, build_factor_observations_v2_with_deribit_and_pm_books,
-    load_research_snapshot, FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest,
+    FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest, build_data_health_report,
+    build_factor_observations_v2_with_deribit_and_pm_books, load_research_snapshot,
 };
 use serde::Serialize;
 
@@ -57,6 +57,10 @@ struct OptimizeSummary<'a> {
     snapshot_schema: &'a str,
     snapshot_hash: &'a str,
     snapshot_generated_at: DateTime<Utc>,
+    snapshot_data_requirements: &'a [String],
+    snapshot_data_audit_status: Option<&'a str>,
+    snapshot_data_audit_report: Option<&'a str>,
+    snapshot_include_deribit: bool,
     symbols: &'a [String],
     train_start: DateTime<Utc>,
     train_end: DateTime<Utc>,
@@ -185,11 +189,7 @@ fn validate_snapshot_scope(
 }
 
 fn finite_or_zero(value: f64) -> f64 {
-    if value.is_finite() {
-        value
-    } else {
-        0.0
-    }
+    if value.is_finite() { value } else { 0.0 }
 }
 
 fn crypto_fee_cost(entry_price: f64) -> f64 {
@@ -203,11 +203,7 @@ fn reward_risk_ratio(entry_price: f64) -> f64 {
     let fee = crypto_fee_cost(entry_price);
     let reward = 1.0 - entry_price - fee;
     let risk = entry_price + fee;
-    if risk <= 0.0 {
-        f64::NAN
-    } else {
-        reward / risk
-    }
+    if risk <= 0.0 { f64::NAN } else { reward / risk }
 }
 
 fn confirmation_score(row: &FactorObservationV2) -> f64 {
@@ -481,6 +477,10 @@ fn write_outputs(
          # validation_trades = {}\n\
          # min_trades = {}\n\
          # min_trades_source = {}\n\
+         # data_requirements = {}\n\
+         # data_audit_status = {}\n\
+         # data_audit_report = {}\n\
+         # include_deribit = {}\n\
          # train_underpowered = {}\n\
          # validation_underpowered = {}\n\
          three_layer_min_direction_prob = {:.6}\n\
@@ -502,6 +502,18 @@ fn write_outputs(
         summary.val_metrics.trades,
         summary.min_trades,
         summary.min_trades_source,
+        if summary.snapshot_data_requirements.is_empty() {
+            "<unspecified>".to_string()
+        } else {
+            summary.snapshot_data_requirements.join(",")
+        },
+        summary
+            .snapshot_data_audit_status
+            .unwrap_or("<not-recorded>"),
+        summary
+            .snapshot_data_audit_report
+            .unwrap_or("<not-recorded>"),
+        summary.snapshot_include_deribit,
         summary.train_underpowered,
         summary.validation_underpowered,
         params.min_direction_prob,
@@ -900,6 +912,10 @@ fn main() -> Result<()> {
         snapshot_schema: &snapshot.manifest.schema_version,
         snapshot_hash,
         snapshot_generated_at: snapshot.manifest.generated_at,
+        snapshot_data_requirements: &snapshot.manifest.data_requirements,
+        snapshot_data_audit_status: snapshot.manifest.data_audit_status.as_deref(),
+        snapshot_data_audit_report: snapshot.manifest.data_audit_report.as_deref(),
+        snapshot_include_deribit: snapshot.manifest.include_deribit,
         symbols: &symbols,
         train_start,
         train_end,

--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -67,10 +67,22 @@ pub struct ResearchSnapshotManifest {
     pub immutable_input: bool,
     pub source_kind: String,
     pub optimizer_data_dir: Option<String>,
+    #[serde(default)]
+    pub data_requirements: Vec<String>,
+    #[serde(default)]
+    pub data_audit_status: Option<String>,
+    #[serde(default)]
+    pub data_audit_report: Option<String>,
+    #[serde(default = "default_include_deribit")]
+    pub include_deribit: bool,
     pub artifacts: ResearchSnapshotArtifacts,
     pub row_counts: ResearchSnapshotRowCounts,
     pub phase_timings: Vec<ResearchSnapshotPhaseTiming>,
     pub quality_flags: Vec<String>,
+}
+
+fn default_include_deribit() -> bool {
+    true
 }
 
 #[derive(Debug, Clone)]
@@ -266,6 +278,10 @@ pub struct ResearchSnapshotBuildOptions {
     pub require_official_settlement: bool,
     pub optimizer_data_dir: Option<String>,
     pub git_sha: Option<String>,
+    pub data_requirements: Vec<String>,
+    pub data_audit_status: Option<String>,
+    pub data_audit_report: Option<String>,
+    pub include_deribit: bool,
 }
 
 #[cfg(feature = "db")]
@@ -273,7 +289,7 @@ pub async fn build_research_snapshot_from_database(
     pool: &sqlx::PgPool,
     options: ResearchSnapshotBuildOptions,
 ) -> Result<ResearchSnapshot> {
-    use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+    use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
     use ploy_market_contracts::MarketUpdate;
 
     use crate::{
@@ -339,22 +355,32 @@ pub async fn build_research_snapshot_from_database(
         rows: Some(all_pm_book_snapshots.len()),
     });
 
-    let started = Instant::now();
-    let deribit_result = load_deribit_feature_snapshots_with_timings(
-        pool,
-        &options.symbols,
-        options.start,
-        options.end,
-        options.observation_sample_secs,
-    )
-    .await;
-    let deribit_snapshots = deribit_result.snapshots;
-    phase_timings.extend(deribit_result.phase_timings);
-    phase_timings.push(ResearchSnapshotPhaseTiming {
-        phase: "deribit_snapshots".to_string(),
-        elapsed_ms: started.elapsed().as_millis(),
-        rows: Some(deribit_snapshots.len()),
-    });
+    let deribit_snapshots = if options.include_deribit {
+        let started = Instant::now();
+        let deribit_result = load_deribit_feature_snapshots_with_timings(
+            pool,
+            &options.symbols,
+            options.start,
+            options.end,
+            options.observation_sample_secs,
+        )
+        .await;
+        let deribit_snapshots = deribit_result.snapshots;
+        phase_timings.extend(deribit_result.phase_timings);
+        phase_timings.push(ResearchSnapshotPhaseTiming {
+            phase: "deribit_snapshots".to_string(),
+            elapsed_ms: started.elapsed().as_millis(),
+            rows: Some(deribit_snapshots.len()),
+        });
+        deribit_snapshots
+    } else {
+        phase_timings.push(ResearchSnapshotPhaseTiming {
+            phase: "deribit_snapshots_skipped".to_string(),
+            elapsed_ms: 0,
+            rows: Some(0),
+        });
+        Vec::new()
+    };
 
     let started = Instant::now();
     let updates_slice = slice_by_time(
@@ -382,7 +408,7 @@ pub async fn build_research_snapshot_from_database(
     if observations.is_empty() {
         quality_flags.push("no_factor_observations".to_string());
     }
-    if deribit_snapshots.is_empty() {
+    if options.include_deribit && deribit_snapshots.is_empty() {
         quality_flags.push("no_deribit_snapshots".to_string());
     }
     if all_pm_book_snapshots.is_empty() {
@@ -407,6 +433,10 @@ pub async fn build_research_snapshot_from_database(
             immutable_input: true,
             source_kind: "tango_postgres_compiled_snapshot".to_string(),
             optimizer_data_dir: options.optimizer_data_dir,
+            data_requirements: options.data_requirements,
+            data_audit_status: options.data_audit_status,
+            data_audit_report: options.data_audit_report,
+            include_deribit: options.include_deribit,
             artifacts: ResearchSnapshotArtifacts::default(),
             row_counts: ResearchSnapshotRowCounts {
                 observations: observations.len(),
@@ -463,6 +493,24 @@ fn compute_snapshot_hash(
     update(&mut hash, manifest.end.to_rfc3339().as_bytes());
     update(&mut hash, manifest.symbols.join(",").as_bytes());
     update(&mut hash, manifest.stake_usd.to_string().as_bytes());
+    update(&mut hash, manifest.data_requirements.join(",").as_bytes());
+    update(&mut hash, manifest.include_deribit.to_string().as_bytes());
+    update(
+        &mut hash,
+        manifest
+            .data_audit_status
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    update(
+        &mut hash,
+        manifest
+            .data_audit_report
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
     for artifact in [
         &manifest.artifacts.observations_json,
         &manifest.artifacts.deribit_snapshots_json,
@@ -501,6 +549,32 @@ fn write_quality_markdown(path: &Path, manifest: &ResearchSnapshotManifest) -> R
             .optimizer_data_dir
             .as_deref()
             .unwrap_or("<missing>")
+    ));
+    body.push_str(&format!(
+        "- Data requirements: `{}`\n",
+        if manifest.data_requirements.is_empty() {
+            "<unspecified>".to_string()
+        } else {
+            manifest.data_requirements.join(",")
+        }
+    ));
+    body.push_str(&format!(
+        "- Data audit status: `{}`\n",
+        manifest
+            .data_audit_status
+            .as_deref()
+            .unwrap_or("<not-recorded>")
+    ));
+    body.push_str(&format!(
+        "- Data audit report: `{}`\n",
+        manifest
+            .data_audit_report
+            .as_deref()
+            .unwrap_or("<not-recorded>")
+    ));
+    body.push_str(&format!(
+        "- Deribit included: `{}`\n",
+        manifest.include_deribit
     ));
     body.push_str(&format!(
         "- Rows: observations={}, deribit={}, pm_books={}\n",
@@ -562,6 +636,10 @@ mod tests {
                 immutable_input: true,
                 source_kind: "unit_test".to_string(),
                 optimizer_data_dir: Some("/tmp/immutable-parquet".to_string()),
+                data_requirements: vec!["polymarket_quotes".to_string()],
+                data_audit_status: Some("ok".to_string()),
+                data_audit_report: Some("data-gap-audit.json".to_string()),
+                include_deribit: false,
                 artifacts: ResearchSnapshotArtifacts::default(),
                 row_counts: ResearchSnapshotRowCounts::default(),
                 phase_timings: vec![ResearchSnapshotPhaseTiming {

--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -9,6 +9,7 @@ existing lightweight deployment bundle.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -28,6 +29,34 @@ DB_URL = (
 DEFAULT_SYMBOLS = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT"
 STATUS_ORDER = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
 IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+SOURCE_PROFILES = {
+    "all": ["*"],
+    "pm5d-core": [
+        "polymarket_quotes",
+        "polymarket_orderbooks",
+        "binance_price",
+        "binance_agg_trades",
+        "binance_lob",
+    ],
+    "pm5d-execution": [
+        "polymarket_quotes",
+        "polymarket_orderbooks",
+        "binance_price",
+        "binance_agg_trades",
+        "binance_lob",
+    ],
+    "pm5d-vol": [
+        "polymarket_quotes",
+        "polymarket_orderbooks",
+        "deribit_iv",
+        "deribit_atm_greeks",
+        "binance_price",
+        "binance_agg_trades",
+        "binance_lob",
+    ],
+    "research-windows": ["research_valid_windows"],
+}
 
 
 @dataclass(frozen=True)
@@ -317,6 +346,7 @@ def parse_symbols(raw: str) -> list[str]:
 def gap_targets(symbols: Iterable[str]) -> list[GapTarget]:
     targets = [
         GapTarget("polymarket_quotes", "clob_quote_ticks", "received_at", 300),
+        GapTarget("polymarket_orderbooks", "clob_orderbook_snapshots", "received_at", 300),
         GapTarget("deribit_iv", "deribit_iv_ticks", "fetched_at", 900),
         GapTarget("deribit_atm_greeks", "deribit_atm_greeks_ticks", "fetched_at", 900),
     ]
@@ -352,6 +382,44 @@ def gap_targets(symbols: Iterable[str]) -> list[GapTarget]:
     return targets
 
 
+def parse_source_requirements(raw: str) -> list[str]:
+    tokens = [item.strip() for item in raw.split(",") if item.strip()]
+    if not tokens:
+        return ["all"]
+    out: list[str] = []
+    for token in tokens:
+        profile = SOURCE_PROFILES.get(token)
+        if profile is None:
+            out.append(token)
+        else:
+            out.extend(profile)
+    return out
+
+
+def source_aliases(target: GapTarget | dict[str, Any]) -> set[str]:
+    if isinstance(target, GapTarget):
+        source_id = target.source_id
+        table_name = target.table_name
+    else:
+        source_id = str(target.get("source_id") or "")
+        table_name = str(target.get("table_name") or "")
+    aliases = {source_id, table_name}
+    if "/" in source_id:
+        aliases.add(source_id.split("/", 1)[0])
+    return aliases
+
+
+def source_is_required(target: GapTarget | dict[str, Any], requirements: list[str]) -> bool:
+    aliases = source_aliases(target)
+    for requirement in requirements:
+        if requirement == "*":
+            return True
+        for alias in aliases:
+            if alias == requirement or fnmatch.fnmatch(alias, requirement):
+                return True
+    return False
+
+
 def overall_status(items: Iterable[dict[str, Any]]) -> str:
     status = "ok"
     for item in items:
@@ -369,6 +437,7 @@ def print_text(payload: dict[str, Any]) -> None:
         f"lookback_hours={payload['lookback_hours']} "
         f"bucket_minutes={payload['bucket_minutes']}"
     )
+    print(f"required_sources={','.join(payload.get('required_sources') or [])}")
     print()
     for item in payload["gap_audits"]:
         filter_value = item.get("filter_value")
@@ -412,12 +481,20 @@ def main() -> int:
         default=os.environ.get("PLOY_AUDIT_SYMBOLS", DEFAULT_SYMBOLS),
         help=f"comma-separated Binance symbols (default: {DEFAULT_SYMBOLS})",
     )
+    parser.add_argument(
+        "--required-sources",
+        default=os.environ.get("PLOY_AUDIT_REQUIRED_SOURCES", "all"),
+        help=(
+            "comma-separated source ids, table names, wildcard patterns, or profiles "
+            f"({', '.join(sorted(SOURCE_PROFILES))}); default: all"
+        ),
+    )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     parser.add_argument(
         "--fail-on",
-        choices=("critical", "unknown", "never"),
+        choices=("critical", "warn", "unknown", "never"),
         default="critical",
-        help="exit non-zero on critical, unknown-or-critical, or never",
+        help="exit non-zero on critical, warn-or-higher, unknown-or-critical, or never",
     )
     args = parser.parse_args()
 
@@ -429,6 +506,10 @@ def main() -> int:
         parser.error("--recent-minutes must be positive")
 
     symbols = parse_symbols(args.symbols)
+    source_requirements = parse_source_requirements(args.required_sources)
+    selected_gap_targets = [
+        target for target in gap_targets(symbols) if source_is_required(target, source_requirements)
+    ]
     gap_results = [
         audit_gap_target(
             target,
@@ -438,12 +519,20 @@ def main() -> int:
             statement_timeout_seconds=args.statement_timeout_seconds,
             psql_timeout_seconds=args.psql_timeout_seconds,
         )
-        for target in gap_targets(symbols)
+        for target in selected_gap_targets
     ]
-    window_results = [
-        audit_research_windows(args.statement_timeout_seconds, args.psql_timeout_seconds)
-    ]
+    window_results = []
+    research_window_target = {
+        "source_id": "research_valid_windows",
+        "table_name": "research_valid_windows",
+    }
+    if source_is_required(research_window_target, source_requirements):
+        window_results.append(
+            audit_research_windows(args.statement_timeout_seconds, args.psql_timeout_seconds)
+        )
     items = gap_results + window_results
+    if not items:
+        parser.error("--required-sources selected no audit targets")
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "database_url_source": "PLOY_DATABASE__URL"
@@ -453,6 +542,7 @@ def main() -> int:
         "bucket_minutes": args.bucket_minutes,
         "recent_minutes": args.recent_minutes,
         "symbols": symbols,
+        "required_sources": source_requirements,
         "overall_status": overall_status(items),
         "gap_audits": gap_results,
         "window_audits": window_results,
@@ -465,6 +555,8 @@ def main() -> int:
 
     if args.fail_on == "never":
         return 0
+    if args.fail_on == "warn" and payload["overall_status"] in {"warn", "unknown", "critical"}:
+        return 1
     if payload["overall_status"] == "critical":
         return 1
     if args.fail_on == "unknown" and payload["overall_status"] in {"critical", "unknown"}:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10222,3 +10222,62 @@ Review:
   in 28s. Post-merge workflow run `25041205036` verified quick + full retained
   window reporting with `fail_on=never` and completed successfully in 1m49s;
   `summary.md`, `quick.json`, and `full.json` were uploaded as artifacts.
+# Data-Requirement Scoped Research Workflows (2026-04-28)
+
+## Files
+
+- `scripts/audit_market_data_gaps.py`
+  - Owner: source-scoped data freshness/coverage audit.
+- `.github/workflows/research-snapshot.yml`
+  - Owner: snapshot compile preflight and provenance.
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: fresh-snapshot factor review path.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: fresh-snapshot walk-forward path.
+- `.github/workflows/optimize.yml`
+  - Owner: snapshot-backed optimizer provenance.
+- `crates/ploy-research/src/research_snapshot.rs`
+  - Owner: immutable snapshot manifest data-requirement metadata.
+- `crates/ploy-research/examples/research_snapshot_compile.rs`
+  - Owner: CLI boundary for compiling scoped snapshots.
+- `tasks/todo.md`
+  - Owner: session tracker.
+
+## Tasks
+
+- [x] Add source/profile filtering to the market-data gap audit so projects can require only the data they consume.
+- [x] Make research snapshot compilation carry explicit data requirements and avoid loading Deribit data when not requested.
+- [x] Wire Research Snapshot, Factor Review, and Walk-Forward workflows to run scoped data audits before fresh snapshot compilation.
+- [x] Preserve scoped-data provenance in optimizer summaries.
+- [ ] Verify syntax, focused tests, PR/CI, and run the scoped workflow from `main`.
+
+## Review
+
+- 2026-04-28: Added scoped data profiles to the gap audit script. `pm5d-execution`
+  requires PM quotes, PM orderbooks, Binance price ticks, Binance agg trades, and
+  Binance LOB; it intentionally excludes Deribit IV/Greeks. `pm5d-vol` and
+  `all` keep Deribit requirements available for strategies that actually consume
+  volatility features.
+- 2026-04-28: Research snapshots now record `data_requirements`,
+  `data_audit_status`, `data_audit_report`, and `include_deribit` in the
+  immutable manifest/quality output. Fresh snapshot compilation supports
+  `--skip-deribit`, so execution-only projects do not load Deribit rows into the
+  snapshot artifact.
+- 2026-04-28: Research Snapshot, Factor Review V2, and Factor Walk-Forward V2 now
+  run a scoped required-source audit before compiling a fresh snapshot. The
+  default `data_gate=never` keeps the downstream workflow moving while preserving
+  the exact audit status in artifacts; operators can choose `critical` or `warn`
+  when they want a blocking gate.
+- 2026-04-28: Read-only Tango smoke of the new `pm5d-execution` profile returned
+  `critical` because `polymarket_orderbooks` had a 185-minute max gap over the
+  168-hour window, while Deribit Greeks were not part of the profile. This
+  confirms the new workflow separates "not needed by this project" from
+  "needed but currently degraded."
+- 2026-04-28: Local verification passed with Python compile for
+  `scripts/audit_market_data_gaps.py`, `git diff --check`, targeted
+  `rustfmt --edition 2024 --check`, workflow YAML parsing, `bash -n` over
+  embedded workflow shell steps, and
+  `CARGO_TARGET_DIR=/tmp/ploy-data-requirements-target rtk cargo test -p
+  ploy-research write_and_load_empty_snapshot_roundtrips_manifest --lib
+  --no-default-features`. Full `cargo fmt --check` was not used as evidence
+  because current repo/vendor files outside this slice already fail formatting.


### PR DESCRIPTION
## Summary
- add source/profile filtering to market-data gap audits, including PM orderbook coverage for PM5D execution
- make research snapshot manifests record data requirements, audit status/report, and whether Deribit was included
- wire Research Snapshot, Factor Review V2, and Factor Walk-Forward V2 to run non-blocking scoped audits before fresh snapshot compilation
- preserve scoped snapshot provenance in optimizer summaries

## Verification
- python3 -m py_compile scripts/audit_market_data_gaps.py
- git diff --check
- rustfmt --edition 2024 --check on modified Rust files
- workflow YAML parse and bash -n over embedded run steps
- read-only Tango pm5d-execution scoped audit via stdin script: critical due polymarket_orderbooks max gap, Deribit excluded as intended
- CARGO_TARGET_DIR=/tmp/ploy-data-requirements-target rtk cargo test -p ploy-research write_and_load_empty_snapshot_roundtrips_manifest --lib --no-default-features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market data scoping and auditing for research workflows with configurable data profiles and custom source requirements.
  * Market data gap audit reports with configurable gating thresholds to control workflow execution.
  * Optional Deribit data inclusion/exclusion controls for snapshot compilation.
  * Enhanced snapshot manifests with audit metadata, data requirements, and audit status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->