### PR TITLE
Select only fillable PM5D snapshot entries

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -634,7 +634,7 @@ fn row_passes_gates(
     if !reward_risk.is_finite() || reward_risk < params.min_reward_risk {
         return false;
     }
-    if profile == StrategyProfile::CexDirectionFirst && !entry_fillable(row) {
+    if !entry_fillable(row) {
         return false;
     }
     let confirmation = confirmation_score(row, profile);
@@ -2206,7 +2206,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_objective_counts_only_fillable_executable_orders() {
+    fn snapshot_gate_rejects_non_fillable_entries_before_selection() {
         let mut params = test_params();
         params.cooldown_secs = 0;
         params.min_entry_score = 0.0;
@@ -2218,9 +2218,10 @@ mod tests {
         let metrics =
             evaluate_snapshot_objective(&rows, &params, 1, 15.0, StrategyProfile::Champion);
 
-        assert_eq!(metrics.selected, 2);
+        assert_eq!(metrics.candidates, 1);
+        assert_eq!(metrics.selected, 1);
         assert_eq!(metrics.trades, 1);
-        assert_eq!(metrics.rejected_non_executable, 1);
+        assert_eq!(metrics.rejected_non_executable, 0);
         assert!((metrics.net_pnl - 2.0).abs() < 1e-9);
         assert!(metrics.avg_expected_value_per_stake.is_finite());
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11404,7 +11404,8 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Record decision criteria and follow-up code-change trigger.
 - [x] Add a CEX-direction-first snapshot optimizer profile for the next experiment.
 - [x] Run `cex_direction_first` on snapshot `25193234029` and compare against champion run `25199998031`.
-- [ ] Tighten `cex_direction_first` confirmation/direction search boundaries and rerun.
+- [x] Tighten `cex_direction_first` confirmation/direction search boundaries and rerun.
+- [ ] Move snapshot selection to real entry-fillable orders before rerunning champion.
 
 ## Review
 
@@ -11474,3 +11475,11 @@ Issue: https://github.com/proerror77/ploy/issues/256
   `three_layer_require_confirmation=false` for this profile and raise its
   direction-probability search floor so it cannot solve by weak CEX direction
   plus cheap PM EV alone.
+- 2026-05-01: PR #275 merged the tighter `cex_direction_first` boundary. Main
+  rerun `25200601584` confirmed pure hard CEX direction is too sparse on this
+  snapshot: validation trades `8/40`, train trades `4/40`, validation PnL
+  `+86.71`, fill rate `100%`, but train PnL was slightly negative and the run
+  correctly failed as underpowered. Next research path is to fix the optimizer
+  accounting boundary for all profiles: require real entry fillability before a
+  row is counted as a selected strategy order, matching the runtime ask-size
+  check and the user's filled-order requirement.


### PR DESCRIPTION
## Summary
- require current entry fillability before a snapshot row can be selected as a strategy order
- update optimizer tests so non-fillable entries are rejected before selection
- record cex_direction_first rerun evidence and the fillable-order accounting fix in tasks/todo.md

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-fillable-selection rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- CARGO_TARGET_DIR=/tmp/ploy-fillable-selection rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- git diff --check

## Research Gate
After merge, rerun champion on snapshot 25193234029 because prior champion 25199998031 narrowly missed fill-rate gate under post-selection fill accounting.