### PR TITLE
Sample stronger PM5D champion in dry-run

### DIFF
--- a/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
@@ -1,5 +1,6 @@
 # Three-layer champion dry-run config
-# Snapshot optimizer run 25096720302, snapshot 5bfb253100d3f573
+# Snapshot optimizer run 25105940653, snapshot 5bfb253100d3f573
+# Dry-run-only candidate: validation was 199/200 trades, so this is for real filled-order sampling, not live promotion.
 
 [runtime]
 strategy_variant = "three_layer"
@@ -20,9 +21,9 @@ no_trade_zone_max = 0.55
 
 min_edge = 0.0
 
-min_time_remaining_secs = 86
-max_time_remaining_secs = 173
-cooldown_secs = 19
+min_time_remaining_secs = 99
+max_time_remaining_secs = 190
+cooldown_secs = 44
 
 stake_usd = 15.0
 max_positions = 1000
@@ -30,17 +31,17 @@ max_daily_trades = 1000
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "champion"
-three_layer_min_entry_score = 0.355216
-three_layer_min_direction_prob = 0.528079
-three_layer_min_distance_over_sigma = 0.085629
+three_layer_min_entry_score = 0.436535
+three_layer_min_direction_prob = 0.518337
+three_layer_min_distance_over_sigma = 0.555811
 three_layer_min_confirmation_score = 0.0
-three_layer_min_drift_confirmation = 0.00036282
-three_layer_min_edge = 0.0
-three_layer_min_reward_risk = 1.306785
+three_layer_min_drift_confirmation = -0.00019681
+three_layer_min_edge = 0.012595
+three_layer_min_reward_risk = 1.886977
 three_layer_alpha_contrarian = true
 three_layer_cex_contrarian = false
-three_layer_probability_shrink = 0.462909
-three_layer_probability_haircut = 0.0
+three_layer_probability_shrink = 0.751883
+three_layer_probability_haircut = 0.062327
 three_layer_take_profit_ask = 0.8437
 three_layer_stop_distance_pct = 0.0152
 three_layer_max_pm_lag_secs = 15

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -86,6 +86,7 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - [x] Rerun optimizer after the direction-probability lower-bound fix and compare by full executable-EV metrics.
 - [x] Decouple raw directional-alpha gating from calibrated EV probability, then rerun optimizer.
 - [x] Widen non-neutral optimizer direction search from `0.525` to `0.515` and rerun optimizer.
+- [ ] Promote the strongest near-powered champion candidate to dry-run only for real filled-order sampling.
 
 ## Review
 
@@ -102,6 +103,7 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - 2026-04-29: Runtime and snapshot optimizer now gate on raw transformed directional alpha, while calibrated probability remains the executable-EV input. Focused verification passed: `rustfmt --edition 2024 crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`33 passed, 103 filtered out`), and `CARGO_TARGET_DIR=/tmp/ploy-alpha-ev-decouple-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`23 passed`).
 - 2026-04-29: PR #239 merged to `main@47909153`; deploy run `25104259509` succeeded. Tango verification showed `ployd` active/running with `NRestarts=0`, `active_alert_count=0`, no cargo/rustc process, PM5D dry-run deployments running, and `pm5d.threelayer.live` still Paused. Post-decoupling optimizer reruns (`25104557967` champion, `25104559763` obi_soft, `25104561219` continuation_soft, `25104562806` mixed) improved PnL but were still validation-underpowered: continuation_soft had validation PnL `+1124.04`, DD `15.26`, EV gap `0`, but only `23` trades; champion had `17`, mixed `8`, obi_soft `5`. No candidate should be promoted yet.
 - 2026-04-29: Widened optimizer direction-probability search lower bound from `0.525` to `0.515` after the post-decoupling runs still selected the lower bound and remained underpowered. This remains non-neutral (`>0.50`) while giving EV/fillable-price selection more room. Focused verification passed: `rustfmt --edition 2024 crates/ploy-research/examples/three_layer_snapshot_optimize.rs`, `git diff --check`, and `CARGO_TARGET_DIR=/tmp/ploy-direction-bound-515-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`23 passed`).
+- 2026-04-29: With `0.515` search bound, shifted-window champion run `25105940653` was the strongest candidate but still technically validation-underpowered by one trade: validation PnL `+7322.43`, trades `199/200`, max DD `120.06`, fill rate `88.05%`, reject rate `11.95%`, avg realized return/stake `2.4531`, EV gap `0`, positive day/symbol `100%/100%`, concentration `52.61%`. Because it is not live-ready by the optimizer's own sample gate, it is only being promoted to `pm5d.threelayer.champion.dryrun` for real filled-order sampling.
 
 # Dry-run Report Contracts And Multi-strategy UI (2026-04-29)
 


### PR DESCRIPTION
## Summary
- Update only `pm5d.threelayer.champion.dryrun` with the strongest corrected optimizer candidate from run `25105940653`.
- Keep live untouched and explicitly label the config as dry-run-only sampling, not live promotion.
- Record the full-metric caveat in `tasks/todo.md`: validation was 199/200 trades, so this still needs Tango filled-order evidence.

## Candidate Evidence
- shifted-window champion, run `25105940653`, snapshot `5bfb253100d3f573`
- validation PnL `+7322.43`
- validation trades `199/200` dynamic floor
- max drawdown `120.06`
- fill rate `88.05%`, reject rate `11.95%`
- avg realized return/stake `2.4531`
- EV gap `0`
- positive day/symbol `100%/100%`
- concentration `52.61%`

## Verification
- `python3` tomllib parsed `config/strategies/02-pm5d-threelayer.champion-dryrun.toml`
- `git diff --check`

## Notes
- This is not a live-ready claim because the optimizer still marked the candidate validation-underpowered by one trade.
- The purpose is to collect real filled-order dry-run evidence on Tango.