### PR TITLE
Promote calibrated PM5D champion dry-run candidate

### DIFF
--- a/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
@@ -1,5 +1,5 @@
 # Three-layer champion dry-run config
-# Snapshot optimizer run 25046098829, snapshot 5bfb253100d3f573
+# Snapshot optimizer run 25096720302, snapshot 5bfb253100d3f573
 
 [runtime]
 strategy_variant = "three_layer"
@@ -18,11 +18,11 @@ max_entry_price = 0.85
 no_trade_zone_min = 0.45
 no_trade_zone_max = 0.55
 
-min_edge = 0.0316
+min_edge = 0.0
 
-min_time_remaining_secs = 66
-max_time_remaining_secs = 184
-cooldown_secs = 23
+min_time_remaining_secs = 86
+max_time_remaining_secs = 173
+cooldown_secs = 19
 
 stake_usd = 15.0
 max_positions = 1000
@@ -30,15 +30,17 @@ max_daily_trades = 1000
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "champion"
-three_layer_min_entry_score = 0.088746
-three_layer_min_direction_prob = 0.603473
-three_layer_min_distance_over_sigma = 0.039284
+three_layer_min_entry_score = 0.355216
+three_layer_min_direction_prob = 0.528079
+three_layer_min_distance_over_sigma = 0.085629
 three_layer_min_confirmation_score = 0.0
-three_layer_min_drift_confirmation = 0.00058099
-three_layer_min_edge = -0.017472
-three_layer_min_reward_risk = 0.946405
+three_layer_min_drift_confirmation = 0.00036282
+three_layer_min_edge = 0.0
+three_layer_min_reward_risk = 1.306785
 three_layer_alpha_contrarian = true
 three_layer_cex_contrarian = false
+three_layer_probability_shrink = 0.462909
+three_layer_probability_haircut = 0.0
 three_layer_take_profit_ask = 0.8437
 three_layer_stop_distance_pct = 0.0152
 three_layer_max_pm_lag_secs = 15

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,6 +8,8 @@
   - Owner: runtime probability calibration before executable EV scoring.
 - `crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
   - Owner: optimizer probability calibration search, realized expectancy diagnostics, and calibration penalties.
+- `config/strategies/02-pm5d-threelayer.champion-dryrun.toml`
+  - Owner: calibrated champion dry-run candidate generated from the profitable calibrated optimizer rerun.
 - `tasks/todo.md`
   - Owner: plan, verification evidence, and optimizer rerun notes.
 
@@ -17,13 +19,16 @@
 - [x] Apply calibrated direction probability before runtime EV gates and snapshot EV scoring.
 - [x] Penalize predicted-EV vs realized-fillable-return mismatch in the optimizer objective.
 - [x] Add focused tests for probability calibration and realized expectancy mismatch.
-- [ ] Run formatter/diff checks, CI tests, rerun optimizer, and compare candidates.
+- [x] Run formatter/diff checks, CI tests, rerun optimizer, and compare candidates.
+- [ ] Promote the calibrated champion dry-run config and redeploy dry-run only.
 
 ## Review
 
 - 2026-04-29: Follow-up correction: EV is now explicit, but optimizer results still show predicted EV per stake far above realized fillable PnL per stake. That means raw/transformed direction probability is overconfident for execution; the next fix should calibrate probability and penalize EV overstatement, not discard probability.
 - 2026-04-29: Runtime and snapshot optimizer now calibrate the transformed direction probability with `three_layer_probability_shrink` and `three_layer_probability_haircut` before EV scoring. The optimizer now records realized return per stake, predicted-vs-realized EV gap, and penalizes calibration overstatement in both stable and train/validation selection objectives.
 - 2026-04-29: Local verification passed: `rustfmt --edition 2024` on touched Rust files, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-calibrated-expectancy-test rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`20 passed`), `CARGO_TARGET_DIR=/tmp/ploy-calibrated-expectancy-test rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`31 passed, 103 filtered out`), and `ploy-strategy-bundles` test/example no-run compilation. CI and optimizer reruns remain pending.
+- 2026-04-29: PR #229 merged to `main@9c7d7fbc`; GitHub Test run `25096237797` passed all required jobs, and deploy run `25096440320` succeeded. Tango verification showed `ployd` active/running with `NRestarts=0`, no alerts, no remote cargo/rustc build process, dry-run deployments running, and `pm5d.threelayer.live` still Paused.
+- 2026-04-29: Calibrated optimizer reruns on `main@9c7d7fbc` and snapshot `25029217647`: champion `25096720302` validation PnL `$3,640.74`, DD `$224.74`, trades `341`, fill `100%`, win `44.28%`, realized return/stake `0.7118`, EV gap `0.1085`, positive day/symbol `100%/100%`; obi_soft `25096721695` validation PnL `-$127.99`, DD `$590.04`; continuation_soft `25096723178` validation PnL `-$290.10`, DD `$1,564.88`. Champion is the only calibrated candidate worth promoting to dry-run config; live remains untouched.
 
 # PM5D Expectancy And Fillable-Order Gate (2026-04-29)
 


### PR DESCRIPTION
## Summary
- update only `02-pm5d-threelayer.champion-dryrun.toml` from calibrated optimizer run `25096720302`
- keep runtime mode `dryrun` and stake `15.0`
- record calibrated optimizer comparison: champion profitable, obi_soft/continuation_soft validation negative

## Validation evidence
- champion validation PnL `$3,640.74`, max DD `$224.74`, trades `341`, fill `100%`, win `44.28%`
- realized return/stake `0.7118`, predicted EV/stake `0.8203`, EV gap `0.1085`
- positive day/symbol rates `100%/100%`

## Verification
- python3 tomllib parse of champion dry-run TOML
- git diff --check

## Notes
- Live config and live deployment state are not changed.
