### PR TITLE
Keep PM5D research binaries executable with persistent targets

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -329,6 +329,14 @@ jobs:
             build_args+=(--example research_snapshot_compile)
           fi
           cargo build "${build_args[@]}"
+          if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+            mkdir -p target/release/examples
+            for binary in factor_review_v2 research_snapshot_compile; do
+              if [ -x "${CARGO_TARGET_DIR}/release/examples/${binary}" ]; then
+                cp "${CARGO_TARGET_DIR}/release/examples/${binary}" "target/release/examples/${binary}"
+              fi
+            done
+          fi
 
       - name: Compile research snapshot
         run: |

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -324,6 +324,14 @@ jobs:
             build_args+=(--example research_snapshot_compile)
           fi
           cargo build "${build_args[@]}"
+          if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+            mkdir -p target/release/examples
+            for binary in factor_walk_forward_v2 research_snapshot_compile; do
+              if [ -x "${CARGO_TARGET_DIR}/release/examples/${binary}" ]; then
+                cp "${CARGO_TARGET_DIR}/release/examples/${binary}" "target/release/examples/${binary}"
+              fi
+            done
+          fi
 
       - name: Compile research snapshot
         run: |

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -186,18 +186,19 @@ jobs:
         run: |
           set -euo pipefail
           . /home/runner/.cargo/env
+          cargo_target_dir="${CARGO_TARGET_DIR:-target}"
           mkdir -p target/release/examples
           if [ -n "${{ github.event.inputs.snapshot_run_id }}" ]; then
             cargo build --release --locked \
               -p ploy-research \
               --example three_layer_snapshot_optimize
-            cp target/release/examples/three_layer_snapshot_optimize target/release/examples/optimize-runner
+            cp "${cargo_target_dir}/release/examples/three_layer_snapshot_optimize" target/release/examples/optimize-runner
           else
             cargo build --release --locked \
               -p ploy-strategy-bundles \
               --features ploy-strategy-bundles/parquet-feed \
               --example optimize_backtest
-            cp target/release/examples/optimize_backtest target/release/examples/optimize-runner
+            cp "${cargo_target_dir}/release/examples/optimize_backtest" target/release/examples/optimize-runner
           fi
           chmod +x target/release/examples/optimize-runner
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11281,3 +11281,35 @@ Review:
   --no-default-features`, and `CARGO_TARGET_DIR=/tmp/ploy-research-all-in-check
   rtk cargo check -p ploy-research --example three_layer_snapshot_optimize
   --no-default-features`.
+
+# PM5D Persistent Target Binary Path Fix (2026-05-01)
+
+## Files
+
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: factor-review binary path compatibility when `CARGO_TARGET_DIR` is set.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: walk-forward binary path compatibility when `CARGO_TARGET_DIR` is set.
+- `.github/workflows/optimize.yml`
+  - Owner: optimizer binary copy path compatibility when `CARGO_TARGET_DIR` is set.
+- `tasks/todo.md`
+  - Owner: failure evidence and verification notes.
+
+## Tasks
+
+- [x] Diagnose failed main walk-forward speed run `25199046583`.
+- [x] Keep persistent target reuse, but copy built example binaries back to the
+  workflow's existing `target/release/examples/` execution path.
+- [ ] Verify workflow syntax and rerun snapshot-backed main speed tests.
+
+## Review
+
+- 2026-05-01: Main speed test `25199046583` proved the new snapshot-reuse path
+  correctly configured `CARGO_TARGET_DIR` and skipped the GitHub cargo cache
+  step, but failed in `Run factor walk-forward` with exit code `127` because
+  the binary was built under the persistent cargo target directory while the run
+  step still executed `./target/release/examples/factor_walk_forward_v2`.
+- 2026-05-01: The minimal fix is to keep the existing workflow execution path
+  stable and copy built example binaries from `${CARGO_TARGET_DIR}` back into
+  `target/release/examples/` after `cargo build`. Optimize now copies from
+  `${CARGO_TARGET_DIR:-target}` before creating `optimize-runner`.


### PR DESCRIPTION
## Summary
- copy factor review / walk-forward example binaries back to the existing target/release/examples execution path when CARGO_TARGET_DIR is set
- make optimize copy its runner from CARGO_TARGET_DIR when using the persistent snapshot target
- record the failed main speed-test evidence from run 25199046583

## Verification
- YAML parse for factor-review-v2, factor-walk-forward-v2, and optimize workflows
- git diff --check
- scripts/check_optimize_verification_gates.sh
- persistent target binary copy smoke

Fixes the workflow-path failure observed in #269's post-merge speed run.
Issue: #256