### PR TITLE
Keep optimize split experiments independent

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -40,12 +40,12 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout, local snapshot registry"
+        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout, local snapshot registry, min_trades"
         required: false
-        default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":"","snapshot_registry_dir":""}'
+        default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":"","snapshot_registry_dir":"","min_trades":""}'
 
 concurrency:
-  group: optimize-${{ github.event.inputs.git_ref || github.ref }}-${{ github.event.inputs.strategy_profile || 'mixed' }}
+  group: optimize-${{ github.event.inputs.git_ref || github.ref }}-${{ github.event.inputs.strategy_profile || 'mixed' }}-${{ github.event.inputs.snapshot_run_id || 'live' }}-${{ github.event.inputs.train_start }}-${{ github.event.inputs.train_end }}-${{ github.event.inputs.val_start }}-${{ github.event.inputs.val_end }}
   cancel-in-progress: true
 
 permissions:
@@ -114,6 +114,7 @@ jobs:
               "allow_live_parquet_debug": "false",
               "issue_number": "",
               "snapshot_registry_dir": "",
+              "min_trades": "",
           }
           bool_keys = {"allow_large_window", "preflight_only", "allow_live_parquet_debug"}
           raw = os.environ.get("OPTIONS_JSON", "").strip()
@@ -135,6 +136,13 @@ jobs:
                       raise SystemExit(f"options_json value for {key} must be boolean")
               else:
                   values[key] = str(value)
+              if key == "min_trades" and values[key]:
+                  try:
+                      parsed = int(values[key])
+                  except ValueError as exc:
+                      raise SystemExit("options_json value for min_trades must be an integer") from exc
+                  if parsed < 1:
+                      raise SystemExit("options_json value for min_trades must be >= 1")
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
               for key, value in values.items():
@@ -392,6 +400,7 @@ jobs:
           fi
 
           extra_flags=()
+          snapshot_flags=()
           if [ "${OPT_ALLOW_LARGE_WINDOW}" = "true" ]; then
             extra_flags+=(--allow-large-window)
           fi
@@ -400,6 +409,9 @@ jobs:
           fi
           if [ "${OPT_ALLOW_LIVE_PARQUET_DEBUG}" = "true" ]; then
             extra_flags+=(--allow-live-parquet-debug)
+          fi
+          if [ -n "${OPT_MIN_TRADES}" ]; then
+            snapshot_flags+=(--min-trades "${OPT_MIN_TRADES}")
           fi
 
           set +e
@@ -417,6 +429,7 @@ jobs:
               --stake-usd 15 \
               --output-dir artifacts/optimize \
               "${time_flags[@]}" \
+              "${snapshot_flags[@]}" \
               2>&1 | tee artifacts/optimize/report.txt
             status=${PIPESTATUS[0]}
           else

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,13 +26,41 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Stop new workflows from embedding full 1GB research snapshots in GitHub artifacts.
 - [x] Run local shell/YAML validation.
 - [x] Push PR.
-- [ ] Verify one new Research Snapshot run plus snapshot-backed walk-forward/optimize reuse on `ploy-ci-1`.
+- [x] Verify one new Research Snapshot run plus snapshot-backed walk-forward/optimize reuse on `ploy-ci-1`.
 
 ## Review
 
 - 2026-05-01: Workflow data flow is now `Tango DB -> ploy-ci-1 local registry -> downstream research jobs`, with GitHub artifacts reduced to provenance/report files. Existing full `research-snapshot-*` artifacts remain a fallback for older run ids.
 - 2026-05-01: Local verification passed: `bash -n scripts/publish_research_snapshot_registry.sh scripts/restore_research_snapshot.sh`, Ruby YAML parse for `research-snapshot.yml`, `optimize.yml`, `factor-review-v2.yml`, and `factor-walk-forward-v2.yml`, `git diff --check`, and a temp-dir publish/restore smoke test. `actionlint` was not installed locally.
 - 2026-05-01: PR #280 was opened and all PR checks passed, including `Workflow lint`, `Rust research heavy features`, and CodeRabbit.
+- 2026-05-01: Main verification passed. Research Snapshot `25203749439` uploaded only `research-snapshot-provenance-25203749439` (`19,702` bytes), and snapshot-backed Optimize `25203900387` restored from `/home/runner/actions-runner/_work/ploy/_ploy-research-snapshots/by-run/25203749439` with `snapshot_backed=true`.
+
+# Optimize Strategy Matrix Controls (2026-05-01)
+
+Issue: https://github.com/proerror77/ploy/issues/256
+
+## Files
+
+- `.github/workflows/optimize.yml`
+  - Owner: allow independent split/profile research runs and expose snapshot optimizer sample-power sensitivity controls.
+- `tasks/todo.md`
+  - Owner: record matrix evidence and workflow-control rationale.
+
+## Tasks
+
+- [x] Diagnose why same-profile split experiments cancelled each other.
+- [x] Include train/validation window and snapshot id in the optimize concurrency key.
+- [x] Expose the snapshot optimizer's existing `--min-trades` flag through `options_json` without changing the default dynamic floor.
+- [x] Run local workflow syntax validation.
+- [ ] Push PR and watch checks.
+- [ ] Re-run continuation split sensitivity after merge.
+
+## Review
+
+- 2026-05-01: Seven-day Research Snapshot `25204438461` succeeded from `main@453f3394` in `23m46s`; `Compile snapshot` took `21m22s`, runner-local publish took `1s`, and the only GitHub artifact was `research-snapshot-provenance-25204438461` (`19,730` bytes).
+- 2026-05-01: First six-profile matrix on `snapshot_run_id=25204438461`, train `2026-04-24..2026-04-28`, validation `2026-04-29..2026-05-01`, showed only `continuation_soft` clearing the default dynamic floor: validation trades `149`, validation PnL `$2755.46`, fill rate `1.0`, win rate `0.564`, positive symbol rate `1.0`, selection objective `8.381`, but EV calibration gap `0.288`.
+- 2026-05-01: Other profiles were underpowered in validation despite positive PnL: `champion` 8 validation trades, `obi_hard` 11, `mixed` 25, `obi_soft` 7, and `cex_direction_first` 9 with negative validation PnL.
+- 2026-05-01: Alternate `continuation_soft` splits were not stable enough for deployment: early split validation had only 14 trades, and late split had train 17 / validation 11 trades with validation EV gap `2.295`. Treat `continuation_soft` as a research candidate, not a dry-run/live promotion yet.
 
 # Central Market Discovery Service (2026-05-01)
 


### PR DESCRIPTION
## Summary
- include snapshot id and train/validation dates in optimize workflow concurrency keys
- expose the snapshot optimizer's existing min_trades override through options_json for sensitivity analysis
- record the seven-day snapshot/profile matrix evidence in tasks/todo.md

## Evidence
- Research Snapshot 25204438461 succeeded in 23m46s and uploaded only provenance (19,730 bytes)
- six-profile matrix on snapshot 25204438461 only cleared the default floor for continuation_soft, but alternate splits were unstable

## Validation
- ruby YAML parse for .github/workflows/optimize.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `min_trades` parameter to optimization workflow for controlling minimum trade requirements.

* **Chores**
  * Updated project checklist documenting completed snapshot optimization enhancements, concurrency handling improvements, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->