### PR TITLE
Keep research snapshots on ploy-ci-1

### DIFF
--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: top_n, snapshot/data/audit settings, issue_number"
+        description: "Advanced options JSON: top_n, snapshot/data/audit settings, issue_number, local snapshot registry"
         required: false
-        default: '{"top_n":50,"min_observations":20,"top_quantile":0.2,"compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":""}'
+        default: '{"top_n":50,"min_observations":20,"top_quantile":0.2,"compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":"","snapshot_registry_dir":""}'
 
 concurrency:
   group: factor-review-v2-${{ github.ref }}
@@ -109,6 +109,7 @@ jobs:
               "audit_lookback_hours": "168",
               "data_gate": "never",
               "issue_number": "",
+              "snapshot_registry_dir": "",
           }
           bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
           choices = {
@@ -274,9 +275,22 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
+          registry_args=()
+          if [ -n "${FACTOR_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${FACTOR_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          if scripts/restore_research_snapshot.sh \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md \
+            "${registry_args[@]}"; then
+            echo "Restored runner-local research snapshot."
+            exit 0
+          fi
           cache_args=()
           if [ -n "${RUNNER_WORKSPACE:-}" ]; then
-            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-artifacts")
           fi
           if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
@@ -366,6 +380,24 @@ jobs:
             --data-audit-report data-gap-audit.json \
             "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
+
+      - name: Publish snapshot to runner-local registry
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
+        run: |
+          set -euo pipefail
+          if [ "${FACTOR_COMPILE_SNAPSHOT}" != "true" ] || [ ! -f artifacts/research-snapshot/manifest.json ]; then
+            echo "No freshly compiled snapshot to publish."
+            exit 0
+          fi
+          registry_args=()
+          if [ -n "${FACTOR_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${FACTOR_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          scripts/publish_research_snapshot_registry.sh \
+            --snapshot-dir artifacts/research-snapshot \
+            --run-id "${GITHUB_RUN_ID}" \
+            --retention-days 14 \
+            "${registry_args[@]}"
 
       - name: Run factor review
         run: |
@@ -461,23 +493,19 @@ jobs:
           if [ -d artifacts/factor-review-v2 ]; then
             cp -R artifacts/factor-review-v2 artifacts/factor-review-v2-upload/
           fi
-          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
-            if [ -d artifacts/research-snapshot ]; then
-              cp -R artifacts/research-snapshot artifacts/factor-review-v2-upload/
+          mkdir -p artifacts/factor-review-v2-upload/snapshot-provenance
+          {
+            echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
+            echo "producer_run_id=${GITHUB_RUN_ID}"
+            echo "full_snapshot_embedded=false"
+            echo "registry=runner-local"
+          } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
+          for file in manifest.json quality.md data-gap-audit.md data-gap-audit.json compile.log; do
+            if [ -f "artifacts/research-snapshot/${file}" ]; then
+              cp "artifacts/research-snapshot/${file}" \
+                "artifacts/factor-review-v2-upload/snapshot-provenance/${file}"
             fi
-          else
-            mkdir -p artifacts/factor-review-v2-upload/snapshot-provenance
-            {
-              echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
-              echo "full_snapshot_embedded=false"
-            } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
-            for file in manifest.json quality.md data-gap-audit.md; do
-              if [ -f "artifacts/research-snapshot/${file}" ]; then
-                cp "artifacts/research-snapshot/${file}" \
-                  "artifacts/factor-review-v2-upload/snapshot-provenance/${file}"
-              fi
-            done
-          fi
+          done
 
       - name: Upload report artifact
         if: always()

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -28,9 +28,9 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings"
+        description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings, local snapshot registry"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":""}'
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","issue_number":"","snapshot_registry_dir":""}'
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
@@ -104,6 +104,7 @@ jobs:
               "audit_lookback_hours": "168",
               "data_gate": "never",
               "issue_number": "",
+              "snapshot_registry_dir": "",
           }
           bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
           choices = {
@@ -269,9 +270,22 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
+          registry_args=()
+          if [ -n "${WALK_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${WALK_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          if scripts/restore_research_snapshot.sh \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md \
+            "${registry_args[@]}"; then
+            echo "Restored runner-local research snapshot."
+            exit 0
+          fi
           cache_args=()
           if [ -n "${RUNNER_WORKSPACE:-}" ]; then
-            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-artifacts")
           fi
           if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \
@@ -362,6 +376,24 @@ jobs:
             "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
 
+      - name: Publish snapshot to runner-local registry
+        if: ${{ github.event.inputs.snapshot_run_id == '' }}
+        run: |
+          set -euo pipefail
+          if [ "${WALK_COMPILE_SNAPSHOT}" != "true" ] || [ ! -f artifacts/research-snapshot/manifest.json ]; then
+            echo "No freshly compiled snapshot to publish."
+            exit 0
+          fi
+          registry_args=()
+          if [ -n "${WALK_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${WALK_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          scripts/publish_research_snapshot_registry.sh \
+            --snapshot-dir artifacts/research-snapshot \
+            --run-id "${GITHUB_RUN_ID}" \
+            --retention-days 14 \
+            "${registry_args[@]}"
+
       - name: Run factor walk-forward
         run: |
           set -euo pipefail
@@ -439,23 +471,19 @@ jobs:
           if [ -d artifacts/factor-walk-forward-v2 ]; then
             cp -R artifacts/factor-walk-forward-v2 artifacts/factor-walk-forward-v2-upload/
           fi
-          if [ -z "${{ github.event.inputs.snapshot_run_id }}" ]; then
-            if [ -d artifacts/research-snapshot ]; then
-              cp -R artifacts/research-snapshot artifacts/factor-walk-forward-v2-upload/
+          mkdir -p artifacts/factor-walk-forward-v2-upload/snapshot-provenance
+          {
+            echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
+            echo "producer_run_id=${GITHUB_RUN_ID}"
+            echo "full_snapshot_embedded=false"
+            echo "registry=runner-local"
+          } > artifacts/factor-walk-forward-v2-upload/snapshot-provenance/source.txt
+          for file in manifest.json quality.md data-gap-audit.md data-gap-audit.json compile.log; do
+            if [ -f "artifacts/research-snapshot/${file}" ]; then
+              cp "artifacts/research-snapshot/${file}" \
+                "artifacts/factor-walk-forward-v2-upload/snapshot-provenance/${file}"
             fi
-          else
-            mkdir -p artifacts/factor-walk-forward-v2-upload/snapshot-provenance
-            {
-              echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
-              echo "full_snapshot_embedded=false"
-            } > artifacts/factor-walk-forward-v2-upload/snapshot-provenance/source.txt
-            for file in manifest.json quality.md data-gap-audit.md; do
-              if [ -f "artifacts/research-snapshot/${file}" ]; then
-                cp "artifacts/research-snapshot/${file}" \
-                  "artifacts/factor-walk-forward-v2-upload/snapshot-provenance/${file}"
-              fi
-            done
-          fi
+          done
 
       - name: Upload report artifact
         if: always()

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout"
+        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout, local snapshot registry"
         required: false
-        default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":""}'
+        default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":"","snapshot_registry_dir":""}'
 
 concurrency:
   group: optimize-${{ github.event.inputs.git_ref || github.ref }}-${{ github.event.inputs.strategy_profile || 'mixed' }}
@@ -113,6 +113,7 @@ jobs:
               "optimize_timeout_minutes": "90",
               "allow_live_parquet_debug": "false",
               "issue_number": "",
+              "snapshot_registry_dir": "",
           }
           bool_keys = {"allow_large_window", "preflight_only", "allow_live_parquet_debug"}
           raw = os.environ.get("OPTIONS_JSON", "").strip()
@@ -150,9 +151,22 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf artifacts/research-snapshot
+          registry_args=()
+          if [ -n "${OPT_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${OPT_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          if scripts/restore_research_snapshot.sh \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md \
+            "${registry_args[@]}"; then
+            echo "Restored runner-local research snapshot."
+            exit 0
+          fi
           cache_args=()
           if [ -n "${RUNNER_WORKSPACE:-}" ]; then
-            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-snapshots")
+            cache_args=(--cache-dir "${RUNNER_WORKSPACE}/_ploy-research-artifacts")
           fi
           if python3 scripts/download_github_artifact.py \
             --run-id "${SNAPSHOT_RUN_ID}" \

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -24,9 +24,9 @@ on:
         required: true
         default: "15"
       options_json:
-        description: "Advanced options JSON: sampling, optimizer_data_dir, data_profile, audit gate"
+        description: "Advanced options JSON: sampling, optimizer_data_dir, data_profile, audit gate, local snapshot registry"
         required: false
-        default: '{"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never"}'
+        default: '{"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":""}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -81,6 +81,7 @@ jobs:
               "custom_required_sources": "",
               "audit_lookback_hours": "168",
               "data_gate": "never",
+              "snapshot_registry_dir": "",
           }
           choices = {
               "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
@@ -260,6 +261,19 @@ jobs:
             "${deribit_args[@]}" \
             2>&1 | tee artifacts/research-snapshot/compile.log
 
+      - name: Publish snapshot to runner-local registry
+        run: |
+          set -euo pipefail
+          registry_args=()
+          if [ -n "${SNAPSHOT_SNAPSHOT_REGISTRY_DIR}" ]; then
+            registry_args=(--registry-dir "${SNAPSHOT_SNAPSHOT_REGISTRY_DIR}")
+          fi
+          scripts/publish_research_snapshot_registry.sh \
+            --snapshot-dir artifacts/research-snapshot \
+            --run-id "${GITHUB_RUN_ID}" \
+            --retention-days 14 \
+            "${registry_args[@]}"
+
       - name: Publish summary
         if: always()
         run: |
@@ -289,11 +303,28 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload research snapshot artifact
+      - name: Stage snapshot provenance artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot-provenance
+          mkdir -p artifacts/research-snapshot-provenance
+          for file in manifest.json quality.md data-gap-audit.md data-gap-audit.json compile.log; do
+            if [ -f "artifacts/research-snapshot/${file}" ]; then
+              cp "artifacts/research-snapshot/${file}" artifacts/research-snapshot-provenance/
+            fi
+          done
+          {
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "full_snapshot_embedded=false"
+            echo "registry=runner-local"
+          } > artifacts/research-snapshot-provenance/source.txt
+
+      - name: Upload snapshot provenance artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: research-snapshot-${{ github.run_id }}
-          path: artifacts/research-snapshot/
+          name: research-snapshot-provenance-${{ github.run_id }}
+          path: artifacts/research-snapshot-provenance/
           compression-level: 0
           retention-days: 14

--- a/scripts/publish_research_snapshot_registry.sh
+++ b/scripts/publish_research_snapshot_registry.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+snapshot_dir=""
+run_id="${GITHUB_RUN_ID:-}"
+registry_dir="${PLOY_RESEARCH_SNAPSHOT_REGISTRY:-}"
+retention_days="14"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --snapshot-dir)
+      snapshot_dir="${2:?missing --snapshot-dir value}"
+      shift 2
+      ;;
+    --run-id)
+      run_id="${2:?missing --run-id value}"
+      shift 2
+      ;;
+    --registry-dir)
+      registry_dir="${2:?missing --registry-dir value}"
+      shift 2
+      ;;
+    --retention-days)
+      retention_days="${2:?missing --retention-days value}"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "${snapshot_dir}" ] || [ ! -d "${snapshot_dir}" ]; then
+  echo "snapshot directory is required" >&2
+  exit 2
+fi
+if [ -z "${run_id}" ]; then
+  echo "run id is required" >&2
+  exit 2
+fi
+if [ -z "${registry_dir}" ]; then
+  registry_dir="${RUNNER_WORKSPACE:-/tmp}/_ploy-research-snapshots"
+fi
+if [ ! -f "${snapshot_dir}/manifest.json" ]; then
+  echo "snapshot manifest not found: ${snapshot_dir}/manifest.json" >&2
+  exit 2
+fi
+
+snapshot_hash="$(
+  python3 - <<'PY' "${snapshot_dir}/manifest.json"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    print(json.load(fh)["snapshot_hash"])
+PY
+)"
+
+mkdir -p "${registry_dir}/by-hash" "${registry_dir}/by-run"
+hash_dir="${registry_dir}/by-hash/${snapshot_hash}"
+tmp_dir="${registry_dir}/by-hash/.${snapshot_hash}.tmp-${GITHUB_RUN_ID:-$$}-${RANDOM}"
+
+if [ ! -d "${hash_dir}" ]; then
+  rm -rf "${tmp_dir}"
+  mkdir -p "${tmp_dir}"
+  cp -a "${snapshot_dir}/." "${tmp_dir}/"
+  mv "${tmp_dir}" "${hash_dir}"
+else
+  rm -rf "${tmp_dir}"
+fi
+
+ln -sfn "../by-hash/${snapshot_hash}" "${registry_dir}/by-run/${run_id}"
+cat > "${registry_dir}/by-run/${run_id}.txt" <<EOF
+snapshot_hash=${snapshot_hash}
+snapshot_path=${hash_dir}
+published_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+if [ "${retention_days}" -gt 0 ] 2>/dev/null; then
+  find "${registry_dir}/by-hash" -mindepth 1 -maxdepth 1 -type d -mtime "+${retention_days}" -exec rm -rf {} + || true
+  find "${registry_dir}/by-run" -mindepth 1 -maxdepth 1 -mtime "+${retention_days}" -exec rm -f {} + || true
+fi
+
+echo "published research snapshot run_id=${run_id} hash=${snapshot_hash} path=${hash_dir}"

--- a/scripts/restore_research_snapshot.sh
+++ b/scripts/restore_research_snapshot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_id="${SNAPSHOT_RUN_ID:-}"
+output_dir=""
+registry_dir="${PLOY_RESEARCH_SNAPSHOT_REGISTRY:-}"
+required_paths=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --run-id)
+      run_id="${2:?missing --run-id value}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:?missing --output-dir value}"
+      shift 2
+      ;;
+    --registry-dir)
+      registry_dir="${2:?missing --registry-dir value}"
+      shift 2
+      ;;
+    --require)
+      required_paths+=("${2:?missing --require value}")
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "${run_id}" ]; then
+  echo "run id is required" >&2
+  exit 2
+fi
+if [ -z "${output_dir}" ]; then
+  echo "output directory is required" >&2
+  exit 2
+fi
+if [ -z "${registry_dir}" ]; then
+  registry_dir="${RUNNER_WORKSPACE:-/tmp}/_ploy-research-snapshots"
+fi
+
+source_dir="${registry_dir}/by-run/${run_id}"
+if [ ! -d "${source_dir}" ]; then
+  echo "local research snapshot not found: ${source_dir}" >&2
+  exit 1
+fi
+
+for path in "${required_paths[@]}"; do
+  if [ ! -e "${source_dir}/${path}" ]; then
+    echo "local research snapshot missing required path: ${path}" >&2
+    exit 1
+  fi
+done
+
+rm -rf "${output_dir}"
+mkdir -p "${output_dir}"
+cp -a "${source_dir}/." "${output_dir}/"
+echo "restored local research snapshot run_id=${run_id} from=${source_dir} to=${output_dir}"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,39 @@
+# Research Snapshot Local Registry Workflow (2026-05-01)
+
+Issue: https://github.com/proerror77/ploy/issues/256
+
+## Files
+
+- `.github/workflows/research-snapshot.yml`
+  - Owner: publish compiled snapshots to runner-local registry and upload only small provenance artifacts.
+- `.github/workflows/factor-review-v2.yml`
+  - Owner: restore snapshots from runner-local registry before GitHub artifact fallback.
+- `.github/workflows/factor-walk-forward-v2.yml`
+  - Owner: restore snapshots from runner-local registry before GitHub artifact fallback.
+- `.github/workflows/optimize.yml`
+  - Owner: restore snapshots from runner-local registry before GitHub artifact fallback.
+- `scripts/publish_research_snapshot_registry.sh`
+  - Owner: atomic by-hash/by-run local snapshot registry publication.
+- `scripts/restore_research_snapshot.sh`
+  - Owner: local snapshot restore into workflow workspace.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Add a runner-local snapshot registry keyed by snapshot hash and workflow run id.
+- [x] Make downstream research workflows prefer local restore over GitHub artifact download.
+- [x] Stop new workflows from embedding full 1GB research snapshots in GitHub artifacts.
+- [x] Run local shell/YAML validation.
+- [x] Push PR.
+- [ ] Verify one new Research Snapshot run plus snapshot-backed walk-forward/optimize reuse on `ploy-ci-1`.
+
+## Review
+
+- 2026-05-01: Workflow data flow is now `Tango DB -> ploy-ci-1 local registry -> downstream research jobs`, with GitHub artifacts reduced to provenance/report files. Existing full `research-snapshot-*` artifacts remain a fallback for older run ids.
+- 2026-05-01: Local verification passed: `bash -n scripts/publish_research_snapshot_registry.sh scripts/restore_research_snapshot.sh`, Ruby YAML parse for `research-snapshot.yml`, `optimize.yml`, `factor-review-v2.yml`, and `factor-walk-forward-v2.yml`, `git diff --check`, and a temp-dir publish/restore smoke test. `actionlint` was not installed locally.
+- 2026-05-01: PR #280 was opened and all PR checks passed, including `Workflow lint`, `Rust research heavy features`, and CodeRabbit.
+
 # Central Market Discovery Service (2026-05-01)
 
 ## Files


### PR DESCRIPTION
## Summary
- publish compiled research snapshots to a runner-local registry keyed by snapshot hash and workflow run id
- make optimize/factor-review/factor-walk-forward restore snapshots locally before falling back to old GitHub artifacts
- reduce new snapshot/report artifacts to provenance files instead of embedding the full 1GB snapshot tree

## Verification
- bash -n scripts/publish_research_snapshot_registry.sh scripts/restore_research_snapshot.sh
- ruby YAML parse for research-snapshot, optimize, factor-review-v2, factor-walk-forward-v2 workflows
- temp-dir publish/restore smoke test
- git diff --check

## Not Tested
- live ploy-ci-1 workflow_dispatch after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced local registry support for research snapshot storage and retrieval across CI workflows.
  * Updated snapshot caching strategy and optimized artifact publishing to include essential provenance metadata only.
  * Enhanced snapshot workflow efficiency with improved fallback mechanisms for artifact downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->