### PR TITLE
Preserve dry-run report diagnostics through contracts

### DIFF
--- a/contracts/schemas/dry-run-performance-report.schema.json
+++ b/contracts/schemas/dry-run-performance-report.schema.json
@@ -49,6 +49,17 @@
         "$ref": "#/definitions/DryRunEquityPoint"
       }
     },
+    "execution_diagnostics": {
+      "default": null,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DryRunExecutionDiagnostics"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "generated_at": {
       "type": "string"
     },
@@ -363,6 +374,33 @@
         }
       }
     },
+    "DryRunExecutionDiagnostics": {
+      "type": "object",
+      "required": [
+        "basis",
+        "partial_buy_threshold_pct",
+        "strategies",
+        "summary"
+      ],
+      "properties": {
+        "basis": {
+          "type": "string"
+        },
+        "partial_buy_threshold_pct": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "strategies": {
+          "type": "array",
+          "items": true
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
     "DryRunMetrics": {
       "type": "object",
       "required": [
@@ -378,6 +416,22 @@
             "null"
           ],
           "format": "double"
+        },
+        "closed_trade_count_for_sharpe": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "daily_sharpe_basis": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "equity_points": {
           "type": "integer",
@@ -407,6 +461,29 @@
           ]
         },
         "sharpe": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "sharpe_basis": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sharpe_daily_ann": {
+          "default": null,
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "sharpe_per_trade": {
+          "default": null,
           "type": [
             "number",
             "null"
@@ -592,6 +669,17 @@
           "items": {
             "$ref": "#/definitions/DryRunEquityPoint"
           }
+        },
+        "execution_diagnostics": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DryRunExecutionDiagnostics"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "label": {
           "type": "string"

--- a/crates/ploy-operator-contracts/src/lib.rs
+++ b/crates/ploy-operator-contracts/src/lib.rs
@@ -14,11 +14,11 @@ pub use deployments::{
     DeploymentSummary, DesiredState, ObservedState,
 };
 pub use diagnostics::{
-    AgentRunRecord, DeploymentDiagnosticsMetrics, DeploymentDiagnosticsReport, DiagnosticsEvidence,
-    DiagnosticsFinding, OversightRecommendedAction, OversightReport, OversightSignal,
-    OversightSnapshotEvent, PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest,
-    ProposalDecisionRequest, ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
-    compute_oversight_report,
+    compute_oversight_report, AgentRunRecord, DeploymentDiagnosticsMetrics,
+    DeploymentDiagnosticsReport, DiagnosticsEvidence, DiagnosticsFinding,
+    OversightRecommendedAction, OversightReport, OversightSignal, OversightSnapshotEvent,
+    PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest, ProposalDecisionRequest,
+    ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
 };
 pub use errors::ControlPlaneErrorResponse;
 pub use events::{
@@ -26,9 +26,10 @@ pub use events::{
     StatusUpdate, SystemSnapshotEvent, TradingSnapshotEvent, WsMessage,
 };
 pub use reports::{
-    DryRunClosedTradeRow, DryRunDailyRow, DryRunDailyWindowRow, DryRunEquityPoint, DryRunMetrics,
-    DryRunOpenPositionRow, DryRunPairingReport, DryRunPerformanceReport, DryRunStrategyReport,
-    DryRunSummary, DryRunSymbolRow, DryRunWindowRow, NumberOrText,
+    DryRunClosedTradeRow, DryRunDailyRow, DryRunDailyWindowRow, DryRunEquityPoint,
+    DryRunExecutionDiagnostics, DryRunMetrics, DryRunOpenPositionRow, DryRunPairingReport,
+    DryRunPerformanceReport, DryRunStrategyReport, DryRunSummary, DryRunSymbolRow, DryRunWindowRow,
+    NumberOrText,
 };
 pub use system::{
     ActiveAlert, AlertKind, AlertSeverity, HeartbeatState, HeartbeatStatus, PlatformMetrics,

--- a/crates/ploy-operator-contracts/src/reports.rs
+++ b/crates/ploy-operator-contracts/src/reports.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DryRunSummary {
@@ -26,6 +27,16 @@ pub enum NumberOrText {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DryRunMetrics {
     pub sharpe: Option<f64>,
+    #[serde(default)]
+    pub sharpe_per_trade: Option<f64>,
+    #[serde(default)]
+    pub sharpe_basis: Option<String>,
+    #[serde(default)]
+    pub closed_trade_count_for_sharpe: Option<usize>,
+    #[serde(default)]
+    pub sharpe_daily_ann: Option<f64>,
+    #[serde(default)]
+    pub daily_sharpe_basis: Option<String>,
     pub profit_factor: Option<NumberOrText>,
     pub max_drawdown: f64,
     pub avg_trade: Option<f64>,
@@ -149,6 +160,14 @@ pub struct DryRunPairingReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunExecutionDiagnostics {
+    pub basis: String,
+    pub partial_buy_threshold_pct: usize,
+    pub summary: BTreeMap<String, serde_json::Value>,
+    pub strategies: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DryRunStrategyReport {
     pub runtime_mode: String,
     pub strategy_id: String,
@@ -165,6 +184,8 @@ pub struct DryRunStrategyReport {
     pub closed_trades: Vec<DryRunClosedTradeRow>,
     pub recent_closed: Vec<DryRunClosedTradeRow>,
     pub open_positions: Vec<DryRunOpenPositionRow>,
+    #[serde(default)]
+    pub execution_diagnostics: Option<DryRunExecutionDiagnostics>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -183,4 +204,133 @@ pub struct DryRunPerformanceReport {
     pub open_positions: Vec<DryRunOpenPositionRow>,
     pub strategies: Vec<DryRunStrategyReport>,
     pub pairing: DryRunPairingReport,
+    #[serde(default)]
+    pub execution_diagnostics: Option<DryRunExecutionDiagnostics>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DryRunPerformanceReport;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn dry_run_report_roundtrip_preserves_diagnostics_fields() {
+        let raw = json!({
+            "generated_at": "2026-04-29T00:00:00Z",
+            "summary": summary(),
+            "metrics": metrics(),
+            "equity_curve": [],
+            "by_window": [],
+            "daily": [],
+            "daily_by_window": [],
+            "symbols": [],
+            "symbols_by_window": [],
+            "closed_trades": [],
+            "recent_closed": [],
+            "open_positions": [],
+            "strategies": [{
+                "runtime_mode": "dryrun",
+                "strategy_id": "pm5d",
+                "deployment_id": "pm5d-dryrun",
+                "label": "dryrun/pm5d/pm5d-dryrun",
+                "summary": summary(),
+                "metrics": metrics(),
+                "equity_curve": [],
+                "by_window": [],
+                "daily": [],
+                "daily_by_window": [],
+                "symbols": [],
+                "symbols_by_window": [],
+                "closed_trades": [],
+                "recent_closed": [],
+                "open_positions": [],
+                "execution_diagnostics": diagnostics()
+            }],
+            "pairing": {
+                "pair_key": "runtime_mode,strategy_id,deployment_id,event_id",
+                "mixed_event_groups": 0,
+                "fills_in_mixed_event_groups": 0,
+                "current_view_rows": 0,
+                "side_aware_rows": 0
+            },
+            "execution_diagnostics": diagnostics()
+        });
+
+        let report: DryRunPerformanceReport = serde_json::from_value(raw).unwrap();
+        let roundtripped = serde_json::to_value(report).unwrap();
+
+        assert_eq!(
+            roundtripped["metrics"]["sharpe_basis"],
+            "closed_trade_pnl_sqrt_n"
+        );
+        assert_eq!(
+            roundtripped["metrics"]["daily_sharpe_basis"],
+            "daily_net_pnl_sqrt_365"
+        );
+        assert_eq!(
+            roundtripped["execution_diagnostics"]["basis"],
+            "strategy_runtime_orders"
+        );
+        assert_eq!(
+            roundtripped["strategies"][0]["execution_diagnostics"]["basis"],
+            "strategy_runtime_orders"
+        );
+        assert_eq!(
+            roundtripped["execution_diagnostics"]["summary"]["rejected_buy_orders"],
+            2
+        );
+    }
+
+    fn summary() -> Value {
+        json!({
+            "total_trades": 1,
+            "closed_trades": 1,
+            "wins": 1,
+            "losses": 0,
+            "win_rate_pct": 100.0,
+            "realized_pnl": 1.25,
+            "total_fees": 0.01,
+            "open_positions": 0,
+            "open_exposure": 0.0,
+            "latest_opened_at": null,
+            "latest_closed_at": null
+        })
+    }
+
+    fn metrics() -> Value {
+        json!({
+            "sharpe": 1.5,
+            "sharpe_per_trade": 1.5,
+            "sharpe_basis": "closed_trade_pnl_sqrt_n",
+            "closed_trade_count_for_sharpe": 3,
+            "sharpe_daily_ann": 2.5,
+            "daily_sharpe_basis": "daily_net_pnl_sqrt_365",
+            "profit_factor": "Infinity",
+            "max_drawdown": -0.25,
+            "avg_trade": 0.42,
+            "gross_profit": 1.25,
+            "gross_loss": 0.0,
+            "equity_points": 1
+        })
+    }
+
+    fn diagnostics() -> Value {
+        json!({
+            "basis": "strategy_runtime_orders",
+            "partial_buy_threshold_pct": 98,
+            "summary": {
+                "total_orders": 7,
+                "buy_orders": 5,
+                "rejected_buy_orders": 2,
+                "buy_fill_rate_pct": 61.5
+            },
+            "strategies": [{
+                "runtime_mode": "dryrun",
+                "strategy_id": "pm5d",
+                "deployment_id": "pm5d-dryrun",
+                "buy_orders": 5,
+                "rejected_buy_orders": 2
+            }]
+        })
+    }
 }

--- a/crates/ploy-operator-contracts/src/schemas.rs
+++ b/crates/ploy-operator-contracts/src/schemas.rs
@@ -3,7 +3,7 @@ use crate::{
     DeploymentSummary, DryRunPerformanceReport, OperatorEvent, PaperIntentRequest,
     PaperIntentResponse, SystemControlResponse, SystemStatus, TradingStateSnapshot,
 };
-use schemars::{JsonSchema, schema::RootSchema};
+use schemars::{schema::RootSchema, JsonSchema};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy)]

--- a/ploy-frontend/src/types/index.ts
+++ b/ploy-frontend/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   DryRunDailyRow,
   DryRunDailyWindowRow,
   DryRunEquityPoint,
+  DryRunExecutionDiagnostics,
   DryRunMetrics,
   DryRunOpenPositionRow,
   DryRunPairingReport,

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -49,13 +49,15 @@ export interface DryRunDailyWindowRow { closed_trade_count: number; losses: numb
 
 export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
 
-export interface DryRunMetrics { avg_trade?: number | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; }
+export interface DryRunExecutionDiagnostics { basis: string; partial_buy_threshold_pct: number; strategies: JsonValue[]; summary: { [key: string]: JsonValue }; }
+
+export interface DryRunMetrics { avg_trade?: number | null; closed_trade_count_for_sharpe?: number | null; daily_sharpe_basis?: string | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; sharpe_basis?: string | null; sharpe_daily_ann?: number | null; sharpe_per_trade?: number | null; }
 
 export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; market_side?: string | null; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
-export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
 
@@ -65,7 +67,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -49,13 +49,15 @@ export interface DryRunDailyWindowRow { closed_trade_count: number; losses: numb
 
 export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
 
-export interface DryRunMetrics { avg_trade?: number | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; }
+export interface DryRunExecutionDiagnostics { basis: string; partial_buy_threshold_pct: number; strategies: JsonValue[]; summary: { [key: string]: JsonValue }; }
+
+export interface DryRunMetrics { avg_trade?: number | null; closed_trade_count_for_sharpe?: number | null; daily_sharpe_basis?: string | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; sharpe_basis?: string | null; sharpe_daily_ann?: number | null; sharpe_per_trade?: number | null; }
 
 export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; market_side?: string | null; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
-export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
 
@@ -65,7 +67,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -196,6 +196,34 @@ Issue: https://github.com/proerror77/ploy/issues/227
 - 2026-04-29: Review correction: runtime deployment rows now join to matching report strategy by `deployment_id`, while the strategy table also lists dry-run deployments that have no report rows yet. Cross-strategy equity uses close-time on the x-axis and does not bridge missing strategy points.
 - 2026-04-29: Verification passed: `node scripts/export_operator_contract_types.mjs --check`, `env CARGO_TARGET_DIR=/tmp/ploy-dryrun-contracts /opt/homebrew/bin/timeout 180 cargo run -p ploy-operator-contracts --example export_schemas -- --check`, `python3 -m py_compile scripts/report_dryrun_summary.py`, `cd ploy-frontend && npm run lint`, `cd ploy-frontend && npm run build`, `env CARGO_TARGET_DIR=/tmp/ploy-dryrun-daemon-check /opt/homebrew/bin/timeout 180 cargo check -p ploy-daemon-host`, and `git diff --check`.
 
+# Dry-run Report Diagnostics Contract Preservation (2026-04-29)
+
+## Files
+
+- `crates/ploy-operator-contracts/src/reports.rs`
+  - Owner: preserve dry-run Sharpe basis fields and execution diagnostics through the daemon contract roundtrip.
+- `contracts/schemas/dry-run-performance-report.schema.json`
+  - Owner: generated schema snapshot for the expanded dry-run report payload.
+- `ploy-frontend/src/types/operator-contracts.ts`
+- `ploy-sidecar/src/contracts/operator-contracts.ts`
+- `ploy-frontend/src/types/index.ts`
+  - Owner: generated and public TypeScript type coverage for the expanded payload.
+
+## Tasks
+
+- [x] Add contract fields for trade/daily Sharpe basis metrics.
+- [x] Add top-level and per-strategy `execution_diagnostics` contract coverage.
+- [x] Add a Rust roundtrip regression test for the daemon parse/reserialize path.
+- [x] Regenerate schema and TypeScript contract snapshots.
+- [x] Run local contract/report verification.
+- [ ] Land via PR, deploy `main` to `tango-1-1` through CI, and verify `/api/reports/dry-run` payload fields on local and public endpoints.
+
+## Review
+
+- 2026-04-29: Root cause after the report-accounting deploy was not the Python report script; `ployd` parses script stdout into `DryRunPerformanceReport` and serializes that typed value back to clients, so undeclared fields were dropped at the operator-contract boundary.
+- 2026-04-29: Added explicit contract coverage for `metrics.sharpe_per_trade`, `metrics.sharpe_basis`, `metrics.closed_trade_count_for_sharpe`, `metrics.sharpe_daily_ann`, `metrics.daily_sharpe_basis`, and `execution_diagnostics` at both report and strategy scope.
+- 2026-04-29: Local verification passed: `cargo fmt -p ploy-operator-contracts -- --check`, `rtk cargo test -p ploy-operator-contracts dry_run_report_roundtrip_preserves_diagnostics_fields`, `rtk cargo check -p ploy-operator-contracts`, `rtk cargo run --locked -p ploy-operator-contracts --example export_schemas -- --check`, `node scripts/export_operator_contract_types.mjs --check`, Python report py-compile, `python3 -m unittest tests.test_dryrun_report_contracts`, and `git diff --check`.
+
 # PM5D Expectancy And Fillable-Order Gate (2026-04-29)
 
 ## Files


### PR DESCRIPTION
## Summary
- add dry-run report contract fields for explicit Sharpe basis metrics and execution diagnostics
- regenerate JSON schema plus frontend/sidecar TypeScript contract types
- add a Rust roundtrip regression test for the ployd parse/reserialize boundary

## Verification
- cargo fmt -p ploy-operator-contracts -- --check
- rtk cargo test -p ploy-operator-contracts dry_run_report_roundtrip_preserves_diagnostics_fields
- rtk cargo check -p ploy-operator-contracts
- rtk cargo run --locked -p ploy-operator-contracts --example export_schemas -- --check
- node scripts/export_operator_contract_types.mjs --check
- python3 -m py_compile scripts/report_dryrun_summary.py scripts/report_strategy.py tests/test_dryrun_report_contracts.py
- python3 -m unittest tests.test_dryrun_report_contracts
- git diff --check

## Deploy follow-up
After merge, deploy main to tango-1-1 through deploy-tango-1-1.yml and verify /api/reports/dry-run preserves metrics.sharpe_basis and execution_diagnostics on both local and public endpoints.