### PR TITLE
Preserve dry-run deployment attribution

### DIFF
--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -28,6 +28,8 @@ pub fn build_worker_launch_spec(
         "run".to_string(),
         "--config".to_string(),
         config_path.to_string_lossy().into_owned(),
+        "--deployment-id".to_string(),
+        record.deployment_id.clone(),
         "--foreground".to_string(),
     ];
     if record.runtime_mode == "paper" {
@@ -187,7 +189,7 @@ pub fn refresh_source_health(control_plane: &mut ControlPlane, listen_addr: &str
 
 #[cfg(test)]
 mod tests {
-    use super::{refresh_source_health, tick_workers, WorkerTickConfig};
+    use super::{WorkerTickConfig, refresh_source_health, tick_workers};
     use ploy_deployments::WorkerSupervisor;
     use ploy_operator_contracts::{DeploymentState, DesiredState, ObservedState};
     use ploy_platform::{ControlPlane, DeploymentRecord};
@@ -301,14 +303,22 @@ mod tests {
             &config,
         );
 
-        assert!(spec
-            .command
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.starts_with("ploy-platform-runtime-test-runner-")));
-        assert!(spec
+        assert!(
+            spec.command
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("ploy-platform-runtime-test-runner-"))
+        );
+        assert!(
+            spec.args
+                .contains(&"config/strategies/02-pm5d.v2-dryrun.toml".to_string())
+        );
+        let deployment_id_arg = spec
             .args
-            .contains(&"config/strategies/02-pm5d.v2-dryrun.toml".to_string()));
+            .windows(2)
+            .find(|window| window[0] == "--deployment-id")
+            .map(|window| window[1].as_str());
+        assert_eq!(deployment_id_arg, Some("pm5d.v2.paper"));
         assert!(spec.args.contains(&"--dry-run".to_string()));
     }
 

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -19,20 +19,22 @@ fn print_usage_for(program: &str) {
     eprintln!("  collect-pm-trades Collect public Polymarket trade prints from Data API");
     eprintln!();
     eprintln!("Options for 'run':");
-    eprintln!("  --config <path>   Unified TOML config file (required)");
-    eprintln!("  --dry-run         Force dry-run mode (simulated execution)");
-    eprintln!("  --foreground      Run in foreground (default, kept for compat)");
+    eprintln!("  --config <path>          Unified TOML config file (required)");
+    eprintln!("  --deployment-id <id>     Platform deployment identity for order attribution");
+    eprintln!("  --dry-run                Force dry-run mode (simulated execution)");
+    eprintln!("  --foreground             Run in foreground (default, kept for compat)");
     #[cfg(feature = "ops")]
     ops::print_usage();
 }
 
 fn print_mode_usage(program: &str) {
-    eprintln!("Usage: {program} --config <path> [--dry-run] [--foreground]");
+    eprintln!("Usage: {program} --config <path> [--deployment-id <id>] [--dry-run] [--foreground]");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --config <path>   Unified TOML config file (required)");
-    eprintln!("  --dry-run         Force dry-run mode (simulated execution)");
-    eprintln!("  --foreground      Run in foreground (default, kept for compat)");
+    eprintln!("  --config <path>          Unified TOML config file (required)");
+    eprintln!("  --deployment-id <id>     Platform deployment identity for order attribution");
+    eprintln!("  --dry-run                Force dry-run mode (simulated execution)");
+    eprintln!("  --foreground             Run in foreground (default, kept for compat)");
 }
 
 fn program_name(args: &[String]) -> String {
@@ -86,7 +88,7 @@ pub async fn run_with_implicit_run_args(args: Vec<String>) {
 
 fn normalize_mode_args(mut args: Vec<String>) -> Vec<String> {
     match args.get(1).map(String::as_str) {
-        None | Some("--config" | "--dry-run" | "--foreground") => {
+        None | Some("--config" | "--deployment-id" | "--dry-run" | "--foreground") => {
             args.insert(1, "run".to_string());
         }
         _ => {}

--- a/crates/ploy-runner-host/src/run.rs
+++ b/crates/ploy-runner-host/src/run.rs
@@ -1,10 +1,11 @@
 use ploy_strategy_bundles::FullConfig;
-use ploy_strategy_runtime::run_strategy;
+use ploy_strategy_runtime::run_strategy_with_deployment_id;
 
 use crate::print_usage;
 
 pub async fn run_command(args: &[String], command: Option<&str>) {
     let mut config_path: Option<String> = None;
+    let mut deployment_id: Option<String> = None;
     let mut force_dry_run = false;
     let mut i = if command == Some("run") { 2 } else { 1 };
     while i < args.len() {
@@ -17,6 +18,15 @@ pub async fn run_command(args: &[String], command: Option<&str>) {
                 }
                 i += 1;
                 config_path = args.get(i).cloned();
+            }
+            "--deployment-id" => {
+                if i + 1 >= args.len() || args[i + 1].starts_with("--") {
+                    eprintln!("Error: --deployment-id requires a value");
+                    print_usage();
+                    std::process::exit(1);
+                }
+                i += 1;
+                deployment_id = args.get(i).cloned();
             }
             "--dry-run" => force_dry_run = true,
             "--foreground" => {}
@@ -47,5 +57,5 @@ pub async fn run_command(args: &[String], command: Option<&str>) {
         }
     };
 
-    run_strategy(config, &config_path, force_dry_run).await;
+    run_strategy_with_deployment_id(config, &config_path, force_dry_run, deployment_id).await;
 }

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -113,6 +113,7 @@ where
     recorder: Box<dyn Recorder>,
     trading: TradingRuntime,
     config: RuntimeConfig,
+    deployment_id: Option<String>,
 }
 
 impl<S, F, E> StrategyRuntime<S, F, E>
@@ -154,7 +155,18 @@ where
             recorder,
             trading,
             config,
+            deployment_id: None,
         }
+    }
+
+    /// Attach the platform deployment identity used to attribute strategy orders.
+    pub fn with_deployment_id(mut self, deployment_id: impl Into<String>) -> Self {
+        let deployment_id = deployment_id.into();
+        let deployment_id = deployment_id.trim();
+        if !deployment_id.is_empty() {
+            self.deployment_id = Some(deployment_id.to_string());
+        }
+        self
     }
 
     /// Run the strategy loop until the feed is exhausted or max_updates reached.
@@ -217,11 +229,12 @@ where
 
             // 2. Execute each decision.
             for decision in decisions {
-                let (intent, signal) = match decision {
+                let (mut intent, signal) = match decision {
                     StrategyDecision::Enter { intent, signal } => (intent, signal),
                     StrategyDecision::Exit(intent) => (intent, None),
                     StrategyDecision::Hold => continue,
                 };
+                self.ensure_deployment_attribution(&mut intent);
                 let strategy_name = self.strategy.name().to_string();
                 let signal_ref = signal.as_ref();
 
@@ -229,7 +242,8 @@ where
                     self.recorder.record_signal(signal).await;
                 }
 
-                let intent = self.executor.prepare_intent(&intent);
+                let mut intent = self.executor.prepare_intent(&intent);
+                self.ensure_deployment_attribution(&mut intent);
                 let order_id = Uuid::new_v4().to_string();
 
                 let report = self.executor.submit(&intent, &order_id).await;
@@ -428,6 +442,23 @@ where
         &self.trading
     }
 
+    fn ensure_deployment_attribution(&self, intent: &mut TradingIntent) {
+        if intent.deployment_id.is_empty() {
+            if let Some(deployment_id) = self.deployment_id.as_deref() {
+                intent.deployment_id = deployment_id.to_string();
+            }
+        }
+
+        if intent.deployment_id.is_empty()
+            && matches!(self.config.mode, RuntimeMode::Live | RuntimeMode::DryRun)
+        {
+            panic!(
+                "strategy runtime in {:?} emitted intent {} without deployment_id and runtime deployment_id is not configured",
+                self.config.mode, intent.intent_id
+            );
+        }
+    }
+
     fn initial_pending_live_orders(&self) -> BTreeMap<String, PendingLiveOrder> {
         if self.config.mode != RuntimeMode::Live {
             return BTreeMap::new();
@@ -574,7 +605,9 @@ where
             );
             retry_intent.quantity = remaining_qty;
             retry_intent.created_at = Utc::now();
-            let retry_intent = self.executor.prepare_intent(&retry_intent);
+            self.ensure_deployment_attribution(&mut retry_intent);
+            let mut retry_intent = self.executor.prepare_intent(&retry_intent);
+            self.ensure_deployment_attribution(&mut retry_intent);
             let retry_order_id = Uuid::new_v4().to_string();
             let report = self.executor.submit(&retry_intent, &retry_order_id).await;
             self.recorder
@@ -661,8 +694,8 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::{
-        retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig, RuntimeMode,
-        StrategyRuntime,
+        RuntimeConfig, RuntimeMode, StrategyRuntime, retry_attempt_from_intent_id,
+        retry_root_intent_id,
     };
     use crate::traits::{
         ExecutionPolicy, ExecutionReport, Executor, Feed, MarketUpdate, Recorder, SignalRecord,
@@ -795,7 +828,7 @@ mod tests {
 
     struct CollectingRecorder {
         signals: Arc<Mutex<Vec<SignalRecord>>>,
-        orders: Arc<Mutex<Vec<(String, String)>>>,
+        orders: Arc<Mutex<Vec<(String, String, String)>>>,
         fills: Arc<Mutex<Vec<String>>>,
     }
 
@@ -813,10 +846,11 @@ mod tests {
             _report: &ExecutionReport,
             _order_id: &str,
         ) {
-            self.orders
-                .lock()
-                .unwrap()
-                .push((strategy.to_string(), intent.intent_id.clone()));
+            self.orders.lock().unwrap().push((
+                strategy.to_string(),
+                intent.intent_id.clone(),
+                intent.deployment_id.clone(),
+            ));
         }
 
         async fn record_fill(
@@ -888,7 +922,8 @@ mod tests {
             skip_settlement_exits: false,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.dryrun");
         let result = runtime.run().await;
 
         assert_eq!(result.intents_submitted, 0);
@@ -928,6 +963,32 @@ mod tests {
                 rejection_reason: None,
                 slippage: Some(Decimal::ZERO),
                 market_impact: Some(Decimal::ZERO),
+            }
+        }
+
+        async fn cancel(&mut self, _order_id: &str) -> bool {
+            true
+        }
+    }
+
+    struct CapturingExecutor {
+        deployment_ids: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Executor for CapturingExecutor {
+        async fn submit(&mut self, intent: &TradingIntent, order_id: &str) -> ExecutionReport {
+            self.deployment_ids
+                .lock()
+                .unwrap()
+                .push(intent.deployment_id.clone());
+            ExecutionReport {
+                order_id: order_id.to_string(),
+                fill: None,
+                rejected: false,
+                rejection_reason: None,
+                slippage: None,
+                market_impact: None,
             }
         }
 
@@ -1102,13 +1163,90 @@ mod tests {
             skip_settlement_exits: false,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.dryrun");
         let result = runtime.run().await;
 
         assert_eq!(result.intents_submitted, 1);
         assert_eq!(result.fills_recorded, 1);
         assert_eq!(order_store.lock().unwrap().len(), 1);
         assert_eq!(fill_store.lock().unwrap().as_slice(), ["fill-1"]);
+    }
+
+    #[tokio::test]
+    async fn fills_empty_intent_deployment_id_before_submit_and_record() {
+        let now = Utc::now();
+        let signal = SignalRecord {
+            strategy: "pm5d.threelayer".into(),
+            event_id: Some("evt1".into()),
+            token_id: Some("token-up".into()),
+            intent_id: Some("intent-attribution".into()),
+            symbol: "BTCUSDT".into(),
+            direction: "UP".into(),
+            p_hat: 0.71,
+            edge: 0.08,
+            entry_price: dec!(0.30),
+            decision: "enter".into(),
+            ts: now,
+        };
+        let intent = TradingIntent {
+            intent_id: "intent-attribution".into(),
+            deployment_id: String::new(),
+            market_id: "evt1".into(),
+            token_id: "token-up".into(),
+            side: TradeSide::Buy,
+            quantity: dec!(10),
+            limit_price: Some(dec!(0.30)),
+            purpose: IntentPurpose::Entry,
+            created_at: now,
+        };
+        let order_store = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Box::new(CollectingRecorder {
+            signals: Arc::new(Mutex::new(Vec::new())),
+            orders: order_store.clone(),
+            fills: Arc::new(Mutex::new(Vec::new())),
+        });
+        let strategy = RecordingStrategy {
+            emitted: false,
+            signal,
+            intent,
+        };
+        let feed = SingleUpdateFeed {
+            next: Some(MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            }),
+        };
+        let submitted_deployments = Arc::new(Mutex::new(Vec::new()));
+        let executor = CapturingExecutor {
+            deployment_ids: submitted_deployments.clone(),
+        };
+        let config = RuntimeConfig {
+            mode: RuntimeMode::DryRun,
+            throttle_hz: None,
+            max_updates: None,
+            skip_settlement_exits: false,
+        };
+
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("pm5d.threelayer.obi-soft.dryrun");
+        let result = runtime.run().await;
+
+        assert_eq!(result.intents_submitted, 1);
+        assert_eq!(
+            submitted_deployments.lock().unwrap().as_slice(),
+            ["pm5d.threelayer.obi-soft.dryrun"]
+        );
+        assert_eq!(
+            order_store.lock().unwrap()[0].2,
+            "pm5d.threelayer.obi-soft.dryrun"
+        );
+        let snapshot = runtime.trading().snapshot(&BTreeMap::new());
+        assert_eq!(
+            snapshot.intents[0].deployment_id,
+            "pm5d.threelayer.obi-soft.dryrun"
+        );
     }
 
     #[tokio::test]
@@ -1167,7 +1305,8 @@ mod tests {
             skip_settlement_exits: false,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.live");
         let result = runtime.run().await;
 
         assert_eq!(result.intents_submitted, 1);
@@ -1229,7 +1368,8 @@ mod tests {
             skip_settlement_exits: true,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.live");
         let _ = runtime.run().await;
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
@@ -1295,7 +1435,8 @@ mod tests {
         };
 
         let mut runtime =
-            StrategyRuntime::new(strategy, feed, SkippedReconcileExecutor, recorder, config);
+            StrategyRuntime::new(strategy, feed, SkippedReconcileExecutor, recorder, config)
+                .with_deployment_id("test.live");
         let _ = runtime.run().await;
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
@@ -1367,7 +1508,8 @@ mod tests {
             skip_settlement_exits: true,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.live");
         let _ = runtime.run().await;
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
@@ -1455,7 +1597,8 @@ mod tests {
             skip_settlement_exits: true,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.live");
         let _ = runtime.run().await;
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
@@ -1588,11 +1731,13 @@ mod tests {
             ["pm5d_BTCUSDT_UP_retry3"]
         );
         assert_eq!(snapshot.orders.len(), 2);
-        assert!(snapshot
-            .orders
-            .iter()
-            .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
-                && order.state == ploy_trading::OrderState::Acknowledged));
+        assert!(
+            snapshot
+                .orders
+                .iter()
+                .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
+                    && order.state == ploy_trading::OrderState::Acknowledged)
+        );
     }
 
     #[tokio::test]
@@ -1635,7 +1780,8 @@ mod tests {
             skip_settlement_exits: true,
         };
 
-        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config);
+        let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
+            .with_deployment_id("test.live");
         let _ = runtime.run().await;
 
         assert_eq!(*fill_count.lock().unwrap(), 0);

--- a/crates/ploy-strategy-bundles/tests/backtest_integration.rs
+++ b/crates/ploy-strategy-bundles/tests/backtest_integration.rs
@@ -450,7 +450,8 @@ async fn recorded_updates_replay_to_the_same_runtime_result() {
         SimulatedExecutor::new(sim_config.clone()),
         Box::new(NullRecorder),
         runtime_config.clone(),
-    );
+    )
+    .with_deployment_id("test.recorded.dryrun");
     let recorded_result = recorded_runtime.run().await;
     let recorded_snapshot = recorded_runtime
         .trading()
@@ -576,7 +577,8 @@ async fn sports_updates_round_trip_without_changing_crypto_runtime_behavior() {
         SimulatedExecutor::new(sim_config.clone()),
         Box::new(NullRecorder),
         runtime_config.clone(),
-    );
+    )
+    .with_deployment_id("test.recorded.dryrun");
     let recorded_result = recorded_runtime.run().await;
     drop(recorded_runtime);
 
@@ -692,7 +694,8 @@ async fn reference_updates_round_trip_without_changing_crypto_runtime_behavior()
         SimulatedExecutor::new(sim_config.clone()),
         Box::new(NullRecorder),
         runtime_config.clone(),
-    );
+    )
+    .with_deployment_id("test.recorded.dryrun");
     let recorded_result = recorded_runtime.run().await;
     drop(recorded_runtime);
 

--- a/crates/ploy-strategy-runtime/src/lib.rs
+++ b/crates/ploy-strategy-runtime/src/lib.rs
@@ -26,13 +26,32 @@ use tracing::info;
 pub use ploy_strategy_bundles::RuntimeMode as StrategyRuntimeMode;
 
 pub async fn run_strategy(config: FullConfig, config_path: &str, force_dry_run: bool) {
+    run_strategy_with_deployment_id(config, config_path, force_dry_run, None).await;
+}
+
+pub async fn run_strategy_with_deployment_id(
+    config: FullConfig,
+    config_path: &str,
+    force_dry_run: bool,
+    deployment_id: Option<String>,
+) {
     let mut runtime_config = config.runtime_config();
     if force_dry_run {
         runtime_config.mode = RuntimeMode::DryRun;
     }
+    let deployment_id = resolve_deployment_id(deployment_id);
+    if matches!(runtime_config.mode, RuntimeMode::Live | RuntimeMode::DryRun)
+        && deployment_id.is_none()
+    {
+        eprintln!(
+            "Live and dry-run strategy runtime requires --deployment-id or PLOY_DEPLOYMENT_ID"
+        );
+        std::process::exit(1);
+    }
 
     info!(
         mode = ?runtime_config.mode,
+        deployment_id = deployment_id.as_deref().unwrap_or(""),
         config = %config_path,
         symbols = ?config.strategy.symbols,
         "ploy-runner starting",
@@ -47,7 +66,14 @@ pub async fn run_strategy(config: FullConfig, config_path: &str, force_dry_run: 
         }
         RuntimeMode::Replay => run_replay_entry(&config, strategy, runtime_config.clone()).await,
         RuntimeMode::Live | RuntimeMode::DryRun => {
-            run_live_or_dry_run_entry(&config, &symbols, strategy, runtime_config.clone()).await
+            run_live_or_dry_run_entry(
+                &config,
+                &symbols,
+                strategy,
+                runtime_config.clone(),
+                deployment_id.expect("deployment_id checked for live/dry-run"),
+            )
+            .await
         }
     };
 
@@ -115,6 +141,7 @@ async fn run_live_or_dry_run_entry(
     _symbols: &[String],
     _strategy: Box<dyn StrategyLogic>,
     _runtime_config: RuntimeModeConfig,
+    _deployment_id: String,
 ) -> (
     ploy_strategy_bundles::RuntimeResult,
     ploy_trading::TradingRuntimeSnapshot,
@@ -124,6 +151,13 @@ async fn run_live_or_dry_run_entry(
 }
 
 type RuntimeModeConfig = ploy_strategy_bundles::RuntimeConfig;
+
+fn resolve_deployment_id(cli_value: Option<String>) -> Option<String> {
+    cli_value
+        .or_else(|| std::env::var("PLOY_DEPLOYMENT_ID").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
 
 fn prepare_feed_symbols(mode: RuntimeMode, strategy_symbols: &[String]) -> Vec<String> {
     match mode {
@@ -139,7 +173,7 @@ fn database_unavailable_is_fatal(mode: RuntimeMode, database_url_present: bool) 
 
 #[cfg(test)]
 mod tests {
-    use super::{database_unavailable_is_fatal, prepare_feed_symbols};
+    use super::{database_unavailable_is_fatal, prepare_feed_symbols, resolve_deployment_id};
     use ploy_strategy_bundles::RuntimeMode;
 
     #[test]
@@ -156,5 +190,14 @@ mod tests {
         assert!(!database_unavailable_is_fatal(RuntimeMode::Backtest, true));
         assert!(!database_unavailable_is_fatal(RuntimeMode::Replay, true));
         assert!(!database_unavailable_is_fatal(RuntimeMode::DryRun, false));
+    }
+
+    #[test]
+    fn trims_empty_deployment_ids() {
+        assert_eq!(
+            resolve_deployment_id(Some(" dep-1 ".to_string())).as_deref(),
+            Some("dep-1")
+        );
+        assert!(resolve_deployment_id(Some(" ".to_string())).is_none());
     }
 }

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -14,7 +14,7 @@ use ploy_trading::{
     TradingRuntime, TradingRuntimeSnapshot,
 };
 use rust_decimal::Decimal;
-use sqlx::{postgres::PgPoolOptions, FromRow, PgPool};
+use sqlx::{FromRow, PgPool, postgres::PgPoolOptions};
 use std::env;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -318,7 +318,7 @@ mod execution {
 }
 
 use crate::recording::build_signal_recorder;
-use crate::{database_unavailable_is_fatal, RuntimeModeConfig};
+use crate::{RuntimeModeConfig, database_unavailable_is_fatal};
 
 #[derive(Debug, FromRow)]
 struct LiveOrderRestoreRow {
@@ -353,11 +353,12 @@ pub(crate) async fn run_live_or_dry_run_entry(
     symbols: &[String],
     strategy: Box<dyn StrategyLogic>,
     runtime_config: RuntimeModeConfig,
+    deployment_id: String,
 ) -> (
     ploy_strategy_bundles::RuntimeResult,
     ploy_trading::TradingRuntimeSnapshot,
 ) {
-    run_live_or_dry_run(config, symbols, strategy, runtime_config).await
+    run_live_or_dry_run(config, symbols, strategy, runtime_config, deployment_id).await
 }
 
 async fn restore_active_live_trading_runtime(pool: &PgPool) -> Option<TradingRuntime> {
@@ -515,6 +516,7 @@ async fn run_live_or_dry_run(
     symbols: &[String],
     strategy: Box<dyn StrategyLogic>,
     runtime_config: RuntimeModeConfig,
+    deployment_id: String,
 ) -> (
     ploy_strategy_bundles::RuntimeResult,
     ploy_trading::TradingRuntimeSnapshot,
@@ -628,7 +630,8 @@ async fn run_live_or_dry_run(
                 recorder,
                 runtime_config,
                 trading,
-            );
+            )
+            .with_deployment_id(deployment_id.clone());
             let result = runtime.run().await;
             let snapshot = runtime
                 .trading()
@@ -643,7 +646,8 @@ async fn run_live_or_dry_run(
             executor,
             recorder,
             runtime_config,
-        );
+        )
+        .with_deployment_id(deployment_id);
         let result = runtime.run().await;
         let snapshot = runtime
             .trading()


### PR DESCRIPTION
## Summary

Fixes #220.

This keeps new dry-run orders/fills attributable to the concrete deployment that launched them:

- ployd worker launch now passes `--deployment-id <record.deployment_id>` to `new-ploy-runner`
- runner CLI parses `--deployment-id` and also supports `PLOY_DEPLOYMENT_ID` fallback
- live/dry-run startup now refuses to run without a deployment identity
- `StrategyRuntime` fills empty strategy-emitted `TradingIntent.deployment_id` before submit, record, and live retry paths

## Why

The old dry-run rows collapsed into `runtime_mode=dry_run`, `strategy_id=three_layer`, `deployment_id=''`, so the UI could not split three dry-run deployments into separate equity/trade buckets. Clearing old rows alone does not fix new rows unless the deployed runner records deployment identity.

## Verification

- `rustfmt --edition 2024` on touched Rust files
- `git diff --check`

Local cargo tests were started but did not complete in reasonable time because this Mac was rebuilding dependencies across active Ploy worktrees. CI must validate before deployment; deployment should still use CI-built artifacts only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--deployment-id` CLI option to specify runtime deployment identifier.

* **Bug Fixes**
  * System now enforces deployment ID requirement for live and dry-run execution modes.
  * Trading intents are now automatically attributed with deployment identifiers during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->