### PR TITLE
Reduce snapshot-backed PM5D workflow overhead

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -81,6 +81,13 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Configure snapshot-reuse cargo target
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        run: |
+          scripts/configure_research_cargo_target.sh \
+            --profile pm5d-factor-research \
+            --features db
+
       - name: Parse advanced options
         env:
           OPTIONS_JSON: ${{ github.event.inputs.options_json }}
@@ -267,12 +274,17 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
+          cache_args=()
+          if [ -n "${RUNNER_WORKSPACE:-}" ]; then
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+          fi
           if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
             --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
             --output-dir artifacts/research-snapshot \
             --require manifest.json \
-            --require quality.md; then
+            --require quality.md \
+            "${cache_args[@]}"; then
             echo "Downloaded standalone research snapshot artifact."
           else
             echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
@@ -283,21 +295,23 @@ jobs:
               --output-dir artifacts/research-snapshot \
               --require manifest.json \
               --require quality.md \
+              "${cache_args[@]}" \
             || python3 scripts/download_github_artifact.py \
               --run-id "${SNAPSHOT_RUN_ID}" \
               --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
               --strip-prefix research-snapshot \
               --output-dir artifacts/research-snapshot \
               --require manifest.json \
-              --require quality.md
+              --require quality.md \
+              "${cache_args[@]}"
           fi
 
       - name: Cache cargo build
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
           cache-targets: "true"
-          save-if: ${{ github.event.inputs.snapshot_run_id == '' }}
           key: factor-review-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
       - name: Build factor review

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Configure snapshot-reuse cargo target
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        run: |
+          scripts/configure_research_cargo_target.sh \
+            --profile pm5d-factor-research \
+            --features db
+
       - name: Parse advanced options
         env:
           OPTIONS_JSON: ${{ github.event.inputs.options_json }}
@@ -262,12 +269,17 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
+          cache_args=()
+          if [ -n "${RUNNER_WORKSPACE:-}" ]; then
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+          fi
           if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
             --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
             --output-dir artifacts/research-snapshot \
             --require manifest.json \
-            --require quality.md; then
+            --require quality.md \
+            "${cache_args[@]}"; then
             echo "Downloaded standalone research snapshot artifact."
           else
             echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
@@ -278,21 +290,23 @@ jobs:
               --output-dir artifacts/research-snapshot \
               --require manifest.json \
               --require quality.md \
+              "${cache_args[@]}" \
             || python3 scripts/download_github_artifact.py \
               --run-id "${SNAPSHOT_RUN_ID}" \
               --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
               --strip-prefix research-snapshot \
               --output-dir artifacts/research-snapshot \
               --require manifest.json \
-              --require quality.md
+              --require quality.md \
+              "${cache_args[@]}"
           fi
 
       - name: Cache cargo build
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
           cache-targets: "true"
-          save-if: ${{ github.event.inputs.snapshot_run_id == '' }}
           key: factor-walk-forward-v2-db-only-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
 
       - name: Build factor walk-forward

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Add cargo to PATH
         run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
 
+      - name: Configure snapshot optimizer cargo target
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        run: |
+          scripts/configure_research_cargo_target.sh \
+            --profile pm5d-snapshot-optimize \
+            --features default
+
       - name: Parse advanced options
         env:
           OPTIONS_JSON: ${{ github.event.inputs.options_json }}
@@ -135,6 +142,46 @@ jobs:
                   handle.write(f"OPT_{key.upper()}={value}\n")
           PY
 
+      - name: Download research snapshot
+        if: ${{ github.event.inputs.snapshot_run_id != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot
+          cache_args=()
+          if [ -n "${RUNNER_WORKSPACE:-}" ]; then
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+          fi
+          if python3 scripts/download_github_artifact.py \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md \
+            "${cache_args[@]}"; then
+            echo "Downloaded standalone research snapshot artifact."
+          else
+            echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
+            python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+              "${cache_args[@]}" \
+            || python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+              "${cache_args[@]}"
+          fi
+
       - name: Build optimize runner
         run: |
           set -euo pipefail
@@ -154,39 +201,6 @@ jobs:
           fi
           chmod +x target/release/examples/optimize-runner
 
-      - name: Download research snapshot
-        if: ${{ github.event.inputs.snapshot_run_id != '' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
-        run: |
-          set -euo pipefail
-          rm -rf artifacts/research-snapshot
-          if python3 scripts/download_github_artifact.py \
-            --run-id "${SNAPSHOT_RUN_ID}" \
-            --name "research-snapshot-${SNAPSHOT_RUN_ID}" \
-            --output-dir artifacts/research-snapshot \
-            --require manifest.json \
-            --require quality.md; then
-            echo "Downloaded standalone research snapshot artifact."
-          else
-            echo "Standalone research snapshot artifact not found; trying embedded downstream artifacts."
-            python3 scripts/download_github_artifact.py \
-              --run-id "${SNAPSHOT_RUN_ID}" \
-              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
-              --strip-prefix research-snapshot \
-              --output-dir artifacts/research-snapshot \
-              --require manifest.json \
-              --require quality.md \
-            || python3 scripts/download_github_artifact.py \
-              --run-id "${SNAPSHOT_RUN_ID}" \
-              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
-              --strip-prefix research-snapshot \
-              --output-dir artifacts/research-snapshot \
-              --require manifest.json \
-              --require quality.md
-          fi
-
       - name: Sync Parquet data from Tango-1-1
         run: |
           set -euo pipefail
@@ -204,6 +218,7 @@ jobs:
             "${OPT_DATA_DIR}/"
 
       - name: Prepare DuckDB spill directory
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
         run: |
           DUCKDB_TEMP_DIR="${RUNNER_TEMP:-/tmp}/ploy-optimize-duckdb-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           rm -rf "${DUCKDB_TEMP_DIR}"
@@ -342,8 +357,10 @@ jobs:
           . /home/runner/.cargo/env
           mkdir -p artifacts/optimize
           started=$(date +%s)
-          rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
-          mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
+          if [ ! -f artifacts/research-snapshot/manifest.json ]; then
+            rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
+            mkdir -p "${PLOY_DUCKDB_TEMP_DIR}"
+          fi
 
           time_flags=()
           if [ -n "${OPT_TRAIN_START_TS}" ]; then
@@ -427,7 +444,11 @@ jobs:
             echo '```'
             date -u
             free -h || true
-            df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+            if [ -f artifacts/research-snapshot/manifest.json ]; then
+              df -h "${OPT_DATA_DIR}" || true
+            else
+              df -h "${OPT_DATA_DIR}" "${PLOY_DUCKDB_TEMP_DIR}" || true
+            fi
             ps -eo pid,ppid,stat,%mem,%cpu,comm,args --sort=-%mem | head -25 || true
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
@@ -441,7 +462,9 @@ jobs:
             fi
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
-          rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
+          if [ ! -f artifacts/research-snapshot/manifest.json ]; then
+            rm -rf "${PLOY_DUCKDB_TEMP_DIR}"
+          fi
           exit "${status}"
 
       - name: Upload optimize provenance

--- a/scripts/configure_research_cargo_target.sh
+++ b/scripts/configure_research_cargo_target.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: configure_research_cargo_target.sh --profile <name> [--features <name>]
+
+Configures a persistent Cargo target directory for self-hosted PM5D research
+workflows. The directory lives outside GITHUB_WORKSPACE so actions/checkout does
+not remove it between jobs.
+
+Set PLOY_RESEARCH_TARGET_KEEP_DAYS to control stale target cleanup. The default
+is 14 days; set it to 0 to disable cleanup.
+EOF
+}
+
+profile=""
+features="default"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="${2:-}"
+      shift 2
+      ;;
+    --features)
+      features="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${profile}" ]]; then
+  echo "--profile is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "${profile}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "--profile must contain only letters, numbers, dot, underscore, or dash" >&2
+  exit 2
+fi
+
+if [[ ! "${features}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "--features must contain only letters, numbers, dot, underscore, or dash" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+target_base="${PLOY_RESEARCH_TARGET_BASE:-}"
+if [[ -z "${target_base}" ]]; then
+  if [[ -n "${RUNNER_WORKSPACE:-}" ]]; then
+    target_base="${RUNNER_WORKSPACE}/_ploy-cargo-targets"
+  else
+    target_base="/tmp/ploy-research-cargo-targets"
+  fi
+fi
+
+hash_inputs=(
+  Cargo.lock
+  Cargo.toml
+  rust-toolchain.toml
+  crates/ploy-research/Cargo.toml
+  crates/ploy-feed-loaders/Cargo.toml
+)
+
+hash_material="$(mktemp)"
+trap 'rm -f "${hash_material}"' EXIT
+
+for path in "${hash_inputs[@]}"; do
+  if [[ -f "${path}" ]]; then
+    sha256sum "${path}" >> "${hash_material}"
+  fi
+done
+
+{
+  printf 'profile=%s\n' "${profile}"
+  printf 'features=%s\n' "${features}"
+  rustc -Vv 2>/dev/null || true
+} >> "${hash_material}"
+
+target_hash="$(sha256sum "${hash_material}" | awk '{print substr($1, 1, 16)}')"
+target_dir="${target_base}/${profile}-${features}-${target_hash}"
+mkdir -p "${target_dir}"
+
+keep_days="${PLOY_RESEARCH_TARGET_KEEP_DAYS:-14}"
+if [[ "${keep_days}" =~ ^[0-9]+$ ]] && [[ "${keep_days}" -gt 0 ]]; then
+  mkdir -p "${target_base}"
+  find "${target_base}" \
+    -mindepth 1 \
+    -maxdepth 1 \
+    -type d \
+    -name "${profile}-${features}-*" \
+    -mtime "+${keep_days}" \
+    ! -path "${target_dir}" \
+    -print \
+    -exec rm -rf {} + || true
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  printf 'CARGO_TARGET_DIR=%s\n' "${target_dir}" >> "${GITHUB_ENV}"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Research Cargo Target"
+    echo ""
+    echo "- Profile: \`${profile}\`"
+    echo "- Features: \`${features}\`"
+    echo "- Target dir: \`${target_dir}\`"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+echo "CARGO_TARGET_DIR=${target_dir}"

--- a/scripts/download_github_artifact.py
+++ b/scripts/download_github_artifact.py
@@ -9,11 +9,14 @@ depending on the action's Node download path on self-hosted runners.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 import zipfile
@@ -88,6 +91,53 @@ def copy_tree_contents(source_dir: Path, output_dir: Path) -> None:
             shutil.copy2(item, target)
 
 
+def required_missing(output_dir: Path, required_paths: list[str]) -> list[str]:
+    return [path for path in required_paths if not (output_dir / path).exists()]
+
+
+def safe_component(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return cleaned or "value"
+
+
+def cache_payload_dir(cache_root: Path, repo: str, run_id: str, artifact: dict[str, Any], strip_prefix: str) -> Path:
+    strip_hash = hashlib.sha256(strip_prefix.encode("utf-8")).hexdigest()[:12]
+    key = "--".join(
+        [
+            safe_component(repo.replace("/", "__")),
+            f"run-{safe_component(run_id)}",
+            f"artifact-{artifact['id']}",
+            safe_component(str(artifact["name"])),
+            f"strip-{strip_hash}",
+        ]
+    )
+    return cache_root / key / "payload"
+
+
+def prune_cache(cache_root: Path, ttl_days: int) -> None:
+    if ttl_days <= 0 or not cache_root.is_dir():
+        return
+    cutoff = time.time() - ttl_days * 24 * 60 * 60
+    for child in cache_root.iterdir():
+        try:
+            if child.is_dir() and child.stat().st_mtime < cutoff:
+                shutil.rmtree(child)
+        except OSError:
+            continue
+
+
+def copy_output_to_cache(output_dir: Path, payload_dir: Path, metadata: dict[str, Any]) -> None:
+    cache_entry = payload_dir.parent
+    tmp_entry = cache_entry.with_name(f"{cache_entry.name}.tmp-{os.getpid()}")
+    shutil.rmtree(tmp_entry, ignore_errors=True)
+    tmp_payload = tmp_entry / "payload"
+    tmp_payload.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(output_dir, tmp_payload)
+    (tmp_entry / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+    shutil.rmtree(cache_entry, ignore_errors=True)
+    tmp_entry.rename(cache_entry)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--run-id", required=True, help="Workflow run id that owns the artifact")
@@ -101,6 +151,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
     parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
     parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"))
+    parser.add_argument(
+        "--cache-dir",
+        default="",
+        help="Optional directory for runner-local extracted artifact cache",
+    )
+    parser.add_argument(
+        "--cache-ttl-days",
+        type=int,
+        default=14,
+        help="Delete cache entries older than this many days; set 0 to disable cleanup",
+    )
     parser.add_argument(
         "--require",
         action="append",
@@ -141,6 +202,21 @@ def main() -> int:
 
     artifact = sorted(artifacts, key=lambda item: item.get("created_at", ""))[-1]
     output_dir = Path(args.output_dir)
+    cache_dir = Path(args.cache_dir).expanduser() if args.cache_dir else None
+    payload_dir: Path | None = None
+    if cache_dir is not None:
+        prune_cache(cache_dir, args.cache_ttl_days)
+        payload_dir = cache_payload_dir(cache_dir, args.repo, args.run_id, artifact, args.strip_prefix)
+        if payload_dir.is_dir() and not required_missing(payload_dir, args.require):
+            shutil.rmtree(output_dir, ignore_errors=True)
+            copy_tree_contents(payload_dir, output_dir)
+            print(
+                "reused cached artifact "
+                f"name={artifact['name']} id={artifact['id']} size={artifact.get('size_in_bytes', 0)} "
+                f"from={payload_dir} to={output_dir}"
+            )
+            return 0
+
     with tempfile.TemporaryDirectory(prefix="ploy-artifact-") as tmp:
         zip_path = Path(tmp) / "artifact.zip"
         extract_dir = Path(tmp) / "extract"
@@ -156,10 +232,23 @@ def main() -> int:
         else:
             safe_extract(zip_path, output_dir)
 
-    missing = [path for path in args.require if not (output_dir / path).exists()]
+    missing = required_missing(output_dir, args.require)
     if missing:
         print(f"artifact extracted but required paths are missing: {', '.join(missing)}", file=sys.stderr)
         return 1
+
+    if payload_dir is not None:
+        metadata = {
+            "repo": args.repo,
+            "run_id": args.run_id,
+            "artifact_id": artifact["id"],
+            "artifact_name": artifact["name"],
+            "artifact_size": artifact.get("size_in_bytes", 0),
+            "strip_prefix": args.strip_prefix,
+            "created_at": artifact.get("created_at"),
+            "cached_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        copy_output_to_cache(output_dir, payload_dir, metadata)
 
     print(
         "downloaded artifact "

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11215,3 +11215,69 @@ Review:
   `26s`, staged slim artifact upload `2s`, and post-cache cleanup `1s`. This
   is materially faster than the previous optimized-main run `25197515190`
   (`4m50s`) and avoids the cache-save stall from `25198044053`.
+
+# PM5D Research Workflow All-In Speed Pass (2026-05-01)
+
+## Files
+
+- `scripts/configure_research_cargo_target.sh`
+  - Owner: persistent local Cargo target selection for self-hosted research jobs.
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: snapshot-reuse build/cache path.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: snapshot-reuse build/cache path.
+- `.github/workflows/optimize.yml`
+  - Owner: snapshot optimizer build/cache path.
+- `tasks/todo.md`
+  - Owner: plan and speed evidence.
+
+## Tasks
+
+- [x] Use Agent Team analysis lanes for cache, binary artifact, and snapshot fast-path opportunities.
+- [x] Add a persistent local `CARGO_TARGET_DIR` helper for PM5D research jobs on self-hosted runners.
+- [x] Skip GitHub cache restore entirely on snapshot-reuse factor review / walk-forward runs.
+- [x] Reuse the persistent local target for snapshot-backed optimizer builds.
+- [x] Add stale-target cleanup to the persistent target helper.
+- [x] Move snapshot download before snapshot optimizer build and skip DuckDB setup on snapshot-backed optimize.
+- [x] Add runner-local extracted snapshot cache to repeated artifact downloads.
+- [x] Verify scripts, workflow syntax, and affected Rust example build boundaries.
+- [ ] Land via PR and rerun main speed tests.
+
+## Review
+
+- 2026-05-01: Native Agent Team review split the remaining speed work into
+  cache/persistent-target, binary-artifact provenance, and snapshot-cache lanes.
+  The team rejected prebuilt research-runner artifacts for now because the repo
+  does not yet have a checksum/manifest/git-sha execution contract for binary
+  reuse. The safer path is persistent self-hosted `CARGO_TARGET_DIR` plus
+  runner-local extracted snapshot reuse.
+- 2026-05-01: Added `scripts/configure_research_cargo_target.sh` so
+  snapshot-backed PM5D research jobs use a stable target directory outside
+  `GITHUB_WORKSPACE`. The helper keys by lockfile, relevant crate manifests,
+  profile, feature set, and `rustc -Vv`, then prunes stale matching target dirs.
+- 2026-05-01: Factor Review V2 and Walk-Forward V2 now skip `Swatinem/rust-cache`
+  entirely when `snapshot_run_id` is set. This avoids both cache restore latency
+  and the earlier post-job cache-upload stall, while the self-hosted runner can
+  still reuse compiled artifacts through the persistent target directory.
+- 2026-05-01: `scripts/download_github_artifact.py` now supports `--cache-dir`
+  for runner-local extracted artifact reuse. The cache key includes repo, run id,
+  artifact id/name, and strip-prefix hash; cached payloads still must satisfy
+  required paths such as `manifest.json` and `quality.md`.
+- 2026-05-01: Snapshot-backed optimize now downloads the research snapshot before
+  building the optimizer, uses its own persistent target profile, and skips
+  DuckDB spill setup on snapshot-backed runs. The raw Parquet/debug path remains
+  gated behind the existing non-snapshot preflight and DuckDB guardrails.
+- 2026-05-01: Local verification passed: `python3 -m py_compile
+  scripts/download_github_artifact.py`, `bash -n
+  scripts/configure_research_cargo_target.sh`, YAML parse for
+  `factor-review-v2.yml`, `factor-walk-forward-v2.yml`, `optimize.yml`, and
+  `research-snapshot.yml`, `git diff --check`,
+  `scripts/check_optimize_verification_gates.sh`, `rtk cargo test --test
+  workflow_security research_workflows_do_not_transfer_runtime_binaries_between_jobs
+  -- --exact`, a cargo-target helper smoke, a downloader strip-prefix/cache
+  smoke, `CARGO_TARGET_DIR=/tmp/ploy-research-all-in-check rtk cargo check -p
+  ploy-research --features db --example factor_review_v2 --example
+  factor_walk_forward_v2 --example research_snapshot_compile
+  --no-default-features`, and `CARGO_TARGET_DIR=/tmp/ploy-research-all-in-check
+  rtk cargo check -p ploy-research --example three_layer_snapshot_optimize
+  --no-default-features`.


### PR DESCRIPTION
## Summary
- add a persistent self-hosted Cargo target helper for snapshot-backed PM5D research workflows
- skip GitHub rust-cache entirely on snapshot-reuse factor review / walk-forward runs
- add runner-local extracted research snapshot caching and tighten snapshot-backed optimize setup

## Verification
- python3 -m py_compile scripts/download_github_artifact.py
- bash -n scripts/configure_research_cargo_target.sh
- YAML parse for factor-review-v2, factor-walk-forward-v2, optimize, research-snapshot workflows
- git diff --check
- scripts/check_optimize_verification_gates.sh
- rtk cargo test --test workflow_security research_workflows_do_not_transfer_runtime_binaries_between_jobs -- --exact
- helper/cache smoke tests
- focused ploy-research cargo checks

Issue: #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows to leverage persistent build directories and improved caching strategies for faster builds.
  * Enhanced artifact download process with local caching and configurable time-to-live support.
  * Refined snapshot-backed builds to skip unnecessary cache operations and simplify directory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->