### PR TITLE
Keep snapshot reuse independent of artifact action cancellation

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -261,12 +261,18 @@ jobs:
 
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
-          path: artifacts/research-snapshot
-          run-id: ${{ github.event.inputs.snapshot_run_id }}
-          github-token: ${{ github.token }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot
+          python3 scripts/download_github_artifact.py \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md
 
       - name: Compile research snapshot
         if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -277,12 +277,18 @@ jobs:
 
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
-          path: artifacts/research-snapshot
-          run-id: ${{ github.event.inputs.snapshot_run_id }}
-          github-token: ${{ github.token }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot
+          python3 scripts/download_github_artifact.py \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md
 
       - name: Compile research snapshot
         if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -187,22 +187,35 @@ jobs:
           ref: ${{ github.event.inputs.git_ref }}
 
       - name: Download optimize runner
-        uses: actions/download-artifact@v8
-        with:
-          name: optimize-runner-${{ github.sha }}
-          path: target/release/examples
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/release/examples
+          rm -f target/release/examples/optimize-runner
+          python3 scripts/download_github_artifact.py \
+            --run-id "${GITHUB_RUN_ID}" \
+            --name "optimize-runner-${GITHUB_SHA}" \
+            --output-dir target/release/examples \
+            --require optimize-runner
 
       - name: Make binary executable
         run: chmod +x target/release/examples/optimize-runner
 
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: research-snapshot-${{ github.event.inputs.snapshot_run_id }}
-          path: artifacts/research-snapshot
-          run-id: ${{ github.event.inputs.snapshot_run_id }}
-          github-token: ${{ github.token }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot
+          python3 scripts/download_github_artifact.py \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md
 
       - name: Sync Parquet data from Tango-1-1
         if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.allow_live_parquet_debug == 'true' }}

--- a/scripts/download_github_artifact.py
+++ b/scripts/download_github_artifact.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Download and extract a GitHub Actions artifact by name.
+
+This intentionally uses the GitHub REST API instead of actions/download-artifact
+so downstream jobs can consume artifacts from previous workflow runs without
+depending on the action's Node download path on self-hosted runners.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+def request_json(url: str, token: str) -> dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def download_file(url: str, token: str, destination: Path) -> None:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    opener = urllib.request.build_opener(NoRedirectHandler)
+    try:
+        resp = opener.open(req, timeout=60)
+    except urllib.error.HTTPError as err:
+        if err.code not in {301, 302, 303, 307, 308} or "Location" not in err.headers:
+            raise
+        blob_url = err.headers["Location"]
+        resp = urllib.request.urlopen(blob_url, timeout=300)
+
+    with resp:
+        with destination.open("wb") as handle:
+            shutil.copyfileobj(resp, handle)
+
+
+def safe_extract(zip_path: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_root = output_dir.resolve()
+    with zipfile.ZipFile(zip_path) as archive:
+        for member in archive.infolist():
+            target = (output_dir / member.filename).resolve()
+            if target != output_root and output_root not in target.parents:
+                raise RuntimeError(f"refusing to extract path outside output dir: {member.filename}")
+        archive.extractall(output_dir)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True, help="Workflow run id that owns the artifact")
+    parser.add_argument("--name", required=True, help="Artifact name to download")
+    parser.add_argument("--output-dir", required=True, help="Directory to extract the artifact into")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"))
+    parser.add_argument(
+        "--require",
+        action="append",
+        default=[],
+        help="Relative path that must exist after extraction; may be repeated",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.repo:
+        print("GITHUB_REPOSITORY is required or pass --repo", file=sys.stderr)
+        return 2
+    if not args.token:
+        print("GITHUB_TOKEN or GH_TOKEN is required", file=sys.stderr)
+        return 2
+
+    artifacts_url = (
+        f"{args.api_url}/repos/{args.repo}/actions/runs/{args.run_id}/artifacts"
+        f"?name={args.name}&per_page=100"
+    )
+    try:
+        payload = request_json(artifacts_url, args.token)
+    except urllib.error.HTTPError as err:
+        print(f"failed to list artifacts: HTTP {err.code}: {err.read().decode('utf-8')}", file=sys.stderr)
+        return 1
+
+    artifacts = [
+        item
+        for item in payload.get("artifacts", [])
+        if item.get("name") == args.name and not item.get("expired", False)
+    ]
+    if not artifacts:
+        found = ", ".join(item.get("name", "<unknown>") for item in payload.get("artifacts", []))
+        print(f"artifact not found: {args.name}; found: {found or '<none>'}", file=sys.stderr)
+        return 1
+
+    artifact = sorted(artifacts, key=lambda item: item.get("created_at", ""))[-1]
+    output_dir = Path(args.output_dir)
+    with tempfile.TemporaryDirectory(prefix="ploy-artifact-") as tmp:
+        zip_path = Path(tmp) / "artifact.zip"
+        try:
+            download_file(artifact["archive_download_url"], args.token, zip_path)
+        except urllib.error.HTTPError as err:
+            print(f"failed to download artifact: HTTP {err.code}: {err.read().decode('utf-8')}", file=sys.stderr)
+            return 1
+        safe_extract(zip_path, output_dir)
+
+    missing = [path for path in args.require if not (output_dir / path).exists()]
+    if missing:
+        print(f"artifact extracted but required paths are missing: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    print(
+        "downloaded artifact "
+        f"name={artifact['name']} id={artifact['id']} size={artifact.get('size_in_bytes', 0)} "
+        f"to={output_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10222,6 +10222,8 @@ Review:
   - Owner: scheduled/manual Tango market-data gap gate.
 - `tasks/todo.md`
   - Owner: session tracker.
+- `scripts/download_github_artifact.py`
+  - Owner: GitHub artifact download fallback for downstream workflow reuse.
 
 ## Tasks
 
@@ -10275,7 +10277,9 @@ Review:
 - [x] Make research snapshot compilation carry explicit data requirements and avoid loading Deribit data when not requested.
 - [x] Wire Research Snapshot, Factor Review, and Walk-Forward workflows to run scoped data audits before fresh snapshot compilation.
 - [x] Preserve scoped-data provenance in optimizer summaries.
-- [ ] Verify syntax, focused tests, PR/CI, and run the scoped workflow from `main`.
+- [x] Verify syntax, focused tests, PR/CI, and run the scoped Research Snapshot workflow from `main`.
+- [x] Replace cancelled cross-run artifact downloads with a GitHub API helper.
+- [ ] Land the artifact download repair and rerun downstream Factor Review / Walk-Forward from `main`.
 
 ## Review
 
@@ -10307,3 +10311,16 @@ Review:
   ploy-research write_and_load_empty_snapshot_roundtrips_manifest --lib
   --no-default-features`. Full `cargo fmt --check` was not used as evidence
   because current repo/vendor files outside this slice already fail formatting.
+- 2026-04-28: PR #211 merged at `813291c9`. Post-merge Research Snapshot run
+  `25044276221` completed successfully from `main`; artifact
+  `research-snapshot-25044276221` records `pm5d-execution` requirements,
+  `include_deribit=false`, `deribit_snapshots=0`, `data_audit_status=critical`,
+  and the expected `polymarket_orderbooks` gap while continuing with
+  `data_gate=never`.
+- 2026-04-28: Downstream snapshot reuse exposed a workflow transport issue:
+  Factor Review V2 run `25045073793` built successfully and skipped fresh
+  psql/audit steps, then `actions/download-artifact@v8` cancelled while
+  downloading `research-snapshot-25044276221` after resolving the 21 MB artifact.
+  Added `scripts/download_github_artifact.py` so Factor Review, Walk-Forward,
+  and Optimize download artifacts through the GitHub REST API and verify
+  required files before running.


### PR DESCRIPTION
## Summary
- add a GitHub REST artifact downloader with required-file checks
- use it for snapshot reuse in Factor Review, Walk-Forward, and Optimize
- record the post-merge snapshot and cancelled artifact-action evidence in tasks/todo.md

## Verification
- python3 -m py_compile scripts/download_github_artifact.py
- local API download of research-snapshot-25044276221 with manifest/quality checks
- git diff --check
- Ruby YAML parse for modified workflows
- bash -n over embedded run steps

## Follow-up
After merge, rerun Factor Review V2 and Walk-Forward V2 from main against snapshot run 25044276221.