### PR TITLE
Keep Event ML builds off ploy-ci

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -52,9 +52,74 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  build-event-ml-examples:
+    name: Build event ML examples on GitHub-hosted runner
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: event-ml-rolling-build-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build database-backed exporter
+        run: |
+          set -euo pipefail
+          cargo build --locked \
+            -p ploy-research \
+            --features db,polars-export \
+            --example factor_research
+
+      - name: Build local event ML executors
+        run: |
+          set -euo pipefail
+          cargo build --locked \
+            -p ploy-research \
+            --features polars-export \
+            --example event_dataset_rolling_windows \
+            --example event_ml_rolling_workflow \
+            --example event_ml_workflow \
+            --example event_dataset_coverage \
+            --example event_factor_attribution \
+            --example event_dataset_baseline \
+            --example event_ml_walk_forward
+
+      - name: Stage event ML binaries
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/event-ml-bin
+          for binary in \
+            factor_research \
+            event_dataset_rolling_windows \
+            event_ml_rolling_workflow \
+            event_ml_workflow \
+            event_dataset_coverage \
+            event_factor_attribution \
+            event_dataset_baseline \
+            event_ml_walk_forward
+          do
+            cp "target/debug/examples/${binary}" "artifacts/event-ml-bin/${binary}"
+          done
+
+      - name: Upload event ML binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: event-ml-example-binaries-${{ github.run_id }}
+          path: artifacts/event-ml-bin/
+          retention-days: 3
+
   event-ml:
     name: Generate event ML rolling evidence on ploy-ci-1
     runs-on: [self-hosted, ploy-ci-1]
+    needs: build-event-ml-examples
     timeout-minutes: 150
     environment: ploy-ci-1
 
@@ -71,8 +136,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.git_ref }}
 
-      - name: Add cargo to PATH
-        run: echo "/home/runner/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Download event ML binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: event-ml-example-binaries-${{ github.run_id }}
+          path: artifacts/event-ml-bin
+
+      - name: Prepare event ML binaries
+        run: chmod +x artifacts/event-ml-bin/*
 
       - name: Parse advanced options
         env:
@@ -110,40 +181,13 @@ jobs:
                   handle.write(f"EVENT_ML_{key.upper()}={value}\n")
           PY
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-targets: "true"
-          key: event-ml-rolling-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
-
-      - name: Build event ML examples
-        run: |
-          set -euo pipefail
-          . /home/runner/.cargo/env
-          cargo build --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_research \
-            --example event_dataset_rolling_windows \
-            --example event_ml_rolling_workflow \
-            --example event_ml_workflow \
-            --example event_dataset_coverage \
-            --example event_factor_attribution \
-            --example event_dataset_baseline \
-            --example event_ml_walk_forward
-
       - name: Export large event-root dataset
         run: |
           set -euo pipefail
-          . /home/runner/.cargo/env
           rm -rf artifacts/event-ml
           mkdir -p artifacts/event-ml/source_event_root artifacts/event-ml/reports
 
-          cargo run --locked \
-            -p ploy-research \
-            --features db,polars-export \
-            --example factor_research -- \
+          artifacts/event-ml-bin/factor_research \
             --db-url "postgresql://postgres:postgres@172.16.0.204:5432/ploy" \
             --symbols "${{ github.event.inputs.symbols }}" \
             --start-date "${{ github.event.inputs.start_date }}" \
@@ -158,12 +202,8 @@ jobs:
       - name: Split source dataset into rolling windows
         run: |
           set -euo pipefail
-          . /home/runner/.cargo/env
 
-          cargo run --locked \
-            -p ploy-research \
-            --features polars-export \
-            --example event_dataset_rolling_windows -- \
+          artifacts/event-ml-bin/event_dataset_rolling_windows \
             --dataset artifacts/event-ml/source_event_root \
             --window-events "${{ github.event.inputs.child_window_events }}" \
             --output-root artifacts/event-ml/rolling_datasets \
@@ -173,13 +213,9 @@ jobs:
         if: ${{ github.event.inputs.run_workflow == 'true' }}
         run: |
           set -euo pipefail
-          . /home/runner/.cargo/env
 
           DATASETS="$(paste -sd, artifacts/event-ml/rolling_datasets/rolling_datasets.txt)"
-          cargo run --locked \
-            -p ploy-research \
-            --features polars-export \
-            --example event_ml_rolling_workflow -- \
+          artifacts/event-ml-bin/event_ml_rolling_workflow \
             --datasets "${DATASETS}" \
             --output-root artifacts/event-ml/rolling_workflow \
             --entry-secs "${EVENT_ML_ENTRY_SECS}" \

--- a/crates/ploy-research/examples/event_ml_rolling_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_rolling_workflow.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
             .output_root
             .join(format!("window_{window_id:03}_event_ml"));
         let command_args = event_ml_workflow_args(&config, dataset, &output_dir, &prior_run_dirs);
-        let command = shell_command("event_ml_workflow", &command_args, true);
+        let command = event_ml_workflow_command_string(&command_args);
 
         eprintln!();
         eprintln!("--- rolling_window={window_id} ---");
@@ -40,18 +40,7 @@ fn main() -> Result<()> {
         } else {
             fs::create_dir_all(&output_dir)
                 .with_context(|| format!("create output dir {}", output_dir.display()))?;
-            let status = Command::new("cargo")
-                .args([
-                    "run",
-                    "-p",
-                    "ploy-research",
-                    "--example",
-                    "event_ml_workflow",
-                    "--features",
-                    "polars-export",
-                    "--",
-                ])
-                .args(&command_args)
+            let status = event_ml_workflow_command(&command_args)
                 .status()
                 .with_context(|| format!("spawn rolling window {window_id}"))?;
             ensure_success(window_id, status)?;
@@ -321,6 +310,50 @@ fn ensure_success(window_id: usize, status: ExitStatus) -> Result<()> {
     } else {
         bail!("rolling window {window_id} failed with status {status}");
     }
+}
+
+fn event_ml_workflow_command(args: &[String]) -> Command {
+    if let Some(binary) = sibling_example_binary("event_ml_workflow") {
+        let mut command = Command::new(binary);
+        command.args(args);
+        command
+    } else {
+        let mut command = Command::new("cargo");
+        command.args([
+            "run",
+            "-p",
+            "ploy-research",
+            "--example",
+            "event_ml_workflow",
+            "--features",
+            "polars-export",
+            "--",
+        ]);
+        command.args(args);
+        command
+    }
+}
+
+fn event_ml_workflow_command_string(args: &[String]) -> String {
+    if let Some(binary) = sibling_example_binary("event_ml_workflow") {
+        let mut parts = vec![shell_quote(&binary.display().to_string())];
+        parts.extend(args.iter().map(|arg| shell_quote(arg)));
+        parts.join(" ")
+    } else {
+        shell_command("event_ml_workflow", args, true)
+    }
+}
+
+fn sibling_example_binary(example: &str) -> Option<PathBuf> {
+    let current = env::current_exe().ok()?;
+    let dir = current.parent()?;
+    let binary_name = if cfg!(windows) {
+        format!("{example}.exe")
+    } else {
+        example.to_string()
+    };
+    let candidate = dir.join(binary_name);
+    candidate.is_file().then_some(candidate)
 }
 
 fn default_output_root() -> PathBuf {

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -198,12 +198,20 @@ gh workflow run event-ml-rolling-evidence.yml \
   -f run_workflow=true
 ```
 
-The workflow runs on `ploy-ci-1`, reads the remote research database at
-`172.16.0.204`, and performs:
+The workflow builds the required Rust examples on a GitHub-hosted Ubuntu
+runner first, uploads those binaries as an artifact, then runs the DB-adjacent
+evidence phase on `ploy-ci-1`. `ploy-ci-1` should only download and execute
+the prebuilt binaries while reading the remote research database at
+`172.16.0.204`; do not reintroduce `cargo build` or `cargo run` steps there.
+The self-hosted phase performs:
 
 1. `factor_research --export-event-dataset`
 2. `event_dataset_rolling_windows`
 3. `event_ml_rolling_workflow`
+
+`event_ml_rolling_workflow` also expects the sibling `event_ml_workflow`
+binary to be present next to it in the downloaded artifact, so rolling windows
+do not spawn nested Cargo builds on `ploy-ci-1`.
 
 It uploads a compact report artifact by default and deliberately avoids
 uploading raw Parquet datasets unless `upload_parquet_datasets=true` is passed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11386,6 +11386,43 @@ Review:
   the fixed optimize path by creating and executing `optimize-runner`
   successfully with `CARGO_TARGET_DIR` set.
 
+# Event ML Build Offload (2026-05-01)
+
+## Files
+
+- `.github/workflows/event-ml-rolling-evidence.yml`
+  - Owner: GitHub-hosted build job and self-hosted execution boundary.
+- `crates/ploy-research/examples/event_ml_rolling_workflow.rs`
+  - Owner: rolling workflow child process selection.
+- `docs/runbooks/event-ml-automl-workflow.md`
+  - Owner: operator-facing workflow boundary.
+- `tasks/todo.md`
+  - Owner: implementation and verification notes.
+
+## Tasks
+
+- [x] Offload Event ML example compilation from `ploy-ci-1` to a GitHub-hosted runner.
+- [x] Ensure rolling Event ML execution uses sibling binaries instead of nested `cargo run`.
+- [x] Document the `ploy-ci-1` no-Cargo-build boundary for Event ML rolling evidence.
+- [x] Verify workflow syntax, Rust formatting/build behavior, and git diff hygiene.
+
+## Review
+
+- 2026-05-01: `event-ml-rolling-evidence.yml` now builds the required
+  `ploy-research` examples on GitHub-hosted `ubuntu-22.04`, uploads them as
+  `event-ml-example-binaries`, and makes the `ploy-ci-1` job download and
+  execute those binaries directly. The self-hosted job no longer has
+  `rust-cache`, `cargo build`, `cargo run`, or `/home/runner/.cargo/env` steps.
+- 2026-05-01: `event_ml_rolling_workflow` now prefers a sibling
+  `event_ml_workflow` binary before falling back to `cargo run`, so downloaded
+  CI artifacts do not spawn nested Cargo builds on `ploy-ci-1`.
+- 2026-05-01: Local verification passed: `ruby -e 'require "yaml";
+  YAML.load_file(".github/workflows/event-ml-rolling-evidence.yml")'`,
+  `rustfmt --check crates/ploy-research/examples/event_ml_rolling_workflow.rs`,
+  `git diff --check`, and `rtk cargo test -p ploy-research --example
+  event_ml_rolling_workflow --features polars-export
+  current_window_receives_prior_run_dirs`.
+
 # PM5D Profile Matrix Research (2026-05-01)
 
 Issue: https://github.com/proerror77/ploy/issues/256


### PR DESCRIPTION
## Summary

- build Event ML Rust examples on GitHub-hosted `ubuntu-22.04` and upload them as a short-lived artifact
- keep `ploy-ci-1` limited to downloading and executing the prebuilt binaries against the internal research DB
- make `event_ml_rolling_workflow` prefer the sibling `event_ml_workflow` binary so rolling windows do not spawn nested `cargo run`
- document the no-Cargo-build boundary for the Event ML rolling evidence workflow

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/event-ml-rolling-evidence.yml")'`
- `rustfmt --check crates/ploy-research/examples/event_ml_rolling_workflow.rs`
- `rtk cargo test -p ploy-research --example event_ml_rolling_workflow --features polars-export current_window_receives_prior_run_dirs`
- `git diff --check`

## Notes

Supersedes the stale/conflicted direction in #176 without reverting current `main` workflow defaults.
