### PR TITLE
Skip cargo cache saves on snapshot reuse

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -297,6 +297,7 @@ jobs:
         with:
           cache-on-failure: true
           cache-targets: "true"
+          save-if: ${{ github.event.inputs.snapshot_run_id == '' }}
           key: factor-review-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
       - name: Build factor review

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -292,6 +292,7 @@ jobs:
         with:
           cache-on-failure: true
           cache-targets: "true"
+          save-if: ${{ github.event.inputs.snapshot_run_id == '' }}
           key: factor-walk-forward-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
       - name: Build factor walk-forward

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11179,6 +11179,7 @@ Review:
 - [x] Stop re-uploading full research snapshots from downstream runs that consumed an existing snapshot.
 - [x] Use no-compression artifact uploads for large already-compressed snapshot/report artifacts.
 - [x] Verify workflow syntax and focused local build boundaries.
+- [x] Disable cargo cache saves on snapshot-reuse factor runs after first-speed-test evidence showed cache upload dominated runtime.
 - [ ] Run a main-equivalent speed test after PR checks.
 
 ## Review
@@ -11199,3 +11200,10 @@ Review:
   ploy-research --features db --example factor_review_v2 --example
   factor_walk_forward_v2 --example research_snapshot_compile
   --no-default-features`.
+- 2026-05-01: First main speed test after PR #266 was run
+  `25198044053`. Core path improved, but whole-workflow runtime regressed to
+  `7m03s` because the new db-only cache key had no hit and `Post Cache cargo
+  build` spent `4m53s` uploading a `339MB` target cache at very low throughput.
+  Snapshot-reuse factor workflows should restore cache/workspace state but not
+  save a cargo cache; fresh snapshot-producing runs remain responsible for
+  warming the cache.


### PR DESCRIPTION
## Summary

- disable `Swatinem/rust-cache` save on Factor Review / Walk-Forward runs that consume `snapshot_run_id`
- keep cache save enabled for fresh snapshot-producing runs, which can still warm the db-only cache
- record the first post-PR #266 speed-test evidence showing cache upload dominated runtime

## Evidence

Run https://github.com/proerror77/ploy/actions/runs/25198044053 completed the core path quickly but total runtime was 7m03s because `Post Cache cargo build` took 4m53s uploading a 339MB cache.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/factor-review-v2.yml .github/workflows/factor-walk-forward-v2.yml`\n- `git diff --check`\n- `scripts/check_optimize_verification_gates.sh`