### PR TITLE
Expose dry-run report accounting diagnostics

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -45,6 +45,7 @@ env:
     035_binance_agg_trade_ticks.sql
     036_research_valid_windows_matview.sql
     037_research_time_conditioned_factor_metrics.sql
+    039_fix_strategy_track_record_side_key.sql
     038_track_record_official_residual_settlement.sql
 
 jobs:

--- a/migrations/039_fix_strategy_track_record_side_key.sql
+++ b/migrations/039_fix_strategy_track_record_side_key.sql
@@ -1,0 +1,190 @@
+-- Migration: 038_fix_strategy_track_record_side_key
+-- Description: Keep strategy runtime track-record rows side-aware.
+--
+-- The event track-record view previously grouped fills by trade_key only. For
+-- Polymarket binary markets, one event can have multiple tokens/sides, so
+-- grouping only by event/intent can merge UP and DOWN legs before reports see
+-- them. Keep token_id and market_side in the grouping key.
+
+DROP VIEW IF EXISTS strategy_runtime_daily_track_record;
+DROP VIEW IF EXISTS strategy_runtime_event_track_record;
+
+CREATE VIEW strategy_runtime_event_track_record AS
+WITH settlement_prices AS (
+    SELECT
+        token_id,
+        CASE
+            WHEN settled_price >= 0.99 THEN 1.0::NUMERIC
+            WHEN settled_price <= 0.01 THEN 0.0::NUMERIC
+            ELSE settled_price
+        END AS official_price
+    FROM pm_token_settlements
+    WHERE resolved = true
+),
+normalized_fills AS (
+    SELECT
+        f.runtime_mode,
+        f.strategy_id,
+        f.deployment_id,
+        COALESCE(NULLIF(f.event_id, ''), f.intent_id) AS trade_key,
+        f.event_id,
+        f.intent_id,
+        f.symbol,
+        f.token_id,
+        f.market_side,
+        f.fill_side,
+        f.quantity,
+        f.price AS recorded_price,
+        sp.official_price AS official_settlement_price,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE 'settle_%'
+                AND sp.official_price IS NOT NULL
+            THEN sp.official_price
+            ELSE f.price
+        END AS effective_price,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE 'settle_%'
+                AND sp.official_price IS NOT NULL
+                AND ABS(f.price - sp.official_price) > 0.00000001::NUMERIC
+            THEN true
+            ELSE false
+        END AS settlement_corrected,
+        f.fee,
+        f.fill_timestamp
+    FROM strategy_runtime_fills f
+    LEFT JOIN settlement_prices sp ON sp.token_id = f.token_id
+),
+aggregated AS (
+    SELECT
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        token_id,
+        market_side,
+        MAX(event_id) AS event_id,
+        MIN(intent_id) AS intent_id,
+        MAX(symbol) AS symbol,
+        BOOL_OR(settlement_corrected) AS settlement_corrected,
+        MIN(fill_timestamp) AS first_fill_at,
+        MAX(fill_timestamp) AS last_fill_at,
+        MIN(fill_timestamp) FILTER (WHERE fill_side = 'BUY') AS opened_at,
+        MAX(fill_timestamp) FILTER (WHERE fill_side = 'SELL') AS closed_at,
+        COUNT(*) AS fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'BUY') AS buy_fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'SELL') AS sell_fill_count,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'BUY'), 0::NUMERIC) AS buy_quantity,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'SELL'), 0::NUMERIC) AS sell_quantity,
+        COALESCE(
+            SUM(quantity * recorded_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS recorded_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'BUY'),
+            0::NUMERIC
+        ) AS buy_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS sell_notional,
+        MAX(official_settlement_price) FILTER (
+            WHERE fill_side = 'SELL'
+              AND intent_id LIKE 'settle_%'
+              AND official_settlement_price IS NOT NULL
+        ) AS official_exit_price,
+        BOOL_OR(
+            fill_side = 'SELL'
+            AND intent_id LIKE 'settle_%'
+            AND official_settlement_price IS NOT NULL
+        ) AS has_official_settlement,
+        COALESCE(SUM(fee), 0::NUMERIC) AS total_fee
+    FROM normalized_fills
+    GROUP BY
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        token_id,
+        market_side
+)
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    trade_key,
+    event_id,
+    intent_id,
+    symbol,
+    token_id,
+    market_side,
+    first_fill_at,
+    last_fill_at,
+    opened_at,
+    closed_at,
+    fill_count,
+    buy_fill_count,
+    sell_fill_count,
+    buy_quantity,
+    sell_quantity,
+    buy_notional,
+    sell_notional,
+    recorded_sell_notional,
+    total_fee,
+    CASE
+        WHEN buy_quantity > 0 THEN buy_notional / buy_quantity
+        ELSE NULL
+    END AS avg_entry_price,
+    CASE
+        WHEN sell_quantity > 0 THEN recorded_sell_notional / sell_quantity
+        ELSE NULL
+    END AS recorded_exit_price,
+    official_exit_price,
+    CASE
+        WHEN sell_quantity > 0 THEN sell_notional / sell_quantity
+        ELSE NULL
+    END AS avg_exit_price,
+    settlement_corrected,
+    has_official_settlement AS is_confirmed,
+    sell_notional - buy_notional AS gross_pnl,
+    sell_notional - buy_notional - total_fee AS net_pnl,
+    buy_quantity > 0
+        AND sell_quantity > 0
+        AND ABS(buy_quantity - sell_quantity) <= 0.00000001::NUMERIC AS is_closed,
+    CASE
+        WHEN buy_quantity > sell_quantity THEN buy_quantity - sell_quantity
+        ELSE 0::NUMERIC
+    END AS open_quantity
+FROM aggregated;
+
+CREATE VIEW strategy_runtime_daily_track_record AS
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date AS trading_day_cst,
+    COUNT(*) AS trade_count,
+    COUNT(*) FILTER (WHERE is_closed) AS closed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed) AS confirmed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND settlement_corrected) AS corrected_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl > 0) AS winning_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl < 0) AS losing_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl > 0) AS winning_trade_count_all,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl < 0) AS losing_trade_count_all,
+    COALESCE(SUM(buy_notional), 0::NUMERIC) AS total_buy_notional,
+    COALESCE(SUM(sell_notional), 0::NUMERIC) AS total_sell_notional,
+    COALESCE(SUM(recorded_sell_notional), 0::NUMERIC) AS total_recorded_sell_notional,
+    COALESCE(SUM(total_fee), 0::NUMERIC) AS total_fee,
+    COALESCE(SUM(gross_pnl), 0::NUMERIC) AS gross_pnl,
+    COALESCE(SUM(net_pnl), 0::NUMERIC) AS net_pnl,
+    COALESCE(AVG(net_pnl), 0::NUMERIC) AS avg_net_pnl,
+    COALESCE(SUM(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_net_pnl,
+    COALESCE(AVG(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_avg_net_pnl,
+    COALESCE(SUM(open_quantity), 0::NUMERIC) AS residual_open_quantity
+FROM strategy_runtime_event_track_record
+GROUP BY
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date;

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import sys
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from statistics import mean, stdev
 
 
@@ -47,6 +47,11 @@ WITH events AS (
     t.is_closed,
     t.open_quantity,
     CASE
+      WHEN m.market_slug IS NOT NULL THEN 'token_settlement_market_metadata'
+      WHEN s.market_slug IS NOT NULL THEN 'token_settlement_without_metadata'
+      ELSE 'missing_token_settlement'
+    END AS metadata_join_status,
+    CASE
       WHEN m.end_time IS NOT NULL AND m.start_time IS NOT NULL
         THEN ROUND(EXTRACT(EPOCH FROM (m.end_time - m.start_time)))::int
       WHEN m.market_slug ILIKE '%15m%' OR m.market_slug ILIKE '%15-minute%' THEN 900
@@ -59,7 +64,8 @@ WITH events AS (
       ELSE NULL
     END AS entry_time_remaining_secs
   FROM strategy_runtime_event_track_record t
-  LEFT JOIN pm_market_metadata m ON m.market_slug = t.event_id
+  LEFT JOIN pm_token_settlements s ON s.token_id = t.token_id
+  LEFT JOIN pm_market_metadata m ON m.market_slug = s.market_slug
   WHERE t.runtime_mode IN ({MODE_FILTER})
 )
 SELECT COALESCE(json_agg(row_to_json(e) ORDER BY e.opened_at, e.trade_key), '[]'::json)::text
@@ -128,6 +134,46 @@ FROM (
   GROUP BY runtime_mode, strategy_id, deployment_id, event_id
   HAVING COUNT(DISTINCT token_id) > 1 OR COUNT(DISTINCT market_side) > 1
 ) mixed;
+"""
+
+ORDER_DIAGNOSTICS_QUERY = f"""
+SELECT COALESCE(json_agg(row_to_json(d) ORDER BY d.runtime_mode, d.strategy_id, d.deployment_id), '[]'::json)::text
+FROM (
+  SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    COUNT(*) AS total_orders,
+    COUNT(*) FILTER (WHERE order_side = 'BUY') AS buy_orders,
+    COUNT(*) FILTER (WHERE order_side = 'SELL') AS sell_orders,
+    COUNT(*) FILTER (
+      WHERE LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL
+    ) AS rejected_orders,
+    COUNT(*) FILTER (
+      WHERE order_side = 'BUY'
+        AND (LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL)
+    ) AS rejected_buy_orders,
+    COUNT(*) FILTER (
+      WHERE order_side = 'BUY'
+        AND filled_quantity > 0
+        AND quantity > 0
+        AND filled_quantity < quantity * 0.98
+    ) AS partial_buy_orders,
+    ROUND(COALESCE(SUM(quantity * COALESCE(limit_price, avg_fill_price, 0)) FILTER (WHERE order_side = 'BUY'), 0), 4) AS buy_requested_notional,
+    ROUND(COALESCE(SUM(filled_quantity * COALESCE(avg_fill_price, limit_price, 0)) FILTER (WHERE order_side = 'BUY'), 0), 4) AS buy_filled_notional,
+    ROUND(
+      CASE
+        WHEN COALESCE(SUM(quantity) FILTER (WHERE order_side = 'BUY'), 0) > 0
+          THEN COALESCE(SUM(filled_quantity) FILTER (WHERE order_side = 'BUY'), 0)
+               / SUM(quantity) FILTER (WHERE order_side = 'BUY') * 100
+        ELSE 0
+      END,
+      2
+    ) AS buy_fill_rate_pct
+  FROM strategy_runtime_orders
+  WHERE runtime_mode IN ({MODE_FILTER})
+  GROUP BY runtime_mode, strategy_id, deployment_id
+) d;
 """
 
 
@@ -206,7 +252,21 @@ def day_from_event(row) -> str | None:
     timestamp = row.get("closed_at") or row.get("last_fill_at") or row.get("opened_at")
     if not timestamp:
         return None
-    return timestamp[:10]
+    parsed = parse_timestamp(timestamp)
+    if parsed is None:
+        return timestamp[:10]
+    if parsed.tzinfo is None:
+        return parsed.date().isoformat()
+    return parsed.astimezone(timezone(timedelta(hours=8))).date().isoformat()
+
+
+def parse_timestamp(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def win_rate(wins: int, closed_count: int) -> float:
@@ -273,16 +333,19 @@ def build_metrics(events, equity_curve):
     elif gross_profit > 0:
         profit_factor = "Infinity"
 
-    sharpe = None
+    sharpe_per_trade = None
     if len(closed_pnls) >= 2:
         sigma = stdev(closed_pnls)
         if sigma > 0:
-            sharpe = round((mean(closed_pnls) / sigma) * math.sqrt(len(closed_pnls)), 4)
+            sharpe_per_trade = round((mean(closed_pnls) / sigma) * math.sqrt(len(closed_pnls)), 4)
 
     max_drawdown = min((point["drawdown"] for point in equity_curve), default=0.0)
     avg_trade = mean(closed_pnls) if closed_pnls else None
     return {
-        "sharpe": sharpe,
+        "sharpe": sharpe_per_trade,
+        "sharpe_per_trade": sharpe_per_trade,
+        "sharpe_basis": "closed_trade_pnl_sqrt_n",
+        "closed_trade_count_for_sharpe": len(closed_pnls),
         "profit_factor": profit_factor,
         "max_drawdown": round(max_drawdown, 4),
         "avg_trade": None if avg_trade is None else round(avg_trade, 4),
@@ -290,6 +353,16 @@ def build_metrics(events, equity_curve):
         "gross_loss": round(gross_loss, 4),
         "equity_points": len(equity_curve),
     }
+
+
+def build_daily_sharpe(daily_rows):
+    daily_pnls = [number(row.get("net_pnl")) for row in daily_rows]
+    if len(daily_pnls) < 2:
+        return None
+    sigma = stdev(daily_pnls)
+    if sigma <= 0:
+        return None
+    return round((mean(daily_pnls) / sigma) * math.sqrt(365), 4)
 
 
 def build_window_rows(events):
@@ -474,9 +547,12 @@ def build_open_positions(events):
 def build_report_slice(events, daily_rows):
     equity_curve = build_equity_curve(events)
     closed_trades = build_closed_trades(events)
+    metrics = build_metrics(events, equity_curve)
+    metrics["sharpe_daily_ann"] = build_daily_sharpe(daily_rows)
+    metrics["daily_sharpe_basis"] = "daily_net_pnl_sqrt_365"
     return {
         "summary": build_summary(events),
-        "metrics": build_metrics(events, equity_curve),
+        "metrics": metrics,
         "equity_curve": equity_curve,
         "by_window": build_window_rows(events),
         "daily": build_daily_rows(daily_rows),
@@ -486,6 +562,41 @@ def build_report_slice(events, daily_rows):
         "closed_trades": closed_trades[:250],
         "recent_closed": closed_trades[:50],
         "open_positions": build_open_positions(events),
+    }
+
+
+def build_execution_diagnostics(rows):
+    totals = defaultdict(float)
+    for row in rows:
+        for key in (
+            "total_orders",
+            "buy_orders",
+            "sell_orders",
+            "rejected_orders",
+            "rejected_buy_orders",
+            "partial_buy_orders",
+            "buy_requested_notional",
+            "buy_filled_notional",
+        ):
+            totals[key] += number(row.get(key))
+
+    buy_orders = totals["buy_orders"]
+    rejected_buy_orders = totals["rejected_buy_orders"]
+    totals["buy_fill_rate_pct"] = (
+        round(totals["buy_filled_notional"] / totals["buy_requested_notional"] * 100, 2)
+        if totals["buy_requested_notional"] > 0
+        else 0
+    )
+    totals["rejected_buy_rate_pct"] = round(rejected_buy_orders / buy_orders * 100, 2) if buy_orders > 0 else 0
+
+    return {
+        "basis": "strategy_runtime_orders",
+        "partial_buy_threshold_pct": 98,
+        "summary": {
+            key: (round(value, 4) if key.endswith("_notional") else int(value) if key.endswith("_orders") else value)
+            for key, value in totals.items()
+        },
+        "strategies": rows,
     }
 
 
@@ -512,6 +623,7 @@ def empty_payload():
             "current_view_rows": 0,
             "side_aware_rows": 0,
         },
+        "execution_diagnostics": build_execution_diagnostics([]),
     }
 
 
@@ -519,11 +631,13 @@ def main() -> int:
     events = run_json_query(EVENTS_QUERY) or []
     daily_rows = run_json_query(DAILY_QUERY) or []
     pairing = run_json_query(PAIRING_QUERY) or empty_payload()["pairing"]
+    order_diagnostics = run_json_query(ORDER_DIAGNOSTICS_QUERY) or []
 
     payload = empty_payload()
     payload["generated_at"] = datetime.now(timezone.utc).isoformat()
     payload.update(build_report_slice(events, daily_rows))
     payload["pairing"] = pairing
+    payload["execution_diagnostics"] = build_execution_diagnostics(order_diagnostics)
 
     events_by_strategy = defaultdict(list)
     for event in events:
@@ -533,11 +647,13 @@ def main() -> int:
     for row in daily_rows:
         daily_by_strategy[strategy_key(row)].append(row)
 
+    diagnostics_by_strategy = {strategy_key(row): row for row in order_diagnostics}
+
     strategies = []
-    strategy_keys = set(events_by_strategy.keys()) | set(daily_by_strategy.keys())
-    for runtime_mode, strategy_id, deployment_id in sorted(strategy_keys):
+    for runtime_mode, strategy_id, deployment_id in sorted(events_by_strategy.keys()):
         strategy_events = events_by_strategy[(runtime_mode, strategy_id, deployment_id)]
         strategy_daily_rows = daily_by_strategy.get((runtime_mode, strategy_id, deployment_id), [])
+        strategy_diagnostics = diagnostics_by_strategy.get((runtime_mode, strategy_id, deployment_id))
         strategy_payload = build_report_slice(strategy_events, strategy_daily_rows)
         strategy_payload.update(
             {
@@ -545,6 +661,9 @@ def main() -> int:
                 "strategy_id": strategy_id,
                 "deployment_id": deployment_id,
                 "label": strategy_label(runtime_mode, strategy_id, deployment_id),
+                "execution_diagnostics": build_execution_diagnostics(
+                    [strategy_diagnostics] if strategy_diagnostics else []
+                ),
             }
         )
         strategies.append(strategy_payload)

--- a/scripts/report_strategy.py
+++ b/scripts/report_strategy.py
@@ -31,6 +31,7 @@ for i, arg in enumerate(sys.argv[1:], 1):
 
 SINCE_FILTER = f"AND COALESCE(closed_at, opened_at) >= '{SINCE}T00:00:00+08'" if SINCE else ""
 DAILY_FILTER = f"AND trading_day_cst >= '{SINCE}'" if SINCE else ""
+ORDERS_FILTER = f"AND created_at >= '{SINCE}T00:00:00+08'" if SINCE else ""
 
 
 def run_sql(query: str) -> str:
@@ -65,19 +66,51 @@ def run_sql(query: str) -> str:
 
 print(f"Fetching data from {HOST}...")
 
-# Q1: All closed trades for cumulative PnL + detail table
+# Q1: All closed trades for cumulative PnL + detail table.
+# Strategy sizing is requested in USD stake, while fills are recorded as shares.
+# Show both requested stake and actual filled notional so liquidity partial fills
+# are visible instead of being mistaken for a smaller configured stake.
 trades_raw = run_sql(f"""
-SELECT symbol, market_side,
-       ROUND(avg_entry_price::numeric, 4),
-       ROUND(avg_exit_price::numeric, 4),
-       ROUND(buy_quantity::numeric, 2),
-       ROUND(net_pnl::numeric, 2),
-       ROUND(total_fee::numeric, 4),
-       to_char(opened_at AT TIME ZONE 'Asia/Shanghai', 'YYYY-MM-DD HH24:MI'),
-       to_char(closed_at AT TIME ZONE 'Asia/Shanghai', 'YYYY-MM-DD HH24:MI')
-FROM strategy_runtime_event_track_record
-WHERE runtime_mode = 'dry_run' AND is_closed {SINCE_FILTER}
-ORDER BY closed_at
+WITH closed AS (
+  SELECT *
+  FROM strategy_runtime_event_track_record
+  WHERE runtime_mode = 'dry_run' AND is_closed {SINCE_FILTER}
+)
+SELECT t.symbol, t.market_side,
+       ROUND(t.avg_entry_price::numeric, 4),
+       ROUND(t.avg_exit_price::numeric, 4),
+       ROUND(t.buy_quantity::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_filled_notional, 0), t.buy_notional)::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_requested_notional, 0), t.buy_notional)::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_filled_quantity, 0), t.buy_quantity)::numeric, 2),
+       COALESCE(o.latest_buy_status, ''),
+       COALESCE(o.buy_orders, 0),
+       COALESCE(o.rejected_buy_orders, 0),
+       ROUND(t.net_pnl::numeric, 2),
+       ROUND(t.total_fee::numeric, 4),
+       to_char(t.opened_at AT TIME ZONE 'Asia/Shanghai', 'YYYY-MM-DD HH24:MI'),
+       to_char(t.closed_at AT TIME ZONE 'Asia/Shanghai', 'YYYY-MM-DD HH24:MI')
+FROM closed t
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(quantity * COALESCE(limit_price, avg_fill_price, 0)) FILTER (WHERE order_side = 'BUY'), 0) AS buy_requested_notional,
+    COALESCE(SUM(filled_quantity * COALESCE(avg_fill_price, limit_price, 0)) FILTER (WHERE order_side = 'BUY'), 0) AS buy_filled_notional,
+    COALESCE(SUM(filled_quantity) FILTER (WHERE order_side = 'BUY'), 0) AS buy_filled_quantity,
+    COUNT(*) FILTER (WHERE order_side = 'BUY') AS buy_orders,
+    COUNT(*) FILTER (
+      WHERE order_side = 'BUY'
+        AND (LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL)
+    ) AS rejected_buy_orders,
+    MAX(status) FILTER (WHERE order_side = 'BUY') AS latest_buy_status
+  FROM strategy_runtime_orders o
+  WHERE o.runtime_mode = t.runtime_mode
+    AND o.strategy_id = t.strategy_id
+    AND (
+      o.intent_id = t.intent_id
+      OR (o.event_id = t.event_id AND o.token_id = t.token_id)
+    )
+) o ON true
+ORDER BY t.closed_at
 """)
 
 trades = []
@@ -86,9 +119,9 @@ for line in trades_raw.split("\n"):
     if not line.strip():
         continue
     parts = line.split("|")
-    if len(parts) < 9:
+    if len(parts) < 15:
         continue
-    pnl = float(parts[5])
+    pnl = float(parts[11])
     cum_pnl += pnl
     exit_px = float(parts[3]) if parts[3] else 0
     if exit_px >= 0.99:
@@ -100,9 +133,16 @@ for line in trades_raw.split("\n"):
     trades.append({
         "symbol": parts[0], "side": parts[1],
         "entry": float(parts[2]), "exit": exit_px,
-        "qty": float(parts[4]), "pnl": pnl, "fee": float(parts[6]),
+        "qty": float(parts[4]),
+        "filled_notional": float(parts[5]),
+        "requested_notional": float(parts[6]),
+        "filled_qty": float(parts[7]),
+        "order_status": parts[8],
+        "buy_orders": int(parts[9] or 0),
+        "rejected_buy_orders": int(parts[10] or 0),
+        "pnl": pnl, "fee": float(parts[12]),
         "exit_type": exit_type,
-        "opened": parts[7], "closed": parts[8],
+        "opened": parts[13], "closed": parts[14],
         "cum_pnl": round(cum_pnl, 2),
     })
 
@@ -136,11 +176,35 @@ open_raw = run_sql(f"""
 SELECT symbol, market_side,
        ROUND(avg_entry_price::numeric, 4),
        ROUND(buy_quantity::numeric, 2),
-       ROUND(buy_notional::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_filled_notional, 0), buy_notional)::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_requested_notional, 0), buy_notional)::numeric, 2),
+       ROUND(COALESCE(NULLIF(o.buy_filled_quantity, 0), buy_quantity)::numeric, 2),
+       COALESCE(o.latest_buy_status, ''),
+       COALESCE(o.buy_orders, 0),
+       COALESCE(o.rejected_buy_orders, 0),
        to_char(opened_at AT TIME ZONE 'Asia/Shanghai', 'YYYY-MM-DD HH24:MI')
-FROM strategy_runtime_event_track_record
-WHERE runtime_mode = 'dry_run' AND NOT is_closed {SINCE_FILTER}
-ORDER BY opened_at DESC
+FROM strategy_runtime_event_track_record t
+LEFT JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(quantity * COALESCE(limit_price, avg_fill_price, 0)) FILTER (WHERE order_side = 'BUY'), 0) AS buy_requested_notional,
+    COALESCE(SUM(filled_quantity * COALESCE(avg_fill_price, limit_price, 0)) FILTER (WHERE order_side = 'BUY'), 0) AS buy_filled_notional,
+    COALESCE(SUM(filled_quantity) FILTER (WHERE order_side = 'BUY'), 0) AS buy_filled_quantity,
+    COUNT(*) FILTER (WHERE order_side = 'BUY') AS buy_orders,
+    COUNT(*) FILTER (
+      WHERE order_side = 'BUY'
+        AND (LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL)
+    ) AS rejected_buy_orders,
+    MAX(status) FILTER (WHERE order_side = 'BUY') AS latest_buy_status
+  FROM strategy_runtime_orders o
+  WHERE o.runtime_mode = t.runtime_mode
+    AND o.strategy_id = t.strategy_id
+    AND (
+      o.intent_id = t.intent_id
+      OR (o.event_id = t.event_id AND o.token_id = t.token_id)
+    )
+) o ON true
+WHERE t.runtime_mode = 'dry_run' AND NOT t.is_closed {SINCE_FILTER}
+ORDER BY t.opened_at DESC
 """)
 
 open_positions = []
@@ -148,12 +212,72 @@ for line in open_raw.split("\n"):
     if not line.strip():
         continue
     parts = line.split("|")
-    if len(parts) < 6:
+    if len(parts) < 11:
         continue
     open_positions.append({
         "symbol": parts[0], "side": parts[1], "entry": float(parts[2]),
-        "qty": float(parts[3]), "notional": float(parts[4]), "opened": parts[5],
+        "qty": float(parts[3]),
+        "notional": float(parts[4]),
+        "requested_notional": float(parts[5]),
+        "filled_qty": float(parts[6]),
+        "order_status": parts[7],
+        "buy_orders": int(parts[8] or 0),
+        "rejected_buy_orders": int(parts[9] or 0),
+        "opened": parts[10],
     })
+
+# Q4: Order diagnostics independent of the trade view, so rejected orders with
+# no fill still show up in the report.
+orders_raw = run_sql(f"""
+SELECT
+  COUNT(*) AS total_orders,
+  COUNT(*) FILTER (WHERE order_side = 'BUY') AS buy_orders,
+  COUNT(*) FILTER (WHERE order_side = 'SELL') AS sell_orders,
+  COUNT(*) FILTER (
+    WHERE LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL
+  ) AS rejected_orders,
+  COUNT(*) FILTER (
+    WHERE order_side = 'BUY'
+      AND (LOWER(status) = 'rejected' OR rejection_reason IS NOT NULL)
+  ) AS rejected_buy_orders,
+  COUNT(*) FILTER (
+    WHERE order_side = 'BUY'
+      AND filled_quantity > 0
+      AND quantity > 0
+      AND filled_quantity < quantity * 0.98
+  ) AS partial_buy_orders,
+  ROUND(COALESCE(SUM(quantity * COALESCE(limit_price, avg_fill_price, 0)) FILTER (WHERE order_side = 'BUY'), 0), 2) AS buy_requested_notional,
+  ROUND(COALESCE(SUM(filled_quantity * COALESCE(avg_fill_price, limit_price, 0)) FILTER (WHERE order_side = 'BUY'), 0), 2) AS buy_filled_notional
+FROM strategy_runtime_orders
+WHERE runtime_mode = 'dry_run' {ORDERS_FILTER}
+""")
+
+order_diagnostics = {
+    "total_orders": 0,
+    "buy_orders": 0,
+    "sell_orders": 0,
+    "rejected_orders": 0,
+    "rejected_buy_orders": 0,
+    "partial_buy_orders": 0,
+    "buy_requested_notional": 0.0,
+    "buy_filled_notional": 0.0,
+}
+for line in orders_raw.split("\n"):
+    if not line.strip():
+        continue
+    parts = line.split("|")
+    if len(parts) < 8:
+        continue
+    order_diagnostics = {
+        "total_orders": int(parts[0] or 0),
+        "buy_orders": int(parts[1] or 0),
+        "sell_orders": int(parts[2] or 0),
+        "rejected_orders": int(parts[3] or 0),
+        "rejected_buy_orders": int(parts[4] or 0),
+        "partial_buy_orders": int(parts[5] or 0),
+        "buy_requested_notional": float(parts[6] or 0),
+        "buy_filled_notional": float(parts[7] or 0),
+    }
 
 # --- Compute summary stats ---
 import math
@@ -166,16 +290,37 @@ win_rate = (wins / total * 100) if total > 0 else 0
 total_pnl = sum(t["pnl"] for t in closed_trades)
 total_fees = sum(t["fee"] for t in closed_trades)
 avg_pnl = total_pnl / total if total > 0 else 0
+total_requested_notional = sum(t["requested_notional"] for t in closed_trades)
+total_filled_notional = sum(t["filled_notional"] for t in closed_trades)
+avg_requested_notional = total_requested_notional / total if total > 0 else 0
+avg_filled_notional = total_filled_notional / total if total > 0 else 0
+partial_fills = sum(
+    1 for t in closed_trades
+    if t["requested_notional"] > 0 and t["filled_notional"] < t["requested_notional"] * 0.98
+)
+rejected_buy_orders = order_diagnostics["rejected_buy_orders"]
+buy_orders = order_diagnostics["buy_orders"]
+rejected_buy_rate = rejected_buy_orders / buy_orders * 100 if buy_orders > 0 else 0
 
-# Sharpe ratio (annualized from daily)
+# Sharpe ratios use explicit bases. Per-trade matches the JSON dry-run report;
+# daily annualized is kept as a secondary diagnostic.
+trade_pnls = [t["pnl"] for t in closed_trades]
+if len(trade_pnls) > 1:
+    mean_t = sum(trade_pnls) / len(trade_pnls)
+    var_t = sum((x - mean_t) ** 2 for x in trade_pnls) / (len(trade_pnls) - 1)
+    std_t = math.sqrt(var_t)
+    trade_sharpe = (mean_t / std_t) * math.sqrt(len(trade_pnls)) if std_t > 0 else 0
+else:
+    trade_sharpe = 0
+
 daily_pnls = [d["pnl"] for d in daily]
 if len(daily_pnls) > 1:
     mean_d = sum(daily_pnls) / len(daily_pnls)
     var_d = sum((x - mean_d) ** 2 for x in daily_pnls) / (len(daily_pnls) - 1)
-    std_d = math.sqrt(var_d) if var_d > 0 else 0.001
-    sharpe = (mean_d / std_d) * math.sqrt(365)
+    std_d = math.sqrt(var_d)
+    daily_sharpe_ann = (mean_d / std_d) * math.sqrt(365) if std_d > 0 else 0
 else:
-    sharpe = 0
+    daily_sharpe_ann = 0
 
 # Max drawdown
 peak = 0
@@ -259,10 +404,20 @@ trade_rows = ""
 for t in recent:
     color = "#22c55e" if t["pnl"] >= 0 else "#ef4444"
     et_color = {"WIN": "#22c55e", "LOSS": "#ef4444", "TP/SL": "#f59e0b"}.get(t["exit_type"], "#888")
+    fill_ratio = (
+        t["filled_notional"] / t["requested_notional"] * 100
+        if t["requested_notional"] > 0 else 0
+    )
+    fill_color = "#f59e0b" if fill_ratio < 98 else "#cbd5e1"
     trade_rows += f"""<tr>
       <td>{t['symbol']}</td><td>{t['side']}</td>
       <td>{t['entry']:.4f}</td><td>{t['exit']:.4f}</td>
       <td style="color:{et_color};font-weight:600">{t['exit_type']}</td>
+      <td>${t['requested_notional']:.2f}</td>
+      <td style="color:{fill_color};font-weight:600">${t['filled_notional']:.2f}</td>
+      <td style="color:{fill_color}">{fill_ratio:.0f}%</td>
+      <td>{t['buy_orders']}</td>
+      <td>{t['rejected_buy_orders']}</td>
       <td>{t['qty']:.1f}</td>
       <td style="color:{color};font-weight:600">${t['pnl']:,.2f}</td>
       <td>{t['opened']}</td><td>{t['closed']}</td>
@@ -271,10 +426,19 @@ for t in recent:
 # Build open positions rows
 open_rows = ""
 for p in open_positions:
+    fill_ratio = (
+        p["notional"] / p["requested_notional"] * 100
+        if p["requested_notional"] > 0 else 0
+    )
+    fill_color = "#f59e0b" if fill_ratio < 98 else "#cbd5e1"
     open_rows += f"""<tr>
       <td>{p['symbol']}</td><td>{p['side']}</td>
-      <td>{p['entry']:.4f}</td><td>{p['qty']:.1f}</td>
-      <td>${p['notional']:.2f}</td><td>{p['opened']}</td>
+      <td>{p['entry']:.4f}</td>
+      <td>${p['requested_notional']:.2f}</td>
+      <td style="color:{fill_color};font-weight:600">${p['notional']:.2f}</td>
+      <td style="color:{fill_color}">{fill_ratio:.0f}%</td>
+      <td>{p['buy_orders']}</td><td>{p['rejected_buy_orders']}</td>
+      <td>{p['qty']:.1f}</td><td>{p['opened']}</td>
     </tr>"""
 
 # Config rows
@@ -332,12 +496,24 @@ html = f"""<!DOCTYPE html>
     <div class="value">{total}</div></div>
   <div class="card"><div class="label">Win Rate</div>
     <div class="value">{win_rate:.1f}%</div></div>
-  <div class="card"><div class="label">Sharpe (ann.)</div>
-    <div class="value">{sharpe:.1f}</div></div>
+  <div class="card"><div class="label">Sharpe / Trade</div>
+    <div class="value">{trade_sharpe:.1f}</div></div>
+  <div class="card"><div class="label">Sharpe Daily Ann</div>
+    <div class="value">{daily_sharpe_ann:.1f}</div></div>
   <div class="card"><div class="label">Max Drawdown</div>
     <div class="value" style="color:#ef4444">${max_dd:,.2f}</div></div>
   <div class="card"><div class="label">Avg PnL/Trade</div>
     <div class="value">${avg_pnl:,.2f}</div></div>
+  <div class="card"><div class="label">Avg Req Stake</div>
+    <div class="value">${avg_requested_notional:,.2f}</div></div>
+  <div class="card"><div class="label">Avg Filled Stake</div>
+    <div class="value">${avg_filled_notional:,.2f}</div></div>
+  <div class="card"><div class="label">Partial Fills</div>
+    <div class="value">{partial_fills}</div></div>
+  <div class="card"><div class="label">Rejected BUY</div>
+    <div class="value">{rejected_buy_orders}</div></div>
+  <div class="card"><div class="label">BUY Reject Rate</div>
+    <div class="value">{rejected_buy_rate:.1f}%</div></div>
   <div class="card"><div class="label">Total Fees</div>
     <div class="value">${total_fees:,.2f}</div></div>
   <div class="card"><div class="label">Open Positions</div>
@@ -373,12 +549,13 @@ html = f"""<!DOCTYPE html>
   <h2>Recent Trades (last 30)</h2>
   <table>
     <tr><th>Symbol</th><th>Side</th><th>Entry</th><th>Exit</th>
-        <th>Type</th><th>Qty</th><th>Net PnL</th><th>Opened</th><th>Closed</th></tr>
+        <th>Type</th><th>Req Stake</th><th>Filled</th><th>Fill %</th>
+        <th>Orders</th><th>Rejected</th><th>Shares</th><th>Net PnL</th><th>Opened</th><th>Closed</th></tr>
     {trade_rows}
   </table>
 </div>
 
-{"<div class='section chart-box'><h2>Open Positions</h2><table><tr><th>Symbol</th><th>Side</th><th>Entry</th><th>Qty</th><th>Notional</th><th>Opened</th></tr>" + open_rows + "</table></div>" if open_positions else ""}
+{"<div class='section chart-box'><h2>Open Positions</h2><table><tr><th>Symbol</th><th>Side</th><th>Entry</th><th>Req Stake</th><th>Filled</th><th>Fill %</th><th>Orders</th><th>Rejected</th><th>Shares</th><th>Opened</th></tr>" + open_rows + "</table></div>" if open_positions else ""}
 
 <div class="section chart-box">
   <h2>Strategy Parameters</h2>
@@ -465,4 +642,8 @@ out_path.parent.mkdir(parents=True, exist_ok=True)
 out_path.write_text(html)
 
 print(f"Report saved to {out_path}")
-print(f"  Trades: {total} | Win rate: {win_rate:.1f}% | PnL: ${total_pnl:,.2f} | Sharpe: {sharpe:.1f}")
+print(
+    f"  Trades: {total} | Win rate: {win_rate:.1f}% | PnL: ${total_pnl:,.2f} "
+    f"| Sharpe/trade: {trade_sharpe:.1f} | Sharpe daily ann: {daily_sharpe_ann:.1f} "
+    f"| Rejected BUY: {rejected_buy_orders}"
+)

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -1,0 +1,94 @@
+import importlib.util
+import math
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUMMARY_SCRIPT = ROOT / "scripts" / "report_dryrun_summary.py"
+HTML_SCRIPT = ROOT / "scripts" / "report_strategy.py"
+SIDE_KEY_MIGRATION = ROOT / "migrations" / "039_fix_strategy_track_record_side_key.sql"
+
+
+def load_summary_module():
+    spec = importlib.util.spec_from_file_location("report_dryrun_summary", SUMMARY_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class DryRunReportContractTests(unittest.TestCase):
+    def test_summary_metadata_join_uses_token_settlement_bridge(self) -> None:
+        script = SUMMARY_SCRIPT.read_text()
+
+        self.assertIn("LEFT JOIN pm_token_settlements s ON s.token_id = t.token_id", script)
+        self.assertIn("LEFT JOIN pm_market_metadata m ON m.market_slug = s.market_slug", script)
+        self.assertNotIn("m.market_slug = t.event_id", script)
+
+    def test_summary_metrics_expose_explicit_sharpe_basis(self) -> None:
+        summary = load_summary_module()
+        events = [
+            {"is_closed": True, "net_pnl": 1.0, "closed_at": "2026-04-29T01:00:00+00:00", "trade_key": "a"},
+            {"is_closed": True, "net_pnl": -0.5, "closed_at": "2026-04-29T02:00:00+00:00", "trade_key": "b"},
+            {"is_closed": True, "net_pnl": 1.5, "closed_at": "2026-04-29T03:00:00+00:00", "trade_key": "c"},
+        ]
+
+        metrics = summary.build_report_slice(events, [{"net_pnl": 1.0}, {"net_pnl": -0.5}])["metrics"]
+
+        expected_trade_sharpe = (sum([1.0, -0.5, 1.5]) / 3) / math.sqrt(13 / 12) * math.sqrt(3)
+        self.assertAlmostEqual(metrics["sharpe_per_trade"], expected_trade_sharpe, places=4)
+        self.assertEqual(metrics["sharpe"], metrics["sharpe_per_trade"])
+        self.assertEqual(metrics["sharpe_basis"], "closed_trade_pnl_sqrt_n")
+        self.assertEqual(metrics["daily_sharpe_basis"], "daily_net_pnl_sqrt_365")
+
+    def test_summary_daily_by_window_uses_cst_day(self) -> None:
+        summary = load_summary_module()
+
+        self.assertEqual(
+            summary.day_from_event({"closed_at": "2026-04-28T17:30:00+00:00"}),
+            "2026-04-29",
+        )
+
+    def test_execution_diagnostics_contract(self) -> None:
+        summary = load_summary_module()
+        diagnostics = summary.build_execution_diagnostics(
+            [
+                {
+                    "total_orders": 3,
+                    "buy_orders": 2,
+                    "sell_orders": 1,
+                    "rejected_orders": 1,
+                    "rejected_buy_orders": 1,
+                    "partial_buy_orders": 1,
+                    "buy_requested_notional": 30,
+                    "buy_filled_notional": 15,
+                }
+            ]
+        )
+
+        self.assertEqual(diagnostics["basis"], "strategy_runtime_orders")
+        self.assertEqual(diagnostics["partial_buy_threshold_pct"], 98)
+        self.assertEqual(diagnostics["summary"]["rejected_buy_orders"], 1)
+        self.assertEqual(diagnostics["summary"]["buy_fill_rate_pct"], 50)
+
+    def test_html_report_aggregates_orders_and_names_sharpe_bases(self) -> None:
+        script = HTML_SCRIPT.read_text()
+
+        self.assertIn("buy_requested_notional", script)
+        self.assertIn("rejected_buy_orders", script)
+        self.assertIn("Rejected BUY", script)
+        self.assertIn("Sharpe / Trade", script)
+        self.assertIn("Sharpe Daily Ann", script)
+        self.assertNotIn("ORDER BY o.created_at ASC\n  LIMIT 1", script)
+        self.assertNotIn("else 0.001", script)
+
+    def test_side_key_migration_groups_by_token_and_market_side(self) -> None:
+        migration = SIDE_KEY_MIGRATION.read_text()
+
+        self.assertIn("trade_key,\n        token_id,\n        market_side", migration)
+        self.assertIn("GROUP BY\n        runtime_mode,\n        strategy_id,\n        deployment_id,\n        trade_key,\n        token_id,\n        market_side", migration)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep dry-run event track-record rows token/side aware via migration 038
- remove unsafe event_id = market_slug metadata join from the dry-run JSON report
- expose explicit Sharpe basis fields and execution diagnostics from report scripts
- include migration 038 in the Tango deploy bundle

## Verification
- python3 -m py_compile scripts/report_dryrun_summary.py scripts/report_strategy.py tests/test_dryrun_report_contracts.py
- python3 -m unittest tests.test_dryrun_report_contracts
- workflow YAML parse for deploy-tango-1-1.yml
- git diff --check
- applied migration 038 and report scripts on tango-1-1; direct report script emits sharpe_basis and execution_diagnostics

## Note
Public /api/reports/dry-run still uses the currently deployed ployd binary contract until a CI-built deploy from main lands.