### PR TITLE
Keep strategy runtime data on private/local paths

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -123,6 +123,11 @@ jobs:
             exit 1
           fi
           if [ -n "${PLOY_RESEARCH_DATABASE_URL}" ]; then
+            db_host="$(python3 -c 'import os; from urllib.parse import urlparse; print(urlparse(os.environ["PLOY_RESEARCH_DATABASE_URL"]).hostname or "")')"
+            if [ "${db_host}" != "172.16.0.204" ]; then
+              echo "PLOY_RESEARCH_DATABASE_URL must target Tango-1-1 private VPC endpoint 172.16.0.204" >&2
+              exit 1
+            fi
             extra_args+=(--db-url "${PLOY_RESEARCH_DATABASE_URL}")
           fi
           ./target/release/examples/run_backtest \

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -47,6 +47,7 @@ env:
     037_research_time_conditioned_factor_metrics.sql
     039_fix_strategy_track_record_side_key.sql
     038_track_record_official_residual_settlement.sql
+    040_polymarket_v2_indexer_events.sql
 
 jobs:
   build-and-deploy:
@@ -178,6 +179,7 @@ jobs:
           cp scripts/audit_market_data_gaps.py dist/scripts/audit_market_data_gaps.py
           cp scripts/report_dryrun_summary.py dist/scripts/report_dryrun_summary.py
           cp scripts/check_dryrun_report_contract.py dist/scripts/check_dryrun_report_contract.py
+          cp scripts/import_polymarket_v2_indexer.py dist/scripts/import_polymarket_v2_indexer.py
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
           cp scripts/fix_clob_trade_partitions.sql dist/scripts/fix_clob_trade_partitions.sql
@@ -193,7 +195,11 @@ jobs:
           cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
           cp deployment/systemd/ploy-market-discovery.service dist/deployment/systemd/ploy-market-discovery.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
+          cp deployment/systemd/ploy-polymarket-v2-indexer-import.service dist/deployment/systemd/ploy-polymarket-v2-indexer-import.service
+          cp deployment/systemd/ploy-polymarket-v2-indexer-import.timer dist/deployment/systemd/ploy-polymarket-v2-indexer-import.timer
+          cp deployment/systemd/polymarket-v2-indexer.service dist/deployment/systemd/polymarket-v2-indexer.service
           cp deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf dist/deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf
+          cp deployment/env.polymarket-v2-indexer.example dist/deployment/env.polymarket-v2-indexer.example
           cp deployment/systemd/ploy-quote-collector.hardening.conf dist/deployment/systemd/ploy-quote-collector.hardening.conf
           tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
             -C dist -cf - . | gzip -n > "${DEPLOY_BUNDLE_NAME}"
@@ -420,6 +426,7 @@ jobs:
             install -m 0755 ./scripts/audit_market_data_gaps.py ${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py
             install -m 0755 ./scripts/report_dryrun_summary.py ${DEPLOY_ROOT}/scripts/report_dryrun_summary.py
             install -m 0755 ./scripts/check_dryrun_report_contract.py ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
+            install -m 0755 ./scripts/import_polymarket_v2_indexer.py ${DEPLOY_ROOT}/scripts/import_polymarket_v2_indexer.py
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
             install -m 0644 ./scripts/fix_clob_trade_partitions.sql ${DEPLOY_ROOT}/scripts/fix_clob_trade_partitions.sql
@@ -437,8 +444,13 @@ jobs:
             install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
             install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
             install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
+            install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.service /etc/systemd/system/ploy-polymarket-v2-indexer-import.service
+            install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.timer /etc/systemd/system/ploy-polymarket-v2-indexer-import.timer
+            install -m 0644 ./deployment/systemd/polymarket-v2-indexer.service /etc/systemd/system/polymarket-v2-indexer.service
+            install -m 0644 ./deployment/env.polymarket-v2-indexer.example ${DEPLOY_ROOT}/env.polymarket-v2-indexer.example
             install -m 0644 ./deployment/systemd/ploy-quote-collector.hardening.conf /etc/systemd/system/ploy-quote-collector.service.d/hardening.conf
             systemctl daemon-reload
+            systemctl enable --now ploy-polymarket-v2-indexer-import.timer
 
             # Apply additive runner migrations before restarting services.
             mkdir -p ${DEPLOY_ROOT}/migrations

--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -363,6 +363,11 @@ jobs:
           if [ "${{ steps.data_scope.outputs.include_deribit }}" != "true" ]; then
             deribit_args+=(--skip-deribit)
           fi
+          db_host="$(python3 -c 'import os; from urllib.parse import urlparse; print(urlparse(os.environ["PLOY_DB_URL"]).hostname or "")')"
+          if [ "${db_host}" != "172.16.0.204" ]; then
+            echo "PLOY_DB_URL must target Tango-1-1 private VPC endpoint 172.16.0.204" >&2
+            exit 1
+          fi
           mkdir -p artifacts/research-snapshot
           ./target/release/examples/research_snapshot_compile \
             --db-url "${PLOY_DB_URL:?PLOY_DB_URL secret is required}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,31 @@ When using a skill:
   `rtk cargo run -p ploy-research --example event_ml_workflow --features polars-export -- --dataset <event-root-dir>`.
 - Do not skip from raw event-root data straight to hyperparameter search, DL, or RL. The required order is coverage diagnostics, AutoML-style factor attribution, governed feature set, fixed baseline, model-family selection, hyperparameter search, walk-forward/executable-price backtest, then DL/RL gates.
 
+## OpenAI Model And Prompt Guidance
+
+- For OpenAI API, Codex, Responses API, or model-migration work, use the
+  `openai-docs` skill and current official OpenAI docs before changing model
+  strings or prompts.
+- Default new OpenAI mainline upgrades to `gpt-5.5` when the user asks for the
+  latest/current/default GPT-5 model. Preserve an explicitly requested target
+  model when the user names one.
+- Keep GPT-5.5 migrations narrow: update active OpenAI model defaults and the
+  directly related prompts only. Do not rewrite historical docs, examples,
+  fixtures, eval baselines, fallback routes, or third-party provider configs
+  unless the user explicitly asks.
+- Prefer outcome-first GPT-5.5 prompts: state the desired result, success
+  criteria, constraints, evidence sources, output shape, retrieval budget, and
+  validation loop. Remove process-heavy prompt scaffolding when it is not a real
+  invariant.
+- Treat `medium` reasoning as the balanced GPT-5.5 starting point. Re-evaluate
+  `low` for latency-sensitive workflows before escalating to `high` or `xhigh`;
+  preserve an existing visible reasoning setting on the first migration pass
+  unless docs or evals justify changing it.
+- For tool-heavy Responses workflows, keep preambles useful and verify that
+  assistant output item `phase` values are preserved when replaying items
+  manually. If phase handling requires code rewiring, report that as a separate
+  implementation task instead of hiding it in a prompt-only migration.
+
 ## Workflow Orchestration
 
 ### 1. Planning Default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,31 @@ When using a skill:
   `rtk cargo run -p ploy-research --example event_ml_workflow --features polars-export -- --dataset <event-root-dir>`.
 - Do not skip from raw event-root data straight to hyperparameter search, DL, or RL. The required order is coverage diagnostics, AutoML-style factor attribution, governed feature set, fixed baseline, model-family selection, hyperparameter search, walk-forward/executable-price backtest, then DL/RL gates.
 
+## OpenAI Model And Prompt Guidance
+
+- For OpenAI API, Codex, Responses API, or model-migration work, use the
+  `openai-docs` skill and current official OpenAI docs before changing model
+  strings or prompts.
+- Default new OpenAI mainline upgrades to `gpt-5.5` when the user asks for the
+  latest/current/default GPT-5 model. Preserve an explicitly requested target
+  model when the user names one.
+- Keep GPT-5.5 migrations narrow: update active OpenAI model defaults and the
+  directly related prompts only. Do not rewrite historical docs, examples,
+  fixtures, eval baselines, fallback routes, or third-party provider configs
+  unless the user explicitly asks.
+- Prefer outcome-first GPT-5.5 prompts: state the desired result, success
+  criteria, constraints, evidence sources, output shape, retrieval budget, and
+  validation loop. Remove process-heavy prompt scaffolding when it is not a real
+  invariant.
+- Treat `medium` reasoning as the balanced GPT-5.5 starting point. Re-evaluate
+  `low` for latency-sensitive workflows before escalating to `high` or `xhigh`;
+  preserve an existing visible reasoning setting on the first migration pass
+  unless docs or evals justify changing it.
+- For tool-heavy Responses workflows, keep preambles useful and verify that
+  assistant output item `phase` values are preserved when replaying items
+  manually. If phase handling requires code rewiring, report that as a separate
+  implementation task instead of hiding it in a prompt-only migration.
+
 ### Installed Skills
 
 - `karpathy-guidelines` — invoke when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.

--- a/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
@@ -5,6 +5,12 @@
 strategy_variant = "three_layer"
 mode = "dryrun"
 throttle_hz = 10
+# Canonical live-feed capture for replaying current/candidate configs against
+# the same MarketUpdate sequence. Keep this on one PM5D profile to avoid
+# duplicating high-frequency L2/aggTrade logs across parallel dry-runs.
+record_market_updates_to = "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson"
+record_market_updates_max_records = 300000
+record_market_updates_max_bytes = 268435456
 
 [strategy]
 symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT", "BNBUSDT"]

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -23,6 +23,7 @@ fn print_usage_for(program: &str) {
     eprintln!("Options for 'run':");
     eprintln!("  --config <path>          Unified TOML config file (required)");
     eprintln!("  --deployment-id <id>     Platform deployment identity for order attribution");
+    eprintln!("  --output-json <path>     Write a machine-readable runtime evaluation");
     eprintln!("  --dry-run                Force dry-run mode (simulated execution)");
     eprintln!("  --foreground             Run in foreground (default, kept for compat)");
     #[cfg(feature = "ops")]
@@ -35,6 +36,7 @@ fn print_mode_usage(program: &str) {
     eprintln!("Options:");
     eprintln!("  --config <path>          Unified TOML config file (required)");
     eprintln!("  --deployment-id <id>     Platform deployment identity for order attribution");
+    eprintln!("  --output-json <path>     Write a machine-readable runtime evaluation");
     eprintln!("  --dry-run                Force dry-run mode (simulated execution)");
     eprintln!("  --foreground             Run in foreground (default, kept for compat)");
 }
@@ -93,7 +95,8 @@ pub async fn run_with_implicit_run_args(args: Vec<String>) {
 
 fn normalize_mode_args(mut args: Vec<String>) -> Vec<String> {
     match args.get(1).map(String::as_str) {
-        None | Some("--config" | "--deployment-id" | "--dry-run" | "--foreground") => {
+        None
+        | Some("--config" | "--deployment-id" | "--output-json" | "--dry-run" | "--foreground") => {
             args.insert(1, "run".to_string());
         }
         _ => {}

--- a/crates/ploy-runner-host/src/run.rs
+++ b/crates/ploy-runner-host/src/run.rs
@@ -1,11 +1,13 @@
 use ploy_strategy_bundles::FullConfig;
-use ploy_strategy_runtime::run_strategy_with_deployment_id;
+use ploy_strategy_runtime::run_strategy_with_deployment_id_and_output;
+use std::path::PathBuf;
 
 use crate::print_usage;
 
 pub async fn run_command(args: &[String], command: Option<&str>) {
     let mut config_path: Option<String> = None;
     let mut deployment_id: Option<String> = None;
+    let mut output_json: Option<PathBuf> = None;
     let mut force_dry_run = false;
     let mut i = if command == Some("run") { 2 } else { 1 };
     while i < args.len() {
@@ -27,6 +29,15 @@ pub async fn run_command(args: &[String], command: Option<&str>) {
                 }
                 i += 1;
                 deployment_id = args.get(i).cloned();
+            }
+            "--output-json" => {
+                if i + 1 >= args.len() || args[i + 1].starts_with("--") {
+                    eprintln!("Error: --output-json requires a value");
+                    print_usage();
+                    std::process::exit(1);
+                }
+                i += 1;
+                output_json = args.get(i).map(PathBuf::from);
             }
             "--dry-run" => force_dry_run = true,
             "--foreground" => {}
@@ -57,5 +68,12 @@ pub async fn run_command(args: &[String], command: Option<&str>) {
         }
     };
 
-    run_strategy_with_deployment_id(config, &config_path, force_dry_run, deployment_id).await;
+    run_strategy_with_deployment_id_and_output(
+        config,
+        &config_path,
+        force_dry_run,
+        deployment_id,
+        output_json.as_deref(),
+    )
+    .await;
 }

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 
 use crate::engine::{RuntimeConfig, RuntimeMode};
 use crate::executor::SimulatedExecutorConfig;
+use crate::feed::RecordingLimits;
 use crate::strategies::directional::DirectionalConfig;
 
 /// Top-level config deserialized from a TOML file.
@@ -74,6 +75,10 @@ pub struct RuntimeSection {
     pub to: Option<String>,
     /// Optional NDJSON log path for canonical `MarketUpdate` recording.
     pub record_market_updates_to: Option<PathBuf>,
+    /// Optional hard cap for a bounded canonical `MarketUpdate` recording.
+    pub record_market_updates_max_records: Option<u64>,
+    /// Optional hard cap for a bounded canonical `MarketUpdate` recording.
+    pub record_market_updates_max_bytes: Option<u64>,
     /// Source boundary for live/dry-run market data.
     ///
     /// Defaults to `local_db`, where strategy runners consume collector-persisted
@@ -332,6 +337,13 @@ impl FullConfig {
         self.runtime.record_market_updates_to.as_deref()
     }
 
+    pub fn record_market_updates_limits(&self) -> RecordingLimits {
+        RecordingLimits {
+            max_records: self.runtime.record_market_updates_max_records,
+            max_bytes: self.runtime.record_market_updates_max_bytes,
+        }
+    }
+
     pub fn replay_market_updates_path(&self) -> Option<&Path> {
         self.runtime.replay_market_updates_from.as_deref()
     }
@@ -372,6 +384,8 @@ mode = "backtest"
 throttle_hz = 1
 max_updates = 10000
 record_market_updates_to = "tmp/sample.ndjson"
+record_market_updates_max_records = 1000
+record_market_updates_max_bytes = 1048576
 market_data_source = "external_direct"
 
 [strategy]
@@ -413,6 +427,18 @@ enable_market_impact = true
         assert_eq!(
             config.runtime.record_market_updates_to.as_deref(),
             Some(Path::new("tmp/sample.ndjson"))
+        );
+        assert_eq!(config.runtime.record_market_updates_max_records, Some(1000));
+        assert_eq!(
+            config.runtime.record_market_updates_max_bytes,
+            Some(1_048_576)
+        );
+        assert_eq!(
+            config.record_market_updates_limits(),
+            RecordingLimits {
+                max_records: Some(1000),
+                max_bytes: Some(1_048_576)
+            }
         );
         assert_eq!(
             config.runtime.market_data_source,

--- a/crates/ploy-strategy-bundles/src/feed/mod.rs
+++ b/crates/ploy-strategy-bundles/src/feed/mod.rs
@@ -14,4 +14,6 @@ pub use live::LiveFeed;
 pub use options::HistoricalLoadOptions;
 #[cfg(feature = "parquet-feed")]
 pub use parquet_stream::StreamingParquetFeed;
-pub use recorded::{RecordedFeed, RecordedFeedError, RecordedMarketUpdate, RecordingFeed};
+pub use recorded::{
+    RecordedFeed, RecordedFeedError, RecordedMarketUpdate, RecordingFeed, RecordingLimits,
+};

--- a/crates/ploy-strategy-bundles/src/feed/recorded.rs
+++ b/crates/ploy-strategy-bundles/src/feed/recorded.rs
@@ -18,11 +18,23 @@ use crate::traits::{Feed, MarketUpdate};
 
 const FLUSH_EVERY_RECORDS: usize = 256;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordingLimits {
+    pub max_records: Option<u64>,
+    pub max_bytes: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecordedMarketUpdate {
     pub sequence: u64,
     pub recorded_at: DateTime<Utc>,
     pub update: MarketUpdate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppendOutcome {
+    Written,
+    LimitReached,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -53,10 +65,12 @@ struct MarketUpdateLogWriter {
     writer: BufWriter<File>,
     next_sequence: u64,
     pending_records: usize,
+    bytes_written: u64,
+    limits: RecordingLimits,
 }
 
 impl MarketUpdateLogWriter {
-    fn create(path: impl AsRef<Path>) -> io::Result<Self> {
+    fn create_with_limits(path: impl AsRef<Path>, limits: RecordingLimits) -> io::Result<Self> {
         let path = path.as_ref().to_path_buf();
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
@@ -96,19 +110,41 @@ impl MarketUpdateLogWriter {
             writer: BufWriter::new(file),
             next_sequence: 0,
             pending_records: 0,
+            bytes_written: 0,
+            limits,
         })
     }
 
-    fn append(&mut self, update: &MarketUpdate) -> io::Result<()> {
+    fn append(&mut self, update: &MarketUpdate) -> io::Result<AppendOutcome> {
+        if self
+            .limits
+            .max_records
+            .is_some_and(|max_records| self.next_sequence >= max_records)
+        {
+            self.flush()?;
+            return Ok(AppendOutcome::LimitReached);
+        }
+
         let record = RecordedMarketUpdate {
             sequence: self.next_sequence,
             recorded_at: Utc::now(),
             update: update.clone(),
         };
-        self.next_sequence += 1;
+        let mut line = serde_json::to_vec(&record).map_err(io::Error::other)?;
+        line.push(b'\n');
 
-        serde_json::to_writer(&mut self.writer, &record).map_err(io::Error::other)?;
-        self.writer.write_all(b"\n")?;
+        if self.bytes_written > 0
+            && self.limits.max_bytes.is_some_and(|max_bytes| {
+                self.bytes_written + u64::try_from(line.len()).unwrap_or(u64::MAX) > max_bytes
+            })
+        {
+            self.flush()?;
+            return Ok(AppendOutcome::LimitReached);
+        }
+
+        self.next_sequence += 1;
+        self.writer.write_all(&line)?;
+        self.bytes_written += u64::try_from(line.len()).unwrap_or(u64::MAX);
         self.pending_records += 1;
 
         let is_lifecycle = matches!(
@@ -120,7 +156,7 @@ impl MarketUpdateLogWriter {
             self.flush()?;
         }
 
-        Ok(())
+        Ok(AppendOutcome::Written)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -150,9 +186,17 @@ pub struct RecordingFeed<F> {
 
 impl<F> RecordingFeed<F> {
     pub fn new(inner: F, path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::with_limits(inner, path, RecordingLimits::default())
+    }
+
+    pub fn with_limits(
+        inner: F,
+        path: impl AsRef<Path>,
+        limits: RecordingLimits,
+    ) -> io::Result<Self> {
         Ok(Self {
             inner,
-            writer: Some(MarketUpdateLogWriter::create(path)?),
+            writer: Some(MarketUpdateLogWriter::create_with_limits(path, limits)?),
         })
     }
 }
@@ -166,13 +210,25 @@ where
         let update = self.inner.next().await?;
 
         if let Some(writer) = self.writer.as_mut() {
-            if let Err(error) = writer.append(&update) {
-                error!(
-                    path = %writer.path.display(),
-                    error = %error,
-                    "Market-update recording failed; disabling recorder for the rest of the run",
-                );
-                self.writer = None;
+            match writer.append(&update) {
+                Ok(AppendOutcome::Written) => {}
+                Ok(AppendOutcome::LimitReached) => {
+                    info!(
+                        path = %writer.path.display(),
+                        records = writer.next_sequence,
+                        bytes = writer.bytes_written,
+                        "Market-update recording limit reached; preserving bounded replay log",
+                    );
+                    self.writer = None;
+                }
+                Err(error) => {
+                    error!(
+                        path = %writer.path.display(),
+                        error = %error,
+                        "Market-update recording failed; disabling recorder for the rest of the run",
+                    );
+                    self.writer = None;
+                }
             }
         }
 
@@ -272,8 +328,8 @@ mod tests {
                 bid: Some(dec!(0.39)),
                 ask: Some(dec!(0.40)),
                 ts: now + Duration::seconds(1),
-                    bid_size: None,
-                    ask_size: None,
+                bid_size: None,
+                ask_size: None,
             },
             MarketUpdate::SportsState {
                 game_id: "19439".into(),
@@ -319,6 +375,55 @@ mod tests {
 
         assert_eq!(recorded, updates);
         assert_eq!(replayed, updates);
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn recording_feed_stops_after_record_limit_without_blocking_feed() {
+        let now = Utc::now();
+        let updates = vec![
+            MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100000),
+                ts: now,
+            },
+            MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100010),
+                ts: now + Duration::seconds(1),
+            },
+            MarketUpdate::SpotPrice {
+                symbol: "BTCUSDT".into(),
+                price: dec!(100020),
+                ts: now + Duration::seconds(2),
+            },
+        ];
+        let path = temp_log_path("recording-feed-limit");
+        let mut feed = RecordingFeed::with_limits(
+            crate::HistoricalFeed::new(updates.clone()),
+            &path,
+            RecordingLimits {
+                max_records: Some(2),
+                max_bytes: None,
+            },
+        )
+        .unwrap();
+
+        let mut forwarded = Vec::new();
+        while let Some(update) = feed.next().await {
+            forwarded.push(update);
+        }
+        drop(feed);
+
+        let mut replay = RecordedFeed::from_path(&path).unwrap();
+        let mut replayed = Vec::new();
+        while let Some(update) = replay.next().await {
+            replayed.push(update);
+        }
+
+        assert_eq!(forwarded, updates);
+        assert_eq!(replayed, updates[..2]);
 
         let _ = fs::remove_file(path);
     }

--- a/crates/ploy-strategy-bundles/src/lib.rs
+++ b/crates/ploy-strategy-bundles/src/lib.rs
@@ -17,6 +17,7 @@ pub use executor::{CallbackExecutor, SimulatedExecutor, SimulatedExecutorConfig}
 pub use feed::StreamingParquetFeed;
 pub use feed::{
     HistoricalFeed, LiveFeed, RecordedFeed, RecordedFeedError, RecordedMarketUpdate, RecordingFeed,
+    RecordingLimits,
 };
 pub use ploy_market_contracts::{Feed, InstrumentKind, MarketUpdate, PredictionFamily, VenueKind};
 pub use recorder::BufferedRecorder;

--- a/crates/ploy-strategy-runtime/src/lib.rs
+++ b/crates/ploy-strategy-runtime/src/lib.rs
@@ -21,6 +21,8 @@ use ploy_strategy_bundles::{FullConfig, RuntimeMode};
 #[cfg(feature = "replay")]
 use replay::run_replay_entry;
 use rust_decimal::Decimal;
+use serde_json::json;
+use std::path::Path;
 use tracing::info;
 
 pub use ploy_strategy_bundles::RuntimeMode as StrategyRuntimeMode;
@@ -35,11 +37,29 @@ pub async fn run_strategy_with_deployment_id(
     force_dry_run: bool,
     deployment_id: Option<String>,
 ) {
+    run_strategy_with_deployment_id_and_output(
+        config,
+        config_path,
+        force_dry_run,
+        deployment_id,
+        None,
+    )
+    .await;
+}
+
+pub async fn run_strategy_with_deployment_id_and_output(
+    config: FullConfig,
+    config_path: &str,
+    force_dry_run: bool,
+    deployment_id: Option<String>,
+    output_json: Option<&Path>,
+) {
     let mut runtime_config = config.runtime_config();
     if force_dry_run {
         runtime_config.mode = RuntimeMode::DryRun;
     }
     let deployment_id = resolve_deployment_id(deployment_id);
+    let deployment_label = deployment_id.clone();
     if matches!(runtime_config.mode, RuntimeMode::Live | RuntimeMode::DryRun)
         && deployment_id.is_none()
     {
@@ -105,6 +125,91 @@ pub async fn run_strategy_with_deployment_id(
             roi_on_deployed_capital = %roi_on_deployed_capital,
             "Replay/backtest cashflow summary",
         );
+    }
+
+    if let Some(output_path) = output_json {
+        write_strategy_evaluation(
+            output_path,
+            config_path,
+            deployment_label.as_deref(),
+            &result,
+            &snapshot,
+        );
+    }
+}
+
+fn write_strategy_evaluation(
+    output_path: &Path,
+    config_path: &str,
+    deployment_id: Option<&str>,
+    result: &ploy_strategy_bundles::RuntimeResult,
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+) {
+    let cashflow = snapshot.fill_cashflow_summary();
+    let artifact = json!({
+        "schema_version": 1,
+        "artifact_type": "strategy_runtime_evaluation",
+        "producer": "new-ploy-runner",
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "config_path": config_path,
+        "deployment_id": deployment_id,
+        "mode": format!("{:?}", result.mode),
+        "result": {
+            "updates_processed": result.updates_processed,
+            "intents_submitted": result.intents_submitted,
+            "fills_recorded": result.fills_recorded,
+            "realized_pnl": result.pnl.realized_pnl,
+            "unrealized_pnl": result.pnl.unrealized_pnl,
+            "total_fees": result.pnl.total_fees,
+            "net_pnl": result.pnl.net_pnl(),
+            "risk": &result.risk,
+            "elapsed_secs": result.elapsed_secs,
+        },
+        "cashflow": {
+            "buy_shares": cashflow.buy_shares,
+            "sell_shares": cashflow.sell_shares,
+            "gross_buy_cost": cashflow.gross_buy_cost,
+            "gross_sell_proceeds": cashflow.gross_sell_proceeds,
+            "total_fees": cashflow.total_fees,
+            "deployed_capital": cashflow.deployed_capital(),
+            "net_pnl": cashflow.net_pnl(),
+            "roi_on_deployed_capital": cashflow.roi_on_deployed_capital(),
+        },
+        "snapshot_counts": {
+            "intents": snapshot.intents.len(),
+            "orders": snapshot.orders.len(),
+            "fills": snapshot.fills.len(),
+            "positions": snapshot.positions.len(),
+        },
+    });
+
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "Failed to create output JSON directory {}: {error}",
+                    parent.display()
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    match serde_json::to_vec_pretty(&artifact)
+        .map(|mut bytes| {
+            bytes.push(b'\n');
+            bytes
+        })
+        .and_then(|bytes| std::fs::write(output_path, bytes).map_err(serde_json::Error::io))
+    {
+        Ok(()) => info!(path = %output_path.display(), "Wrote strategy runtime evaluation JSON"),
+        Err(error) => {
+            eprintln!(
+                "Failed to write strategy runtime evaluation JSON {}: {error}",
+                output_path.display()
+            );
+            std::process::exit(1);
+        }
     }
 }
 

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -616,7 +616,12 @@ async fn run_live_or_dry_run(
 
     let feed: Box<dyn Feed> = if let Some(record_path) = config.record_market_updates_path() {
         Box::new(
-            RecordingFeed::new(LiveFeed::new(rx), record_path).unwrap_or_else(|error| {
+            RecordingFeed::with_limits(
+                LiveFeed::new(rx),
+                record_path,
+                config.record_market_updates_limits(),
+            )
+            .unwrap_or_else(|error| {
                 eprintln!(
                     "Failed to open market-update log {}: {error}",
                     record_path.display()

--- a/deployment/env.polymarket-v2-indexer.example
+++ b/deployment/env.polymarket-v2-indexer.example
@@ -1,0 +1,12 @@
+# Copy to /opt/polymarket-v2-indexer/.env on tango-1-1 and fill the token.
+#
+# Envio hosted/runtime environments only expose ENVIO_ prefixed variables.
+# Keep this file private; it must not be committed with a real token.
+
+ENVIO_API_TOKEN=
+
+# Keep the GraphQL surface private to the host. Ploy imports through
+# /opt/ploy/env/polymarket-v2-indexer.env using this local endpoint.
+ENVIO_HOST=127.0.0.1
+ENVIO_PORT=8080
+TUI_OFF=true

--- a/deployment/systemd/ploy-polymarket-v2-indexer-import.service
+++ b/deployment/systemd/ploy-polymarket-v2-indexer-import.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Ploy Polymarket V2 Indexer Import
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/ploy
+
+Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
+Environment=PLOY_PM_V2_ENTITIES=order_fills,order_matches,fee_events,polyusd_transfers,polyusd_wraps
+Environment=PLOY_PM_V2_MIN_BLOCK=84902320
+EnvironmentFile=-/opt/ploy/env/polymarket-v2-indexer.env
+
+ExecStart=/bin/bash -lc 'if [[ -z "${PLOY_PM_V2_INDEXER_URL:-}" ]]; then echo "ploy-polymarket-v2-indexer-import: PLOY_PM_V2_INDEXER_URL not configured; skipping"; exit 0; fi; exec /usr/bin/python3 /opt/ploy/scripts/import_polymarket_v2_indexer.py --endpoint "$PLOY_PM_V2_INDEXER_URL" --entities "$PLOY_PM_V2_ENTITIES" --min-block "$PLOY_PM_V2_MIN_BLOCK" --from-sync-state'
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/ploy/tmp
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ploy-polymarket-v2-indexer-import

--- a/deployment/systemd/ploy-polymarket-v2-indexer-import.timer
+++ b/deployment/systemd/ploy-polymarket-v2-indexer-import.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Import Polymarket V2 indexer events into Ploy periodically
+
+[Timer]
+OnBootSec=15m
+OnUnitActiveSec=10m
+Persistent=true
+Unit=ploy-polymarket-v2-indexer-import.service
+
+[Install]
+WantedBy=timers.target

--- a/deployment/systemd/polymarket-v2-indexer.service
+++ b/deployment/systemd/polymarket-v2-indexer.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Envio Polymarket V2 Indexer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/polymarket-v2-indexer
+EnvironmentFile=/opt/polymarket-v2-indexer/.env
+Environment=TUI_OFF=true
+Environment=ENVIO_HOST=127.0.0.1
+Environment=ENVIO_PORT=8080
+ExecStart=/usr/bin/pnpm start
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=polymarket-v2-indexer
+
+# Keep the indexer bounded away from trading services. The indexer is a
+# reconciliation sidecar, not a realtime execution dependency.
+MemoryHigh=1024M
+MemoryMax=2048M
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/runbooks/polymarket-v2-indexer.md
+++ b/docs/runbooks/polymarket-v2-indexer.md
@@ -1,0 +1,184 @@
+# Polymarket V2 Indexer Sidecar
+
+This runbook integrates the Envio `polymarket-v2-indexer` as a sidecar data
+source for Ploy.
+
+The sidecar is for chain-truth reconciliation, collateral flow checks, and
+research labels. It is not a realtime strategy feed. PM5D and other live
+strategies must continue to use the CLOB/orderbook and internal runtime paths
+for execution decisions.
+
+## Source
+
+- Repository: `https://github.com/enviodev/polymarket-v2-indexer`
+- Checked reference during integration: `7ad70d9`
+- Stack: Envio HyperIndex, TypeScript, GraphQL, PostgreSQL
+
+Indexed contracts on Polygon:
+
+| Surface | Address | Ploy use |
+| --- | --- | --- |
+| CTFExchange V2 standard | `0xe111180000d2663c0091e4f400237545b87b996b` | OrderFilled, OrdersMatched, fees |
+| CTFExchange V2 neg-risk | `0xe2222d279d744050d28e00520010520000310f59` | Neg-risk order fills and matches |
+| CTFExchange V2 third instance | `0xe2222d002000ba0053cef3375333610f64600036` | Track separately until venue semantics are confirmed |
+| PolyUSD | `0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb` | pUSD transfers, wrap, unwrap |
+| Rewards | `0xdd8db71ce3be8d71ff148b2163d64da181a29e8b` | Sponsorship/rewards research, not wired by default |
+
+## Database Boundary
+
+Migration `040_polymarket_v2_indexer_events.sql` creates only sidecar tables:
+
+- `polymarket_v2_order_fills`
+- `polymarket_v2_order_matches`
+- `polymarket_v2_fee_events`
+- `polymarket_v2_polyusd_events`
+- `polymarket_v2_indexer_sync_state`
+- `polymarket_v2_indexer_health`
+
+It intentionally does not alter:
+
+- `strategy_runtime_orders`
+- `strategy_runtime_fills`
+- `clob_quote_ticks`
+- `clob_orderbook_snapshots`
+
+The first cut stores raw integer amounts from chain events. Do not convert those
+to trading PnL in reports until the side, token, and maker/taker amount semantics
+are validated against live fills.
+
+## Run the Envio Indexer
+
+Run this outside the Ploy daemon process. The indexer needs Node 22+, pnpm,
+Docker or Podman, and an Envio HyperSync token.
+
+```bash
+git clone https://github.com/enviodev/polymarket-v2-indexer /opt/polymarket-v2-indexer
+cd /opt/polymarket-v2-indexer
+cp .env.example .env
+# set ENVIO_API_TOKEN in .env
+pnpm install
+pnpm codegen
+TUI_OFF=true pnpm dev
+```
+
+On `tango-1-1`, the prepared service path is:
+
+```bash
+install -m 0644 deployment/env.polymarket-v2-indexer.example /opt/polymarket-v2-indexer/.env
+install -m 0644 deployment/systemd/polymarket-v2-indexer.service /etc/systemd/system/polymarket-v2-indexer.service
+systemctl daemon-reload
+```
+
+Do not start the service until `/opt/polymarket-v2-indexer/.env` contains a real
+`ENVIO_API_TOKEN`. The service binds the GraphQL surface to `127.0.0.1:8080` and
+has a 2 GiB memory cap so it stays isolated from trading services.
+
+The default local GraphQL playground is usually exposed on `http://127.0.0.1:8080`.
+Keep it private or bind it behind an internal-only network path. Do not expose it
+publicly without authentication.
+
+## Import Into Ploy
+
+Apply the migration first on the target Ploy database.
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f migrations/040_polymarket_v2_indexer_events.sql
+```
+
+Then import from the sidecar GraphQL endpoint:
+
+```bash
+PLOY_PM_V2_INDEXER_URL=http://127.0.0.1:8080/v1/graphql \
+PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy \
+python3 scripts/import_polymarket_v2_indexer.py --min-block 84902320
+```
+
+For periodic imports, set the private endpoint in the host env file:
+
+```bash
+install -d -m 0755 /opt/ploy/env
+printf 'PLOY_PM_V2_INDEXER_URL=http://127.0.0.1:8080/v1/graphql\n' \
+  > /opt/ploy/env/polymarket-v2-indexer.env
+systemctl enable --now ploy-polymarket-v2-indexer-import.timer
+```
+
+The timer uses `--from-sync-state`, so subsequent runs continue from
+`polymarket_v2_indexer_sync_state` instead of rescanning from the deployment
+start block. If `PLOY_PM_V2_INDEXER_URL` is not configured, the service exits
+successfully without importing.
+
+For a dry-run parse without writing:
+
+```bash
+python3 scripts/import_polymarket_v2_indexer.py \
+  --endpoint http://127.0.0.1:8080/v1/graphql \
+  --min-block 84902320 \
+  --dry-run
+```
+
+If GraphQL schema naming changes in Envio, export JSON/JSONL from the indexer
+and import it without relying on the query builder:
+
+```bash
+python3 scripts/import_polymarket_v2_indexer.py --input /tmp/pm-v2-events.jsonl --dry-run
+python3 scripts/import_polymarket_v2_indexer.py --input /tmp/pm-v2-events.jsonl
+```
+
+JSONL rows must include an `entity` field such as `OrderFill`, `OrderMatch`,
+`FeeEvent`, `PolyUSDTransfer`, or `PolyUSDWrap`.
+
+## Reconciliation Queries
+
+Latest indexer cursor:
+
+```sql
+SELECT * FROM polymarket_v2_indexer_health;
+```
+
+Recent chain fills for a token:
+
+```sql
+SELECT block_timestamp, transaction_hash, side, token_id, maker_amount_raw,
+       taker_amount_raw, fee_raw, builder
+FROM polymarket_v2_order_fills
+WHERE token_id = '<token_id>'
+ORDER BY block_timestamp DESC
+LIMIT 50;
+```
+
+Candidate runtime-to-chain comparison by token and time window:
+
+```sql
+SELECT
+  f.fill_timestamp,
+  f.strategy_id,
+  f.deployment_id,
+  f.token_id,
+  f.quantity,
+  f.price,
+  c.block_timestamp AS chain_time,
+  c.transaction_hash,
+  c.fee_raw,
+  c.builder
+FROM strategy_runtime_fills f
+LEFT JOIN polymarket_v2_order_fills c
+  ON c.token_id = f.token_id
+ AND c.block_timestamp BETWEEN f.fill_timestamp - INTERVAL '2 minutes'
+                           AND f.fill_timestamp + INTERVAL '2 minutes'
+WHERE f.runtime_mode NOT IN ('dry_run', 'dryrun', 'paper')
+ORDER BY f.fill_timestamp DESC
+LIMIT 100;
+```
+
+This join is only a first-pass audit. Use order hash or venue order IDs when the
+runtime records expose them consistently.
+
+## Deployment Notes
+
+- Do not run the Envio indexer inside `ployd`.
+- Do not make PM5D entry logic depend on indexer lag.
+- Keep importer scheduling independent from dry-run/live services.
+- On `tango-1-1`, deploy the importer as `ploy-polymarket-v2-indexer-import.timer`
+  after confirming the indexer endpoint is local/private.
+- Rewards entities are intentionally not imported in this first cut. Add them
+  only when a concrete research or accounting report consumes them.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -189,6 +189,9 @@ different.
 - `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub Actions
   secrets `PLOY_RESEARCH_DATABASE_URL` and `PLOY_DB_URL`; verify the private
   endpoint with Aliyun CLI before changing those secrets.
+- DB-mode research workflows must fail closed unless the research database URL
+  targets Tango's private VPC endpoint `172.16.0.204`. A public Tango endpoint
+  can turn large backtest query results into billable公网出流量.
 - ACK/ACR image workflows must use immutable checked-out commit SHA tags only.
   Do not push or deploy `latest`. ACK deployments must also pass through the
   protected `ack` environment before mutating the cluster.

--- a/migrations/040_polymarket_v2_indexer_events.sql
+++ b/migrations/040_polymarket_v2_indexer_events.sql
@@ -1,0 +1,148 @@
+-- Migration: 040_polymarket_v2_indexer_events
+-- Description: Persist Polymarket V2 chain-indexer events for reconciliation and research.
+
+CREATE TABLE IF NOT EXISTS polymarket_v2_indexer_sync_state (
+    source TEXT PRIMARY KEY,
+    last_block_number BIGINT NOT NULL DEFAULT 0,
+    last_block_timestamp TIMESTAMPTZ,
+    last_transaction_hash TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS polymarket_v2_order_fills (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL DEFAULT 137,
+    block_number BIGINT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_timestamp TIMESTAMPTZ NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    tx_from TEXT,
+    exchange TEXT NOT NULL,
+    order_hash TEXT NOT NULL,
+    maker TEXT NOT NULL,
+    taker TEXT NOT NULL,
+    side SMALLINT NOT NULL CHECK (side IN (0, 1)),
+    token_id TEXT NOT NULL,
+    market_id TEXT,
+    maker_amount_raw NUMERIC(78,0) NOT NULL,
+    taker_amount_raw NUMERIC(78,0) NOT NULL,
+    fee_raw NUMERIC(78,0) NOT NULL DEFAULT 0,
+    builder TEXT NOT NULL DEFAULT '0x0000000000000000000000000000000000000000000000000000000000000000',
+    metadata TEXT NOT NULL DEFAULT '0x0000000000000000000000000000000000000000000000000000000000000000',
+    raw_event JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source TEXT NOT NULL DEFAULT 'envio_polymarket_v2_indexer',
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chain_id, block_number, log_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_fills_token_time
+    ON polymarket_v2_order_fills(token_id, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_fills_tx
+    ON polymarket_v2_order_fills(transaction_hash);
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_fills_maker_time
+    ON polymarket_v2_order_fills(maker, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_fills_taker_time
+    ON polymarket_v2_order_fills(taker, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_fills_builder_time
+    ON polymarket_v2_order_fills(builder, block_timestamp DESC)
+    WHERE builder <> '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+CREATE TABLE IF NOT EXISTS polymarket_v2_order_matches (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL DEFAULT 137,
+    block_number BIGINT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_timestamp TIMESTAMPTZ NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    exchange TEXT NOT NULL,
+    taker_order_hash TEXT NOT NULL,
+    taker_order_maker TEXT NOT NULL,
+    side SMALLINT NOT NULL CHECK (side IN (0, 1)),
+    token_id TEXT NOT NULL,
+    market_id TEXT,
+    maker_amount_raw NUMERIC(78,0) NOT NULL,
+    taker_amount_raw NUMERIC(78,0) NOT NULL,
+    raw_event JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source TEXT NOT NULL DEFAULT 'envio_polymarket_v2_indexer',
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chain_id, block_number, log_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_matches_token_time
+    ON polymarket_v2_order_matches(token_id, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_order_matches_tx
+    ON polymarket_v2_order_matches(transaction_hash);
+
+CREATE TABLE IF NOT EXISTS polymarket_v2_fee_events (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL DEFAULT 137,
+    block_number BIGINT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_timestamp TIMESTAMPTZ NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    receiver TEXT NOT NULL,
+    amount_raw NUMERIC(78,0) NOT NULL,
+    raw_event JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source TEXT NOT NULL DEFAULT 'envio_polymarket_v2_indexer',
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chain_id, block_number, log_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_fee_events_receiver_time
+    ON polymarket_v2_fee_events(receiver, block_timestamp DESC);
+
+CREATE TABLE IF NOT EXISTS polymarket_v2_polyusd_events (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id INTEGER NOT NULL DEFAULT 137,
+    block_number BIGINT NOT NULL,
+    log_index INTEGER NOT NULL,
+    block_timestamp TIMESTAMPTZ NOT NULL,
+    transaction_hash TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('transfer', 'wrap', 'unwrap')),
+    address_from TEXT,
+    address_to TEXT,
+    caller TEXT,
+    asset TEXT,
+    amount_raw NUMERIC(78,0) NOT NULL,
+    raw_event JSONB NOT NULL DEFAULT '{}'::jsonb,
+    source TEXT NOT NULL DEFAULT 'envio_polymarket_v2_indexer',
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chain_id, block_number, log_index, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_polyusd_events_to_time
+    ON polymarket_v2_polyusd_events(address_to, block_timestamp DESC)
+    WHERE address_to IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_polyusd_events_from_time
+    ON polymarket_v2_polyusd_events(address_from, block_timestamp DESC)
+    WHERE address_from IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_polymarket_v2_polyusd_events_caller_time
+    ON polymarket_v2_polyusd_events(caller, block_timestamp DESC)
+    WHERE caller IS NOT NULL;
+
+CREATE OR REPLACE VIEW polymarket_v2_indexer_health AS
+SELECT
+    source,
+    last_block_number,
+    last_block_timestamp,
+    last_transaction_hash,
+    updated_at,
+    NOW() - updated_at AS cursor_age
+FROM polymarket_v2_indexer_sync_state;
+
+COMMENT ON TABLE polymarket_v2_order_fills IS
+    'Polymarket V2 CTFExchange OrderFilled events from the Envio sidecar indexer. Use for reconciliation and research, not realtime trading signals.';
+COMMENT ON TABLE polymarket_v2_polyusd_events IS
+    'Polymarket V2 pUSD Transfer/Wrapped/Unwrapped events used for collateral and wallet-flow reconciliation.';
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ploy') THEN
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.polymarket_v2_indexer_sync_state TO ploy';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.polymarket_v2_order_fills TO ploy';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.polymarket_v2_order_matches TO ploy';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.polymarket_v2_fee_events TO ploy';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.polymarket_v2_polyusd_events TO ploy';
+        EXECUTE 'GRANT SELECT ON TABLE public.polymarket_v2_indexer_health TO ploy';
+    END IF;
+END $$;

--- a/scripts/import_polymarket_v2_indexer.py
+++ b/scripts/import_polymarket_v2_indexer.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Import Polymarket V2 Envio indexer events into the Ploy database.
+
+The importer is intentionally a sidecar bridge. It persists chain-indexed truth
+for reconciliation and research, but it does not feed realtime strategy logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+
+DB_URL = (
+    os.environ.get("PLOY_DATABASE__URL")
+    or os.environ.get("DATABASE_URL")
+    or "postgresql://postgres:postgres@localhost:5432/ploy"
+)
+
+ZERO_BYTES32 = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+GRAPHQL_FIELDS = {
+    "OrderFill": """
+      id orderHash maker taker side tokenId makerAmountFilled takerAmountFilled
+      fee builder metadata exchange timestamp blockNumber transactionHash txFrom
+      market { id slug conditionId }
+    """,
+    "OrderMatch": """
+      id takerOrderHash takerOrderMaker side tokenId makerAmountFilled
+      takerAmountFilled exchange timestamp blockNumber transactionHash
+      market { id slug conditionId }
+    """,
+    "FeeEvent": """
+      id receiver amount timestamp blockNumber transactionHash
+    """,
+    "PolyUSDTransfer": """
+      id from to amount timestamp blockNumber transactionHash
+    """,
+    "PolyUSDWrap": """
+      id eventType caller asset to amount timestamp blockNumber transactionHash
+    """,
+}
+
+GRAPHQL_ENTITY_BY_TABLE = {
+    "order_fills": "OrderFill",
+    "order_matches": "OrderMatch",
+    "fee_events": "FeeEvent",
+    "polyusd_transfers": "PolyUSDTransfer",
+    "polyusd_wraps": "PolyUSDWrap",
+}
+
+
+@dataclass(frozen=True)
+class NormalizedEvent:
+    table: str
+    row: dict[str, Any]
+
+
+def parse_event_id(value: Any) -> tuple[int, int | None, int | None]:
+    """Parse Envio ids like `137_84902320_4` into chain/block/log parts."""
+
+    if not value:
+        return (137, None, None)
+    parts = str(value).split("_")
+    if len(parts) < 3:
+        return (137, None, None)
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return (137, None, None)
+
+
+def get_any(row: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return default
+
+
+def parse_timestamp(value: Any) -> datetime:
+    if value is None:
+        raise ValueError("event timestamp is required")
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    text = str(value)
+    if text.isdigit():
+        return datetime.fromtimestamp(int(text), tz=timezone.utc)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def as_decimal(value: Any) -> Decimal:
+    if value is None:
+        return Decimal(0)
+    return Decimal(str(value))
+
+
+def as_text(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def market_id_from(row: dict[str, Any]) -> str | None:
+    direct = get_any(row, "market_id", "marketId")
+    if direct:
+        return str(direct)
+    market = row.get("market")
+    if isinstance(market, dict):
+        return as_text(get_any(market, "slug", "id", "conditionId"), default="") or None
+    if market:
+        return str(market)
+    return None
+
+
+def normalize_common(row: dict[str, Any]) -> dict[str, Any]:
+    chain_id, id_block, id_log = parse_event_id(row.get("id"))
+    block_number = int(get_any(row, "blockNumber", "block_number", default=id_block))
+    log_index = int(get_any(row, "logIndex", "log_index", default=id_log))
+    return {
+        "chain_id": int(get_any(row, "chainId", "chain_id", default=chain_id)),
+        "block_number": block_number,
+        "log_index": log_index,
+        "block_timestamp": parse_timestamp(get_any(row, "timestamp", "blockTimestamp")),
+        "transaction_hash": as_text(get_any(row, "transactionHash", "transaction_hash")),
+    }
+
+
+def normalize_order_fill(row: dict[str, Any]) -> NormalizedEvent:
+    common = normalize_common(row)
+    normalized = {
+        **common,
+        "tx_from": as_text(get_any(row, "txFrom", "tx_from"), default=""),
+        "exchange": as_text(row.get("exchange")),
+        "order_hash": as_text(get_any(row, "orderHash", "order_hash")),
+        "maker": as_text(row.get("maker")),
+        "taker": as_text(row.get("taker")),
+        "side": int(row.get("side")),
+        "token_id": as_text(get_any(row, "tokenId", "token_id")),
+        "market_id": market_id_from(row),
+        "maker_amount_raw": as_decimal(get_any(row, "makerAmountFilled", "maker_amount_raw")),
+        "taker_amount_raw": as_decimal(get_any(row, "takerAmountFilled", "taker_amount_raw")),
+        "fee_raw": as_decimal(get_any(row, "fee", "fee_raw")),
+        "builder": as_text(row.get("builder"), ZERO_BYTES32),
+        "metadata": as_text(row.get("metadata"), ZERO_BYTES32),
+        "raw_event": row,
+    }
+    return NormalizedEvent("polymarket_v2_order_fills", normalized)
+
+
+def normalize_order_match(row: dict[str, Any]) -> NormalizedEvent:
+    common = normalize_common(row)
+    normalized = {
+        **common,
+        "exchange": as_text(row.get("exchange")),
+        "taker_order_hash": as_text(get_any(row, "takerOrderHash", "taker_order_hash")),
+        "taker_order_maker": as_text(get_any(row, "takerOrderMaker", "taker_order_maker")),
+        "side": int(row.get("side")),
+        "token_id": as_text(get_any(row, "tokenId", "token_id")),
+        "market_id": market_id_from(row),
+        "maker_amount_raw": as_decimal(get_any(row, "makerAmountFilled", "maker_amount_raw")),
+        "taker_amount_raw": as_decimal(get_any(row, "takerAmountFilled", "taker_amount_raw")),
+        "raw_event": row,
+    }
+    return NormalizedEvent("polymarket_v2_order_matches", normalized)
+
+
+def normalize_fee_event(row: dict[str, Any]) -> NormalizedEvent:
+    common = normalize_common(row)
+    normalized = {
+        **common,
+        "receiver": as_text(row.get("receiver")),
+        "amount_raw": as_decimal(get_any(row, "amount", "amount_raw")),
+        "raw_event": row,
+    }
+    return NormalizedEvent("polymarket_v2_fee_events", normalized)
+
+
+def normalize_polyusd_transfer(row: dict[str, Any]) -> NormalizedEvent:
+    common = normalize_common(row)
+    normalized = {
+        **common,
+        "event_type": "transfer",
+        "address_from": as_text(get_any(row, "from", "address_from"), default=""),
+        "address_to": as_text(get_any(row, "to", "address_to"), default=""),
+        "caller": None,
+        "asset": None,
+        "amount_raw": as_decimal(get_any(row, "amount", "amount_raw")),
+        "raw_event": row,
+    }
+    return NormalizedEvent("polymarket_v2_polyusd_events", normalized)
+
+
+def normalize_polyusd_wrap(row: dict[str, Any]) -> NormalizedEvent:
+    common = normalize_common(row)
+    event_type = as_text(get_any(row, "eventType", "event_type"), default="wrap").lower()
+    if event_type not in {"wrap", "unwrap"}:
+        raise ValueError(f"unsupported PolyUSD wrap eventType={event_type!r}")
+    normalized = {
+        **common,
+        "event_type": event_type,
+        "address_from": None,
+        "address_to": as_text(get_any(row, "to", "address_to"), default=""),
+        "caller": as_text(row.get("caller"), default=""),
+        "asset": as_text(row.get("asset"), default=""),
+        "amount_raw": as_decimal(get_any(row, "amount", "amount_raw")),
+        "raw_event": row,
+    }
+    return NormalizedEvent("polymarket_v2_polyusd_events", normalized)
+
+
+NORMALIZERS = {
+    "OrderFill": normalize_order_fill,
+    "OrderMatch": normalize_order_match,
+    "FeeEvent": normalize_fee_event,
+    "PolyUSDTransfer": normalize_polyusd_transfer,
+    "PolyUSDWrap": normalize_polyusd_wrap,
+}
+
+
+INSERT_SQL = {
+    "polymarket_v2_order_fills": """
+        INSERT INTO polymarket_v2_order_fills (
+          chain_id, block_number, log_index, block_timestamp, transaction_hash,
+          tx_from, exchange, order_hash, maker, taker, side, token_id, market_id,
+          maker_amount_raw, taker_amount_raw, fee_raw, builder, metadata, raw_event
+        ) VALUES (
+          %(chain_id)s, %(block_number)s, %(log_index)s, %(block_timestamp)s,
+          %(transaction_hash)s, %(tx_from)s, %(exchange)s, %(order_hash)s,
+          %(maker)s, %(taker)s, %(side)s, %(token_id)s, %(market_id)s,
+          %(maker_amount_raw)s, %(taker_amount_raw)s, %(fee_raw)s, %(builder)s,
+          %(metadata)s, %(raw_event)s
+        )
+        ON CONFLICT (chain_id, block_number, log_index) DO UPDATE SET
+          block_timestamp = EXCLUDED.block_timestamp,
+          transaction_hash = EXCLUDED.transaction_hash,
+          market_id = EXCLUDED.market_id,
+          raw_event = EXCLUDED.raw_event,
+          ingested_at = NOW()
+    """,
+    "polymarket_v2_order_matches": """
+        INSERT INTO polymarket_v2_order_matches (
+          chain_id, block_number, log_index, block_timestamp, transaction_hash,
+          exchange, taker_order_hash, taker_order_maker, side, token_id, market_id,
+          maker_amount_raw, taker_amount_raw, raw_event
+        ) VALUES (
+          %(chain_id)s, %(block_number)s, %(log_index)s, %(block_timestamp)s,
+          %(transaction_hash)s, %(exchange)s, %(taker_order_hash)s,
+          %(taker_order_maker)s, %(side)s, %(token_id)s, %(market_id)s,
+          %(maker_amount_raw)s, %(taker_amount_raw)s, %(raw_event)s
+        )
+        ON CONFLICT (chain_id, block_number, log_index) DO UPDATE SET
+          block_timestamp = EXCLUDED.block_timestamp,
+          transaction_hash = EXCLUDED.transaction_hash,
+          market_id = EXCLUDED.market_id,
+          raw_event = EXCLUDED.raw_event,
+          ingested_at = NOW()
+    """,
+    "polymarket_v2_fee_events": """
+        INSERT INTO polymarket_v2_fee_events (
+          chain_id, block_number, log_index, block_timestamp, transaction_hash,
+          receiver, amount_raw, raw_event
+        ) VALUES (
+          %(chain_id)s, %(block_number)s, %(log_index)s, %(block_timestamp)s,
+          %(transaction_hash)s, %(receiver)s, %(amount_raw)s, %(raw_event)s
+        )
+        ON CONFLICT (chain_id, block_number, log_index) DO UPDATE SET
+          block_timestamp = EXCLUDED.block_timestamp,
+          amount_raw = EXCLUDED.amount_raw,
+          raw_event = EXCLUDED.raw_event,
+          ingested_at = NOW()
+    """,
+    "polymarket_v2_polyusd_events": """
+        INSERT INTO polymarket_v2_polyusd_events (
+          chain_id, block_number, log_index, block_timestamp, transaction_hash,
+          event_type, address_from, address_to, caller, asset, amount_raw, raw_event
+        ) VALUES (
+          %(chain_id)s, %(block_number)s, %(log_index)s, %(block_timestamp)s,
+          %(transaction_hash)s, %(event_type)s, %(address_from)s, %(address_to)s,
+          %(caller)s, %(asset)s, %(amount_raw)s, %(raw_event)s
+        )
+        ON CONFLICT (chain_id, block_number, log_index, event_type) DO UPDATE SET
+          block_timestamp = EXCLUDED.block_timestamp,
+          amount_raw = EXCLUDED.amount_raw,
+          raw_event = EXCLUDED.raw_event,
+          ingested_at = NOW()
+    """,
+}
+
+
+def graphql_query(entity: str) -> str:
+    fields = GRAPHQL_FIELDS[entity]
+    return f"""
+    query ImportPolymarketV2($limit: Int!, $offset: Int!, $minBlock: Int!) {{
+      {entity}(
+        limit: $limit,
+        offset: $offset,
+        where: {{ blockNumber: {{ _gte: $minBlock }} }},
+        order_by: [{{ blockNumber: asc }}, {{ id: asc }}]
+      ) {{
+        {fields}
+      }}
+    }}
+    """
+
+
+def post_graphql(endpoint: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GraphQL HTTP {exc.code}: {body}") from exc
+
+
+def fetch_graphql(endpoint: str, entity: str, min_block: int, page_size: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    query = graphql_query(entity)
+    while True:
+        payload = post_graphql(
+            endpoint,
+            query,
+            {"limit": page_size, "offset": offset, "minBlock": min_block},
+        )
+        if payload.get("errors"):
+            raise RuntimeError(json.dumps(payload["errors"], indent=2))
+        page = payload.get("data", {}).get(entity) or []
+        rows.extend(page)
+        if len(page) < page_size:
+            return rows
+        offset += page_size
+
+
+def read_input(path: Path) -> dict[str, list[dict[str, Any]]]:
+    if path.suffix == ".jsonl":
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        with path.open() as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                entity = payload.pop("entity", None) or payload.pop("_entity", None)
+                if not entity:
+                    raise ValueError("JSONL rows must include entity or _entity")
+                grouped[entity].append(payload)
+        return dict(grouped)
+
+    payload = json.loads(path.read_text())
+    if isinstance(payload, list):
+        grouped = defaultdict(list)
+        for item in payload:
+            entity = item.pop("entity", None) or item.pop("_entity", None)
+            if not entity:
+                raise ValueError("JSON array rows must include entity or _entity")
+            grouped[entity].append(item)
+        return dict(grouped)
+    if isinstance(payload, dict):
+        return {key: value for key, value in payload.items() if isinstance(value, list)}
+    raise ValueError("input must be a JSON object, JSON array, or JSONL")
+
+
+def normalize_rows(grouped: dict[str, list[dict[str, Any]]]) -> list[NormalizedEvent]:
+    events: list[NormalizedEvent] = []
+    for entity, rows in grouped.items():
+        normalizer = NORMALIZERS.get(entity)
+        if normalizer is None:
+            raise ValueError(f"unsupported entity {entity!r}")
+        for row in rows:
+            events.append(normalizer(dict(row)))
+    return events
+
+
+def jsonb_wrapper(value: dict[str, Any]) -> Any:
+    try:
+        from psycopg.types.json import Jsonb  # type: ignore
+    except ImportError as exc:
+        raise SystemExit(
+            "psycopg is required for DB import. Install with: python3 -m pip install psycopg[binary]"
+        ) from exc
+    return Jsonb(value)
+
+
+def write_events(db_url: str, events: list[NormalizedEvent], source: str) -> Counter:
+    try:
+        import psycopg  # type: ignore
+    except ImportError as exc:
+        raise SystemExit(
+            "psycopg is required for DB import. Install with: python3 -m pip install psycopg[binary]"
+        ) from exc
+
+    counts: Counter = Counter()
+    max_event: NormalizedEvent | None = None
+    with psycopg.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            for event in events:
+                row = dict(event.row)
+                row["raw_event"] = jsonb_wrapper(row["raw_event"])
+                cur.execute(INSERT_SQL[event.table], row)
+                counts[event.table] += 1
+                if max_event is None or row["block_number"] > max_event.row["block_number"]:
+                    max_event = event
+
+            if max_event is not None:
+                cur.execute(
+                    """
+                    INSERT INTO polymarket_v2_indexer_sync_state (
+                      source, last_block_number, last_block_timestamp, last_transaction_hash
+                    ) VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (source) DO UPDATE SET
+                      last_block_number = GREATEST(
+                        polymarket_v2_indexer_sync_state.last_block_number,
+                        EXCLUDED.last_block_number
+                      ),
+                      last_block_timestamp = EXCLUDED.last_block_timestamp,
+                      last_transaction_hash = EXCLUDED.last_transaction_hash,
+                      updated_at = NOW()
+                    """,
+                    (
+                        source,
+                        max_event.row["block_number"],
+                        max_event.row["block_timestamp"],
+                        max_event.row["transaction_hash"],
+                    ),
+                )
+        conn.commit()
+    return counts
+
+
+def read_sync_min_block(db_url: str, source: str, fallback: int) -> int:
+    try:
+        import psycopg  # type: ignore
+    except ImportError as exc:
+        raise SystemExit(
+            "psycopg is required for sync-state reads. Install with: python3 -m pip install psycopg[binary]"
+        ) from exc
+
+    with psycopg.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT last_block_number FROM polymarket_v2_indexer_sync_state WHERE source = %s",
+                (source,),
+            )
+            row = cur.fetchone()
+    if not row or row[0] is None:
+        return fallback
+    return max(fallback, int(row[0]) + 1)
+
+
+def selected_graphql_entities(names: str) -> list[str]:
+    entities: list[str] = []
+    for name in names.split(","):
+        key = name.strip()
+        if not key:
+            continue
+        entity = GRAPHQL_ENTITY_BY_TABLE.get(key, key)
+        if entity not in GRAPHQL_FIELDS:
+            raise ValueError(f"unknown entity/table selector {key!r}")
+        entities.append(entity)
+    return entities
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", default=DB_URL)
+    parser.add_argument("--endpoint", default=os.environ.get("PLOY_PM_V2_INDEXER_URL", ""))
+    parser.add_argument("--input", type=Path, help="JSON/JSONL export from the Envio indexer")
+    parser.add_argument("--min-block", type=int, default=84902320)
+    parser.add_argument(
+        "--from-sync-state",
+        action="store_true",
+        help="Start from persisted polymarket_v2_indexer_sync_state when querying GraphQL",
+    )
+    parser.add_argument("--page-size", type=int, default=250)
+    parser.add_argument(
+        "--entities",
+        default="order_fills,order_matches,fee_events,polyusd_transfers,polyusd_wraps",
+        help="Comma-separated entity names or aliases",
+    )
+    parser.add_argument("--source", default="envio_polymarket_v2_indexer")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.input and not args.endpoint:
+        parser.error("provide --input or --endpoint/PLOY_PM_V2_INDEXER_URL")
+
+    if args.input:
+        grouped = read_input(args.input)
+    else:
+        if args.from_sync_state:
+            args.min_block = read_sync_min_block(args.db_url, args.source, args.min_block)
+        grouped = {}
+        for entity in selected_graphql_entities(args.entities):
+            grouped[entity] = fetch_graphql(args.endpoint, entity, args.min_block, args.page_size)
+
+    events = normalize_rows(grouped)
+    counts = Counter(event.table for event in events)
+    max_block = max((event.row["block_number"] for event in events), default=None)
+
+    print(
+        json.dumps(
+            {
+                "entities": {entity: len(rows) for entity, rows in grouped.items()},
+                "tables": counts,
+                "max_block": max_block,
+                "dry_run": args.dry_run,
+            },
+            default=str,
+            sort_keys=True,
+        )
+    )
+
+    if args.dry_run or not events:
+        return 0
+
+    written = write_events(args.db_url, events, args.source)
+    print(json.dumps({"written": written}, default=str, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ploy_maintenance.sh
+++ b/scripts/ploy_maintenance.sh
@@ -22,7 +22,7 @@ RETENTION_BINANCE_AGGTRADE_DAYS="${PLOY_RETENTION_BINANCE_AGGTRADE_DAYS:-7}"
 RETENTION_BINANCE_LOB_DAYS="${PLOY_RETENTION_BINANCE_LOB_DAYS:-7}"
 RETENTION_NBA_OBS_DAYS="${PLOY_RETENTION_NBA_OBS_DAYS:-7}"
 RETENTION_ORDER_EXEC_DAYS="${PLOY_RETENTION_ORDER_EXEC_DAYS:-7}"
-RETENTION_LOG_DAYS="${PLOY_RETENTION_LOG_DAYS:-14}"
+RETENTION_LOG_DAYS="${PLOY_RETENTION_LOG_DAYS:-7}"
 JOURNAL_VACUUM_SIZE="${PLOY_JOURNAL_VACUUM_SIZE:-200M}"
 DERIBIT_PARTITION_LOOKBACK_DAYS="${PLOY_DERIBIT_PARTITION_LOOKBACK_DAYS:-7}"
 DERIBIT_PARTITION_LOOKAHEAD_DAYS="${PLOY_DERIBIT_PARTITION_LOOKAHEAD_DAYS:-14}"
@@ -236,6 +236,25 @@ SQL
 
 echo "==> Log retention"
 if [[ -d "$LOG_DIR" ]]; then
+  if cutoff_epoch=$(date -d "today - $((RETENTION_LOG_DAYS - 1)) days" +%s 2>/dev/null); then
+    while IFS= read -r -d '' path; do
+      basename="${path##*/}"
+      if [[ "$basename" =~ ([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+        file_date="${BASH_REMATCH[1]}"
+        file_epoch=$(date -d "${file_date} 00:00:00" +%s 2>/dev/null || echo 0)
+        if (( file_epoch > 0 && file_epoch < cutoff_epoch )); then
+          rm -f -- "$path"
+        fi
+      fi
+    done < <(
+      find "$LOG_DIR" -maxdepth 1 -type f \
+        \( -name 'ploy.log.*' -o -name 'ploy.log.*.gz' \) \
+        -print0
+    )
+  else
+    echo "Skipping filename-date log pruning because GNU date -d is unavailable"
+  fi
+
   # Compress older uncompressed logs.
   find "$LOG_DIR" -maxdepth 1 -type f -name 'ploy.log.*' -mtime +1 ! -name '*.gz' -print0 \
     | xargs -0 -r gzip -9

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -105,7 +105,7 @@ class DryRunReportContractTests(unittest.TestCase):
                 "daily_sharpe_basis": "daily_net_pnl_sqrt_365",
             },
             "execution_diagnostics": {"basis": "strategy_runtime_orders"},
-            "strategies": [{"execution_diagnostics": {}}],
+            "strategies": [{"deployment_id": "test-deploy", "execution_diagnostics": {}}],
         }
 
         result = subprocess.run(
@@ -117,7 +117,7 @@ class DryRunReportContractTests(unittest.TestCase):
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("strategies[0].execution_diagnostics.basis", result.stderr)
+        self.assertIn("strategies[test-deploy].execution_diagnostics.basis", result.stderr)
 
     def test_strategy_label_prefers_versioned_experiment_label(self) -> None:
         summary = load_summary_module()

--- a/tests/test_polymarket_v2_indexer_contracts.py
+++ b/tests/test_polymarket_v2_indexer_contracts.py
@@ -1,0 +1,123 @@
+import importlib.util
+import sys
+from datetime import timezone
+from decimal import Decimal
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SCRIPT = ROOT / "scripts" / "import_polymarket_v2_indexer.py"
+MIGRATION = ROOT / "migrations" / "040_polymarket_v2_indexer_events.sql"
+DEPLOY_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml"
+IMPORT_SERVICE = ROOT / "deployment" / "systemd" / "ploy-polymarket-v2-indexer-import.service"
+IMPORT_TIMER = ROOT / "deployment" / "systemd" / "ploy-polymarket-v2-indexer-import.timer"
+
+
+def load_importer_module():
+    spec = importlib.util.spec_from_file_location(
+        "import_polymarket_v2_indexer", IMPORTER_SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PolymarketV2IndexerContractTests(unittest.TestCase):
+    def test_migration_adds_sidecar_tables_without_touching_runtime_tables(self) -> None:
+        migration = MIGRATION.read_text()
+
+        self.assertIn("CREATE TABLE IF NOT EXISTS polymarket_v2_order_fills", migration)
+        self.assertIn("CREATE TABLE IF NOT EXISTS polymarket_v2_polyusd_events", migration)
+        self.assertIn("CREATE TABLE IF NOT EXISTS polymarket_v2_indexer_sync_state", migration)
+        self.assertIn("UNIQUE (chain_id, block_number, log_index)", migration)
+        self.assertIn("not realtime trading signals", migration)
+        self.assertNotIn("ALTER TABLE strategy_runtime_fills", migration)
+        self.assertNotIn("ALTER TABLE clob_quote_ticks", migration)
+
+    def test_order_fill_normalization_preserves_raw_chain_fields(self) -> None:
+        importer = load_importer_module()
+        normalized = importer.normalize_order_fill(
+            {
+                "id": "137_84902321_7",
+                "orderHash": "0xorder",
+                "maker": "0xmaker",
+                "taker": "0xtaker",
+                "side": 0,
+                "tokenId": "12345",
+                "market": {"slug": "btc-updown-15m"},
+                "makerAmountFilled": "1000000",
+                "takerAmountFilled": "420000",
+                "fee": "120",
+                "builder": "0xbuilder",
+                "metadata": "0xmeta",
+                "exchange": "0xe111180000d2663c0091e4f400237545b87b996b",
+                "timestamp": 1777440000,
+                "blockNumber": 84902321,
+                "transactionHash": "0xtx",
+                "txFrom": "0xsender",
+            }
+        )
+
+        row = normalized.row
+        self.assertEqual(normalized.table, "polymarket_v2_order_fills")
+        self.assertEqual(row["chain_id"], 137)
+        self.assertEqual(row["block_number"], 84902321)
+        self.assertEqual(row["log_index"], 7)
+        self.assertEqual(row["token_id"], "12345")
+        self.assertEqual(row["market_id"], "btc-updown-15m")
+        self.assertEqual(row["maker_amount_raw"], Decimal("1000000"))
+        self.assertEqual(row["fee_raw"], Decimal("120"))
+        self.assertEqual(row["block_timestamp"].tzinfo, timezone.utc)
+
+    def test_polyusd_wrap_normalization_uses_single_flow_table(self) -> None:
+        importer = load_importer_module()
+        normalized = importer.normalize_polyusd_wrap(
+            {
+                "id": "137_84902322_2",
+                "eventType": "unwrap",
+                "caller": "0xwallet",
+                "asset": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+                "to": "0xwallet",
+                "amount": "25000000",
+                "timestamp": "2026-04-29T12:00:00Z",
+                "blockNumber": 84902322,
+                "transactionHash": "0xtx2",
+            }
+        )
+
+        self.assertEqual(normalized.table, "polymarket_v2_polyusd_events")
+        self.assertEqual(normalized.row["event_type"], "unwrap")
+        self.assertEqual(normalized.row["caller"], "0xwallet")
+        self.assertEqual(normalized.row["amount_raw"], Decimal("25000000"))
+
+    def test_jsonl_input_requires_entity_and_groups_events(self) -> None:
+        importer = load_importer_module()
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl") as handle:
+            handle.write('{"entity":"FeeEvent","id":"137_1_1","receiver":"0xfee","amount":"4","timestamp":1,"blockNumber":1,"transactionHash":"0xtx"}\n')
+            handle.flush()
+
+            grouped = importer.read_input(Path(handle.name))
+
+        self.assertEqual(list(grouped), ["FeeEvent"])
+        self.assertEqual(grouped["FeeEvent"][0]["receiver"], "0xfee")
+
+    def test_importer_and_timer_are_wired_for_deploy_without_realtime_dependency(self) -> None:
+        workflow = DEPLOY_WORKFLOW.read_text()
+        service = IMPORT_SERVICE.read_text()
+        timer = IMPORT_TIMER.read_text()
+
+        self.assertIn("040_polymarket_v2_indexer_events.sql", workflow)
+        self.assertIn("scripts/import_polymarket_v2_indexer.py", workflow)
+        self.assertIn("ploy-polymarket-v2-indexer-import.timer", workflow)
+        self.assertIn("polymarket-v2-indexer.service", workflow)
+        self.assertIn("--from-sync-state", service)
+        self.assertIn("PLOY_PM_V2_INDEXER_URL not configured; skipping", service)
+        self.assertIn("OnUnitActiveSec=10m", timer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STRATEGY_DIR = ROOT / "config" / "strategies"
+
+
+class StrategyConfigContractTests(unittest.TestCase):
+    def test_pm5d_threelayer_has_one_bounded_canonical_recording_source(self) -> None:
+        dryrun_configs = sorted(STRATEGY_DIR.glob("02-pm5d-threelayer.*-dryrun.toml"))
+        self.assertGreaterEqual(len(dryrun_configs), 4)
+
+        recorders = []
+        for path in dryrun_configs:
+            config = tomllib.loads(path.read_text())
+            runtime = config.get("runtime", {})
+            record_path = runtime.get("record_market_updates_to")
+            if record_path:
+                recorders.append((path.name, runtime))
+
+        self.assertEqual(
+            [name for name, _ in recorders],
+            ["02-pm5d-threelayer.obi-soft-dryrun.toml"],
+        )
+        runtime = recorders[0][1]
+        self.assertEqual(
+            runtime["record_market_updates_to"],
+            "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson",
+        )
+        self.assertGreater(runtime["record_market_updates_max_records"], 0)
+        self.assertGreater(runtime["record_market_updates_max_bytes"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -465,6 +465,68 @@ fn host_deploy_workflows_require_main_provenance_and_pinned_ssh() {
 }
 
 #[test]
+fn research_workflows_require_private_tango_db_endpoint() {
+    let mut offenders = Vec::new();
+
+    let backtest = workflow_contents(".github/workflows/backtest.yml");
+    if !backtest.contains(
+        "PLOY_RESEARCH_DATABASE_URL must target Tango-1-1 private VPC endpoint 172.16.0.204",
+    ) {
+        offenders.push("backtest.yml: missing private Tango DB endpoint guard".to_string());
+    }
+    if !backtest.contains(
+        "urlparse(os.environ[\"PLOY_RESEARCH_DATABASE_URL\"]).hostname",
+    ) {
+        offenders.push("backtest.yml: must parse the research DB URL host before use".to_string());
+    }
+
+    let factor_review = workflow_contents(".github/workflows/factor-review-v2.yml");
+    if !factor_review
+        .contains("PLOY_DB_URL must target Tango-1-1 private VPC endpoint 172.16.0.204")
+    {
+        offenders.push("factor-review-v2.yml: missing private Tango DB endpoint guard".to_string());
+    }
+    if !factor_review.contains("urlparse(os.environ[\"PLOY_DB_URL\"]).hostname") {
+        offenders.push(
+            "factor-review-v2.yml: must parse the research DB URL host before use".to_string(),
+        );
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research workflow private DB guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn optimize_workflow_builds_and_runs_in_one_job() {
+    let content = workflow_contents(".github/workflows/optimize.yml");
+    let mut offenders = Vec::new();
+
+    if content.contains("download-artifact") || content.contains("optimize_backtest-${{ github.sha }}") {
+        offenders.push(
+            "optimize.yml: must not pass optimize_backtest through a binary artifact".to_string(),
+        );
+    }
+    if content.contains("Swatinem/rust-cache") {
+        offenders.push(
+            "optimize.yml: must not use Swatinem/rust-cache after cache post-step hangs"
+                .to_string(),
+        );
+    }
+    if !content.contains("name: Build and run optimize on ploy-ci-1") {
+        offenders.push("optimize.yml: must use the single build-and-run job".to_string());
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "optimize workflow single-job guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn checked_in_platform_service_enforces_guardrails() {
     let content = workflow_contents("deployment/ployd.service");
     let required = [


### PR DESCRIPTION
## Summary
- Make strategy runners default to local DB market-data feeds and gate direct public Polymarket/Gamma/RTDS feeds behind explicit opt-in.
- Add bounded dry-run MarketUpdate recording and runner JSON output support for replay parity.
- Add Polymarket V2 sidecar importer/deploy wiring with migration renumbered to 040 on the current mainline.
- Preserve supporting guardrails: private DB research endpoint docs, shorter stale log retention, OpenAI model migration guidance, and dry-run contract checker identity test.

## Verification
- git diff --check
- python3 -m unittest tests.test_runtime_market_data_boundary tests.test_strategy_config_contracts tests.test_dryrun_report_contracts tests.test_polymarket_v2_indexer_contracts
- ruby YAML parse for backtest.yml, factor-review-v2.yml, deploy-tango-1-1.yml
- bash -n scripts/ploy_maintenance.sh scripts/import_polymarket_v2_indexer.py
- rtk cargo check -p ploy-market-data
- rtk cargo check -p ploy-strategy-runtime --features live,db-recorder
- rtk cargo test -p ploy-strategy-bundles config --lib
- rtk cargo check -p ploy-runner-host --features ops
- rtk cargo test --test workflow_security

## Notes
- Skipped replaying the old dry-run label commit because current main already contains the identity-based label/type/test behavior.
- Skipped the stale task-log-only commit because it duplicated current task sections and referenced the old 039 Polymarket migration number.
