### PR TITLE
Check dry-run report payload during Tango deploy

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -154,6 +154,7 @@ jobs:
           cp scripts/report_market_data_health.py dist/scripts/report_market_data_health.py
           cp scripts/audit_market_data_gaps.py dist/scripts/audit_market_data_gaps.py
           cp scripts/report_dryrun_summary.py dist/scripts/report_dryrun_summary.py
+          cp scripts/check_dryrun_report_contract.py dist/scripts/check_dryrun_report_contract.py
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
           cp scripts/fix_clob_trade_partitions.sql dist/scripts/fix_clob_trade_partitions.sql
@@ -384,6 +385,7 @@ jobs:
             install -m 0755 ./scripts/report_market_data_health.py ${DEPLOY_ROOT}/scripts/report_market_data_health.py
             install -m 0755 ./scripts/audit_market_data_gaps.py ${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py
             install -m 0755 ./scripts/report_dryrun_summary.py ${DEPLOY_ROOT}/scripts/report_dryrun_summary.py
+            install -m 0755 ./scripts/check_dryrun_report_contract.py ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
             install -m 0644 ./scripts/fix_clob_trade_partitions.sql ${DEPLOY_ROOT}/scripts/fix_clob_trade_partitions.sql
@@ -464,6 +466,7 @@ jobs:
             if service_exists ployd.service; then
               systemctl is-active --quiet ployd.service
               curl -fsS http://127.0.0.1:8081/health
+              curl -fsS http://127.0.0.1:8081/api/reports/dry-run | ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
               ${DEPLOY_ROOT}/bin/ployctl deployments list
             fi
 

--- a/scripts/check_dryrun_report_contract.py
+++ b/scripts/check_dryrun_report_contract.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate the deployed dry-run report API payload contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+EXPECTED = {
+    "metrics.sharpe_basis": "closed_trade_pnl_sqrt_n",
+    "metrics.daily_sharpe_basis": "daily_net_pnl_sqrt_365",
+    "execution_diagnostics.basis": "strategy_runtime_orders",
+    "strategies[0].execution_diagnostics.basis": "strategy_runtime_orders",
+}
+
+
+def nested_value(payload: dict, path: str):
+    value = payload
+    for part in path.split("."):
+        if part == "strategies[0]":
+            strategies = value.get("strategies") or []
+            value = strategies[0] if strategies else {}
+            continue
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    failures = {
+        path: {"expected": expected, "actual": nested_value(payload, path)}
+        for path, expected in EXPECTED.items()
+        if nested_value(payload, path) != expected
+    }
+    if failures:
+        print(json.dumps({"dry_run_report_contract_failures": failures}, sort_keys=True), file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "dry_run_report_contract": "ok",
+                "total_trades": nested_value(payload, "summary.total_trades"),
+                "sharpe_basis": nested_value(payload, "metrics.sharpe_basis"),
+                "execution_diagnostics": nested_value(payload, "execution_diagnostics.basis"),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable dry-run report payload contract checker
- install it with the Tango deploy bundle
- fail deploy postflight if /api/reports/dry-run drops Sharpe basis or execution diagnostics fields

## Verification
- python3 -m py_compile scripts/check_dryrun_report_contract.py
- curl -fsS http://8.221.143.151/api/reports/dry-run | python3 scripts/check_dryrun_report_contract.py
- YAML parse for .github/workflows/deploy-tango-1-1.yml
- git diff --check

## Follow-up
After merge, trigger deploy-tango-1-1.yml again so the new postflight check runs on tango-1-1.