### PR TITLE
Expose row-level audit for inverted edge research

### DIFF
--- a/crates/ploy-research/examples/three_layer_edge_matrix.rs
+++ b/crates/ploy-research/examples/three_layer_edge_matrix.rs
@@ -106,6 +106,28 @@ struct MatrixResult {
     deployable_candidate: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct SelectionAuditRow {
+    hypothesis: String,
+    split: String,
+    direction_mode: DirectionMode,
+    fill_mode: FillMode,
+    pm_mode: PmMode,
+    event_id: String,
+    symbol: String,
+    tick_ts: DateTime<Utc>,
+    side: String,
+    raw_side_model_prob: f64,
+    transformed_probability: f64,
+    calibrated_probability: f64,
+    entry_ask: f64,
+    expected_value_per_stake: f64,
+    side_distance_over_sigma: f64,
+    settlement_win: f64,
+    executable_pnl_15u: f64,
+    selection_status: String,
+}
+
 #[derive(Debug, Serialize)]
 struct MatrixSummary {
     snapshot_hash: String,
@@ -356,6 +378,7 @@ fn evaluate_hypothesis(
     split: &str,
     min_trades: usize,
     gate_rows: &mut Vec<GateRow>,
+    selection_audit_rows: &mut Vec<SelectionAuditRow>,
 ) -> MatrixResult {
     let mut current = rows.iter().collect::<Vec<_>>();
     gate_rows.push(gate_row(h, split, 0, "base", &current));
@@ -396,7 +419,7 @@ fn evaluate_hypothesis(
     });
     gate_rows.push(gate_row(h, split, 6, "reward_risk", &current));
 
-    selected_metrics(&current, h, split, min_trades)
+    selected_metrics(&current, h, split, min_trades, selection_audit_rows)
 }
 
 fn selected_metrics(
@@ -404,6 +427,7 @@ fn selected_metrics(
     h: MatrixHypothesis,
     split: &str,
     min_trades: usize,
+    selection_audit_rows: &mut Vec<SelectionAuditRow>,
 ) -> MatrixResult {
     let mut last_trade_by_symbol: HashMap<String, DateTime<Utc>> = HashMap::new();
     let mut traded_event_sides: HashSet<String> = HashSet::new();
@@ -422,20 +446,24 @@ fn selected_metrics(
         let event_side_key = format!("{}:{}", row.event_id, row.side.as_str());
         if traded_event_sides.contains(&event_side_key) {
             rejected_duplicate += 1;
+            selection_audit_rows.push(selection_audit_row(row, h, split, "duplicate", None));
             continue;
         }
         if let Some(last_ts) = last_trade_by_symbol.get(&row.symbol) {
             if (row.tick_ts - *last_ts).num_seconds() < h.cooldown_secs {
                 rejected_cooldown += 1;
+                selection_audit_rows.push(selection_audit_row(row, h, split, "cooldown", None));
                 continue;
             }
         }
         let Some(pnl) = executable_pnl(row) else {
             rejected_non_executable += 1;
+            selection_audit_rows.push(selection_audit_row(row, h, split, "non_executable", None));
             continue;
         };
         traded_event_sides.insert(event_side_key);
         last_trade_by_symbol.insert(row.symbol.clone(), row.tick_ts);
+        selection_audit_rows.push(selection_audit_row(row, h, split, "accepted", Some(pnl)));
         pnls.push(pnl);
         entry_sum += row.entry_ask;
         ev_stake_sum += expected_value_per_stake(calibrated_probability(row, h), row.entry_ask);
@@ -522,6 +550,37 @@ fn selected_metrics(
         min_trades,
         underpowered,
         deployable_candidate,
+    }
+}
+
+fn selection_audit_row(
+    row: &FactorObservationV2,
+    h: MatrixHypothesis,
+    split: &str,
+    status: &str,
+    pnl: Option<f64>,
+) -> SelectionAuditRow {
+    let transformed = transformed_probability(row, h.direction_mode);
+    let calibrated = calibrated_probability(row, h);
+    SelectionAuditRow {
+        hypothesis: h.name.to_string(),
+        split: split.to_string(),
+        direction_mode: h.direction_mode,
+        fill_mode: h.fill_mode,
+        pm_mode: h.pm_mode,
+        event_id: row.event_id.clone(),
+        symbol: row.symbol.clone(),
+        tick_ts: row.tick_ts,
+        side: row.side.as_str().to_string(),
+        raw_side_model_prob: row.side_model_prob,
+        transformed_probability: transformed,
+        calibrated_probability: calibrated,
+        entry_ask: row.entry_ask,
+        expected_value_per_stake: expected_value_per_stake(calibrated, row.entry_ask),
+        side_distance_over_sigma: row.side_distance_over_sigma,
+        settlement_win: row.label_settlement_win.unwrap_or(f64::NAN),
+        executable_pnl_15u: pnl.unwrap_or(f64::NAN),
+        selection_status: status.to_string(),
     }
 }
 
@@ -661,6 +720,7 @@ fn main() -> Result<()> {
     let val_rows = slice_by_time(&v2_rows, val_start, val_end);
     let hypotheses = hypotheses();
     let mut gate_rows = Vec::new();
+    let mut selection_audit_rows = Vec::new();
     let mut results = Vec::new();
     for h in &hypotheses {
         results.push(evaluate_hypothesis(
@@ -669,6 +729,7 @@ fn main() -> Result<()> {
             "train",
             min_trades,
             &mut gate_rows,
+            &mut selection_audit_rows,
         ));
         results.push(evaluate_hypothesis(
             &val_rows,
@@ -676,6 +737,7 @@ fn main() -> Result<()> {
             "validation",
             min_trades,
             &mut gate_rows,
+            &mut selection_audit_rows,
         ));
     }
 
@@ -803,6 +865,56 @@ fn main() -> Result<()> {
             "avg_executable_pnl",
         ],
         &gate_csv_rows,
+    )?;
+
+    let selection_audit_csv_rows = selection_audit_rows
+        .iter()
+        .map(|row| {
+            vec![
+                row.hypothesis.clone(),
+                row.split.clone(),
+                format!("{:?}", row.direction_mode),
+                format!("{:?}", row.fill_mode),
+                format!("{:?}", row.pm_mode),
+                row.event_id.clone(),
+                row.symbol.clone(),
+                row.tick_ts.to_rfc3339(),
+                row.side.clone(),
+                format!("{:.6}", row.raw_side_model_prob),
+                format!("{:.6}", row.transformed_probability),
+                format!("{:.6}", row.calibrated_probability),
+                format!("{:.6}", row.entry_ask),
+                format!("{:.6}", row.expected_value_per_stake),
+                format!("{:.6}", row.side_distance_over_sigma),
+                format!("{:.6}", row.settlement_win),
+                format!("{:.6}", row.executable_pnl_15u),
+                row.selection_status.clone(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    write_csv(
+        output_dir.join("selection-audit.csv"),
+        &[
+            "hypothesis",
+            "split",
+            "direction_mode",
+            "fill_mode",
+            "pm_mode",
+            "event_id",
+            "symbol",
+            "tick_ts",
+            "side",
+            "raw_side_model_prob",
+            "transformed_probability",
+            "calibrated_probability",
+            "entry_ask",
+            "expected_value_per_stake",
+            "side_distance_over_sigma",
+            "settlement_win",
+            "executable_pnl_15u",
+            "selection_status",
+        ],
+        &selection_audit_csv_rows,
     )?;
 
     let mut best_validation = summary

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21,7 +21,10 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Push PR and watch checks.
 - [x] Run the matrix against snapshot `25204438461` and parse artifacts.
 - [x] Fix matrix fillability accounting so duplicate/cooldown throttling is not misreported as CLOB fill failure.
-- [ ] Push fillability-accounting fix and rerun strict matrix on `main`.
+- [x] Push fillability-accounting fix and rerun strict matrix on `main`.
+- [x] Audit UP/DOWN side-label generation for obvious sign reversal.
+- [x] Add row-level selection audit output to diagnose whether `inverted` is a true contrarian edge or a probability semantics error.
+- [ ] Rerun strict matrix with `selection-audit.csv` artifacts.
 
 ## Review
 
@@ -31,6 +34,9 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - 2026-05-01: PR #289 merged as `691dd570cc135e5ac60eb96f0d97b4cb59968e14`. Strict matrix run `25210900032` used snapshot `25204438461`, train `2026-04-24 -> 2026-04-28`, validation `2026-04-29 -> 2026-05-01`, six symbols, and `min_trades=80`. It failed closed with no deployable candidate. The strongest validation family was `inverted + pm_none`, especially wide/middle windows: top row `inverted_entry_only_pm_none_wide_ev0.05` had `65` validation trades, PnL `+$705.62`, realized/stake `+0.724`, positive symbol rate `100%`, but missed sample power, EV calibration (`gap=0.348`), and positive day gate (`66.7%`).
 - 2026-05-01: Rolling diagnostic runs `25210972310`, `25210972276`, and `25210972363` with `min_trades=20` showed the same broad pattern: inverted direction was positive across folds while model direction was mostly negative. Across four matrix views, `Inverted` averaged `+$504.91` per validation row set with `316/324` positive rows; `Model` averaged `-$104.57` with only `82/324` positive rows. This supports investigating direction inversion/regime calibration, not removing direction probability.
 - 2026-05-01: While parsing artifacts, found a matrix-accounting bug: `fill_rate` was calculated as `trades / selected rows`, so duplicate event-side rows and cooldown-throttled rows were counted as unfilled orders. That conflates signal density with CLOB execution. The follow-up fix changes `fill_rate` to executable fills after duplicate/cooldown throttling and emits separate `selection_rate`, duplicate/cooldown rates, and non-executable rate.
+- 2026-05-01: PR #290 merged as `425368e8db4bfc44117afc5d2ea9086f52114763`. Strict rerun `25211226040` showed top inverted candidates have `fill_rate=100%`; the remaining blockers are sample power, EV calibration gap, and positive-day stability, not executable fillability.
+- 2026-05-01: Side-label audit found no obvious UP/DOWN settlement reversal in `FactorObservationV2`: UP rows use `model_prob_up`, `pm_up_ask`, and `settlement_up`; DOWN rows use `1 - model_prob_up`, `pm_down_ask`, and `1 - settlement_up`. The suspicious part is the matrix `Inverted` mode itself: it uses `1 - side_model_prob` while still buying the same side, so it is a contrarian same-side probability transform rather than an opposite-side trade.
+- 2026-05-01: Added `selection-audit.csv` to the matrix artifacts. It records raw side probability, transformed probability, calibrated probability, side, settlement win, executable PnL, and selection status for rows after all gates. This is needed to decide whether the inverted family is a real contrarian/PM-lag edge or just a probability-semantics bug.
 
 # Stable Reversal Fillability Snapshot Research (2026-05-01)
 


### PR DESCRIPTION
## Summary
- add `selection-audit.csv` to strategy research matrix artifacts
- record raw side probability, transformed/calibrated probability, side, settlement win, executable PnL, and selection status
- document that current inverted mode is a same-side contrarian transform, not an opposite-side trade

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-edge-audit-check rtk cargo check -p ploy-research --example three_layer_edge_matrix --no-default-features
- CARGO_TARGET_DIR=/tmp/ploy-edge-audit-check-default rtk cargo check -p ploy-research --example three_layer_edge_matrix
- git diff --check
