### PR TITLE
Keep strategy runners off direct public data feeds

### DIFF
--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -7,14 +7,14 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
-use chrono::{DateTime, Timelike, Utc};
+use chrono::{DateTime, Duration, Timelike, Utc};
 use futures::StreamExt;
-use ploy_market_contracts::{l2_updates_from_depth_totals, MarketUpdate};
+use ploy_market_contracts::{MarketUpdate, l2_updates_from_depth_totals, normalize_token_id};
 use polymarket_client_sdk::rtds::{Client as RtdsClient, EquityPriceMessage};
 use polymarket_client_sdk::types::U256;
 use polymarket_client_sdk::ws::config::{Config as PolymarketWsConfig, ReconnectConfig};
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use serde::Deserialize;
 use serde_json::Value;
 use sqlx::PgPool;
@@ -23,9 +23,9 @@ use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, error, info, warn};
 
 use crate::reference_prices::{
-    infer_pyth_asset_class, market_symbol_to_binance_symbol, normalize_reference_symbol,
-    pyth_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
-    ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
+    ReferenceAssetClass, ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot,
+    ReferencePriceSource, infer_pyth_asset_class, market_symbol_to_binance_symbol,
+    normalize_reference_symbol, pyth_symbol, upsert_reference_price,
 };
 
 const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
@@ -461,6 +461,222 @@ pub fn spawn_db_l2_feed(
             }
         }
     })
+}
+
+/// Spawn a task that consumes collector-persisted Polymarket events and quotes.
+///
+/// This is the strategy-runtime boundary for live/dry-run mode: collector
+/// services own public Polymarket/Gamma/CLOB connectivity, while strategy
+/// runners consume the local database projection.
+pub fn spawn_db_polymarket_feed(
+    tx: Arc<broadcast::Sender<MarketUpdate>>,
+    symbols: Vec<String>,
+    pool: PgPool,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let symbols_upper: Vec<String> = symbols.iter().map(|s| s.to_uppercase()).collect();
+        let mut discovered_events = HashSet::new();
+        let mut expired_events = HashSet::new();
+        let mut last_quote_ts: HashMap<String, DateTime<Utc>> = HashMap::new();
+
+        info!(
+            symbols = ?symbols_upper,
+            "Starting DB Polymarket event/quote feed"
+        );
+
+        loop {
+            let now = Utc::now();
+            let mut active_tokens = Vec::new();
+
+            let rows: Vec<(
+                String,
+                Option<String>,
+                Option<DateTime<Utc>>,
+                Option<DateTime<Utc>>,
+                Option<String>,
+                Option<String>,
+                Option<Decimal>,
+            )> = match sqlx::query_as(
+                r#"
+                SELECT
+                    market_slug,
+                    symbol,
+                    start_time,
+                    end_time,
+                    ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>0) AS up_token_id,
+                    ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>1) AS down_token_id,
+                    price_to_beat
+                FROM pm_market_metadata
+                WHERE symbol = ANY($1)
+                  AND end_time > NOW() - INTERVAL '120 seconds'
+                  AND COALESCE(start_time, end_time - INTERVAL '300 seconds')
+                        < NOW() + INTERVAL '6 minutes'
+                  AND raw_market->'markets'->0->'clobTokenIds' IS NOT NULL
+                ORDER BY start_time, end_time, market_slug
+                "#,
+            )
+            .bind(&symbols_upper)
+            .fetch_all(&pool)
+            .await
+            {
+                Ok(rows) => rows,
+                Err(error) => {
+                    warn!(error = %error, "DB Polymarket event query failed");
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    continue;
+                }
+            };
+
+            for (event_id, symbol, start_time, end_time, up_token, down_token, price_to_beat) in
+                rows
+            {
+                let Some(symbol) = symbol.filter(|value| !value.is_empty()) else {
+                    continue;
+                };
+                let Some(end_time) = end_time else {
+                    continue;
+                };
+                let Some(up_token) = up_token.map(|value| normalize_token_id(&value)) else {
+                    continue;
+                };
+                let Some(down_token) = down_token.map(|value| normalize_token_id(&value)) else {
+                    continue;
+                };
+                if up_token.is_empty() || down_token.is_empty() {
+                    continue;
+                }
+
+                let start_time = start_time.unwrap_or(end_time - Duration::seconds(300));
+                let window_secs = (end_time - start_time).num_seconds().max(0) as u64;
+
+                if discovered_events.insert(event_id.clone()) {
+                    let _ = tx.send(MarketUpdate::EventDiscovered {
+                        event_id: Arc::from(event_id.as_str()),
+                        symbol: Arc::from(symbol.as_str()),
+                        up_token: Arc::from(up_token.as_str()),
+                        down_token: Arc::from(down_token.as_str()),
+                        end_time,
+                        window_secs,
+                        price_to_beat,
+                        resolved_up_won: None,
+                    });
+                }
+
+                if end_time <= now {
+                    if expired_events.insert(event_id.clone()) {
+                        let resolved_up_won =
+                            resolve_db_event_outcome(&pool, &event_id, &up_token, &down_token)
+                                .await;
+                        let _ = tx.send(MarketUpdate::EventExpired {
+                            event_id: Arc::from(event_id.as_str()),
+                            end_time,
+                            resolved_up_won,
+                        });
+                    }
+                } else {
+                    active_tokens.push(up_token);
+                    active_tokens.push(down_token);
+                }
+            }
+
+            if !active_tokens.is_empty() {
+                let quote_rows: Vec<(
+                    String,
+                    Option<Decimal>,
+                    Option<Decimal>,
+                    Option<Decimal>,
+                    Option<Decimal>,
+                    DateTime<Utc>,
+                )> = match sqlx::query_as(
+                    r#"
+                    SELECT DISTINCT ON (token_id)
+                        token_id, best_bid, best_ask, bid_size, ask_size, received_at
+                    FROM clob_quote_ticks
+                    WHERE token_id = ANY($1)
+                      AND received_at > NOW() - INTERVAL '30 seconds'
+                      AND (best_bid IS NOT NULL OR best_ask IS NOT NULL)
+                    ORDER BY token_id, received_at DESC
+                    "#,
+                )
+                .bind(&active_tokens)
+                .fetch_all(&pool)
+                .await
+                {
+                    Ok(rows) => rows,
+                    Err(error) => {
+                        warn!(error = %error, "DB Polymarket quote query failed");
+                        Vec::new()
+                    }
+                };
+
+                for (token_id, bid, ask, bid_size, ask_size, ts) in quote_rows {
+                    if last_quote_ts
+                        .get(&token_id)
+                        .is_some_and(|last_ts| *last_ts >= ts)
+                    {
+                        continue;
+                    }
+                    last_quote_ts.insert(token_id.clone(), ts);
+                    if tx
+                        .send(MarketUpdate::Quote {
+                            token_id: Arc::from(token_id.as_str()),
+                            bid,
+                            ask,
+                            bid_size,
+                            ask_size,
+                            ts,
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    })
+}
+
+async fn resolve_db_event_outcome(
+    pool: &PgPool,
+    event_id: &str,
+    up_token: &str,
+    down_token: &str,
+) -> Option<bool> {
+    let token_ids = vec![up_token.to_string(), down_token.to_string()];
+    let rows: Vec<(String, Option<Decimal>)> = sqlx::query_as(
+        r#"
+        SELECT token_id, settled_price
+        FROM pm_token_settlements
+        WHERE market_slug = $1
+          AND token_id = ANY($2)
+          AND resolved = TRUE
+        "#,
+    )
+    .bind(event_id)
+    .bind(&token_ids)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let mut up = None;
+    let mut down = None;
+    for (token_id, settled_price) in rows {
+        let token_id = normalize_token_id(&token_id);
+        if token_id == up_token {
+            up = settled_price;
+        } else if token_id == down_token {
+            down = settled_price;
+        }
+    }
+
+    match (up, down) {
+        (Some(up), Some(down)) if up != down => Some(up > down),
+        (Some(up), _) => Some(up > Decimal::new(5, 1)),
+        (_, Some(down)) => Some(down < Decimal::new(5, 1)),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -1128,8 +1344,8 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 #[cfg(test)]
 mod tests {
     use super::{
-        book_quote_from_rest, l2_updates_from_book, parse_agg_trade_msg,
-        rtds_market_data_ws_config, RestBook,
+        RestBook, book_quote_from_rest, l2_updates_from_book, parse_agg_trade_msg,
+        rtds_market_data_ws_config,
     };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -74,8 +74,43 @@ pub struct RuntimeSection {
     pub to: Option<String>,
     /// Optional NDJSON log path for canonical `MarketUpdate` recording.
     pub record_market_updates_to: Option<PathBuf>,
+    /// Source boundary for live/dry-run market data.
+    ///
+    /// Defaults to `local_db`, where strategy runners consume collector-persisted
+    /// data and never open their own public Polymarket/RTDS/Gamma feeds.
+    #[serde(default)]
+    pub market_data_source: MarketDataSource,
     /// Required when `mode = "replay"`; points at a previously recorded NDJSON log.
     pub replay_market_updates_from: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MarketDataSource {
+    /// Consume locally persisted collector data only.
+    LocalDb,
+    /// Open direct public feeds from this strategy runner.
+    ExternalDirect,
+    /// Consume local DB feeds and also open direct public feeds.
+    Dual,
+}
+
+impl Default for MarketDataSource {
+    fn default() -> Self {
+        Self::LocalDb
+    }
+}
+
+impl MarketDataSource {
+    #[must_use]
+    pub fn uses_local_db(self) -> bool {
+        matches!(self, Self::LocalDb | Self::Dual)
+    }
+
+    #[must_use]
+    pub fn uses_external_direct(self) -> bool {
+        matches!(self, Self::ExternalDirect | Self::Dual)
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -337,6 +372,7 @@ mode = "backtest"
 throttle_hz = 1
 max_updates = 10000
 record_market_updates_to = "tmp/sample.ndjson"
+market_data_source = "external_direct"
 
 [strategy]
 symbols = ["BTCUSDT", "ETHUSDT"]
@@ -377,6 +413,10 @@ enable_market_impact = true
         assert_eq!(
             config.runtime.record_market_updates_to.as_deref(),
             Some(Path::new("tmp/sample.ndjson"))
+        );
+        assert_eq!(
+            config.runtime.market_data_source,
+            MarketDataSource::ExternalDirect
         );
         assert_eq!(config.strategy.symbols, vec!["BTCUSDT", "ETHUSDT"]);
         assert_eq!(config.reference_data.pyth_symbols, vec!["AAPL", "XAUUSD"]);
@@ -443,6 +483,9 @@ mode = "dryrun"
         );
         assert!(config.reference_data.pyth_symbols.is_empty());
         assert!(!config.reference_data.capture_sports_state);
+        assert_eq!(config.runtime.market_data_source, MarketDataSource::LocalDb);
+        assert!(config.runtime.market_data_source.uses_local_db());
+        assert!(!config.runtime.market_data_source.uses_external_direct());
         assert!(!config.backtest_data.include_reference_prices);
         assert!(!config.backtest_data.include_sports_state);
         assert!(!config.backtest_data.require_official_settlement);

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use ploy_market_data::feeds::{
-    spawn_chainlink_feed, spawn_db_aggtrade_feed, spawn_db_l2_feed, spawn_db_spot_feed,
-    spawn_pyth_reference_feed, spawn_spot_feed,
+    spawn_chainlink_feed, spawn_db_aggtrade_feed, spawn_db_l2_feed, spawn_db_polymarket_feed,
+    spawn_db_spot_feed, spawn_pyth_reference_feed, spawn_spot_feed,
 };
 use ploy_market_data::reference_prices::new_reference_price_registry;
 use ploy_market_data::scanner::spawn_market_scanner;
@@ -14,7 +14,7 @@ use ploy_trading::{
     TradingRuntime, TradingRuntimeSnapshot,
 };
 use rust_decimal::Decimal;
-use sqlx::{postgres::PgPoolOptions, FromRow, PgPool};
+use sqlx::{FromRow, PgPool, postgres::PgPoolOptions};
 use std::env;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -318,7 +318,7 @@ mod execution {
 }
 
 use crate::recording::build_signal_recorder;
-use crate::{database_unavailable_is_fatal, RuntimeModeConfig};
+use crate::{RuntimeModeConfig, database_unavailable_is_fatal};
 
 #[derive(Debug, FromRow)]
 struct LiveOrderRestoreRow {
@@ -550,48 +550,69 @@ async fn run_live_or_dry_run(
     let (tx, rx) = broadcast::channel(8192);
     let tx = Arc::new(tx);
     let reference_prices = new_reference_price_registry();
+    let market_data_source = config.runtime.market_data_source;
 
-    let spot_handle = spawn_spot_feed(
-        tx.clone(),
-        reference_prices.clone(),
-        symbols.to_vec(),
-        db_pool.clone(),
-    );
-    let mut db_feed_handles = Vec::new();
-    if let Some(ref db) = db_pool {
-        db_feed_handles.push(spawn_db_spot_feed(tx.clone(), symbols.to_vec(), db.clone()));
-        db_feed_handles.push(spawn_db_aggtrade_feed(
-            tx.clone(),
-            symbols.to_vec(),
-            db.clone(),
-        ));
-        db_feed_handles.push(spawn_db_l2_feed(tx.clone(), symbols.to_vec(), db.clone()));
+    if market_data_source.uses_local_db() && db_pool.is_none() {
+        error!(
+            source = ?market_data_source,
+            "Local market-data source requires DATABASE_URL; refusing to open direct public feeds"
+        );
+        std::process::exit(1);
     }
-    let chainlink_handle = spawn_chainlink_feed(
-        tx.clone(),
-        reference_prices.clone(),
-        symbols.to_vec(),
-        db_pool.clone(),
-    );
-    let pyth_handle = spawn_pyth_reference_feed(
-        tx.clone(),
-        reference_prices.clone(),
-        config.reference_data.pyth_symbols.clone(),
-        db_pool.clone(),
-    );
-    let scanner_handle = spawn_market_scanner(
-        tx.clone(),
-        reference_prices.clone(),
-        symbols.to_vec(),
-        db_pool.clone(),
-        config.reference_data.capture_sports_state,
-    );
 
-    let sports_handle = if config.reference_data.capture_sports_state {
-        Some(spawn_sports_feed(tx.clone(), db_pool.clone()))
-    } else {
-        None
-    };
+    let mut feed_handles = Vec::new();
+    if market_data_source.uses_local_db() {
+        if let Some(ref db) = db_pool {
+            feed_handles.push(spawn_db_spot_feed(tx.clone(), symbols.to_vec(), db.clone()));
+            feed_handles.push(spawn_db_aggtrade_feed(
+                tx.clone(),
+                symbols.to_vec(),
+                db.clone(),
+            ));
+            feed_handles.push(spawn_db_l2_feed(tx.clone(), symbols.to_vec(), db.clone()));
+            feed_handles.push(spawn_db_polymarket_feed(
+                tx.clone(),
+                symbols.to_vec(),
+                db.clone(),
+            ));
+        }
+    }
+
+    if market_data_source.uses_external_direct() {
+        feed_handles.push(spawn_spot_feed(
+            tx.clone(),
+            reference_prices.clone(),
+            symbols.to_vec(),
+            db_pool.clone(),
+        ));
+        feed_handles.push(spawn_chainlink_feed(
+            tx.clone(),
+            reference_prices.clone(),
+            symbols.to_vec(),
+            db_pool.clone(),
+        ));
+        feed_handles.push(spawn_pyth_reference_feed(
+            tx.clone(),
+            reference_prices.clone(),
+            config.reference_data.pyth_symbols.clone(),
+            db_pool.clone(),
+        ));
+        feed_handles.push(spawn_market_scanner(
+            tx.clone(),
+            reference_prices.clone(),
+            symbols.to_vec(),
+            db_pool.clone(),
+            config.reference_data.capture_sports_state,
+        ));
+
+        if config.reference_data.capture_sports_state {
+            feed_handles.push(spawn_sports_feed(tx.clone(), db_pool.clone()));
+        }
+    } else if config.reference_data.capture_sports_state {
+        warn!(
+            "capture_sports_state requires market_data_source = external_direct or dual; local_db runtime will not open the sports WebSocket"
+        );
+    }
 
     let feed: Box<dyn Feed> = if let Some(record_path) = config.record_market_updates_path() {
         Box::new(
@@ -656,14 +677,7 @@ async fn run_live_or_dry_run(
         (result, snapshot)
     };
 
-    spot_handle.abort();
-    for handle in db_feed_handles {
-        handle.abort();
-    }
-    chainlink_handle.abort();
-    pyth_handle.abort();
-    scanner_handle.abort();
-    if let Some(handle) = sports_handle {
+    for handle in feed_handles {
         handle.abort();
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# Strategy Runtime Local Market-Data Boundary (2026-05-01)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/config.rs`
+- `crates/ploy-market-data/src/feeds.rs`
+- `crates/ploy-strategy-runtime/src/live.rs`
+- `tests/test_runtime_market_data_boundary.py`
+- `tasks/todo.md`
+
+## Tasks
+
+- [x] Add an explicit market-data source contract so live/dry-run runners default to local DB feeds.
+- [x] Add a local DB Polymarket feed for event discovery, quotes, and expiry signals.
+- [x] Gate all direct Polymarket/RTDS/Gamma runtime feeds behind explicit opt-in.
+- [x] Add regression tests/static guards for the default local-only boundary.
+- [x] Run targeted verification and record remaining deployment risk.
+
+## Review
+
+- 2026-05-01: Added `[runtime].market_data_source` with default `local_db`; `external_direct` and `dual` are now explicit opt-in modes for strategy runners that intentionally open public feeds.
+- 2026-05-01: Added `spawn_db_polymarket_feed` so live/dry-run strategy runtimes can consume collector-owned `pm_market_metadata`, `clob_quote_ticks`, and `pm_token_settlements` rows for event discovery, quotes, and expiry signals without calling public Polymarket/Gamma endpoints.
+- 2026-05-01: `live.rs` now starts DB spot/aggTrade/L2/Polymarket feeds by default and refuses to start local-db live/dry-run mode without `DATABASE_URL`; direct RTDS/Gamma/scanner/sports feeds are behind `market_data_source.uses_external_direct()`.
+- 2026-05-01: Verification passed in a clean worktree: `rustfmt --edition 2024` on touched Rust files, `git diff --check`, `python3 -m unittest tests.test_runtime_market_data_boundary`, `rtk cargo test -p ploy-strategy-bundles config --lib`, `rtk cargo check -p ploy-market-data`, and `rtk cargo check -p ploy-strategy-runtime --features live,db-recorder`. Cargo emitted pre-existing dead-code/profile warnings only.
+
 # Research Snapshot Reuse Workflow Fix (2026-05-01)
 
 Issue: https://github.com/proerror77/ploy/issues/256

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STRATEGY_DIR = ROOT / "config" / "strategies"
+
+
+class RuntimeMarketDataBoundaryTests(unittest.TestCase):
+    def test_pm5d_runtime_configs_default_to_local_market_data(self) -> None:
+        configs = sorted(STRATEGY_DIR.glob("02-pm5d*.toml"))
+        self.assertGreaterEqual(len(configs), 1)
+
+        for path in configs:
+            config = tomllib.loads(path.read_text())
+            mode = config.get("runtime", {}).get("mode", "")
+            if mode not in {"dryrun", "live"}:
+                continue
+            source = config.get("runtime", {}).get("market_data_source", "local_db")
+            self.assertEqual(
+                source,
+                "local_db",
+                f"{path.name} must not opt strategy runners back into direct public feeds",
+            )
+
+    def test_live_runtime_direct_feeds_are_explicitly_gated(self) -> None:
+        live_rs = ROOT / "crates" / "ploy-strategy-runtime" / "src" / "live.rs"
+        text = live_rs.read_text()
+
+        self.assertIn("market_data_source.uses_external_direct()", text)
+        self.assertIn("market_data_source.uses_local_db()", text)
+        self.assertIn("spawn_db_polymarket_feed", text)
+
+        external_gate = text.index("market_data_source.uses_external_direct()")
+        for direct_feed in (
+            "spawn_spot_feed(",
+            "spawn_chainlink_feed(",
+            "spawn_pyth_reference_feed(",
+            "spawn_market_scanner(",
+            "spawn_sports_feed(",
+        ):
+            self.assertGreater(
+                text.index(direct_feed),
+                external_gate,
+                f"{direct_feed} must stay behind explicit external-direct opt-in",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- default live/dry-run strategy runtime market data to collector-backed local DB feeds
- add DB Polymarket event/quote/expiry feed from pm_market_metadata, clob_quote_ticks, and pm_token_settlements
- gate direct RTDS/Gamma/scanner/sports feeds behind explicit market_data_source opt-in
- add a static regression guard for PM5D configs and live runtime wiring

## Verification
- rustfmt --edition 2024 crates/ploy-strategy-bundles/src/config.rs crates/ploy-market-data/src/feeds.rs crates/ploy-strategy-runtime/src/live.rs
- git diff --check
- python3 -m unittest tests.test_runtime_market_data_boundary
- rtk cargo test -p ploy-strategy-bundles config --lib
- rtk cargo check -p ploy-market-data
- rtk cargo check -p ploy-strategy-runtime --features live,db-recorder

## Deployment note
Deploy from main only after CI passes; no Rust build on tango-1-1.