### PR TITLE
Reuse embedded research snapshots in CI workflows

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -283,12 +283,30 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
-          python3 scripts/download_github_artifact.py \
+          if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
             --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
             --output-dir artifacts/research-snapshot \
             --require manifest.json \
-            --require quality.md
+            --require quality.md; then
+            echo "Downloaded standalone research snapshot artifact."
+          else
+            echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
+            python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+            || python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md
+          fi
 
       - name: Compile research snapshot
         run: |

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -278,12 +278,30 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
-          python3 scripts/download_github_artifact.py \
+          if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
             --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
             --output-dir artifacts/research-snapshot \
             --require manifest.json \
-            --require quality.md
+            --require quality.md; then
+            echo "Downloaded standalone research snapshot artifact."
+          else
+            echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
+            python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+            || python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md
+          fi
 
       - name: Compile research snapshot
         run: |

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -162,12 +162,30 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
-          python3 scripts/download_github_artifact.py \
+          if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
             --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
             --output-dir artifacts/research-snapshot \
             --require manifest.json \
-            --require quality.md
+            --require quality.md; then
+            echo "Downloaded standalone research snapshot artifact."
+          else
+            echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
+            python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+            || python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md
+          fi
 
       - name: Sync Parquet data from Tango-1-1
         run: |

--- a/scripts/download_github_artifact.py
+++ b/scripts/download_github_artifact.py
@@ -73,11 +73,31 @@ def safe_extract(zip_path: Path, output_dir: Path) -> None:
         archive.extractall(output_dir)
 
 
+def copy_tree_contents(source_dir: Path, output_dir: Path) -> None:
+    if not source_dir.is_dir():
+        raise RuntimeError(f"strip prefix is not a directory in artifact: {source_dir}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for item in source_dir.iterdir():
+        target = output_dir / item.name
+        if item.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(item, target)
+        else:
+            shutil.copy2(item, target)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--run-id", required=True, help="Workflow run id that owns the artifact")
     parser.add_argument("--name", required=True, help="Artifact name to download")
     parser.add_argument("--output-dir", required=True, help="Directory to extract the artifact into")
+    parser.add_argument(
+        "--strip-prefix",
+        default="",
+        help="Optional artifact subdirectory whose contents should become the output root",
+    )
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
     parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
     parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"))
@@ -123,12 +143,18 @@ def main() -> int:
     output_dir = Path(args.output_dir)
     with tempfile.TemporaryDirectory(prefix="ploy-artifact-") as tmp:
         zip_path = Path(tmp) / "artifact.zip"
+        extract_dir = Path(tmp) / "extract"
         try:
             download_file(artifact["archive_download_url"], args.token, zip_path)
         except urllib.error.HTTPError as err:
             print(f"failed to download artifact: HTTP {err.code}: {err.read().decode('utf-8')}", file=sys.stderr)
             return 1
-        safe_extract(zip_path, output_dir)
+        if args.strip_prefix:
+            safe_extract(zip_path, extract_dir)
+            shutil.rmtree(output_dir, ignore_errors=True)
+            copy_tree_contents(extract_dir / args.strip_prefix, output_dir)
+        else:
+            safe_extract(zip_path, output_dir)
 
     missing = [path for path in args.require if not (output_dir / path).exists()]
     if missing:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,44 @@
+# Research Snapshot Reuse Workflow Fix (2026-05-01)
+
+Issue: https://github.com/proerror77/ploy/issues/256
+
+## Files
+
+- `scripts/download_github_artifact.py`
+  - Owner: cross-workflow artifact download and embedded snapshot extraction.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: walk-forward snapshot reuse before expensive fresh compile.
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: factor-review snapshot reuse before expensive fresh compile.
+- `.github/workflows/optimize.yml`
+  - Owner: optimizer snapshot reuse before direct/live data fallback.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Diagnose why `snapshot_run_id=25194611895` failed to reuse the completed walk-forward snapshot.
+- [x] Add artifact extraction support for embedded `research-snapshot/` directories.
+- [x] Add workflow fallback from standalone `research-snapshot-*` to embedded downstream artifacts.
+- [x] Run local script/workflow text verification.
+- [ ] Push PR and verify a snapshot-reuse walk-forward run against `25194611895`.
+
+## Review
+
+- 2026-05-01: Root cause was artifact naming, not strategy runtime. The completed
+  walk-forward run uploaded `factor-walk-forward-v2-25194611895`, with
+  `research-snapshot/` embedded inside it, while downstream jobs only searched
+  for a standalone `research-snapshot-25194611895` artifact. That forced fresh
+  DB snapshot compiles for small follow-up studies.
+- 2026-05-01: Added `--strip-prefix` to the artifact downloader so embedded
+  snapshot directories can become the target snapshot root. Updated
+  factor-review, walk-forward, and optimize workflows to try standalone
+  snapshots first, then embedded factor-review/walk-forward artifacts.
+- 2026-05-01: Local verification passed: `python3 -m py_compile
+  scripts/download_github_artifact.py`, a local zip smoke test for
+  `research-snapshot/` extraction, `rg` checks for fallback artifact names, and
+  `git diff --check`.
+
 # PM5D Binance Direction EV Audit (2026-05-01)
 
 Issue: https://github.com/proerror77/ploy/issues/256


### PR DESCRIPTION
## Summary\n- let the artifact downloader strip embedded directory prefixes such as research-snapshot/\n- let factor review, walk-forward, and optimize reuse embedded snapshot artifacts from prior research runs\n- document the workflow-speed root cause and verification in tasks/todo.md\n\n## Verification\n- python3 -m py_compile scripts/download_github_artifact.py\n- local zip strip-prefix smoke test\n- ruby YAML parse for factor-review-v2, factor-walk-forward-v2, optimize\n- git diff --check\n\n## Follow-up remote proof\nAfter this PR branch is available, run factor-walk-forward-v2 with snapshot_run_id=25194611895 and compile_snapshot=true. Expected behavior: Download research snapshot succeeds via factor-walk-forward-v2-25194611895 fallback, Compile research snapshot skips, and the workflow goes directly to Run factor walk-forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact download resilience with automatic fallback to alternative sources when primary artifacts are unavailable.

* **New Features**
  * Enhanced snapshot artifact resolution to support extracting embedded snapshots from alternative artifact sources.
  * Added diagnostic logging to indicate which artifact source path was successfully used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->