### PR TITLE
Make dry-run reports a typed multi-strategy surface

### DIFF
--- a/contracts/schemas/dry-run-performance-report.schema.json
+++ b/contracts/schemas/dry-run-performance-report.schema.json
@@ -1,0 +1,852 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DryRunPerformanceReport",
+  "type": "object",
+  "required": [
+    "by_window",
+    "closed_trades",
+    "daily",
+    "daily_by_window",
+    "equity_curve",
+    "generated_at",
+    "metrics",
+    "open_positions",
+    "pairing",
+    "recent_closed",
+    "strategies",
+    "summary",
+    "symbols",
+    "symbols_by_window"
+  ],
+  "properties": {
+    "by_window": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunWindowRow"
+      }
+    },
+    "closed_trades": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunClosedTradeRow"
+      }
+    },
+    "daily": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunDailyRow"
+      }
+    },
+    "daily_by_window": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunDailyWindowRow"
+      }
+    },
+    "equity_curve": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunEquityPoint"
+      }
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "metrics": {
+      "$ref": "#/definitions/DryRunMetrics"
+    },
+    "open_positions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunOpenPositionRow"
+      }
+    },
+    "pairing": {
+      "$ref": "#/definitions/DryRunPairingReport"
+    },
+    "recent_closed": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunClosedTradeRow"
+      }
+    },
+    "strategies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunStrategyReport"
+      }
+    },
+    "summary": {
+      "$ref": "#/definitions/DryRunSummary"
+    },
+    "symbols": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunSymbolRow"
+      }
+    },
+    "symbols_by_window": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunSymbolRow"
+      }
+    }
+  },
+  "definitions": {
+    "DryRunClosedTradeRow": {
+      "type": "object",
+      "required": [
+        "exit_type",
+        "net_pnl",
+        "notional",
+        "quantity",
+        "window_label"
+      ],
+      "properties": {
+        "closed_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "deployment_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entry_price": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "entry_time_remaining_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "event_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exit_price": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "exit_type": {
+          "type": "string"
+        },
+        "market_side": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "notional": {
+          "type": "number",
+          "format": "double"
+        },
+        "opened_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quantity": {
+          "type": "number",
+          "format": "double"
+        },
+        "runtime_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strategy_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trade_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_label": {
+          "type": "string"
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        }
+      }
+    },
+    "DryRunDailyRow": {
+      "type": "object",
+      "required": [
+        "closed_trade_count",
+        "confirmed_pnl",
+        "confirmed_trade_count",
+        "fees",
+        "losses",
+        "net_pnl",
+        "open_quantity",
+        "trade_count",
+        "wins"
+      ],
+      "properties": {
+        "closed_trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "confirmed_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "confirmed_trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "fees": {
+          "type": "number",
+          "format": "double"
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "open_quantity": {
+          "type": "number",
+          "format": "double"
+        },
+        "trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "trading_day_cst": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunDailyWindowRow": {
+      "type": "object",
+      "required": [
+        "closed_trade_count",
+        "losses",
+        "net_pnl",
+        "trade_count",
+        "trading_day_cst",
+        "window_label",
+        "wins"
+      ],
+      "properties": {
+        "closed_trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "trading_day_cst": {
+          "type": "string"
+        },
+        "window_label": {
+          "type": "string"
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunEquityPoint": {
+      "type": "object",
+      "required": [
+        "cumulative",
+        "drawdown",
+        "index",
+        "label",
+        "pnl"
+      ],
+      "properties": {
+        "cumulative": {
+          "type": "number",
+          "format": "double"
+        },
+        "drawdown": {
+          "type": "number",
+          "format": "double"
+        },
+        "index": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "label": {
+          "type": "string"
+        },
+        "pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestamp": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "DryRunMetrics": {
+      "type": "object",
+      "required": [
+        "equity_points",
+        "gross_loss",
+        "gross_profit",
+        "max_drawdown"
+      ],
+      "properties": {
+        "avg_trade": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "equity_points": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "gross_loss": {
+          "type": "number",
+          "format": "double"
+        },
+        "gross_profit": {
+          "type": "number",
+          "format": "double"
+        },
+        "max_drawdown": {
+          "type": "number",
+          "format": "double"
+        },
+        "profit_factor": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumberOrText"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sharpe": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        }
+      }
+    },
+    "DryRunOpenPositionRow": {
+      "type": "object",
+      "required": [
+        "notional",
+        "quantity",
+        "window_label"
+      ],
+      "properties": {
+        "deployment_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entry_price": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "entry_time_remaining_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "event_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "market_side": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notional": {
+          "type": "number",
+          "format": "double"
+        },
+        "opened_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quantity": {
+          "type": "number",
+          "format": "double"
+        },
+        "runtime_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strategy_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trade_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_label": {
+          "type": "string"
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        }
+      }
+    },
+    "DryRunPairingReport": {
+      "type": "object",
+      "required": [
+        "current_view_rows",
+        "fills_in_mixed_event_groups",
+        "mixed_event_groups",
+        "pair_key",
+        "side_aware_rows"
+      ],
+      "properties": {
+        "current_view_rows": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "fills_in_mixed_event_groups": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "mixed_event_groups": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "pair_key": {
+          "type": "string"
+        },
+        "side_aware_rows": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunStrategyReport": {
+      "type": "object",
+      "required": [
+        "by_window",
+        "closed_trades",
+        "daily",
+        "daily_by_window",
+        "deployment_id",
+        "equity_curve",
+        "label",
+        "metrics",
+        "open_positions",
+        "recent_closed",
+        "runtime_mode",
+        "strategy_id",
+        "summary",
+        "symbols",
+        "symbols_by_window"
+      ],
+      "properties": {
+        "by_window": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunWindowRow"
+          }
+        },
+        "closed_trades": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunClosedTradeRow"
+          }
+        },
+        "daily": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunDailyRow"
+          }
+        },
+        "daily_by_window": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunDailyWindowRow"
+          }
+        },
+        "deployment_id": {
+          "type": "string"
+        },
+        "equity_curve": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunEquityPoint"
+          }
+        },
+        "label": {
+          "type": "string"
+        },
+        "metrics": {
+          "$ref": "#/definitions/DryRunMetrics"
+        },
+        "open_positions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunOpenPositionRow"
+          }
+        },
+        "recent_closed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunClosedTradeRow"
+          }
+        },
+        "runtime_mode": {
+          "type": "string"
+        },
+        "strategy_id": {
+          "type": "string"
+        },
+        "summary": {
+          "$ref": "#/definitions/DryRunSummary"
+        },
+        "symbols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunSymbolRow"
+          }
+        },
+        "symbols_by_window": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunSymbolRow"
+          }
+        }
+      }
+    },
+    "DryRunSummary": {
+      "type": "object",
+      "required": [
+        "closed_trades",
+        "losses",
+        "open_exposure",
+        "open_positions",
+        "realized_pnl",
+        "total_fees",
+        "total_trades",
+        "win_rate_pct",
+        "wins"
+      ],
+      "properties": {
+        "closed_trades": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "latest_closed_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "latest_opened_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "open_exposure": {
+          "type": "number",
+          "format": "double"
+        },
+        "open_positions": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "realized_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "total_fees": {
+          "type": "number",
+          "format": "double"
+        },
+        "total_trades": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "win_rate_pct": {
+          "type": "number",
+          "format": "double"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunSymbolRow": {
+      "type": "object",
+      "required": [
+        "losses",
+        "net_pnl",
+        "symbol",
+        "trades",
+        "wins"
+      ],
+      "properties": {
+        "avg_entry": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "symbol": {
+          "type": "string"
+        },
+        "trades": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "window_label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunWindowRow": {
+      "type": "object",
+      "required": [
+        "closed_trades",
+        "losses",
+        "realized_pnl",
+        "total_trades",
+        "win_rate_pct",
+        "window_label",
+        "wins"
+      ],
+      "properties": {
+        "avg_entry": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "avg_pnl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "closed_trades": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_entry_ttr_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "min_entry_ttr_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "realized_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "total_trades": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "win_rate_pct": {
+          "type": "number",
+          "format": "double"
+        },
+        "window_label": {
+          "type": "string"
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "NumberOrText": {
+      "anyOf": [
+        {
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/crates/ploy-daemon-host/src/http.rs
+++ b/crates/ploy-daemon-host/src/http.rs
@@ -6,10 +6,10 @@ use ploy_operator_contracts::{
     compute_oversight_report, AgentRunRecord, AlertSnapshotEvent, AuditLogEntry,
     ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
     DeploymentDiagnosticsReport, DeploymentSnapshotEvent, DiagnosticsEvidence, DiagnosticsFinding,
-    IntentPurpose, MetricsSnapshotEvent, OperatorEvent, OrderReplaceRequest,
-    OversightSnapshotEvent, PaperIntentRequest, PlatformDiagnosticsReport, ProposalCreateRequest,
-    ProposalDecisionRequest, ProposalSnapshotEvent, StatusUpdate, SystemSnapshotEvent,
-    SystemStatus, TradingSnapshotEvent,
+    DryRunPerformanceReport, IntentPurpose, MetricsSnapshotEvent, OperatorEvent,
+    OrderReplaceRequest, OversightSnapshotEvent, PaperIntentRequest, PlatformDiagnosticsReport,
+    ProposalCreateRequest, ProposalDecisionRequest, ProposalSnapshotEvent, StatusUpdate,
+    SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
 };
 use ploy_trading::{TradeSide, TradingIntent};
 use secrecy::{ExposeSecret, SecretString};
@@ -362,7 +362,23 @@ fn build_dry_run_summary_json(state: &Arc<AppState>) -> (u16, String) {
         );
     }
 
-    (200, body)
+    let report: DryRunPerformanceReport = match serde_json::from_str(&body) {
+        Ok(report) => report,
+        Err(err) => {
+            return json_error(
+                500,
+                "dry_run_summary_invalid",
+                Some(format!(
+                    "dry-run summary script returned payload outside the operator contract: {err}"
+                )),
+            );
+        }
+    };
+
+    (
+        200,
+        serde_json::to_string(&report).unwrap_or_else(|_| body.to_string()),
+    )
 }
 
 fn html_error(status_code: u16, message: &str) -> (u16, String) {

--- a/crates/ploy-operator-contracts/src/lib.rs
+++ b/crates/ploy-operator-contracts/src/lib.rs
@@ -3,6 +3,7 @@ pub mod deployments;
 pub mod diagnostics;
 pub mod errors;
 pub mod events;
+pub mod reports;
 pub mod schemas;
 pub mod system;
 pub mod trading;
@@ -13,16 +14,21 @@ pub use deployments::{
     DeploymentSummary, DesiredState, ObservedState,
 };
 pub use diagnostics::{
-    compute_oversight_report, AgentRunRecord, DeploymentDiagnosticsMetrics,
-    DeploymentDiagnosticsReport, DiagnosticsEvidence, DiagnosticsFinding,
-    OversightRecommendedAction, OversightReport, OversightSignal, OversightSnapshotEvent,
-    PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest, ProposalDecisionRequest,
-    ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
+    AgentRunRecord, DeploymentDiagnosticsMetrics, DeploymentDiagnosticsReport, DiagnosticsEvidence,
+    DiagnosticsFinding, OversightRecommendedAction, OversightReport, OversightSignal,
+    OversightSnapshotEvent, PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest,
+    ProposalDecisionRequest, ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
+    compute_oversight_report,
 };
 pub use errors::ControlPlaneErrorResponse;
 pub use events::{
     AlertSnapshotEvent, DeploymentSnapshotEvent, LogEntry, MetricsSnapshotEvent, OperatorEvent,
     StatusUpdate, SystemSnapshotEvent, TradingSnapshotEvent, WsMessage,
+};
+pub use reports::{
+    DryRunClosedTradeRow, DryRunDailyRow, DryRunDailyWindowRow, DryRunEquityPoint, DryRunMetrics,
+    DryRunOpenPositionRow, DryRunPairingReport, DryRunPerformanceReport, DryRunStrategyReport,
+    DryRunSummary, DryRunSymbolRow, DryRunWindowRow, NumberOrText,
 };
 pub use system::{
     ActiveAlert, AlertKind, AlertSeverity, HeartbeatState, HeartbeatStatus, PlatformMetrics,

--- a/crates/ploy-operator-contracts/src/reports.rs
+++ b/crates/ploy-operator-contracts/src/reports.rs
@@ -1,0 +1,186 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunSummary {
+    pub total_trades: usize,
+    pub closed_trades: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub win_rate_pct: f64,
+    pub realized_pnl: f64,
+    pub total_fees: f64,
+    pub open_positions: usize,
+    pub open_exposure: f64,
+    pub latest_opened_at: Option<String>,
+    pub latest_closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum NumberOrText {
+    Number(f64),
+    Text(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunMetrics {
+    pub sharpe: Option<f64>,
+    pub profit_factor: Option<NumberOrText>,
+    pub max_drawdown: f64,
+    pub avg_trade: Option<f64>,
+    pub gross_profit: f64,
+    pub gross_loss: f64,
+    pub equity_points: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunEquityPoint {
+    pub index: usize,
+    pub label: String,
+    pub timestamp: Option<String>,
+    pub symbol: Option<String>,
+    pub pnl: f64,
+    pub cumulative: f64,
+    pub drawdown: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunWindowRow {
+    pub window_secs: Option<i64>,
+    pub window_label: String,
+    pub total_trades: usize,
+    pub closed_trades: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub win_rate_pct: f64,
+    pub realized_pnl: f64,
+    pub avg_pnl: Option<f64>,
+    pub avg_entry: Option<f64>,
+    pub min_entry_ttr_secs: Option<i64>,
+    pub max_entry_ttr_secs: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunDailyRow {
+    pub trading_day_cst: Option<String>,
+    pub trade_count: usize,
+    pub closed_trade_count: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub confirmed_trade_count: usize,
+    pub net_pnl: f64,
+    pub confirmed_pnl: f64,
+    pub fees: f64,
+    pub open_quantity: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunDailyWindowRow {
+    pub trading_day_cst: String,
+    pub window_secs: Option<i64>,
+    pub window_label: String,
+    pub trade_count: usize,
+    pub closed_trade_count: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub net_pnl: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunSymbolRow {
+    pub symbol: String,
+    pub trades: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub net_pnl: f64,
+    pub avg_entry: Option<f64>,
+    pub window_secs: Option<i64>,
+    pub window_label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunClosedTradeRow {
+    pub runtime_mode: Option<String>,
+    pub strategy_id: Option<String>,
+    pub deployment_id: Option<String>,
+    pub trade_key: Option<String>,
+    pub event_id: Option<String>,
+    pub symbol: Option<String>,
+    pub window_secs: Option<i64>,
+    pub window_label: String,
+    pub market_side: Option<String>,
+    pub entry_price: Option<f64>,
+    pub exit_price: Option<f64>,
+    pub exit_type: String,
+    pub quantity: f64,
+    pub notional: f64,
+    pub net_pnl: f64,
+    pub entry_time_remaining_secs: Option<i64>,
+    pub opened_at: Option<String>,
+    pub closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunOpenPositionRow {
+    pub runtime_mode: Option<String>,
+    pub strategy_id: Option<String>,
+    pub deployment_id: Option<String>,
+    pub trade_key: Option<String>,
+    pub event_id: Option<String>,
+    pub symbol: Option<String>,
+    pub window_secs: Option<i64>,
+    pub window_label: String,
+    pub market_side: Option<String>,
+    pub entry_price: Option<f64>,
+    pub quantity: f64,
+    pub notional: f64,
+    pub entry_time_remaining_secs: Option<i64>,
+    pub opened_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunPairingReport {
+    pub pair_key: String,
+    pub mixed_event_groups: usize,
+    pub fills_in_mixed_event_groups: usize,
+    pub current_view_rows: usize,
+    pub side_aware_rows: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunStrategyReport {
+    pub runtime_mode: String,
+    pub strategy_id: String,
+    pub deployment_id: String,
+    pub label: String,
+    pub summary: DryRunSummary,
+    pub metrics: DryRunMetrics,
+    pub equity_curve: Vec<DryRunEquityPoint>,
+    pub by_window: Vec<DryRunWindowRow>,
+    pub daily: Vec<DryRunDailyRow>,
+    pub daily_by_window: Vec<DryRunDailyWindowRow>,
+    pub symbols: Vec<DryRunSymbolRow>,
+    pub symbols_by_window: Vec<DryRunSymbolRow>,
+    pub closed_trades: Vec<DryRunClosedTradeRow>,
+    pub recent_closed: Vec<DryRunClosedTradeRow>,
+    pub open_positions: Vec<DryRunOpenPositionRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunPerformanceReport {
+    pub generated_at: String,
+    pub summary: DryRunSummary,
+    pub metrics: DryRunMetrics,
+    pub equity_curve: Vec<DryRunEquityPoint>,
+    pub by_window: Vec<DryRunWindowRow>,
+    pub daily: Vec<DryRunDailyRow>,
+    pub daily_by_window: Vec<DryRunDailyWindowRow>,
+    pub symbols: Vec<DryRunSymbolRow>,
+    pub symbols_by_window: Vec<DryRunSymbolRow>,
+    pub closed_trades: Vec<DryRunClosedTradeRow>,
+    pub recent_closed: Vec<DryRunClosedTradeRow>,
+    pub open_positions: Vec<DryRunOpenPositionRow>,
+    pub strategies: Vec<DryRunStrategyReport>,
+    pub pairing: DryRunPairingReport,
+}

--- a/crates/ploy-operator-contracts/src/schemas.rs
+++ b/crates/ploy-operator-contracts/src/schemas.rs
@@ -1,9 +1,9 @@
 use crate::{
     AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
-    DeploymentSummary, OperatorEvent, PaperIntentRequest, PaperIntentResponse,
-    SystemControlResponse, SystemStatus, TradingStateSnapshot,
+    DeploymentSummary, DryRunPerformanceReport, OperatorEvent, PaperIntentRequest,
+    PaperIntentResponse, SystemControlResponse, SystemStatus, TradingStateSnapshot,
 };
-use schemars::{schema::RootSchema, JsonSchema};
+use schemars::{JsonSchema, schema::RootSchema};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy)]
@@ -58,6 +58,10 @@ pub fn contract_schemas() -> Vec<ContractSchema> {
         ContractSchema::new::<TradingStateSnapshot>(
             "trading-state-snapshot.schema.json",
             "TradingStateSnapshot",
+        ),
+        ContractSchema::new::<DryRunPerformanceReport>(
+            "dry-run-performance-report.schema.json",
+            "DryRunPerformanceReport",
         ),
         ContractSchema::new::<SystemStatus>("system-status.schema.json", "SystemStatus"),
         ContractSchema::new::<SystemControlResponse>(

--- a/ploy-frontend/src/components/Layout.tsx
+++ b/ploy-frontend/src/components/Layout.tsx
@@ -29,6 +29,7 @@ function getErrorMessage(error: unknown, fallback: string) {
 const navigation = [
   { name: '仪表盘', href: '/', icon: LayoutDashboard },
   { name: '运营驾驶舱', href: '/cockpit', icon: Gauge },
+  { name: 'Dry-run 报表', href: '/dry-run', icon: TrendingUp },
   { name: '交易历史', href: '/trades', icon: History },
   { name: '实时日志', href: '/monitor', icon: Activity },
   { name: 'Dry/Live 对比', href: '/parity', icon: GitCompare },

--- a/ploy-frontend/src/pages/OperatorCockpit.tsx
+++ b/ploy-frontend/src/pages/OperatorCockpit.tsx
@@ -2,6 +2,16 @@ import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
   Activity,
   AlertTriangle,
   ArrowUpRight,
@@ -26,7 +36,11 @@ import { ws } from '@/services/websocket';
 import { useStore } from '@/store';
 import type {
   ActiveAlert,
+  DryRunClosedTradeRow,
+  DryRunEquityPoint,
+  DryRunOpenPositionRow,
   DryRunPerformanceReport,
+  DryRunStrategyReport,
   DeploymentSummary,
   LogEntry,
   PlatformMetrics,
@@ -36,6 +50,12 @@ import type {
 import { cn, formatCurrency, formatDuration, formatNumber, formatTimestamp } from '@/lib/utils';
 
 type Health = 'good' | 'watch' | 'bad' | 'neutral';
+
+type EquityChartRow = {
+  timestamp: number;
+  label: string | null;
+  [seriesKey: string]: number | string | null;
+};
 
 interface HealthCardProps {
   title: string;
@@ -86,6 +106,50 @@ function formatSecondsBrief(value?: number | null) {
   const minutes = Math.floor(seconds / 60);
   const rest = seconds % 60;
   return minutes > 0 ? `${minutes}m${rest.toString().padStart(2, '0')}s` : `${rest}s`;
+}
+
+const aggregateSeriesKey = 'all_dry_run';
+const strategyPalette = ['#0f172a', '#0f766e', '#2563eb', '#b45309', '#7c3aed', '#be123c', '#15803d'];
+const emptyDryRunStrategies: DryRunStrategyReport[] = [];
+const emptyDryRunEquityCurve: DryRunEquityPoint[] = [];
+const emptyDryRunClosedTrades: DryRunClosedTradeRow[] = [];
+const emptyDryRunOpenPositions: DryRunOpenPositionRow[] = [];
+
+function strategySeriesKey(index: number) {
+  return `strategy_${index}`;
+}
+
+function compactStrategyLabel(strategy: DryRunStrategyReport) {
+  return strategy.label || strategy.deployment_id || strategy.strategy_id || strategy.runtime_mode;
+}
+
+function closedTradeStrategyLabel(row: DryRunClosedTradeRow) {
+  return row.deployment_id || row.strategy_id || row.runtime_mode || 'unknown';
+}
+
+function equityPointTime(point: DryRunEquityPoint) {
+  const timestamp = Date.parse(point.timestamp ?? '');
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function formatChartTimestamp(value: unknown) {
+  const timestamp = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(timestamp)) return '-';
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatOptionalMetric(value?: number | null, digits = 2) {
+  return value == null || !Number.isFinite(value) ? '-' : value.toFixed(digits);
+}
+
+function formatProfitFactor(value: DryRunStrategyReport['metrics']['profit_factor']) {
+  if (value == null) return '-';
+  return typeof value === 'number' ? value.toFixed(2) : value;
 }
 
 function ageSeconds(timestamp?: string | null) {
@@ -310,10 +374,77 @@ export function OperatorCockpit() {
   const reportedWinRate = reportedSummary == null ? null : toNumber(reportedSummary.win_rate_pct);
   const dryRunWindows = dryRunPerformance?.by_window ?? [];
   const dryRunPairing = dryRunPerformance?.pairing;
+  const dryRunStrategies = dryRunPerformance?.strategies ?? emptyDryRunStrategies;
+  const dryRunEquityCurve = dryRunPerformance?.equity_curve ?? emptyDryRunEquityCurve;
+  const dryRunRecentClosed = dryRunPerformance?.recent_closed ?? emptyDryRunClosedTrades;
+  const dryRunOpenPositions = dryRunPerformance?.open_positions ?? emptyDryRunOpenPositions;
   const pairingHasMismatch =
     dryRunPairing != null &&
     (dryRunPairing.mixed_event_groups > 0 ||
       dryRunPairing.current_view_rows !== dryRunPairing.side_aware_rows);
+  const strategyEquity = useMemo(() => {
+    const series = [
+      ...(dryRunEquityCurve.length > 0
+        ? [
+            {
+              key: aggregateSeriesKey,
+              label: 'All dry-run',
+              color: strategyPalette[0],
+            },
+          ]
+        : []),
+      ...dryRunStrategies
+        .filter((strategy) => strategy.equity_curve.length > 0)
+        .map((strategy, index) => ({
+          key: strategySeriesKey(index),
+          label: compactStrategyLabel(strategy),
+          color: strategyPalette[(index + 1) % strategyPalette.length],
+        })),
+    ];
+
+    const rows = new Map<number, EquityChartRow>();
+    for (const point of dryRunEquityCurve) {
+      const timestamp = equityPointTime(point);
+      if (timestamp == null) continue;
+      const row = rows.get(timestamp) ?? { timestamp, label: point.timestamp ?? null };
+      row[aggregateSeriesKey] = point.cumulative;
+      rows.set(timestamp, row);
+    }
+    dryRunStrategies.forEach((strategy, index) => {
+      const key = strategySeriesKey(index);
+      for (const point of strategy.equity_curve) {
+        const timestamp = equityPointTime(point);
+        if (timestamp == null) continue;
+        const row = rows.get(timestamp) ?? { timestamp, label: point.timestamp ?? null };
+        row[key] = point.cumulative;
+        rows.set(timestamp, row);
+      }
+    });
+
+    return {
+      series,
+      data: Array.from(rows.values()).sort((a, b) => toNumber(a.timestamp) - toNumber(b.timestamp)),
+    };
+  }, [dryRunEquityCurve, dryRunStrategies]);
+  const rankedStrategies = useMemo(() => {
+    return [...dryRunStrategies].sort(
+      (a, b) =>
+        toNumber(b.summary.realized_pnl) - toNumber(a.summary.realized_pnl) ||
+        b.summary.closed_trades - a.summary.closed_trades
+    );
+  }, [dryRunStrategies]);
+  const dryRunStrategyByDeployment = useMemo(() => {
+    const byDeployment = new Map<string, DryRunStrategyReport>();
+    for (const strategy of dryRunStrategies) {
+      if (strategy.deployment_id) {
+        byDeployment.set(strategy.deployment_id, strategy);
+      }
+    }
+    return byDeployment;
+  }, [dryRunStrategies]);
+  const unreportedDryRunDeployments = dryRunDeployments.filter(
+    (deployment) => !dryRunStrategyByDeployment.has(deployment.deployment_id)
+  );
 
   const eventAge = lastEventAt == null ? null : Math.max(0, Math.round((Date.now() - lastEventAt) / 1000));
   const cpuPressure =
@@ -433,6 +564,278 @@ export function OperatorCockpit() {
         />
       </div>
 
+      {dryRunPerformance ? (
+        <Card className="mb-5">
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between gap-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <FileText className="h-5 w-5" />
+                Dry-run Strategy Report
+              </CardTitle>
+              <Badge variant={dryRunStrategies.length > 1 ? 'success' : 'secondary'}>
+                {dryRunStrategies.length} strategies
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-5 2xl:grid-cols-[1.2fr_0.8fr]">
+              <div className="rounded-md border bg-white p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">Cumulative equity curve</div>
+                    <div className="text-xs text-muted-foreground">
+                      {dryRunPerformance.metrics.equity_points} closed trades · x-axis is close time · max drawdown{' '}
+                      {formatCurrency(dryRunPerformance.metrics.max_drawdown)}
+                    </div>
+                  </div>
+                  <Badge variant={reportedNetPnl >= 0 ? 'success' : 'destructive'}>
+                    {formatCurrency(reportedNetPnl)}
+                  </Badge>
+                </div>
+                {strategyEquity.series.length > 0 && strategyEquity.data.length > 0 ? (
+                  <div className="h-[320px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={strategyEquity.data}>
+                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                        <XAxis
+                          dataKey="timestamp"
+                          type="number"
+                          domain={['dataMin', 'dataMax']}
+                          tick={{ fontSize: 12 }}
+                          tickFormatter={formatChartTimestamp}
+                        />
+                        <YAxis
+                          tick={{ fontSize: 12 }}
+                          tickFormatter={(value) => `$${Number(value).toFixed(0)}`}
+                          width={64}
+                        />
+                        <Tooltip
+                          formatter={(value, name) => {
+                            const seriesName = String(name);
+                            return [
+                              formatCurrency(toNumber(value)),
+                              strategyEquity.series.find((entry) => entry.key === seriesName)?.label ?? seriesName,
+                            ];
+                          }}
+                          labelFormatter={formatChartTimestamp}
+                        />
+                        <Legend
+                          formatter={(value) => (
+                            <span className="text-xs text-muted-foreground">{value}</span>
+                          )}
+                        />
+                        {strategyEquity.series.map((series) => (
+                          <Line
+                            key={series.key}
+                            type="monotone"
+                            dataKey={series.key}
+                            name={series.label}
+                            stroke={series.color}
+                            strokeWidth={series.key === aggregateSeriesKey ? 3 : 2}
+                            dot={false}
+                          />
+                        ))}
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="flex h-[320px] items-center justify-center rounded-md bg-muted text-sm text-muted-foreground">
+                    No closed-trade equity points yet.
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-md border bg-white p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">Strategy attribution</div>
+                    <div className="text-xs text-muted-foreground">
+                      grouped by strategy_id and deployment_id
+                    </div>
+                  </div>
+                  <Badge variant={pairingHasMismatch ? 'warning' : 'success'}>
+                    {dryRunPairing?.mixed_event_groups ?? 0} mixed events
+                  </Badge>
+                </div>
+                <div className="overflow-hidden rounded-md border">
+                  <div className="grid grid-cols-[1.5fr_0.8fr_0.8fr_0.8fr_0.8fr] bg-muted px-3 py-2 text-xs font-medium uppercase text-muted-foreground">
+                    <span>strategy</span>
+                    <span>closed</span>
+                    <span>win</span>
+                    <span>sharpe</span>
+                    <span className="text-right">pnl</span>
+                  </div>
+                  {rankedStrategies.length === 0 && unreportedDryRunDeployments.length === 0 ? (
+                    <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                      No strategy-level dry-run rows yet.
+                    </div>
+                  ) : (
+                    <>
+                      {rankedStrategies.map((strategy) => {
+                        const pnl = toNumber(strategy.summary.realized_pnl);
+                        return (
+                          <div
+                            key={`${strategy.runtime_mode}:${strategy.strategy_id}:${strategy.deployment_id}`}
+                            className="grid grid-cols-[1.5fr_0.8fr_0.8fr_0.8fr_0.8fr] items-center border-t px-3 py-2 text-sm"
+                          >
+                            <div className="min-w-0">
+                              <div className="truncate font-medium">{compactStrategyLabel(strategy)}</div>
+                              <div className="truncate text-xs text-muted-foreground">
+                                {strategy.strategy_id || 'unknown'} · {strategy.runtime_mode || 'unknown'}
+                              </div>
+                            </div>
+                            <div>{strategy.summary.closed_trades}</div>
+                            <div>{formatOptionalMetric(strategy.summary.win_rate_pct, 1)}%</div>
+                            <div>{formatOptionalMetric(strategy.metrics.sharpe, 2)}</div>
+                            <div className={cn('text-right font-medium', pnl < 0 ? 'text-destructive' : 'text-success')}>
+                              {formatCurrency(pnl)}
+                              <div className="text-xs font-normal text-muted-foreground">
+                                PF {formatProfitFactor(strategy.metrics.profit_factor)}
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      {unreportedDryRunDeployments.map((deployment) => (
+                        <div
+                          key={`unreported:${deployment.deployment_id}`}
+                          className="grid grid-cols-[1.5fr_0.8fr_0.8fr_0.8fr_0.8fr] items-center border-t px-3 py-2 text-sm"
+                        >
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">{deployment.deployment_id}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              running deployment · no dry-run report rows
+                            </div>
+                          </div>
+                          <div>0</div>
+                          <div>-</div>
+                          <div>-</div>
+                          <div className="text-right text-muted-foreground">
+                            no data
+                          </div>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5 rounded-md border bg-white">
+              <div className="flex items-start justify-between gap-3 border-b px-4 py-3">
+                <div>
+                  <div className="font-medium">Closed trade ledger</div>
+                  <div className="text-xs text-muted-foreground">
+                    strategy/deployment attribution from dry-run track records
+                  </div>
+                </div>
+                <Badge variant="secondary">{dryRunRecentClosed.length} recent</Badge>
+              </div>
+              {dryRunRecentClosed.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No closed dry-run trades yet.
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <div className="min-w-[1040px]">
+                    <div className="grid grid-cols-[1.4fr_1.1fr_0.75fr_0.75fr_0.75fr_0.75fr_1fr_1fr] bg-muted px-4 py-2 text-xs font-medium uppercase text-muted-foreground">
+                      <span>strategy</span>
+                      <span>symbol</span>
+                      <span>side</span>
+                      <span>exit</span>
+                      <span>qty</span>
+                      <span>notional</span>
+                      <span className="text-right">pnl</span>
+                      <span className="text-right">closed</span>
+                    </div>
+                    {dryRunRecentClosed.map((trade) => {
+                      const pnl = toNumber(trade.net_pnl);
+                      return (
+                        <div
+                          key={trade.trade_key ?? `${trade.strategy_id}:${trade.symbol}:${trade.closed_at}`}
+                          className="grid grid-cols-[1.4fr_1.1fr_0.75fr_0.75fr_0.75fr_0.75fr_1fr_1fr] items-center border-t px-4 py-2 text-sm"
+                        >
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">{closedTradeStrategyLabel(trade)}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {trade.strategy_id || 'unknown'} · {trade.runtime_mode || 'unknown'}
+                            </div>
+                          </div>
+                          <div className="min-w-0">
+                            <div className="truncate">{trade.symbol || 'unknown'}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {trade.event_id || trade.trade_key || '-'}
+                            </div>
+                          </div>
+                          <div>{trade.market_side || '-'}</div>
+                          <div>{trade.exit_type}</div>
+                          <div>{formatNumber(toNumber(trade.quantity))}</div>
+                          <div>{formatCurrency(toNumber(trade.notional))}</div>
+                          <div className={cn('text-right font-medium', pnl < 0 ? 'text-destructive' : 'text-success')}>
+                            {formatCurrency(pnl)}
+                          </div>
+                          <div className="text-right text-xs text-muted-foreground">
+                            {trade.closed_at ? formatTimestamp(trade.closed_at) : '-'}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {dryRunOpenPositions.length > 0 ? (
+              <div className="mt-5 rounded-md border bg-white">
+                <div className="flex items-start justify-between gap-3 border-b px-4 py-3">
+                  <div>
+                    <div className="font-medium">Open dry-run positions</div>
+                    <div className="text-xs text-muted-foreground">
+                      current exposure grouped by original strategy/deployment
+                    </div>
+                  </div>
+                  <Badge variant="warning">{dryRunOpenPositions.length} open</Badge>
+                </div>
+                <div className="overflow-x-auto">
+                  <div className="min-w-[900px]">
+                    <div className="grid grid-cols-[1.4fr_1.2fr_0.8fr_0.8fr_0.8fr_1fr] bg-muted px-4 py-2 text-xs font-medium uppercase text-muted-foreground">
+                      <span>strategy</span>
+                      <span>symbol</span>
+                      <span>side</span>
+                      <span>qty</span>
+                      <span>notional</span>
+                      <span className="text-right">opened</span>
+                    </div>
+                    {dryRunOpenPositions.map((position) => (
+                      <div
+                        key={position.trade_key ?? `${position.strategy_id}:${position.symbol}:${position.opened_at}`}
+                        className="grid grid-cols-[1.4fr_1.2fr_0.8fr_0.8fr_0.8fr_1fr] items-center border-t px-4 py-2 text-sm"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate font-medium">
+                            {position.deployment_id || position.strategy_id || position.runtime_mode || 'unknown'}
+                          </div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {position.strategy_id || 'unknown'} · {position.runtime_mode || 'unknown'}
+                          </div>
+                        </div>
+                        <div className="truncate">{position.symbol || 'unknown'}</div>
+                        <div>{position.market_side || '-'}</div>
+                        <div>{formatNumber(toNumber(position.quantity))}</div>
+                        <div>{formatCurrency(toNumber(position.notional))}</div>
+                        <div className="text-right text-xs text-muted-foreground">
+                          {position.opened_at ? formatTimestamp(position.opened_at) : '-'}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+
       <div className="grid grid-cols-1 gap-5 xl:grid-cols-12">
         <div className="space-y-5 xl:col-span-8">
           <Card>
@@ -467,7 +870,19 @@ export function OperatorCockpit() {
                     );
                     const risk = snapshot?.risk;
                     const isDryRun = isDryRunDeployment(deployment);
-                    const pnl = isDryRun ? reportedNetPnl : toNumber(snapshot?.pnl.net_pnl);
+                    const reportStrategy = isDryRun
+                      ? dryRunStrategyByDeployment.get(deployment.deployment_id)
+                      : undefined;
+                    const hasPnl = reportStrategy != null || snapshot != null;
+                    const pnl = reportStrategy
+                      ? toNumber(reportStrategy.summary.realized_pnl)
+                      : toNumber(snapshot?.pnl.net_pnl);
+                    const fees = reportStrategy
+                      ? toNumber(reportStrategy.summary.total_fees)
+                      : toNumber(snapshot?.pnl.total_fees);
+                    const exposure = reportStrategy
+                      ? toNumber(reportStrategy.summary.open_exposure)
+                      : toNumber(risk?.total_gross_exposure);
                     return (
                       <div
                         key={deployment.deployment_id}
@@ -488,9 +903,9 @@ export function OperatorCockpit() {
                           </div>
                         </div>
                         <div className={cn('font-medium', pnl < 0 ? 'text-destructive' : 'text-success')}>
-                          {snapshot || isDryRun ? formatCurrency(pnl) : '-'}
+                          {hasPnl ? formatCurrency(pnl) : '-'}
                           <div className="text-xs font-normal text-muted-foreground">
-                            fees {formatCurrency(isDryRun ? reportedFees : toNumber(snapshot?.pnl.total_fees))}
+                            {hasPnl ? `fees ${formatCurrency(fees)}` : 'no report rows'}
                           </div>
                         </div>
                         <div>
@@ -502,7 +917,7 @@ export function OperatorCockpit() {
                         <div>
                           <div>{deployment.account_id ?? 'default'}</div>
                           <div className="text-xs text-muted-foreground">
-                            {formatCurrency(isDryRun ? reportedOpenExposure : toNumber(risk?.total_gross_exposure))}
+                            {hasPnl ? formatCurrency(exposure) : '-'}
                           </div>
                         </div>
                       </div>

--- a/ploy-frontend/src/types/index.ts
+++ b/ploy-frontend/src/types/index.ts
@@ -20,6 +20,18 @@ export type {
   DeploymentState,
   DeploymentSummary,
   DesiredState,
+  DryRunClosedTradeRow,
+  DryRunDailyRow,
+  DryRunDailyWindowRow,
+  DryRunEquityPoint,
+  DryRunMetrics,
+  DryRunOpenPositionRow,
+  DryRunPairingReport,
+  DryRunPerformanceReport,
+  DryRunStrategyReport,
+  DryRunSummary,
+  DryRunSymbolRow,
+  DryRunWindowRow,
   HeartbeatState,
   HeartbeatStatus,
   IntentPurpose,
@@ -147,116 +159,4 @@ export interface MarketDataHealth {
   sources: MarketDataHealthSource[];
   deribit_iv_samples: DeribitIvSample[];
   deribit_greeks_samples: DeribitGreeksSample[];
-}
-
-export interface DryRunSummary {
-  total_trades: number;
-  closed_trades: number;
-  wins: number;
-  losses: number;
-  win_rate_pct: string | number;
-  realized_pnl: string | number;
-  total_fees: string | number;
-  open_positions: number;
-  open_exposure: string | number;
-  latest_opened_at: string | null;
-  latest_closed_at: string | null;
-}
-
-export interface DryRunDailyRow {
-  trading_day_cst: string;
-  trade_count: number;
-  closed_trade_count: number;
-  wins: number;
-  losses: number;
-  confirmed_trade_count?: number;
-  net_pnl: string | number;
-  confirmed_pnl: string | number;
-  fees: string | number;
-  open_quantity: string | number;
-}
-
-export interface DryRunWindowRow {
-  window_secs: number | null;
-  window_label: string;
-  total_trades: number;
-  closed_trades: number;
-  wins: number;
-  losses: number;
-  win_rate_pct: string | number;
-  realized_pnl: string | number;
-  avg_pnl: string | number | null;
-  avg_entry: string | number | null;
-  min_entry_ttr_secs: number | null;
-  max_entry_ttr_secs: number | null;
-}
-
-export interface DryRunDailyWindowRow {
-  trading_day_cst: string;
-  window_secs: number | null;
-  window_label: string;
-  trade_count: number;
-  closed_trade_count: number;
-  wins: number;
-  losses: number;
-  net_pnl: string | number;
-}
-
-export interface DryRunSymbolRow {
-  symbol: string;
-  window_secs?: number | null;
-  window_label?: string;
-  trades: number;
-  wins: number;
-  losses: number;
-  net_pnl: string | number;
-  avg_entry: string | number | null;
-}
-
-export interface DryRunClosedTradeRow {
-  symbol: string;
-  window_secs?: number | null;
-  window_label?: string;
-  market_side: string;
-  entry_price: string | number | null;
-  exit_price: string | number | null;
-  exit_type: string;
-  quantity: string | number;
-  net_pnl: string | number;
-  entry_time_remaining_secs?: number | null;
-  opened_at: string;
-  closed_at: string;
-}
-
-export interface DryRunOpenPositionRow {
-  symbol: string;
-  window_secs?: number | null;
-  window_label?: string;
-  market_side: string;
-  entry_price: string | number | null;
-  quantity: string | number;
-  notional: string | number;
-  entry_time_remaining_secs?: number | null;
-  opened_at: string;
-}
-
-export interface DryRunPairingReport {
-  pair_key: string;
-  mixed_event_groups: number;
-  fills_in_mixed_event_groups: number;
-  current_view_rows: number;
-  side_aware_rows: number;
-}
-
-export interface DryRunPerformanceReport {
-  generated_at: string;
-  summary: DryRunSummary;
-  by_window: DryRunWindowRow[];
-  daily: DryRunDailyRow[];
-  daily_by_window: DryRunDailyWindowRow[];
-  symbols: DryRunSymbolRow[];
-  symbols_by_window: DryRunSymbolRow[];
-  recent_closed: DryRunClosedTradeRow[];
-  open_positions: DryRunOpenPositionRow[];
-  pairing?: DryRunPairingReport;
 }

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -41,6 +41,32 @@ export interface TradingIntentSnapshot { created_at: string; intent_id: string; 
 
 export interface TradingStateSnapshot { deployment_id: string; fills: FillSnapshot[]; intents: TradingIntentSnapshot[]; orders: OrderSnapshot[]; pnl: PnlSnapshotResponse; positions: PositionSnapshotResponse[]; risk: RiskSnapshotResponse; runtime_mode: string; }
 
+export interface DryRunClosedTradeRow { closed_at?: string | null; deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; exit_price?: number | null; exit_type: string; market_side?: string | null; net_pnl: number; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
+
+export interface DryRunDailyRow { closed_trade_count: number; confirmed_pnl: number; confirmed_trade_count: number; fees: number; losses: number; net_pnl: number; open_quantity: number; trade_count: number; trading_day_cst?: string | null; wins: number; }
+
+export interface DryRunDailyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_day_cst: string; window_label: string; window_secs?: number | null; wins: number; }
+
+export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
+
+export interface DryRunMetrics { avg_trade?: number | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; }
+
+export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; market_side?: string | null; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
+
+export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
+
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+
+export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
+
+export interface DryRunSymbolRow { avg_entry?: number | null; losses: number; net_pnl: number; symbol: string; trades: number; window_label?: string | null; window_secs?: number | null; wins: number; }
+
+export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number | null; closed_trades: number; losses: number; max_entry_ttr_secs?: number | null; min_entry_ttr_secs?: number | null; realized_pnl: number; total_trades: number; win_rate_pct: number; window_label: string; window_secs?: number | null; wins: number; }
+
+export type NumberOrText = number | string;
+
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 
 export interface SystemControlResponse { message: string; success: boolean; }

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -41,6 +41,32 @@ export interface TradingIntentSnapshot { created_at: string; intent_id: string; 
 
 export interface TradingStateSnapshot { deployment_id: string; fills: FillSnapshot[]; intents: TradingIntentSnapshot[]; orders: OrderSnapshot[]; pnl: PnlSnapshotResponse; positions: PositionSnapshotResponse[]; risk: RiskSnapshotResponse; runtime_mode: string; }
 
+export interface DryRunClosedTradeRow { closed_at?: string | null; deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; exit_price?: number | null; exit_type: string; market_side?: string | null; net_pnl: number; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
+
+export interface DryRunDailyRow { closed_trade_count: number; confirmed_pnl: number; confirmed_trade_count: number; fees: number; losses: number; net_pnl: number; open_quantity: number; trade_count: number; trading_day_cst?: string | null; wins: number; }
+
+export interface DryRunDailyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_day_cst: string; window_label: string; window_secs?: number | null; wins: number; }
+
+export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
+
+export interface DryRunMetrics { avg_trade?: number | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; }
+
+export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; market_side?: string | null; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
+
+export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
+
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+
+export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
+
+export interface DryRunSymbolRow { avg_entry?: number | null; losses: number; net_pnl: number; symbol: string; trades: number; window_label?: string | null; window_secs?: number | null; wins: number; }
+
+export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number | null; closed_trades: number; losses: number; max_entry_ttr_secs?: number | null; min_entry_ttr_secs?: number | null; realized_pnl: number; total_trades: number; win_rate_pct: number; window_label: string; window_secs?: number | null; wins: number; }
+
+export type NumberOrText = number | string;
+
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 
 export interface SystemControlResponse { message: string; success: boolean; }

--- a/scripts/export_operator_contract_types.mjs
+++ b/scripts/export_operator_contract_types.mjs
@@ -16,6 +16,7 @@ const schemaFiles = [
   "paper-intent-request.schema.json",
   "paper-intent-response.schema.json",
   "trading-state-snapshot.schema.json",
+  "dry-run-performance-report.schema.json",
   "system-status.schema.json",
   "system-control-response.schema.json",
   "audit-log-entry.schema.json",

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -534,7 +534,8 @@ def main() -> int:
         daily_by_strategy[strategy_key(row)].append(row)
 
     strategies = []
-    for runtime_mode, strategy_id, deployment_id in sorted(events_by_strategy.keys()):
+    strategy_keys = set(events_by_strategy.keys()) | set(daily_by_strategy.keys())
+    for runtime_mode, strategy_id, deployment_id in sorted(strategy_keys):
         strategy_events = events_by_strategy[(runtime_mode, strategy_id, deployment_id)]
         strategy_daily_rows = daily_by_strategy.get((runtime_mode, strategy_id, deployment_id), [])
         strategy_payload = build_report_slice(strategy_events, strategy_daily_rows)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -25,6 +25,61 @@
 - 2026-04-29: Runtime and snapshot optimizer now calibrate the transformed direction probability with `three_layer_probability_shrink` and `three_layer_probability_haircut` before EV scoring. The optimizer now records realized return per stake, predicted-vs-realized EV gap, and penalizes calibration overstatement in both stable and train/validation selection objectives.
 - 2026-04-29: Local verification passed: `rustfmt --edition 2024` on touched Rust files, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-calibrated-expectancy-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`20 passed`), `CARGO_TARGET_DIR=/tmp/ploy-calibrated-expectancy-test rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`31 passed, 103 filtered out`), and `ploy-strategy-bundles` test/example no-run compilation. CI and optimizer reruns remain pending.
 
+# Dry-run Report Contracts And Multi-strategy UI (2026-04-29)
+
+Issue: https://github.com/proerror77/ploy/issues/227
+
+## Files
+
+- `crates/ploy-operator-contracts/src/reports.rs`
+  - Owner: typed dry-run performance report payload matching `scripts/report_dryrun_summary.py`.
+- `crates/ploy-daemon-host/src/http.rs`
+  - Owner: server-side enforcement of the dry-run performance report contract before API responses.
+- `crates/ploy-operator-contracts/src/lib.rs`
+  - Owner: public operator-contract exports for dry-run report types.
+- `crates/ploy-operator-contracts/src/schemas.rs`
+  - Owner: JSON schema registration for dry-run report payloads.
+- `contracts/schemas/dry-run-performance-report.schema.json`
+  - Owner: generated schema snapshot consumed by TypeScript contract generation.
+- `scripts/export_operator_contract_types.mjs`
+  - Owner: generated TypeScript contract type coverage.
+- `scripts/report_dryrun_summary.py`
+  - Owner: dry-run report payload generation and per-strategy grouping.
+- `ploy-frontend/src/types/index.ts`
+  - Owner: frontend type exports for dry-run report data.
+- `ploy-frontend/src/types/operator-contracts.ts`
+  - Owner: generated frontend operator contract types.
+- `ploy-sidecar/src/contracts/operator-contracts.ts`
+  - Owner: generated sidecar operator contract types.
+- `ploy-frontend/src/pages/OperatorCockpit.tsx`
+  - Owner: multi-strategy dry-run equity, attribution, and trade ledger UI.
+- `ploy-frontend/src/components/Layout.tsx`
+  - Owner: explicit dry-run report navigation entry.
+- `tasks/todo.md`
+  - Owner: implementation plan and verification evidence.
+
+## Tasks
+
+- [x] Add first-class operator contract/schema types for the dry-run performance report.
+- [x] Generate frontend and sidecar TypeScript contract types from the schema snapshot.
+- [x] Replace local handwritten dry-run frontend interfaces with generated contract exports.
+- [x] Surface full dry-run equity plus per-strategy equity lines and strategy attribution metrics.
+- [x] Add closed-trade/open-position attribution tables showing strategy, deployment, side, size, and PnL.
+- [x] Enforce the dry-run report contract in the daemon route before returning script output.
+- [x] Keep dry-run deployment runtime rows deployment-specific instead of repeating portfolio totals.
+- [x] Include daily-only strategy rows so stale/no-current-event strategies can still appear.
+- [x] Add direct cockpit navigation for the dry-run report surface.
+- [x] Run focused contract, frontend, and diff verification.
+
+## Review
+
+- 2026-04-29: `report_dryrun_summary.py` already emits root-level full dry-run data plus per-strategy slices grouped by `runtime_mode`, `strategy_id`, and `deployment_id`; the missing boundary was a typed operator contract and a UI that made those distinctions visible.
+- 2026-04-29: Added `DryRunPerformanceReport` and nested row/report types to `ploy-operator-contracts`, preserving nullable timestamps/IDs and `profit_factor` as `number|string` because the report can emit `"Infinity"`.
+- 2026-04-29: OperatorCockpit now shows an aggregate `All dry-run` equity line alongside each strategy line, ranks strategies by realized PnL/closed trades, and includes closed-trade/open-position ledgers with strategy/deployment attribution so losing strategies and order provenance are visible in the history view.
+- 2026-04-29: Review correction: `/api/reports/dry-run` now parses script stdout into `DryRunPerformanceReport` before returning JSON, so script/schema drift fails loudly instead of silently passing through to the frontend.
+- 2026-04-29: Review correction: runtime deployment rows now join to matching report strategy by `deployment_id`, while the strategy table also lists dry-run deployments that have no report rows yet. Cross-strategy equity uses close-time on the x-axis and does not bridge missing strategy points.
+- 2026-04-29: Verification passed: `node scripts/export_operator_contract_types.mjs --check`, `env CARGO_TARGET_DIR=/tmp/ploy-dryrun-contracts /opt/homebrew/bin/timeout 180 cargo run -p ploy-operator-contracts --example export_schemas -- --check`, `python3 -m py_compile scripts/report_dryrun_summary.py`, `cd ploy-frontend && npm run lint`, `cd ploy-frontend && npm run build`, `env CARGO_TARGET_DIR=/tmp/ploy-dryrun-daemon-check /opt/homebrew/bin/timeout 180 cargo check -p ploy-daemon-host`, and `git diff --check`.
+
 # PM5D Expectancy And Fillable-Order Gate (2026-04-29)
 
 ## Files


### PR DESCRIPTION
## Summary
- add a first-class dry-run performance report contract/schema and generated TS types
- validate /api/reports/dry-run script output against the Rust operator contract before returning JSON
- update OperatorCockpit with aggregate + per-strategy equity curves, strategy attribution, closed-trade ledger, and open-position attribution
- keep dry-run deployment runtime rows deployment-specific instead of repeating portfolio-wide totals

## Verification
- node scripts/export_operator_contract_types.mjs --check
- env CARGO_TARGET_DIR=/tmp/ploy-dryrun-contracts /opt/homebrew/bin/timeout 180 cargo run -p ploy-operator-contracts --example export_schemas -- --check
- python3 -m py_compile scripts/report_dryrun_summary.py
- cd ploy-frontend && npm run lint
- cd ploy-frontend && npm run build
- env CARGO_TARGET_DIR=/tmp/ploy-dryrun-daemon-check /opt/homebrew/bin/timeout 180 cargo check -p ploy-daemon-host
- git diff --check

## Notes
- Does not deploy to Tango or run a real dry-run DB report in this PR.
- Follow-up remains to split /dry-run into a dedicated overview/detail route instead of sharing OperatorCockpit.