### PR TITLE
Measure PM5D optimizer log growth against risk budget

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 const OPTIMIZER_MIN_DIRECTION_PROB: f64 = 0.515;
 const OPTIMIZER_MAX_DIRECTION_PROB: f64 = 0.68;
 const CEX_DIRECTION_FIRST_MIN_DIRECTION_PROB: f64 = 0.55;
+const LOG_GROWTH_RISK_BUDGET_STAKES: f64 = 40.0;
 
 #[derive(Debug, Clone, Copy, Serialize)]
 struct SnapshotThreeLayerParams {
@@ -984,9 +985,9 @@ fn max_drawdown(pnls: &[f64]) -> f64 {
 }
 
 fn compounded_log_growth(pnls: &[f64], stake_usd: f64) -> f64 {
-    let stake = stake_usd.max(1.0);
+    let risk_budget = (stake_usd * LOG_GROWTH_RISK_BUDGET_STAKES).max(1.0);
     pnls.iter()
-        .map(|pnl| (1.0 + (pnl / stake).clamp(-0.99, 10.0)).ln())
+        .map(|pnl| (1.0 + (pnl / risk_budget).clamp(-0.99, 10.0)).ln())
         .sum()
 }
 
@@ -2309,7 +2310,14 @@ mod tests {
     fn drawdown_and_log_growth_capture_compounding_risk() {
         assert_eq!(max_drawdown(&[10.0, -5.0, -20.0, 15.0]), 25.0);
         assert!(compounded_log_growth(&[1.0, 1.0, 1.0], 15.0) > 0.0);
-        assert!(compounded_log_growth(&[-15.0], 15.0) < -4.0);
+        assert!(
+            compounded_log_growth(&[-15.0], 15.0) > -0.1,
+            "a fixed-size binary loss should be measured against the research risk budget, not treated as total ruin"
+        );
+        assert!(
+            compounded_log_growth(&[-15.0, 5.0, 5.0, 5.0], 15.0).abs() < 0.01,
+            "fixed-dollar sizing should make offsetting PnL roughly neutral in log-growth terms"
+        );
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11405,7 +11405,8 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Add a CEX-direction-first snapshot optimizer profile for the next experiment.
 - [x] Run `cex_direction_first` on snapshot `25193234029` and compare against champion run `25199998031`.
 - [x] Tighten `cex_direction_first` confirmation/direction search boundaries and rerun.
-- [ ] Move snapshot selection to real entry-fillable orders before rerunning champion.
+- [x] Move snapshot selection to real entry-fillable orders before rerunning champion.
+- [ ] Fix optimizer log-growth risk budget so fixed 15u binary losses are not treated as total bankroll ruin.
 
 ## Review
 
@@ -11483,3 +11484,12 @@ Issue: https://github.com/proerror77/ploy/issues/256
   accounting boundary for all profiles: require real entry fillability before a
   row is counted as a selected strategy order, matching the runtime ask-size
   check and the user's filled-order requirement.
+- 2026-05-01: PR #276 merged the fillable-first selector accounting. Champion
+  reruns on main showed the edge did not disappear under real fillability:
+  `25200727084` had validation trades `51/40`, PnL `+1408.82`, fill rate
+  `100%`, realized/stake `+1.842`, EV gap `0.000`; `25200752154` had
+  validation trades `93/40`, PnL `+1297.33`, fill rate `100%`. Both still had
+  negative selection objective because `compounded_log_growth` measured
+  `ln(1 + pnl / stake)`, so a normal fixed-size binary loss near `-15u` was
+  treated like near-total bankroll ruin. The next fix should measure log growth
+  against a research risk budget, not one order's stake.


### PR DESCRIPTION
## Summary
- change snapshot optimizer log-growth accounting from pnl / one-order stake to pnl / research risk budget
- keep log-growth as a bounded path-risk term without treating one fixed-size binary loss as bankruptcy
- record fillable-first champion rerun evidence in tasks/todo.md

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-log-growth-risk rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- CARGO_TARGET_DIR=/tmp/ploy-log-growth-risk rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --no-default-features
- git diff --check

## Research Gate
After merge, rerun champion on snapshot 25193234029. Objective values before this commit are not directly comparable.