### PR TITLE
Require calibrated PM5D direction gate

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -453,10 +453,6 @@ fn executable_edge_score(edge: f64, params: &SnapshotThreeLayerParams) -> f64 {
     directional_score(edge, executable_edge_threshold(params), 0.08, false)
 }
 
-fn executable_model_edge(row: &FactorObservationV2, params: &SnapshotThreeLayerParams) -> f64 {
-    expected_value_per_share(calibrated_model_probability(row, params), row.entry_ask)
-}
-
 fn directional_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> f64 {
     if !value.is_finite() || !threshold.is_finite() || !scale.is_finite() || scale <= 0.0 {
         return -0.50;
@@ -507,7 +503,12 @@ fn row_passes_gates(
         return false;
     }
 
-    let edge = executable_model_edge(row, params);
+    let direction_probability = calibrated_model_probability(row, params);
+    if !direction_probability.is_finite() || direction_probability < params.min_direction_prob {
+        return false;
+    }
+
+    let edge = expected_value_per_share(direction_probability, row.entry_ask);
     if !edge.is_finite() || edge < executable_edge_threshold(params) {
         return false;
     }
@@ -1611,7 +1612,7 @@ mod tests {
         default_min_trades_from_coverage, directional_score, evaluate_snapshot_objective,
         executable_edge_score, expected_value_per_share, expected_value_per_staked_dollar,
         holistic_selection_objective, max_drawdown, parse_date_end, reward_risk_ratio,
-        sample_power_multiplier, stable_compounding_objective, trade_sharpe,
+        row_passes_gates, sample_power_multiplier, stable_compounding_objective, trade_sharpe,
         transformed_model_probability,
     };
     use chrono::{TimeZone, Utc};
@@ -1916,6 +1917,19 @@ mod tests {
             expected_value_per_staked_dollar(0.57, 0.28)
                 > expected_value_per_staked_dollar(0.72, 0.70),
             "lower probability can still be better when payoff per staked dollar is higher"
+        );
+    }
+
+    #[test]
+    fn snapshot_gate_rejects_cheap_neutral_direction_probability() {
+        let mut params = test_params();
+        params.min_direction_prob = 0.56;
+        params.min_entry_score = 0.0;
+        let row = test_row("event-cheap-neutral", 0.51, 0.12, Some(12.0), true, 0);
+
+        assert!(
+            !row_passes_gates(&row, &params, StrategyProfile::Champion),
+            "cheap executable odds must not pass when calibrated direction probability is below the configured gate"
         );
     }
 

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -511,6 +511,9 @@ fn evaluate_direction_score(
         config.probability_shrink,
         config.probability_haircut,
     );
+    if !effective_p.is_finite() || effective_p < config.min_direction_prob {
+        return None;
+    }
 
     // In contrarian mode the direction is inverted, but the alpha strength is
     // still the distance from 50/50. Do not treat the faded side's raw model
@@ -2023,6 +2026,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
         let mut config = test_config();
         config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
         let mut strategy = ThreeLayerStrategy::new(config);
         discover_test_event(&mut strategy, now);
         let positions = PositionLedger::default();
@@ -2061,6 +2065,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
         let mut config = test_config();
         config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
         let mut strategy = ThreeLayerStrategy::new(config);
         discover_test_event(&mut strategy, now);
         let positions = PositionLedger::default();
@@ -2095,6 +2100,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
         let mut config = test_config();
         config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
         let mut strategy = ThreeLayerStrategy::new(config);
         discover_test_event(&mut strategy, now);
         let positions = PositionLedger::default();
@@ -2207,6 +2213,20 @@ mod tests {
         assert!(
             score > 0.0,
             "direction score should be positive for strong signal"
+        );
+    }
+
+    #[test]
+    fn direction_rejects_when_calibrated_probability_is_neutral() {
+        let mut config = test_config();
+        config.probability_shrink = 0.0;
+        config.probability_haircut = 0.0;
+
+        let result = evaluate_direction_score(2.0, 0.02, 0.0, 0.0, Regime::Early, &config);
+
+        assert!(
+            result.is_none(),
+            "cheap executable odds must not override neutral calibrated direction probability"
         );
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,6 +31,32 @@
 - 2026-04-29: Calibrated optimizer reruns on `main@9c7d7fbc` and snapshot `25029217647`: champion `25096720302` validation PnL `$3,640.74`, DD `$224.74`, trades `341`, fill `100%`, win `44.28%`, realized return/stake `0.7118`, EV gap `0.1085`, positive day/symbol `100%/100%`; obi_soft `25096721695` validation PnL `-$127.99`, DD `$590.04`; continuation_soft `25096723178` validation PnL `-$290.10`, DD `$1,564.88`. Champion is the only calibrated candidate worth promoting to dry-run config; live remains untouched.
 - 2026-04-29: PR #231 merged to `main@f5e2f787`; GitHub Test run `25097131517` passed, and deploy run `25097228117` succeeded. Tango verification after redeploy: `ployd` active/running, `NRestarts=0`, `active_alerts=0`, no cargo/rustc build processes, `pm5d.threelayer.champion.dryrun` desired/observed `Running`, and `pm5d.threelayer.live` desired/observed `Paused`. Remote champion TOML now has `three_layer_probability_shrink=0.462909`, `three_layer_probability_haircut=0.0`, `three_layer_min_entry_score=0.355216`, and dry-run mode with `stake_usd=15.0`.
 
+# PM5D Tango Dry-run Expectancy Monitoring (2026-04-29)
+
+## Files
+
+- `scripts/report_dryrun_summary.py`
+  - Owner: side-aware dry-run reporting and raw-fill reconciliation checks.
+- `tasks/todo.md`
+  - Owner: current monitoring plan, evidence, and decision notes.
+
+## Tasks
+
+- [x] Verify Tango deployment state, no active alerts, no on-host Rust build, and live still paused.
+- [x] Inspect raw `strategy_runtime_*` schema and confirm report aggregation uses a side-aware/fillable execution view.
+- [x] Recompute current dry-run metrics from real orders/fills by `deployment_id`, including PnL, drawdown, fill coverage, return per stake, side/symbol concentration, and sample size.
+- [x] Decide whether the next action is report repair, more dry-run monitoring, or a dry-run-only strategy/config correction.
+- [x] Verify the direction-probability gate correction with focused checks.
+- [ ] Land via PR and deploy dry-run-only from `main`; keep live untouched.
+
+## Review
+
+- 2026-04-29: User correction for continuation: do not optimize by win rate alone. Direction probability remains important, but entry/promotion must be judged by executable expected value and realized fillable order performance: PnL, drawdown, fill rate, return per stake, EV gap, symbol/day coverage, and concentration.
+- 2026-04-29: Tango source-of-truth check showed `ployd` active/running, `NRestarts=0`, `active_alerts=0`, no cargo/rustc on host, dry-run deployments running, and `pm5d.threelayer.live` desired/observed `Paused`. Deployment IDs currently monitored: `pm5d.threelayer.champion.dryrun`, `pm5d.threelayer.continuation-soft.dryrun`, `pm5d.threelayer.dryrun`, and `pm5d.threelayer.obi-soft.dryrun`.
+- 2026-04-29: Raw order/fill validation used `strategy_runtime_orders`, `strategy_runtime_fills`, and `strategy_runtime_event_track_record`. Post-deploy orders were all `FILLED` with `quantity_fill_ratio=1.0`; this is a real filled-order sample, not a signal-only sample. Current post-deploy closed sample is still small and negative across all four deployments, so it is not enough to promote a different candidate by PnL alone.
+- 2026-04-29: Found a strategy semantics bug from runtime logs: entries could pass with calibrated `p_hat` near `0.50` when cheap executable price and PM momentum lifted total score above threshold. Fixed runtime and snapshot optimizer so `three_layer_min_direction_prob` is a hard gate on calibrated direction probability before EV/entry scoring. Direction probability stays as alpha input; EV remains the execution-scale gate after probability passes.
+- 2026-04-29: Focused verification passed after the hard direction-probability gate: `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`32 passed, 103 filtered out`), and `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`21 passed`).
+
 # Dry-run Report Contracts And Multi-strategy UI (2026-04-29)
 
 Issue: https://github.com/proerror77/ploy/issues/227


### PR DESCRIPTION
## Summary
- make PM5D three-layer runtime reject entries when calibrated direction probability is below three_layer_min_direction_prob
- align snapshot optimizer row gating with the same calibrated direction-probability hard gate
- record Tango dry-run evidence and verification in tasks/todo.md

## Verification
- rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib
- CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features

Live remains untouched; deploy path should remain main -> deploy-tango-1-1 dry-run verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved direction probability validation to properly enforce minimum probability thresholds in strategy evaluation.

* **Tests**
  * Added test coverage for probability validation edge cases.

* **Documentation**
  * Updated monitoring plan with verification findings and next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->