### PR TITLE
Reduce PM5D research workflow overhead

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -259,22 +259,6 @@ jobs:
               raise SystemExit(f"scoped data audit gate failed: {status}")
           PY
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: factor-review-v2-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
-
-      - name: Build factor review and snapshot compiler
-        run: |
-          . /home/runner/.cargo/env
-          cargo build --release --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_review_v2 \
-            --example research_snapshot_compile
-
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
         env:
@@ -307,6 +291,29 @@ jobs:
               --require manifest.json \
               --require quality.md
           fi
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: factor-review-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build factor review
+        run: |
+          set -euo pipefail
+          . /home/runner/.cargo/env
+          build_args=(
+            --release
+            --locked
+            -p ploy-research
+            --features db
+            --example factor_review_v2
+          )
+          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
+            build_args+=(--example research_snapshot_compile)
+          fi
+          cargo build "${build_args[@]}"
 
       - name: Compile research snapshot
         run: |
@@ -422,14 +429,40 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Stage report artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/factor-review-v2-upload
+          mkdir -p artifacts/factor-review-v2-upload
+          if [ -d artifacts/factor-review-v2 ]; then
+            cp -R artifacts/factor-review-v2 artifacts/factor-review-v2-upload/
+          fi
+          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
+            if [ -d artifacts/research-snapshot ]; then
+              cp -R artifacts/research-snapshot artifacts/factor-review-v2-upload/
+            fi
+          else
+            mkdir -p artifacts/factor-review-v2-upload/snapshot-provenance
+            {
+              echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
+              echo "full_snapshot_embedded=false"
+            } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
+            for file in manifest.json quality.md data-gap-audit.md; do
+              if [ -f "artifacts/research-snapshot/${file}" ]; then
+                cp "artifacts/research-snapshot/${file}" \
+                  "artifacts/factor-review-v2-upload/snapshot-provenance/${file}"
+              fi
+            done
+          fi
+
       - name: Upload report artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: factor-review-v2-${{ github.run_id }}
-          path: |
-            artifacts/factor-review-v2/
-            artifacts/research-snapshot/
+          path: artifacts/factor-review-v2-upload/
+          compression-level: 0
           retention-days: 14
 
       - name: Comment factor evidence on issue

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -254,22 +254,6 @@ jobs:
               raise SystemExit(f"scoped data audit gate failed: {status}")
           PY
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: factor-walk-forward-v2-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
-
-      - name: Build factor walk-forward and snapshot compiler
-        run: |
-          . /home/runner/.cargo/env
-          cargo build --release --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_walk_forward_v2 \
-            --example research_snapshot_compile
-
       - name: Download research snapshot
         if: ${{ github.event.inputs.snapshot_run_id != '' }}
         env:
@@ -302,6 +286,29 @@ jobs:
               --require manifest.json \
               --require quality.md
           fi
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: factor-walk-forward-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build factor walk-forward
+        run: |
+          set -euo pipefail
+          . /home/runner/.cargo/env
+          build_args=(
+            --release
+            --locked
+            -p ploy-research
+            --features db
+            --example factor_walk_forward_v2
+          )
+          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
+            build_args+=(--example research_snapshot_compile)
+          fi
+          cargo build "${build_args[@]}"
 
       - name: Compile research snapshot
         run: |
@@ -400,14 +407,40 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Stage report artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/factor-walk-forward-v2-upload
+          mkdir -p artifacts/factor-walk-forward-v2-upload
+          if [ -d artifacts/factor-walk-forward-v2 ]; then
+            cp -R artifacts/factor-walk-forward-v2 artifacts/factor-walk-forward-v2-upload/
+          fi
+          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
+            if [ -d artifacts/research-snapshot ]; then
+              cp -R artifacts/research-snapshot artifacts/factor-walk-forward-v2-upload/
+            fi
+          else
+            mkdir -p artifacts/factor-walk-forward-v2-upload/snapshot-provenance
+            {
+              echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
+              echo "full_snapshot_embedded=false"
+            } > artifacts/factor-walk-forward-v2-upload/snapshot-provenance/source.txt
+            for file in manifest.json quality.md data-gap-audit.md; do
+              if [ -f "artifacts/research-snapshot/${file}" ]; then
+                cp "artifacts/research-snapshot/${file}" \
+                  "artifacts/factor-walk-forward-v2-upload/snapshot-provenance/${file}"
+              fi
+            done
+          fi
+
       - name: Upload report artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: factor-walk-forward-v2-${{ github.run_id }}
-          path: |
-            artifacts/factor-walk-forward-v2/
-            artifacts/research-snapshot/
+          path: artifacts/factor-walk-forward-v2-upload/
+          compression-level: 0
           retention-days: 14
 
       - name: Comment walk-forward evidence on issue

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -225,14 +225,14 @@ jobs:
         with:
           cache-on-failure: true
           cache-targets: "true"
-          key: research-snapshot-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+          key: research-snapshot-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
       - name: Build research_snapshot_compile
         run: |
           . /home/runner/.cargo/env
           cargo build --release --locked \
             -p ploy-research \
-            --features db,polars-export \
+            --features db \
             --example research_snapshot_compile
 
       - name: Compile snapshot
@@ -295,4 +295,5 @@ jobs:
         with:
           name: research-snapshot-${{ github.run_id }}
           path: artifacts/research-snapshot/
+          compression-level: 0
           retention-days: 14

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11158,3 +11158,44 @@ Review:
 - 2026-04-30: The root cause is predicate shape, not a missing index. `LOWER(market_family)` and `COALESCE(end_time/start_time, NOW())` prevent the planner from using existing btree indexes. Rewriting to `market_family = 'crypto'` plus explicit null-aware time predicates produced a `Bitmap Heap Scan` using `idx_pm_market_catalog_family_end_time` and executed in `~0.08-0.18ms` on the live DB.
 - 2026-04-30: Local verification passed: `rtk cargo test -p ploy-market-data active_markets_query_keeps_catalog_filters_indexable --lib`, `rtk cargo test -p ploy-market-data trade_collector_config_fills_safe_defaults --lib`, `rtk cargo check -p ploy-market-data`, and `git diff --check`. Full rustfmt check was not used because current crate import ordering outside this slice would create unrelated formatting churn.
 - 2026-04-30: PR #250 merged and deployed artifact `0eb6efa7`, but deploy run `25138661077` failed at the dry-run report postflight because the report had zero `strategies` rows immediately after restart while top-level diagnostics were valid. The deployed collector and `ployd` services remained active with `NRestarts=0`. The postflight checker should require top-level contract fields and validate per-strategy diagnostics only when strategy diagnostics are present.
+
+# PM5D Research Workflow Speed Pass (2026-05-01)
+
+## Files
+
+- `.github/workflows/research-snapshot.yml`
+  - Owner: fresh snapshot build/upload cost.
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: snapshot-backed factor review build/upload cost.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: snapshot-backed walk-forward build/upload cost.
+- `tasks/todo.md`
+  - Owner: speed-pass plan and review evidence.
+
+## Tasks
+
+- [x] Remove unnecessary `polars-export` builds from PM5D research workflow binaries that only require `db`.
+- [x] Build only the factor binary on snapshot-reuse runs instead of also building `research_snapshot_compile`.
+- [x] Stop re-uploading full research snapshots from downstream runs that consumed an existing snapshot.
+- [x] Use no-compression artifact uploads for large already-compressed snapshot/report artifacts.
+- [x] Verify workflow syntax and focused local build boundaries.
+- [ ] Run a main-equivalent speed test after PR checks.
+
+## Review
+
+- 2026-05-01: Snapshot-reuse factor review / walk-forward runs now download
+  the snapshot before Rust build, compile only the relevant factor binary, and
+  omit `research_snapshot_compile` when `snapshot_run_id` is provided. The
+  workflows also use `--features db` instead of `db,polars-export`, matching the
+  example feature requirements in `crates/ploy-research/Cargo.toml`.
+- 2026-05-01: Downstream factor review / walk-forward artifacts no longer
+  re-upload the full `research-snapshot/` tree when they consumed an existing
+  snapshot. They upload result artifacts plus `snapshot-provenance/` instead, so
+  the run remains auditable without paying the 100MB+ snapshot upload cost or
+  accidentally advertising itself as a reusable snapshot source.
+- 2026-05-01: Local verification passed with workflow YAML parsing,
+  `git diff --check`, `scripts/check_optimize_verification_gates.sh`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-research-workflow-speed-check rtk cargo check -p
+  ploy-research --features db --example factor_review_v2 --example
+  factor_walk_forward_v2 --example research_snapshot_compile
+  --no-default-features`.


### PR DESCRIPTION
## Summary

- build PM5D factor review / walk-forward / snapshot compiler with only the required `db` feature instead of `db,polars-export`
- skip building `research_snapshot_compile` on downstream snapshot-reuse factor runs
- stop re-uploading full consumed snapshots from downstream factor runs; upload result artifacts plus snapshot provenance instead
- use no-compression artifact uploads for large snapshot/report artifacts

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/research-snapshot.yml .github/workflows/factor-review-v2.yml .github/workflows/factor-walk-forward-v2.yml .github/workflows/optimize.yml`\n- `git diff --check`\n- `scripts/check_optimize_verification_gates.sh`\n- `CARGO_TARGET_DIR=/tmp/ploy-research-workflow-speed-check rtk cargo check -p ploy-research --features db --example factor_review_v2 --example factor_walk_forward_v2 --example research_snapshot_compile --no-default-features`\n\n## Speed expectation\n\nFor snapshot-reuse walk-forward/review runs, this should reduce Rust build work and avoid the previous 100MB+ full snapshot re-upload. The core replay timing should stay unchanged; the gain is workflow overhead.