### PR TITLE
Separate PM5D alpha gating from calibrated EV

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -368,7 +368,8 @@ fn three_layer_entry_score(
     params: &SnapshotThreeLayerParams,
     profile: StrategyProfile,
 ) -> f64 {
-    let alpha_prob = calibrated_model_probability(row, params);
+    let alpha_prob = direction_alpha_probability(row, params);
+    let calibrated_prob = calibrated_model_probability(row, params);
     let direction_score = directional_score(alpha_prob, params.min_direction_prob, 0.25, false);
     let distance_score = directional_score(
         row.side_distance_over_sigma,
@@ -378,7 +379,7 @@ fn three_layer_entry_score(
     );
     let per_share_edge_score = executable_edge_score(edge, params);
     let per_stake_expectancy_score = directional_score(
-        expected_value_per_staked_dollar(alpha_prob, row.entry_ask),
+        expected_value_per_staked_dollar(calibrated_prob, row.entry_ask),
         0.0,
         0.25,
         false,
@@ -437,12 +438,19 @@ fn transformed_model_probability(side_model_prob: f64, alpha_contrarian: bool) -
     }
 }
 
+fn direction_alpha_probability(
+    row: &FactorObservationV2,
+    params: &SnapshotThreeLayerParams,
+) -> f64 {
+    transformed_model_probability(row.side_model_prob, params.alpha_contrarian)
+}
+
 fn calibrated_model_probability(
     row: &FactorObservationV2,
     params: &SnapshotThreeLayerParams,
 ) -> f64 {
     calibrate_direction_probability(
-        transformed_model_probability(row.side_model_prob, params.alpha_contrarian),
+        direction_alpha_probability(row, params),
         params.probability_shrink,
         params.probability_haircut,
     )
@@ -506,11 +514,12 @@ fn row_passes_gates(
         return false;
     }
 
-    let direction_probability = calibrated_model_probability(row, params);
-    if !direction_probability.is_finite() || direction_probability < params.min_direction_prob {
+    let direction_alpha = direction_alpha_probability(row, params);
+    if !direction_alpha.is_finite() || direction_alpha < params.min_direction_prob {
         return false;
     }
 
+    let direction_probability = calibrated_model_probability(row, params);
     let edge = expected_value_per_share(direction_probability, row.entry_ask);
     if !edge.is_finite() || edge < executable_edge_threshold(params) {
         return false;
@@ -1617,11 +1626,11 @@ mod tests {
         OPTIMIZER_MAX_DIRECTION_PROB, OPTIMIZER_MIN_DIRECTION_PROB, SnapshotObjectiveMetrics,
         SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
         calibrate_direction_probability, calibrated_model_probability, compounded_log_growth,
-        default_min_trades_from_coverage, directional_score, evaluate_snapshot_objective,
-        executable_edge_score, expected_value_per_share, expected_value_per_staked_dollar,
-        holistic_selection_objective, max_drawdown, parse_date_end, reward_risk_ratio,
-        row_passes_gates, sample_power_multiplier, stable_compounding_objective, trade_sharpe,
-        transformed_model_probability,
+        default_min_trades_from_coverage, direction_alpha_probability, directional_score,
+        evaluate_snapshot_objective, executable_edge_score, expected_value_per_share,
+        expected_value_per_staked_dollar, holistic_selection_objective, max_drawdown,
+        parse_date_end, reward_risk_ratio, row_passes_gates, sample_power_multiplier,
+        stable_compounding_objective, trade_sharpe, transformed_model_probability,
     };
     use chrono::{TimeZone, Utc};
     use ploy_research::{FactorObservationV2, Regime, ReviewSide};
@@ -1946,7 +1955,24 @@ mod tests {
 
         assert!(
             !row_passes_gates(&row, &params, StrategyProfile::Champion),
-            "cheap executable odds must not pass when calibrated direction probability is below the configured gate"
+            "cheap executable odds must not pass when directional alpha is below the configured gate"
+        );
+    }
+
+    #[test]
+    fn snapshot_gate_uses_alpha_probability_before_calibrated_ev() {
+        let mut params = test_params();
+        params.min_direction_prob = 0.56;
+        params.probability_shrink = 0.0;
+        params.probability_haircut = 0.0;
+        params.min_entry_score = 0.0;
+        let row = test_row("event-strong-alpha-cheap", 0.70, 0.12, Some(12.0), true, 0);
+
+        assert!(direction_alpha_probability(&row, &params) >= params.min_direction_prob);
+        assert!((calibrated_model_probability(&row, &params) - 0.50).abs() < 1e-9);
+        assert!(
+            row_passes_gates(&row, &params, StrategyProfile::Champion),
+            "strong directional alpha should reach calibrated EV scoring instead of being double-gated by probability shrink"
         );
     }
 

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -454,12 +454,13 @@ fn evaluate_entry_score(config: &ThreeLayerConfig, inputs: EntryScoreInputs) -> 
 }
 
 /// Layer 1: Direction score (0.0 – 1.0).
-/// Returns Some((direction_sign, effective_probability, direction_score)) or None
+/// Returns Some((direction_sign, calibrated_probability, direction_score)) or None
 /// only when the signal is too weak to even consider (below minimum distance in Early).
 ///
 /// In snapshot-scored profiles, contrarian mode inverts the direction but keeps
 /// the transformed alpha probability monotonic: stronger inverse alpha scores
-/// higher, and execution edge is evaluated separately.
+/// higher. The hard direction gate uses raw alpha strength, while execution EV
+/// is evaluated with the calibrated probability.
 fn evaluate_direction_score(
     distance_over_sigma: f64,
     _sigma_horizon: f64,
@@ -506,12 +507,16 @@ fn evaluate_direction_score(
     } else {
         (-1.0_f64, 1.0 - direction_prob)
     };
+    if !raw_effective_p.is_finite() || raw_effective_p < config.min_direction_prob {
+        return None;
+    }
+
     let effective_p = calibrate_direction_probability(
         raw_effective_p,
         config.probability_shrink,
         config.probability_haircut,
     );
-    if !effective_p.is_finite() || effective_p < config.min_direction_prob {
+    if !effective_p.is_finite() {
         return None;
     }
 
@@ -519,7 +524,7 @@ fn evaluate_direction_score(
     // still the distance from 50/50. Do not treat the faded side's raw model
     // probability as the executable probability.
     let direction_score = if config.profile.uses_snapshot_scoring() {
-        threshold_score(effective_p, config.min_direction_prob, 0.25, false)
+        threshold_score(raw_effective_p, config.min_direction_prob, 0.25, false)
     } else {
         ((effective_p - 0.50) / 0.50).clamp(0.0, 1.0)
     };
@@ -2217,16 +2222,32 @@ mod tests {
     }
 
     #[test]
-    fn direction_rejects_when_calibrated_probability_is_neutral() {
+    fn direction_rejects_when_raw_alpha_probability_is_neutral() {
+        let config = test_config();
+
+        let result = evaluate_direction_score(0.05, 0.02, 0.0, 0.0, Regime::Middle, &config);
+
+        assert!(
+            result.is_none(),
+            "cheap executable odds must not override neutral directional alpha"
+        );
+    }
+
+    #[test]
+    fn direction_gate_allows_strong_alpha_to_reach_calibrated_ev() {
         let mut config = test_config();
+        config.profile = ThreeLayerProfile::Champion;
         config.probability_shrink = 0.0;
         config.probability_haircut = 0.0;
 
         let result = evaluate_direction_score(2.0, 0.02, 0.0, 0.0, Regime::Early, &config);
 
+        let (_dir, prob, score) =
+            result.expect("strong raw directional alpha should pass the direction gate");
+        assert!((prob - 0.50).abs() < 1e-9);
         assert!(
-            result.is_none(),
-            "cheap executable odds must not override neutral calibrated direction probability"
+            score > 0.0,
+            "direction score should remain based on alpha strength before EV calibration"
         );
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -83,7 +83,8 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - [x] Verify the direction-probability gate correction with focused checks.
 - [x] Prevent optimizer reruns from rediscovering a neutral `0.50` direction-probability gate.
 - [ ] Land via PR and deploy dry-run-only from `main`; keep live untouched.
-- [ ] Rerun optimizer after the direction-probability lower-bound fix and compare by full executable-EV metrics.
+- [x] Rerun optimizer after the direction-probability lower-bound fix and compare by full executable-EV metrics.
+- [x] Decouple raw directional-alpha gating from calibrated EV probability, then rerun optimizer.
 
 ## Review
 
@@ -94,6 +95,10 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - 2026-04-29: Focused verification passed after the hard direction-probability gate: `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`32 passed, 103 filtered out`), and `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-gate-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`21 passed`).
 - 2026-04-29: Post-deploy optimizer rerun exposed a second issue: the optimizer search space could still choose `three_layer_min_direction_prob=0.500000`, turning the hard gate into a neutral gate. Raised the optimizer search lower bound to `0.525` so subsequent candidates must retain directional alpha before EV/fillable-price scoring.
 - 2026-04-29: Focused verification for the optimizer lower-bound fix passed: `rustfmt --edition 2024 crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, and `CARGO_TARGET_DIR=/tmp/ploy-direction-prob-bound-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`22 passed`).
+- 2026-04-29: PR #236 merged to `main@3fdeb48e`; deploy run `25103076272` succeeded. Tango verification showed `ployd` active/running with `NRestarts=0`, `active_alert_count=0`, no cargo/rustc process, PM5D dry-run deployments running, and `pm5d.threelayer.live` still Paused.
+- 2026-04-29: Post-bound optimizer reruns (`25103416008` champion, `25103417798` obi_soft, `25103419812` continuation_soft, `25103421469` mixed) all failed promotion criteria. Champion/obi/continuation were validation-underpowered with only `1`/`1`/`2` validation trades; mixed had `7` validation trades and negative validation PnL. No candidate should be promoted from this batch.
+- 2026-04-29: The underpowered reruns show the calibrated-probability hard gate is too restrictive when paired with probability shrink/haircut. Next correction decouples the hard direction gate from calibration: raw transformed alpha probability must clear `three_layer_min_direction_prob`, while calibrated probability remains the EV/executable-price input.
+- 2026-04-29: Runtime and snapshot optimizer now gate on raw transformed directional alpha, while calibrated probability remains the executable-EV input. Focused verification passed: `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`33 passed, 103 filtered out`), and `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`23 passed`).
 
 # Dry-run Report Contracts And Multi-strategy UI (2026-04-29)
 


### PR DESCRIPTION
## Summary
- Gate PM5D entries on raw transformed directional alpha so direction probability remains a hard requirement.
- Keep calibrated probability as the executable-EV input, so shrink/haircut correct overconfident expected value without double-gating sample coverage.
- Mirror the runtime semantics in the snapshot optimizer and add regression tests for both neutral-alpha rejection and strong-alpha calibrated-EV scoring.

## Evidence
- Post-bound optimizer reruns after PR #236 were not promotion-grade: champion/obi/continuation had only 1/1/2 validation trades; mixed had 7 validation trades and negative PnL.
- This change addresses that failure mode before any new candidate is considered.

## Verification
- `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`33 passed, 103 filtered out`)
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`23 passed`)

## Notes
- No live config is changed.
- Optimizer reruns must be repeated after this lands, and judged by PnL, drawdown, fill rate, return per stake, EV gap, symbol/day coverage, and concentration, not win rate alone.