### PR TITLE
Harden strategy research CI/CD

### DIFF
--- a/.github/ISSUE_TEMPLATE/strategy_implementation.yml
+++ b/.github/ISSUE_TEMPLATE/strategy_implementation.yml
@@ -1,0 +1,49 @@
+name: Strategy Runtime Implementation
+description: Track implementation work promoted from a research issue.
+title: "[Strategy] "
+labels: "runtime:strategy"
+body:
+  - type: input
+    id: research_issue
+    attributes:
+      label: Linked research issue
+      description: Link the research issue that justified this implementation.
+      placeholder: "#123"
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Runtime behavior change
+      description: Describe the exact strategy/runtime behavior this issue should change.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Expected code scope
+      description: List likely crates, configs, migrations, workflows, or frontend surfaces.
+      placeholder: crates/ploy-strategy-bundles, crates/ploy-strategy-runtime, config/strategies, .github/workflows
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification plan
+      description: Include local checks, PR checks, research workflows, and deployment verification.
+      value: |
+        - Local/targeted:
+        - PR CI:
+        - Replay/backtest workflow:
+        - Dry-run deploy workflow:
+        - Replay vs dry-run parity check:
+        - Remote verification:
+    validations:
+      required: true
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk limits
+      description: State dry-run/live boundary, stake cap, daily loss cap, and rollback condition when relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/strategy_research.yml
+++ b/.github/ISSUE_TEMPLATE/strategy_research.yml
@@ -1,0 +1,84 @@
+name: Strategy Research Hypothesis
+description: Track one testable strategy research idea, factor, filter, or data question.
+title: "[Research] "
+labels: "research:hypothesis"
+body:
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis
+      description: State the single claim this issue should test.
+      placeholder: "Example: PM5D entries improve when CEX momentum reverses while PM quote lags and LOB support remains one-sided."
+    validations:
+      required: true
+  - type: textarea
+    id: edge
+    attributes:
+      label: Expected edge mechanism
+      description: Explain why this should make money after spread, fees, stale quotes, and queue effects.
+    validations:
+      required: true
+  - type: textarea
+    id: data
+    attributes:
+      label: Required data
+      description: List tables, windows, symbols, labels, settlement fields, or freshness checks.
+      placeholder: binance_price_ticks, binance_lob_ticks, clob_quote_ticks, pm_token_settlements, signal_history
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow plan
+      description: Name the workflow and inputs that should test this idea.
+      placeholder: factor-review-v2.yml with start_date, end_date, symbols, stake_usd, options_json
+    validations:
+      required: true
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Success and failure criteria
+      description: Define the metrics and thresholds that decide continue, revise, reject, or promote.
+    validations:
+      required: true
+  - type: textarea
+    id: accounting
+    attributes:
+      label: Accounting contract
+      description: State whether this is exploratory diagnostics or executable strategy accounting.
+      placeholder: One PM5D event counts as one deployable trade; multiple entry-time rows are diagnostics unless a runtime rule can execute them.
+    validations:
+      required: true
+  - type: textarea
+    id: parity
+    attributes:
+      label: Replay / dry-run parity plan
+      description: Define how replay results will be compared against dry-run behavior.
+      value: |
+        - Replay window:
+        - Dry-run window:
+        - Event ids / markets:
+        - Compare fields: decision timestamp, quote, signal inputs, side, entry price, fill status, settlement, PnL
+        - Expected acceptable mismatch:
+        - Follow-up issue trigger:
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Fill this after the workflow run.
+      value: |
+        - Workflow:
+        - Run URL:
+        - Git ref:
+        - Dataset/window:
+        - Symbols:
+        - Config:
+        - Artifact:
+        - Headline metrics:
+        - Replay/dry-run parity:
+        - Caveats:
+        - Decision:
+    validations:
+      required: false

--- a/.github/scripts/research-issue-labels.js
+++ b/.github/scripts/research-issue-labels.js
@@ -1,0 +1,156 @@
+const LABEL_DEFINITIONS = {
+  "decision:pending": {
+    color: "fbca04",
+    description: "Research evidence exists, but no promotion/rejection decision has been made",
+  },
+  "decision:continue": {
+    color: "0e8a16",
+    description: "Research evidence supports continuing the current line",
+  },
+  "decision:collect-more": {
+    color: "fbca04",
+    description: "Research evidence is promising but underpowered",
+  },
+  "decision:promote": {
+    color: "0e8a16",
+    description: "Research evidence supports promotion to implementation or runtime",
+  },
+  "decision:reject": {
+    color: "b60205",
+    description: "Research evidence rejects the hypothesis",
+  },
+  "decision:revise": {
+    color: "d93f0b",
+    description: "Research evidence requires hypothesis or config revision",
+  },
+  "decision:fix-data": {
+    color: "d93f0b",
+    description: "Research evidence is blocked by data quality or source issues",
+  },
+  "decision:fix-runtime": {
+    color: "d93f0b",
+    description: "Research evidence is blocked by replay/runtime mismatch",
+  },
+  "decision:fix-workflow": {
+    color: "d93f0b",
+    description: "Research evidence is blocked by workflow or artifact defects",
+  },
+  "evidence:backtest": {
+    color: "1d76db",
+    description: "Issue has backtest workflow evidence",
+  },
+  "evidence:factor-review": {
+    color: "1d76db",
+    description: "Issue has factor review workflow evidence",
+  },
+  "evidence:walk-forward": {
+    color: "1d76db",
+    description: "Issue has walk-forward workflow evidence",
+  },
+  "evidence:optimize": {
+    color: "1d76db",
+    description: "Issue has optimize workflow evidence",
+  },
+  "evidence:parity": {
+    color: "1d76db",
+    description: "Issue has replay/dry-run parity workflow evidence",
+  },
+  "evidence:missing-artifact": {
+    color: "d73a4a",
+    description: "Workflow evidence artifact is missing",
+  },
+  "evidence:missing-metrics": {
+    color: "d73a4a",
+    description: "Workflow evidence is missing headline metrics",
+  },
+  "parity:blocked": {
+    color: "d73a4a",
+    description: "Replay/dry-run parity is not decision-grade yet",
+  },
+  "parity:ready": {
+    color: "0e8a16",
+    description: "Replay/dry-run parity exposed strict matching evidence",
+  },
+};
+
+const MANAGED_STATE_PREFIXES = ["decision:", "parity:", "evidence:missing-"];
+
+function normalizeLabel(name) {
+  return String(name || "").trim();
+}
+
+function labelsForDecision(decision) {
+  const value = String(decision || "").toLowerCase();
+  if (!value || value.includes("pending")) return ["decision:pending"];
+  if (value.includes("promote")) return ["decision:promote"];
+  if (value.includes("reject")) return ["decision:reject"];
+  if (value.includes("collect")) return ["decision:collect-more"];
+  if (value.includes("revise")) return ["decision:revise"];
+  if (value.includes("fix-data-or-runtime")) return ["decision:fix-data", "decision:fix-runtime"];
+  if (value.includes("fix-data") || value.includes("data-source")) return ["decision:fix-data"];
+  if (value.includes("fix-runtime") || value.includes("runtime-mismatch")) return ["decision:fix-runtime"];
+  if (value.includes("fix-workflow") || value.includes("artifact")) return ["decision:fix-workflow"];
+  if (value.includes("continue")) return ["decision:continue"];
+  return ["decision:pending"];
+}
+
+async function ensureLabel({ github, context, core, name }) {
+  const definition = LABEL_DEFINITIONS[name] || {
+    color: "cfd3d7",
+    description: "Managed by research CI/CD evidence workflows",
+  };
+  try {
+    await github.rest.issues.createLabel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      name,
+      color: definition.color,
+      description: definition.description,
+    });
+    if (core) core.info(`Created label ${name}`);
+  } catch (error) {
+    if (error.status !== 422) throw error;
+  }
+}
+
+async function applyResearchIssueLabels({ github, context, core, issue_number, labels }) {
+  const nextLabels = Array.from(new Set((labels || []).map(normalizeLabel).filter(Boolean)));
+  for (const name of nextLabels) {
+    await ensureLabel({ github, context, core, name });
+  }
+
+  const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number,
+    per_page: 100,
+  });
+  const nextSet = new Set(nextLabels);
+
+  for (const label of current) {
+    const name = label.name;
+    const managed = MANAGED_STATE_PREFIXES.some((prefix) => name.startsWith(prefix));
+    if (!managed || nextSet.has(name)) continue;
+    await github.rest.issues.removeLabel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number,
+      name,
+    });
+  }
+
+  if (nextLabels.length > 0) {
+    await github.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number,
+      labels: nextLabels,
+    });
+  }
+  if (core) core.info(`Applied research labels: ${nextLabels.join(", ") || "none"}`);
+}
+
+module.exports = {
+  applyResearchIssueLabels,
+  labelsForDecision,
+};

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -61,8 +63,26 @@ jobs:
         id: fmt
         run: |
           set +e
-          cargo fmt --all -- --check > fmt.log 2>&1
-          status=$?
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only --diff-filter=ACMRT \
+              "${{ github.event.pull_request.base.sha }}"...HEAD \
+              -- '*.rs' ':!vendor/**' > fmt-files.txt
+          else
+            git ls-files '*.rs' ':!vendor/**' > fmt-files.txt
+          fi
+
+          if [ -s fmt-files.txt ]; then
+            {
+              echo "Checked Rust files:"
+              sed 's/^/- /' fmt-files.txt
+              echo
+              xargs rustfmt --check < fmt-files.txt
+            } > fmt.log 2>&1
+            status=$?
+          else
+            echo "No changed Rust files to format-check." > fmt.log
+            status=0
+          fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
           tail -n 80 fmt.log > fmt.tail.log || true
           exit 0
@@ -74,7 +94,13 @@ jobs:
           SCCACHE_CACHE_SIZE: 10G
         run: |
           set +e
-          cargo clippy --all-targets --features rl > clippy.log 2>&1
+          {
+            echo "## default workspace members"
+            cargo clippy --locked --all-targets
+            echo
+            echo "## research heavy feature contract"
+            cargo check --locked -p ploy-research --features db,polars-export,ml,rl,strategy-runtime --lib
+          } > clippy.log 2>&1
           status=$?
           echo "status=$status" >> "$GITHUB_OUTPUT"
           tail -n 120 clippy.log > clippy.tail.log || true

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -36,28 +36,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91
-          components: clippy, rustfmt
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld
-          sudo apt-get install -y sccache || cargo install sccache --locked
-          sudo apt-get install -y mold || true
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: auto-review
-
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/sccache
-          key: ${{ runner.os }}-sccache-auto-review-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-sccache-auto-review-
-            ${{ runner.os }}-sccache-
+          components: rustfmt
 
       - name: Check formatting
         id: fmt
@@ -87,41 +66,16 @@ jobs:
           tail -n 80 fmt.log > fmt.tail.log || true
           exit 0
 
-      - name: Run clippy review
-        id: clippy
-        env:
-          RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 10G
-        run: |
-          set +e
-          {
-            echo "## default workspace members"
-            cargo clippy --locked --all-targets
-            echo
-            echo "## research heavy feature contract"
-            cargo check --locked -p ploy-research --features db,polars-export,ml,rl,strategy-runtime --lib
-          } > clippy.log 2>&1
-          status=$?
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-          tail -n 120 clippy.log > clippy.tail.log || true
-          exit 0
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats || true
-
       - name: Create or update auto-review comment
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v9
         env:
           FMT_STATUS: ${{ steps.fmt.outputs.status }}
-          CLIPPY_STATUS: ${{ steps.clippy.outputs.status }}
         with:
           script: |
             const fs = require("fs");
             const marker = "<!-- auto-review-bot -->";
             const fmtOk = process.env.FMT_STATUS === "0";
-            const clippyOk = process.env.CLIPPY_STATUS === "0";
 
             const readLog = (path) => {
               try {
@@ -133,27 +87,18 @@ jobs:
             };
 
             const fmtLog = readLog("fmt.tail.log");
-            const clippyLog = readLog("clippy.tail.log");
 
             const body = [
               marker,
               "## Auto Review Summary",
               "",
-              `- \`cargo fmt --check\`: ${fmtOk ? "PASS" : "NEEDS FIX"}`,
-              `- \`cargo clippy\`: ${clippyOk ? "PASS" : "NEEDS FIX"}`,
+              `- Changed Rust formatting: ${fmtOk ? "PASS" : "NEEDS FIX"}`,
+              "- Compile/test matrix: handled by the required `Test` workflow checks.",
               "",
               "<details><summary>fmt output (tail)</summary>",
               "",
               "```text",
               fmtLog,
-              "```",
-              "",
-              "</details>",
-              "",
-              "<details><summary>clippy output (tail)</summary>",
-              "",
-              "```text",
-              clippyLog,
               "```",
               "",
               "</details>",

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -166,6 +166,7 @@ jobs:
         with:
           script: |
             const fs = require("fs");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
             const issue_number = Number("${{ github.event.inputs.issue_number }}");
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let metrics = null;
@@ -205,3 +206,11 @@ jobs:
               issue_number,
               body
             });
+            const labels = ["evidence:backtest", ...labelsForDecision(decision)];
+            if (riskFlags.includes("missing_headline_metrics")) {
+              labels.push("evidence:missing-metrics");
+            }
+            if (riskFlags.includes("missing_evaluation_artifact")) {
+              labels.push("evidence:missing-artifact");
+            }
+            await applyResearchIssueLabels({ github, context, core, issue_number, labels });

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -27,6 +27,10 @@ on:
         description: "Sync the full Parquet tree from Tango before running"
         required: false
         default: "false"
+      issue_number:
+        description: "Optional GitHub issue number for posting backtest evidence"
+        required: false
+        default: ""
 
 concurrency:
   group: backtest-${{ github.ref }}
@@ -34,16 +38,17 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: Build run_backtest binary
+  backtest:
+    name: Build and run backtest on ploy-ci-1
     runs-on: [self-hosted, ploy-ci-1]
-    timeout-minutes: 45
+    timeout-minutes: 75
     environment: ploy-ci-1
 
     steps:
@@ -51,7 +56,7 @@ jobs:
         run: |
           if [ -d "${GITHUB_WORKSPACE}" ]; then
             sudo chown -R "$(id -un):$(id -gn)" "${GITHUB_WORKSPACE}" || true
-            sudo rm -rf "${GITHUB_WORKSPACE}/target" "${GITHUB_WORKSPACE}/.cargo-lock" || true
+            sudo rm -rf "${GITHUB_WORKSPACE}/.cargo-lock" || true
           fi
 
       - name: Checkout code
@@ -62,49 +67,23 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: backtest-${{ hashFiles('crates/ploy-strategy-bundles/**', 'Cargo.lock') }}
-
       - name: Build run_backtest
+        env:
+          DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
+          set -euo pipefail
           . /home/runner/.cargo/env
-          cargo build --release --locked \
-            -p ploy-strategy-bundles \
-            --features ploy-strategy-bundles/parquet-feed \
+          cargo_args=(
+            build
+            --release
+            --locked
+            -p ploy-strategy-bundles
             --example run_backtest
-
-      - name: Upload run_backtest binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: run_backtest-${{ github.sha }}
-          path: target/release/examples/run_backtest
-          retention-days: 1
-
-  backtest:
-    name: Run backtest on ploy-ci-1
-    runs-on: [self-hosted, ploy-ci-1]
-    timeout-minutes: 30
-    environment: ploy-ci-1
-    needs: [build]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.git_ref }}
-
-      - name: Download run_backtest binary
-        uses: actions/download-artifact@v8
-        with:
-          name: run_backtest-${{ github.sha }}
-          path: target/release/examples
-
-      - name: Make binary executable
-        run: chmod +x target/release/examples/run_backtest
+          )
+          if [ -n "$DATA_DIR" ]; then
+            cargo_args+=(--features ploy-strategy-bundles/parquet-feed)
+          fi
+          cargo "${cargo_args[@]}"
 
       - name: Sync Parquet data from Tango-1-1
         if: ${{ github.event.inputs.data_dir != '' && github.event.inputs.sync_parquet_data == 'true' }}
@@ -112,8 +91,6 @@ jobs:
           DATA_DIR: ${{ github.event.inputs.data_dir }}
         run: |
           set -euo pipefail
-          mkdir -p artifacts/backtest
-          started=$(date +%s)
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
           chmod 600 ~/.ssh/tango_key
@@ -122,9 +99,6 @@ jobs:
             -e "ssh -i ~/.ssh/tango_key -o StrictHostKeyChecking=no" \
             root@172.16.0.204:/opt/ploy/data/parquet/ \
             "${DATA_DIR}/"
-          elapsed=$(( $(date +%s) - started ))
-          printf '{"phase":"rsync_parquet","wall_secs":%s,"data_dir":"%s"}\n' "${elapsed}" "${DATA_DIR}" \
-            > artifacts/backtest/rsync-timing.json
 
       - name: Run backtest
         env:
@@ -133,49 +107,101 @@ jobs:
           END_DATE: ${{ github.event.inputs.end_date }}
           DATA_DIR: ${{ github.event.inputs.data_dir }}
           SYNC_PARQUET_DATA: ${{ github.event.inputs.sync_parquet_data }}
+          PLOY_RESEARCH_DATABASE_URL: ${{ secrets.PLOY_RESEARCH_DATABASE_URL || vars.PLOY_RESEARCH_DATABASE_URL }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           mkdir -p artifacts/backtest
-          started=$(date +%s)
           extra_args=()
           if [ -n "$DATA_DIR" ]; then
             if [ ! -d "$DATA_DIR" ]; then
-              echo "ERROR: DATA_DIR '$DATA_DIR' does not exist; set sync_parquet_data=true or leave data_dir empty to use DB" \
-                | tee artifacts/backtest/report.txt
-              printf '{"phase":"backtest_workflow_step","wall_secs":0,"status":2,"missing_data_dir":"%s","sync_parquet_data":"%s"}\n' \
-                "$DATA_DIR" "$SYNC_PARQUET_DATA" > artifacts/backtest/workflow-timing.json
+              echo "DATA_DIR '$DATA_DIR' does not exist (sync_parquet_data=$SYNC_PARQUET_DATA); set sync_parquet_data=true or leave data_dir empty to use DB" >&2
               exit 2
             fi
             extra_args=(--data-dir "$DATA_DIR")
+          elif [ -z "${PLOY_RESEARCH_DATABASE_URL}" ]; then
+            echo "PLOY_RESEARCH_DATABASE_URL is required when data_dir is empty" >&2
+            exit 1
           fi
-          set +e
+          if [ -n "${PLOY_RESEARCH_DATABASE_URL}" ]; then
+            extra_args+=(--db-url "${PLOY_RESEARCH_DATABASE_URL}")
+          fi
           ./target/release/examples/run_backtest \
             --config "${CONFIG}" \
-            --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --start-date "${START_DATE}" \
             --end-date "${END_DATE}" \
-            --timing-json artifacts/backtest/timing.json \
-            "${extra_args[@]}" \
-            2>&1 | tee artifacts/backtest/report.txt
-          status=${PIPESTATUS[0]}
-          elapsed=$(( $(date +%s) - started ))
-          printf '{"phase":"backtest_workflow_step","wall_secs":%s,"status":%s}\n' "${elapsed}" "${status}" \
-            > artifacts/backtest/workflow-timing.json
-          if [ -f artifacts/backtest/timing.json ]; then
-            {
-              echo "## Backtest timing"
-              echo '```json'
-              cat artifacts/backtest/timing.json
-              echo '```'
-            } >> "${GITHUB_STEP_SUMMARY}"
-          fi
-          exit "${status}"
+            --git-ref "${{ github.event.inputs.git_ref }}" \
+            --output-json artifacts/backtest/evaluation.json \
+            "${extra_args[@]}"
 
-      - name: Upload backtest report
-        if: ${{ always() }}
+      - name: Publish backtest summary
+        if: always()
+        run: |
+          {
+            echo "## PM5D Backtest"
+            echo ""
+            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Config: \`${{ github.event.inputs.config }}\`"
+            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
+            if [ -f artifacts/backtest/evaluation.json ]; then
+              echo "- Artifact: \`backtest-evaluation-${{ github.run_id }}\`"
+              echo ""
+              echo '```json'
+              python3 -c 'import json; data=json.load(open("artifacts/backtest/evaluation.json")); print(json.dumps({"producer": data.get("producer"), "replay_mode": data.get("replay_mode"), "canonical_result": data.get("canonical_result"), "metrics": data.get("metrics"), "risk_flags": data.get("risk_flags")}, indent=2, sort_keys=True))'
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload backtest evaluation artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: backtest-report-${{ github.run_id }}
-          path: artifacts/backtest
+          name: backtest-evaluation-${{ github.run_id }}
+          path: artifacts/backtest/
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Comment backtest evidence on issue
+        if: ${{ always() && github.event.inputs.issue_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const issue_number = Number("${{ github.event.inputs.issue_number }}");
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let metrics = null;
+            let riskFlags = [];
+            let decision = "pending replay/dry-run parity review";
+            if (fs.existsSync("artifacts/backtest/evaluation.json")) {
+              const data = JSON.parse(fs.readFileSync("artifacts/backtest/evaluation.json", "utf8"));
+              metrics = data.metrics || null;
+              riskFlags = data.risk_flags || [];
+              if (!metrics || Object.keys(metrics).length === 0) {
+                riskFlags.push("missing_headline_metrics");
+                decision = "fix-workflow-or-artifact";
+              }
+            } else {
+              riskFlags.push("missing_evaluation_artifact");
+              decision = "fix-workflow-or-data-source";
+            }
+            const headlineMetrics = metrics && Object.keys(metrics).length > 0
+              ? JSON.stringify(metrics)
+              : "unavailable";
+            const body = [
+              "Backtest evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Git ref: ${{ github.event.inputs.git_ref }}`,
+              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
+              `- Config: \`${{ github.event.inputs.config }}\``,
+              `- Artifact: \`backtest-evaluation-${process.env.GITHUB_RUN_ID}\``,
+              `- Headline metrics: \`${headlineMetrics}\``,
+              `- Caveats: \`${riskFlags.join(", ") || "none"}\``,
+              `- Decision: ${decision}`
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/build-push-acr.yml
+++ b/.github/workflows/build-push-acr.yml
@@ -10,7 +10,10 @@ on:
       push_images:
         description: "Push images to ACR"
         type: boolean
-        default: true
+        default: false
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,6 +37,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Capture checked-out commit
+        run: echo "BUILD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Enforce immutable image push provenance
+        if: ${{ github.event.inputs.push_images == 'true' }}
+        run: |
+          if [ "${{ github.event.inputs.git_ref }}" != "main" ]; then
+            echo "ACR image pushes must use git_ref=main" >&2
+            exit 1
+          fi
 
       - name: Set reproducible build environment
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
@@ -109,28 +123,25 @@ jobs:
       - name: Build and push ploy-runner image
         run: |
           IMAGE="${ACR_REGISTRY}/${ACR_NAMESPACE}/ploy-runner"
-          docker build -f Dockerfile.runner -t "${IMAGE}:${{ github.sha }}" -t "${IMAGE}:latest" .
+          docker build -f Dockerfile.runner -t "${IMAGE}:${BUILD_SHA}" .
           if [ "${{ github.event.inputs.push_images }}" = "true" ]; then
-            docker push "${IMAGE}:${{ github.sha }}"
-            docker push "${IMAGE}:latest"
+            docker push "${IMAGE}:${BUILD_SHA}"
           fi
 
       - name: Build and push ploy-collector image
         run: |
           IMAGE="${ACR_REGISTRY}/${ACR_NAMESPACE}/ploy-collector"
-          docker build -f Dockerfile.collector -t "${IMAGE}:${{ github.sha }}" -t "${IMAGE}:latest" .
+          docker build -f Dockerfile.collector -t "${IMAGE}:${BUILD_SHA}" .
           if [ "${{ github.event.inputs.push_images }}" = "true" ]; then
-            docker push "${IMAGE}:${{ github.sha }}"
-            docker push "${IMAGE}:latest"
+            docker push "${IMAGE}:${BUILD_SHA}"
           fi
 
       - name: Build and push ploy-research image
         run: |
           IMAGE="${ACR_REGISTRY}/${ACR_NAMESPACE}/ploy-research"
-          docker build -f Dockerfile.research -t "${IMAGE}:${{ github.sha }}" -t "${IMAGE}:latest" .
+          docker build -f Dockerfile.research -t "${IMAGE}:${BUILD_SHA}" .
           if [ "${{ github.event.inputs.push_images }}" = "true" ]; then
-            docker push "${IMAGE}:${{ github.sha }}"
-            docker push "${IMAGE}:latest"
+            docker push "${IMAGE}:${BUILD_SHA}"
           fi
 
       - name: Summary
@@ -140,5 +151,6 @@ jobs:
             echo "- ploy-runner: built"
             echo "- ploy-collector: built"
             echo "- ploy-research: built"
-            echo "- SHA: ${{ github.sha }}"
+            echo "- Image tag: \`${BUILD_SHA}\`"
+            echo "- Push images: \`${{ github.event.inputs.push_images }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-ack.yml
+++ b/.github/workflows/deploy-ack.yml
@@ -4,23 +4,67 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Image tag to deploy (SHA or 'latest')"
+        description: "Immutable 40-character image SHA tag to deploy"
         required: true
-        default: "latest"
+        default: ""
+      provenance_ref:
+        description: "Reviewed provenance ref containing image_tag (main, release/*, or version tag)"
+        required: true
+        default: "main"
       component:
         description: "Component to deploy (all/ployd/strategy/collectors)"
         required: true
         default: "all"
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
     name: Deploy to ACK cluster
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: ack
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Validate immutable image tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          image_tag="${{ github.event.inputs.image_tag }}"
+          provenance_ref="${{ github.event.inputs.provenance_ref }}"
+          if [ -z "${image_tag}" ]; then
+            echo "image_tag is required and must be the immutable SHA tag produced by build-push-acr.yml" >&2
+            exit 1
+          fi
+          if [ "${image_tag}" = "latest" ]; then
+            echo "ACK deploy cannot use mutable latest image tags" >&2
+            exit 1
+          fi
+          if ! printf '%s' "${image_tag}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "image_tag must be a full 40-character lowercase git SHA tag" >&2
+            exit 1
+          fi
+          case "${provenance_ref}" in
+            main|release/*|v[0-9]*)
+              ;;
+            *)
+              echo "provenance_ref must be main, release/*, or a version tag" >&2
+              exit 1
+              ;;
+          esac
+          status="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${image_tag}...${provenance_ref}" --jq .status)"
+          case "${status}" in
+            ahead|identical)
+              ;;
+            *)
+              echo "image_tag ${image_tag} is not contained in provenance ref ${provenance_ref}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -61,6 +61,29 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
+      - name: Validate deploy provenance
+        if: ${{ inputs.deploy }}
+        env:
+          INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Deployments to tango-1-1 must dispatch the workflow from main; got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          if [ "${INPUT_GIT_REF}" != "main" ]; then
+            echo "Deployments to tango-1-1 must use git_ref=main; got ${INPUT_GIT_REF}" >&2
+            exit 1
+          fi
+          git fetch --no-tags --depth=1 origin main
+          checked_out_sha="$(git rev-parse HEAD)"
+          main_sha="$(git rev-parse origin/main)"
+          if [ "${checked_out_sha}" != "${main_sha}" ]; then
+            echo "Checked-out deploy SHA ${checked_out_sha} does not match origin/main ${main_sha}" >&2
+            exit 1
+          fi
+          echo "Deploy provenance verified: git_ref=main sha=${checked_out_sha}"
+
       - name: Set reproducible build environment
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
 
@@ -228,8 +251,17 @@ jobs:
 
       - name: Configure SSH for deploy
         if: ${{ inputs.deploy }}
+        env:
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
         run: |
+          set -euo pipefail
           install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
           chmod 600 ~/.ssh/tango_1_1_key
           cat > ~/.ssh/config <<EOF
@@ -237,8 +269,9 @@ jobs:
             HostName ${DEPLOY_HOST}
             User root
             IdentityFile ~/.ssh/tango_1_1_key
-            StrictHostKeyChecking no
-            UserKnownHostsFile /dev/null
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
             ServerAliveInterval 30
             ServerAliveCountMax 20
             ConnectTimeout 30

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -11,7 +11,7 @@ on:
         description: "Copy the built runner to ploy-trade-1 and restart services"
         type: boolean
         required: true
-        default: true
+        default: false
 
 concurrency:
   group: deploy-trade-1
@@ -35,12 +35,36 @@ jobs:
     name: Build and deploy to ploy-trade-1
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    environment: ploy-trade-1
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Validate deploy provenance
+        if: ${{ inputs.deploy }}
+        env:
+          INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Deployments to ploy-trade-1 must dispatch the workflow from main; got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          if [ "${INPUT_GIT_REF}" != "main" ]; then
+            echo "Deployments to ploy-trade-1 must use git_ref=main; got ${INPUT_GIT_REF}" >&2
+            exit 1
+          fi
+          git fetch --no-tags --depth=1 origin main
+          checked_out_sha="$(git rev-parse HEAD)"
+          main_sha="$(git rev-parse origin/main)"
+          if [ "${checked_out_sha}" != "${main_sha}" ]; then
+            echo "Checked-out deploy SHA ${checked_out_sha} does not match origin/main ${main_sha}" >&2
+            exit 1
+          fi
+          echo "Deploy provenance verified: git_ref=main sha=${checked_out_sha}"
 
       - name: Set reproducible build environment
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
@@ -103,8 +127,17 @@ jobs:
 
       - name: Configure SSH
         if: ${{ inputs.deploy }}
+        env:
+          PLOY_TRADE_1_KNOWN_HOSTS: ${{ secrets.PLOY_TRADE_1_KNOWN_HOSTS }}
         run: |
+          set -euo pipefail
           install -m 700 -d ~/.ssh
+          if [ -z "${PLOY_TRADE_1_KNOWN_HOSTS}" ]; then
+            echo "PLOY_TRADE_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          printf '%s\n' "${PLOY_TRADE_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           printf '%s\n' '${{ secrets.PLOY_TRADE_1_SSH_KEY }}' > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           cat > ~/.ssh/config <<EOF
@@ -112,8 +145,9 @@ jobs:
             HostName ${{ secrets.PLOY_TRADE_1_HOST }}
             User root
             IdentityFile ~/.ssh/deploy_key
-            StrictHostKeyChecking no
-            UserKnownHostsFile /dev/null
+            HostKeyAlias ploy-trade-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
             ServerAliveInterval 30
             ServerAliveCountMax 20
             ConnectTimeout 30
@@ -153,6 +187,11 @@ jobs:
             if systemctl is-enabled --quiet ploy-strategy-dryrun.service; then
               systemctl is-active --quiet ploy-strategy-dryrun.service
               echo "ploy-strategy-dryrun.service: active"
+            fi
+            if pgrep -af '(^|/)cargo|(^|/)rustc' >/dev/null; then
+              echo "Unexpected Rust build process running on ploy-trade-1" >&2
+              pgrep -af '(^|/)cargo|(^|/)rustc' >&2
+              exit 1
             fi
           REMOTE
 

--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -27,38 +27,6 @@ on:
         description: "Chronological events per child event-root dataset"
         required: true
         default: "150"
-      lob_sample_secs:
-        description: "Binance LOB sample interval for factor export"
-        required: false
-        default: "30"
-      max_quote_age_secs:
-        description: "Maximum PM quote age for factor observations"
-        required: false
-        default: "30"
-      entry_secs:
-        description: "Event ML entry seconds before settlement"
-        required: false
-        default: "60"
-      tolerance_secs:
-        description: "Entry row tolerance in seconds"
-        required: false
-        default: "30"
-      search_l2:
-        description: "Comma-separated logistic L2 grid"
-        required: false
-        default: "0,0.001,0.01"
-      search_min_edge:
-        description: "Comma-separated minimum edge grid"
-        required: false
-        default: "0,0.02,0.05"
-      search_learning_rate:
-        description: "Comma-separated learning-rate grid"
-        required: false
-        default: "0.03,0.05"
-      search_epochs:
-        description: "Logistic search epochs per candidate"
-        required: false
-        default: "500"
       run_workflow:
         description: "Run full event_ml_rolling_workflow after dataset split"
         required: false
@@ -67,6 +35,10 @@ on:
         description: "Upload raw event-root Parquet datasets as artifacts"
         required: false
         default: "false"
+      options_json:
+        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid"
+        required: false
+        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500}'
 
 concurrency:
   group: event-ml-rolling-evidence-${{ github.ref }}
@@ -101,6 +73,42 @@ jobs:
 
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "lob_sample_secs": "30",
+              "max_quote_age_secs": "30",
+              "entry_secs": "60",
+              "tolerance_secs": "30",
+              "search_l2": "0,0.001,0.01",
+              "search_min_edge": "0,0.02,0.05",
+              "search_learning_rate": "0.03,0.05",
+              "search_epochs": "500",
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+          values = dict(defaults)
+          values.update({key: str(value) for key, value in data.items()})
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"EVENT_ML_{key.upper()}={value}\n")
+          PY
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -142,8 +150,8 @@ jobs:
             --end-date "${{ github.event.inputs.end_date }}" \
             --discover-valid-5m-windows \
             --max-windows "${{ github.event.inputs.source_windows }}" \
-            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
-            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --lob-sample-secs "${EVENT_ML_LOB_SAMPLE_SECS}" \
+            --max-quote-age-secs "${EVENT_ML_MAX_QUOTE_AGE_SECS}" \
             --export-event-dataset artifacts/event-ml/source_event_root \
             | tee artifacts/event-ml/reports/source_export.txt
 
@@ -174,12 +182,12 @@ jobs:
             --example event_ml_rolling_workflow -- \
             --datasets "${DATASETS}" \
             --output-root artifacts/event-ml/rolling_workflow \
-            --entry-secs "${{ github.event.inputs.entry_secs }}" \
-            --tolerance-secs "${{ github.event.inputs.tolerance_secs }}" \
-            --search-l2 "${{ github.event.inputs.search_l2 }}" \
-            --search-min-edge "${{ github.event.inputs.search_min_edge }}" \
-            --search-learning-rate "${{ github.event.inputs.search_learning_rate }}" \
-            --search-epochs "${{ github.event.inputs.search_epochs }}" \
+            --entry-secs "${EVENT_ML_ENTRY_SECS}" \
+            --tolerance-secs "${EVENT_ML_TOLERANCE_SECS}" \
+            --search-l2 "${EVENT_ML_SEARCH_L2}" \
+            --search-min-edge "${EVENT_ML_SEARCH_MIN_EDGE}" \
+            --search-learning-rate "${EVENT_ML_SEARCH_LEARNING_RATE}" \
+            --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
             | tee artifacts/event-ml/reports/rolling_workflow.txt
 
       - name: Collect compact reports

--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -35,61 +35,14 @@ on:
         description: "Maximum PM quote age"
         required: false
         default: "30"
-      top_n:
-        description: "Number of factor rows to print"
-        required: false
-        default: "50"
-      min_observations:
-        description: "Minimum observations for a factor"
-        required: false
-        default: "20"
-      top_quantile:
-        description: "Selected quantile for execution metrics"
-        required: false
-        default: "0.2"
       snapshot_run_id:
         description: "Optional Research Snapshot workflow run id to consume"
         required: false
         default: ""
-      compile_snapshot:
-        description: "Compile a fresh snapshot before review when snapshot_run_id is empty"
+      options_json:
+        description: "Advanced options JSON: top_n, snapshot/data/audit settings, issue_number"
         required: false
-        default: "true"
-      allow_direct_db_debug:
-        description: "Allow non-canonical direct DB review when no snapshot is present"
-        required: false
-        default: "false"
-      optimizer_data_dir:
-        description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
-        required: false
-        default: "/tmp/ploy-parquet"
-      data_profile:
-        description: "Project data requirements profile for fresh snapshots"
-        type: choice
-        required: true
-        default: "pm5d-execution"
-        options:
-          - pm5d-execution
-          - pm5d-vol
-          - all
-          - custom
-      custom_required_sources:
-        description: "Comma-separated sources when data_profile=custom"
-        required: false
-        default: ""
-      audit_lookback_hours:
-        description: "Market-data audit lookback in hours"
-        required: false
-        default: "168"
-      data_gate:
-        description: "Fail threshold for required-source audit"
-        type: choice
-        required: true
-        default: "never"
-        options:
-          - critical
-          - warn
-          - never
+        default: '{"top_n":50,"min_observations":20,"top_quantile":0.2,"compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":""}'
 
 concurrency:
   group: factor-review-v2-${{ github.ref }}
@@ -98,6 +51,7 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -127,10 +81,70 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Ensure psql client
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
         run: |
           set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "top_n": "50",
+              "min_observations": "20",
+              "top_quantile": "0.2",
+              "compile_snapshot": "true",
+              "allow_direct_db_debug": "false",
+              "optimizer_data_dir": "/tmp/ploy-parquet",
+              "data_profile": "pm5d-execution",
+              "custom_required_sources": "",
+              "audit_lookback_hours": "168",
+              "data_gate": "never",
+              "issue_number": "",
+          }
+          bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
+          choices = {
+              "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
+              "data_gate": {"critical", "warn", "never"},
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          for key, value in data.items():
+              if key in bool_keys:
+                  if isinstance(value, bool):
+                      values[key] = "true" if value else "false"
+                  elif str(value).lower() in {"true", "false"}:
+                      values[key] = str(value).lower()
+                  else:
+                      raise SystemExit(f"options_json value for {key} must be boolean")
+              else:
+                  values[key] = str(value)
+              if key in choices and values[key] not in choices[key]:
+                  allowed = ", ".join(sorted(choices[key]))
+                  raise SystemExit(f"options_json value for {key} must be one of: {allowed}")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"FACTOR_{key.upper()}={value}\n")
+          PY
+
+      - name: Ensure psql client
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${FACTOR_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping psql client check."
+            exit 0
+          fi
           if command -v psql >/dev/null 2>&1; then
             psql --version
             exit 0
@@ -145,12 +159,10 @@ jobs:
 
       - name: Resolve data requirements
         id: data_scope
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
-        env:
-          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
-          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
         run: |
           set -euo pipefail
+          DATA_PROFILE="${FACTOR_DATA_PROFILE}"
+          CUSTOM_REQUIRED_SOURCES="${FACTOR_CUSTOM_REQUIRED_SOURCES}"
           case "${DATA_PROFILE}" in
             pm5d-execution)
               required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
@@ -185,13 +197,17 @@ jobs:
 
       - name: Audit required market data
         id: data_audit
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         env:
           REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
-          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
-          DATA_GATE: ${{ github.event.inputs.data_gate }}
         run: |
           set -euo pipefail
+          AUDIT_LOOKBACK_HOURS="${FACTOR_AUDIT_LOOKBACK_HOURS}"
+          export DATA_GATE="${FACTOR_DATA_GATE}"
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${FACTOR_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping scoped data audit."
+            echo "overall_status=skipped" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
           mkdir -p artifacts/research-snapshot
           PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
             scripts/audit_market_data_gaps.py \
@@ -275,9 +291,12 @@ jobs:
             --require quality.md
 
       - name: Compile research snapshot
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         run: |
           set -euo pipefail
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${FACTOR_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping snapshot compile."
+            exit 0
+          fi
           deribit_args=()
           if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
             deribit_args+=(--skip-deribit)
@@ -293,7 +312,7 @@ jobs:
             --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
             --output-dir artifacts/research-snapshot \
-            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --optimizer-data-dir "${FACTOR_OPTIMIZER_DATA_DIR}" \
             --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
             --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
             --data-audit-report data-gap-audit.json \
@@ -308,7 +327,7 @@ jobs:
           if [ -f artifacts/research-snapshot/manifest.json ]; then
             source_args=(--snapshot-dir artifacts/research-snapshot)
             echo "canonical_result=snapshot" | tee artifacts/factor-review-v2/source.txt
-          elif [ "${{ github.event.inputs.allow_direct_db_debug }}" = "true" ]; then
+          elif [ "${FACTOR_ALLOW_DIRECT_DB_DEBUG}" = "true" ]; then
             source_args=(--db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" --allow-direct-db-debug)
             echo "canonical_result=no direct_db_debug=true" | tee artifacts/factor-review-v2/source.txt
           else
@@ -324,9 +343,9 @@ jobs:
             --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
             --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
             --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
-            --min-observations "${{ github.event.inputs.min_observations }}" \
-            --top-quantile "${{ github.event.inputs.top_quantile }}" \
-            --top-n "${{ github.event.inputs.top_n }}" \
+            --min-observations "${FACTOR_MIN_OBSERVATIONS}" \
+            --top-quantile "${FACTOR_TOP_QUANTILE}" \
+            --top-n "${FACTOR_TOP_N}" \
             | tee artifacts/factor-review-v2/report.txt
 
       - name: Publish summary
@@ -367,3 +386,33 @@ jobs:
             artifacts/factor-review-v2/
             artifacts/research-snapshot/
           retention-days: 14
+
+      - name: Comment factor evidence on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumberRaw = process.env.FACTOR_ISSUE_NUMBER || "";
+            if (!issueNumberRaw) {
+              core.info("No issue_number configured in options_json; skipping issue comment.");
+              return;
+            }
+            const issue_number = Number(issueNumberRaw);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "Factor review evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Git ref: ${{ github.event.inputs.git_ref }}`,
+              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
+              `- Symbols: ${{ github.event.inputs.symbols }}`,
+              `- Artifact: \`factor-review-v2-${process.env.GITHUB_RUN_ID}\``,
+              "- Decision: pending"
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -392,6 +392,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const { applyResearchIssueLabels } = require("./.github/scripts/research-issue-labels.js");
             const issueNumberRaw = process.env.FACTOR_ISSUE_NUMBER || "";
             if (!issueNumberRaw) {
               core.info("No issue_number configured in options_json; skipping issue comment.");
@@ -415,4 +416,11 @@ jobs:
               repo: context.repo.repo,
               issue_number,
               body
+            });
+            await applyResearchIssueLabels({
+              github,
+              context,
+              core,
+              issue_number,
+              labels: ["evidence:factor-review", "decision:pending"]
             });

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -23,97 +23,23 @@ on:
         description: "Fixed notional per candidate"
         required: true
         default: "15"
-      train_window_days:
-        description: "Training window length in days"
-        required: false
-        default: "2"
-      test_window_days:
-        description: "Test window length in days"
-        required: false
-        default: "1"
-      step_days:
-        description: "Rolling step length in days"
-        required: false
-        default: "1"
-      lob_sample_secs:
-        description: "Binance and PM LOB sample interval"
-        required: false
-        default: "30"
-      observation_sample_secs:
-        description: "Factor observation output interval"
-        required: false
-        default: "30"
-      max_quote_age_secs:
-        description: "Maximum PM quote age"
-        required: false
-        default: "30"
-      top_n:
-        description: "Number of factor rows to keep per test window"
-        required: false
-        default: "20"
-      min_observations:
-        description: "Minimum observations for a factor"
-        required: false
-        default: "20"
-      top_quantile:
-        description: "Train-window selected quantile"
-        required: false
-        default: "0.2"
-      factor_name_filter:
-        description: "Optional comma-separated factor-name substrings"
-        required: false
-        default: ""
       snapshot_run_id:
         description: "Optional Research Snapshot workflow run id to consume"
         required: false
         default: ""
-      compile_snapshot:
-        description: "Compile a fresh snapshot before walk-forward when snapshot_run_id is empty"
+      options_json:
+        description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings"
         required: false
-        default: "true"
-      allow_direct_db_debug:
-        description: "Allow non-canonical direct DB walk-forward when no snapshot is present"
-        required: false
-        default: "false"
-      optimizer_data_dir:
-        description: "Immutable parquet-feed dir recorded in compiled snapshot manifests"
-        required: false
-        default: "/tmp/ploy-parquet"
-      data_profile:
-        description: "Project data requirements profile for fresh snapshots"
-        type: choice
-        required: true
-        default: "pm5d-execution"
-        options:
-          - pm5d-execution
-          - pm5d-vol
-          - all
-          - custom
-      custom_required_sources:
-        description: "Comma-separated sources when data_profile=custom"
-        required: false
-        default: ""
-      audit_lookback_hours:
-        description: "Market-data audit lookback in hours"
-        required: false
-        default: "168"
-      data_gate:
-        description: "Fail threshold for required-source audit"
-        type: choice
-        required: true
-        default: "never"
-        options:
-          - critical
-          - warn
-          - never
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":""}'
 
 concurrency:
-  group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.factor_name_filter || 'all' }}
+  group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
   cancel-in-progress: false
 
 permissions:
   contents: read
   actions: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -143,10 +69,77 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Ensure psql client
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
         run: |
           set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "train_window_days": "2",
+              "test_window_days": "1",
+              "step_days": "1",
+              "lob_sample_secs": "30",
+              "observation_sample_secs": "30",
+              "max_quote_age_secs": "30",
+              "top_n": "20",
+              "min_observations": "20",
+              "top_quantile": "0.2",
+              "factor_name_filter": "",
+              "compile_snapshot": "true",
+              "allow_direct_db_debug": "false",
+              "optimizer_data_dir": "/tmp/ploy-parquet",
+              "data_profile": "pm5d-execution",
+              "custom_required_sources": "",
+              "audit_lookback_hours": "168",
+              "data_gate": "never",
+              "issue_number": "",
+          }
+          bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
+          choices = {
+              "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
+              "data_gate": {"critical", "warn", "never"},
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          for key, value in data.items():
+              if key in bool_keys:
+                  if isinstance(value, bool):
+                      values[key] = "true" if value else "false"
+                  elif str(value).lower() in {"true", "false"}:
+                      values[key] = str(value).lower()
+                  else:
+                      raise SystemExit(f"options_json value for {key} must be boolean")
+              else:
+                  values[key] = str(value)
+              if key in choices and values[key] not in choices[key]:
+                  allowed = ", ".join(sorted(choices[key]))
+                  raise SystemExit(f"options_json value for {key} must be one of: {allowed}")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"WALK_{key.upper()}={value}\n")
+          PY
+
+      - name: Ensure psql client
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${WALK_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping psql client check."
+            exit 0
+          fi
           if command -v psql >/dev/null 2>&1; then
             psql --version
             exit 0
@@ -161,12 +154,10 @@ jobs:
 
       - name: Resolve data requirements
         id: data_scope
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
-        env:
-          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
-          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
         run: |
           set -euo pipefail
+          DATA_PROFILE="${WALK_DATA_PROFILE}"
+          CUSTOM_REQUIRED_SOURCES="${WALK_CUSTOM_REQUIRED_SOURCES}"
           case "${DATA_PROFILE}" in
             pm5d-execution)
               required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
@@ -201,13 +192,17 @@ jobs:
 
       - name: Audit required market data
         id: data_audit
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         env:
           REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
-          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
-          DATA_GATE: ${{ github.event.inputs.data_gate }}
         run: |
           set -euo pipefail
+          AUDIT_LOOKBACK_HOURS="${WALK_AUDIT_LOOKBACK_HOURS}"
+          export DATA_GATE="${WALK_DATA_GATE}"
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${WALK_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping scoped data audit."
+            echo "overall_status=skipped" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
           mkdir -p artifacts/research-snapshot
           PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
             scripts/audit_market_data_gaps.py \
@@ -291,9 +286,12 @@ jobs:
             --require quality.md
 
       - name: Compile research snapshot
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.compile_snapshot == 'true' }}
         run: |
           set -euo pipefail
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${WALK_COMPILE_SNAPSHOT}" != "true" ]; then
+            echo "No fresh snapshot requested; skipping snapshot compile."
+            exit 0
+          fi
           deribit_args=()
           if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
             deribit_args+=(--skip-deribit)
@@ -305,11 +303,11 @@ jobs:
             --start-date "${{ github.event.inputs.start_date }}" \
             --end-date "${{ github.event.inputs.end_date }}" \
             --stake-usd "${{ github.event.inputs.stake_usd }}" \
-            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
-            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
-            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --lob-sample-secs "${WALK_LOB_SAMPLE_SECS}" \
+            --observation-sample-secs "${WALK_OBSERVATION_SAMPLE_SECS}" \
+            --max-quote-age-secs "${WALK_MAX_QUOTE_AGE_SECS}" \
             --output-dir artifacts/research-snapshot \
-            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --optimizer-data-dir "${WALK_OPTIMIZER_DATA_DIR}" \
             --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
             --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
             --data-audit-report data-gap-audit.json \
@@ -324,7 +322,7 @@ jobs:
           if [ -f artifacts/research-snapshot/manifest.json ]; then
             source_args=(--snapshot-dir artifacts/research-snapshot)
             echo "canonical_result=snapshot" | tee artifacts/factor-walk-forward-v2/source.txt
-          elif [ "${{ github.event.inputs.allow_direct_db_debug }}" = "true" ]; then
+          elif [ "${WALK_ALLOW_DIRECT_DB_DEBUG}" = "true" ]; then
             source_args=(--db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" --allow-direct-db-debug)
             echo "canonical_result=no direct_db_debug=true" | tee artifacts/factor-walk-forward-v2/source.txt
           else
@@ -337,18 +335,18 @@ jobs:
             --start-date "${{ github.event.inputs.start_date }}"
             --end-date "${{ github.event.inputs.end_date }}"
             --stake-usd "${{ github.event.inputs.stake_usd }}"
-            --train-window-days "${{ github.event.inputs.train_window_days }}"
-            --test-window-days "${{ github.event.inputs.test_window_days }}"
-            --step-days "${{ github.event.inputs.step_days }}"
-            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}"
-            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}"
-            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}"
-            --min-observations "${{ github.event.inputs.min_observations }}"
-            --top-quantile "${{ github.event.inputs.top_quantile }}"
-            --top-n "${{ github.event.inputs.top_n }}"
+            --train-window-days "${WALK_TRAIN_WINDOW_DAYS}"
+            --test-window-days "${WALK_TEST_WINDOW_DAYS}"
+            --step-days "${WALK_STEP_DAYS}"
+            --lob-sample-secs "${WALK_LOB_SAMPLE_SECS}"
+            --observation-sample-secs "${WALK_OBSERVATION_SAMPLE_SECS}"
+            --max-quote-age-secs "${WALK_MAX_QUOTE_AGE_SECS}"
+            --min-observations "${WALK_MIN_OBSERVATIONS}"
+            --top-quantile "${WALK_TOP_QUANTILE}"
+            --top-n "${WALK_TOP_N}"
           )
-          if [ -n "${{ github.event.inputs.factor_name_filter }}" ]; then
-            args+=(--factor-name-filter "${{ github.event.inputs.factor_name_filter }}")
+          if [ -n "${WALK_FACTOR_NAME_FILTER}" ]; then
+            args+=(--factor-name-filter "${WALK_FACTOR_NAME_FILTER}")
           fi
           ./target/release/examples/factor_walk_forward_v2 "${args[@]}" \
             | tee artifacts/factor-walk-forward-v2/report.txt
@@ -360,10 +358,10 @@ jobs:
             echo "## Factor Walk-Forward V2"
             echo ""
             echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
-            echo "- Train/Test: ${{ github.event.inputs.train_window_days }}d / ${{ github.event.inputs.test_window_days }}d"
+            echo "- Train/Test: ${WALK_TRAIN_WINDOW_DAYS}d / ${WALK_TEST_WINDOW_DAYS}d"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
-            echo "- Factor filter: ${{ github.event.inputs.factor_name_filter || '<none>' }}"
+            echo "- Factor filter: ${WALK_FACTOR_NAME_FILTER:-<none>}"
             if [ -f artifacts/factor-walk-forward-v2/source.txt ]; then
               echo "- Source: $(cat artifacts/factor-walk-forward-v2/source.txt)"
             fi
@@ -393,3 +391,33 @@ jobs:
             artifacts/factor-walk-forward-v2/
             artifacts/research-snapshot/
           retention-days: 14
+
+      - name: Comment walk-forward evidence on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumberRaw = process.env.WALK_ISSUE_NUMBER || "";
+            if (!issueNumberRaw) {
+              core.info("No issue_number configured in options_json; skipping issue comment.");
+              return;
+            }
+            const issue_number = Number(issueNumberRaw);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "Factor walk-forward evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Git ref: ${{ github.event.inputs.git_ref }}`,
+              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
+              `- Symbols: ${{ github.event.inputs.symbols }}`,
+              `- Artifact: \`factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}\``,
+              "- Decision: pending"
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -397,6 +397,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const { applyResearchIssueLabels } = require("./.github/scripts/research-issue-labels.js");
             const issueNumberRaw = process.env.WALK_ISSUE_NUMBER || "";
             if (!issueNumberRaw) {
               core.info("No issue_number configured in options_json; skipping issue comment.");
@@ -420,4 +421,11 @@ jobs:
               repo: context.repo.repo,
               issue_number,
               body
+            });
+            await applyResearchIssueLabels({
+              github,
+              context,
+              core,
+              issue_number,
+              labels: ["evidence:walk-forward", "decision:pending"]
             });

--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -123,11 +123,13 @@ jobs:
             *) echo "invalid fail_on value: ${fail_on}" >&2; exit 1 ;;
           esac
 
-          echo "run_full=${run_full}" >> "$GITHUB_OUTPUT"
-          echo "lookback_hours=${lookback_hours}" >> "$GITHUB_OUTPUT"
-          echo "bucket_minutes=${bucket_minutes}" >> "$GITHUB_OUTPUT"
-          echo "symbols=${symbols}" >> "$GITHUB_OUTPUT"
-          echo "fail_on=${fail_on}" >> "$GITHUB_OUTPUT"
+          {
+            echo "run_full=${run_full}"
+            echo "lookback_hours=${lookback_hours}"
+            echo "bucket_minutes=${bucket_minutes}"
+            echo "symbols=${symbols}"
+            echo "fail_on=${fail_on}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run remote gap audits
         env:
@@ -146,6 +148,7 @@ jobs:
             local remote_file="${remote_dir}/${audit_kind}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
             local local_file="artifacts/market-data-gap-audit/${audit_kind}.json"
 
+            # shellcheck disable=SC2029
             ssh tango-1-1 \
               "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
           set -euo pipefail

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -440,6 +440,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const { applyResearchIssueLabels } = require("./.github/scripts/research-issue-labels.js");
             const issueNumberRaw = process.env.OPT_ISSUE_NUMBER || "";
             if (!issueNumberRaw) {
               core.info("No issue_number configured in options_json; skipping issue comment.");
@@ -463,4 +464,11 @@ jobs:
               repo: context.repo.repo,
               issue_number,
               body
+            });
+            await applyResearchIssueLabels({
+              github,
+              context,
+              core,
+              issue_number,
+              labels: ["evidence:optimize", "decision:pending"]
             });

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -23,22 +23,6 @@ on:
         description: "Validation end date (YYYY-MM-DD)"
         required: true
         default: "2026-04-20"
-      train_start_ts:
-        description: "Optional train start timestamp (RFC3339); overrides train_start"
-        required: false
-        default: ""
-      train_end_ts:
-        description: "Optional train end timestamp (RFC3339); overrides train_end"
-        required: false
-        default: ""
-      val_start_ts:
-        description: "Optional validation start timestamp (RFC3339); overrides val_start"
-        required: false
-        default: ""
-      val_end_ts:
-        description: "Optional validation end timestamp (RFC3339); overrides val_end"
-        required: false
-        default: ""
       trials:
         description: "Number of optimization trials"
         required: true
@@ -51,54 +35,14 @@ on:
         description: "Comma-separated symbols to optimize"
         required: false
         default: "BTCUSDT,ETHUSDT"
-      data_dir:
-        description: "Local Parquet data dir (rsynced from tango)"
-        required: false
-        default: "/tmp/ploy-parquet"
-      max_preflight_rows:
-        description: "Fail before replay when estimated train+val rows exceed this"
-        required: false
-        default: "15000000"
-      max_preflight_bytes:
-        description: "Fail before replay when local Parquet bytes exceed this (supports GiB)"
-        required: false
-        default: "80GiB"
-      max_symbols:
-        description: "Fail before replay when symbol count exceeds this"
-        required: false
-        default: "6"
-      max_days:
-        description: "Fail before replay when train start through validation end exceeds this many days"
-        required: false
-        default: "8"
-      allow_large_window:
-        description: "Override preflight guardrails after bounded smoke/host-health checks"
-        required: false
-        default: "false"
-      preflight_only:
-        description: "Only produce the manifest and exit before replay/optimization"
-        required: false
-        default: "false"
-      max_updates:
-        description: "Optional smoke-only runtime update cap; blank is canonical full replay"
-        required: false
-        default: ""
-      duckdb_memory_limit:
-        description: "DuckDB memory_limit for preflight/replay"
-        required: false
-        default: "6GB"
-      optimize_timeout_minutes:
-        description: "Process timeout for optimize_backtest"
-        required: false
-        default: "90"
       snapshot_run_id:
         description: "Research Snapshot workflow run id; required for canonical optimizer runs"
         required: false
         default: ""
-      allow_live_parquet_debug:
-        description: "Allow non-canonical direct live parquet optimization without snapshot manifest"
+      options_json:
+        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout"
         required: false
-        default: "false"
+        default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":""}'
 
 concurrency:
   group: optimize-${{ github.event.inputs.git_ref || github.ref }}-${{ github.event.inputs.strategy_profile || 'mixed' }}
@@ -107,16 +51,17 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: Build optimize runner
+  optimize:
+    name: Build and run optimize on ploy-ci-1
     runs-on: [self-hosted, ploy-ci-1]
-    timeout-minutes: 45
+    timeout-minutes: 150
     environment: ploy-ci-1
 
     steps:
@@ -135,72 +80,79 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: optimize-${{ hashFiles('crates/ploy-strategy-bundles/**', 'crates/ploy-research/**', 'Cargo.lock') }}
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "train_start_ts": "",
+              "train_end_ts": "",
+              "val_start_ts": "",
+              "val_end_ts": "",
+              "data_dir": "/tmp/ploy-parquet",
+              "max_preflight_rows": "15000000",
+              "max_preflight_bytes": "80GiB",
+              "max_symbols": "6",
+              "max_days": "8",
+              "allow_large_window": "false",
+              "preflight_only": "false",
+              "max_updates": "",
+              "duckdb_memory_limit": "6GB",
+              "optimize_timeout_minutes": "90",
+              "allow_live_parquet_debug": "false",
+              "issue_number": "",
+          }
+          bool_keys = {"allow_large_window", "preflight_only", "allow_live_parquet_debug"}
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          for key, value in data.items():
+              if key in bool_keys:
+                  if isinstance(value, bool):
+                      values[key] = "true" if value else "false"
+                  elif str(value).lower() in {"true", "false"}:
+                      values[key] = str(value).lower()
+                  else:
+                      raise SystemExit(f"options_json value for {key} must be boolean")
+              else:
+                  values[key] = str(value)
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"OPT_{key.upper()}={value}\n")
+          PY
 
       - name: Build optimize runner
         run: |
+          set -euo pipefail
           . /home/runner/.cargo/env
-          mkdir -p artifacts/optimize-bin
+          mkdir -p target/release/examples
           if [ -n "${{ github.event.inputs.snapshot_run_id }}" ]; then
             cargo build --release --locked \
               -p ploy-research \
               --example three_layer_snapshot_optimize
-            cp target/release/examples/three_layer_snapshot_optimize artifacts/optimize-bin/optimize-runner
+            cp target/release/examples/three_layer_snapshot_optimize target/release/examples/optimize-runner
           else
             cargo build --release --locked \
               -p ploy-strategy-bundles \
               --features ploy-strategy-bundles/parquet-feed \
               --example optimize_backtest
-            cp target/release/examples/optimize_backtest artifacts/optimize-bin/optimize-runner
+            cp target/release/examples/optimize_backtest target/release/examples/optimize-runner
           fi
-
-      - name: Upload optimize runner
-        uses: actions/upload-artifact@v7
-        with:
-          name: optimize-runner-${{ github.sha }}
-          path: artifacts/optimize-bin/optimize-runner
-          retention-days: 1
-
-  optimize:
-    name: Run optimize on ploy-ci-1
-    runs-on: [self-hosted, ploy-ci-1]
-    timeout-minutes: 120
-    environment: ploy-ci-1
-    needs: [build]
-
-    steps:
-      - name: Repair runner workspace permissions
-        run: |
-          if [ -d "${GITHUB_WORKSPACE}" ]; then
-            sudo chown -R "$(id -un):$(id -gn)" "${GITHUB_WORKSPACE}" || true
-            sudo rm -rf "${GITHUB_WORKSPACE}/target" "${GITHUB_WORKSPACE}/.cargo-lock" || true
-          fi
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.git_ref }}
-
-      - name: Download optimize runner
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p target/release/examples
-          rm -f target/release/examples/optimize-runner
-          python3 scripts/download_github_artifact.py \
-            --run-id "${GITHUB_RUN_ID}" \
-            --name "optimize-runner-${GITHUB_SHA}" \
-            --output-dir target/release/examples \
-            --require optimize-runner
-
-      - name: Make binary executable
-        run: chmod +x target/release/examples/optimize-runner
+          chmod +x target/release/examples/optimize-runner
 
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
@@ -218,16 +170,20 @@ jobs:
             --require quality.md
 
       - name: Sync Parquet data from Tango-1-1
-        if: ${{ github.event.inputs.snapshot_run_id == '' && github.event.inputs.allow_live_parquet_debug == 'true' }}
         run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.snapshot_run_id }}" ] || [ "${OPT_ALLOW_LIVE_PARQUET_DEBUG}" != "true" ]; then
+            echo "No direct live parquet debug requested; skipping rsync."
+            exit 0
+          fi
           mkdir -p ~/.ssh
           echo "${{ secrets.TANGO_SSH_KEY }}" > ~/.ssh/tango_key
           chmod 600 ~/.ssh/tango_key
-          mkdir -p ${{ github.event.inputs.data_dir }}
+          mkdir -p "${OPT_DATA_DIR}"
           rsync -az \
             -e "ssh -i ~/.ssh/tango_key -o StrictHostKeyChecking=no" \
             root@172.16.0.204:/opt/ploy/data/parquet/ \
-            ${{ github.event.inputs.data_dir }}/
+            "${OPT_DATA_DIR}/"
 
       - name: Prepare DuckDB spill directory
         run: |
@@ -235,7 +191,7 @@ jobs:
           rm -rf "${DUCKDB_TEMP_DIR}"
           mkdir -p "${DUCKDB_TEMP_DIR}"
           echo "PLOY_DUCKDB_TEMP_DIR=${DUCKDB_TEMP_DIR}" >> "${GITHUB_ENV}"
-          echo "PLOY_DUCKDB_MEMORY_LIMIT=${{ github.event.inputs.duckdb_memory_limit }}" >> "${GITHUB_ENV}"
+          echo "PLOY_DUCKDB_MEMORY_LIMIT=${OPT_DUCKDB_MEMORY_LIMIT}" >> "${GITHUB_ENV}"
           echo "DuckDB spill directory: ${DUCKDB_TEMP_DIR}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Publish snapshot provenance
@@ -293,13 +249,14 @@ jobs:
           mkdir -p artifacts/optimize
           started=$(date +%s)
 
+          # shellcheck disable=SC2329
           health_summary() {
             echo "## Optimize preflight host health" >> "${GITHUB_STEP_SUMMARY}"
             {
               echo '```'
               date -u
               free -h || true
-              df -h "${{ github.event.inputs.data_dir }}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+              df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
               ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
               echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
@@ -307,27 +264,27 @@ jobs:
           trap 'status=$?; health_summary; rm -rf "${PLOY_DUCKDB_TEMP_DIR}"; exit ${status}' EXIT
 
           time_flags=()
-          if [ -n "${{ github.event.inputs.train_start_ts }}" ]; then
-            time_flags+=(--train-start-ts "${{ github.event.inputs.train_start_ts }}")
+          if [ -n "${OPT_TRAIN_START_TS}" ]; then
+            time_flags+=(--train-start-ts "${OPT_TRAIN_START_TS}")
           fi
-          if [ -n "${{ github.event.inputs.train_end_ts }}" ]; then
-            time_flags+=(--train-end-ts "${{ github.event.inputs.train_end_ts }}")
+          if [ -n "${OPT_TRAIN_END_TS}" ]; then
+            time_flags+=(--train-end-ts "${OPT_TRAIN_END_TS}")
           fi
-          if [ -n "${{ github.event.inputs.val_start_ts }}" ]; then
-            time_flags+=(--val-start-ts "${{ github.event.inputs.val_start_ts }}")
+          if [ -n "${OPT_VAL_START_TS}" ]; then
+            time_flags+=(--val-start-ts "${OPT_VAL_START_TS}")
           fi
-          if [ -n "${{ github.event.inputs.val_end_ts }}" ]; then
-            time_flags+=(--val-end-ts "${{ github.event.inputs.val_end_ts }}")
+          if [ -n "${OPT_VAL_END_TS}" ]; then
+            time_flags+=(--val-end-ts "${OPT_VAL_END_TS}")
           fi
 
           extra_flags=()
-          if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
+          if [ "${OPT_ALLOW_LARGE_WINDOW}" = "true" ]; then
             extra_flags+=(--allow-large-window)
           fi
-          if [ -n "${{ github.event.inputs.max_updates }}" ]; then
-            extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
+          if [ -n "${OPT_MAX_UPDATES}" ]; then
+            extra_flags+=(--max-updates "${OPT_MAX_UPDATES}")
           fi
-          if [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+          if [ "${OPT_ALLOW_LIVE_PARQUET_DEBUG}" = "true" ]; then
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
@@ -336,7 +293,7 @@ jobs:
             --preflight-only \
             --strategy-variant three_layer \
             --config config/strategies/02-pm5d-threelayer.unified.toml \
-            --data-dir "${{ github.event.inputs.data_dir }}" \
+            --data-dir "${OPT_DATA_DIR}" \
             --train-start "${{ github.event.inputs.train_start }}" \
             --train-end "${{ github.event.inputs.train_end }}" \
             --val-start "${{ github.event.inputs.val_start }}" \
@@ -345,11 +302,11 @@ jobs:
             --trials "${{ github.event.inputs.trials }}" \
             --require-official-settlement \
             --require-lob-liquidity \
-            --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
-            --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
-            --max-symbols "${{ github.event.inputs.max_symbols }}" \
-            --max-days "${{ github.event.inputs.max_days }}" \
-            --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
+            --max-preflight-rows "${OPT_MAX_PREFLIGHT_ROWS}" \
+            --max-preflight-bytes "${OPT_MAX_PREFLIGHT_BYTES}" \
+            --max-symbols "${OPT_MAX_SYMBOLS}" \
+            --max-days "${OPT_MAX_DAYS}" \
+            --duckdb-memory-limit "${OPT_DUCKDB_MEMORY_LIMIT}" \
             --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
             --timing-json artifacts/optimize/preflight-timing.json \
             "${time_flags[@]}" \
@@ -362,26 +319,31 @@ jobs:
           exit "${status}"
 
       - name: Run optimize
-        if: ${{ github.event.inputs.preflight_only != 'true' }}
         run: |
           set -euo pipefail
+          if [ "${OPT_PREFLIGHT_ONLY}" = "true" ]; then
+            echo "preflight_only=true; skipping optimize replay" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           . /home/runner/.cargo/env
           mkdir -p artifacts/optimize
           started=$(date +%s)
           rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
           mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
 
+          # shellcheck disable=SC2329
           health_summary() {
             echo "## Optimize host health" >> "${GITHUB_STEP_SUMMARY}"
             {
               echo '```'
               date -u
               free -h || true
-              df -h "${{ github.event.inputs.data_dir }}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+              df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
               ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
               echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
           }
+          # shellcheck disable=SC2329
           cleanup() {
             status=$?
             health_summary
@@ -391,33 +353,33 @@ jobs:
           trap cleanup EXIT
 
           time_flags=()
-          if [ -n "${{ github.event.inputs.train_start_ts }}" ]; then
-            time_flags+=(--train-start-ts "${{ github.event.inputs.train_start_ts }}")
+          if [ -n "${OPT_TRAIN_START_TS}" ]; then
+            time_flags+=(--train-start-ts "${OPT_TRAIN_START_TS}")
           fi
-          if [ -n "${{ github.event.inputs.train_end_ts }}" ]; then
-            time_flags+=(--train-end-ts "${{ github.event.inputs.train_end_ts }}")
+          if [ -n "${OPT_TRAIN_END_TS}" ]; then
+            time_flags+=(--train-end-ts "${OPT_TRAIN_END_TS}")
           fi
-          if [ -n "${{ github.event.inputs.val_start_ts }}" ]; then
-            time_flags+=(--val-start-ts "${{ github.event.inputs.val_start_ts }}")
+          if [ -n "${OPT_VAL_START_TS}" ]; then
+            time_flags+=(--val-start-ts "${OPT_VAL_START_TS}")
           fi
-          if [ -n "${{ github.event.inputs.val_end_ts }}" ]; then
-            time_flags+=(--val-end-ts "${{ github.event.inputs.val_end_ts }}")
+          if [ -n "${OPT_VAL_END_TS}" ]; then
+            time_flags+=(--val-end-ts "${OPT_VAL_END_TS}")
           fi
 
           extra_flags=()
-          if [ "${{ github.event.inputs.allow_large_window }}" = "true" ]; then
+          if [ "${OPT_ALLOW_LARGE_WINDOW}" = "true" ]; then
             extra_flags+=(--allow-large-window)
           fi
-          if [ -n "${{ github.event.inputs.max_updates }}" ]; then
-            extra_flags+=(--max-updates "${{ github.event.inputs.max_updates }}")
+          if [ -n "${OPT_MAX_UPDATES}" ]; then
+            extra_flags+=(--max-updates "${OPT_MAX_UPDATES}")
           fi
-          if [ "${{ github.event.inputs.allow_live_parquet_debug }}" = "true" ]; then
+          if [ "${OPT_ALLOW_LIVE_PARQUET_DEBUG}" = "true" ]; then
             extra_flags+=(--allow-live-parquet-debug)
           fi
 
           set +e
           if [ -f artifacts/research-snapshot/manifest.json ]; then
-            timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
+            timeout --preserve-status "${OPT_OPTIMIZE_TIMEOUT_MINUTES}m" \
             ./target/release/examples/optimize-runner \
               --snapshot-dir artifacts/research-snapshot \
               --train-start "${{ github.event.inputs.train_start }}" \
@@ -433,11 +395,11 @@ jobs:
               2>&1 | tee artifacts/optimize/report.txt
             status=${PIPESTATUS[0]}
           else
-            timeout --preserve-status "${{ github.event.inputs.optimize_timeout_minutes }}m" \
+            timeout --preserve-status "${OPT_OPTIMIZE_TIMEOUT_MINUTES}m" \
             ./target/release/examples/optimize-runner \
               --strategy-variant three_layer \
               --config config/strategies/02-pm5d-threelayer.unified.toml \
-              --data-dir "${{ github.event.inputs.data_dir }}" \
+              --data-dir "${OPT_DATA_DIR}" \
               --train-start "${{ github.event.inputs.train_start }}" \
               --train-end "${{ github.event.inputs.train_end }}" \
               --val-start "${{ github.event.inputs.val_start }}" \
@@ -446,11 +408,11 @@ jobs:
               --trials "${{ github.event.inputs.trials }}" \
               --require-official-settlement \
               --require-lob-liquidity \
-              --max-preflight-rows "${{ github.event.inputs.max_preflight_rows }}" \
-              --max-preflight-bytes "${{ github.event.inputs.max_preflight_bytes }}" \
-              --max-symbols "${{ github.event.inputs.max_symbols }}" \
-              --max-days "${{ github.event.inputs.max_days }}" \
-              --duckdb-memory-limit "${{ github.event.inputs.duckdb_memory_limit }}" \
+              --max-preflight-rows "${OPT_MAX_PREFLIGHT_ROWS}" \
+              --max-preflight-bytes "${OPT_MAX_PREFLIGHT_BYTES}" \
+              --max-symbols "${OPT_MAX_SYMBOLS}" \
+              --max-days "${OPT_MAX_DAYS}" \
+              --duckdb-memory-limit "${OPT_DUCKDB_MEMORY_LIMIT}" \
               --duckdb-temp-dir "${PLOY_DUCKDB_TEMP_DIR}" \
               --timing-json artifacts/optimize/timing.json \
               "${time_flags[@]}" \
@@ -458,15 +420,23 @@ jobs:
               2>&1 | tee artifacts/optimize/report.txt
             status=${PIPESTATUS[0]}
           fi
+
+          snapshot_backed=false
+          if [ -f artifacts/research-snapshot/manifest.json ]; then
+            snapshot_backed=true
+          fi
           elapsed=$(( $(date +%s) - started ))
           printf '{"phase":"optimize_workflow_step","wall_secs":%s,"status":%s,"snapshot_backed":%s}\n' \
-            "${elapsed}" "${status}" \
-            "$([ -f artifacts/research-snapshot/manifest.json ] && echo true || echo false)" \
+            "${elapsed}" "${status}" "${snapshot_backed}" \
             > artifacts/optimize/workflow-timing.json
           {
             echo "## Optimize timing"
             echo '```json'
-            [ -f artifacts/optimize/timing.json ] && cat artifacts/optimize/timing.json || cat artifacts/optimize/workflow-timing.json
+            if [ -f artifacts/optimize/timing.json ]; then
+              cat artifacts/optimize/timing.json
+            else
+              cat artifacts/optimize/workflow-timing.json
+            fi
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
@@ -479,3 +449,33 @@ jobs:
           path: artifacts/optimize
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Comment optimize evidence on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumberRaw = process.env.OPT_ISSUE_NUMBER || "";
+            if (!issueNumberRaw) {
+              core.info("No issue_number configured in options_json; skipping issue comment.");
+              return;
+            }
+            const issue_number = Number(issueNumberRaw);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              "Optimize evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Git ref: ${{ github.event.inputs.git_ref }}`,
+              `- Dataset/window: train ${{ github.event.inputs.train_start }} -> ${{ github.event.inputs.train_end }}, validation ${{ github.event.inputs.val_start }} -> ${{ github.event.inputs.val_end }}`,
+              `- Symbols: ${{ github.event.inputs.symbols }}`,
+              `- Artifact: \`optimize-provenance-${process.env.GITHUB_RUN_ID}\``,
+              "- Decision: pending"
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -249,20 +249,6 @@ jobs:
           mkdir -p artifacts/optimize
           started=$(date +%s)
 
-          # shellcheck disable=SC2329
-          health_summary() {
-            echo "## Optimize preflight host health" >> "${GITHUB_STEP_SUMMARY}"
-            {
-              echo '```'
-              date -u
-              free -h || true
-              df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
-              ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
-              echo '```'
-            } >> "${GITHUB_STEP_SUMMARY}"
-          }
-          trap 'status=$?; health_summary; rm -rf "${PLOY_DUCKDB_TEMP_DIR}"; exit ${status}' EXIT
-
           time_flags=()
           if [ -n "${OPT_TRAIN_START_TS}" ]; then
             time_flags+=(--train-start-ts "${OPT_TRAIN_START_TS}")
@@ -316,6 +302,16 @@ jobs:
           elapsed=$(( $(date +%s) - started ))
           printf '{"phase":"optimize_preflight_workflow_step","wall_secs":%s,"status":%s}\n' "${elapsed}" "${status}" \
             > artifacts/optimize/preflight-workflow-timing.json
+          {
+            echo "## Optimize preflight host health"
+            echo '```'
+            date -u
+            free -h || true
+            df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+            ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
           exit "${status}"
 
       - name: Run optimize
@@ -330,27 +326,6 @@ jobs:
           started=$(date +%s)
           rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
           mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
-
-          # shellcheck disable=SC2329
-          health_summary() {
-            echo "## Optimize host health" >> "${GITHUB_STEP_SUMMARY}"
-            {
-              echo '```'
-              date -u
-              free -h || true
-              df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
-              ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
-              echo '```'
-            } >> "${GITHUB_STEP_SUMMARY}"
-          }
-          # shellcheck disable=SC2329
-          cleanup() {
-            status=$?
-            health_summary
-            rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
-            exit "${status}"
-          }
-          trap cleanup EXIT
 
           time_flags=()
           if [ -n "${OPT_TRAIN_START_TS}" ]; then
@@ -430,6 +405,15 @@ jobs:
             "${elapsed}" "${status}" "${snapshot_backed}" \
             > artifacts/optimize/workflow-timing.json
           {
+            echo "## Optimize host health"
+            echo '```'
+            date -u
+            free -h || true
+            df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+            ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          {
             echo "## Optimize timing"
             echo '```json'
             if [ -f artifacts/optimize/timing.json ]; then
@@ -439,6 +423,7 @@ jobs:
             fi
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
+          rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
           exit "${status}"
 
       - name: Upload optimize provenance

--- a/.github/workflows/replay-dryrun-parity.yml
+++ b/.github/workflows/replay-dryrun-parity.yml
@@ -1,0 +1,129 @@
+name: Replay Dry-run Parity
+
+on:
+  workflow_dispatch:
+    inputs:
+      replay_run_id:
+        description: "GitHub Actions run id containing a replay/backtest artifact"
+        required: true
+      replay_artifact_name:
+        description: "Artifact name from the replay/backtest run"
+        required: true
+      dryrun_report_url:
+        description: "Dry-run JSON report URL to compare against replay"
+        required: true
+      issue_number:
+        description: "Optional GitHub issue number for posting parity evidence"
+        required: false
+        default: ""
+
+concurrency:
+  group: replay-dryrun-parity-${{ github.event.inputs.replay_run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  parity:
+    name: Compare replay and dry-run evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download replay artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/replay
+          gh run download "${{ github.event.inputs.replay_run_id }}" \
+            --name "${{ github.event.inputs.replay_artifact_name }}" \
+            --dir artifacts/replay
+
+      - name: Fetch dry-run report
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/dryrun
+          curl -fsSL "${{ github.event.inputs.dryrun_report_url }}" \
+            -o artifacts/dryrun/dryrun.json
+
+      - name: Run parity comparison
+        run: |
+          set -euo pipefail
+          python3 scripts/replay_dryrun_parity.py \
+            --replay-json artifacts/replay \
+            --dryrun-json artifacts/dryrun/dryrun.json \
+            --output-json artifacts/parity/parity-evaluation.json
+
+      - name: Publish parity summary
+        if: always()
+        run: |
+          {
+            echo "## Replay vs Dry-run Parity"
+            echo ""
+            echo "- Replay run: ${{ github.event.inputs.replay_run_id }}"
+            echo "- Replay artifact: \`${{ github.event.inputs.replay_artifact_name }}\`"
+            echo "- Dry-run report: ${{ github.event.inputs.dryrun_report_url }}"
+            if [ -f artifacts/parity/parity-evaluation.json ]; then
+              echo "- Artifact: \`replay-dryrun-parity-${{ github.run_id }}\`"
+              echo ""
+              echo '```json'
+              python3 -c 'import json; data=json.load(open("artifacts/parity/parity-evaluation.json")); event=data.get("event_comparison") or {}; print(json.dumps({"decision": data.get("decision"), "risk_flags": data.get("risk_flags"), "strict_parity_ready": event.get("strict_parity_ready"), "missing_strict_fields": event.get("missing_strict_fields"), "shared_event_count": event.get("shared_event_count")}, indent=2, sort_keys=True))'
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload parity evaluation artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: replay-dryrun-parity-${{ github.run_id }}
+          path: artifacts/parity/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Comment parity evidence on issue
+        if: ${{ always() && github.event.inputs.issue_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const issue_number = Number("${{ github.event.inputs.issue_number }}");
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let decision = "missing parity artifact";
+            let flags = [];
+            let strictReady = false;
+            let missingFields = [];
+            if (fs.existsSync("artifacts/parity/parity-evaluation.json")) {
+              const data = JSON.parse(fs.readFileSync("artifacts/parity/parity-evaluation.json", "utf8"));
+              decision = data.decision || decision;
+              flags = data.risk_flags || [];
+              strictReady = Boolean(data.event_comparison?.strict_parity_ready);
+              missingFields = data.event_comparison?.missing_strict_fields || [];
+            }
+            const body = [
+              "Replay/dry-run parity evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Replay run: ${{ github.event.inputs.replay_run_id }}`,
+              `- Replay artifact: \`${{ github.event.inputs.replay_artifact_name }}\``,
+              `- Dry-run report: ${{ github.event.inputs.dryrun_report_url }}`,
+              `- Artifact: \`replay-dryrun-parity-${process.env.GITHUB_RUN_ID}\``,
+              `- Strict parity ready: \`${strictReady}\``,
+              `- Missing strict fields: \`${missingFields.join(", ") || "none"}\``,
+              `- Caveats: \`${flags.join(", ") || "none"}\``,
+              `- Decision: ${decision}`
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/replay-dryrun-parity.yml
+++ b/.github/workflows/replay-dryrun-parity.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           script: |
             const fs = require("fs");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
             const issue_number = Number("${{ github.event.inputs.issue_number }}");
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let decision = "missing parity artifact";
@@ -127,3 +128,12 @@ jobs:
               issue_number,
               body
             });
+            const labels = [
+              "evidence:parity",
+              strictReady ? "parity:ready" : "parity:blocked",
+              ...labelsForDecision(decision)
+            ];
+            if (decision === "missing parity artifact") {
+              labels.push("evidence:missing-artifact");
+            }
+            await applyResearchIssueLabels({ github, context, core, issue_number, labels });

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -23,49 +23,10 @@ on:
         description: "Fixed notional used by executable labels"
         required: true
         default: "15"
-      lob_sample_secs:
-        description: "Binance and PM LOB sample interval"
+      options_json:
+        description: "Advanced options JSON: sampling, optimizer_data_dir, data_profile, audit gate"
         required: false
-        default: "30"
-      observation_sample_secs:
-        description: "Factor observation output interval"
-        required: false
-        default: "30"
-      max_quote_age_secs:
-        description: "Maximum PM quote age"
-        required: false
-        default: "30"
-      optimizer_data_dir:
-        description: "Immutable parquet-feed dir used by optimize_backtest"
-        required: true
-        default: "/tmp/ploy-parquet"
-      data_profile:
-        description: "Project data requirements profile"
-        type: choice
-        required: true
-        default: "pm5d-execution"
-        options:
-          - pm5d-execution
-          - pm5d-vol
-          - all
-          - custom
-      custom_required_sources:
-        description: "Comma-separated sources when data_profile=custom"
-        required: false
-        default: ""
-      audit_lookback_hours:
-        description: "Market-data audit lookback in hours"
-        required: false
-        default: "168"
-      data_gate:
-        description: "Fail threshold for required-source audit"
-        type: choice
-        required: true
-        default: "never"
-        options:
-          - critical
-          - warn
-          - never
+        default: '{"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never"}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -102,6 +63,51 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "lob_sample_secs": "30",
+              "observation_sample_secs": "30",
+              "max_quote_age_secs": "30",
+              "optimizer_data_dir": "/tmp/ploy-parquet",
+              "data_profile": "pm5d-execution",
+              "custom_required_sources": "",
+              "audit_lookback_hours": "168",
+              "data_gate": "never",
+          }
+          choices = {
+              "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
+              "data_gate": {"critical", "warn", "never"},
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          values.update({key: str(value) for key, value in data.items()})
+          for key, allowed in choices.items():
+              if values[key] not in allowed:
+                  choices_text = ", ".join(sorted(allowed))
+                  raise SystemExit(f"options_json value for {key} must be one of: {choices_text}")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"SNAPSHOT_{key.upper()}={value}\n")
+          PY
+
       - name: Ensure psql client
         run: |
           set -euo pipefail
@@ -119,11 +125,10 @@ jobs:
 
       - name: Resolve data requirements
         id: data_scope
-        env:
-          DATA_PROFILE: ${{ github.event.inputs.data_profile }}
-          CUSTOM_REQUIRED_SOURCES: ${{ github.event.inputs.custom_required_sources }}
         run: |
           set -euo pipefail
+          DATA_PROFILE="${SNAPSHOT_DATA_PROFILE}"
+          CUSTOM_REQUIRED_SOURCES="${SNAPSHOT_CUSTOM_REQUIRED_SOURCES}"
           case "${DATA_PROFILE}" in
             pm5d-execution)
               required_sources="polymarket_quotes,polymarket_orderbooks,binance_price,binance_agg_trades,binance_lob"
@@ -160,10 +165,10 @@ jobs:
         id: data_audit
         env:
           REQUIRED_SOURCES: ${{ steps.data_scope.outputs.required_sources }}
-          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
-          DATA_GATE: ${{ github.event.inputs.data_gate }}
         run: |
           set -euo pipefail
+          AUDIT_LOOKBACK_HOURS="${SNAPSHOT_AUDIT_LOOKBACK_HOURS}"
+          export DATA_GATE="${SNAPSHOT_DATA_GATE}"
           mkdir -p artifacts/research-snapshot
           PLOY_DATABASE__URL="${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \
             scripts/audit_market_data_gaps.py \
@@ -244,11 +249,11 @@ jobs:
             --start-date "${{ github.event.inputs.start_date }}" \
             --end-date "${{ github.event.inputs.end_date }}" \
             --stake-usd "${{ github.event.inputs.stake_usd }}" \
-            --lob-sample-secs "${{ github.event.inputs.lob_sample_secs }}" \
-            --observation-sample-secs "${{ github.event.inputs.observation_sample_secs }}" \
-            --max-quote-age-secs "${{ github.event.inputs.max_quote_age_secs }}" \
+            --lob-sample-secs "${SNAPSHOT_LOB_SAMPLE_SECS}" \
+            --observation-sample-secs "${SNAPSHOT_OBSERVATION_SAMPLE_SECS}" \
+            --max-quote-age-secs "${SNAPSHOT_MAX_QUOTE_AGE_SECS}" \
             --output-dir artifacts/research-snapshot \
-            --optimizer-data-dir "${{ github.event.inputs.optimizer_data_dir }}" \
+            --optimizer-data-dir "${SNAPSHOT_OPTIMIZER_DATA_DIR}" \
             --data-requirements "${{ steps.data_scope.outputs.required_sources }}" \
             --data-audit-status "${{ steps.data_audit.outputs.overall_status }}" \
             --data-audit-report data-gap-audit.json \
@@ -264,7 +269,7 @@ jobs:
             echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
-            echo "- Data profile: ${{ github.event.inputs.data_profile }}"
+            echo "- Data profile: ${SNAPSHOT_DATA_PROFILE}"
             echo "- Data requirements: ${{ steps.data_scope.outputs.required_sources }}"
             echo "- Include Deribit: ${{ steps.data_scope.outputs.include_deribit }}"
             echo ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,21 @@ jobs:
             exit 1
           fi
 
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Run actionlint
+        run: |
+          "${HOME}/go/bin/actionlint" -color
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest
@@ -599,6 +614,7 @@ jobs:
   open-followup-issue:
     name: Open Follow-up Issue
     needs:
+      - workflow-lint
       - audit
       - rust-control-plane
       - rust-runner-lean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,94 @@ Prefer **atomic commits** for landed repo changes:
 - Use one integration session to merge work: `git switch main && git pull --rebase`, then `git cherry-pick <sha...>`.
 - After merge, remove temporary worktrees to prevent stale branches and accidental edits.
 
+## Git Flow
+
+**One feature = one branch = one PR.** Never accumulate multiple unrelated features on a single branch.
+
+### Branch naming
+```
+feat/<short-description>      — new feature
+fix/<short-description>       — bug fix
+refactor/<short-description>  — refactoring, no behavior change
+docs/<short-description>      — documentation only
+ci/<short-description>        — CI/workflow changes
+```
+
+### Lifecycle
+1. Branch from latest main: `git fetch origin && git checkout -b feat/xxx origin/main`
+2. Work in small atomic commits (one logical change per commit)
+3. When done: run tests locally, then push and open PR -> main
+4. CI runs on PR (`test.yml` triggers on `pull_request: branches: [main]`)
+5. Merge PR -> main triggers deploy eligibility
+6. Delete branch after merge
+
+### Deployment
+- **Backtest**: trigger `backtest.yml` (workflow_dispatch) with `git_ref=main`
+- **Deploy dryrun/live**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
+- **Deploy trade**: trigger `deploy-trade.yml` (workflow_dispatch) with `git_ref=main`
+- **Release platform**: trigger `release-platform.yml` (workflow_dispatch) with `git_ref=main`
+- **ACK deploy**: trigger `build-push-acr.yml` with `push_images=true` only from `git_ref=main`, then `deploy-ack.yml` with the immutable 40-character SHA image tag
+- Never deploy from a feature branch directly
+- Never build Rust on tango-1-1 — CI builds and ships artifacts only
+
+### GitHub Actions / CLI Principles
+
+- Use GitHub Actions as the default build, test, research, and deploy execution
+  surface when work needs Linux, remote data, repository secrets, or trading-host
+  delivery.
+- Use `gh` as the default control surface for PR checks, workflow dispatch,
+  run monitoring, failed-log inspection, and workflow result evidence.
+- Treat CI failure as actionable engineering feedback: inspect the failed run,
+  fix the root cause, push a new commit, and re-run the relevant checks.
+- Treat successful CI as necessary but not sufficient for deployments. After
+  deploy, verify the affected remote service, config, systemd guardrails, and
+  public/operator endpoint.
+- Deployments that affect `tango-1-1`, trade services, ACK, or production-like
+  state must run from `main`. Feature branches may run build-only or
+  research-only workflows only when they do not mutate deployment state.
+- Container/image deploy paths must use immutable checked-out commit SHA tags.
+  Do not push or deploy mutable `latest` tags.
+- Keep deployment secrets in GitHub environments/repository secrets. Never place
+  secrets in local files, commits, logs, pasted command output, or ad hoc scripts.
+- Prefer environment-scoped workflows (`tango-1-1`, `production`, `ploy-ci-1`,
+  `ack`) over direct SSH when an equivalent workflow exists.
+- Do not recover from failed CI/CD by hot-patching Rust binaries or compiling
+  source on trading hosts. Fix the workflow or source and redeploy CI-built
+  artifacts.
+
+### Research Issue Workflow
+
+- Strategy research ideas should be captured as GitHub issues instead of staying
+  only in chat, local notes, or one-off scripts.
+- Follow `docs/runbooks/strategy-research-cicd.md` for the canonical research
+  issue -> workflow -> evidence -> implementation -> deployment loop.
+- For PM5D / five-minute strategy work, split ideas by factor, hypothesis, data
+  source, execution assumption, or implementation lane so each issue has one
+  testable claim.
+- Each research issue should include: hypothesis, expected edge mechanism,
+  required data, backtest or replay method, success metrics, failure criteria,
+  and the next decision the result should unlock.
+- Prefer issue chains for compound strategy work: parent issue for the strategy
+  direction, child issues for individual factors, filters, execution models,
+  and runtime integration.
+- Backtest/research issues must distinguish exploratory diagnostics from
+  executable strategy accounting. Do not treat multiple entry-time rows from the
+  same event as independent deployable trades.
+- Research evidence should be attached back to the issue: workflow run URL,
+  git ref, dataset/window, config, headline metrics, known caveats, and the
+  resulting decision (`continue`, `revise`, `reject`, or `promote to runtime`).
+- Missing artifacts, empty headline metrics, or missing replay/dry-run strict
+  parity fields are caveats that block promotion; record them as follow-up work
+  instead of treating the run as successful evidence.
+- When an issue leads to implementation, create or link a separate
+  implementation issue/PR so research conclusions, code changes, and deployment
+  decisions stay traceable.
+
+### Local environment
+- No local database. All data, backtests, and services run on tango-1-1 via CI/CD.
+- Do not run `psql`, `cargo run --example run_backtest -- --db-url`, or any command
+  that assumes a local PostgreSQL instance.
+
 ## Skills
 
 Skills are local instruction sets stored in `SKILL.md` files (usually under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,64 @@ ci/<short-description>        — CI/workflow changes
 ### Deployment
 - **Backtest**: trigger `backtest.yml` (workflow_dispatch) with `git_ref=main`
 - **Deploy dryrun/live**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
+- **Deploy trade**: trigger `deploy-trade.yml` (workflow_dispatch) with `git_ref=main`
+- **Release platform**: trigger `release-platform.yml` (workflow_dispatch) with `git_ref=main`
+- **ACK deploy**: trigger `build-push-acr.yml` with `push_images=true` only from `git_ref=main`, then `deploy-ack.yml` with the immutable 40-character SHA image tag
 - Never deploy from a feature branch directly
 - Never build Rust on tango-1-1 — CI builds and ships artifacts only
+
+### GitHub Actions / CLI Principles
+
+- Use GitHub Actions as the default build, test, research, and deploy execution
+  surface when work needs Linux, remote data, repository secrets, or trading-host
+  delivery.
+- Use `gh` as the default control surface for PR checks, workflow dispatch,
+  run monitoring, failed-log inspection, and workflow result evidence.
+- Treat CI failure as actionable engineering feedback: inspect the failed run,
+  fix the root cause, push a new commit, and re-run the relevant checks.
+- Treat successful CI as necessary but not sufficient for deployments. After
+  deploy, verify the affected remote service, config, systemd guardrails, and
+  public/operator endpoint.
+- Deployments that affect `tango-1-1`, trade services, ACK, or production-like
+  state must run from `main`. Feature branches may run build-only or
+  research-only workflows only when they do not mutate deployment state.
+- Container/image deploy paths must use immutable checked-out commit SHA tags.
+  Do not push or deploy mutable `latest` tags.
+- Keep deployment secrets in GitHub environments/repository secrets. Never place
+  secrets in local files, commits, logs, pasted command output, or ad hoc scripts.
+- Prefer environment-scoped workflows (`tango-1-1`, `production`, `ploy-ci-1`,
+  `ack`) over direct SSH when an equivalent workflow exists.
+- Do not recover from failed CI/CD by hot-patching Rust binaries or compiling
+  source on trading hosts. Fix the workflow or source and redeploy CI-built
+  artifacts.
+
+### Research Issue Workflow
+
+- Strategy research ideas should be captured as GitHub issues instead of staying
+  only in chat, local notes, or one-off scripts.
+- Follow `docs/runbooks/strategy-research-cicd.md` for the canonical research
+  issue -> workflow -> evidence -> implementation -> deployment loop.
+- For PM5D / five-minute strategy work, split ideas by factor, hypothesis, data
+  source, execution assumption, or implementation lane so each issue has one
+  testable claim.
+- Each research issue should include: hypothesis, expected edge mechanism,
+  required data, backtest or replay method, success metrics, failure criteria,
+  and the next decision the result should unlock.
+- Prefer issue chains for compound strategy work: parent issue for the strategy
+  direction, child issues for individual factors, filters, execution models,
+  and runtime integration.
+- Backtest/research issues must distinguish exploratory diagnostics from
+  executable strategy accounting. Do not treat multiple entry-time rows from the
+  same event as independent deployable trades.
+- Research evidence should be attached back to the issue: workflow run URL,
+  git ref, dataset/window, config, headline metrics, known caveats, and the
+  resulting decision (`continue`, `revise`, `reject`, or `promote to runtime`).
+- Missing artifacts, empty headline metrics, or missing replay/dry-run strict
+  parity fields are caveats that block promotion; record them as follow-up work
+  instead of treating the run as successful evidence.
+- When an issue leads to implementation, create or link a separate
+  implementation issue/PR so research conclusions, code changes, and deployment
+  decisions stay traceable.
 
 ### Local environment
 - No local database. All data, backtests, and services run on tango-1-1 via CI/CD.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -1,0 +1,159 @@
+# Strategy Research CI/CD Runbook
+
+This runbook defines how strategy ideas move from research issues to GitHub
+Actions, evidence, implementation, and deployment decisions.
+
+## Current Workflow Map
+
+| Purpose | Workflow | Default role |
+| --- | --- | --- |
+| PR validation | `.github/workflows/test.yml` | Required correctness gate for code, contracts, frontend, integration, and workflow lint |
+| PM5D factor diagnostics | `.github/workflows/factor-review-v2.yml` | Snapshot-backed factor review on `ploy-ci-1` |
+| PM5D walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Snapshot-backed rolling factor validation |
+| Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
+| Tick-preserving optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit live-parquet debug path |
+| PM5D backtest | `.github/workflows/backtest.yml` | Build and run `run_backtest` on `ploy-ci-1` against remote DB or synced Parquet |
+| Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest artifact evidence against a dry-run JSON report |
+| Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports |
+| Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
+| Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |
+| ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` GitHub environment |
+| Tango deploy | `.github/workflows/deploy-tango-1-1.yml` | Ship CI-built artifacts to `tango-1-1` and verify host health |
+| Trade deploy | `.github/workflows/deploy-trade.yml` | Deploy runner/configs to `ploy-trade-1` |
+| Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
+
+## Research Lifecycle
+
+1. Create a parent strategy issue for a strategy direction, for example
+   `PM5D three-layer factor expansion`.
+2. Create child research issues for individual factors, filters, execution
+   assumptions, data-source checks, or accounting questions.
+3. Run the smallest workflow that can falsify the child issue's hypothesis:
+   `research-snapshot.yml` for reusable evidence, `factor-review-v2.yml` or
+   `factor-walk-forward-v2.yml` for diagnostics, `optimize.yml` for parameter
+   search, and `backtest.yml` for executable replay/backtest checks.
+4. Attach evidence back to the issue: workflow URL, git ref, input window,
+   symbols, config, artifact name, headline metrics, caveats, and decision.
+5. Close rejected ideas with the failure reason. Keep promising ideas open until
+   they are linked to an implementation issue or PR.
+6. Promote only after the research issue has a concrete decision:
+   `continue`, `revise`, `reject`, or `promote to runtime`.
+7. Create a separate implementation issue/PR for runtime changes. Do not mix
+   exploratory research conclusions and deployable runtime edits in one issue.
+8. Deploy only after PR validation passes and the deployment workflow is run
+   from `main`.
+
+## Idea Validation Loop
+
+For a new strategy idea, the default loop is:
+
+```text
+Idea
+  -> define hypothesis and expected edge
+  -> create or update a GitHub research issue
+  -> design the replay/backtest experiment
+  -> run remote workflow on ploy-ci-1/Tango/ACK data
+  -> inspect accounting, labels, fills, quote age, and rejected opportunities
+  -> implement the smallest runtime change needed for dry-run
+  -> deploy dry-run from main through GitHub Actions
+  -> compare replay vs dry-run on the same market/event/time window
+  -> decide: revise idea, fix data/runtime mismatch, keep collecting, or promote
+```
+
+The loop is not complete after a profitable backtest. It is complete only when
+the dry-run behavior can be reconciled against replay expectations or the
+mismatch is understood and turned into the next issue.
+
+Required loop gates:
+
+- **Backtest design gate**: define the hypothesis, event window, data sources,
+  execution assumptions, entry/exit rules, stake model, and expected metrics
+  before running the workflow.
+- **Replay evidence gate**: record the workflow run, git ref, config, dataset
+  window, selected events, predicted entries, fills, PnL, quote age, and known
+  data gaps.
+- **Dry-run gate**: deploy only from `main`, keep risk limits explicit, and
+  verify the remote service/config after the workflow completes.
+- **Parity gate**: compare replay and dry-run on event id, decision timestamp,
+  observed quote, signal inputs, intended side, entry price, fill/not-fill,
+  settlement, and PnL.
+- **Decision gate**: close the loop with one of `revise`, `fix-data`,
+  `fix-runtime`, `collect-more`, `reject`, or `promote`.
+
+Replay/dry-run mismatches are first-class findings. Do not hide them inside a
+single research report. Open or link a follow-up issue for the specific mismatch:
+data freshness, quote reconstruction, runtime config drift, fill model,
+settlement label, signal timing, or execution friction.
+
+## Evidence Contract
+
+Every research issue should end with an evidence block:
+
+```text
+Evidence:
+- Workflow:
+- Run URL:
+- Git ref:
+- Dataset/window:
+- Symbols:
+- Config:
+- Artifact:
+- Headline metrics:
+- Caveats:
+- Decision:
+```
+
+Backtest evidence must explicitly state whether it is exploratory diagnostics or
+executable strategy accounting. For PM5D, one event should not be counted as
+multiple deployable trades just because multiple entry-time rows were observed.
+
+## CI/CD Architecture
+
+The intended control loop is:
+
+```text
+GitHub issue
+  -> workflow_dispatch with explicit git_ref and inputs
+  -> GitHub Actions run on ubuntu-latest, ploy-ci-1, tango-1-1, or ACK
+  -> structured artifact plus step summary
+  -> issue evidence comment and decision label
+  -> implementation issue / PR when promoted
+  -> PR validation
+  -> main merge
+  -> deploy workflow from main
+  -> remote service/config/health verification
+```
+
+Keep the control planes separate:
+
+- Research workflows can run on feature branches when they do not mutate
+  deployment state.
+- Keep `workflow_dispatch` inputs at or below GitHub's 10-input limit. Put
+  advanced or rarely changed knobs into an `options_json` input, validate keys
+  in the workflow, and fail on unknown options so typoed experiments do not run
+  with silent defaults.
+- Deployment workflows that affect `tango-1-1`, `ploy-trade-1`, ACK, or
+  production state must run from `main`.
+- Remote data and heavy research belong on `ploy-ci-1`, `tango-1-1`, ACK, or
+  CI-built artifacts, not local PostgreSQL assumptions.
+- `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub Actions
+  secrets `PLOY_RESEARCH_DATABASE_URL` and `PLOY_DB_URL`; verify the private
+  endpoint with Aliyun CLI before changing those secrets.
+- ACK/ACR image workflows must use immutable checked-out commit SHA tags only.
+  Do not push or deploy `latest`. ACK deployments must also pass through the
+  GitHub `ack` environment, which requires reviewer approval and disables admin
+  bypass before mutating the cluster.
+- Runtime deployment evidence must include remote host verification, not only
+  a successful workflow conclusion.
+- Replay/dry-run parity is promotion evidence only when the parity artifact says
+  `strict_parity_ready=true`. Missing strict fields are a follow-up issue, not a
+  pass.
+
+## Recommended Improvements
+
+1. Add label automation for research decisions after evidence is posted.
+2. Make the dry-run report expose stricter event-level parity fields when the
+   operator API contract is ready.
+3. Keep ACK workflows marked as cluster/deployment workflows, separate from the
+   current Tango-first PM5D research loop unless ACK becomes the canonical
+   research runner.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -157,12 +157,11 @@ Keep the control planes separate:
 
 ## Recommended Improvements
 
-1. Add label automation for research decisions after evidence is posted.
-2. Make the dry-run report expose stricter event-level parity fields when the
+1. Make the dry-run report expose stricter event-level parity fields when the
    operator API contract is ready.
-3. Configure repository settings so `main`, `tango-1-1`, `ploy-trade-1`,
+2. Configure repository settings so `main`, `tango-1-1`, `ploy-trade-1`,
    `production`, and `ploy-ci-1` enforce the same branch/environment policy that
    the workflow files expect.
-4. Keep ACK workflows marked as cluster/deployment workflows, separate from the
+3. Keep ACK workflows marked as cluster/deployment workflows, separate from the
    current Tango-first PM5D research loop unless ACK becomes the canonical
    research runner.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -134,6 +134,12 @@ Keep the control planes separate:
   with silent defaults.
 - Deployment workflows that affect `tango-1-1`, `ploy-trade-1`, ACK, or
   production state must run from `main`.
+- Host deployment workflows must be dispatched from `main` with `git_ref=main`
+  before mutating remote state. Tango and trade SSH deploys require pinned
+  `known_hosts` secrets (`TANGO_1_1_KNOWN_HOSTS` and
+  `PLOY_TRADE_1_KNOWN_HOSTS`), not opportunistic host-key acceptance. The
+  entries should be keyed by the workflow aliases `tango-1-1` and
+  `ploy-trade-1` because the deploy SSH config sets `HostKeyAlias`.
 - Remote data and heavy research belong on `ploy-ci-1`, `tango-1-1`, ACK, or
   CI-built artifacts, not local PostgreSQL assumptions.
 - `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub Actions
@@ -154,6 +160,9 @@ Keep the control planes separate:
 1. Add label automation for research decisions after evidence is posted.
 2. Make the dry-run report expose stricter event-level parity fields when the
    operator API contract is ready.
-3. Keep ACK workflows marked as cluster/deployment workflows, separate from the
+3. Configure repository settings so `main`, `tango-1-1`, `ploy-trade-1`,
+   `production`, and `ploy-ci-1` enforce the same branch/environment policy that
+   the workflow files expect.
+4. Keep ACK workflows marked as cluster/deployment workflows, separate from the
    current Tango-first PM5D research loop unless ACK becomes the canonical
    research runner.

--- a/scripts/check_optimize_verification_gates.sh
+++ b/scripts/check_optimize_verification_gates.sh
@@ -58,6 +58,12 @@ if [[ -f "${workflow}" ]]; then
   require_any_text "${workflow}" "timestamp validation-start narrow-window control" "val_start_ts" "val-start-ts"
   require_any_text "${workflow}" "timestamp validation-end narrow-window control" "val_end_ts" "val-end-ts"
   require_text "${workflow}" "timeout" "optimize process timeout wrapper"
+  if grep -Fq "Swatinem/rust-cache" "${workflow}"; then
+    failures+=("optimize workflow must not use Swatinem/rust-cache post steps after the backtest cache hang")
+  fi
+  if grep -Fq "download-artifact" "${workflow}" || grep -Fq "optimize-runner-\${{ github.sha }}" "${workflow}"; then
+    failures+=("optimize workflow must build and run the optimize runner in one job, not pass the binary through artifacts")
+  fi
 
   if ! python3 - "${workflow}" <<'PY'
 import re

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Compare replay/backtest evidence with dry-run report evidence.
+
+The script is intentionally schema-tolerant: current research artifacts and
+operator reports are still evolving, so it extracts the common strategy
+evaluation fields first and records missing strict parity fields as risk flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STRICT_FIELDS = [
+    "event_id",
+    "decision_ts",
+    "quote",
+    "signal_inputs",
+    "side",
+    "entry_price",
+    "fill_status",
+    "settlement",
+    "pnl",
+]
+
+STRICT_FIELD_ALIASES = {
+    "event_id": ("event_id", "market_id", "market_slug", "token_id"),
+    "decision_ts": ("decision_ts", "opened_at", "timestamp"),
+    "quote": ("quote", "observed_quote"),
+    "signal_inputs": ("signal_inputs", "decision_features", "features"),
+    "side": ("side", "market_side", "direction"),
+    "entry_price": ("entry_price", "avg_entry_price"),
+    "fill_status": ("fill_status", "status"),
+    "settlement": ("settlement", "resolved_up_won"),
+    "pnl": ("pnl", "net_pnl", "realized_pnl"),
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def find_first_json(root: Path) -> Path:
+    if root.is_file():
+        return root
+    candidates = sorted(root.rglob("*.json"))
+    if not candidates:
+        raise SystemExit(f"no JSON files found under {root}")
+    preferred = [path for path in candidates if path.name == "evaluation.json"]
+    return preferred[0] if preferred else candidates[0]
+
+
+def get_path(data: Any, *path: str) -> Any:
+    current = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def extract_metrics(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        return {}
+    metrics = data.get("metrics")
+    if isinstance(metrics, dict):
+        return metrics
+    validation = data.get("validation")
+    if isinstance(validation, dict):
+        return validation
+    report = data.get("report")
+    if isinstance(report, dict):
+        return {
+            "health": report.get("health"),
+            "review_count": len(report.get("reviews") or []),
+        }
+    return {}
+
+
+def extract_events(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if not isinstance(data, dict):
+        return []
+    events: list[dict[str, Any]] = []
+    for path in [
+        ("events",),
+        ("trades",),
+        ("fills",),
+        ("closed_trades",),
+        ("recent_closed",),
+        ("open_positions",),
+        ("report", "events"),
+        ("report", "trades"),
+        ("report", "closed_trades"),
+        ("report", "recent_closed"),
+        ("dry_run", "events"),
+        ("data", "events"),
+    ]:
+        value = get_path(data, *path)
+        if isinstance(value, list):
+            events.extend(item for item in value if isinstance(item, dict))
+
+    strategies = data.get("strategies")
+    if isinstance(strategies, list):
+        for strategy in strategies:
+            if not isinstance(strategy, dict):
+                continue
+            for key in ("events", "trades", "fills", "closed_trades", "recent_closed", "open_positions"):
+                value = strategy.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            enriched = dict(item)
+                            for identity_key in ("runtime_mode", "strategy_id", "deployment_id", "experiment_label"):
+                                enriched.setdefault(identity_key, strategy.get(identity_key))
+                            events.append(enriched)
+
+    if events:
+        deduped = {}
+        for idx, event in enumerate(events):
+            key = (
+                event.get("trade_key")
+                or event.get("intent_id")
+                or event.get("event_id")
+                or event.get("token_id")
+                or f"row-{idx}"
+            )
+            deduped[str(key)] = event
+        return list(deduped.values())
+    return []
+
+
+def canonical_field(event: dict[str, Any], field: str) -> Any:
+    for key in STRICT_FIELD_ALIASES.get(field, (field,)):
+        if key in event and event[key] is not None:
+            return event[key]
+    return None
+
+
+def available_strict_fields(events: list[dict[str, Any]]) -> list[str]:
+    available = set()
+    for event in events:
+        for field in STRICT_FIELDS:
+            if canonical_field(event, field) is not None:
+                available.add(field)
+    return sorted(available)
+
+
+def index_events(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    indexed = {}
+    for idx, event in enumerate(events):
+        key = (
+            event.get("trade_key")
+            or event.get("intent_id")
+            or event.get("event_id")
+            or event.get("market_id")
+            or event.get("market_slug")
+            or event.get("token_id")
+            or f"row-{idx}"
+        )
+        indexed[str(key)] = event
+    return indexed
+
+
+def compare_events(
+    replay_events: list[dict[str, Any]], dryrun_events: list[dict[str, Any]]
+) -> dict[str, Any]:
+    replay_index = index_events(replay_events)
+    dryrun_index = index_events(dryrun_events)
+    shared_keys = sorted(set(replay_index) & set(dryrun_index))
+    mismatches: list[dict[str, Any]] = []
+    missing_fields = set()
+    replay_available = available_strict_fields(replay_events)
+    dryrun_available = available_strict_fields(dryrun_events)
+
+    for key in shared_keys:
+        replay = replay_index[key]
+        dryrun = dryrun_index[key]
+        for field in STRICT_FIELDS:
+            replay_value = canonical_field(replay, field)
+            dryrun_value = canonical_field(dryrun, field)
+            if replay_value is None or dryrun_value is None:
+                missing_fields.add(field)
+                continue
+            if replay_value != dryrun_value:
+                mismatches.append(
+                    {
+                        "event_key": key,
+                        "field": field,
+                        "replay": replay_value,
+                        "dryrun": dryrun_value,
+                    }
+                )
+
+    return {
+        "replay_event_count": len(replay_events),
+        "dryrun_event_count": len(dryrun_events),
+        "shared_event_count": len(shared_keys),
+        "strict_required_fields": STRICT_FIELDS,
+        "replay_available_strict_fields": replay_available,
+        "dryrun_available_strict_fields": dryrun_available,
+        "missing_replay_events": sorted(set(dryrun_index) - set(replay_index))[:50],
+        "missing_dryrun_events": sorted(set(replay_index) - set(dryrun_index))[:50],
+        "mismatches": mismatches[:100],
+        "missing_strict_fields": sorted(missing_fields),
+        "strict_parity_ready": bool(shared_keys) and not missing_fields and not mismatches,
+    }
+
+
+def build_result(replay: Any, dryrun: Any, replay_path: Path, dryrun_path: Path) -> dict[str, Any]:
+    replay_events = extract_events(replay)
+    dryrun_events = extract_events(dryrun)
+    event_comparison = compare_events(replay_events, dryrun_events)
+    risk_flags: list[str] = []
+
+    if not replay_events:
+        risk_flags.append("replay_has_no_event_level_rows")
+    if not dryrun_events:
+        risk_flags.append("dryrun_has_no_event_level_rows")
+    if event_comparison["missing_dryrun_events"]:
+        risk_flags.append("events_present_in_replay_missing_from_dryrun")
+    if event_comparison["missing_replay_events"]:
+        risk_flags.append("events_present_in_dryrun_missing_from_replay")
+    if event_comparison["mismatches"]:
+        risk_flags.append("strict_field_mismatches")
+    if event_comparison["missing_strict_fields"]:
+        risk_flags.append("missing_strict_parity_fields")
+
+    decision = "continue"
+    if not event_comparison["strict_parity_ready"]:
+        decision = "fix-data-or-runtime-mismatch"
+
+    return {
+        "schema_version": 1,
+        "artifact_type": "strategy_parity_evaluation",
+        "producer": "replay_dryrun_parity",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "replay_source": str(replay_path),
+        "dryrun_source": str(dryrun_path),
+        "replay_metrics": extract_metrics(replay),
+        "dryrun_metrics": extract_metrics(dryrun),
+        "event_comparison": event_comparison,
+        "risk_flags": risk_flags,
+        "decision": decision,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--replay-json", required=True)
+    parser.add_argument("--dryrun-json", required=True)
+    parser.add_argument("--output-json", required=True)
+    args = parser.parse_args()
+
+    replay_path = find_first_json(Path(args.replay_json))
+    dryrun_path = find_first_json(Path(args.dryrun_json))
+    result = build_result(
+        load_json(replay_path),
+        load_json(dryrun_path),
+        replay_path,
+        dryrun_path,
+    )
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as handle:
+        json.dump(result, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
+# Research Issue Label Automation (2026-04-30)
+
+## Files
+
+- `.github/scripts/research-issue-labels.js`
+  - Owner: shared GitHub issue label helper for research evidence workflows.
+- `.github/workflows/backtest.yml`
+- `.github/workflows/replay-dryrun-parity.yml`
+- `.github/workflows/factor-review-v2.yml`
+- `.github/workflows/factor-walk-forward-v2.yml`
+- `.github/workflows/optimize.yml`
+  - Owner: apply evidence and decision labels after issue evidence comments.
+- `tests/workflow_security.rs`
+  - Owner: guard that research workflows keep label automation wired.
+- `docs/runbooks/strategy-research-cicd.md`
+- `tasks/todo.md`
+
+## Tasks
+
+- [x] Add a shared helper that creates missing research labels and rotates managed state labels.
+- [x] Apply `evidence:*`, `decision:*`, and `parity:*` labels from research workflows.
+- [x] Add workflow security tests for label automation wiring.
+- [x] Run focused verification and push the PR update.
+
+## Review
+
+- 2026-04-30: Added a shared research issue label helper that creates missing
+  labels, applies evidence/decision/parity labels, and removes stale managed
+  `decision:*`, `parity:*`, and `evidence:missing-*` labels.
+- 2026-04-30: Wired label automation into backtest, replay/dry-run parity,
+  factor review, walk-forward, and optimize evidence comments.
+- 2026-04-30: Verification passed: `node --check
+  .github/scripts/research-issue-labels.js`, `git diff --check`, and
+  `/opt/homebrew/bin/timeout 180 rtk cargo test --test workflow_security`.
+  Local `actionlint` was unavailable; GitHub workflow lint remains the source
+  of truth after push.
+
 # CI/CD Deployment Hardening (2026-04-30)
 
 ## Files

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
+# CI/CD Deployment Hardening (2026-04-30)
+
+## Files
+
+- `.github/workflows/deploy-tango-1-1.yml`
+  - Owner: main-only Tango deployment provenance and pinned SSH host verification.
+- `.github/workflows/deploy-trade.yml`
+  - Owner: protected trade deployment, default-safe dispatch, and pinned SSH host verification.
+- `tests/workflow_security.rs`
+  - Owner: regression guards for host deploy workflow policy.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: CI/CD runbook updates for deploy provenance and host-key policy.
+- `tasks/todo.md`
+  - Owner: plan and verification notes.
+
+## Tasks
+
+- [x] Add a hard deploy gate requiring workflow dispatch from `main` with `git_ref=main`.
+- [x] Require pinned SSH `known_hosts` secrets for Tango and trade deploys.
+- [x] Put trade deploy behind a dedicated GitHub environment and default real deploys to false.
+- [x] Add workflow security tests for deploy provenance and SSH host-key verification.
+- [x] Run focused workflow security verification and push the PR update.
+
+## Review
+
+- 2026-04-30: Added deploy-time provenance gates to Tango and trade workflows:
+  real deployment now requires the workflow dispatch branch and checked-out
+  `git_ref` to both resolve to `origin/main`.
+- 2026-04-30: Replaced disabled SSH host verification with required pinned
+  `known_hosts` secrets and `HostKeyAlias` for `tango-1-1` and `ploy-trade-1`.
+  Trade deploy now uses the `ploy-trade-1` GitHub environment and defaults
+  `deploy=false`.
+- 2026-04-30: Verification passed: `git diff --check` and
+  `/opt/homebrew/bin/timeout 180 rtk cargo test --test workflow_security`.
+  Local `actionlint` was unavailable; GitHub workflow lint remains the source
+  of truth after push.
+
 # PM5D OBI-Hard Dry-Run Candidate (2026-04-29)
 
 ## Files

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -282,6 +282,62 @@ fn release_platform_workflow_pins_host_fingerprints() {
 }
 
 #[test]
+fn host_deploy_workflows_require_main_provenance_and_pinned_ssh() {
+    let tango = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
+    let trade = workflow_contents(".github/workflows/deploy-trade.yml");
+    let mut offenders = Vec::new();
+
+    for (name, content, environment, known_hosts_secret) in [
+        (
+            "deploy-tango-1-1.yml",
+            &tango,
+            "environment: tango-1-1",
+            "TANGO_1_1_KNOWN_HOSTS",
+        ),
+        (
+            "deploy-trade.yml",
+            &trade,
+            "environment: ploy-trade-1",
+            "PLOY_TRADE_1_KNOWN_HOSTS",
+        ),
+    ] {
+        if !content.contains(environment) {
+            offenders.push(format!("{name}: missing protected deployment environment"));
+        }
+        if !content.contains("Validate deploy provenance") {
+            offenders.push(format!("{name}: missing deploy provenance validation step"));
+        }
+        if !content.contains("must dispatch the workflow from main")
+            || !content.contains("must use git_ref=main")
+            || !content.contains("does not match origin/main")
+        {
+            offenders.push(format!("{name}: deployment is not hard-gated to main provenance"));
+        }
+        if content.contains("StrictHostKeyChecking no")
+            || content.contains("UserKnownHostsFile /dev/null")
+        {
+            offenders.push(format!("{name}: disables SSH host-key verification"));
+        }
+        if !content.contains("StrictHostKeyChecking yes")
+            || !content.contains("UserKnownHostsFile ~/.ssh/known_hosts")
+            || !content.contains(known_hosts_secret)
+        {
+            offenders.push(format!("{name}: missing pinned known_hosts SSH verification"));
+        }
+    }
+
+    if !trade.contains("default: false") {
+        offenders.push("deploy-trade.yml: live trade deploy should default deploy=false".to_string());
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "host deploy workflow hardening check failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn checked_in_platform_service_enforces_guardrails() {
     let content = workflow_contents("deployment/ployd.service");
     let required = [

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -219,11 +219,9 @@ fn auto_review_uses_bounded_workspace_checks() {
                 .to_string(),
         );
     }
-    if !content
-        .contains("cargo check --locked -p ploy-research --features db,polars-export,ml,rl,strategy-runtime --lib")
-    {
+    if content.contains("cargo clippy") || content.contains("Swatinem/rust-cache") {
         offenders.push(
-            "auto-review.yml: missing bounded ploy-research heavy feature contract check"
+            "auto-review.yml: advisory review should not duplicate heavy compile/test matrix work"
                 .to_string(),
         );
     }
@@ -231,6 +229,26 @@ fn auto_review_uses_bounded_workspace_checks() {
     assert!(
         offenders.is_empty(),
         "auto-review workflow guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn test_matrix_owns_research_heavy_feature_contract() {
+    let content = workflow_contents(".github/workflows/test.yml");
+    let mut offenders = Vec::new();
+
+    if !content
+        .contains("cargo check --locked -p ploy-research --features db,polars-export,ml,rl,strategy-runtime --lib")
+    {
+        offenders.push(
+            "test.yml: missing ploy-research heavy feature contract check".to_string(),
+        );
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research heavy CI guard failed:\n{}",
         offenders.join("\n")
     );
 }

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -146,7 +146,9 @@ fn research_workflows_do_not_transfer_runtime_binaries_between_jobs() {
         "optimize-runner-${{ github.sha }}",
     ] {
         if optimize.contains(forbidden) {
-            offenders.push(format!("optimize.yml: fragile binary artifact pattern still contains `{forbidden}`"));
+            offenders.push(format!(
+                "optimize.yml: fragile binary artifact pattern still contains `{forbidden}`"
+            ));
         }
     }
     for forbidden in [
@@ -155,7 +157,9 @@ fn research_workflows_do_not_transfer_runtime_binaries_between_jobs() {
         "run_backtest-${{ github.sha }}",
     ] {
         if backtest.contains(forbidden) {
-            offenders.push(format!("backtest.yml: fragile binary artifact pattern still contains `{forbidden}`"));
+            offenders.push(format!(
+                "backtest.yml: fragile binary artifact pattern still contains `{forbidden}`"
+            ));
         }
     }
 
@@ -173,7 +177,8 @@ fn replay_dryrun_parity_reports_strict_readiness() {
     let mut offenders = Vec::new();
 
     if !script.contains("strict_parity_ready") {
-        offenders.push("replay_dryrun_parity.py: missing strict parity readiness field".to_string());
+        offenders
+            .push("replay_dryrun_parity.py: missing strict parity readiness field".to_string());
     }
     if !script.contains("missing_strict_parity_fields") {
         offenders.push("replay_dryrun_parity.py: missing strict parity caveat".to_string());
@@ -185,6 +190,47 @@ fn replay_dryrun_parity_reports_strict_readiness() {
     assert!(
         offenders.is_empty(),
         "replay/dry-run parity guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn auto_review_uses_bounded_workspace_checks() {
+    let content = workflow_contents(".github/workflows/auto-review.yml");
+    let mut offenders = Vec::new();
+
+    if content.contains("cargo fmt --all -- --check") {
+        offenders.push(
+            "auto-review.yml: cargo fmt --all also formats local path dependencies such as vendor SDKs"
+                .to_string(),
+        );
+    }
+    if content.contains("cargo clippy --all-targets --features rl") {
+        offenders.push(
+            "auto-review.yml: rl is not a feature on the default workspace member set".to_string(),
+        );
+    }
+    if !content.contains("git diff --name-only --diff-filter=ACMRT")
+        || !content.contains("':!vendor/**'")
+        || !content.contains("xargs rustfmt --check")
+    {
+        offenders.push(
+            "auto-review.yml: formatting should target PR Rust file changes only and exclude vendor path dependencies"
+                .to_string(),
+        );
+    }
+    if !content
+        .contains("cargo check --locked -p ploy-research --features db,polars-export,ml,rl,strategy-runtime --lib")
+    {
+        offenders.push(
+            "auto-review.yml: missing bounded ploy-research heavy feature contract check"
+                .to_string(),
+        );
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "auto-review workflow guard failed:\n{}",
         offenders.join("\n")
     );
 }
@@ -202,15 +248,12 @@ fn release_platform_workflow_pins_host_fingerprints() {
 
     if content.matches("fingerprint:").count() != 2 {
         offenders.push(
-            "release-platform.yml: expected fingerprint pinning on both appleboy steps"
-                .to_string(),
+            "release-platform.yml: expected fingerprint pinning on both appleboy steps".to_string(),
         );
     }
 
     if !content.contains("EC2_HOST_FINGERPRINT || secrets.AWS_EC2_HOST_FINGERPRINT") {
-        offenders.push(
-            "release-platform.yml: missing EC2 fingerprint secret wiring".to_string(),
-        );
+        offenders.push("release-platform.yml: missing EC2 fingerprint secret wiring".to_string());
     }
 
     assert!(

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -8,10 +8,47 @@ fn workflow_contents(relative_path: &str) -> String {
         .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
 }
 
+fn workflow_dispatch_input_count(content: &str) -> usize {
+    let mut in_inputs = false;
+    let mut base_indent = 0usize;
+    let mut count = 0usize;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if trimmed == "inputs:" {
+            in_inputs = true;
+            base_indent = indent;
+            continue;
+        }
+        if in_inputs {
+            if indent <= base_indent {
+                break;
+            }
+            if indent == base_indent + 2 && trimmed.ends_with(':') {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}
+
 #[test]
 fn ci_runs_dependency_vulnerability_audit() {
     let content = workflow_contents(".github/workflows/test.yml");
     let mut offenders = Vec::new();
+
+    if !content.contains("name: Workflow lint") {
+        offenders.push("test.yml: missing workflow lint job".to_string());
+    }
+
+    if !content.contains("actionlint/cmd/actionlint@v1.7.7") {
+        offenders.push("test.yml: missing pinned actionlint installation".to_string());
+    }
 
     if !content.contains("taiki-e/install-action@cargo-audit") {
         offenders.push("test.yml: missing cargo-audit installer step".to_string());
@@ -27,6 +64,127 @@ fn ci_runs_dependency_vulnerability_audit() {
     assert!(
         offenders.is_empty(),
         "workflow dependency-audit guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn workflow_dispatch_inputs_stay_lintable() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow_dir = repo_root.join(".github/workflows");
+    let mut offenders = Vec::new();
+
+    for entry in fs::read_dir(&workflow_dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", workflow_dir.display()))
+    {
+        let path = entry.expect("workflow dir entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("yml") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        if !content.contains("workflow_dispatch:") {
+            continue;
+        }
+        let input_count = workflow_dispatch_input_count(&content);
+        if input_count > 10 {
+            offenders.push(format!(
+                "{}: workflow_dispatch has {input_count} inputs; move advanced knobs to options_json",
+                path.strip_prefix(repo_root).unwrap_or(&path).display()
+            ));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "workflow_dispatch input-count guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn ack_images_use_immutable_sha_tags() {
+    let build = workflow_contents(".github/workflows/build-push-acr.yml");
+    let deploy = workflow_contents(".github/workflows/deploy-ack.yml");
+    let mut offenders = Vec::new();
+
+    if !build.contains("default: false") {
+        offenders.push("build-push-acr.yml: image pushes should default to false".to_string());
+    }
+    if build.contains(":latest") {
+        offenders.push("build-push-acr.yml: must not build or push latest tags".to_string());
+    }
+    if !build.contains("ACR image pushes must use git_ref=main") {
+        offenders.push("build-push-acr.yml: missing main-only push provenance gate".to_string());
+    }
+    if deploy.contains("default: \"latest\"") || deploy.contains("SHA or 'latest'") {
+        offenders.push("deploy-ack.yml: must not accept latest as a deploy default".to_string());
+    }
+    if !deploy.contains("environment: ack") {
+        offenders.push("deploy-ack.yml: missing protected ack environment".to_string());
+    }
+    if !deploy.contains("^[0-9a-f]{40}$") {
+        offenders.push("deploy-ack.yml: missing full SHA image-tag validation".to_string());
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "ACK immutable image guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn research_workflows_do_not_transfer_runtime_binaries_between_jobs() {
+    let optimize = workflow_contents(".github/workflows/optimize.yml");
+    let backtest = workflow_contents(".github/workflows/backtest.yml");
+    let mut offenders = Vec::new();
+
+    for forbidden in [
+        "Upload optimize runner",
+        "Download optimize runner",
+        "optimize-runner-${{ github.sha }}",
+    ] {
+        if optimize.contains(forbidden) {
+            offenders.push(format!("optimize.yml: fragile binary artifact pattern still contains `{forbidden}`"));
+        }
+    }
+    for forbidden in [
+        "Upload run_backtest binary",
+        "Download run_backtest binary",
+        "run_backtest-${{ github.sha }}",
+    ] {
+        if backtest.contains(forbidden) {
+            offenders.push(format!("backtest.yml: fragile binary artifact pattern still contains `{forbidden}`"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research workflow binary handoff guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn replay_dryrun_parity_reports_strict_readiness() {
+    let script = workflow_contents("scripts/replay_dryrun_parity.py");
+    let workflow = workflow_contents(".github/workflows/replay-dryrun-parity.yml");
+    let mut offenders = Vec::new();
+
+    if !script.contains("strict_parity_ready") {
+        offenders.push("replay_dryrun_parity.py: missing strict parity readiness field".to_string());
+    }
+    if !script.contains("missing_strict_parity_fields") {
+        offenders.push("replay_dryrun_parity.py: missing strict parity caveat".to_string());
+    }
+    if !workflow.contains("Replay/dry-run parity evidence") {
+        offenders.push("replay-dryrun-parity.yml: missing issue evidence comment".to_string());
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "replay/dry-run parity guard failed:\n{}",
         offenders.join("\n")
     );
 }

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -195,6 +195,48 @@ fn replay_dryrun_parity_reports_strict_readiness() {
 }
 
 #[test]
+fn research_issue_workflows_apply_decision_labels() {
+    let helper = workflow_contents(".github/scripts/research-issue-labels.js");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "applyResearchIssueLabels",
+        "labelsForDecision",
+        "decision:pending",
+        "decision:fix-data",
+        "decision:fix-runtime",
+        "evidence:missing-metrics",
+        "parity:blocked",
+    ] {
+        if !helper.contains(needle) {
+            offenders.push(format!("research-issue-labels.js: missing `{needle}`"));
+        }
+    }
+
+    for (workflow, evidence_label) in [
+        (".github/workflows/backtest.yml", "evidence:backtest"),
+        (".github/workflows/replay-dryrun-parity.yml", "evidence:parity"),
+        (".github/workflows/factor-review-v2.yml", "evidence:factor-review"),
+        (".github/workflows/factor-walk-forward-v2.yml", "evidence:walk-forward"),
+        (".github/workflows/optimize.yml", "evidence:optimize"),
+    ] {
+        let content = workflow_contents(workflow);
+        if !content.contains("research-issue-labels.js") {
+            offenders.push(format!("{workflow}: missing shared research label helper"));
+        }
+        if !content.contains(evidence_label) {
+            offenders.push(format!("{workflow}: missing evidence label `{evidence_label}`"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research issue label guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn auto_review_uses_bounded_workspace_checks() {
     let content = workflow_contents(".github/workflows/auto-review.yml");
     let mut offenders = Vec::new();


### PR DESCRIPTION
## Summary
- make strategy/research workflows actionlint-clean on current main by keeping workflow_dispatch inputs within GitHub's 10-input limit and validating advanced options_json keys
- require immutable SHA image tags for ACR/ACK, remove latest image pushes, and protect ACK deploys through the ack environment
- keep optimize/backtest build+run in the same self-hosted job, add replay/dry-run parity evidence, and document the issue-driven research loop

## Verification
- workflow and issue YAML parse
- actionlint
- ./scripts/check_optimize_verification_gates.sh
- rtk cargo test -p ploy --test workflow_security
- replay_dryrun_parity smoke
- GitHub Test: https://github.com/proerror77/ploy/actions/runs/25146806492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub issue templates for strategy research hypothesis and runtime implementation tracking.
  * Introduced automated replay/dry-run parity validation workflow to detect mismatches between test scenarios.
  * Added workflow linting to CI pipeline for improved automation quality.

* **Improvements**
  * Enhanced deployment workflows with stricter validation controls and immutable image tagging requirements.
  * Streamlined workflow configuration by consolidating multiple inputs into structured options.
  * Added comprehensive security and provenance checks for deployments.

* **Documentation**
  * New runbook documenting strategy research and CI/CD lifecycle.
  * Updated operational guidelines for building, testing, and deploying changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->