### PR TITLE
Separate edge matrix fillability from throttling

### DIFF
--- a/crates/ploy-research/examples/three_layer_edge_matrix.rs
+++ b/crates/ploy-research/examples/three_layer_edge_matrix.rs
@@ -12,8 +12,8 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use ploy_research::{
-    FactorObservationV2, FactorReviewOptions, build_data_health_report,
-    build_factor_observations_v2_with_deribit_and_pm_books, load_research_snapshot,
+    build_data_health_report, build_factor_observations_v2_with_deribit_and_pm_books,
+    load_research_snapshot, FactorObservationV2, FactorReviewOptions,
 };
 use serde::Serialize;
 
@@ -88,7 +88,12 @@ struct MatrixResult {
     rejected_non_executable: usize,
     net_pnl: f64,
     avg_pnl: f64,
+    trade_attempts_after_throttle: usize,
+    selection_rate: f64,
     fill_rate: f64,
+    duplicate_rate: f64,
+    cooldown_rate: f64,
+    non_executable_rate: f64,
     win_rate: f64,
     avg_entry_price: f64,
     avg_expected_value_per_stake: f64,
@@ -205,7 +210,11 @@ fn reward_risk_ratio(entry_price: f64) -> f64 {
     let fee = fee_cost(entry_price);
     let reward = 1.0 - entry_price - fee;
     let risk = entry_price + fee;
-    if risk <= 0.0 { f64::NAN } else { reward / risk }
+    if risk <= 0.0 {
+        f64::NAN
+    } else {
+        reward / risk
+    }
 }
 
 fn executable_pnl(row: &FactorObservationV2) -> Option<f64> {
@@ -243,7 +252,11 @@ fn pm_dynamics_score(row: &FactorObservationV2) -> f64 {
 }
 
 fn finite_or_zero(value: f64) -> f64 {
-    if value.is_finite() { value } else { 0.0 }
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
 }
 
 fn pm_mode_passes(row: &FactorObservationV2, mode: PmMode) -> bool {
@@ -460,7 +473,12 @@ fn selected_metrics(
         } else {
             f64::NAN
         };
-    let fill_rate = ratio(trades, selected);
+    let trade_attempts_after_throttle = trades + rejected_non_executable;
+    let selection_rate = ratio(trades, selected);
+    let fill_rate = ratio(trades, trade_attempts_after_throttle);
+    let duplicate_rate = ratio(rejected_duplicate, selected);
+    let cooldown_rate = ratio(rejected_cooldown, selected);
+    let non_executable_rate = ratio(rejected_non_executable, trade_attempts_after_throttle);
     let win_rate = ratio(pnls.iter().filter(|pnl| **pnl > 0.0).count(), trades);
     let positive_day_rate = positive_bucket_rate(&pnl_by_day);
     let positive_symbol_rate = positive_bucket_rate(&pnl_by_symbol);
@@ -488,7 +506,12 @@ fn selected_metrics(
         rejected_non_executable,
         net_pnl,
         avg_pnl,
+        trade_attempts_after_throttle,
+        selection_rate,
         fill_rate,
+        duplicate_rate,
+        cooldown_rate,
+        non_executable_rate,
         win_rate,
         avg_entry_price,
         avg_expected_value_per_stake,
@@ -689,8 +712,17 @@ fn main() -> Result<()> {
                 format!("{:?}", row.fill_mode),
                 format!("{:?}", row.pm_mode),
                 row.trades.to_string(),
+                row.selected.to_string(),
+                row.trade_attempts_after_throttle.to_string(),
+                row.rejected_duplicate.to_string(),
+                row.rejected_cooldown.to_string(),
+                row.rejected_non_executable.to_string(),
                 format!("{:.6}", row.net_pnl),
+                format!("{:.6}", row.selection_rate),
                 format!("{:.6}", row.fill_rate),
+                format!("{:.6}", row.duplicate_rate),
+                format!("{:.6}", row.cooldown_rate),
+                format!("{:.6}", row.non_executable_rate),
                 format!("{:.6}", row.win_rate),
                 format!("{:.6}", row.avg_realized_return_per_stake),
                 format!("{:.6}", row.avg_expected_value_per_stake),
@@ -711,8 +743,17 @@ fn main() -> Result<()> {
             "fill_mode",
             "pm_mode",
             "trades",
+            "selected",
+            "trade_attempts_after_throttle",
+            "rejected_duplicate",
+            "rejected_cooldown",
+            "rejected_non_executable",
             "net_pnl",
+            "selection_rate",
             "fill_rate",
+            "duplicate_rate",
+            "cooldown_rate",
+            "non_executable_rate",
             "win_rate",
             "avg_realized_return_per_stake",
             "avg_expected_value_per_stake",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,14 +18,19 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Emit both `gate-attrition.csv` and `strategy-matrix-results.csv` instead of relying on one-off profile outcomes.
 - [x] Add GitHub Actions workflow for snapshot-backed matrix research.
 - [x] Run local compile/tests and workflow syntax checks.
-- [ ] Push PR and watch checks.
-- [ ] Run the matrix against snapshot `25204438461` and parse artifacts.
+- [x] Push PR and watch checks.
+- [x] Run the matrix against snapshot `25204438461` and parse artifacts.
+- [x] Fix matrix fillability accounting so duplicate/cooldown throttling is not misreported as CLOB fill failure.
+- [ ] Push fillability-accounting fix and rerun strict matrix on `main`.
 
 ## Review
 
 - 2026-05-01: Added a systematic research path so edge discovery can move from single-profile trial-and-error to batch hypothesis testing. The first matrix spans model vs inverted direction probability, full-depth vs executable vs entry-only fillability, no/soft/hard PM confirmation, three time windows, and three EV floors.
 - 2026-05-01: The runner is intentionally deterministic and optimizer-free. It records row/event-side attrition after each gate, then reports realized executable PnL, fill rate, EV calibration gap, positive day/symbol rates, and deployable-candidate status for train and validation separately.
 - 2026-05-01: Local verification passed: `CARGO_TARGET_DIR=/tmp/ploy-edge-matrix rtk cargo check -p ploy-research --example three_layer_edge_matrix --no-default-features`, `CARGO_TARGET_DIR=/tmp/ploy-edge-matrix-default rtk cargo check -p ploy-research --example three_layer_edge_matrix`, Ruby YAML parse for `strategy-research-matrix.yml`, and `git diff --check`. Cargo emitted only the pre-existing vendor profile warning.
+- 2026-05-01: PR #289 merged as `691dd570cc135e5ac60eb96f0d97b4cb59968e14`. Strict matrix run `25210900032` used snapshot `25204438461`, train `2026-04-24 -> 2026-04-28`, validation `2026-04-29 -> 2026-05-01`, six symbols, and `min_trades=80`. It failed closed with no deployable candidate. The strongest validation family was `inverted + pm_none`, especially wide/middle windows: top row `inverted_entry_only_pm_none_wide_ev0.05` had `65` validation trades, PnL `+$705.62`, realized/stake `+0.724`, positive symbol rate `100%`, but missed sample power, EV calibration (`gap=0.348`), and positive day gate (`66.7%`).
+- 2026-05-01: Rolling diagnostic runs `25210972310`, `25210972276`, and `25210972363` with `min_trades=20` showed the same broad pattern: inverted direction was positive across folds while model direction was mostly negative. Across four matrix views, `Inverted` averaged `+$504.91` per validation row set with `316/324` positive rows; `Model` averaged `-$104.57` with only `82/324` positive rows. This supports investigating direction inversion/regime calibration, not removing direction probability.
+- 2026-05-01: While parsing artifacts, found a matrix-accounting bug: `fill_rate` was calculated as `trades / selected rows`, so duplicate event-side rows and cooldown-throttled rows were counted as unfilled orders. That conflates signal density with CLOB execution. The follow-up fix changes `fill_rate` to executable fills after duplicate/cooldown throttling and emits separate `selection_rate`, duplicate/cooldown rates, and non-executable rate.
 
 # Stable Reversal Fillability Snapshot Research (2026-05-01)
 


### PR DESCRIPTION
## Summary
- make edge matrix fill_rate measure executable fills after duplicate/cooldown throttling
- emit selection_rate plus duplicate/cooldown/non-executable rates for attribution
- record strict and rolling matrix evidence in tasks/todo.md

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-edge-matrix-fillfix2 rtk cargo check -p ploy-research --example three_layer_edge_matrix --no-default-features
- CARGO_TARGET_DIR=/tmp/ploy-edge-matrix-fillfix2-default rtk cargo check -p ploy-research --example three_layer_edge_matrix
- git diff --check