### PR TITLE
Expose research loop timing artifacts

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -107,6 +107,9 @@ jobs:
         env:
           DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
+          set -euo pipefail
+          mkdir -p artifacts/backtest
+          started=$(date +%s)
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
           chmod 600 ~/.ssh/tango_key
@@ -115,6 +118,9 @@ jobs:
             -e "ssh -i ~/.ssh/tango_key -o StrictHostKeyChecking=no" \
             root@172.16.0.204:/opt/ploy/data/parquet/ \
             "${DATA_DIR}/"
+          elapsed=$(( $(date +%s) - started ))
+          printf '{"phase":"rsync_parquet","wall_secs":%s,"data_dir":"%s"}\n' "${elapsed}" "${DATA_DIR}" \
+            > artifacts/backtest/rsync-timing.json
 
       - name: Run backtest
         env:
@@ -123,13 +129,41 @@ jobs:
           END_DATE: ${{ github.event.inputs.end_date }}
           DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
+          set -uo pipefail
+          mkdir -p artifacts/backtest
+          started=$(date +%s)
           extra_args=()
           if [ -n "$DATA_DIR" ]; then
             extra_args=(--data-dir "$DATA_DIR")
           fi
+          set +e
           ./target/release/examples/run_backtest \
             --config "${CONFIG}" \
             --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --start-date "${START_DATE}" \
             --end-date "${END_DATE}" \
-            "${extra_args[@]}"
+            --timing-json artifacts/backtest/timing.json \
+            "${extra_args[@]}" \
+            2>&1 | tee artifacts/backtest/report.txt
+          status=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - started ))
+          printf '{"phase":"backtest_workflow_step","wall_secs":%s,"status":%s}\n' "${elapsed}" "${status}" \
+            > artifacts/backtest/workflow-timing.json
+          if [ -f artifacts/backtest/timing.json ]; then
+            {
+              echo "## Backtest timing"
+              echo '```json'
+              cat artifacts/backtest/timing.json
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          exit "${status}"
+
+      - name: Upload backtest report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: backtest-report-${{ github.run_id }}
+          path: artifacts/backtest
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -22,7 +22,11 @@ on:
       data_dir:
         description: "Local Parquet data dir (leave empty to use DB)"
         required: false
-        default: "/tmp/ploy-parquet"
+        default: ""
+      sync_parquet_data:
+        description: "Sync the full Parquet tree from Tango before running"
+        required: false
+        default: "false"
 
 concurrency:
   group: backtest-${{ github.ref }}
@@ -103,7 +107,7 @@ jobs:
         run: chmod +x target/release/examples/run_backtest
 
       - name: Sync Parquet data from Tango-1-1
-        if: ${{ github.event.inputs.data_dir != '' }}
+        if: ${{ github.event.inputs.data_dir != '' && github.event.inputs.sync_parquet_data == 'true' }}
         env:
           DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
@@ -128,12 +132,20 @@ jobs:
           START_DATE: ${{ github.event.inputs.start_date }}
           END_DATE: ${{ github.event.inputs.end_date }}
           DATA_DIR: ${{ github.event.inputs.data_dir }}
+          SYNC_PARQUET_DATA: ${{ github.event.inputs.sync_parquet_data }}
         run: |
           set -uo pipefail
           mkdir -p artifacts/backtest
           started=$(date +%s)
           extra_args=()
           if [ -n "$DATA_DIR" ]; then
+            if [ ! -d "$DATA_DIR" ]; then
+              echo "ERROR: DATA_DIR '$DATA_DIR' does not exist; set sync_parquet_data=true or leave data_dir empty to use DB" \
+                | tee artifacts/backtest/report.txt
+              printf '{"phase":"backtest_workflow_step","wall_secs":0,"status":2,"missing_data_dir":"%s","sync_parquet_data":"%s"}\n' \
+                "$DATA_DIR" "$SYNC_PARQUET_DATA" > artifacts/backtest/workflow-timing.json
+              exit 2
+            fi
             extra_args=(--data-dir "$DATA_DIR")
           fi
           set +e

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -290,6 +290,8 @@ jobs:
         run: |
           set -euo pipefail
           . /home/runner/.cargo/env
+          mkdir -p artifacts/optimize
+          started=$(date +%s)
 
           health_summary() {
             echo "## Optimize preflight host health" >> "${GITHUB_STEP_SUMMARY}"
@@ -329,6 +331,7 @@ jobs:
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
+          set +e
           ./target/release/examples/optimize-runner \
             --preflight-only \
             --strategy-variant three_layer \
@@ -348,14 +351,23 @@ jobs:
             --max-days "${{ github.event.inputs.max_days }}" \
             --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
             --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+            --timing-json artifacts/optimize/preflight-timing.json \
             "${time_flags[@]}" \
-            "${extra_flags[@]}"
+            "${extra_flags[@]}" \
+            2>&1 | tee artifacts/optimize/preflight-report.txt
+          status=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - started ))
+          printf '{"phase":"optimize_preflight_workflow_step","wall_secs":%s,"status":%s}\n' "${elapsed}" "${status}" \
+            > artifacts/optimize/preflight-workflow-timing.json
+          exit "${status}"
 
       - name: Run optimize
         if: ${{ github.event.inputs.preflight_only != 'true' }}
         run: |
           set -euo pipefail
           . /home/runner/.cargo/env
+          mkdir -p artifacts/optimize
+          started=$(date +%s)
           rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
           mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
 
@@ -403,6 +415,7 @@ jobs:
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
+          set +e
           if [ -f artifacts/research-snapshot/manifest.json ]; then
             timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
             ./target/release/examples/optimize-runner \
@@ -416,7 +429,9 @@ jobs:
               --strategy-profile "${{ github.event.inputs.strategy_profile }}" \
               --stake-usd 15 \
               --output-dir artifacts/optimize \
-              "${time_flags[@]}"
+              "${time_flags[@]}" \
+              2>&1 | tee artifacts/optimize/report.txt
+            status=${PIPESTATUS[0]}
           else
             timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
             ./target/release/examples/optimize-runner \
@@ -437,9 +452,24 @@ jobs:
               --max-days "${{ github.event.inputs.max_days }}" \
               --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
               --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
+              --timing-json artifacts/optimize/timing.json \
               "${time_flags[@]}" \
-              "${extra_flags[@]}"
+              "${extra_flags[@]}" \
+              2>&1 | tee artifacts/optimize/report.txt
+            status=${PIPESTATUS[0]}
           fi
+          elapsed=$(( $(date +%s) - started ))
+          printf '{"phase":"optimize_workflow_step","wall_secs":%s,"status":%s,"snapshot_backed":%s}\n' \
+            "${elapsed}" "${status}" \
+            "$([ -f artifacts/research-snapshot/manifest.json ] && echo true || echo false)" \
+            > artifacts/optimize/workflow-timing.json
+          {
+            echo "## Optimize timing"
+            echo '```json'
+            [ -f artifacts/optimize/timing.json ] && cat artifacts/optimize/timing.json || cat artifacts/optimize/workflow-timing.json
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit "${status}"
 
       - name: Upload optimize provenance
         if: ${{ always() }}

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -52,9 +52,12 @@ use ploy_strategy_bundles::{
 use ploy_trading::{FillRecord, TradeSide, TradingIntent};
 use rust_decimal_macros::dec;
 use serde::Deserialize;
+use serde_json::json;
 use sqlx::postgres::PgPoolOptions;
 use std::collections::{BTreeMap, HashMap};
+use std::fs;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 const DEFAULT_THREE_LAYER_CONFIG: &str = "config/strategies/02-pm5d-threelayer.unified.toml";
 
@@ -989,6 +992,66 @@ fn source_hint(source: &ReplaySource) -> String {
         .unwrap_or_else(|| "streaming".to_string())
 }
 
+fn round_secs(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
+}
+
+fn throughput(updates: u64, seconds: f64) -> f64 {
+    if seconds <= 0.0 {
+        0.0
+    } else {
+        updates as f64 / seconds
+    }
+}
+
+fn outcome_timing_json(
+    split: &str,
+    source: &ReplaySource,
+    outcome: &BacktestOutcome,
+    wall_secs: f64,
+    score: Option<f64>,
+) -> serde_json::Value {
+    json!({
+        "split": split,
+        "source_label": source.label(),
+        "source_kind": source.kind(),
+        "score": score,
+        "sharpe": outcome.sharpe,
+        "net_pnl": round_secs(outcome.net_pnl),
+        "trade_count": outcome.trade_count,
+        "updates_processed": outcome.updates_processed,
+        "runtime_elapsed_secs": round_secs(outcome.elapsed_secs),
+        "wall_secs": round_secs(wall_secs),
+        "updates_per_sec": round_secs(throughput(outcome.updates_processed, wall_secs)),
+        "intents_submitted": outcome.intents_submitted,
+        "fills_recorded": outcome.fills_recorded,
+        "orders_rejected": outcome.diagnostics.orders_rejected,
+    })
+}
+
+fn write_timing_json(path: Option<&str>, payload: serde_json::Value) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!(
+                "warning: failed to create timing dir {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    match serde_json::to_string_pretty(&payload) {
+        Ok(body) => {
+            if let Err(error) = fs::write(path, format!("{body}\n")) {
+                eprintln!("warning: failed to write timing json {path}: {error}");
+            }
+        }
+        Err(error) => eprintln!("warning: failed to encode timing json {path}: {error}"),
+    }
+}
+
 /// Run a single backtest and return compact analyzer-style metrics.
 fn run_backtest(
     strategy_variant: &str,
@@ -1249,10 +1312,13 @@ fn make_three_layer_config(
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
+    let total_started = Instant::now();
 
     let db_url = flag_value(&args, "--db-url");
     let mut data_dir = flag_value(&args, "--data-dir");
     let snapshot_dir = flag_value(&args, "--snapshot-dir");
+    let timing_json = flag_value(&args, "--timing-json");
+    let mut phase_timings = Vec::new();
     let allow_live_parquet_debug = flag_present(&args, "--allow-live-parquet-debug");
     let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
     let mut snapshot_manifest = None;
@@ -1498,9 +1564,16 @@ fn main() {
     });
 
     let (train_source, val_source) = if let Some(ref dir) = data_dir {
+        let preflight_started = Instant::now();
         let manifest =
             parquet_preflight_manifest(dir, &symbols, train_from, train_to, val_from, val_to)
                 .expect("Failed to build Parquet preflight manifest");
+        phase_timings.push(json!({
+            "phase": "parquet_preflight",
+            "source": "parquet-stream",
+            "wall_secs": round_secs(preflight_started.elapsed().as_secs_f64()),
+            "data_dir": dir,
+        }));
         manifest.print();
         if let Err(error) = validate_preflight(
             &manifest,
@@ -1515,6 +1588,23 @@ fn main() {
         }
         if preflight_only {
             eprintln!("Preflight-only mode complete; exiting before replay/optimization.");
+            write_timing_json(
+                timing_json.as_deref(),
+                json!({
+                    "command": "optimize_backtest",
+                    "mode": "preflight-only",
+                    "strategy_variant": &strategy_variant,
+                    "symbols": &symbols,
+                    "train_start": train_start_ts.as_deref().unwrap_or(&train_start),
+                    "train_end": train_end_ts.as_deref().unwrap_or(&train_end),
+                    "val_start": val_start_ts.as_deref().unwrap_or(&val_start),
+                    "val_end": val_end_ts.as_deref().unwrap_or(&val_end),
+                    "trials_requested": n_trials,
+                    "source": "parquet-stream",
+                    "phase_timings": phase_timings,
+                    "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+                }),
+            );
             return;
         }
 
@@ -1524,14 +1614,21 @@ fn main() {
         )
     } else {
         let db_url = db_url.as_deref().unwrap();
+        let db_connect_started = Instant::now();
         let pool = rt
             .block_on(PgPoolOptions::new().max_connections(3).connect(db_url))
             .expect("DB connection failed");
+        phase_timings.push(json!({
+            "phase": "db_connect",
+            "source": "db-eager",
+            "wall_secs": round_secs(db_connect_started.elapsed().as_secs_f64()),
+        }));
 
         eprintln!(
             "Loading training data into db-eager replay ({} → {})...",
             train_start, train_end
         );
+        let train_load_started = Instant::now();
         let train = rt
             .block_on(load_from_database_with_options(
                 &pool,
@@ -1545,11 +1642,18 @@ fn main() {
             ))
             .expect("Failed to load training data");
         eprintln!("  {} updates loaded", train.len());
+        phase_timings.push(json!({
+            "phase": "db_load_train",
+            "source": "db-eager",
+            "wall_secs": round_secs(train_load_started.elapsed().as_secs_f64()),
+            "updates_loaded": train.len(),
+        }));
 
         eprintln!(
             "Loading validation data into db-eager replay ({} → {})...",
             val_start, val_end
         );
+        let val_load_started = Instant::now();
         let val = rt
             .block_on(load_from_database_with_options(
                 &pool,
@@ -1563,6 +1667,12 @@ fn main() {
             ))
             .expect("Failed to load validation data");
         eprintln!("  {} updates loaded\n", val.len());
+        phase_timings.push(json!({
+            "phase": "db_load_validation",
+            "source": "db-eager",
+            "wall_secs": round_secs(val_load_started.elapsed().as_secs_f64()),
+            "updates_loaded": val.len(),
+        }));
         (
             ReplaySource::db_eager("train", train),
             ReplaySource::db_eager("validation", val),
@@ -1582,6 +1692,8 @@ fn main() {
         source_hint(&val_source)
     );
 
+    let trial_timings: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut validation_timings = Vec::new();
     let symbols_ref = Arc::new(symbols.clone());
     let executor_config = Arc::new(executor_config);
     let three_layer_base_config = three_layer_base_config.map(Arc::new);
@@ -1601,9 +1713,11 @@ fn main() {
         let p_pm_lag_c = p_pm_lag.clone();
         let p_min_edge_c = p_min_edge.clone();
         let executor_config_c = Arc::clone(&executor_config);
+        let trial_timings_c = Arc::clone(&trial_timings);
 
         study
             .optimize(n_trials, move |trial: &mut Trial| {
+                let trial_id = trial.id();
                 let params = ReversalSearchParams {
                     max_distance_pct: p_max_distance_c.suggest(trial)?,
                     max_drift_flip_age_secs: 60,
@@ -1618,6 +1732,7 @@ fn main() {
                 };
 
                 let config = make_reversal_config(symbols_ref_c.as_slice(), &params);
+                let trial_started = Instant::now();
                 let outcome = match run_backtest(
                     "reversal",
                     config,
@@ -1627,9 +1742,18 @@ fn main() {
                 ) {
                     Ok(outcome) => outcome,
                     Err(error) => {
+                        trial_timings_c.lock().unwrap().push(json!({
+                            "trial_id": trial_id,
+                            "strategy_variant": "reversal",
+                            "split": "train",
+                            "source_label": train_ref.label(),
+                            "source_kind": train_ref.kind(),
+                            "wall_secs": round_secs(trial_started.elapsed().as_secs_f64()),
+                            "error": &error,
+                        }));
                         eprintln!(
                             "  Trial {:>3}: source={} error={error}",
-                            trial.id(),
+                            trial_id,
                             train_ref.kind()
                         );
                         return Ok::<f64, Error>(-1_000_000.0);
@@ -1642,10 +1766,16 @@ fn main() {
                 } else {
                     outcome.sharpe
                 };
+                let trial_wall_secs = trial_started.elapsed().as_secs_f64();
+                let mut record =
+                    outcome_timing_json("train", &train_ref, &outcome, trial_wall_secs, Some(score));
+                record["trial_id"] = json!(trial_id);
+                record["strategy_variant"] = json!("reversal");
+                trial_timings_c.lock().unwrap().push(record);
 
                 eprintln!(
                     "  Trial {:>3}: source={} score={:>7.3} sharpe={:>7.3} pnl=${:>8.2} trades={:>4} updates={} elapsed={:.1}s dist={:.4} flip={} drift={:.5} lob={:.2} ask={:.3} lag={}",
-                    trial.id(),
+                    trial_id,
                     train_ref.kind(),
                     score,
                     outcome.sharpe,
@@ -1660,7 +1790,7 @@ fn main() {
                     params.max_ask_for_reversal,
                     params.max_pm_lag_secs,
                 );
-                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
+                print_backtest_diagnostics(&format!("trial {trial_id}"), &outcome);
 
                 Ok::<f64, Error>(score)
             })
@@ -1722,6 +1852,7 @@ fn main() {
 
         eprintln!("\n=== Validation (held-out) ===");
         let val_config = make_reversal_config(symbols_ref.as_slice(), &best_params);
+        let validation_started = Instant::now();
         let val_outcome = run_backtest(
             "reversal",
             val_config,
@@ -1730,6 +1861,13 @@ fn main() {
             max_updates,
         )
         .expect("Validation backtest failed");
+        validation_timings.push(outcome_timing_json(
+            "validation",
+            &val_source,
+            &val_outcome,
+            validation_started.elapsed().as_secs_f64(),
+            Some(val_outcome.sharpe),
+        ));
         eprintln!("Val Source:  {}", val_source.kind());
         eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
         eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
@@ -1794,6 +1932,28 @@ fn main() {
                 trial.get(&p_min_edge).unwrap_or(0.0),
             );
         }
+        let trial_timing_snapshot = trial_timings.lock().unwrap().clone();
+        write_timing_json(
+            timing_json.as_deref(),
+            json!({
+                "command": "optimize_backtest",
+                "strategy_variant": "reversal",
+                "algorithm": algorithm_label("reversal"),
+                "trials_requested": n_trials,
+                "trials_recorded": trial_timing_snapshot.len(),
+                "train_source": {"label": train_source.label(), "kind": train_source.kind(), "updates": source_hint(&train_source)},
+                "validation_source": {"label": val_source.label(), "kind": val_source.kind(), "updates": source_hint(&val_source)},
+                "symbols": &symbols,
+                "phase_timings": phase_timings,
+                "trial_timings": trial_timing_snapshot,
+                "validation_timings": validation_timings,
+                "best_training_score": best.value,
+                "validation_sharpe": val_outcome.sharpe,
+                "validation_net_pnl": round_secs(val_outcome.net_pnl),
+                "validation_trades": val_outcome.trade_count,
+                "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+            }),
+        );
     } else if strategy_variant == "three_layer" {
         let base_config = three_layer_base_config
             .as_ref()
@@ -1803,6 +1963,7 @@ fn main() {
         let symbols_ref_c = Arc::clone(&symbols_ref);
         let executor_config_c = Arc::clone(&executor_config);
         let base_config_c = Arc::clone(base_config);
+        let trial_timings_c = Arc::clone(&trial_timings);
 
         let p_min_direction_prob =
             FloatParam::new(0.52, 0.70).name("three_layer_min_direction_prob");
@@ -1835,6 +1996,7 @@ fn main() {
 
         study
             .optimize(n_trials, move |trial: &mut Trial| {
+                let trial_id = trial.id();
                 let min_time_remaining_secs = p_min_time_remaining_secs_c.suggest(trial)?;
                 let params = ThreeLayerSearchParams {
                     min_direction_prob: p_min_direction_prob_c.suggest(trial)?,
@@ -1856,6 +2018,7 @@ fn main() {
                     &params,
                     base_config_c.as_ref(),
                 );
+                let trial_started = Instant::now();
                 let outcome = match run_backtest(
                     "three_layer",
                     config,
@@ -1865,9 +2028,18 @@ fn main() {
                 ) {
                     Ok(outcome) => outcome,
                     Err(error) => {
+                        trial_timings_c.lock().unwrap().push(json!({
+                            "trial_id": trial_id,
+                            "strategy_variant": "three_layer",
+                            "split": "train",
+                            "source_label": train_ref.label(),
+                            "source_kind": train_ref.kind(),
+                            "wall_secs": round_secs(trial_started.elapsed().as_secs_f64()),
+                            "error": &error,
+                        }));
                         eprintln!(
                             "  Trial {:>3}: source={} error={error}",
-                            trial.id(),
+                            trial_id,
                             train_ref.kind()
                         );
                         return Ok::<f64, Error>(-1_000_000.0);
@@ -1877,10 +2049,16 @@ fn main() {
                 // Sharpe = mean(pnl_per_trade) / std(pnl_per_trade) * sqrt(trades_per_year).
                 // Penalty for sparse trials is already applied inside run_backtest.
                 let score = outcome.sharpe;
+                let trial_wall_secs = trial_started.elapsed().as_secs_f64();
+                let mut record =
+                    outcome_timing_json("train", &train_ref, &outcome, trial_wall_secs, Some(score));
+                record["trial_id"] = json!(trial_id);
+                record["strategy_variant"] = json!("three_layer");
+                trial_timings_c.lock().unwrap().push(record);
 
                 eprintln!(
                     "  Trial {:>3}: source={} sharpe={:>7.3} trades={:>4} pnl=${:>8.2} updates={} elapsed={:.1}s | params: dir_prob={:.3} dist_sigma={:.3} conf={:.3} drift={:.5} edge={:.3} rr={:.2} tp={:.3} stop={:.4} cd={}s",
-                    trial.id(),
+                    trial_id,
                     train_ref.kind(),
                     outcome.sharpe,
                     outcome.trade_count,
@@ -1897,7 +2075,7 @@ fn main() {
                     params.stop_distance_pct,
                     params.cooldown_secs,
                 );
-                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
+                print_backtest_diagnostics(&format!("trial {trial_id}"), &outcome);
 
                 Ok::<f64, Error>(score)
             })
@@ -1926,6 +2104,7 @@ fn main() {
         eprintln!("\n=== Validation (held-out, out-of-sample) ===");
         let val_config =
             make_three_layer_config(symbols_ref.as_slice(), &best_params, base_config.as_ref());
+        let validation_started = Instant::now();
         let val_outcome = run_backtest(
             "three_layer",
             val_config,
@@ -1934,6 +2113,13 @@ fn main() {
             max_updates,
         )
         .expect("Validation backtest failed");
+        validation_timings.push(outcome_timing_json(
+            "validation",
+            &val_source,
+            &val_outcome,
+            validation_started.elapsed().as_secs_f64(),
+            Some(val_outcome.sharpe),
+        ));
         eprintln!("Val Source:  {}", val_source.kind());
         eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
         eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
@@ -1982,6 +2168,28 @@ fn main() {
             "max_time_remaining_secs = {}",
             best_params.max_time_remaining_secs
         );
+        let trial_timing_snapshot = trial_timings.lock().unwrap().clone();
+        write_timing_json(
+            timing_json.as_deref(),
+            json!({
+                "command": "optimize_backtest",
+                "strategy_variant": "three_layer",
+                "algorithm": algorithm_label("three_layer"),
+                "trials_requested": n_trials,
+                "trials_recorded": trial_timing_snapshot.len(),
+                "train_source": {"label": train_source.label(), "kind": train_source.kind(), "updates": source_hint(&train_source)},
+                "validation_source": {"label": val_source.label(), "kind": val_source.kind(), "updates": source_hint(&val_source)},
+                "symbols": &symbols,
+                "phase_timings": phase_timings,
+                "trial_timings": trial_timing_snapshot,
+                "validation_timings": validation_timings,
+                "best_training_score": best.value,
+                "validation_sharpe": val_outcome.sharpe,
+                "validation_net_pnl": round_secs(val_outcome.net_pnl),
+                "validation_trades": val_outcome.trade_count,
+                "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+            }),
+        );
     } else {
         let p_min_prob = FloatParam::new(0.50, 0.72).name("min_probability");
         let p_min_edge = FloatParam::new(0.005, 0.06).name("min_edge");
@@ -1999,9 +2207,11 @@ fn main() {
         let p_min_time_c = p_min_time.clone();
         let p_max_time_c = p_max_time.clone();
         let executor_config_c = Arc::clone(&executor_config);
+        let trial_timings_c = Arc::clone(&trial_timings);
 
         study
             .optimize(n_trials, move |trial: &mut Trial| {
+                let trial_id = trial.id();
                 let min_prob = p_min_prob_c.suggest(trial)?;
                 let min_edge = p_min_edge_c.suggest(trial)?;
                 let max_entry = p_max_entry_c.suggest(trial)?;
@@ -2010,6 +2220,15 @@ fn main() {
                 let max_time = p_max_time_c.suggest(trial)?;
 
                 if max_time <= min_time || max_entry <= 0.45 {
+                    trial_timings_c.lock().unwrap().push(json!({
+                        "trial_id": trial_id,
+                        "strategy_variant": "directional",
+                        "split": "train",
+                        "source_label": train_ref.label(),
+                        "source_kind": train_ref.kind(),
+                        "score": -10.0,
+                        "skipped": "invalid_parameter_combo",
+                    }));
                     return Ok::<f64, Error>(-10.0);
                 }
 
@@ -2022,6 +2241,7 @@ fn main() {
                     min_time,
                     max_time,
                 );
+                let trial_started = Instant::now();
                 let outcome = match run_backtest(
                     "directional",
                     config,
@@ -2031,18 +2251,34 @@ fn main() {
                 ) {
                     Ok(outcome) => outcome,
                     Err(error) => {
+                        trial_timings_c.lock().unwrap().push(json!({
+                            "trial_id": trial_id,
+                            "strategy_variant": "directional",
+                            "split": "train",
+                            "source_label": train_ref.label(),
+                            "source_kind": train_ref.kind(),
+                            "wall_secs": round_secs(trial_started.elapsed().as_secs_f64()),
+                            "error": &error,
+                        }));
                         eprintln!(
                             "  Trial {:>3}: source={} error={error}",
-                            trial.id(),
+                            trial_id,
                             train_ref.kind()
                         );
                         return Ok::<f64, Error>(-1_000_000.0);
                     }
                 };
+                let score = outcome.sharpe;
+                let trial_wall_secs = trial_started.elapsed().as_secs_f64();
+                let mut record =
+                    outcome_timing_json("train", &train_ref, &outcome, trial_wall_secs, Some(score));
+                record["trial_id"] = json!(trial_id);
+                record["strategy_variant"] = json!("directional");
+                trial_timings_c.lock().unwrap().push(record);
 
                 eprintln!(
                     "  Trial {:>3}: source={} sharpe={:>7.3}  pnl=${:>8.2}  trades={:>4}  updates={} elapsed={:.1}s  p={:.3}  edge={:.4}  max={:.2}  cd={}s",
-                    trial.id(),
+                    trial_id,
                     train_ref.kind(),
                     outcome.sharpe,
                     outcome.net_pnl,
@@ -2054,9 +2290,9 @@ fn main() {
                     max_entry,
                     cooldown
                 );
-                print_backtest_diagnostics(&format!("trial {}", trial.id()), &outcome);
+                print_backtest_diagnostics(&format!("trial {trial_id}"), &outcome);
 
-                Ok(outcome.sharpe)
+                Ok(score)
             })
             .expect("Optimization failed");
 
@@ -2087,6 +2323,7 @@ fn main() {
             best_min_time,
             best_max_time,
         );
+        let validation_started = Instant::now();
         let val_outcome = run_backtest(
             "directional",
             val_config,
@@ -2095,6 +2332,13 @@ fn main() {
             max_updates,
         )
         .expect("Validation backtest failed");
+        validation_timings.push(outcome_timing_json(
+            "validation",
+            &val_source,
+            &val_outcome,
+            validation_started.elapsed().as_secs_f64(),
+            Some(val_outcome.sharpe),
+        ));
         eprintln!("Val Source:  {}", val_source.kind());
         eprintln!("Val Sharpe:  {:.3}", val_outcome.sharpe);
         eprintln!("Val PnL:     ${:.2}", val_outcome.net_pnl);
@@ -2134,5 +2378,27 @@ fn main() {
                 trial.get(&p_min_time).unwrap_or(0),
             );
         }
+        let trial_timing_snapshot = trial_timings.lock().unwrap().clone();
+        write_timing_json(
+            timing_json.as_deref(),
+            json!({
+                "command": "optimize_backtest",
+                "strategy_variant": "directional",
+                "algorithm": algorithm_label("directional"),
+                "trials_requested": n_trials,
+                "trials_recorded": trial_timing_snapshot.len(),
+                "train_source": {"label": train_source.label(), "kind": train_source.kind(), "updates": source_hint(&train_source)},
+                "validation_source": {"label": val_source.label(), "kind": val_source.kind(), "updates": source_hint(&val_source)},
+                "symbols": &symbols,
+                "phase_timings": phase_timings,
+                "trial_timings": trial_timing_snapshot,
+                "validation_timings": validation_timings,
+                "best_training_score": best.value,
+                "validation_sharpe": val_outcome.sharpe,
+                "validation_net_pnl": round_secs(val_outcome.net_pnl),
+                "validation_trades": val_outcome.trade_count,
+                "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+            }),
+        );
     }
 }

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -161,6 +161,29 @@ mod tests {
         assert!(error.contains("train split has zero rows"));
         assert!(error.contains("val split has zero rows"));
     }
+
+    #[test]
+    fn cheap_preflight_rejects_oversized_request_before_manifest_scan() {
+        let limits = PreflightLimits {
+            max_rows: 15_000_000,
+            max_bytes: 80 * 1024 * 1024 * 1024,
+            max_symbols: 2,
+            max_days: 3,
+            allow_large_window: false,
+        };
+        let symbols = vec![
+            "BTCUSDT".to_string(),
+            "ETHUSDT".to_string(),
+            "SOLUSDT".to_string(),
+        ];
+
+        let error = validate_preflight_request(&symbols, utc_ts(21), utc_ts(27), &limits)
+            .expect_err("oversized request should be rejected before parquet scan");
+
+        assert!(error.contains("symbol count 3 exceeds --max-symbols 2"));
+        assert!(error.contains("date span 7 days exceeds --max-days 3"));
+        assert!(error.contains("before parquet preflight scan"));
+    }
 }
 
 fn load_research_snapshot_manifest(path: &str) -> ResearchSnapshotManifestProbe {
@@ -394,6 +417,41 @@ fn validate_preflight(
     } else {
         Err(format!(
             "{}; rerun with --allow-large-window only after bounded smoke/host-health checks",
+            failures.join("; ")
+        ))
+    }
+}
+
+fn validate_preflight_request(
+    symbols: &[String],
+    from: chrono::DateTime<Utc>,
+    to: chrono::DateTime<Utc>,
+    limits: &PreflightLimits,
+) -> std::result::Result<(), String> {
+    if limits.allow_large_window {
+        return Ok(());
+    }
+
+    let days = (to.date_naive() - from.date_naive()).num_days().abs() + 1;
+    let mut failures = Vec::new();
+    if symbols.len() > limits.max_symbols {
+        failures.push(format!(
+            "symbol count {} exceeds --max-symbols {}",
+            symbols.len(),
+            limits.max_symbols
+        ));
+    }
+    if days > limits.max_days {
+        failures.push(format!(
+            "date span {days} days exceeds --max-days {}",
+            limits.max_days
+        ));
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{}; rejected before parquet preflight scan; rerun with --allow-large-window only after bounded smoke/host-health checks",
             failures.join("; ")
         ))
     }
@@ -1564,6 +1622,44 @@ fn main() {
     });
 
     let (train_source, val_source) = if let Some(ref dir) = data_dir {
+        let request_guardrail_started = Instant::now();
+        if let Err(error) =
+            validate_preflight_request(&symbols, train_from, val_to, &preflight_limits)
+        {
+            eprintln!("ERROR: optimize request rejected: {error}");
+            phase_timings.push(json!({
+                "phase": "request_guardrail",
+                "source": "parquet-stream",
+                "wall_secs": round_secs(request_guardrail_started.elapsed().as_secs_f64()),
+                "result": "rejected",
+                "error": &error,
+            }));
+            write_timing_json(
+                timing_json.as_deref(),
+                json!({
+                    "command": "optimize_backtest",
+                    "mode": if preflight_only { "preflight-only" } else { "optimize" },
+                    "strategy_variant": &strategy_variant,
+                    "symbols": &symbols,
+                    "train_start": train_start_ts.as_deref().unwrap_or(&train_start),
+                    "train_end": train_end_ts.as_deref().unwrap_or(&train_end),
+                    "val_start": val_start_ts.as_deref().unwrap_or(&val_start),
+                    "val_end": val_end_ts.as_deref().unwrap_or(&val_end),
+                    "trials_requested": n_trials,
+                    "source": "parquet-stream",
+                    "phase_timings": phase_timings,
+                    "error": error,
+                    "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+                }),
+            );
+            std::process::exit(2);
+        }
+        phase_timings.push(json!({
+            "phase": "request_guardrail",
+            "source": "parquet-stream",
+            "wall_secs": round_secs(request_guardrail_started.elapsed().as_secs_f64()),
+            "result": "passed",
+        }));
         let preflight_started = Instant::now();
         let manifest =
             parquet_preflight_manifest(dir, &symbols, train_from, train_to, val_from, val_to)

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -22,9 +22,12 @@ use ploy_strategy_bundles::{
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
+use serde_json::json;
 use sqlx::postgres::PgPoolOptions;
 use std::collections::BTreeMap;
+use std::fs;
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Generate synthetic market data: 1 hour of 5-min windows for 3 symbols.
 ///
@@ -182,12 +185,14 @@ fn flag_value(args: &[String], flag: &str) -> Option<String> {
 fn main() {
     // Parse CLI flags
     let args: Vec<String> = std::env::args().collect();
+    let total_started = Instant::now();
     let config_path = flag_value(&args, "--config")
         .or_else(|| args.get(1).filter(|a| !a.starts_with('-')).cloned());
     let db_url = flag_value(&args, "--db-url");
     let data_dir = flag_value(&args, "--data-dir");
     let start_date = flag_value(&args, "--start-date");
     let end_date = flag_value(&args, "--end-date");
+    let timing_json = flag_value(&args, "--timing-json");
 
     let (strategy_variant, strategy_config, sim_config, runtime_config, backtest_options) =
         if let Some(ref path) = config_path {
@@ -338,6 +343,7 @@ fn main() {
                     .unwrap(),
             );
             eprintln!("Streaming Parquet data from: {dir} ({from} → {to})");
+            let source_started = Instant::now();
             let feed = StreamingParquetFeed::new(
                 dir,
                 &strategy_config.symbols,
@@ -345,14 +351,42 @@ fn main() {
                 to_dt,
                 &backtest_options,
             );
+            let source_open_secs = source_started.elapsed().as_secs_f64();
             let mut runtime =
                 StrategyRuntime::new(strategy, feed, executor, recorder, runtime_config);
+            let run_started = Instant::now();
             let result = rt.block_on(runtime.run());
+            let runtime_wall_secs = run_started.elapsed().as_secs_f64();
             let mark_prices = BTreeMap::new();
             let snapshot = runtime.trading().snapshot(&mark_prices);
-            print_results(result, snapshot, stake_usd);
+            write_timing_json(
+                timing_json.as_deref(),
+                json!({
+                    "command": "run_backtest",
+                    "source": "parquet-stream",
+                    "config": config_path.as_deref(),
+                    "strategy_variant": &strategy_variant,
+                    "symbols": &strategy_config.symbols,
+                    "start_date": from,
+                    "end_date": to,
+                    "data_dir": dir,
+                    "source_open_secs": round_secs(source_open_secs),
+                    "runtime_wall_secs": round_secs(runtime_wall_secs),
+                    "runtime_elapsed_secs": round_secs(result.elapsed_secs),
+                    "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+                    "updates_processed": result.updates_processed,
+                    "updates_per_sec": round_secs(throughput(result.updates_processed, runtime_wall_secs)),
+                    "fills_recorded": result.fills_recorded,
+                    "intents_submitted": result.intents_submitted,
+                    "net_pnl": result.pnl.net_pnl().to_string(),
+                    "open_positions": result.risk.open_positions,
+                    "gross_exposure": result.risk.gross_exposure.to_string(),
+                }),
+            );
+            print_results(&result, &snapshot, stake_usd);
         }
     } else {
+        let eager_source_load_secs;
         let data: Vec<MarketUpdate> = if let Some(ref url) = db_url {
             let from = start_date.as_deref().unwrap_or("2026-03-28");
             let to = end_date.as_deref().unwrap_or("2026-04-03");
@@ -369,6 +403,7 @@ fn main() {
                     .unwrap(),
             );
             eprintln!("Loading DB data: {} → {}", from, to);
+            let source_started = Instant::now();
             let pool = rt
                 .block_on(PgPoolOptions::new().max_connections(5).connect(url))
                 .expect("DB connection failed");
@@ -382,24 +417,56 @@ fn main() {
                     &backtest_options,
                 ))
                 .expect("Failed to load from database");
+            let source_load_secs = source_started.elapsed().as_secs_f64();
+            eager_source_load_secs = Some(source_load_secs);
             eprintln!("Loaded {} market updates from DB\n", updates.len());
             print_data_breakdown(&updates);
             updates
         } else {
+            let source_started = Instant::now();
             let updates = generate_synthetic_data(&["BTCUSDT", "ETHUSDT", "SOLUSDT"], 60);
+            let source_load_secs = source_started.elapsed().as_secs_f64();
+            eager_source_load_secs = Some(source_load_secs);
             eprintln!(
                 "Generated {} market updates (1 hour synthetic)\n",
                 updates.len()
             );
+            eprintln!("Synthetic generation elapsed: {:.3}s", source_load_secs);
             updates
         };
 
         let feed = HistoricalFeed::new(data);
         let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, runtime_config);
+        let run_started = Instant::now();
         let result = rt.block_on(runtime.run());
+        let runtime_wall_secs = run_started.elapsed().as_secs_f64();
         let mark_prices = BTreeMap::new();
         let snapshot = runtime.trading().snapshot(&mark_prices);
-        print_results(result, snapshot, stake_usd);
+        write_timing_json(
+            timing_json.as_deref(),
+            json!({
+                "command": "run_backtest",
+                "source": if db_url.is_some() { "db-eager" } else { "synthetic" },
+                "config": config_path.as_deref(),
+                "strategy_variant": &strategy_variant,
+                "symbols": &strategy_config.symbols,
+                "start_date": start_date.as_deref(),
+                "end_date": end_date.as_deref(),
+                "source_load_secs": eager_source_load_secs.map(round_secs),
+                "updates_loaded": result.updates_processed,
+                "runtime_wall_secs": round_secs(runtime_wall_secs),
+                "runtime_elapsed_secs": round_secs(result.elapsed_secs),
+                "total_wall_secs": round_secs(total_started.elapsed().as_secs_f64()),
+                "updates_processed": result.updates_processed,
+                "updates_per_sec": round_secs(throughput(result.updates_processed, runtime_wall_secs)),
+                "fills_recorded": result.fills_recorded,
+                "intents_submitted": result.intents_submitted,
+                "net_pnl": result.pnl.net_pnl().to_string(),
+                "open_positions": result.risk.open_positions,
+                "gross_exposure": result.risk.gross_exposure.to_string(),
+            }),
+        );
+        print_results(&result, &snapshot, stake_usd);
     }
 }
 
@@ -432,9 +499,44 @@ fn print_data_breakdown(updates: &[MarketUpdate]) {
     );
 }
 
+fn round_secs(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
+}
+
+fn throughput(updates: u64, seconds: f64) -> f64 {
+    if seconds <= 0.0 {
+        0.0
+    } else {
+        updates as f64 / seconds
+    }
+}
+
+fn write_timing_json(path: Option<&str>, payload: serde_json::Value) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!(
+                "warning: failed to create timing dir {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    match serde_json::to_string_pretty(&payload) {
+        Ok(body) => {
+            if let Err(error) = fs::write(path, format!("{body}\n")) {
+                eprintln!("warning: failed to write timing json {path}: {error}");
+            }
+        }
+        Err(error) => eprintln!("warning: failed to encode timing json {path}: {error}"),
+    }
+}
+
 fn print_results(
-    result: ploy_strategy_bundles::RuntimeResult,
-    snapshot: ploy_trading::TradingRuntimeSnapshot,
+    result: &ploy_strategy_bundles::RuntimeResult,
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
     stake_usd: Decimal,
 ) {
     let cashflow = snapshot.fill_cashflow_summary();

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,6 +22,41 @@
 - 2026-04-29: Runtime entry scoring now computes expected value explicitly from direction probability, executable ask, payout/loss, and crypto fee. Snapshot profiles still require non-negative configured EV (`three_layer_min_edge`), and score also includes expected value per staked dollar so lower-probability but better-priced orders can outrank high-probability rich entries.
 - 2026-04-29: Snapshot optimizer now emits average expected value per share and per staked dollar, includes per-stake EV in the stability objective/generalization penalty, and has focused tests proving non-fillable rows are selected/rejected as non-executable rather than counted as executable PnL.
 
+# Research Loop Observability And Speedup (2026-04-29)
+
+Issue: https://github.com/proerror77/ploy/issues/227
+
+## Files
+
+- `.github/workflows/backtest.yml`
+  - Owner: backtest artifact capture and timing report upload.
+- `.github/workflows/optimize.yml`
+  - Owner: optimizer preflight/replay timing artifacts and workflow summaries.
+- `crates/ploy-strategy-bundles/examples/run_backtest.rs`
+  - Owner: per-run backtest timing/throughput JSON.
+- `crates/ploy-strategy-bundles/examples/optimize_backtest.rs`
+  - Owner: optimizer phase timing and per-trial replay throughput observability.
+- `tasks/todo.md`
+  - Owner: implementation plan and verification evidence.
+
+## Tasks
+
+- [x] Add low-overhead timing records to `run_backtest`.
+- [x] Add optimizer phase timing plus per-trial replay throughput records.
+- [x] Upload timing/report artifacts from `backtest.yml` and `optimize.yml`.
+- [x] Run focused formatting and no-run checks without heavy local replay.
+
+## Review
+
+- 2026-04-29: Multi-agent review found the slow loop is not one isolated bottleneck. The highest-impact issues are repeated Parquet preflight scans, per-trial replay/runtime/feed setup in `optimize_backtest`, default full-tree Parquet rsync in `backtest.yml`, and a broader lack of one canonical snapshot/tape boundary across research, backtest, replay, dry-run, and reporting.
+- 2026-04-29: Added `--timing-json` to `run_backtest` for source open/load time, runtime wall time, runtime elapsed time, total wall time, updates processed, updates/sec, intents/fills, PnL, exposure, source, strategy variant, symbols, dates, and config.
+- 2026-04-29: Added `--timing-json` to non-snapshot `optimize_backtest` for Parquet preflight / DB connect / DB load phase timings, per-trial replay wall time, runtime elapsed time, updates/sec, score, Sharpe, PnL, trades, fills, intents, rejected orders, errors, and held-out validation timing.
+- 2026-04-29: Updated `backtest.yml` to save `artifacts/backtest/report.txt`, `timing.json`, `rsync-timing.json`, `workflow-timing.json`, upload them as `backtest-report-${{ github.run_id }}`, and print timing JSON into the step summary when present.
+- 2026-04-29: Updated `optimize.yml` to save preflight/report/workflow timing under `artifacts/optimize`, pass `--timing-json` for non-snapshot optimizer paths, keep snapshot-backed optimizer report capture, and upload the optimize artifact directory.
+- 2026-04-29: UI/reporting review found `report_dryrun_summary.py` already has multi-strategy and equity-curve data, but `ploy-frontend` and `ploy-operator-contracts` still lack a first-class dry-run report contract and routes. Follow-up should make `strategy_id` the primary grouping key and `deployment_id` the secondary key, with side-aware orders/fills/PnL attribution.
+- 2026-04-29: Verification passed: `rustfmt --edition 2024 crates/ploy-strategy-bundles/examples/run_backtest.rs crates/ploy-strategy-bundles/examples/optimize_backtest.rs`, `git diff --check`, and workflow YAML parsing via Ruby for `.github/workflows/backtest.yml` and `.github/workflows/optimize.yml`.
+- 2026-04-29: Full local Rust compile was intentionally stopped after repeated long dependency rebuilds on the Mac. `cargo test --no-run` for `run_backtest` was terminated after several minutes of dependency compilation; a bounded 180s `cargo check` for `optimize_backtest` also timed out. No real backtest/replay was executed locally.
+
 # PM5D Holistic Snapshot Optimizer Fix (2026-04-29)
 
 Issue: https://github.com/proerror77/ploy/issues/224

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -44,6 +44,8 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - [x] Add low-overhead timing records to `run_backtest`.
 - [x] Add optimizer phase timing plus per-trial replay throughput records.
 - [x] Upload timing/report artifacts from `backtest.yml` and `optimize.yml`.
+- [x] Stop `backtest.yml` from syncing the full Parquet tree by default.
+- [x] Reject oversized optimizer symbol/date requests before scanning Parquet.
 - [x] Run focused formatting and no-run checks without heavy local replay.
 
 ## Review
@@ -53,9 +55,12 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - 2026-04-29: Added `--timing-json` to non-snapshot `optimize_backtest` for Parquet preflight / DB connect / DB load phase timings, per-trial replay wall time, runtime elapsed time, updates/sec, score, Sharpe, PnL, trades, fills, intents, rejected orders, errors, and held-out validation timing.
 - 2026-04-29: Updated `backtest.yml` to save `artifacts/backtest/report.txt`, `timing.json`, `rsync-timing.json`, `workflow-timing.json`, upload them as `backtest-report-${{ github.run_id }}`, and print timing JSON into the step summary when present.
 - 2026-04-29: Updated `optimize.yml` to save preflight/report/workflow timing under `artifacts/optimize`, pass `--timing-json` for non-snapshot optimizer paths, keep snapshot-backed optimizer report capture, and upload the optimize artifact directory.
+- 2026-04-29: After rebasing onto current `main`, changed `backtest.yml` so `data_dir` defaults to empty DB mode and full Parquet rsync only runs when `sync_parquet_data=true`. If an operator supplies `data_dir` without a local directory or sync, the workflow now fails fast with a clear report and timing JSON instead of silently doing expensive setup.
+- 2026-04-29: Added an optimizer request guardrail before `parquet_preflight_manifest`. Oversized symbol/date requests are rejected before DuckDB scans Parquet; row/byte/liquidity checks still run after manifest generation for requests that pass the cheap guardrail.
 - 2026-04-29: UI/reporting review found `report_dryrun_summary.py` already has multi-strategy and equity-curve data, but `ploy-frontend` and `ploy-operator-contracts` still lack a first-class dry-run report contract and routes. Follow-up should make `strategy_id` the primary grouping key and `deployment_id` the secondary key, with side-aware orders/fills/PnL attribution.
 - 2026-04-29: Verification passed: `rustfmt --edition 2024 crates/ploy-strategy-bundles/examples/run_backtest.rs crates/ploy-strategy-bundles/examples/optimize_backtest.rs`, `git diff --check`, and workflow YAML parsing via Ruby for `.github/workflows/backtest.yml` and `.github/workflows/optimize.yml`.
-- 2026-04-29: Full local Rust compile was intentionally stopped after repeated long dependency rebuilds on the Mac. `cargo test --no-run` for `run_backtest` was terminated after several minutes of dependency compilation; a bounded 180s `cargo check` for `optimize_backtest` also timed out. No real backtest/replay was executed locally.
+- 2026-04-29: Follow-up verification passed: `rustfmt --edition 2024 crates/ploy-strategy-bundles/examples/run_backtest.rs crates/ploy-strategy-bundles/examples/optimize_backtest.rs`, `git diff --check`, and workflow YAML parsing via Ruby for `.github/workflows/backtest.yml` and `.github/workflows/optimize.yml`.
+- 2026-04-29: Full local Rust compile was intentionally stopped after repeated long dependency rebuilds on the Mac. `cargo test --no-run` for `run_backtest` was terminated after several minutes of dependency compilation; a bounded 180s `cargo check` for `optimize_backtest` and a bounded 240s targeted test for the cheap guardrail also timed out while rebuilding dependencies. No real backtest/replay was executed locally.
 
 # PM5D Holistic Snapshot Optimizer Fix (2026-04-29)
 


### PR DESCRIPTION
## Summary
- add `--timing-json` to `run_backtest` for source/load/runtime throughput evidence
- add non-snapshot `optimize_backtest` phase, trial, and validation timing JSON
- capture backtest/optimize reports and workflow timing artifacts in GitHub Actions
- document multi-agent review findings and link follow-up issue #227

## Verification
- `rustfmt --edition 2024 crates/ploy-strategy-bundles/examples/run_backtest.rs crates/ploy-strategy-bundles/examples/optimize_backtest.rs`
- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/backtest.yml .github/workflows/optimize.yml].each { |f| YAML.load_file(f); puts f }'`\n\n## Not tested\n- Full local Rust compile timed out while rebuilding dependencies on the Mac; CI should do the full compile.\n- No real backtest or optimizer replay was run locally.\n\nRelated: #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timing instrumentation to capture performance metrics in JSON format.
  * Introduced validation guardrails to catch invalid inputs early with exit status 2.

* **Bug Fixes**
  * Improved exit code handling and capture for more reliable failure detection.
  * Enhanced artifact uploads and step summary reporting.

* **Chores**
  * Updated workflows to create deterministic report files and directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->