### PR TITLE
Tighten PM5D CEX-first optimizer gates

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -22,6 +22,7 @@ use serde::Serialize;
 
 const OPTIMIZER_MIN_DIRECTION_PROB: f64 = 0.515;
 const OPTIMIZER_MAX_DIRECTION_PROB: f64 = 0.68;
+const CEX_DIRECTION_FIRST_MIN_DIRECTION_PROB: f64 = 0.55;
 
 #[derive(Debug, Clone, Copy, Serialize)]
 struct SnapshotThreeLayerParams {
@@ -130,11 +131,8 @@ impl StrategyProfile {
     fn fixes_require_confirmation(self) -> Option<bool> {
         match self {
             Self::ObiHard => Some(true),
-            Self::Mixed
-            | Self::Champion
-            | Self::ObiSoft
-            | Self::ContinuationSoft
-            | Self::CexDirectionFirst => None,
+            Self::CexDirectionFirst => Some(false),
+            Self::Mixed | Self::Champion | Self::ObiSoft | Self::ContinuationSoft => None,
         }
     }
 }
@@ -362,6 +360,17 @@ fn calibrate_direction_probability(
     let shrink = probability_shrink.clamp(0.0, 1.0);
     let haircut = probability_haircut.clamp(0.0, 0.49);
     (0.5 + (direction_probability - 0.5) * shrink - haircut).clamp(0.01, 0.99)
+}
+
+fn direction_probability_search_floor(profile: StrategyProfile) -> f64 {
+    match profile {
+        StrategyProfile::CexDirectionFirst => CEX_DIRECTION_FIRST_MIN_DIRECTION_PROB,
+        StrategyProfile::Mixed
+        | StrategyProfile::Champion
+        | StrategyProfile::ObiSoft
+        | StrategyProfile::ObiHard
+        | StrategyProfile::ContinuationSoft => OPTIMIZER_MIN_DIRECTION_PROB,
+    }
 }
 
 fn cex_direction_signal(row: &FactorObservationV2) -> f64 {
@@ -1392,9 +1401,11 @@ fn main() -> Result<()> {
     let train_rows = Arc::new(train_rows);
     let val_rows = Arc::new(val_rows);
     let study: Study<f64> = Study::maximize(TpeSampler::new());
-    let p_min_direction_prob =
-        FloatParam::new(OPTIMIZER_MIN_DIRECTION_PROB, OPTIMIZER_MAX_DIRECTION_PROB)
-            .name("three_layer_min_direction_prob");
+    let p_min_direction_prob = FloatParam::new(
+        direction_probability_search_floor(strategy_profile),
+        OPTIMIZER_MAX_DIRECTION_PROB,
+    )
+    .name("three_layer_min_direction_prob");
     let p_min_distance_over_sigma =
         FloatParam::new(-0.20, 0.60).name("three_layer_min_distance_over_sigma");
     let p_min_confirmation_score =
@@ -1533,7 +1544,7 @@ fn main() -> Result<()> {
     let best_params = SnapshotThreeLayerParams {
         min_direction_prob: best
             .get(&p_min_direction_prob)
-            .unwrap_or(OPTIMIZER_MIN_DIRECTION_PROB),
+            .unwrap_or_else(|| direction_probability_search_floor(strategy_profile)),
         min_distance_over_sigma: best.get(&p_min_distance_over_sigma).unwrap_or(0.10),
         min_confirmation_score: strategy_profile
             .fixes_confirmation_threshold()
@@ -1757,12 +1768,12 @@ mod tests {
         SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
         calibrate_direction_probability, calibrated_model_probability,
         calibrated_profile_probability, cex_direction_probability, compounded_log_growth,
-        default_min_trades_from_coverage, direction_alpha_probability, directional_score,
-        evaluate_snapshot_objective, executable_edge_score, expected_value_per_share,
-        expected_value_per_staked_dollar, holistic_selection_objective, max_drawdown,
-        parse_date_end, profile_direction_probability, reward_risk_ratio, row_passes_gates,
-        sample_power_multiplier, stable_compounding_objective, trade_sharpe,
-        transformed_model_probability,
+        default_min_trades_from_coverage, direction_alpha_probability,
+        direction_probability_search_floor, directional_score, evaluate_snapshot_objective,
+        executable_edge_score, expected_value_per_share, expected_value_per_staked_dollar,
+        holistic_selection_objective, max_drawdown, parse_date_end, profile_direction_probability,
+        reward_risk_ratio, row_passes_gates, sample_power_multiplier, stable_compounding_objective,
+        trade_sharpe, transformed_model_probability,
     };
     use chrono::{TimeZone, Utc};
     use ploy_research::{FactorObservationV2, Regime, ReviewSide};
@@ -2085,6 +2096,11 @@ mod tests {
             "optimizer must not search neutral direction-probability gates"
         );
         assert!(OPTIMIZER_MIN_DIRECTION_PROB < OPTIMIZER_MAX_DIRECTION_PROB);
+        assert!(
+            direction_probability_search_floor(StrategyProfile::CexDirectionFirst)
+                > OPTIMIZER_MIN_DIRECTION_PROB,
+            "CEX-direction-first must not solve by hugging the legacy weak direction floor"
+        );
     }
 
     #[test]
@@ -2422,6 +2438,10 @@ mod tests {
         assert_eq!(
             StrategyProfile::ObiHard.fixes_require_confirmation(),
             Some(true)
+        );
+        assert_eq!(
+            StrategyProfile::CexDirectionFirst.fixes_require_confirmation(),
+            Some(false)
         );
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11403,7 +11403,8 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Promote only a passing profile to a wider symbol/window test.
 - [x] Record decision criteria and follow-up code-change trigger.
 - [x] Add a CEX-direction-first snapshot optimizer profile for the next experiment.
-- [ ] Run `cex_direction_first` on snapshot `25193234029` and compare against champion run `25199998031`.
+- [x] Run `cex_direction_first` on snapshot `25193234029` and compare against champion run `25199998031`.
+- [ ] Tighten `cex_direction_first` confirmation/direction search boundaries and rerun.
 
 ## Review
 
@@ -11459,3 +11460,17 @@ Issue: https://github.com/proerror77/ploy/issues/256
   ploy-research --example three_layer_snapshot_optimize --no-default-features`
   and `CARGO_TARGET_DIR=/tmp/ploy-cex-direction-first rtk cargo check -p
   ploy-research --example three_layer_snapshot_optimize --no-default-features`.
+- 2026-05-01: Main optimize run `25200366917` tested `cex_direction_first`
+  with 75 trials on snapshot `25193234029`. The run was powered and executable:
+  validation trades `68/40`, PnL `+1091.39`, fill rate `100%`, realized/stake
+  `+1.070`, and EV gap `0.133`. It is still not promotable because selection
+  objective was `-85.794`, below champion baseline `+3.815`, and the best
+  threshold hugged the weak legacy floor (`three_layer_min_direction_prob =
+  0.515`).
+- 2026-05-01: Follow-up run `25200409666` with 150 trials confirmed the current
+  `cex_direction_first` search boundary is not robust: the best result was
+  underpowered (`train=19`, `validation=8`, `min_trades=40`) and exited
+  non-zero by design. Next fix is not more blind trials; pin
+  `three_layer_require_confirmation=false` for this profile and raise its
+  direction-probability search floor so it cannot solve by weak CEX direction
+  plus cheap PM EV alone.


### PR DESCRIPTION
## Summary
- pin cex_direction_first confirmation off in the snapshot optimizer
- raise the profile-specific direction probability search floor to avoid weak CEX-direction solutions
- record cex_direction_first 75-trial and 150-trial evidence in tasks/todo.md

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-cex-direction-gate rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- CARGO_TARGET_DIR=/tmp/ploy-cex-direction-gate rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- git diff --check

## Research Gate
Next step after merge is a main snapshot optimize rerun on 25193234029. Do not promote to dry-run/live unless it beats champion 25199998031 and clears fill/sample gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal optimization examples and testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->