### PR TITLE
Restore collector-owned market discovery

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -191,6 +191,7 @@ jobs:
           cp deployment/systemd/ploy-binance-aggtrade-collector.service dist/deployment/systemd/ploy-binance-aggtrade-collector.service
           cp deployment/systemd/ploy-binance-lob-collector.service dist/deployment/systemd/ploy-binance-lob-collector.service
           cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
+          cp deployment/systemd/ploy-market-discovery.service dist/deployment/systemd/ploy-market-discovery.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
           cp deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf dist/deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf
           cp deployment/systemd/ploy-quote-collector.hardening.conf dist/deployment/systemd/ploy-quote-collector.hardening.conf
@@ -434,6 +435,7 @@ jobs:
             install -m 0644 ./deployment/systemd/ploy-binance-aggtrade-collector.service /etc/systemd/system/ploy-binance-aggtrade-collector.service
             install -m 0644 ./deployment/systemd/ploy-binance-lob-collector.service /etc/systemd/system/ploy-binance-lob-collector.service
             install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
+            install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
             install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
             install -m 0644 ./deployment/systemd/ploy-quote-collector.hardening.conf /etc/systemd/system/ploy-quote-collector.service.d/hardening.conf
             systemctl daemon-reload
@@ -466,6 +468,18 @@ jobs:
             fi
             systemctl enable --now ploy-deribit-greeks-collector.service
             systemctl restart ploy-deribit-greeks-collector.service
+            systemctl enable --now ploy-market-discovery.service
+            systemctl restart ploy-market-discovery.service
+            wait_for_recent_rows \
+              "SELECT EXISTS (SELECT 1 FROM pm_market_catalog WHERE market_family = 'crypto' AND strategy_symbol IS NOT NULL AND end_time >= NOW())" \
+              "pm_market_catalog has no active crypto markets after market-discovery restart" \
+              20 \
+              3
+            wait_for_recent_rows \
+              "SELECT EXISTS (SELECT 1 FROM pm_market_metadata WHERE symbol IS NOT NULL AND end_time >= NOW())" \
+              "pm_market_metadata has no active crypto markets after market-discovery restart" \
+              20 \
+              3
             if service_exists ploy-quote-collector.service; then
               systemctl enable --now ploy-quote-collector.service
               systemctl restart ploy-quote-collector.service
@@ -496,6 +510,8 @@ jobs:
             fi
             systemctl is-active --quiet ploy-deribit-greeks-collector.service
             require_service_guardrails ploy-deribit-greeks-collector.service
+            systemctl is-active --quiet ploy-market-discovery.service
+            require_service_guardrails ploy-market-discovery.service
             if service_exists ployd.service; then
               systemctl is-active --quiet ployd.service
               curl -fsS http://127.0.0.1:8081/health
@@ -533,6 +549,16 @@ jobs:
               20 \
               3
             wait_for_recent_rows \
+              "SELECT EXISTS (SELECT 1 FROM pm_market_catalog WHERE market_family = 'crypto' AND strategy_symbol IS NOT NULL AND end_time >= NOW())" \
+              "pm_market_catalog has no active crypto markets after deploy" \
+              20 \
+              3
+            wait_for_recent_rows \
+              "SELECT EXISTS (SELECT 1 FROM pm_market_metadata WHERE symbol IS NOT NULL AND end_time >= NOW())" \
+              "pm_market_metadata has no active crypto markets after deploy" \
+              20 \
+              3
+            wait_for_recent_rows \
               "SELECT EXISTS (SELECT 1 FROM clob_trade_ticks WHERE received_at >= NOW() - INTERVAL '5 minutes')" \
               "clob_trade_ticks is not receiving PM trade prints after deploy" \
               20 \
@@ -561,6 +587,10 @@ jobs:
               "Traceback|psql failed|column \"option_type\" does not exist|column \"strike\" does not exist" \
               "deribit greeks collector failed after deploy"
             assert_no_recent_logs \
+              "ploy-market-discovery.service" \
+              "Failed to connect to database|panic|thread '.*' panicked" \
+              "market discovery collector failed after deploy"
+            assert_no_recent_logs \
               "ploy-pm-trade-collector.service" \
               "no partition of relation \"clob_trade_ticks\"" \
               "pm trade collector still lacks active partitions"
@@ -578,6 +608,7 @@ jobs:
             if service_exists ployd.service; then
               systemctl status ployd.service --no-pager
             fi
+            systemctl status ploy-market-discovery.service --no-pager
             if service_exists ploy-quote-collector.service; then
               systemctl status ploy-quote-collector.service --no-pager
             fi
@@ -596,6 +627,7 @@ jobs:
             if service_exists ployd.service; then
               journalctl -u ployd.service -n 20 --no-pager
             fi
+            journalctl -u ploy-market-discovery.service -n 20 --no-pager
             if service_exists ploy-quote-collector.service; then
               journalctl -u ploy-quote-collector.service -n 20 --no-pager
             fi
@@ -611,7 +643,7 @@ jobs:
             echo "- Target: \`${{ secrets.TANGO_1_1_HOST }}\`"
             echo "- Transport: \`GitHub Actions -> OSS -> ECS\`"
             echo "- OSS object: \`${{ steps.upload_bundle_to_oss.outputs.bundle_object }}\`"
-            echo "- Services: \`ployd\` (if installed), \`ploy-binance-aggtrade-collector\`, \`ploy-binance-price-collector\`, \`ploy-binance-lob-collector\`, \`ploy-deribit-iv-collector\`, \`ploy-quote-collector\`, \`ploy-pm-trade-collector\`"
+            echo "- Services: \`ployd\` (if installed), \`ploy-binance-aggtrade-collector\`, \`ploy-binance-price-collector\`, \`ploy-binance-lob-collector\`, \`ploy-deribit-iv-collector\`, \`ploy-market-discovery\`, \`ploy-quote-collector\`, \`ploy-pm-trade-collector\`"
             echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
             echo "- Migrations: \`${DEPLOY_MIGRATIONS}\`"
             echo "- Postgres pre/postflight: required"

--- a/crates/ploy-market-data/src/scanner.rs
+++ b/crates/ploy-market-data/src/scanner.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use ploy_market_contracts::MarketUpdate;
-use polymarket_client_sdk::gamma::types::request::MarketsRequest;
 use polymarket_client_sdk::gamma::Client as GammaClient;
+use polymarket_client_sdk::gamma::types::request::MarketsRequest;
 use polymarket_client_sdk::types::U256;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
@@ -21,16 +21,17 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::discovery::crypto::discover_crypto_markets;
 use crate::discovery::crypto::DiscoveredCryptoMarket;
+use crate::discovery::crypto::discover_crypto_markets;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
 use crate::feeds::spawn_quote_feed_until;
-use crate::reference_prices::ReferencePriceRegistry;
+use crate::reference_prices::{ReferencePriceRegistry, new_reference_price_registry};
 
 const SCAN_INTERVAL_SECS: u64 = 30;
 const SPORTS_DISCOVERY_REFRESH_SECS: i64 = 300;
 const SPORTS_DISCOVERY_LIMIT: i32 = 500;
+const DEFAULT_DISCOVERY_LOOKAHEAD_MINUTES: i64 = 20;
 const QUOTE_FEED_GRACE_SECS: i64 = 90;
 /// How far back to look for open positions that need recovery on startup.
 const RECOVERY_LOOKBACK_HOURS: i64 = 48;
@@ -39,6 +40,85 @@ struct TrackedEvent {
     end_time: chrono::DateTime<Utc>,
     symbol: String,
     price_to_beat: Option<Decimal>,
+}
+
+/// Configuration for the central Polymarket market-discovery collector.
+///
+/// This collector owns Gamma/catalog discovery for live infrastructure. Strategy
+/// runners should consume the persisted rows instead of opening their own Gamma
+/// scanners.
+#[derive(Debug, Clone)]
+pub struct MarketDiscoveryCollectorConfig {
+    pub symbols: Vec<String>,
+    pub refresh_interval_secs: u64,
+    pub lookahead_minutes: i64,
+    pub capture_sports_catalog: bool,
+}
+
+impl MarketDiscoveryCollectorConfig {
+    #[must_use]
+    pub fn with_safe_defaults(mut self) -> Self {
+        if self.symbols.is_empty() {
+            self.symbols = vec![
+                "BTCUSDT".to_string(),
+                "ETHUSDT".to_string(),
+                "SOLUSDT".to_string(),
+            ];
+        }
+        if self.refresh_interval_secs == 0 {
+            self.refresh_interval_secs = SCAN_INTERVAL_SECS;
+        }
+        if self.lookahead_minutes <= 0 {
+            self.lookahead_minutes = DEFAULT_DISCOVERY_LOOKAHEAD_MINUTES;
+        }
+        self
+    }
+}
+
+/// Run the central market-discovery loop.
+///
+/// This intentionally persists catalog/metadata only. It does not emit runtime
+/// events or spawn quote feeds; dedicated collector services own those concerns.
+pub async fn run_market_discovery_collector(config: MarketDiscoveryCollectorConfig, pool: PgPool) {
+    let config = config.with_safe_defaults();
+    let client = GammaClient::default();
+    let reference_prices = new_reference_price_registry();
+    let mut last_sports_refresh: Option<DateTime<Utc>> = None;
+
+    info!(
+        symbols = ?config.symbols,
+        refresh_secs = config.refresh_interval_secs,
+        lookahead_minutes = config.lookahead_minutes,
+        capture_sports_catalog = config.capture_sports_catalog,
+        "Starting Polymarket market-discovery collector"
+    );
+
+    loop {
+        let now = Utc::now();
+        let discovered = refresh_crypto_catalog(
+            &client,
+            &pool,
+            &reference_prices,
+            &config.symbols,
+            now,
+            config.lookahead_minutes,
+        )
+        .await;
+
+        info!(discovered, "Polymarket market-discovery refresh complete");
+
+        if should_refresh_sports_catalog(
+            now,
+            last_sports_refresh,
+            true,
+            config.capture_sports_catalog,
+        ) {
+            refresh_sports_catalog(&client, Some(&pool)).await;
+            last_sports_refresh = Some(now);
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(config.refresh_interval_secs)).await;
+    }
 }
 
 /// Spawn a background task that periodically discovers active 5-min binary
@@ -525,6 +605,36 @@ fn should_refresh_sports_catalog(
             .unwrap_or(true)
 }
 
+async fn refresh_crypto_catalog(
+    client: &GammaClient,
+    pool: &PgPool,
+    reference_prices: &ReferencePriceRegistry,
+    symbols: &[String],
+    now: DateTime<Utc>,
+    lookahead_minutes: i64,
+) -> usize {
+    let mut request = MarketsRequest::default();
+    request.end_date_min = Some(now - Duration::minutes(1));
+    request.end_date_max = Some(now + Duration::minutes(lookahead_minutes));
+    request.closed = Some(false);
+    request.limit = Some(500);
+
+    match client.markets(&request).await {
+        Ok(markets) => {
+            let discovered =
+                discover_crypto_markets(&markets, symbols, reference_prices, now).await;
+            for market in &discovered {
+                persist_discovered_crypto_market(Some(pool), market).await;
+            }
+            discovered.len()
+        }
+        Err(error) => {
+            warn!(error = %error, "Gamma markets query failed during catalog refresh");
+            0
+        }
+    }
+}
+
 async fn refresh_sports_catalog(client: &GammaClient, pool: Option<&PgPool>) {
     let Some(pool) = pool else {
         return;
@@ -643,17 +753,44 @@ mod tests {
     use chrono::{Duration, TimeZone, Utc};
 
     use super::{
-        extend_quote_feed_stop_at, parse_token_id, quote_feed_deadline,
-        should_refresh_sports_catalog,
+        MarketDiscoveryCollectorConfig, extend_quote_feed_stop_at, parse_token_id,
+        quote_feed_deadline, should_refresh_sports_catalog,
     };
 
     #[test]
     fn token_id_parser_accepts_decimal_strings() {
-        assert!(parse_token_id(
-            "27239049953613250678046988034203198692578441444398010699401021233149338414941"
-        )
-        .is_some());
+        assert!(
+            parse_token_id(
+                "27239049953613250678046988034203198692578441444398010699401021233149338414941"
+            )
+            .is_some()
+        );
         assert!(parse_token_id("not-a-token").is_none());
+    }
+
+    #[test]
+    fn market_discovery_config_fills_safe_defaults() {
+        let config = MarketDiscoveryCollectorConfig {
+            symbols: Vec::new(),
+            refresh_interval_secs: 0,
+            lookahead_minutes: 0,
+            capture_sports_catalog: false,
+        }
+        .with_safe_defaults();
+
+        assert_eq!(
+            config.symbols,
+            vec![
+                "BTCUSDT".to_string(),
+                "ETHUSDT".to_string(),
+                "SOLUSDT".to_string()
+            ]
+        );
+        assert_eq!(config.refresh_interval_secs, super::SCAN_INTERVAL_SECS);
+        assert_eq!(
+            config.lookahead_minutes,
+            super::DEFAULT_DISCOVERY_LOOKAHEAD_MINUTES
+        );
     }
 
     #[test]

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -14,6 +14,8 @@ fn print_usage_for(program: &str) {
     #[cfg(feature = "ops")]
     eprintln!("  check-db          Check database data completeness");
     #[cfg(feature = "ops")]
+    eprintln!("  collect-markets  Discover Polymarket markets into the local DB catalog");
+    #[cfg(feature = "ops")]
     eprintln!("  collect-quotes    Collect orderbook quotes from Polymarket CLOB WebSocket");
     #[cfg(feature = "ops")]
     eprintln!("  collect-pm-trades Collect public Polymarket trade prints from Data API");
@@ -55,6 +57,9 @@ pub async fn run_with_args(args: Vec<String>) {
         }
         Some("collect-quotes") => {
             run_collect_quotes(&args).await;
+        }
+        Some("collect-markets") => {
+            run_collect_markets(&args).await;
         }
         Some("collect-pm-trades") => {
             run_collect_pm_trades(&args).await;
@@ -132,6 +137,17 @@ async fn run_collect_quotes(args: &[String]) {
 #[cfg(not(feature = "ops"))]
 async fn run_collect_quotes(_args: &[String]) {
     eprintln!("The collect-quotes command requires the full/ops runner build");
+    std::process::exit(1);
+}
+
+#[cfg(feature = "ops")]
+async fn run_collect_markets(args: &[String]) {
+    ops::run_collect_markets(args).await;
+}
+
+#[cfg(not(feature = "ops"))]
+async fn run_collect_markets(_args: &[String]) {
+    eprintln!("The collect-markets command requires the full/ops runner build");
     std::process::exit(1);
 }
 

--- a/crates/ploy-runner-host/src/ops.rs
+++ b/crates/ploy-runner-host/src/ops.rs
@@ -1,6 +1,7 @@
 use ploy_market_data::collector::{CollectorConfig, QuoteCollector};
 use ploy_market_data::diagnostics::check_database;
 use ploy_market_data::pm_trades::{TradeCollector, TradeCollectorConfig};
+use ploy_market_data::scanner::{MarketDiscoveryCollectorConfig, run_market_discovery_collector};
 use sqlx::postgres::PgPoolOptions;
 
 pub fn print_usage() {
@@ -20,6 +21,19 @@ pub fn print_usage() {
     );
     eprintln!(
         "  env PLOY_QUOTE_COLLECTOR_STALE_AFTER_SECS Stale self-restart threshold (default: 120)"
+    );
+    eprintln!();
+    eprintln!("Options for 'collect-markets':");
+    eprintln!("  --symbols <list>  Comma-separated symbols (default: BTCUSDT,ETHUSDT,SOLUSDT)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!(
+        "  env PLOY_MARKET_DISCOVERY_REFRESH_SECS     Gamma catalog refresh interval (default: 30)"
+    );
+    eprintln!(
+        "  env PLOY_MARKET_DISCOVERY_LOOKAHEAD_MINUTES Future expiry discovery window (default: 20)"
+    );
+    eprintln!(
+        "  env PLOY_MARKET_DISCOVERY_CAPTURE_SPORTS   true/false sports catalog capture (default: false)"
     );
     eprintln!();
     eprintln!("Options for 'collect-pm-trades':");
@@ -47,6 +61,44 @@ pub fn print_usage() {
     eprintln!(
         "  env PLOY_PM_TRADE_COLLECTOR_TAKER_ONLY      true/false Data API takerOnly (default: true)"
     );
+}
+
+pub async fn run_collect_markets(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+
+    let symbols_str = arg_value(args, "--symbols")
+        .map(String::as_str)
+        .unwrap_or("BTCUSDT,ETHUSDT,SOLUSDT");
+
+    let symbols = parse_symbols(symbols_str);
+
+    let pool = match PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&db_url)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(error) => {
+            eprintln!("Failed to connect to database: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let config = MarketDiscoveryCollectorConfig {
+        symbols,
+        refresh_interval_secs: env_u64("PLOY_MARKET_DISCOVERY_REFRESH_SECS", 30),
+        lookahead_minutes: env_i64("PLOY_MARKET_DISCOVERY_LOOKAHEAD_MINUTES", 20),
+        capture_sports_catalog: env_bool("PLOY_MARKET_DISCOVERY_CAPTURE_SPORTS", false),
+    };
+
+    run_market_discovery_collector(config, pool).await;
 }
 
 pub async fn run_check_db(args: &[String]) {

--- a/deployment/systemd/ploy-market-discovery.service
+++ b/deployment/systemd/ploy-market-discovery.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Polymarket Market Discovery Collector
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/ploy
+ExecStart=/opt/ploy/bin/ploy-runner collect-markets \
+    --symbols BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT \
+    --db-url postgresql://postgres:postgres@localhost:5432/ploy
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+MemoryHigh=512M
+MemoryMax=768M
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,30 @@
+# Central Market Discovery Service (2026-05-01)
+
+## Files
+
+- `crates/ploy-market-data/src/scanner.rs`
+- `crates/ploy-runner-host/src/lib.rs`
+- `crates/ploy-runner-host/src/ops.rs`
+- `deployment/systemd/ploy-market-discovery.service`
+- `.github/workflows/deploy-tango-1-1.yml`
+- `tests/test_runtime_market_data_boundary.py`
+- `tasks/todo.md`
+
+## Tasks
+
+- [x] Diagnose why the first local-market-data deploy left PM quote/trade collectors with zero active markets.
+- [x] Add a central `collect-markets` runner command that refreshes PM market catalog/metadata without starting strategy runtime feeds.
+- [x] Deploy a `ploy-market-discovery.service` and start it before quote/trade collectors.
+- [x] Add deployment gates that require active PM catalog/metadata rows before downstream PM collectors start.
+- [x] Run targeted local verification before PR/merge/deploy.
+- [ ] Merge, deploy, and verify Tango service/network state.
+
+## Review
+
+- 2026-05-01: The deploy failure exposed the hidden coupling: strategy runners had been providing market discovery by opening Gamma scanners directly. After runners were correctly moved to local DB feeds, the collector layer needed its own catalog refresh service.
+- 2026-05-01: Added central `collect-markets` / `ploy-market-discovery.service`; deploy now starts it before PM quote/trade collectors and gates on active `pm_market_catalog` plus `pm_market_metadata` rows.
+- 2026-05-01: Local verification passed: `rustfmt --edition 2024` on touched Rust files, `git diff --check`, `python3 -m unittest tests.test_runtime_market_data_boundary`, `rtk cargo test -p ploy-market-data scanner --lib`, and `rtk cargo check -p ploy-runner-host --features ops`. Cargo emitted pre-existing warnings only.
+
 # Strategy Runtime Local Market-Data Boundary (2026-05-01)
 
 ## Files

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -46,6 +46,39 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
                 f"{direct_feed} must stay behind explicit external-direct opt-in",
             )
 
+    def test_central_market_discovery_service_owns_pm_catalog_refresh(self) -> None:
+        runner_lib = ROOT / "crates" / "ploy-runner-host" / "src" / "lib.rs"
+        runner_ops = ROOT / "crates" / "ploy-runner-host" / "src" / "ops.rs"
+        scanner = ROOT / "crates" / "ploy-market-data" / "src" / "scanner.rs"
+        service = ROOT / "deployment" / "systemd" / "ploy-market-discovery.service"
+        workflow = ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml"
+
+        self.assertIn("collect-markets", runner_lib.read_text())
+        self.assertIn("run_market_discovery_collector", runner_ops.read_text())
+
+        scanner_text = scanner.read_text()
+        self.assertIn("MarketDiscoveryCollectorConfig", scanner_text)
+        self.assertIn("refresh_crypto_catalog", scanner_text)
+        self.assertIn("persist_discovered_crypto_market", scanner_text)
+
+        service_text = service.read_text()
+        self.assertIn("ExecStart=/opt/ploy/bin/ploy-runner collect-markets", service_text)
+        self.assertIn("Restart=always", service_text)
+        self.assertIn("MemoryMax=768M", service_text)
+
+        workflow_text = workflow.read_text()
+        self.assertIn("ploy-market-discovery.service", workflow_text)
+        self.assertLess(
+            workflow_text.index("systemctl restart ploy-market-discovery.service"),
+            workflow_text.index("systemctl restart ploy-quote-collector.service"),
+            "market discovery must refresh catalog before quote collector subscribes",
+        )
+        self.assertLess(
+            workflow_text.index("systemctl restart ploy-market-discovery.service"),
+            workflow_text.index("systemctl restart ploy-pm-trade-collector.service"),
+            "market discovery must refresh catalog before trade collector polls",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a central collect-markets ops command that refreshes Polymarket catalog/metadata without running strategy feeds
- deploy it as ploy-market-discovery.service before quote/trade collectors
- gate Tango deploy on active pm_market_catalog and pm_market_metadata rows so PM collectors do not start from an empty catalog

## Verification
- rustfmt --edition 2024 crates/ploy-market-data/src/scanner.rs crates/ploy-runner-host/src/lib.rs crates/ploy-runner-host/src/ops.rs
- git diff --check
- python3 -m unittest tests.test_runtime_market_data_boundary
- rtk cargo test -p ploy-market-data scanner --lib
- rtk cargo check -p ploy-runner-host --features ops