### PR TITLE
Optimize PM trade active-market lookup

### DIFF
--- a/crates/ploy-market-data/src/pm_trades.rs
+++ b/crates/ploy-market-data/src/pm_trades.rs
@@ -224,23 +224,7 @@ impl TradeCollector {
         let lookback_idx = self.config.symbols.len() + 1;
         let lookahead_idx = self.config.symbols.len() + 2;
 
-        let query = format!(
-            r#"
-            SELECT
-                market_id,
-                COALESCE(market_slug, market_id) AS market_slug,
-                strategy_symbol AS symbol,
-                raw_market->>'conditionId' AS condition_id
-            FROM pm_market_catalog
-            WHERE LOWER(market_family) = 'crypto'
-              AND strategy_symbol IN ({})
-              AND raw_market->>'conditionId' IS NOT NULL
-              AND COALESCE(end_time, NOW()) >= NOW() - (${}::bigint * INTERVAL '1 second')
-              AND COALESCE(start_time, NOW()) <= NOW() + (${}::bigint * INTERVAL '1 second')
-            ORDER BY start_time NULLS LAST, end_time NULLS LAST, market_id
-            "#,
-            placeholders, lookback_idx, lookahead_idx
-        );
+        let query = active_markets_query(&placeholders, lookback_idx, lookahead_idx);
 
         let mut q = sqlx::query_as::<_, ActiveTradeMarketRow>(&query);
         for symbol in &self.config.symbols {
@@ -297,6 +281,26 @@ impl TradeCollector {
 
         Ok((fetched, inserted, skipped))
     }
+}
+
+fn active_markets_query(placeholders: &str, lookback_idx: usize, lookahead_idx: usize) -> String {
+    format!(
+        r#"
+        SELECT
+            market_id,
+            COALESCE(market_slug, market_id) AS market_slug,
+            strategy_symbol AS symbol,
+            raw_market->>'conditionId' AS condition_id
+        FROM pm_market_catalog
+        WHERE market_family = 'crypto'
+          AND strategy_symbol IN ({})
+          AND raw_market->>'conditionId' IS NOT NULL
+          AND (end_time IS NULL OR end_time >= NOW() - (${}::bigint * INTERVAL '1 second'))
+          AND (start_time IS NULL OR start_time <= NOW() + (${}::bigint * INTERVAL '1 second'))
+        ORDER BY start_time NULLS LAST, end_time NULLS LAST, market_id
+        "#,
+        placeholders, lookback_idx, lookahead_idx
+    )
 }
 
 async fn persist_trades(
@@ -409,7 +413,7 @@ fn stale_for_too_long(last_success_at: Option<DateTime<Utc>>, stale_after_secs: 
 #[cfg(test)]
 mod tests {
     use super::{
-        trade_side, trade_timestamp, TradeCollectorConfig, DEFAULT_API_LIMIT,
+        active_markets_query, trade_side, trade_timestamp, TradeCollectorConfig, DEFAULT_API_LIMIT,
         DEFAULT_MARKET_LOOKAHEAD_SECS, DEFAULT_MARKET_LOOKBACK_SECS, DEFAULT_REFRESH_INTERVAL_SECS,
         DEFAULT_STALE_AFTER_SECS, DEFAULT_TRADE_LOOKBACK_SECS,
     };
@@ -457,5 +461,17 @@ mod tests {
     fn trade_timestamp_accepts_unix_seconds() {
         let ts = trade_timestamp(1_712_205_600).expect("valid timestamp");
         assert_eq!(ts.to_rfc3339(), "2024-04-04T04:40:00+00:00");
+    }
+
+    #[test]
+    fn active_markets_query_keeps_catalog_filters_indexable() {
+        let query = active_markets_query("$1, $2", 3, 4);
+
+        assert!(query.contains("WHERE market_family = 'crypto'"));
+        assert!(query.contains("AND (end_time IS NULL OR end_time >="));
+        assert!(query.contains("AND (start_time IS NULL OR start_time <="));
+        assert!(!query.contains("LOWER(market_family)"));
+        assert!(!query.contains("COALESCE(end_time"));
+        assert!(!query.contains("COALESCE(start_time"));
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10785,3 +10785,24 @@ Review:
 ## Review
 
 - 2026-04-30: Dry-run report rows now expose `experiment_label` such as `TL v4 OBI-hard EVCal`; the cockpit uses that label first and shows deployment ID as the stable identity instead of collapsing visible names to `three_layer`.
+
+# PM Trade Collector Active-Market Query Optimization (2026-04-30)
+
+## Files
+
+- `crates/ploy-market-data/src/pm_trades.rs`
+  - Owner: active Polymarket trade market lookup used by `ploy-pm-trade-collector.service`.
+
+## Tasks
+
+- [x] Confirm the slow query on `tango-1-1` with live logs and read-only `EXPLAIN`.
+- [x] Rewrite active-market predicates to use existing `pm_market_catalog` indexes.
+- [x] Add a unit test preventing `LOWER(market_family)` / `COALESCE(end_time/start_time)` regressions in this query.
+- [x] Run focused local verification.
+- [ ] Land via PR, deploy `main` to `tango-1-1`, and verify recent collector logs no longer show the active-market query slow path.
+
+## Review
+
+- 2026-04-30: Live `EXPLAIN (ANALYZE, BUFFERS)` on `tango-1-1` showed the current query doing a `Seq Scan` over `49,794` `pm_market_catalog` rows with `228k` shared-buffer hits and `~1.1-2.5s` execution time even when returning zero rows.
+- 2026-04-30: The root cause is predicate shape, not a missing index. `LOWER(market_family)` and `COALESCE(end_time/start_time, NOW())` prevent the planner from using existing btree indexes. Rewriting to `market_family = 'crypto'` plus explicit null-aware time predicates produced a `Bitmap Heap Scan` using `idx_pm_market_catalog_family_end_time` and executed in `~0.08-0.18ms` on the live DB.
+- 2026-04-30: Local verification passed: `rtk cargo test -p ploy-market-data active_markets_query_keeps_catalog_filters_indexable --lib`, `rtk cargo test -p ploy-market-data trade_collector_config_fills_safe_defaults --lib`, `rtk cargo check -p ploy-market-data`, and `git diff --check`. Full rustfmt check was not used because current crate import ordering outside this slice would create unrelated formatting churn.


### PR DESCRIPTION
## Summary
- rewrite the Polymarket trade collector active-market query to keep catalog predicates indexable
- avoid LOWER/COALESCE wrappers on pm_market_catalog hot-path filters
- add a focused unit test for the generated SQL shape

## Evidence
- live current query on tango-1-1: Seq Scan over 49,794 rows, ~1.1-2.5s, 228k shared-buffer hits
- live rewritten query on tango-1-1: Bitmap Heap Scan using existing idx_pm_market_catalog_family_end_time, ~0.08-0.18ms

## Verification
- rtk cargo test -p ploy-market-data active_markets_query_keeps_catalog_filters_indexable --lib
- rtk cargo test -p ploy-market-data trade_collector_config_fills_safe_defaults --lib
- rtk cargo check -p ploy-market-data
- git diff --check

## Deploy follow-up
After merge, deploy main with deploy-tango-1-1.yml and verify recent ploy-pm-trade-collector logs no longer show the active-market query slow path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal market data query performance and reliability through refactored query construction.
  * Extended automated tests to validate query behavior.
  * Updated development documentation to track optimization efforts and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->