### PR TITLE
Keep PM5D optimizer from neutral direction gates

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -20,6 +20,9 @@ use ploy_research::{
 };
 use serde::Serialize;
 
+const OPTIMIZER_MIN_DIRECTION_PROB: f64 = 0.525;
+const OPTIMIZER_MAX_DIRECTION_PROB: f64 = 0.68;
+
 #[derive(Debug, Clone, Copy, Serialize)]
 struct SnapshotThreeLayerParams {
     min_direction_prob: f64,
@@ -1269,7 +1272,9 @@ fn main() -> Result<()> {
     let train_rows = Arc::new(train_rows);
     let val_rows = Arc::new(val_rows);
     let study: Study<f64> = Study::maximize(TpeSampler::new());
-    let p_min_direction_prob = FloatParam::new(0.50, 0.68).name("three_layer_min_direction_prob");
+    let p_min_direction_prob =
+        FloatParam::new(OPTIMIZER_MIN_DIRECTION_PROB, OPTIMIZER_MAX_DIRECTION_PROB)
+            .name("three_layer_min_direction_prob");
     let p_min_distance_over_sigma =
         FloatParam::new(-0.20, 0.60).name("three_layer_min_distance_over_sigma");
     let p_min_confirmation_score =
@@ -1398,7 +1403,9 @@ fn main() -> Result<()> {
         .context("no completed optimizer trials")?;
     let best_min_time_remaining_secs = best.get(&p_min_time_remaining_secs).unwrap_or(30);
     let best_params = SnapshotThreeLayerParams {
-        min_direction_prob: best.get(&p_min_direction_prob).unwrap_or(0.52),
+        min_direction_prob: best
+            .get(&p_min_direction_prob)
+            .unwrap_or(OPTIMIZER_MIN_DIRECTION_PROB),
         min_distance_over_sigma: best.get(&p_min_distance_over_sigma).unwrap_or(0.10),
         min_confirmation_score: strategy_profile
             .fixes_confirmation_threshold()
@@ -1607,7 +1614,8 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        SnapshotObjectiveMetrics, SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
+        OPTIMIZER_MAX_DIRECTION_PROB, OPTIMIZER_MIN_DIRECTION_PROB, SnapshotObjectiveMetrics,
+        SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
         calibrate_direction_probability, calibrated_model_probability, compounded_log_growth,
         default_min_trades_from_coverage, directional_score, evaluate_snapshot_objective,
         executable_edge_score, expected_value_per_share, expected_value_per_staked_dollar,
@@ -1918,6 +1926,15 @@ mod tests {
                 > expected_value_per_staked_dollar(0.72, 0.70),
             "lower probability can still be better when payoff per staked dollar is higher"
         );
+    }
+
+    #[test]
+    fn optimizer_search_keeps_direction_probability_meaningful() {
+        assert!(
+            OPTIMIZER_MIN_DIRECTION_PROB > 0.50,
+            "optimizer must not search neutral direction-probability gates"
+        );
+        assert!(OPTIMIZER_MIN_DIRECTION_PROB < OPTIMIZER_MAX_DIRECTION_PROB);
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,7 +47,9 @@
 - [x] Recompute current dry-run metrics from real orders/fills by `deployment_id`, including PnL, drawdown, fill coverage, return per stake, side/symbol concentration, and sample size.
 - [x] Decide whether the next action is report repair, more dry-run monitoring, or a dry-run-only strategy/config correction.
 - [x] Verify the direction-probability gate correction with focused checks.
+- [x] Prevent optimizer reruns from rediscovering a neutral `0.50` direction-probability gate.
 - [ ] Land via PR and deploy dry-run-only from `main`; keep live untouched.
+- [ ] Rerun optimizer after the direction-probability lower-bound fix and compare by full executable-EV metrics.
 
 ## Review
 
@@ -56,6 +58,8 @@
 - 2026-04-29: Raw order/fill validation used `strategy_runtime_orders`, `strategy_runtime_fills`, and `strategy_runtime_event_track_record`. Post-deploy orders were all `FILLED` with `quantity_fill_ratio=1.0`; this is a real filled-order sample, not a signal-only sample. Current post-deploy closed sample is still small and negative across all four deployments, so it is not enough to promote a different candidate by PnL alone.
 - 2026-04-29: Found a strategy semantics bug from runtime logs: entries could pass with calibrated `p_hat` near `0.50` when cheap executable price and PM momentum lifted total score above threshold. Fixed runtime and snapshot optimizer so `three_layer_min_direction_prob` is a hard gate on calibrated direction probability before EV/entry scoring. Direction probability stays as alpha input; EV remains the execution-scale gate after probability passes.
 - 2026-04-29: Focused verification passed after the hard direction-probability gate: `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`32 passed, 103 filtered out`), and `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`21 passed`).
+- 2026-04-29: Post-deploy optimizer rerun exposed a second issue: the optimizer search space could still choose `three_layer_min_direction_prob=0.500000`, turning the hard gate into a neutral gate. Raised the optimizer search lower bound to `0.525` so subsequent candidates must retain directional alpha before EV/fillable-price scoring.
+- 2026-04-29: Focused verification for the optimizer lower-bound fix passed: `rustfmt --edition 2024 crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, and `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-bound-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`22 passed`).
 
 # Dry-run Report Contracts And Multi-strategy UI (2026-04-29)
 


### PR DESCRIPTION
## Summary
- Raise the snapshot optimizer `three_layer_min_direction_prob` search lower bound from neutral `0.500` to `0.525`.
- Add constants and a regression test so optimizer reruns cannot silently emit neutral direction gates again.
- Record the follow-up decision and verification in `tasks/todo.md`.

## Verification
- `rustfmt --edition 2024 crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-bound-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`22 passed`)

## Notes
- This does not touch live settings.
- Optimizer reruns should be relaunched after this lands on `main`, then judged by executable EV/PnL/drawdown/fill/coverage metrics rather than win rate alone.