### PR TITLE
Test PM5D CEX-first direction profile

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -28,7 +28,7 @@ on:
         required: true
         default: "5"
       strategy_profile:
-        description: "Snapshot optimizer profile: mixed, champion, obi_soft, obi_hard, continuation_soft"
+        description: "Snapshot optimizer profile: mixed, champion, obi_soft, obi_hard, continuation_soft, cex_direction_first"
         required: false
         default: "mixed"
       symbols:

--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -55,6 +55,9 @@ enum StrategyProfile {
     ObiHard,
     /// Strategy C: Strategy A plus CEX continuation soft score.
     ContinuationSoft,
+    /// CEX direction first: Binance-side momentum is the directional selector;
+    /// Polymarket ask/liquidity only gate executable EV.
+    CexDirectionFirst,
 }
 
 impl StrategyProfile {
@@ -69,8 +72,11 @@ impl StrategyProfile {
             "continuation" | "continuation_soft" | "c" | "cex_continuation" => {
                 Ok(Self::ContinuationSoft)
             }
+            "cex_direction_first" | "cex_direction" | "direction_first" | "binance_direction" => {
+                Ok(Self::CexDirectionFirst)
+            }
             other => anyhow::bail!(
-                "unknown --strategy-profile {other:?}; expected mixed, champion, obi_soft, obi_hard, or continuation_soft"
+                "unknown --strategy-profile {other:?}; expected mixed, champion, obi_soft, obi_hard, continuation_soft, or cex_direction_first"
             ),
         }
     }
@@ -82,6 +88,7 @@ impl StrategyProfile {
             Self::ObiSoft => "obi_soft",
             Self::ObiHard => "obi_hard",
             Self::ContinuationSoft => "continuation_soft",
+            Self::CexDirectionFirst => "cex_direction_first",
         }
     }
 
@@ -92,6 +99,9 @@ impl StrategyProfile {
             Self::ObiSoft => "champion + CEX/PM order-book imbalance soft score",
             Self::ObiHard => "champion + hard CEX/PM order-book confirmation gate",
             Self::ContinuationSoft => "champion + CEX continuation soft score",
+            Self::CexDirectionFirst => {
+                "CEX direction first + Polymarket executable EV/liquidity gates"
+            }
         }
     }
 
@@ -99,19 +109,20 @@ impl StrategyProfile {
         match self {
             Self::Mixed => None,
             Self::Champion | Self::ObiSoft | Self::ObiHard | Self::ContinuationSoft => Some(true),
+            Self::CexDirectionFirst => Some(true),
         }
     }
 
     fn fixes_cex_contrarian(self) -> Option<bool> {
         match self {
-            Self::Champion | Self::ObiHard => Some(false),
+            Self::Champion | Self::ObiHard | Self::CexDirectionFirst => Some(false),
             Self::Mixed | Self::ObiSoft | Self::ContinuationSoft => None,
         }
     }
 
     fn fixes_confirmation_threshold(self) -> Option<f64> {
         match self {
-            Self::Champion => Some(0.0),
+            Self::Champion | Self::CexDirectionFirst => Some(0.0),
             Self::Mixed | Self::ObiSoft | Self::ObiHard | Self::ContinuationSoft => None,
         }
     }
@@ -119,7 +130,11 @@ impl StrategyProfile {
     fn fixes_require_confirmation(self) -> Option<bool> {
         match self {
             Self::ObiHard => Some(true),
-            Self::Mixed | Self::Champion | Self::ObiSoft | Self::ContinuationSoft => None,
+            Self::Mixed
+            | Self::Champion
+            | Self::ObiSoft
+            | Self::ContinuationSoft
+            | Self::CexDirectionFirst => None,
         }
     }
 }
@@ -349,6 +364,24 @@ fn calibrate_direction_probability(
     (0.5 + (direction_probability - 0.5) * shrink - haircut).clamp(0.01, 0.99)
 }
 
+fn cex_direction_signal(row: &FactorObservationV2) -> f64 {
+    let side = row.side.multiplier();
+    let return_60s = finite_or_zero(row.cex_bar_return_60s * side / 0.006).clamp(-1.0, 1.0);
+    let return_30s = finite_or_zero(row.cex_bar_return_30s * side / 0.003).clamp(-1.0, 1.0);
+    let continuation = finite_or_zero(row.cex_continuation_score_side).clamp(-1.0, 1.0);
+    let consecutive = finite_or_zero(row.cex_consecutive_bar_side / 3.0).clamp(-1.0, 1.0);
+
+    0.35 * return_60s + 0.25 * return_30s + 0.25 * continuation + 0.15 * consecutive
+}
+
+fn cex_direction_probability(row: &FactorObservationV2) -> f64 {
+    let signal = cex_direction_signal(row);
+    if !signal.is_finite() {
+        return f64::NAN;
+    }
+    (0.5 + 0.20 * signal).clamp(0.01, 0.99)
+}
+
 fn confirmation_score(row: &FactorObservationV2, profile: StrategyProfile) -> f64 {
     let side = row.side.multiplier();
     let continuation = finite_or_zero(row.cex_continuation_score_side).clamp(-1.0, 1.0);
@@ -373,6 +406,7 @@ fn confirmation_score(row: &FactorObservationV2, profile: StrategyProfile) -> f6
                 + 0.05 * trade_imbalance
         }
         StrategyProfile::ContinuationSoft => continuation,
+        StrategyProfile::CexDirectionFirst => cex_direction_signal(row),
     }
 }
 
@@ -383,8 +417,8 @@ fn three_layer_entry_score(
     params: &SnapshotThreeLayerParams,
     profile: StrategyProfile,
 ) -> f64 {
-    let alpha_prob = direction_alpha_probability(row, params);
-    let calibrated_prob = calibrated_model_probability(row, params);
+    let alpha_prob = profile_direction_probability(row, params, profile);
+    let calibrated_prob = calibrated_profile_probability(row, params, profile);
     let direction_score = directional_score(alpha_prob, params.min_direction_prob, 0.25, false);
     let distance_score = directional_score(
         row.side_distance_over_sigma,
@@ -425,6 +459,9 @@ fn three_layer_entry_score(
         0.50,
         params.cex_contrarian,
     );
+    if profile == StrategyProfile::CexDirectionFirst {
+        return 0.55 * direction_score + 0.28 * distance_score + 0.17 * drift_score;
+    }
     if profile == StrategyProfile::Champion {
         return 0.33 * direction_score
             + 0.17 * distance_score
@@ -482,6 +519,40 @@ fn calibrated_model_probability(
     )
 }
 
+fn profile_direction_probability(
+    row: &FactorObservationV2,
+    params: &SnapshotThreeLayerParams,
+    profile: StrategyProfile,
+) -> f64 {
+    match profile {
+        StrategyProfile::CexDirectionFirst => cex_direction_probability(row),
+        StrategyProfile::Mixed
+        | StrategyProfile::Champion
+        | StrategyProfile::ObiSoft
+        | StrategyProfile::ObiHard
+        | StrategyProfile::ContinuationSoft => direction_alpha_probability(row, params),
+    }
+}
+
+fn calibrated_profile_probability(
+    row: &FactorObservationV2,
+    params: &SnapshotThreeLayerParams,
+    profile: StrategyProfile,
+) -> f64 {
+    match profile {
+        StrategyProfile::CexDirectionFirst => calibrate_direction_probability(
+            cex_direction_probability(row),
+            params.probability_shrink,
+            params.probability_haircut,
+        ),
+        StrategyProfile::Mixed
+        | StrategyProfile::Champion
+        | StrategyProfile::ObiSoft
+        | StrategyProfile::ObiHard
+        | StrategyProfile::ContinuationSoft => calibrated_model_probability(row, params),
+    }
+}
+
 fn executable_edge_threshold(params: &SnapshotThreeLayerParams) -> f64 {
     params.min_edge.max(0.0)
 }
@@ -528,7 +599,7 @@ fn row_passes_gates(
     if !row.pm_lag_secs.is_finite() || row.pm_lag_secs < 0.0 || row.pm_lag_secs > 15.0 {
         return false;
     }
-    if !row.side_model_prob.is_finite() {
+    if profile != StrategyProfile::CexDirectionFirst && !row.side_model_prob.is_finite() {
         return false;
     }
     if !row.side_distance_over_sigma.is_finite() {
@@ -540,18 +611,21 @@ fn row_passes_gates(
         return false;
     }
 
-    let direction_alpha = direction_alpha_probability(row, params);
+    let direction_alpha = profile_direction_probability(row, params, profile);
     if !direction_alpha.is_finite() || direction_alpha < params.min_direction_prob {
         return false;
     }
 
-    let direction_probability = calibrated_model_probability(row, params);
+    let direction_probability = calibrated_profile_probability(row, params, profile);
     let edge = expected_value_per_share(direction_probability, row.entry_ask);
     if !edge.is_finite() || edge < executable_edge_threshold(params) {
         return false;
     }
     let reward_risk = reward_risk_ratio(row.entry_ask);
     if !reward_risk.is_finite() || reward_risk < params.min_reward_risk {
+        return false;
+    }
+    if profile == StrategyProfile::CexDirectionFirst && !entry_fillable(row) {
         return false;
     }
     let confirmation = confirmation_score(row, profile);
@@ -626,7 +700,7 @@ fn evaluate_snapshot_objective(
             rejected_non_executable += 1;
             continue;
         }
-        let direction_probability = calibrated_model_probability(row, params);
+        let direction_probability = calibrated_profile_probability(row, params, profile);
         let ev_per_share = expected_value_per_share(direction_probability, row.entry_ask);
         let ev_per_stake = expected_value_per_staked_dollar(direction_probability, row.entry_ask);
         if !ev_per_share.is_finite() || !ev_per_stake.is_finite() {
@@ -1681,12 +1755,14 @@ mod tests {
     use super::{
         OPTIMIZER_MAX_DIRECTION_PROB, OPTIMIZER_MIN_DIRECTION_PROB, SnapshotObjectiveMetrics,
         SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
-        calibrate_direction_probability, calibrated_model_probability, compounded_log_growth,
+        calibrate_direction_probability, calibrated_model_probability,
+        calibrated_profile_probability, cex_direction_probability, compounded_log_growth,
         default_min_trades_from_coverage, direction_alpha_probability, directional_score,
         evaluate_snapshot_objective, executable_edge_score, expected_value_per_share,
         expected_value_per_staked_dollar, holistic_selection_objective, max_drawdown,
-        parse_date_end, reward_risk_ratio, row_passes_gates, sample_power_multiplier,
-        stable_compounding_objective, trade_sharpe, transformed_model_probability,
+        parse_date_end, profile_direction_probability, reward_risk_ratio, row_passes_gates,
+        sample_power_multiplier, stable_compounding_objective, trade_sharpe,
+        transformed_model_probability,
     };
     use chrono::{TimeZone, Utc};
     use ploy_research::{FactorObservationV2, Regime, ReviewSide};
@@ -1896,6 +1972,14 @@ mod tests {
         }
     }
 
+    fn with_cex_direction(mut row: FactorObservationV2, direction: f64) -> FactorObservationV2 {
+        row.cex_bar_return_30s = 0.003 * direction;
+        row.cex_bar_return_60s = 0.006 * direction;
+        row.cex_consecutive_bar_side = 3.0 * direction;
+        row.cex_continuation_score_side = 0.80 * direction;
+        row
+    }
+
     #[test]
     fn date_end_is_exclusive_next_day() {
         assert_eq!(
@@ -2050,6 +2134,58 @@ mod tests {
         assert!(
             !row_passes_gates(&row, &params, StrategyProfile::ObiHard),
             "OBI-hard must keep direction/EV gates but add a fillable confirmation veto"
+        );
+    }
+
+    #[test]
+    fn cex_direction_first_rejects_cheap_pm_entry_without_cex_direction() {
+        let mut params = test_params();
+        params.min_direction_prob = 0.56;
+        params.min_entry_score = 0.0;
+        params.min_reward_risk = 0.20;
+        let row = test_row(
+            "event-cheap-but-neutral-cex",
+            0.90,
+            0.12,
+            Some(12.0),
+            true,
+            0,
+        );
+
+        assert_eq!(
+            cex_direction_probability(&row),
+            0.50,
+            "neutral CEX state should not inherit PM model probability"
+        );
+        assert!(
+            !row_passes_gates(&row, &params, StrategyProfile::CexDirectionFirst),
+            "PM ask/edge alone must not pass the CEX-direction-first selector"
+        );
+    }
+
+    #[test]
+    fn cex_direction_first_uses_cex_probability_before_pm_ev_gate() {
+        let mut params = test_params();
+        params.min_direction_prob = 0.56;
+        params.min_entry_score = 0.0;
+        params.min_reward_risk = 0.20;
+        let row = with_cex_direction(
+            test_row("event-cex-supported", 0.10, 0.30, Some(5.0), true, 0),
+            1.0,
+        );
+
+        assert!(direction_alpha_probability(&row, &params) < params.min_direction_prob);
+        assert!(
+            profile_direction_probability(&row, &params, StrategyProfile::CexDirectionFirst)
+                >= params.min_direction_prob
+        );
+        assert!(
+            calibrated_profile_probability(&row, &params, StrategyProfile::CexDirectionFirst)
+                > 0.65
+        );
+        assert!(
+            row_passes_gates(&row, &params, StrategyProfile::CexDirectionFirst),
+            "supported Binance/CEX direction should reach the PM executable EV gate even when the old PM-side model disagrees"
         );
     }
 
@@ -2236,6 +2372,10 @@ mod tests {
             StrategyProfile::parse("cex_continuation").unwrap(),
             StrategyProfile::ContinuationSoft
         );
+        assert_eq!(
+            StrategyProfile::parse("cex_direction_first").unwrap(),
+            StrategyProfile::CexDirectionFirst
+        );
         assert!(StrategyProfile::parse("unknown").is_err());
     }
 
@@ -2257,13 +2397,25 @@ mod tests {
             StrategyProfile::ContinuationSoft.fixes_alpha_contrarian(),
             Some(true)
         );
+        assert_eq!(
+            StrategyProfile::CexDirectionFirst.fixes_alpha_contrarian(),
+            Some(true)
+        );
         assert_eq!(StrategyProfile::Mixed.fixes_alpha_contrarian(), None);
         assert_eq!(
             StrategyProfile::Champion.fixes_cex_contrarian(),
             Some(false)
         );
         assert_eq!(
+            StrategyProfile::CexDirectionFirst.fixes_cex_contrarian(),
+            Some(false)
+        );
+        assert_eq!(
             StrategyProfile::Champion.fixes_confirmation_threshold(),
+            Some(0.0)
+        );
+        assert_eq!(
+            StrategyProfile::CexDirectionFirst.fixes_confirmation_threshold(),
             Some(0.0)
         );
         assert_eq!(StrategyProfile::ObiHard.fixes_cex_contrarian(), Some(false));

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11385,3 +11385,77 @@ Review:
   `target/release/examples/` path, and post-merge run `25199304478` verified
   the fixed optimize path by creating and executing `optimize-runner`
   successfully with `CARGO_TARGET_DIR` set.
+
+# PM5D Profile Matrix Research (2026-05-01)
+
+Issue: https://github.com/proerror77/ploy/issues/256
+
+## Files
+
+- `tasks/todo.md`
+  - Owner: profile-matrix plan, run IDs, and decision evidence.
+
+## Tasks
+
+- [x] Stop the accidental broad profile sweep that included legacy `mixed`.
+- [x] Verify whether evidence run `25193234029` contains a reusable research snapshot.
+- [x] Run staged BTC/ETH optimize matrix on `25193234029`.
+- [x] Promote only a passing profile to a wider symbol/window test.
+- [x] Record decision criteria and follow-up code-change trigger.
+- [x] Add a CEX-direction-first snapshot optimizer profile for the next experiment.
+- [ ] Run `cex_direction_first` on snapshot `25193234029` and compare against champion run `25199998031`.
+
+## Review
+
+- 2026-05-01: `25193234029` contains `factor-review-v2-25193234029` with an
+  embedded `research-snapshot/manifest.json`, so it is usable as a
+  snapshot-backed optimizer input. Its actual snapshot window is
+  `2026-04-25 -> 2026-04-27` and symbols are `BTCUSDT,ETHUSDT`; the staged
+  optimizer dates must use that actual coverage instead of the initially
+  suggested `2026-04-15 -> 2026-04-19` window.
+- 2026-05-01: Accidental broad sweep on snapshot `25194611895` was stopped or
+  discounted. `mixed` run `25199829515` was cancelled. `obi_soft` run
+  `25199829516` succeeded but failed the practical promotion gate because
+  validation fill rate was only `34.07%` despite positive PnL. `champion`
+  `25199829539`, `obi_hard` `25199829510`, and `continuation_soft`
+  `25199829538` were underpowered or failed.
+- 2026-05-01: Promotion gate for current three-layer code: validation must not
+  be underpowered, selection objective should be positive, validation PnL and
+  realized return per stake should be positive, fill rate should be at least
+  `75%`, expectancy calibration gap should stay near zero, and wider-symbol
+  tests should have positive symbol rate at least `67%`. Repeated failure means
+  the next code change should move to a CEX-direction-first selector with PM
+  mispricing/liquidity as the executable gate, rather than more tuning of the
+  old PM-side selection lineage.
+- 2026-05-01: Staged BTC/ETH matrix on snapshot `25193234029` used the actual
+  snapshot coverage (`train=2026-04-25`, `validation=2026-04-26`). Initial
+  25-trial runs were not promotable: `champion` run `25199922914` missed the
+  validation floor by one trade (`39/40`) despite validation PnL `+1303.61`;
+  `obi_hard` run `25199922736` had only `21/40` validation trades; `obi_soft`
+  run `25199922973` was powered (`46` validation trades) with PnL `+1250.99`
+  and fill rate `86.79%`, but selection objective stayed negative (`-11.768`).
+- 2026-05-01: 75-trial reruns found the current best baseline but still not a
+  deployable strategy. `champion` run `25199998031` was powered (`41/40`),
+  validation PnL `+1215.38`, selection objective `+3.815`, realized/stake
+  `+1.976`, EV gap `0.000`, and win rate `78.05%`, but fill rate was only
+  `73.21%`, just under the `75%` practical gate. `obi_soft` run `25199998469`
+  had better fill rate (`89.80%`) but objective `-25.068` and weaker PnL
+  `+846.29`. A 150-trial `champion` rerun `25200043068` overfit into an
+  underpowered validation slice (`23/40`) even though PnL stayed positive.
+- 2026-05-01: Current interpretation: direction probability is not being
+  ignored, and the optimizer is not merely selecting the lowest allowed
+  threshold. The fragile point is selector structure. The old PM/model-side
+  lineage can find profitable validation pockets, but sample power and
+  fillability are unstable. Blindly adding more trials is now lower value than
+  testing a selector that chooses direction from supported Binance/CEX factors
+  first, then uses Polymarket ask/liquidity only as executable EV gates.
+- 2026-05-01: Added snapshot optimizer profile `cex_direction_first`. Its
+  direction probability comes from side-aligned CEX 60s/30s returns,
+  continuation score, and consecutive-bar state. It keeps the meaningful
+  `min_direction_prob`, calibrated EV, reward/risk, PM freshness, and real
+  entry-fillability gates, but the selector score no longer rewards PM
+  momentum or liquidity labels. Local verification passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-cex-direction-first rtk cargo test -p
+  ploy-research --example three_layer_snapshot_optimize --no-default-features`
+  and `CARGO_TARGET_DIR=/tmp/ploy-cex-direction-first rtk cargo check -p
+  ploy-research --example three_layer_snapshot_optimize --no-default-features`.


### PR DESCRIPTION
## Summary
- add snapshot optimizer profile 
- derive direction probability from side-aligned Binance/CEX returns, continuation, and consecutive-bar state
- keep PM ask, reward/risk, freshness, and entry fillability as executable gates instead of selector rewards
- record staged PM5D profile-matrix evidence in 

## Verification
- cargo test: 26 passed (1 suite, 0.00s)
- cargo build: 0 errors, 1 warnings (0 crates)
═══════════════════════════════════════
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/proerror/Documents/ploy-side-audit/vendor/polymarket-client-sdk/Cargo.toml
workspace: /Users/proerror/Documents/ploy-side-audit/Cargo.toml
- 
-  YAML parse

## Research Gate
Do not promote to dry-run/live from this PR. Next step is snapshot-backed optimize on run , comparing against champion baseline .