### PR TITLE
Hide stopped drill manifests from dry-run rankings

### DIFF
--- a/ploy-frontend/src/pages/DryRunReport.tsx
+++ b/ploy-frontend/src/pages/DryRunReport.tsx
@@ -120,6 +120,16 @@ function isDryRunDeployment(deployment: DeploymentSummary) {
   return isDryRunId(deployment.deployment_id);
 }
 
+function shouldShowUnreportedDryRunDeployment(deployment: DeploymentSummary, snapshot?: TradingStateSnapshot) {
+  if (snapshot) return true;
+  return (
+    deployment.desired_state === 'running' ||
+    deployment.observed_state === 'running' ||
+    deployment.observed_state === 'starting' ||
+    deployment.observed_state === 'degraded'
+  );
+}
+
 function isDryRunSnapshot(snapshot: TradingStateSnapshot) {
   return isDryRunId(snapshot.deployment_id) || isDryRunId(snapshot.runtime_mode);
 }
@@ -545,7 +555,10 @@ export function DryRunReport() {
 
     const reportedDeploymentIds = new Set(reported.map((row) => row.deploymentId));
     const missing = dryRunDeployments
-      .filter((deployment) => !reportedDeploymentIds.has(deployment.deployment_id))
+      .filter((deployment) => {
+        if (reportedDeploymentIds.has(deployment.deployment_id)) return false;
+        return shouldShowUnreportedDryRunDeployment(deployment, snapshotByDeployment.get(deployment.deployment_id));
+      })
       .map((deployment): StrategySurfaceRow => {
         const snapshot = snapshotByDeployment.get(deployment.deployment_id);
         const pnl = toNumber(snapshot?.pnl.net_pnl);

--- a/ploy-frontend/src/pages/OperatorCockpit.tsx
+++ b/ploy-frontend/src/pages/OperatorCockpit.tsx
@@ -91,6 +91,16 @@ function isDryRunDeployment(deployment: DeploymentSummary) {
   return isDryRunId(deployment.deployment_id);
 }
 
+function shouldShowUnreportedDryRunDeployment(deployment: DeploymentSummary, snapshot?: TradingStateSnapshot) {
+  if (snapshot) return true;
+  return (
+    deployment.desired_state === 'running' ||
+    deployment.observed_state === 'running' ||
+    deployment.observed_state === 'starting' ||
+    deployment.observed_state === 'degraded'
+  );
+}
+
 function compactTime(timestamp?: string | null) {
   if (!timestamp) return '-';
   return new Date(timestamp).toLocaleTimeString('zh-CN', {
@@ -442,8 +452,14 @@ export function OperatorCockpit() {
     }
     return byDeployment;
   }, [dryRunStrategies]);
+  const tradingByDeployment = useMemo(
+    () => new Map(dryRunTrading.map((snapshot) => [snapshot.deployment_id, snapshot])),
+    [dryRunTrading]
+  );
   const unreportedDryRunDeployments = dryRunDeployments.filter(
-    (deployment) => !dryRunStrategyByDeployment.has(deployment.deployment_id)
+    (deployment) =>
+      !dryRunStrategyByDeployment.has(deployment.deployment_id) &&
+      shouldShowUnreportedDryRunDeployment(deployment, tradingByDeployment.get(deployment.deployment_id))
   );
 
   const eventAge = lastEventAt == null ? null : Math.max(0, Math.round((Date.now() - lastEventAt) / 1000));


### PR DESCRIPTION
## Summary
- keep reported dry-run strategy rows authoritative
- only show fallback deployment rows when the deployment is active or has a trading snapshot
- removes stopped example drill manifests from the dry-run strategy ranking

## Verification
- npm run lint
- npm run build