### PR TITLE
Allow empty dry-run report contract checks

### DIFF
--- a/scripts/check_dryrun_report_contract.py
+++ b/scripts/check_dryrun_report_contract.py
@@ -11,6 +11,9 @@ EXPECTED = {
     "metrics.sharpe_basis": "closed_trade_pnl_sqrt_n",
     "metrics.daily_sharpe_basis": "daily_net_pnl_sqrt_365",
     "execution_diagnostics.basis": "strategy_runtime_orders",
+}
+
+EXPECTED_WHEN_STRATEGIES_EXIST = {
     "strategies[0].execution_diagnostics.basis": "strategy_runtime_orders",
 }
 
@@ -30,10 +33,14 @@ def nested_value(payload: dict, path: str):
 
 def main() -> int:
     payload = json.load(sys.stdin)
+    expected = dict(EXPECTED)
+    if payload.get("strategies"):
+        expected.update(EXPECTED_WHEN_STRATEGIES_EXIST)
+
     failures = {
-        path: {"expected": expected, "actual": nested_value(payload, path)}
-        for path, expected in EXPECTED.items()
-        if nested_value(payload, path) != expected
+        path: {"expected": expected_value, "actual": nested_value(payload, path)}
+        for path, expected_value in expected.items()
+        if nested_value(payload, path) != expected_value
     }
     if failures:
         print(json.dumps({"dry_run_report_contract_failures": failures}, sort_keys=True), file=sys.stderr)

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -1,12 +1,16 @@
 import importlib.util
+import json
 import math
 from pathlib import Path
+import subprocess
+import sys
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SUMMARY_SCRIPT = ROOT / "scripts" / "report_dryrun_summary.py"
 HTML_SCRIPT = ROOT / "scripts" / "report_strategy.py"
+CHECK_SCRIPT = ROOT / "scripts" / "check_dryrun_report_contract.py"
 SIDE_KEY_MIGRATION = ROOT / "migrations" / "039_fix_strategy_track_record_side_key.sql"
 
 
@@ -71,6 +75,49 @@ class DryRunReportContractTests(unittest.TestCase):
         self.assertEqual(diagnostics["partial_buy_threshold_pct"], 98)
         self.assertEqual(diagnostics["summary"]["rejected_buy_orders"], 1)
         self.assertEqual(diagnostics["summary"]["buy_fill_rate_pct"], 50)
+
+    def test_report_contract_checker_accepts_clean_empty_dryrun(self) -> None:
+        payload = {
+            "summary": {"total_trades": 0},
+            "metrics": {
+                "sharpe_basis": "closed_trade_pnl_sqrt_n",
+                "daily_sharpe_basis": "daily_net_pnl_sqrt_365",
+            },
+            "execution_diagnostics": {"basis": "strategy_runtime_orders"},
+            "strategies": [],
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(CHECK_SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_report_contract_checker_validates_strategy_rows_when_present(self) -> None:
+        payload = {
+            "summary": {"total_trades": 1},
+            "metrics": {
+                "sharpe_basis": "closed_trade_pnl_sqrt_n",
+                "daily_sharpe_basis": "daily_net_pnl_sqrt_365",
+            },
+            "execution_diagnostics": {"basis": "strategy_runtime_orders"},
+            "strategies": [{"execution_diagnostics": {}}],
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(CHECK_SCRIPT)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("strategies[0].execution_diagnostics.basis", result.stderr)
 
     def test_strategy_label_prefers_versioned_experiment_label(self) -> None:
         summary = load_summary_module()


### PR DESCRIPTION
## Summary
- allow the dry-run report contract checker to pass when a clean reset has no strategy rows yet
- keep strategy-level execution diagnostics validation once strategy rows exist
- add regression tests for both empty and non-empty report payloads

## Verification
- python3 -m unittest tests.test_dryrun_report_contracts
- current Tango empty dry-run report piped through updated checker