### PR TITLE
Make strategy CI/CD framing family-agnostic

### DIFF
--- a/.github/ISSUE_TEMPLATE/strategy_implementation.yml
+++ b/.github/ISSUE_TEMPLATE/strategy_implementation.yml
@@ -18,6 +18,22 @@ body:
       description: Describe the exact strategy/runtime behavior this issue should change.
     validations:
       required: true
+  - type: input
+    id: strategy_family
+    attributes:
+      label: Strategy family
+      description: Broad family affected by this implementation.
+      placeholder: binary-options, sports, copy-trading, market-making, event-ML
+    validations:
+      required: true
+  - type: input
+    id: strategy_profile
+    attributes:
+      label: Strategy profile / config
+      description: Concrete profile or config affected by this implementation.
+      placeholder: config/strategies/<family>.<profile>.toml
+    validations:
+      required: true
   - type: textarea
     id: scope
     attributes:

--- a/.github/ISSUE_TEMPLATE/strategy_research.yml
+++ b/.github/ISSUE_TEMPLATE/strategy_research.yml
@@ -3,12 +3,28 @@ description: Track one testable strategy research idea, factor, filter, or data 
 title: "[Research] "
 labels: "research:hypothesis"
 body:
+  - type: input
+    id: strategy_family
+    attributes:
+      label: Strategy family
+      description: Broad family this hypothesis belongs to.
+      placeholder: binary-options, sports, copy-trading, market-making, event-ML
+    validations:
+      required: true
+  - type: input
+    id: strategy_profile
+    attributes:
+      label: Strategy profile / config
+      description: Concrete profile or config under test. Use `new` if it does not exist yet.
+      placeholder: config/strategies/<family>.<profile>.toml or new
+    validations:
+      required: true
   - type: textarea
     id: hypothesis
     attributes:
       label: Hypothesis
       description: State the single claim this issue should test.
-      placeholder: "Example: PM5D entries improve when CEX momentum reverses while PM quote lags and LOB support remains one-sided."
+      placeholder: "Example: Entries improve when the external reference market moves first while the prediction-market quote lags and liquidity remains one-sided."
     validations:
       required: true
   - type: textarea
@@ -23,7 +39,7 @@ body:
     attributes:
       label: Required data
       description: List tables, windows, symbols, labels, settlement fields, or freshness checks.
-      placeholder: binance_price_ticks, binance_lob_ticks, clob_quote_ticks, pm_token_settlements, signal_history
+      placeholder: price ticks, order-book snapshots, prediction-market quotes, settlement labels, runtime order/fill history
     validations:
       required: true
   - type: textarea
@@ -31,7 +47,7 @@ body:
     attributes:
       label: Workflow plan
       description: Name the workflow and inputs that should test this idea.
-      placeholder: factor-review-v2.yml with start_date, end_date, symbols, stake_usd, options_json
+      placeholder: research-snapshot.yml, factor-review-v2.yml, optimize.yml, backtest.yml, or replay-dryrun-parity.yml with exact inputs
     validations:
       required: true
   - type: textarea
@@ -46,7 +62,7 @@ body:
     attributes:
       label: Accounting contract
       description: State whether this is exploratory diagnostics or executable strategy accounting.
-      placeholder: One PM5D event counts as one deployable trade; multiple entry-time rows are diagnostics unless a runtime rule can execute them.
+      placeholder: One market event counts as one deployable trade unless the runtime can execute multiple entries under the same risk rules.
     validations:
       required: true
   - type: textarea
@@ -72,8 +88,9 @@ body:
         - Workflow:
         - Run URL:
         - Git ref:
+        - Strategy family/profile:
         - Dataset/window:
-        - Symbols:
+        - Symbols/markets:
         - Config:
         - Artifact:
         - Headline metrics:

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -1,4 +1,4 @@
-name: Backtest pm_5m_directional
+name: Strategy Backtest
 
 on:
   workflow_dispatch:
@@ -137,7 +137,7 @@ jobs:
         if: always()
         run: |
           {
-            echo "## PM5D Backtest"
+            echo "## Strategy Backtest"
             echo ""
             echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
             echo "- Config: \`${{ github.event.inputs.config }}\`"

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -1,4 +1,4 @@
-name: Optimize three_layer params (snapshot-backed)
+name: Optimize strategy params (snapshot-backed)
 
 on:
   workflow_dispatch:

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -1,145 +1,189 @@
-# Strategy Research CI/CD Runbook
+# Strategy-Agnostic Research and Runtime CI/CD Runbook
 
-This runbook defines how strategy ideas move from research issues to GitHub
-Actions, evidence, implementation, and deployment decisions.
+This runbook defines the generic path for any strategy family to move from an
+idea to research evidence, implementation, dry-run observation, parity review,
+and promotion or rejection.
 
-## Current Workflow Map
+PM5D is one current strategy profile, not the center of the CI/CD model. New
+families such as sports, copy-trading, market-making, or event-ML should reuse
+the same control loop and add only profile-specific configs, data requirements,
+and verification thresholds.
 
-| Purpose | Workflow | Default role |
+## Four-Layer Model
+
+| Layer | Purpose | Output |
 | --- | --- | --- |
-| PR validation | `.github/workflows/test.yml` | Required correctness gate for code, contracts, frontend, integration, and workflow lint |
-| PM5D factor diagnostics | `.github/workflows/factor-review-v2.yml` | Snapshot-backed factor review on `ploy-ci-1` |
-| PM5D walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Snapshot-backed rolling factor validation |
-| Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
-| Tick-preserving optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit live-parquet debug path |
-| PM5D backtest | `.github/workflows/backtest.yml` | Build and run `run_backtest` on `ploy-ci-1` against remote DB or synced Parquet |
-| Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest artifact evidence against a dry-run JSON report |
-| Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports |
-| Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
-| Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |
-| ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` GitHub environment |
-| Tango deploy | `.github/workflows/deploy-tango-1-1.yml` | Ship CI-built artifacts to `tango-1-1` and verify host health |
-| Trade deploy | `.github/workflows/deploy-trade.yml` | Deploy runner/configs to `ploy-trade-1` |
-| Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
+| Platform CI | Prove code, contracts, dependencies, workflow syntax, frontend, and integration lanes are healthy | Mergeable PR |
+| Research CI | Turn a hypothesis into auditable evidence without mutating runtime state | Evidence artifact, issue comment, decision labels |
+| Runtime CD | Deploy only reviewed `main` artifacts to protected environments | Remote health and config verification |
+| Promotion Gate | Reconcile replay expectations with dry-run behavior before scaling risk | `promote`, `collect-more`, `revise`, `fix-*`, or `reject` |
 
-## Research Lifecycle
-
-1. Create a parent strategy issue for a strategy direction, for example
-   `PM5D three-layer factor expansion`.
-2. Create child research issues for individual factors, filters, execution
-   assumptions, data-source checks, or accounting questions.
-3. Run the smallest workflow that can falsify the child issue's hypothesis:
-   `research-snapshot.yml` for reusable evidence, `factor-review-v2.yml` or
-   `factor-walk-forward-v2.yml` for diagnostics, `optimize.yml` for parameter
-   search, and `backtest.yml` for executable replay/backtest checks.
-4. Attach evidence back to the issue: workflow URL, git ref, input window,
-   symbols, config, artifact name, headline metrics, caveats, and decision.
-5. Close rejected ideas with the failure reason. Keep promising ideas open until
-   they are linked to an implementation issue or PR.
-6. Promote only after the research issue has a concrete decision:
-   `continue`, `revise`, `reject`, or `promote to runtime`.
-7. Create a separate implementation issue/PR for runtime changes. Do not mix
-   exploratory research conclusions and deployable runtime edits in one issue.
-8. Deploy only after PR validation passes and the deployment workflow is run
-   from `main`.
-
-## Idea Validation Loop
-
-For a new strategy idea, the default loop is:
+## Generic Control Loop
 
 ```text
-Idea
-  -> define hypothesis and expected edge
-  -> create or update a GitHub research issue
-  -> design the replay/backtest experiment
-  -> run remote workflow on ploy-ci-1/Tango/ACK data
-  -> inspect accounting, labels, fills, quote age, and rejected opportunities
-  -> implement the smallest runtime change needed for dry-run
-  -> deploy dry-run from main through GitHub Actions
-  -> compare replay vs dry-run on the same market/event/time window
-  -> decide: revise idea, fix data/runtime mismatch, keep collecting, or promote
+Idea / hypothesis
+  -> create a research issue
+  -> declare strategy_family, profile, data window, assumptions, and success criteria
+  -> run the smallest research workflow that can falsify the hypothesis
+  -> attach artifact-backed evidence and labels to the issue
+  -> if evidence supports runtime work, create an implementation issue / PR
+  -> PR validation through Platform CI
+  -> merge to protected main
+  -> deploy dry-run from main through protected Runtime CD
+  -> verify remote service, config, persistence, and data freshness
+  -> compare replay/backtest evidence with dry-run evidence
+  -> decide: promote, collect-more, revise, fix-data, fix-runtime, fix-workflow, or reject
 ```
 
 The loop is not complete after a profitable backtest. It is complete only when
-the dry-run behavior can be reconciled against replay expectations or the
-mismatch is understood and turned into the next issue.
+the dry-run behavior is reconciled against replay expectations, or when the
+mismatch is understood and tracked as a follow-up issue.
 
-Required loop gates:
+## Workflow Map
 
-- **Backtest design gate**: define the hypothesis, event window, data sources,
-  execution assumptions, entry/exit rules, stake model, and expected metrics
-  before running the workflow.
-- **Replay evidence gate**: record the workflow run, git ref, config, dataset
-  window, selected events, predicted entries, fills, PnL, quote age, and known
-  data gaps.
-- **Dry-run gate**: deploy only from `main`, keep risk limits explicit, and
-  verify the remote service/config after the workflow completes.
-- **Parity gate**: compare replay and dry-run on event id, decision timestamp,
-  observed quote, signal inputs, intended side, entry price, fill/not-fill,
-  settlement, and PnL.
-- **Decision gate**: close the loop with one of `revise`, `fix-data`,
-  `fix-runtime`, `collect-more`, `reject`, or `promote`.
+| Purpose | Workflow | Default role |
+| --- | --- | --- |
+| PR validation | `.github/workflows/test.yml` | Required Platform CI gate for code, contracts, frontend, integration, dependency audit, and workflow lint |
+| Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
+| Factor diagnostics | `.github/workflows/factor-review-v2.yml` | Snapshot-backed factor review on `ploy-ci-1` |
+| Walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Rolling factor validation across train/test windows |
+| Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
+| Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
+| Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
+| Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports |
+| Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
+| Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |
+| ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` environment |
+| Tango deploy | `.github/workflows/deploy-tango-1-1.yml` | Ship CI-built artifacts to `tango-1-1` and verify host health |
+| Trade deploy | `.github/workflows/deploy-trade.yml` | Deploy runner/configs to `ploy-trade-1` through a protected environment |
+| Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
 
-Replay/dry-run mismatches are first-class findings. Do not hide them inside a
-single research report. Open or link a follow-up issue for the specific mismatch:
-data freshness, quote reconstruction, runtime config drift, fill model,
-settlement label, signal timing, or execution friction.
+## Research Issue Contract
 
-## Evidence Contract
+Every research issue must describe one testable claim. Use child issues when a
+strategy direction splits into independent factors, filters, data checks, or
+execution assumptions.
 
-Every research issue should end with an evidence block:
+Required fields:
+
+- `strategy_family`: broad family such as binary-options, sports, copy-trading,
+  market-making, or event-ML.
+- `strategy_profile`: concrete profile/config under test, or `new` if it does
+  not exist yet.
+- `hypothesis`: the single claim this issue should prove or falsify.
+- `expected edge mechanism`: why the idea should survive spread, fees, stale
+  quotes, queue position, settlement, and execution friction.
+- `required data`: tables, symbols, windows, labels, settlement fields, and
+  freshness checks.
+- `workflow plan`: the workflow and exact inputs to run.
+- `success and failure criteria`: thresholds for continue, revise, reject, or
+  promote.
+- `accounting contract`: whether the workflow is exploratory diagnostics or
+  executable strategy accounting.
+- `parity plan`: how replay/backtest behavior will be compared against dry-run
+  behavior.
+
+Evidence block:
 
 ```text
 Evidence:
 - Workflow:
 - Run URL:
 - Git ref:
+- Strategy family/profile:
 - Dataset/window:
-- Symbols:
+- Symbols/markets:
 - Config:
 - Artifact:
 - Headline metrics:
+- Replay/dry-run parity:
 - Caveats:
 - Decision:
 ```
 
 Backtest evidence must explicitly state whether it is exploratory diagnostics or
-executable strategy accounting. For PM5D, one event should not be counted as
-multiple deployable trades just because multiple entry-time rows were observed.
+executable strategy accounting. Event-scoped strategies must not count multiple
+diagnostic rows as multiple deployable trades unless the runtime can execute the
+same entries under the same risk rules.
 
-## CI/CD Architecture
+## Decision Labels
 
-The intended control loop is:
+Research workflows write evidence comments and apply labels so the issue queue
+can be filtered without reading every artifact.
 
-```text
-GitHub issue
-  -> workflow_dispatch with explicit git_ref and inputs
-  -> GitHub Actions run on ubuntu-latest, ploy-ci-1, tango-1-1, or ACK
-  -> structured artifact plus step summary
-  -> issue evidence comment and decision label
-  -> implementation issue / PR when promoted
-  -> PR validation
-  -> main merge
-  -> deploy workflow from main
-  -> remote service/config/health verification
-```
+Evidence labels:
 
-Keep the control planes separate:
+- `evidence:factor-review`
+- `evidence:walk-forward`
+- `evidence:optimize`
+- `evidence:backtest`
+- `evidence:parity`
+- `evidence:missing-artifact`
+- `evidence:missing-metrics`
+
+Decision labels:
+
+- `decision:pending`
+- `decision:continue`
+- `decision:collect-more`
+- `decision:promote`
+- `decision:reject`
+- `decision:revise`
+- `decision:fix-data`
+- `decision:fix-runtime`
+- `decision:fix-workflow`
+
+Parity labels:
+
+- `parity:blocked`
+- `parity:ready`
+
+## Promotion Rules
+
+Do not promote a strategy from research directly to live. Promotion is staged:
+
+1. `decision:promote` on the research issue means it can become an
+   implementation issue or PR.
+2. Runtime code/config changes must pass Platform CI and merge to `main`.
+3. Dry-run deployment must be triggered from `main` through a protected
+   environment.
+4. Remote verification must prove service health, expected config, persistence,
+   data freshness, and no on-host Rust build.
+5. Replay/dry-run parity must either report `strict_parity_ready=true` or create
+   a follow-up issue explaining the mismatch.
+6. Live promotion requires a separate approval with explicit stake, loss, and
+   rollback limits.
+
+## Current Strategy Profiles
+
+Current workflows still include profile defaults for the active binary-options
+line. Treat these as defaults, not architecture:
+
+| Family | Profile/config examples | Notes |
+| --- | --- | --- |
+| binary-options | `02-pm5d-threelayer.*.toml`, `pm5d.threelayer.*.dryrun` | Current most exercised strategy family |
+| event-ML | event-root rolling evidence workflows | Research/data pipeline, not a live strategy by itself |
+
+When adding a new family, update configs and workflow inputs so the family can
+reuse the same evidence, PR, deploy, and parity loop. Do not fork a separate
+CI/CD architecture unless the data plane or runtime target is genuinely
+different.
+
+## Control-Plane Rules
 
 - Research workflows can run on feature branches when they do not mutate
   deployment state.
 - Keep `workflow_dispatch` inputs at or below GitHub's 10-input limit. Put
-  advanced or rarely changed knobs into an `options_json` input, validate keys
-  in the workflow, and fail on unknown options so typoed experiments do not run
-  with silent defaults.
+  advanced or rarely changed knobs into `options_json`, validate keys in the
+  workflow, and fail on unknown options.
 - Deployment workflows that affect `tango-1-1`, `ploy-trade-1`, ACK, or
   production state must run from `main`.
 - Host deployment workflows must be dispatched from `main` with `git_ref=main`
-  before mutating remote state. Tango and trade SSH deploys require pinned
-  `known_hosts` secrets (`TANGO_1_1_KNOWN_HOSTS` and
-  `PLOY_TRADE_1_KNOWN_HOSTS`), not opportunistic host-key acceptance. The
-  entries should be keyed by the workflow aliases `tango-1-1` and
-  `ploy-trade-1` because the deploy SSH config sets `HostKeyAlias`.
+  before mutating remote state.
+- Tango and trade SSH deploys require pinned `known_hosts` secrets
+  (`TANGO_1_1_KNOWN_HOSTS` and `PLOY_TRADE_1_KNOWN_HOSTS`). Entries should be
+  keyed by the workflow aliases `tango-1-1` and `ploy-trade-1` because the deploy
+  SSH config sets `HostKeyAlias`.
 - Remote data and heavy research belong on `ploy-ci-1`, `tango-1-1`, ACK, or
   CI-built artifacts, not local PostgreSQL assumptions.
 - `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub Actions
@@ -147,21 +191,16 @@ Keep the control planes separate:
   endpoint with Aliyun CLI before changing those secrets.
 - ACK/ACR image workflows must use immutable checked-out commit SHA tags only.
   Do not push or deploy `latest`. ACK deployments must also pass through the
-  GitHub `ack` environment, which requires reviewer approval and disables admin
-  bypass before mutating the cluster.
-- Runtime deployment evidence must include remote host verification, not only
-  a successful workflow conclusion.
-- Replay/dry-run parity is promotion evidence only when the parity artifact says
-  `strict_parity_ready=true`. Missing strict fields are a follow-up issue, not a
-  pass.
+  protected `ack` environment before mutating the cluster.
+- Runtime deployment evidence must include remote host verification, not only a
+  successful workflow conclusion.
 
-## Recommended Improvements
+## Remaining Improvements
 
-1. Make the dry-run report expose stricter event-level parity fields when the
-   operator API contract is ready.
-2. Configure repository settings so `main`, `tango-1-1`, `ploy-trade-1`,
-   `production`, and `ploy-ci-1` enforce the same branch/environment policy that
-   the workflow files expect.
-3. Keep ACK workflows marked as cluster/deployment workflows, separate from the
-   current Tango-first PM5D research loop unless ACK becomes the canonical
-   research runner.
+1. Make dry-run reports and replay artifacts expose the same strict event-level
+   fields so parity can become a full proof instead of a readiness gate.
+2. Move family/profile selection into first-class workflow inputs where the
+   implementation currently relies on profile-specific defaults.
+3. Add automated metric parsers for factor, walk-forward, and optimize evidence
+   so workflows can label `decision:collect-more`, `decision:reject`, or
+   `decision:promote` without manual review.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# Strategy-Agnostic CI/CD Framing (2026-04-30)
+
+## Files
+
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: generic research/runtime CI/CD architecture and promotion gates.
+- `.github/ISSUE_TEMPLATE/strategy_research.yml`
+  - Owner: strategy-family/profile issue fields and generic hypothesis template.
+- `.github/ISSUE_TEMPLATE/strategy_implementation.yml`
+  - Owner: promoted runtime implementation template.
+- `.github/workflows/backtest.yml`
+  - Owner: generic backtest workflow naming.
+- `.github/workflows/optimize.yml`
+  - Owner: generic optimizer workflow naming.
+- `tests/workflow_security.rs`
+  - Owner: regression guard that generic CI/CD docs/templates stay strategy-agnostic.
+- `tasks/todo.md`
+  - Owner: plan and verification notes.
+
+## Tasks
+
+- [x] Reframe CI/CD as Platform CI, Research CI, Runtime CD, and Promotion Gate.
+- [x] Move PM5D from the main flow into a current-profile example section.
+- [x] Add strategy family/profile fields to research and implementation issue templates.
+- [x] Rename backtest/optimize workflow display names to be strategy-agnostic.
+- [x] Add workflow security regression checks for the generic framing.
+- [x] Run focused verification and push a PR.
+
+## Review
+
+- 2026-04-30: Rewrote the strategy CI/CD runbook around four generic layers:
+  Platform CI, Research CI, Runtime CD, and Promotion Gate. PM5D is now listed
+  only as a current binary-options profile, not as the architecture.
+- 2026-04-30: Added `strategy_family` and `strategy_profile` fields to research
+  and implementation issue templates, and removed PM5D-specific placeholders
+  from the generic issue forms.
+- 2026-04-30: Renamed the backtest and optimize workflow display names to
+  generic strategy terms while preserving their current default configs.
+- 2026-04-30: Verification passed: `rustfmt --edition 2024
+  tests/workflow_security.rs`, `git diff --check`, `/opt/homebrew/bin/timeout
+  180 rtk cargo test --test workflow_security`, and YAML parsing for the touched
+  issue templates/workflows. Local `actionlint` was unavailable; GitHub workflow
+  lint remains the source of truth after push.
+
 # Research Issue Label Automation (2026-04-30)
 
 ## Files

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -215,9 +215,18 @@ fn research_issue_workflows_apply_decision_labels() {
 
     for (workflow, evidence_label) in [
         (".github/workflows/backtest.yml", "evidence:backtest"),
-        (".github/workflows/replay-dryrun-parity.yml", "evidence:parity"),
-        (".github/workflows/factor-review-v2.yml", "evidence:factor-review"),
-        (".github/workflows/factor-walk-forward-v2.yml", "evidence:walk-forward"),
+        (
+            ".github/workflows/replay-dryrun-parity.yml",
+            "evidence:parity",
+        ),
+        (
+            ".github/workflows/factor-review-v2.yml",
+            "evidence:factor-review",
+        ),
+        (
+            ".github/workflows/factor-walk-forward-v2.yml",
+            "evidence:walk-forward",
+        ),
         (".github/workflows/optimize.yml", "evidence:optimize"),
     ] {
         let content = workflow_contents(workflow);
@@ -225,13 +234,84 @@ fn research_issue_workflows_apply_decision_labels() {
             offenders.push(format!("{workflow}: missing shared research label helper"));
         }
         if !content.contains(evidence_label) {
-            offenders.push(format!("{workflow}: missing evidence label `{evidence_label}`"));
+            offenders.push(format!(
+                "{workflow}: missing evidence label `{evidence_label}`"
+            ));
         }
     }
 
     assert!(
         offenders.is_empty(),
         "research issue label guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn strategy_research_runbook_stays_strategy_agnostic() {
+    let runbook = workflow_contents("docs/runbooks/strategy-research-cicd.md");
+    let research_template = workflow_contents(".github/ISSUE_TEMPLATE/strategy_research.yml");
+    let implementation_template =
+        workflow_contents(".github/ISSUE_TEMPLATE/strategy_implementation.yml");
+    let backtest = workflow_contents(".github/workflows/backtest.yml");
+    let optimize = workflow_contents(".github/workflows/optimize.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "Strategy-Agnostic Research and Runtime CI/CD Runbook",
+        "Four-Layer Model",
+        "Platform CI",
+        "Research CI",
+        "Runtime CD",
+        "Promotion Gate",
+        "PM5D is one current strategy profile, not the center of the CI/CD model",
+        "strategy_family",
+        "strategy_profile",
+    ] {
+        if !runbook.contains(needle) {
+            offenders.push(format!("strategy-research-cicd.md: missing `{needle}`"));
+        }
+    }
+
+    for forbidden in [
+        "PM5D factor diagnostics",
+        "PM5D walk-forward diagnostics",
+        "PM5D backtest",
+        "For PM5D, one event",
+    ] {
+        if runbook.contains(forbidden) {
+            offenders.push(format!(
+                "strategy-research-cicd.md: workflow contract is still PM5D-centered via `{forbidden}`"
+            ));
+        }
+    }
+
+    if research_template.contains("PM5D") {
+        offenders
+            .push("strategy_research.yml: placeholders should be strategy-agnostic".to_string());
+    }
+    if !research_template.contains("id: strategy_family")
+        || !research_template.contains("id: strategy_profile")
+    {
+        offenders.push("strategy_research.yml: missing strategy family/profile fields".to_string());
+    }
+    if !implementation_template.contains("id: strategy_family")
+        || !implementation_template.contains("id: strategy_profile")
+    {
+        offenders.push(
+            "strategy_implementation.yml: missing strategy family/profile fields".to_string(),
+        );
+    }
+    if !backtest.contains("name: Strategy Backtest") || backtest.contains("## PM5D Backtest") {
+        offenders.push("backtest.yml: workflow naming should be strategy-agnostic".to_string());
+    }
+    if !optimize.contains("name: Optimize strategy params") {
+        offenders.push("optimize.yml: workflow naming should be strategy-agnostic".to_string());
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "strategy-agnostic CI/CD guard failed:\n{}",
         offenders.join("\n")
     );
 }
@@ -353,7 +433,9 @@ fn host_deploy_workflows_require_main_provenance_and_pinned_ssh() {
             || !content.contains("must use git_ref=main")
             || !content.contains("does not match origin/main")
         {
-            offenders.push(format!("{name}: deployment is not hard-gated to main provenance"));
+            offenders.push(format!(
+                "{name}: deployment is not hard-gated to main provenance"
+            ));
         }
         if content.contains("StrictHostKeyChecking no")
             || content.contains("UserKnownHostsFile /dev/null")
@@ -364,12 +446,15 @@ fn host_deploy_workflows_require_main_provenance_and_pinned_ssh() {
             || !content.contains("UserKnownHostsFile ~/.ssh/known_hosts")
             || !content.contains(known_hosts_secret)
         {
-            offenders.push(format!("{name}: missing pinned known_hosts SSH verification"));
+            offenders.push(format!(
+                "{name}: missing pinned known_hosts SSH verification"
+            ));
         }
     }
 
     if !trade.contains("default: false") {
-        offenders.push("deploy-trade.yml: live trade deploy should default deploy=false".to_string());
+        offenders
+            .push("deploy-trade.yml: live trade deploy should default deploy=false".to_string());
     }
 
     assert!(


### PR DESCRIPTION
## Summary
- Reframe the strategy research CI/CD runbook around Platform CI, Research CI, Runtime CD, and Promotion Gate instead of PM5D-specific flow language.
- Add strategy family/profile fields to research and implementation issue templates.
- Rename backtest/optimize workflow display names to generic strategy terms while preserving current defaults.
- Add workflow_security coverage so the generic CI/CD framing does not regress back to PM5D-centered docs/templates.

## Verification
- rustfmt --edition 2024 tests/workflow_security.rs
- git diff --check
- /opt/homebrew/bin/timeout 180 rtk cargo test --test workflow_security
- ruby YAML parse for touched issue templates/workflows

## Notes
- Existing workflows still carry current PM5D defaults where those values actually drive execution. This PR changes the architecture framing and issue inputs without adding unused dispatch inputs.