### PR TITLE
Deploy PM5D three-layer dry-run profiles

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -140,6 +140,8 @@ jobs:
           cp config/strategies/02-pm5d.live.toml dist/config/strategies/02-pm5d.live.toml
           cp config/strategies/02-pm5d-threelayer.unified.toml dist/config/strategies/02-pm5d-threelayer.unified.toml
           cp config/strategies/02-pm5d-threelayer.live.toml dist/config/strategies/02-pm5d-threelayer.live.toml
+          cp config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml dist/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
+          cp config/strategies/02-pm5d-threelayer.champion-dryrun.toml dist/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
           cp config/deployments/*.json dist/config/deployments/
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
@@ -366,6 +368,8 @@ jobs:
             install -m 0644 ./config/strategies/02-pm5d.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.live.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.live.toml
+            install -m 0644 ./config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
+            install -m 0644 ./config/strategies/02-pm5d-threelayer.champion-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
             install -m 0644 ./config/deployments/*.json ${DEPLOY_ROOT}/config/deployments/
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py

--- a/config/deployments/pm5d.threelayer.champion.dryrun.json
+++ b/config/deployments/pm5d.threelayer.champion.dryrun.json
@@ -1,0 +1,8 @@
+{
+  "deployment_id": "pm5d.threelayer.champion.dryrun",
+  "bundle_id": "02-pm5d-threelayer.champion-dryrun",
+  "account_id": "acct-pm5d-dryrun",
+  "max_gross_exposure": "5.00",
+  "runtime_mode": "paper",
+  "desired_state": "running"
+}

--- a/config/deployments/pm5d.threelayer.obi-soft.dryrun.json
+++ b/config/deployments/pm5d.threelayer.obi-soft.dryrun.json
@@ -1,0 +1,8 @@
+{
+  "deployment_id": "pm5d.threelayer.obi-soft.dryrun",
+  "bundle_id": "02-pm5d-threelayer.obi-soft-dryrun",
+  "account_id": "acct-pm5d-dryrun",
+  "max_gross_exposure": "5.00",
+  "runtime_mode": "paper",
+  "desired_state": "running"
+}

--- a/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
@@ -1,0 +1,62 @@
+# Three-layer champion dry-run config
+# Snapshot optimizer run 25046098829, snapshot 5bfb253100d3f573
+
+[runtime]
+strategy_variant = "three_layer"
+mode = "dryrun"
+throttle_hz = 10
+
+[strategy]
+symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT", "BNBUSDT"]
+
+vol_floor = 0.001
+min_probability = 0.51
+min_z_score = 0.20
+
+min_entry_price = 0.10
+max_entry_price = 0.85
+no_trade_zone_min = 0.45
+no_trade_zone_max = 0.55
+
+min_edge = 0.0316
+
+min_time_remaining_secs = 66
+max_time_remaining_secs = 184
+cooldown_secs = 23
+
+stake_usd = 15.0
+max_positions = 1000
+max_daily_trades = 1000
+allowed_window_secs = [300, 900]
+
+three_layer_strategy_profile = "champion"
+three_layer_min_entry_score = 0.088746
+three_layer_min_direction_prob = 0.603473
+three_layer_min_distance_over_sigma = 0.039284
+three_layer_min_confirmation_score = 0.0
+three_layer_min_drift_confirmation = 0.00058099
+three_layer_min_edge = -0.017472
+three_layer_min_reward_risk = 0.946405
+three_layer_alpha_contrarian = true
+three_layer_cex_contrarian = false
+three_layer_take_profit_ask = 0.8437
+three_layer_stop_distance_pct = 0.0152
+three_layer_max_pm_lag_secs = 15
+
+[execution]
+use_spread = true
+spread_pct = 0.08
+enable_partial_fills = false
+min_fill_pct = 0.5
+enable_market_impact = true
+impact_coefficient = 0.1
+default_depth_shares = 500
+require_lob_liquidity = true
+
+[reference_data]
+capture_sports_state = false
+
+[backtest_data]
+include_reference_prices = false
+include_sports_state = false
+require_official_settlement = true

--- a/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
@@ -1,0 +1,62 @@
+# Three-layer OBI-soft dry-run config
+# Snapshot optimizer run 25046098899, snapshot 5bfb253100d3f573
+
+[runtime]
+strategy_variant = "three_layer"
+mode = "dryrun"
+throttle_hz = 10
+
+[strategy]
+symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT", "BNBUSDT"]
+
+vol_floor = 0.001
+min_probability = 0.51
+min_z_score = 0.20
+
+min_entry_price = 0.10
+max_entry_price = 0.85
+no_trade_zone_min = 0.45
+no_trade_zone_max = 0.55
+
+min_edge = 0.0316
+
+min_time_remaining_secs = 93
+max_time_remaining_secs = 213
+cooldown_secs = 35
+
+stake_usd = 15.0
+max_positions = 1000
+max_daily_trades = 1000
+allowed_window_secs = [300, 900]
+
+three_layer_strategy_profile = "obi_soft"
+three_layer_min_entry_score = 0.500422
+three_layer_min_direction_prob = 0.560897
+three_layer_min_distance_over_sigma = -0.185344
+three_layer_min_confirmation_score = 0.041704
+three_layer_min_drift_confirmation = -0.00017463
+three_layer_min_edge = 0.041937
+three_layer_min_reward_risk = 0.275789
+three_layer_alpha_contrarian = true
+three_layer_cex_contrarian = false
+three_layer_take_profit_ask = 0.8437
+three_layer_stop_distance_pct = 0.0152
+three_layer_max_pm_lag_secs = 15
+
+[execution]
+use_spread = true
+spread_pct = 0.08
+enable_partial_fills = false
+min_fill_pct = 0.5
+enable_market_impact = true
+impact_coefficient = 0.1
+default_depth_shares = 500
+require_lob_liquidity = true
+
+[reference_data]
+capture_sports_state = false
+
+[backtest_data]
+include_reference_prices = false
+include_sports_state = false
+require_official_settlement = true

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -41,13 +41,13 @@ use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_feed_loaders::{
-    load_from_database_with_options, HistoricalLoadOptions as DbHistoricalLoadOptions,
+    HistoricalLoadOptions as DbHistoricalLoadOptions, load_from_database_with_options,
 };
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
     DirectionalStrategy, ExecutionReport, Feed, FullConfig, HistoricalFeed, MarketUpdate, Recorder,
     ReversalStrategy, RuntimeConfig, RuntimeMode, SignalRecord, SimulatedExecutor,
-    SimulatedExecutorConfig, StrategyLogic, StrategyRuntime, ThreeLayerStrategy,
+    SimulatedExecutorConfig, StrategyLogic, StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy,
 };
 use ploy_trading::{FillRecord, TradeSide, TradingIntent};
 use rust_decimal_macros::dec;
@@ -151,15 +151,8 @@ mod tests {
         };
         let symbols = vec!["BTCUSDT".to_string()];
 
-        let error = validate_preflight(
-            &manifest,
-            &symbols,
-            utc_ts(21),
-            utc_ts(27),
-            &limits,
-            true,
-        )
-        .expect_err("empty parquet manifest should be rejected");
+        let error = validate_preflight(&manifest, &symbols, utc_ts(21), utc_ts(27), &limits, true)
+            .expect_err("empty parquet manifest should be rejected");
 
         assert!(error.contains("zero rows"));
         assert!(error.contains("train split has zero rows"));
@@ -1126,6 +1119,7 @@ fn make_directional_config(
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: min_time as u64,
         max_time_remaining_secs: max_time as u64,
         cooldown_secs: cooldown_secs as u64,
@@ -1193,6 +1187,7 @@ fn make_reversal_config(symbols: &[String], params: &ReversalSearchParams) -> Di
         reversal_max_pm_lag_secs: params.max_pm_lag_secs as u64,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: params.min_time_remaining_secs as u64,
         max_time_remaining_secs: params.max_time_remaining_secs as u64,
         cooldown_secs: params.cooldown_secs as u64,

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -13,12 +13,12 @@
 //! If no --db-url is given, uses synthetic market data.
 
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    config::FullConfig, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
-    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
-    StrategyLogic, StrategyRuntime, ThreeLayerStrategy,
+    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
+    RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
+    StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy, config::FullConfig,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -241,6 +241,7 @@ fn main() {
                     reversal_max_pm_lag_secs: 30,
                     reversal_take_profit_ask: 0.65,
                     reversal_stop_distance_pct: 0.025,
+                    three_layer_strategy_profile: ThreeLayerProfile::Mixed,
                     min_time_remaining_secs: 60,
                     max_time_remaining_secs: 300,
                     cooldown_secs: 60,

--- a/crates/ploy-strategy-bundles/src/lib.rs
+++ b/crates/ploy-strategy-bundles/src/lib.rs
@@ -22,7 +22,6 @@ pub use ploy_market_contracts::{Feed, InstrumentKind, MarketUpdate, PredictionFa
 pub use recorder::BufferedRecorder;
 pub use runtime::emit_intents;
 pub use signals::{MarketSignal, SignalConfig};
-pub use strategies::registry::{build_strategy, canonical_strategy_variant};
 pub use strategies::BayesianDirectionalStrategy;
 pub use strategies::DiffEnhancedStrategy;
 pub use strategies::DiffRegularStrategy;
@@ -32,7 +31,9 @@ pub use strategies::ProbChaseStrategy;
 pub use strategies::ProbReversalStrategy;
 pub use strategies::ReversalStrategy;
 pub use strategies::SweepStrategy;
+pub use strategies::ThreeLayerProfile;
 pub use strategies::ThreeLayerStrategy;
+pub use strategies::registry::{build_strategy, canonical_strategy_variant};
 pub use traits::{
     ExecutionPolicy, ExecutionReport, Executor, NullRecorder, Recorder, SignalRecord,
     StrategyDecision, StrategyLogic,

--- a/crates/ploy-strategy-bundles/src/strategies/directional.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/directional.rs
@@ -13,8 +13,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
@@ -22,6 +22,7 @@ use tracing::{debug, info, warn};
 use super::common::event::EventWindow;
 use super::common::fees::crypto_fee_cost;
 use super::common::quote::QuoteState;
+use super::three_layer_profile::ThreeLayerProfile;
 use crate::traits::{MarketUpdate, SignalRecord, StrategyDecision, StrategyLogic};
 
 // ── Probability Model ────────────────────────────────────
@@ -145,6 +146,10 @@ pub struct DirectionalConfig {
     pub reversal_stop_distance_pct: f64,
 
     // ── Three-Layer strategy parameters ──────────────────────────────
+    /// Runtime profile for profile-specific snapshot optimizer parity.
+    #[serde(default, alias = "strategy_profile")]
+    pub three_layer_strategy_profile: ThreeLayerProfile,
+
     /// Direction gate: minimum effective probability to consider a trade.
     #[serde(default = "default_tl_min_direction_prob")]
     pub three_layer_min_direction_prob: f64,
@@ -1790,6 +1795,7 @@ mod tests {
             reversal_max_pm_lag_secs: 30,
             reversal_take_profit_ask: 0.65,
             reversal_stop_distance_pct: 0.025,
+            three_layer_strategy_profile: ThreeLayerProfile::Mixed,
             three_layer_min_direction_prob: 0.56,
             three_layer_min_distance_over_sigma: 0.3,
             three_layer_min_confirmation_score: 0.10,

--- a/crates/ploy-strategy-bundles/src/strategies/mean_reversion.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/mean_reversion.rs
@@ -11,8 +11,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use tracing::{debug, info, warn};
 
@@ -1044,6 +1044,7 @@ mod tests {
             reversal_max_pm_lag_secs: 30,
             reversal_take_profit_ask: 0.65,
             reversal_stop_distance_pct: 0.025,
+            three_layer_strategy_profile: crate::strategies::ThreeLayerProfile::Mixed,
             min_time_remaining_secs: 60,
             max_time_remaining_secs: 300,
             cooldown_secs: 0,

--- a/crates/ploy-strategy-bundles/src/strategies/mod.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/mod.rs
@@ -12,6 +12,7 @@ pub mod registry;
 pub mod reversal;
 pub mod sweep;
 pub mod three_layer;
+pub mod three_layer_profile;
 
 pub use diff_enhanced::DiffEnhancedStrategy;
 pub use diff_regular::DiffRegularStrategy;
@@ -23,3 +24,4 @@ pub use prob_reversal::ProbReversalStrategy;
 pub use reversal::ReversalStrategy;
 pub use sweep::SweepStrategy;
 pub use three_layer::ThreeLayerStrategy;
+pub use three_layer_profile::ThreeLayerProfile;

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, OrderState, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -14,6 +14,7 @@ use super::common::event::EventWindow;
 use super::common::fees::crypto_fee_cost;
 use super::common::quote::QuoteState;
 use super::common::settlement;
+use super::three_layer_profile::ThreeLayerProfile;
 use crate::strategies::directional::DirectionalConfig;
 use crate::traits::{MarketUpdate, SignalRecord, StrategyDecision, StrategyLogic};
 use ploy_operator_contracts::Regime;
@@ -22,6 +23,7 @@ use ploy_operator_contracts::Regime;
 #[derive(Debug, Clone)]
 pub struct ThreeLayerConfig {
     pub symbols: Vec<String>,
+    pub profile: ThreeLayerProfile,
     pub min_direction_prob: f64,
     pub min_distance_over_sigma: f64,
     pub min_confirmation_score: f64,
@@ -49,6 +51,7 @@ impl From<DirectionalConfig> for ThreeLayerConfig {
     fn from(c: DirectionalConfig) -> Self {
         Self {
             symbols: c.symbols,
+            profile: c.three_layer_strategy_profile,
             min_direction_prob: c.three_layer_min_direction_prob,
             min_distance_over_sigma: c.three_layer_min_distance_over_sigma,
             min_confirmation_score: c.three_layer_min_confirmation_score,
@@ -182,6 +185,42 @@ struct QuoteDepth {
     ask_size: Option<Decimal>,
 }
 
+struct QuoteAskHistory {
+    entries: VecDeque<(DateTime<Utc>, f64)>,
+}
+
+impl QuoteAskHistory {
+    fn new() -> Self {
+        Self {
+            entries: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, ts: DateTime<Utc>, ask: f64) {
+        if !ask.is_finite() {
+            return;
+        }
+        self.entries.push_back((ts, ask));
+        while self.entries.len() > 1 {
+            let oldest = self.entries.front().unwrap().0;
+            if (ts - oldest).num_seconds() > 35 {
+                self.entries.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn change_since(&self, ts: DateTime<Utc>, now_ask: f64, secs: i64) -> Option<f64> {
+        let cutoff = ts - chrono::Duration::seconds(secs);
+        self.entries
+            .iter()
+            .rev()
+            .find(|(entry_ts, _)| *entry_ts <= cutoff)
+            .map(|(_, ask)| now_ask - *ask)
+    }
+}
+
 #[derive(Clone, Copy, Default)]
 struct LobState {
     obi: f64,
@@ -270,11 +309,7 @@ fn norm_cdf(x: f64) -> f64 {
     let d = 0.3989422804014327 * (-x * x / 2.0).exp();
     let p =
         d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 {
-        1.0 - p
-    } else {
-        p
-    }
+    if x >= 0.0 { 1.0 - p } else { p }
 }
 
 fn threshold_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> f64 {
@@ -287,6 +322,107 @@ fn threshold_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> 
         value - threshold
     };
     (signed / scale).clamp(-0.50, 1.0)
+}
+
+fn profile_confirmation_score(
+    direction_sign: f64,
+    lob: &LobState,
+    cum_mprice_drift_5m: f64,
+    drift_30s: f64,
+    regime: Regime,
+    config: &ThreeLayerConfig,
+) -> f64 {
+    match config.profile {
+        ThreeLayerProfile::Mixed => evaluate_confirmation_bonus(
+            direction_sign,
+            lob,
+            cum_mprice_drift_5m,
+            drift_30s,
+            regime,
+            config,
+        ),
+        ThreeLayerProfile::Champion => 0.0,
+        ThreeLayerProfile::ObiSoft => {
+            let obi = (lob.obi * direction_sign).clamp(-1.0, 1.0);
+            let obi_delta = (lob.obi_delta() * direction_sign).clamp(-1.0, 1.0);
+            let depth = (lob.depth_imbalance() * direction_sign).clamp(-1.0, 1.0);
+            let microprice = (cum_mprice_drift_5m * direction_sign).clamp(-1.0, 1.0);
+            let trade_imbalance =
+                ((lob.signed_trade_imbalance / 50.0) * direction_sign).clamp(-1.0, 1.0);
+
+            0.30 * obi
+                + 0.20 * obi_delta
+                + 0.20 * obi
+                + 0.15 * depth
+                + 0.10 * microprice
+                + 0.05 * trade_imbalance
+        }
+        ThreeLayerProfile::ContinuationSoft => {
+            let drift_continuation = (drift_30s * direction_sign * 800.0).clamp(-1.0, 1.0);
+            let microprice = (cum_mprice_drift_5m * direction_sign).clamp(-1.0, 1.0);
+            let trade_imbalance =
+                ((lob.signed_trade_imbalance / 50.0) * direction_sign).clamp(-1.0, 1.0);
+            0.50 * drift_continuation + 0.30 * microprice + 0.20 * trade_imbalance
+        }
+    }
+}
+
+struct EntryScoreInputs {
+    direction_score: f64,
+    distance_over_sigma: f64,
+    direction_sign: f64,
+    edge: f64,
+    edge_score: f64,
+    confirmation: f64,
+    drift_30s: f64,
+    pm_momentum_score: f64,
+    liquidity_score: f64,
+}
+
+fn evaluate_entry_score(config: &ThreeLayerConfig, inputs: EntryScoreInputs) -> f64 {
+    if !config.profile.uses_snapshot_scoring() {
+        return inputs.direction_score * 0.50
+            + inputs.edge_score * 0.35
+            + inputs.confirmation * 0.15;
+    }
+
+    let side_distance = inputs.distance_over_sigma * inputs.direction_sign;
+    let distance_score = threshold_score(
+        side_distance,
+        config.min_distance_over_sigma,
+        0.60,
+        config.alpha_contrarian,
+    );
+    let edge_score = threshold_score(inputs.edge, config.min_edge, 0.08, config.alpha_contrarian);
+    let drift_side = inputs.drift_30s * inputs.direction_sign;
+    let drift_score = ((drift_side - config.min_drift_confirmation) * 800.0).clamp(-0.50, 1.0);
+    let confirmation_score = threshold_score(
+        inputs.confirmation,
+        config.min_confirmation_score,
+        0.50,
+        config.cex_contrarian,
+    );
+
+    match config.profile {
+        ThreeLayerProfile::Champion => {
+            0.33 * inputs.direction_score
+                + 0.17 * distance_score
+                + 0.25 * edge_score
+                + 0.10 * drift_score
+                + 0.10 * inputs.pm_momentum_score
+                + 0.05 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::ObiSoft | ThreeLayerProfile::ContinuationSoft => {
+            0.25 * inputs.direction_score
+                + 0.12 * distance_score
+                + 0.18 * edge_score
+                + 0.15 * confirmation_score
+                + 0.10 * drift_score
+                + 0.12 * inputs.pm_momentum_score
+                + 0.08 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),
+    }
 }
 
 /// Layer 1: Direction score (0.0 – 1.0).
@@ -421,6 +557,7 @@ pub struct ThreeLayerStrategy {
     spot: HashMap<Arc<str>, Decimal>,
     quotes: HashMap<Arc<str>, QuoteState>,
     quote_depth: HashMap<Arc<str>, QuoteDepth>,
+    quote_ask_history: HashMap<Arc<str>, QuoteAskHistory>,
     token_symbol: HashMap<Arc<str>, Arc<str>>,
     token_event: HashMap<Arc<str>, Arc<str>>,
     events: HashMap<Arc<str>, Vec<EventWindow>>,
@@ -443,6 +580,7 @@ impl ThreeLayerStrategy {
             spot: HashMap::new(),
             quotes: HashMap::new(),
             quote_depth: HashMap::new(),
+            quote_ask_history: HashMap::new(),
             token_symbol: HashMap::new(),
             token_event: HashMap::new(),
             events: HashMap::new(),
@@ -537,6 +675,36 @@ impl ThreeLayerStrategy {
         match self.balance_exhausted_until {
             Some(existing) if existing >= until => {}
             _ => self.balance_exhausted_until = Some(until),
+        }
+    }
+
+    fn record_quote_ask(&mut self, token_id: Arc<str>, ask: Option<Decimal>, ts: DateTime<Utc>) {
+        let Some(ask) = ask.and_then(|price| price.to_f64()) else {
+            return;
+        };
+        self.quote_ask_history
+            .entry(token_id)
+            .or_insert_with(QuoteAskHistory::new)
+            .push(ts, ask);
+    }
+
+    fn pm_momentum_score(&self, token_id: &str, ask: f64, now: DateTime<Utc>) -> f64 {
+        let Some(history) = self.quote_ask_history.get(token_id) else {
+            return 0.0;
+        };
+        let pm_momentum = [
+            history.change_since(now, ask, 10),
+            history.change_since(now, ask, 30),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|value| value.is_finite())
+        .fold(f64::NEG_INFINITY, f64::max);
+
+        if pm_momentum.is_finite() {
+            (pm_momentum / 0.08).clamp(-0.50, 1.0)
+        } else {
+            0.0
         }
     }
 
@@ -676,9 +844,9 @@ impl ThreeLayerStrategy {
                 continue;
             }
 
-            // Layer 2: Confirmation bonus
+            // Layer 2: profile-specific confirmation component
             let lob = self.lob.get(symbol).copied().unwrap_or_default();
-            let confirmation_bonus = evaluate_confirmation_bonus(
+            let confirmation_score = profile_confirmation_score(
                 direction_sign,
                 &lob,
                 cum_mprice_drift_5m,
@@ -688,16 +856,32 @@ impl ThreeLayerStrategy {
             );
 
             // Layer 3: Edge score
-            let Some((entry_price_f, edge, _rr, edge_score)) =
+            let Some((entry_price_f, edge, rr, edge_score)) =
                 evaluate_edge_score(effective_p, ask, regime, &self.config)
             else {
                 self.bump("skip_edge_score");
                 continue;
             };
+            if self.config.profile.uses_snapshot_scoring() && rr < self.config.min_reward_risk {
+                self.bump("skip_reward_risk");
+                continue;
+            }
 
-            // Composite scoring model
-            let total_score =
-                direction_score * 0.50 + edge_score * 0.35 + confirmation_bonus * 0.15;
+            let pm_momentum_score = self.pm_momentum_score(token_id, ask, now);
+            let total_score = evaluate_entry_score(
+                &self.config,
+                EntryScoreInputs {
+                    direction_score,
+                    distance_over_sigma,
+                    direction_sign,
+                    edge,
+                    edge_score,
+                    confirmation: confirmation_score,
+                    drift_30s,
+                    pm_momentum_score,
+                    liquidity_score: 1.0,
+                },
+            );
 
             if total_score < self.config.min_entry_score {
                 self.bump("skip_entry_score");
@@ -708,8 +892,10 @@ impl ThreeLayerStrategy {
                     total_score = format!("{:.3}", total_score),
                     direction_score = format!("{:.3}", direction_score),
                     edge_score = format!("{:.3}", edge_score),
-                    confirmation_bonus = format!("{:.3}", confirmation_bonus),
+                    confirmation_score = format!("{:.3}", confirmation_score),
+                    pm_momentum_score = format!("{:.3}", pm_momentum_score),
                     min_entry_score = self.config.min_entry_score,
+                    profile = %self.config.profile,
                     regime = regime.as_str(),
                     "score below threshold"
                 );
@@ -796,10 +982,12 @@ impl ThreeLayerStrategy {
                 total_score = format!("{:.3}", total_score),
                 direction_score = format!("{:.3}", direction_score),
                 edge_score = format!("{:.3}", edge_score),
-                confirmation_bonus = format!("{:.3}", confirmation_bonus),
+                confirmation_score = format!("{:.3}", confirmation_score),
+                pm_momentum_score = format!("{:.3}", pm_momentum_score),
                 p_hat = effective_p,
                 edge,
                 entry_price = %entry_price,
+                profile = %self.config.profile,
                 regime = regime.as_str(),
                 "entry signal"
             );
@@ -1078,6 +1266,7 @@ impl StrategyLogic for ThreeLayerStrategy {
                         ask_size: *ask_size,
                     },
                 );
+                self.record_quote_ask(token_id.clone(), *ask, *ts);
 
                 let Some(symbol) = self.token_symbol.get(token_id).cloned() else {
                     return Vec::new();
@@ -1344,11 +1533,19 @@ mod tests {
     fn config_from_directional_preserves_fields() {
         let dc: DirectionalConfig = serde_json::from_str("{}").unwrap();
         let tlc: ThreeLayerConfig = dc.into();
+        assert_eq!(tlc.profile, ThreeLayerProfile::Mixed);
         assert_eq!(tlc.min_edge, 0.03);
         assert_eq!(tlc.min_reward_risk, 1.2);
         assert_eq!(tlc.take_profit_ask, 0.70);
         assert!((tlc.min_entry_score - 0.30).abs() < f64::EPSILON);
         assert!(!tlc.symbols.is_empty());
+    }
+
+    #[test]
+    fn config_from_directional_accepts_profile_aliases() {
+        let dc: DirectionalConfig = serde_json::from_str(r#"{"strategy_profile":"obi"}"#).unwrap();
+        let tlc: ThreeLayerConfig = dc.into();
+        assert_eq!(tlc.profile, ThreeLayerProfile::ObiSoft);
     }
 
     #[test]
@@ -1402,6 +1599,7 @@ mod tests {
     fn test_config() -> ThreeLayerConfig {
         ThreeLayerConfig {
             symbols: vec!["BTCUSDT".into()],
+            profile: ThreeLayerProfile::Mixed,
             min_direction_prob: 0.56,
             min_distance_over_sigma: 0.3,
             min_confirmation_score: 0.10,
@@ -1996,6 +2194,62 @@ mod tests {
             bonus > 0.0,
             "opposing LOB should be rewarded in contrarian confirmation mode, got {}",
             bonus
+        );
+    }
+
+    #[test]
+    fn champion_profile_ignores_confirmation_component() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::Champion;
+        let total = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.50,
+                distance_over_sigma: -0.20,
+                direction_sign: -1.0,
+                edge: 0.01,
+                edge_score: 0.20,
+                confirmation: -1.0,
+                drift_30s: 0.0,
+                pm_momentum_score: 0.0,
+                liquidity_score: 1.0,
+            },
+        );
+        let with_positive_confirmation = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.50,
+                distance_over_sigma: -0.20,
+                direction_sign: -1.0,
+                edge: 0.01,
+                edge_score: 0.20,
+                confirmation: 1.0,
+                drift_30s: 0.0,
+                pm_momentum_score: 0.0,
+                liquidity_score: 1.0,
+            },
+        );
+        assert!((total - with_positive_confirmation).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn obi_soft_profile_scores_side_aware_book_imbalance() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::ObiSoft;
+        let lob = LobState {
+            obi: -0.5,
+            obi_prev: -0.2,
+            spread_bps: 10,
+            bid_depth_near: 50.0,
+            ask_depth_near: 100.0,
+            signed_trade_imbalance: -20.0,
+            last_aggtrade_ts: None,
+            ts: None,
+        };
+        let score = profile_confirmation_score(-1.0, &lob, -0.5, 0.0, Regime::Middle, &config);
+        assert!(
+            score > 0.0,
+            "DOWN-side OBI profile should reward opposing raw UP pressure, got {score}"
         );
     }
 

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
@@ -1,0 +1,73 @@
+//! Runtime profile selector for the PM5D three-layer strategy.
+
+use serde::{Deserialize, Deserializer, Serialize, de};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreeLayerProfile {
+    /// Historical runtime behavior: blended CEX continuation and book confirmation.
+    Mixed,
+    /// Snapshot Strategy A: contrarian alpha plus executable liquidity/risk gates.
+    Champion,
+    /// Snapshot Strategy B: Champion plus CEX/PM order-book imbalance soft score.
+    ObiSoft,
+    /// Snapshot Strategy C: Champion plus CEX continuation soft score.
+    ContinuationSoft,
+}
+
+impl Default for ThreeLayerProfile {
+    fn default() -> Self {
+        Self::Mixed
+    }
+}
+
+impl ThreeLayerProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mixed => "mixed",
+            Self::Champion => "champion",
+            Self::ObiSoft => "obi_soft",
+            Self::ContinuationSoft => "continuation_soft",
+        }
+    }
+
+    pub fn uses_snapshot_scoring(self) -> bool {
+        !matches!(self, Self::Mixed)
+    }
+}
+
+impl FromStr for ThreeLayerProfile {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "mixed" | "legacy" => Ok(Self::Mixed),
+            "champion" | "a" | "alpha" | "alpha_only" | "contrarian_alpha" => Ok(Self::Champion),
+            "obi" | "obi_soft" | "b" | "book_imbalance" | "orderbook" => Ok(Self::ObiSoft),
+            "continuation" | "continuation_soft" | "c" | "cex_continuation" => {
+                Ok(Self::ContinuationSoft)
+            }
+            other => Err(format!(
+                "unknown three_layer_strategy_profile {other:?}; expected mixed, champion, obi_soft, or continuation_soft"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for ThreeLayerProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreeLayerProfile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::from_str(&raw).map_err(de::Error::custom)
+    }
+}

--- a/crates/ploy-strategy-bundles/tests/backtest_integration.rs
+++ b/crates/ploy-strategy-bundles/tests/backtest_integration.rs
@@ -11,6 +11,7 @@ use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
     DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, RecordedFeed, RecordingFeed,
     RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyRuntime,
+    ThreeLayerProfile,
 };
 use rust_decimal_macros::dec;
 use std::fs;
@@ -189,6 +190,7 @@ async fn backtest_full_loop_produces_entry() {
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: 60,
         max_time_remaining_secs: 300,
         cooldown_secs: 0,
@@ -324,6 +326,7 @@ async fn empty_feed_produces_zero_trades() {
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: 60,
         max_time_remaining_secs: 300,
         cooldown_secs: 0,
@@ -397,6 +400,7 @@ async fn recorded_updates_replay_to_the_same_runtime_result() {
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: 60,
         max_time_remaining_secs: 300,
         cooldown_secs: 0,
@@ -519,6 +523,7 @@ async fn sports_updates_round_trip_without_changing_crypto_runtime_behavior() {
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: 60,
         max_time_remaining_secs: 300,
         cooldown_secs: 0,
@@ -634,6 +639,7 @@ async fn reference_updates_round_trip_without_changing_crypto_runtime_behavior()
         reversal_max_pm_lag_secs: 30,
         reversal_take_profit_ask: 0.65,
         reversal_stop_distance_pct: 0.025,
+        three_layer_strategy_profile: ThreeLayerProfile::Mixed,
         min_time_remaining_secs: 60,
         max_time_remaining_secs: 300,
         cooldown_secs: 0,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -29,6 +29,7 @@
 - 2026-04-28: Added a three-layer runtime profile selector with legacy `mixed` as the default. `champion` uses the snapshot optimizer's contrarian-alpha weighted score without confirmation, while `obi_soft` adds side-aware OBI/depth/microprice/trade-imbalance soft confirmation. Runtime now honors the snapshot reward/risk gate for non-legacy profiles and keeps the previous `mixed` composite score unchanged.
 - 2026-04-28: Added dry-run configs/manifests for `pm5d.threelayer.obi-soft.dryrun` and `pm5d.threelayer.champion.dryrun`, both with fixed `stake_usd=15.0`, six symbols, dry-run mode, and optimizer params from runs `25046098899` and `25046098829`. The Tango deploy workflow now bundles and installs both strategy TOMLs.
 - 2026-04-28: Local focused verification passed: `rustfmt --edition 2024` on touched Rust files, JSON parsing for both manifests, Python `tomllib` parsing for both strategy configs with `stake_usd=15.0`, workflow YAML parse via Ruby, `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test -p ploy-strategy-bundles three_layer --lib`, and `git diff --check`.
+- 2026-04-28: PR CI initially caught a missing `three_layer_strategy_profile` field in the built-in `run_backtest` example defaults. Added the field and root re-export, then verified `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test --locked -p ploy-strategy-bundles --example run_backtest --no-run` plus the focused three-layer lib tests.
 
 ## Files
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,6 +30,7 @@
 - 2026-04-28: Added dry-run configs/manifests for `pm5d.threelayer.obi-soft.dryrun` and `pm5d.threelayer.champion.dryrun`, both with fixed `stake_usd=15.0`, six symbols, dry-run mode, and optimizer params from runs `25046098899` and `25046098829`. The Tango deploy workflow now bundles and installs both strategy TOMLs.
 - 2026-04-28: Local focused verification passed: `rustfmt --edition 2024` on touched Rust files, JSON parsing for both manifests, Python `tomllib` parsing for both strategy configs with `stake_usd=15.0`, workflow YAML parse via Ruby, `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test -p ploy-strategy-bundles three_layer --lib`, and `git diff --check`.
 - 2026-04-28: PR CI initially caught a missing `three_layer_strategy_profile` field in the built-in `run_backtest` example defaults. Added the field and root re-export, then verified `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test --locked -p ploy-strategy-bundles --example run_backtest --no-run` plus the focused three-layer lib tests.
+- 2026-04-28: A second CI pass found the same missing default in integration-test and optimizer-example hand-written configs. Added `ThreeLayerProfile::Mixed` there and verified `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test --locked -p ploy-strategy-bundles --tests --no-run`, `--example optimize_backtest --no-run`, `--example run_backtest --no-run`, and `git diff --check`.
 
 ## Files
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,35 @@
 # PM5D Three-Arm Snapshot Optimization (2026-04-28)
 
+# PM5D Three-Layer Profile Dry-Run Deployment (2026-04-28)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer*.rs`
+  - Owner: runtime profile parity for optimized `champion` and `obi_soft` dry-run candidates.
+- `config/strategies/02-pm5d-threelayer.*.dryrun.toml`
+  - Owner: dry-run strategy configs generated from the validated snapshot optimizer parameters.
+- `config/deployments/pm5d.threelayer.*.dryrun.json`
+  - Owner: dry-run deployment manifests for Tango control-plane application.
+- `.github/workflows/deploy-tango-1-1.yml`
+  - Owner: CI artifact bundle coverage for the new strategy configs.
+- `tasks/todo.md`
+  - Owner: deploy plan, verification, and remote evidence.
+
+## Tasks
+
+- [x] Inspect the current runtime/config gap between snapshot profiles and deployed three-layer strategy behavior.
+- [x] Add runtime support for profile-specific three-layer scoring while preserving the legacy `mixed` default.
+- [x] Add `obi_soft` and `champion` dry-run configs/manifests using the 2026-04-28 200-trial snapshot optimizer parameters.
+- [x] Verify focused tests, config parsing, JSON/YAML validity, and diff hygiene.
+- [ ] Open/merge PR to `main`, then trigger CI-built `deploy-tango-1-1` dry-run deployment.
+- [ ] Apply/verify Tango dry-run deployments and confirm live remains paused.
+
+## Review
+
+- 2026-04-28: Added a three-layer runtime profile selector with legacy `mixed` as the default. `champion` uses the snapshot optimizer's contrarian-alpha weighted score without confirmation, while `obi_soft` adds side-aware OBI/depth/microprice/trade-imbalance soft confirmation. Runtime now honors the snapshot reward/risk gate for non-legacy profiles and keeps the previous `mixed` composite score unchanged.
+- 2026-04-28: Added dry-run configs/manifests for `pm5d.threelayer.obi-soft.dryrun` and `pm5d.threelayer.champion.dryrun`, both with fixed `stake_usd=15.0`, six symbols, dry-run mode, and optimizer params from runs `25046098899` and `25046098829`. The Tango deploy workflow now bundles and installs both strategy TOMLs.
+- 2026-04-28: Local focused verification passed: `rustfmt --edition 2024` on touched Rust files, JSON parsing for both manifests, Python `tomllib` parsing for both strategy configs with `stake_usd=15.0`, workflow YAML parse via Ruby, `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test -p ploy-strategy-bundles three_layer --lib`, and `git diff --check`.
+
 ## Files
 
 - `crates/ploy-research/examples/three_layer_snapshot_optimize.rs`


### PR DESCRIPTION
## Summary
- add runtime profile support for PM5D three-layer `champion` and `obi_soft` scoring while preserving legacy `mixed`
- add dry-run configs/manifests for `pm5d.threelayer.obi-soft.dryrun` and `pm5d.threelayer.champion.dryrun`
- bundle/install the new configs in `deploy-tango-1-1`

## Verification
- `rustfmt --edition 2024` on touched Rust files
- JSON parse for both deployment manifests
- Python `tomllib` parse for both strategy configs with `stake_usd=15.0`
- Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`
- `CARGO_TARGET_DIR=/tmp/ploy-profile-dryrun-test rtk cargo test -p ploy-strategy-bundles three_layer --lib`
- `git diff --check`

## Deploy Plan
- merge to `main`
- run `deploy-tango-1-1` from `main`
- apply the two dry-run manifests on Tango
- verify live remains paused