### PR TITLE
Make replay evidence comparable to Tango runtime rows

### DIFF
--- a/.github/workflows/replay-dryrun-parity.yml
+++ b/.github/workflows/replay-dryrun-parity.yml
@@ -74,7 +74,7 @@ jobs:
               echo "- Artifact: \`replay-dryrun-parity-${{ github.run_id }}\`"
               echo ""
               echo '```json'
-              python3 -c 'import json; data=json.load(open("artifacts/parity/parity-evaluation.json")); event=data.get("event_comparison") or {}; print(json.dumps({"decision": data.get("decision"), "risk_flags": data.get("risk_flags"), "strict_parity_ready": event.get("strict_parity_ready"), "missing_strict_fields": event.get("missing_strict_fields"), "shared_event_count": event.get("shared_event_count")}, indent=2, sort_keys=True))'
+              python3 -c 'import json; data=json.load(open("artifacts/parity/parity-evaluation.json")); runtime=data.get("runtime_evidence_comparison") or {}; orders=runtime.get("orders") or {}; fills=runtime.get("fills") or {}; print(json.dumps({"decision": data.get("decision"), "risk_flags": data.get("risk_flags"), "strict_parity_ready": runtime.get("strict_parity_ready"), "missing_strict_fields": runtime.get("missing_strict_fields"), "shared_orders": orders.get("shared_count"), "shared_fills": fills.get("shared_count")}, indent=2, sort_keys=True))'
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -105,8 +105,8 @@ jobs:
               const data = JSON.parse(fs.readFileSync("artifacts/parity/parity-evaluation.json", "utf8"));
               decision = data.decision || decision;
               flags = data.risk_flags || [];
-              strictReady = Boolean(data.event_comparison?.strict_parity_ready);
-              missingFields = data.event_comparison?.missing_strict_fields || [];
+              strictReady = Boolean(data.runtime_evidence_comparison?.strict_parity_ready);
+              missingFields = data.runtime_evidence_comparison?.missing_strict_fields || [];
             }
             const body = [
               "Replay/dry-run parity evidence:",

--- a/crates/ploy-research/Cargo.toml
+++ b/crates/ploy-research/Cargo.toml
@@ -14,7 +14,7 @@ db = ["dep:sqlx", "dep:ploy-feed-loaders"]
 polars-export = ["dep:polars"]
 ml = []
 rl = ["dep:burn", "dep:burn-ndarray"]
-strategy-runtime = ["dep:ploy-strategy-bundles"]
+strategy-runtime = []
 
 [dependencies]
 rand.workspace = true
@@ -23,7 +23,7 @@ polars = { workspace = true, optional = true }
 ploy-market-contracts.workspace = true
 ploy-operator-contracts.workspace = true
 ploy-feed-loaders = { workspace = true, optional = true }
-ploy-strategy-bundles = { workspace = true, optional = true }
+ploy-strategy-bundles.workspace = true
 ploy-trading.workspace = true
 rust_decimal.workspace = true
 serde.workspace = true

--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -18,6 +18,8 @@ use ploy_research::{
     FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest, build_data_health_report,
     build_factor_observations_v2_with_deribit_and_pm_books, load_research_snapshot,
 };
+use ploy_strategy_bundles::ThreeLayerProfile;
+use ploy_strategy_bundles::strategies::three_layer_model as tl_model;
 use serde::Serialize;
 
 const OPTIMIZER_MIN_DIRECTION_PROB: f64 = 0.515;
@@ -27,6 +29,8 @@ const STABLE_DIRECTION_MIN_DIRECTION_PROB: f64 = 0.55;
 const STABLE_REVERSAL_SOFT_MIN_DIRECTION_PROB: f64 = 0.54;
 const STABLE_REVERSAL_FILLABLE_MIN_DIRECTION_PROB: f64 = 0.535;
 const LOG_GROWTH_RISK_BUDGET_STAKES: f64 = 40.0;
+const SNAPSHOT_MIN_ENTRY_PRICE: f64 = 0.10;
+const SNAPSHOT_MAX_ENTRY_PRICE: f64 = 0.85;
 
 #[derive(Debug, Clone, Copy, Serialize)]
 struct SnapshotThreeLayerParams {
@@ -221,6 +225,43 @@ impl StrategyProfile {
             | Self::CexDirectionFirst => None,
         }
     }
+
+    fn runtime_profile(self) -> Option<ThreeLayerProfile> {
+        match self {
+            Self::Mixed => Some(ThreeLayerProfile::Mixed),
+            Self::Champion => Some(ThreeLayerProfile::Champion),
+            Self::ObiSoft => Some(ThreeLayerProfile::ObiSoft),
+            Self::ObiHard => Some(ThreeLayerProfile::ObiHard),
+            Self::ContinuationSoft => Some(ThreeLayerProfile::ContinuationSoft),
+            Self::CexDirectionFirst => None,
+            Self::StableDirection
+            | Self::StableReversal
+            | Self::StableReversalSoft
+            | Self::StableReversalFillable => None,
+        }
+    }
+}
+
+fn model_config(
+    params: &SnapshotThreeLayerParams,
+    profile: StrategyProfile,
+) -> Option<tl_model::ThreeLayerModelConfig> {
+    Some(tl_model::ThreeLayerModelConfig {
+        profile: profile.runtime_profile()?,
+        min_direction_prob: params.min_direction_prob,
+        min_distance_over_sigma: params.min_distance_over_sigma,
+        min_confirmation_score: params.min_confirmation_score,
+        min_drift_confirmation: params.min_drift_confirmation,
+        min_edge: params.min_edge,
+        min_reward_risk: params.min_reward_risk,
+        alpha_contrarian: params.alpha_contrarian,
+        cex_contrarian: params.cex_contrarian,
+        probability_shrink: params.probability_shrink,
+        probability_haircut: params.probability_haircut,
+        min_entry_price: SNAPSHOT_MIN_ENTRY_PRICE,
+        max_entry_price: SNAPSHOT_MAX_ENTRY_PRICE,
+        min_entry_score: params.min_entry_score,
+    })
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -396,40 +437,16 @@ fn finite_or_zero(value: f64) -> f64 {
     if value.is_finite() { value } else { 0.0 }
 }
 
-fn crypto_fee_cost(entry_price: f64) -> f64 {
-    0.02 * entry_price * (1.0 - entry_price)
-}
-
 fn reward_risk_ratio(entry_price: f64) -> f64 {
-    if !entry_price.is_finite() || entry_price <= 0.0 || entry_price >= 1.0 {
-        return f64::NAN;
-    }
-    let fee = crypto_fee_cost(entry_price);
-    let reward = 1.0 - entry_price - fee;
-    let risk = entry_price + fee;
-    if risk <= 0.0 { f64::NAN } else { reward / risk }
+    tl_model::reward_risk_ratio(entry_price)
 }
 
 fn expected_value_per_share(direction_probability: f64, entry_price: f64) -> f64 {
-    if !direction_probability.is_finite()
-        || !entry_price.is_finite()
-        || !(0.0..=1.0).contains(&direction_probability)
-        || !(0.0..1.0).contains(&entry_price)
-    {
-        return f64::NAN;
-    }
-    let fee = crypto_fee_cost(entry_price);
-    let win_payoff = 1.0 - entry_price - fee;
-    let loss_cost = entry_price + fee;
-    direction_probability * win_payoff - (1.0 - direction_probability) * loss_cost
+    tl_model::expected_value_per_share(direction_probability, entry_price)
 }
 
 fn expected_value_per_staked_dollar(direction_probability: f64, entry_price: f64) -> f64 {
-    let expected_value = expected_value_per_share(direction_probability, entry_price);
-    if !expected_value.is_finite() || !entry_price.is_finite() || entry_price <= 0.0 {
-        return f64::NAN;
-    }
-    expected_value / entry_price
+    tl_model::expected_value_per_staked_dollar(direction_probability, entry_price)
 }
 
 fn calibrate_direction_probability(
@@ -437,15 +454,11 @@ fn calibrate_direction_probability(
     probability_shrink: f64,
     probability_haircut: f64,
 ) -> f64 {
-    if !direction_probability.is_finite()
-        || !probability_shrink.is_finite()
-        || !probability_haircut.is_finite()
-    {
-        return f64::NAN;
-    }
-    let shrink = probability_shrink.clamp(0.0, 1.0);
-    let haircut = probability_haircut.clamp(0.0, 0.49);
-    (0.5 + (direction_probability - 0.5) * shrink - haircut).clamp(0.01, 0.99)
+    tl_model::calibrate_direction_probability(
+        direction_probability,
+        probability_shrink,
+        probability_haircut,
+    )
 }
 
 fn direction_probability_search_floor(profile: StrategyProfile) -> f64 {
@@ -500,37 +513,43 @@ fn cex_direction_probability(row: &FactorObservationV2) -> f64 {
     (0.5 + 0.20 * signal).clamp(0.01, 0.99)
 }
 
-fn confirmation_score(row: &FactorObservationV2, profile: StrategyProfile) -> f64 {
+fn confirmation_score(
+    row: &FactorObservationV2,
+    params: &SnapshotThreeLayerParams,
+    profile: StrategyProfile,
+) -> f64 {
     let side = row.side.multiplier();
-    let continuation = finite_or_zero(row.cex_continuation_score_side).clamp(-1.0, 1.0);
-    let obi = finite_or_zero(row.obi_10 * side).clamp(-1.0, 1.0);
-    let obi_delta_10s = finite_or_zero(row.obi_delta_10s_side).clamp(-1.0, 1.0);
-    let obi_persistence_30s = finite_or_zero(row.obi_persistence_30s_side).clamp(-1.0, 1.0);
-    let depth = finite_or_zero(row.depth_imbalance * side).clamp(-1.0, 1.0);
-    let microprice = finite_or_zero(row.microprice_offset_bps * side / 10.0).clamp(-1.0, 1.0);
-    let trade_imbalance = finite_or_zero(row.trade_imbalance_delta_10s_side).clamp(-1.0, 1.0);
-
     match profile {
-        StrategyProfile::Mixed => {
-            0.45 * continuation + 0.25 * obi + 0.15 * depth + 0.15 * microprice
-        }
-        StrategyProfile::Champion => 0.0,
-        StrategyProfile::ObiSoft | StrategyProfile::ObiHard => {
-            0.30 * obi
-                + 0.20 * obi_delta_10s
-                + 0.20 * obi_persistence_30s
-                + 0.15 * depth
-                + 0.10 * microprice
-                + 0.05 * trade_imbalance
-        }
-        StrategyProfile::ContinuationSoft => continuation,
-        StrategyProfile::CexDirectionFirst => cex_direction_signal(row),
-        StrategyProfile::StableDirection => stable_direction_confirmation_score(row),
-        StrategyProfile::StableReversal => stable_reversal_confirmation_score(row),
+        StrategyProfile::CexDirectionFirst => return cex_direction_signal(row),
+        StrategyProfile::StableDirection => return stable_direction_confirmation_score(row),
+        StrategyProfile::StableReversal => return stable_reversal_confirmation_score(row),
         StrategyProfile::StableReversalSoft | StrategyProfile::StableReversalFillable => {
-            stable_reversal_soft_confirmation_score(row)
+            return stable_reversal_soft_confirmation_score(row);
         }
+        StrategyProfile::Mixed
+        | StrategyProfile::Champion
+        | StrategyProfile::ObiSoft
+        | StrategyProfile::ObiHard
+        | StrategyProfile::ContinuationSoft => {}
     }
+    let Some(config) = model_config(params, profile) else {
+        return f64::NAN;
+    };
+    tl_model::profile_confirmation_score(
+        tl_model::BookConfirmationInputs {
+            direction_sign: side,
+            obi: finite_or_zero(row.obi_10),
+            obi_delta: finite_or_zero(row.obi_delta_10s_side * side),
+            depth_imbalance: finite_or_zero(row.depth_imbalance),
+            cum_mprice_drift_5m: finite_or_zero(row.microprice_offset_bps / 10.0),
+            drift_30s: finite_or_zero(row.drift_30s),
+            signed_trade_imbalance: finite_or_zero(
+                row.trade_imbalance_delta_10s_side * side * 50.0,
+            ),
+            regime: row.regime,
+        },
+        &config,
+    )
 }
 
 fn is_stable_research_profile(profile: StrategyProfile) -> bool {
@@ -629,34 +648,23 @@ fn three_layer_entry_score(
     params: &SnapshotThreeLayerParams,
     profile: StrategyProfile,
 ) -> f64 {
+    if profile == StrategyProfile::CexDirectionFirst {
+        let alpha_prob = profile_direction_probability(row, params, profile);
+        let direction_score = directional_score(alpha_prob, params.min_direction_prob, 0.25, false);
+        let distance_score = directional_score(
+            row.side_distance_over_sigma,
+            params.min_distance_over_sigma,
+            0.60,
+            params.alpha_contrarian,
+        );
+        let drift_side = row.drift_30s * row.side.multiplier();
+        let drift_score = ((drift_side - params.min_drift_confirmation) * 800.0).clamp(-0.50, 1.0);
+        return 0.55 * direction_score + 0.28 * distance_score + 0.17 * drift_score;
+    }
+
     let alpha_prob = profile_direction_probability(row, params, profile);
     let calibrated_prob = calibrated_profile_probability(row, params, profile);
     let direction_score = directional_score(alpha_prob, params.min_direction_prob, 0.25, false);
-    let distance_score = directional_score(
-        row.side_distance_over_sigma,
-        params.min_distance_over_sigma,
-        0.60,
-        params.alpha_contrarian,
-    );
-    let per_share_edge_score = executable_edge_score(edge, params);
-    let ev_per_stake = expected_value_per_staked_dollar(calibrated_prob, row.entry_ask);
-    let per_stake_expectancy_score = directional_score(
-        ev_per_stake,
-        if is_stable_research_profile(profile) {
-            params.min_edge
-        } else {
-            0.0
-        },
-        0.25,
-        false,
-    );
-    let expectancy_score = if is_stable_research_profile(profile) {
-        per_stake_expectancy_score
-    } else {
-        (0.70 * per_share_edge_score + 0.30 * per_stake_expectancy_score).clamp(-0.50, 1.0)
-    };
-    let drift_side = row.drift_30s * row.side.multiplier();
-    let drift_score = ((drift_side - params.min_drift_confirmation) * 800.0).clamp(-0.50, 1.0);
     let pm_momentum = row
         .entry_ask_change_10s
         .max(row.entry_ask_change_30s)
@@ -666,44 +674,59 @@ fn three_layer_entry_score(
     } else {
         0.0
     };
-    let liquidity_score = if row.label_full_depth_entry_fillable {
-        1.0
-    } else if row.label_executable_fillable {
-        0.5
-    } else {
-        -0.5
-    };
-    let confirmation_score = directional_score(
-        confirmation,
-        params.min_confirmation_score,
-        0.50,
-        params.cex_contrarian,
-    );
-    if profile == StrategyProfile::CexDirectionFirst {
-        return 0.55 * direction_score + 0.28 * distance_score + 0.17 * drift_score;
-    }
+
     if is_stable_research_profile(profile) {
+        let distance_score = directional_score(
+            row.side_distance_over_sigma,
+            params.min_distance_over_sigma,
+            0.60,
+            params.alpha_contrarian,
+        );
+        let ev_per_stake = expected_value_per_staked_dollar(calibrated_prob, row.entry_ask);
+        let expectancy_score = directional_score(ev_per_stake, params.min_edge, 0.25, false);
+        let confirmation_score = directional_score(
+            confirmation,
+            params.min_confirmation_score,
+            0.50,
+            params.cex_contrarian,
+        );
+        let liquidity_score = if row.label_full_depth_entry_fillable {
+            1.0
+        } else if row.label_executable_fillable {
+            0.5
+        } else {
+            -0.5
+        };
         return 0.24 * direction_score
             + 0.12 * distance_score
             + 0.28 * expectancy_score
             + 0.26 * confirmation_score
             + 0.10 * liquidity_score;
     }
-    if profile == StrategyProfile::Champion {
-        return 0.33 * direction_score
-            + 0.17 * distance_score
-            + 0.25 * expectancy_score
-            + 0.10 * drift_score
-            + 0.10 * pm_momentum_score
-            + 0.05 * liquidity_score;
-    }
-    0.25 * direction_score
-        + 0.12 * distance_score
-        + 0.18 * expectancy_score
-        + 0.15 * confirmation_score
-        + 0.10 * drift_score
-        + 0.12 * pm_momentum_score
-        + 0.08 * liquidity_score
+
+    let Some(config) = model_config(params, profile) else {
+        return -0.50;
+    };
+    let Some(edge_score) = tl_model::evaluate_edge_score(calibrated_prob, row.entry_ask, &config)
+        .map(|s| s.edge_score)
+    else {
+        return -0.50;
+    };
+
+    tl_model::evaluate_entry_score(
+        &config,
+        tl_model::EntryScoreInputs {
+            direction_score,
+            distance_over_sigma: row.side_distance_over_sigma * row.side.multiplier(),
+            direction_sign: row.side.multiplier(),
+            edge,
+            edge_score,
+            confirmation,
+            drift_30s: row.drift_30s,
+            pm_momentum_score,
+            liquidity_score: 1.0,
+        },
+    )
 }
 
 fn confirmation_gate_passes(value: f64, threshold: f64, contrarian: bool) -> bool {
@@ -792,20 +815,13 @@ fn executable_edge_threshold(params: &SnapshotThreeLayerParams) -> f64 {
     params.min_edge.max(0.0)
 }
 
+#[cfg(test)]
 fn executable_edge_score(edge: f64, params: &SnapshotThreeLayerParams) -> f64 {
-    directional_score(edge, executable_edge_threshold(params), 0.08, false)
+    tl_model::threshold_score(edge, executable_edge_threshold(params), 0.08, false)
 }
 
 fn directional_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> f64 {
-    if !value.is_finite() || !threshold.is_finite() || !scale.is_finite() || scale <= 0.0 {
-        return -0.50;
-    }
-    let signed = if contrarian {
-        threshold - value
-    } else {
-        value - threshold
-    };
-    (signed / scale).clamp(-0.50, 1.0)
+    tl_model::threshold_score(value, threshold, scale, contrarian)
 }
 
 fn executable_pnl(row: &FactorObservationV2) -> Option<f64> {
@@ -833,7 +849,10 @@ fn row_passes_gates(
     {
         return false;
     }
-    if !row.entry_ask.is_finite() || row.entry_ask < 0.10 || row.entry_ask > 0.85 {
+    if !row.entry_ask.is_finite()
+        || row.entry_ask < SNAPSHOT_MIN_ENTRY_PRICE
+        || row.entry_ask > SNAPSHOT_MAX_ENTRY_PRICE
+    {
         return false;
     }
     if !row.pm_lag_secs.is_finite() || row.pm_lag_secs < 0.0 || row.pm_lag_secs > 15.0 {
@@ -892,7 +911,7 @@ fn row_passes_gates(
     if !entry_fillable(row) {
         return false;
     }
-    let confirmation = confirmation_score(row, profile);
+    let confirmation = confirmation_score(row, params, profile);
     if !confirmation.is_finite() {
         return false;
     }

--- a/crates/ploy-strategy-bundles/src/strategies/mod.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/mod.rs
@@ -12,6 +12,7 @@ pub mod registry;
 pub mod reversal;
 pub mod sweep;
 pub mod three_layer;
+pub mod three_layer_model;
 pub mod three_layer_profile;
 
 pub use diff_enhanced::DiffEnhancedStrategy;

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -11,9 +11,11 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use super::common::event::EventWindow;
-use super::common::fees::crypto_fee_cost;
 use super::common::quote::QuoteState;
 use super::common::settlement;
+use super::three_layer_model::{
+    self, BookConfirmationInputs, EntryScoreInputs, ThreeLayerModelConfig,
+};
 use super::three_layer_profile::ThreeLayerProfile;
 use crate::strategies::directional::DirectionalConfig;
 use crate::traits::{MarketUpdate, SignalRecord, StrategyDecision, StrategyLogic};
@@ -83,7 +85,27 @@ impl From<DirectionalConfig> for ThreeLayerConfig {
     }
 }
 
-const DRIFT_WINDOW_SECS: f64 = 30.0;
+impl ThreeLayerConfig {
+    fn model_config(&self) -> ThreeLayerModelConfig {
+        ThreeLayerModelConfig {
+            profile: self.profile,
+            min_direction_prob: self.min_direction_prob,
+            min_distance_over_sigma: self.min_distance_over_sigma,
+            min_confirmation_score: self.min_confirmation_score,
+            min_drift_confirmation: self.min_drift_confirmation,
+            min_edge: self.min_edge,
+            min_reward_risk: self.min_reward_risk,
+            alpha_contrarian: self.alpha_contrarian,
+            cex_contrarian: self.cex_contrarian,
+            probability_shrink: self.probability_shrink,
+            probability_haircut: self.probability_haircut,
+            min_entry_price: self.min_entry_price,
+            max_entry_price: self.max_entry_price,
+            min_entry_score: self.min_entry_score,
+        }
+    }
+}
+
 const VOL_WINDOW_SECS: f64 = 120.0;
 const MIN_VOL_POINTS: usize = 5;
 const ACCOUNT_BALANCE_REJECT_PAUSE_SECS: i64 = 15;
@@ -297,61 +319,26 @@ impl LobState {
         self.signed_trade_imbalance = self.signed_trade_imbalance * decay + signed_qty;
         self.last_aggtrade_ts = Some(ts);
     }
-
-    fn confirmation_score(&self) -> f64 {
-        let trade_score = (self.signed_trade_imbalance / 50.0).clamp(-1.0, 1.0) * 0.30;
-        let obi_score = self.obi.clamp(-1.0, 1.0) * 0.25;
-        let obi_delta_score = self.obi_delta().clamp(-1.0, 1.0) * 0.25;
-        let depth_score = self.depth_imbalance().clamp(-1.0, 1.0) * 0.20;
-        trade_score + obi_score + obi_delta_score + depth_score
-    }
 }
 
 // ── Gate Functions ──────────────────────────────────────────────────
 
-/// Normal CDF approximation (Abramowitz & Stegun).
+#[cfg(test)]
 fn norm_cdf(x: f64) -> f64 {
-    let t = 1.0 / (1.0 + 0.2316419 * x.abs());
-    let d = 0.3989422804014327 * (-x * x / 2.0).exp();
-    let p =
-        d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 { 1.0 - p } else { p }
+    three_layer_model::norm_cdf(x)
 }
 
-fn threshold_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> f64 {
-    if !value.is_finite() || !threshold.is_finite() || !scale.is_finite() || scale <= 0.0 {
-        return -0.50;
-    }
-    let signed = if contrarian {
-        threshold - value
-    } else {
-        value - threshold
-    };
-    (signed / scale).clamp(-0.50, 1.0)
-}
-
+#[cfg(test)]
 fn calibrate_direction_probability(
     direction_probability: f64,
     probability_shrink: f64,
     probability_haircut: f64,
 ) -> f64 {
-    if !direction_probability.is_finite()
-        || !probability_shrink.is_finite()
-        || !probability_haircut.is_finite()
-    {
-        return f64::NAN;
-    }
-    let shrink = probability_shrink.clamp(0.0, 1.0);
-    let haircut = probability_haircut.clamp(0.0, 0.49);
-    (0.5 + (direction_probability - 0.5) * shrink - haircut).clamp(0.01, 0.99)
-}
-
-fn executable_edge_threshold(config: &ThreeLayerConfig) -> f64 {
-    if config.profile.uses_snapshot_scoring() {
-        config.min_edge.max(0.0)
-    } else {
-        config.min_edge
-    }
+    three_layer_model::calibrate_direction_probability(
+        direction_probability,
+        probability_shrink,
+        probability_haircut,
+    )
 }
 
 fn profile_confirmation_score(
@@ -362,120 +349,29 @@ fn profile_confirmation_score(
     regime: Regime,
     config: &ThreeLayerConfig,
 ) -> f64 {
-    match config.profile {
-        ThreeLayerProfile::Mixed => evaluate_confirmation_bonus(
+    three_layer_model::profile_confirmation_score(
+        BookConfirmationInputs {
             direction_sign,
-            lob,
+            obi: lob.obi,
+            obi_delta: lob.obi_delta(),
+            depth_imbalance: lob.depth_imbalance(),
             cum_mprice_drift_5m,
             drift_30s,
+            signed_trade_imbalance: lob.signed_trade_imbalance,
             regime,
-            config,
-        ),
-        ThreeLayerProfile::Champion => 0.0,
-        ThreeLayerProfile::ObiSoft | ThreeLayerProfile::ObiHard => {
-            let obi = (lob.obi * direction_sign).clamp(-1.0, 1.0);
-            let obi_delta = (lob.obi_delta() * direction_sign).clamp(-1.0, 1.0);
-            let depth = (lob.depth_imbalance() * direction_sign).clamp(-1.0, 1.0);
-            let microprice = (cum_mprice_drift_5m * direction_sign).clamp(-1.0, 1.0);
-            let trade_imbalance =
-                ((lob.signed_trade_imbalance / 50.0) * direction_sign).clamp(-1.0, 1.0);
-
-            0.30 * obi
-                + 0.20 * obi_delta
-                + 0.20 * obi
-                + 0.15 * depth
-                + 0.10 * microprice
-                + 0.05 * trade_imbalance
-        }
-        ThreeLayerProfile::ContinuationSoft => {
-            let drift_continuation = (drift_30s * direction_sign * 800.0).clamp(-1.0, 1.0);
-            let microprice = (cum_mprice_drift_5m * direction_sign).clamp(-1.0, 1.0);
-            let trade_imbalance =
-                ((lob.signed_trade_imbalance / 50.0) * direction_sign).clamp(-1.0, 1.0);
-            0.50 * drift_continuation + 0.30 * microprice + 0.20 * trade_imbalance
-        }
-    }
-}
-
-struct EntryScoreInputs {
-    direction_score: f64,
-    distance_over_sigma: f64,
-    direction_sign: f64,
-    edge: f64,
-    edge_score: f64,
-    confirmation: f64,
-    drift_30s: f64,
-    pm_momentum_score: f64,
-    liquidity_score: f64,
+        },
+        &config.model_config(),
+    )
 }
 
 fn evaluate_entry_score(config: &ThreeLayerConfig, inputs: EntryScoreInputs) -> f64 {
-    if !config.profile.uses_snapshot_scoring() {
-        return inputs.direction_score * 0.50
-            + inputs.edge_score * 0.35
-            + inputs.confirmation * 0.15;
-    }
-
-    let side_distance = inputs.distance_over_sigma * inputs.direction_sign;
-    let distance_score = threshold_score(
-        side_distance,
-        config.min_distance_over_sigma,
-        0.60,
-        config.alpha_contrarian,
-    );
-    let edge_score = threshold_score(inputs.edge, executable_edge_threshold(config), 0.08, false);
-    let drift_side = inputs.drift_30s * inputs.direction_sign;
-    let drift_score = ((drift_side - config.min_drift_confirmation) * 800.0).clamp(-0.50, 1.0);
-    let confirmation_score = threshold_score(
-        inputs.confirmation,
-        config.min_confirmation_score,
-        0.50,
-        config.cex_contrarian,
-    );
-
-    match config.profile {
-        ThreeLayerProfile::Champion => {
-            0.33 * inputs.direction_score
-                + 0.17 * distance_score
-                + 0.25 * edge_score
-                + 0.10 * drift_score
-                + 0.10 * inputs.pm_momentum_score
-                + 0.05 * inputs.liquidity_score
-        }
-        ThreeLayerProfile::ObiSoft
-        | ThreeLayerProfile::ObiHard
-        | ThreeLayerProfile::ContinuationSoft => {
-            0.25 * inputs.direction_score
-                + 0.12 * distance_score
-                + 0.18 * edge_score
-                + 0.15 * confirmation_score
-                + 0.10 * drift_score
-                + 0.12 * inputs.pm_momentum_score
-                + 0.08 * inputs.liquidity_score
-        }
-        ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),
-    }
+    three_layer_model::evaluate_entry_score(&config.model_config(), inputs)
 }
 
 fn confirmation_gate_passes(value: f64, threshold: f64, contrarian: bool) -> bool {
-    if !value.is_finite() || !threshold.is_finite() {
-        return false;
-    }
-    if contrarian {
-        value <= threshold
-    } else {
-        value >= threshold
-    }
+    three_layer_model::confirmation_gate_passes(value, threshold, contrarian)
 }
 
-/// Layer 1: Direction score (0.0 – 1.0).
-/// Returns Some((direction_sign, calibrated_probability, direction_score)) or None
-/// only when the signal is too weak to even consider (below minimum distance in Early).
-///
-/// In snapshot-scored profiles, contrarian mode inverts the direction but keeps
-/// the transformed alpha probability monotonic: stronger inverse alpha scores
-/// higher. The hard direction gate uses raw alpha strength, while execution EV
-/// is evaluated with the calibrated probability.
 fn evaluate_direction_score(
     distance_over_sigma: f64,
     _sigma_horizon: f64,
@@ -484,71 +380,21 @@ fn evaluate_direction_score(
     regime: Regime,
     config: &ThreeLayerConfig,
 ) -> Option<(f64, f64, f64)> {
-    if !config.alpha_contrarian
-        && distance_over_sigma.abs() < config.min_distance_over_sigma
-        && regime == Regime::Early
-    {
-        return None;
-    }
-
-    let model_prob_up = norm_cdf(distance_over_sigma);
-
-    let direction_prob = match regime {
-        Regime::Early => model_prob_up,
-        Regime::Middle => {
-            let lob_nudge = (cum_mprice_drift_5m / 100.0).clamp(-0.08, 0.08);
-            (model_prob_up + lob_nudge).clamp(0.01, 0.99)
-        }
-        Regime::Late => {
-            let drift_nudge = (drift_30s * 500.0).clamp(-0.12, 0.12);
-            let lob_nudge = (cum_mprice_drift_5m / 80.0).clamp(-0.06, 0.06);
-            (model_prob_up + drift_nudge + lob_nudge).clamp(0.01, 0.99)
-        }
-        Regime::Expiry => {
-            let drift_nudge = (drift_30s * 800.0).clamp(-0.15, 0.15);
-            (model_prob_up + drift_nudge).clamp(0.01, 0.99)
-        }
-    };
-
-    let (direction_sign, raw_effective_p) = if config.alpha_contrarian {
-        let inverse_alpha_p = direction_prob.max(1.0 - direction_prob);
-        if direction_prob >= 0.5 {
-            (-1.0_f64, inverse_alpha_p)
-        } else {
-            (1.0_f64, inverse_alpha_p)
-        }
-    } else if direction_prob >= 0.5 {
-        (1.0_f64, direction_prob)
-    } else {
-        (-1.0_f64, 1.0 - direction_prob)
-    };
-    if !raw_effective_p.is_finite() || raw_effective_p < config.min_direction_prob {
-        return None;
-    }
-
-    let effective_p = calibrate_direction_probability(
-        raw_effective_p,
-        config.probability_shrink,
-        config.probability_haircut,
-    );
-    if !effective_p.is_finite() {
-        return None;
-    }
-
-    // In contrarian mode the direction is inverted, but the alpha strength is
-    // still the distance from 50/50. Do not treat the faded side's raw model
-    // probability as the executable probability.
-    let direction_score = if config.profile.uses_snapshot_scoring() {
-        threshold_score(raw_effective_p, config.min_direction_prob, 0.25, false)
-    } else {
-        ((effective_p - 0.50) / 0.50).clamp(0.0, 1.0)
-    };
-
-    Some((direction_sign, effective_p, direction_score))
+    let score = three_layer_model::evaluate_direction_score(
+        distance_over_sigma,
+        cum_mprice_drift_5m,
+        drift_30s,
+        regime,
+        &config.model_config(),
+    )?;
+    Some((
+        score.direction_sign,
+        score.effective_probability,
+        score.direction_score,
+    ))
 }
 
-/// Layer 2: Confirmation bonus (-0.2 to +0.2).
-/// Positive = LOB confirms direction, negative = LOB opposes (penalty, not veto).
+#[cfg(test)]
 fn evaluate_confirmation_bonus(
     direction_sign: f64,
     lob: &LobState,
@@ -557,88 +403,47 @@ fn evaluate_confirmation_bonus(
     regime: Regime,
     config: &ThreeLayerConfig,
 ) -> f64 {
-    let raw_score = lob.confirmation_score() + (cum_mprice_drift_5m / 200.0).clamp(-0.15, 0.15);
-    let aligned_score = direction_sign * raw_score;
-
-    // In Late/Expiry, drift agreement adds extra bonus/penalty.
-    let drift_factor = match regime {
-        Regime::Late | Regime::Expiry => {
-            let drift_aligned = drift_30s * direction_sign;
-            (drift_aligned * 500.0).clamp(-0.10, 0.10)
-        }
-        _ => 0.0,
-    };
-
-    let score = aligned_score + drift_factor;
-    if config.cex_contrarian {
-        (-score).clamp(-0.20, 0.20)
-    } else {
-        score.clamp(-0.20, 0.20)
-    }
+    let mut model_config = config.model_config();
+    model_config.profile = ThreeLayerProfile::Mixed;
+    three_layer_model::profile_confirmation_score(
+        BookConfirmationInputs {
+            direction_sign,
+            obi: lob.obi,
+            obi_delta: lob.obi_delta(),
+            depth_imbalance: lob.depth_imbalance(),
+            cum_mprice_drift_5m,
+            drift_30s,
+            signed_trade_imbalance: lob.signed_trade_imbalance,
+            regime,
+        },
+        &model_config,
+    )
 }
 
+#[cfg(test)]
 fn expected_value_per_share(direction_probability: f64, entry_price: f64) -> f64 {
-    if !direction_probability.is_finite()
-        || !entry_price.is_finite()
-        || !(0.0..=1.0).contains(&direction_probability)
-        || !(0.0..1.0).contains(&entry_price)
-    {
-        return f64::NAN;
-    }
-    let fee = crypto_fee_cost(entry_price);
-    let win_payoff = 1.0 - entry_price - fee;
-    let loss_cost = entry_price + fee;
-    direction_probability * win_payoff - (1.0 - direction_probability) * loss_cost
+    three_layer_model::expected_value_per_share(direction_probability, entry_price)
 }
 
+#[cfg(test)]
 fn expected_value_per_staked_dollar(direction_probability: f64, entry_price: f64) -> f64 {
-    let expected_value = expected_value_per_share(direction_probability, entry_price);
-    if !expected_value.is_finite() || !entry_price.is_finite() || entry_price <= 0.0 {
-        return f64::NAN;
-    }
-    expected_value / entry_price
+    three_layer_model::expected_value_per_staked_dollar(direction_probability, entry_price)
 }
 
-/// Layer 3: Expected-value score (0.0 – 1.0).
-/// Returns Some((entry_price, expected_value_per_share, reward_risk, expectancy_score)) or None
-/// only when the price is outside tradeable bounds.
 fn evaluate_edge_score(
     direction_probability: f64,
     ask: f64,
     _regime: Regime,
     config: &ThreeLayerConfig,
 ) -> Option<(f64, f64, f64, f64)> {
-    if ask < config.min_entry_price || ask > config.max_entry_price {
-        return None;
-    }
-
-    let fee = crypto_fee_cost(ask);
-    let edge = expected_value_per_share(direction_probability, ask);
-    if !edge.is_finite() {
-        return None;
-    }
-
-    let reward = 1.0 - ask - fee;
-    let risk = ask + fee;
-    let rr = if risk > 0.0 { reward / risk } else { 0.0 };
-
-    // Execution edge is always monotonic: higher cost-adjusted edge scores
-    // better. Contrarian mode can invert alpha, but not executable edge.
-    let required_edge = executable_edge_threshold(config);
-    if config.profile.uses_snapshot_scoring() && edge < required_edge {
-        return None;
-    }
-
-    let stake_expectancy = expected_value_per_staked_dollar(direction_probability, ask);
-    let edge_score = if config.profile.uses_snapshot_scoring() {
-        let per_share_score = threshold_score(edge, required_edge, 0.08, false);
-        let per_stake_score = threshold_score(stake_expectancy, 0.0, 0.25, false);
-        (0.70 * per_share_score + 0.30 * per_stake_score).clamp(-0.50, 1.0)
-    } else {
-        (stake_expectancy / 0.40).clamp(0.0, 1.0)
-    };
-
-    Some((ask, edge, rr, edge_score))
+    let score =
+        three_layer_model::evaluate_edge_score(direction_probability, ask, &config.model_config())?;
+    Some((
+        score.entry_price,
+        score.expected_value_per_share,
+        score.reward_risk,
+        score.edge_score,
+    ))
 }
 
 // ── ThreeLayerStrategy ─────────────────────────────────────────────

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -1,0 +1,374 @@
+//! Pure three-layer scoring model shared by runtime and research tools.
+
+use ploy_operator_contracts::Regime;
+
+use super::common::fees::crypto_fee_cost;
+use super::three_layer_profile::ThreeLayerProfile;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ThreeLayerModelConfig {
+    pub profile: ThreeLayerProfile,
+    pub min_direction_prob: f64,
+    pub min_distance_over_sigma: f64,
+    pub min_confirmation_score: f64,
+    pub min_drift_confirmation: f64,
+    pub min_edge: f64,
+    pub min_reward_risk: f64,
+    pub alpha_contrarian: bool,
+    pub cex_contrarian: bool,
+    pub probability_shrink: f64,
+    pub probability_haircut: f64,
+    pub min_entry_price: f64,
+    pub max_entry_price: f64,
+    pub min_entry_score: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BookConfirmationInputs {
+    pub direction_sign: f64,
+    pub obi: f64,
+    pub obi_delta: f64,
+    pub depth_imbalance: f64,
+    pub cum_mprice_drift_5m: f64,
+    pub drift_30s: f64,
+    pub signed_trade_imbalance: f64,
+    pub regime: Regime,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EntryScoreInputs {
+    pub direction_score: f64,
+    pub distance_over_sigma: f64,
+    pub direction_sign: f64,
+    pub edge: f64,
+    pub edge_score: f64,
+    pub confirmation: f64,
+    pub drift_30s: f64,
+    pub pm_momentum_score: f64,
+    pub liquidity_score: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DirectionScore {
+    pub direction_sign: f64,
+    pub effective_probability: f64,
+    pub direction_score: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeScore {
+    pub entry_price: f64,
+    pub expected_value_per_share: f64,
+    pub reward_risk: f64,
+    pub edge_score: f64,
+}
+
+pub fn threshold_score(value: f64, threshold: f64, scale: f64, contrarian: bool) -> f64 {
+    if !value.is_finite() || !threshold.is_finite() || !scale.is_finite() || scale <= 0.0 {
+        return -0.50;
+    }
+    let signed = if contrarian {
+        threshold - value
+    } else {
+        value - threshold
+    };
+    (signed / scale).clamp(-0.50, 1.0)
+}
+
+/// Normal CDF approximation (Abramowitz & Stegun).
+pub fn norm_cdf(x: f64) -> f64 {
+    let t = 1.0 / (1.0 + 0.2316419 * x.abs());
+    let d = 0.3989422804014327 * (-x * x / 2.0).exp();
+    let p =
+        d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+    if x >= 0.0 { 1.0 - p } else { p }
+}
+
+pub fn calibrate_direction_probability(
+    direction_probability: f64,
+    probability_shrink: f64,
+    probability_haircut: f64,
+) -> f64 {
+    if !direction_probability.is_finite()
+        || !probability_shrink.is_finite()
+        || !probability_haircut.is_finite()
+    {
+        return f64::NAN;
+    }
+    let shrink = probability_shrink.clamp(0.0, 1.0);
+    let haircut = probability_haircut.clamp(0.0, 0.49);
+    (0.5 + (direction_probability - 0.5) * shrink - haircut).clamp(0.01, 0.99)
+}
+
+pub fn transformed_side_probability(side_model_prob: f64, alpha_contrarian: bool) -> f64 {
+    if !side_model_prob.is_finite() {
+        return f64::NAN;
+    }
+    if alpha_contrarian {
+        1.0 - side_model_prob
+    } else {
+        side_model_prob
+    }
+}
+
+pub fn executable_edge_threshold(config: &ThreeLayerModelConfig) -> f64 {
+    if config.profile.uses_snapshot_scoring() {
+        config.min_edge.max(0.0)
+    } else {
+        config.min_edge
+    }
+}
+
+pub fn expected_value_per_share(direction_probability: f64, entry_price: f64) -> f64 {
+    if !direction_probability.is_finite()
+        || !entry_price.is_finite()
+        || !(0.0..=1.0).contains(&direction_probability)
+        || !(0.0..1.0).contains(&entry_price)
+    {
+        return f64::NAN;
+    }
+    let fee = crypto_fee_cost(entry_price);
+    let win_payoff = 1.0 - entry_price - fee;
+    let loss_cost = entry_price + fee;
+    direction_probability * win_payoff - (1.0 - direction_probability) * loss_cost
+}
+
+pub fn expected_value_per_staked_dollar(direction_probability: f64, entry_price: f64) -> f64 {
+    let expected_value = expected_value_per_share(direction_probability, entry_price);
+    if !expected_value.is_finite() || !entry_price.is_finite() || entry_price <= 0.0 {
+        return f64::NAN;
+    }
+    expected_value / entry_price
+}
+
+pub fn reward_risk_ratio(entry_price: f64) -> f64 {
+    if !entry_price.is_finite() || entry_price <= 0.0 || entry_price >= 1.0 {
+        return f64::NAN;
+    }
+    let fee = crypto_fee_cost(entry_price);
+    let reward = 1.0 - entry_price - fee;
+    let risk = entry_price + fee;
+    if risk <= 0.0 { f64::NAN } else { reward / risk }
+}
+
+pub fn evaluate_direction_score(
+    distance_over_sigma: f64,
+    cum_mprice_drift_5m: f64,
+    drift_30s: f64,
+    regime: Regime,
+    config: &ThreeLayerModelConfig,
+) -> Option<DirectionScore> {
+    if !config.alpha_contrarian
+        && distance_over_sigma.abs() < config.min_distance_over_sigma
+        && regime == Regime::Early
+    {
+        return None;
+    }
+
+    let model_prob_up = norm_cdf(distance_over_sigma);
+    let direction_prob = match regime {
+        Regime::Early => model_prob_up,
+        Regime::Middle => {
+            let lob_nudge = (cum_mprice_drift_5m / 100.0).clamp(-0.08, 0.08);
+            (model_prob_up + lob_nudge).clamp(0.01, 0.99)
+        }
+        Regime::Late => {
+            let drift_nudge = (drift_30s * 500.0).clamp(-0.12, 0.12);
+            let lob_nudge = (cum_mprice_drift_5m / 80.0).clamp(-0.06, 0.06);
+            (model_prob_up + drift_nudge + lob_nudge).clamp(0.01, 0.99)
+        }
+        Regime::Expiry => {
+            let drift_nudge = (drift_30s * 800.0).clamp(-0.15, 0.15);
+            (model_prob_up + drift_nudge).clamp(0.01, 0.99)
+        }
+    };
+
+    let (direction_sign, raw_effective_p) = if config.alpha_contrarian {
+        let inverse_alpha_p = direction_prob.max(1.0 - direction_prob);
+        if direction_prob >= 0.5 {
+            (-1.0_f64, inverse_alpha_p)
+        } else {
+            (1.0_f64, inverse_alpha_p)
+        }
+    } else if direction_prob >= 0.5 {
+        (1.0_f64, direction_prob)
+    } else {
+        (-1.0_f64, 1.0 - direction_prob)
+    };
+    if !raw_effective_p.is_finite() || raw_effective_p < config.min_direction_prob {
+        return None;
+    }
+
+    let effective_probability = calibrate_direction_probability(
+        raw_effective_p,
+        config.probability_shrink,
+        config.probability_haircut,
+    );
+    if !effective_probability.is_finite() {
+        return None;
+    }
+
+    let direction_score = if config.profile.uses_snapshot_scoring() {
+        threshold_score(raw_effective_p, config.min_direction_prob, 0.25, false)
+    } else {
+        ((effective_probability - 0.50) / 0.50).clamp(0.0, 1.0)
+    };
+
+    Some(DirectionScore {
+        direction_sign,
+        effective_probability,
+        direction_score,
+    })
+}
+
+pub fn profile_confirmation_score(
+    inputs: BookConfirmationInputs,
+    config: &ThreeLayerModelConfig,
+) -> f64 {
+    match config.profile {
+        ThreeLayerProfile::Mixed => {
+            let raw_score = (inputs.signed_trade_imbalance / 50.0).clamp(-1.0, 1.0) * 0.30
+                + inputs.obi.clamp(-1.0, 1.0) * 0.25
+                + inputs.obi_delta.clamp(-1.0, 1.0) * 0.25
+                + inputs.depth_imbalance.clamp(-1.0, 1.0) * 0.20
+                + (inputs.cum_mprice_drift_5m / 200.0).clamp(-0.15, 0.15);
+            let aligned_score = inputs.direction_sign * raw_score;
+            let drift_factor = match inputs.regime {
+                Regime::Late | Regime::Expiry => {
+                    let drift_aligned = inputs.drift_30s * inputs.direction_sign;
+                    (drift_aligned * 500.0).clamp(-0.10, 0.10)
+                }
+                _ => 0.0,
+            };
+            let score = aligned_score + drift_factor;
+            if config.cex_contrarian {
+                (-score).clamp(-0.20, 0.20)
+            } else {
+                score.clamp(-0.20, 0.20)
+            }
+        }
+        ThreeLayerProfile::Champion => 0.0,
+        ThreeLayerProfile::ObiSoft | ThreeLayerProfile::ObiHard => {
+            let obi = (inputs.obi * inputs.direction_sign).clamp(-1.0, 1.0);
+            let obi_delta = (inputs.obi_delta * inputs.direction_sign).clamp(-1.0, 1.0);
+            let depth = (inputs.depth_imbalance * inputs.direction_sign).clamp(-1.0, 1.0);
+            let microprice = (inputs.cum_mprice_drift_5m * inputs.direction_sign).clamp(-1.0, 1.0);
+            let trade_imbalance =
+                ((inputs.signed_trade_imbalance / 50.0) * inputs.direction_sign).clamp(-1.0, 1.0);
+
+            0.50 * obi
+                + 0.20 * obi_delta
+                + 0.15 * depth
+                + 0.10 * microprice
+                + 0.05 * trade_imbalance
+        }
+        ThreeLayerProfile::ContinuationSoft => {
+            let drift_continuation =
+                (inputs.drift_30s * inputs.direction_sign * 800.0).clamp(-1.0, 1.0);
+            let microprice = (inputs.cum_mprice_drift_5m * inputs.direction_sign).clamp(-1.0, 1.0);
+            let trade_imbalance =
+                ((inputs.signed_trade_imbalance / 50.0) * inputs.direction_sign).clamp(-1.0, 1.0);
+            0.50 * drift_continuation + 0.30 * microprice + 0.20 * trade_imbalance
+        }
+    }
+}
+
+pub fn confirmation_gate_passes(value: f64, threshold: f64, contrarian: bool) -> bool {
+    if !value.is_finite() || !threshold.is_finite() {
+        return false;
+    }
+    if contrarian {
+        value <= threshold
+    } else {
+        value >= threshold
+    }
+}
+
+pub fn evaluate_edge_score(
+    direction_probability: f64,
+    ask: f64,
+    config: &ThreeLayerModelConfig,
+) -> Option<EdgeScore> {
+    if ask < config.min_entry_price || ask > config.max_entry_price {
+        return None;
+    }
+
+    let edge = expected_value_per_share(direction_probability, ask);
+    if !edge.is_finite() {
+        return None;
+    }
+
+    let reward_risk = reward_risk_ratio(ask);
+    if !reward_risk.is_finite() {
+        return None;
+    }
+
+    let required_edge = executable_edge_threshold(config);
+    if config.profile.uses_snapshot_scoring() && edge < required_edge {
+        return None;
+    }
+
+    let stake_expectancy = expected_value_per_staked_dollar(direction_probability, ask);
+    let edge_score = if config.profile.uses_snapshot_scoring() {
+        let per_share_score = threshold_score(edge, required_edge, 0.08, false);
+        let per_stake_score = threshold_score(stake_expectancy, 0.0, 0.25, false);
+        (0.70 * per_share_score + 0.30 * per_stake_score).clamp(-0.50, 1.0)
+    } else {
+        (stake_expectancy / 0.40).clamp(0.0, 1.0)
+    };
+
+    Some(EdgeScore {
+        entry_price: ask,
+        expected_value_per_share: edge,
+        reward_risk,
+        edge_score,
+    })
+}
+
+pub fn evaluate_entry_score(config: &ThreeLayerModelConfig, inputs: EntryScoreInputs) -> f64 {
+    if !config.profile.uses_snapshot_scoring() {
+        return inputs.direction_score * 0.50
+            + inputs.edge_score * 0.35
+            + inputs.confirmation * 0.15;
+    }
+
+    let side_distance = inputs.distance_over_sigma * inputs.direction_sign;
+    let distance_score = threshold_score(
+        side_distance,
+        config.min_distance_over_sigma,
+        0.60,
+        config.alpha_contrarian,
+    );
+    let edge_score = threshold_score(inputs.edge, executable_edge_threshold(config), 0.08, false);
+    let drift_side = inputs.drift_30s * inputs.direction_sign;
+    let drift_score = ((drift_side - config.min_drift_confirmation) * 800.0).clamp(-0.50, 1.0);
+    let confirmation_score = threshold_score(
+        inputs.confirmation,
+        config.min_confirmation_score,
+        0.50,
+        config.cex_contrarian,
+    );
+
+    match config.profile {
+        ThreeLayerProfile::Champion => {
+            0.33 * inputs.direction_score
+                + 0.17 * distance_score
+                + 0.25 * edge_score
+                + 0.10 * drift_score
+                + 0.10 * inputs.pm_momentum_score
+                + 0.05 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::ObiSoft
+        | ThreeLayerProfile::ObiHard
+        | ThreeLayerProfile::ContinuationSoft => {
+            0.25 * inputs.direction_score
+                + 0.12 * distance_score
+                + 0.18 * edge_score
+                + 0.15 * confirmation_score
+                + 0.10 * drift_score
+                + 0.12 * inputs.pm_momentum_score
+                + 0.08 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),
+    }
+}

--- a/crates/ploy-strategy-runtime/src/lib.rs
+++ b/crates/ploy-strategy-runtime/src/lib.rs
@@ -22,6 +22,7 @@ use ploy_strategy_bundles::{FullConfig, RuntimeMode};
 use replay::run_replay_entry;
 use rust_decimal::Decimal;
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::path::Path;
 use tracing::info;
 
@@ -181,6 +182,7 @@ fn write_strategy_evaluation(
             "fills": snapshot.fills.len(),
             "positions": snapshot.positions.len(),
         },
+        "runtime_evidence": normalized_runtime_evidence(snapshot, deployment_id),
     });
 
     if let Some(parent) = output_path.parent() {
@@ -210,6 +212,195 @@ fn write_strategy_evaluation(
             );
             std::process::exit(1);
         }
+    }
+}
+
+fn normalized_runtime_evidence(
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+    fallback_deployment_id: Option<&str>,
+) -> serde_json::Value {
+    let intents_by_id: BTreeMap<&str, &ploy_trading::TradingIntent> = snapshot
+        .intents
+        .iter()
+        .map(|intent| (intent.intent_id.as_str(), intent))
+        .collect();
+    let orders_by_id: BTreeMap<&str, &ploy_trading::OrderRecord> = snapshot
+        .orders
+        .iter()
+        .map(|order| (order.order_id.as_str(), order))
+        .collect();
+
+    let mut fill_quantity_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    let mut fill_notional_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    for fill in &snapshot.fills {
+        *fill_quantity_by_order
+            .entry(fill.order_id.as_str())
+            .or_default() += fill.quantity;
+        *fill_notional_by_order
+            .entry(fill.order_id.as_str())
+            .or_default() += fill.quantity * fill.price;
+    }
+
+    let intents: Vec<_> = snapshot
+        .intents
+        .iter()
+        .map(|intent| {
+            let deployment_id =
+                evidence_deployment_id(intent.deployment_id.as_str(), fallback_deployment_id);
+            json!({
+                "deployment_id": deployment_id,
+                "intent_id": intent.intent_id.as_str(),
+                "event_id": intent.market_id.as_str(),
+                "market_id": intent.market_id.as_str(),
+                "token_id": intent.token_id.as_str(),
+                "side": trade_side_label(intent.side),
+                "order_side": trade_side_label(intent.side),
+                "purpose": intent_purpose_label(intent.purpose),
+                "quantity": intent.quantity,
+                "requested_qty": intent.quantity,
+                "limit_price": intent.limit_price,
+                "created_at": intent.created_at,
+            })
+        })
+        .collect();
+
+    let orders: Vec<_> = snapshot
+        .orders
+        .iter()
+        .map(|order| {
+            let intent = intents_by_id.get(order.intent_id.as_str()).copied();
+            let deployment_id =
+                evidence_deployment_id(order.deployment_id.as_str(), fallback_deployment_id)
+                    .or_else(|| {
+                        intent.and_then(|intent| {
+                            evidence_deployment_id(
+                                intent.deployment_id.as_str(),
+                                fallback_deployment_id,
+                            )
+                        })
+                    });
+            let fill_quantity = fill_quantity_by_order
+                .get(order.order_id.as_str())
+                .copied()
+                .unwrap_or(order.filled_qty);
+            let avg_fill_price = if fill_quantity.is_zero() {
+                None
+            } else {
+                fill_notional_by_order
+                    .get(order.order_id.as_str())
+                    .map(|notional| *notional / fill_quantity)
+            };
+
+            json!({
+                "deployment_id": deployment_id,
+                "intent_id": order.intent_id.as_str(),
+                "order_id": order.order_id.as_str(),
+                "venue_order_id": order.venue_order_id.as_deref(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": order.token_id.as_str(),
+                "market_side": None::<String>,
+                "order_side": intent
+                    .map(|intent| trade_side_label(intent.side))
+                    .unwrap_or("UNKNOWN"),
+                "purpose": intent.map(|intent| intent_purpose_label(intent.purpose)),
+                "quantity": order.requested_qty,
+                "requested_qty": order.requested_qty,
+                "limit_price": order.limit_price,
+                "filled_quantity": fill_quantity,
+                "avg_fill_price": avg_fill_price,
+                "status": order_state_label(order.state),
+                "rejection_reason": order.rejection_reason.as_deref(),
+                "last_error": order.last_error.as_deref(),
+                "created_at": intent.map(|intent| intent.created_at),
+            })
+        })
+        .collect();
+
+    let fills: Vec<_> = snapshot
+        .fills
+        .iter()
+        .map(|fill| {
+            let order = orders_by_id.get(fill.order_id.as_str()).copied();
+            let intent =
+                order.and_then(|order| intents_by_id.get(order.intent_id.as_str()).copied());
+            let deployment_id = order
+                .and_then(|order| {
+                    evidence_deployment_id(order.deployment_id.as_str(), fallback_deployment_id)
+                })
+                .or_else(|| {
+                    intent.and_then(|intent| {
+                        evidence_deployment_id(
+                            intent.deployment_id.as_str(),
+                            fallback_deployment_id,
+                        )
+                    })
+                });
+            json!({
+                "deployment_id": deployment_id,
+                "intent_id": order.map(|order| order.intent_id.as_str()),
+                "order_id": fill.order_id.as_str(),
+                "fill_id": fill.fill_id.as_str(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": fill.token_id.as_str(),
+                "market_side": None::<String>,
+                "fill_side": trade_side_label(fill.side),
+                "purpose": intent.map(|intent| intent_purpose_label(intent.purpose)),
+                "quantity": fill.quantity,
+                "price": fill.price,
+                "fee": fill.fee,
+                "fill_timestamp": fill.timestamp,
+            })
+        })
+        .collect();
+
+    json!({
+        "schema_version": 1,
+        "basis": "trading_runtime_snapshot",
+        "comparison_contract": "Compare these normalized rows against strategy_runtime_orders and strategy_runtime_fills exported from Tango for the same deployment/config/feed window.",
+        "intents": intents,
+        "orders": orders,
+        "fills": fills,
+    })
+}
+
+fn evidence_deployment_id<'a>(
+    deployment_id: &'a str,
+    fallback_deployment_id: Option<&'a str>,
+) -> Option<&'a str> {
+    if deployment_id.is_empty() {
+        fallback_deployment_id
+    } else {
+        Some(deployment_id)
+    }
+}
+
+fn trade_side_label(side: ploy_trading::TradeSide) -> &'static str {
+    match side {
+        ploy_trading::TradeSide::Buy => "BUY",
+        ploy_trading::TradeSide::Sell => "SELL",
+    }
+}
+
+fn intent_purpose_label(purpose: ploy_trading::IntentPurpose) -> &'static str {
+    match purpose {
+        ploy_trading::IntentPurpose::Entry => "ENTRY",
+        ploy_trading::IntentPurpose::Exit => "EXIT",
+        ploy_trading::IntentPurpose::Reduce => "REDUCE",
+        ploy_trading::IntentPurpose::Hedge => "HEDGE",
+        ploy_trading::IntentPurpose::Cancel => "CANCEL",
+    }
+}
+
+fn order_state_label(state: ploy_trading::OrderState) -> &'static str {
+    match state {
+        ploy_trading::OrderState::Pending => "PENDING",
+        ploy_trading::OrderState::Acknowledged => "ACKNOWLEDGED",
+        ploy_trading::OrderState::PartiallyFilled => "PARTIALLY_FILLED",
+        ploy_trading::OrderState::Filled => "FILLED",
+        ploy_trading::OrderState::Canceled => "CANCELED",
+        ploy_trading::OrderState::Rejected => "REJECTED",
     }
 }
 

--- a/scripts/export_strategy_runtime_evidence.py
+++ b/scripts/export_strategy_runtime_evidence.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Export Tango strategy_runtime_orders/fills as replay parity evidence JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def sql_array(values: list[str]) -> str:
+    return "ARRAY[" + ", ".join(sql_literal(value) for value in values) + "]::text[]"
+
+
+def run_psql(db_url: str, sql: str, timeout: int) -> dict:
+    result = subprocess.run(
+        ["psql", db_url, "-t", "-A", "-v", "ON_ERROR_STOP=1", "-c", sql],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr or result.stdout or f"psql failed with {result.returncode}")
+    payload = result.stdout.strip()
+    if not payload:
+        raise SystemExit("psql returned no JSON payload")
+    return json.loads(payload)
+
+
+def build_sql(args: argparse.Namespace) -> str:
+    conditions = [f"runtime_mode = {sql_literal(args.runtime_mode)}"]
+    if args.deployment_id:
+        conditions.append(f"deployment_id = ANY({sql_array(args.deployment_id)})")
+    if args.since:
+        conditions.append(f"recorded_at >= {sql_literal(args.since)}::timestamptz")
+    if args.until:
+        conditions.append(f"recorded_at < {sql_literal(args.until)}::timestamptz")
+
+    order_where = " AND ".join(f"o.{condition}" for condition in conditions)
+    fill_where = " AND ".join(
+        f"f.{condition}" if condition.startswith("runtime_mode") or condition.startswith("deployment_id") else f"f.{condition}"
+        for condition in conditions
+    )
+
+    return f"""
+SELECT jsonb_build_object(
+  'schema_version', 1,
+  'artifact_type', 'strategy_runtime_db_evidence',
+  'producer', 'export_strategy_runtime_evidence',
+  'generated_at', {sql_literal(datetime.now(timezone.utc).isoformat())},
+  'runtime_mode', {sql_literal(args.runtime_mode)},
+  'deployment_ids', to_jsonb({sql_array(args.deployment_id) if args.deployment_id else "ARRAY[]::text[]"}),
+  'runtime_evidence', jsonb_build_object(
+    'schema_version', 1,
+    'basis', 'strategy_runtime_orders_and_fills',
+    'orders', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'deployment_id', o.deployment_id,
+        'intent_id', o.intent_id,
+        'order_id', o.order_id,
+        'venue_order_id', o.venue_order_id,
+        'event_id', o.event_id,
+        'market_id', o.event_id,
+        'token_id', o.token_id,
+        'market_side', o.market_side,
+        'order_side', o.order_side,
+        'quantity', o.quantity,
+        'requested_qty', o.quantity,
+        'limit_price', o.limit_price,
+        'filled_quantity', o.filled_quantity,
+        'avg_fill_price', o.avg_fill_price,
+        'status', o.status,
+        'rejection_reason', o.rejection_reason,
+        'created_at', o.recorded_at
+      ) ORDER BY o.recorded_at, o.order_id)
+      FROM strategy_runtime_orders o
+      WHERE {order_where}
+    ), '[]'::jsonb),
+    'fills', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'deployment_id', f.deployment_id,
+        'intent_id', f.intent_id,
+        'order_id', f.order_id,
+        'fill_id', f.fill_id,
+        'event_id', f.event_id,
+        'market_id', f.event_id,
+        'token_id', f.token_id,
+        'market_side', f.market_side,
+        'fill_side', f.fill_side,
+        'quantity', f.quantity,
+        'price', f.price,
+        'fee', f.fee,
+        'fill_timestamp', f.fill_timestamp
+      ) ORDER BY f.fill_timestamp, f.fill_id)
+      FROM strategy_runtime_fills f
+      WHERE {fill_where}
+    ), '[]'::jsonb)
+  )
+)::text;
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--runtime-mode", default="dry_run")
+    parser.add_argument("--deployment-id", action="append", default=[])
+    parser.add_argument("--since", help="inclusive recorded_at lower bound, timestamptz")
+    parser.add_argument("--until", help="exclusive recorded_at upper bound, timestamptz")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--timeout", type=int, default=30)
+    args = parser.parse_args()
+
+    if not args.db_url:
+        raise SystemExit("--db-url or DATABASE_URL is required")
+
+    payload = run_psql(args.db_url, build_sql(args), args.timeout)
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,50 @@ STRICT_FIELD_ALIASES = {
     "settlement": ("settlement", "resolved_up_won"),
     "pnl": ("pnl", "net_pnl", "realized_pnl"),
 }
+
+ORDER_STRICT_FIELDS = [
+    "deployment_id",
+    "intent_id",
+    "order_id",
+    "event_id",
+    "token_id",
+    "order_side",
+    "purpose",
+    "quantity",
+    "limit_price",
+    "filled_quantity",
+    "status",
+    "created_at",
+]
+
+FILL_STRICT_FIELDS = [
+    "deployment_id",
+    "intent_id",
+    "order_id",
+    "fill_id",
+    "event_id",
+    "token_id",
+    "fill_side",
+    "quantity",
+    "price",
+    "fee",
+    "fill_timestamp",
+]
+
+NUMERIC_FIELDS = {
+    "quantity",
+    "requested_qty",
+    "limit_price",
+    "filled_quantity",
+    "avg_fill_price",
+    "price",
+    "fee",
+}
+
+TIMESTAMP_FIELDS = {"created_at", "fill_timestamp"}
+
+NUMERIC_TOLERANCE = Decimal("0.000001")
+TIMESTAMP_TOLERANCE_SECONDS = 1.0
 
 
 def load_json(path: Path) -> Any:
@@ -168,6 +213,283 @@ def index_events(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return indexed
 
 
+def first_present(row: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return None
+
+
+def normalize_text(value: Any, *, upper: bool = False) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.upper() if upper else text
+
+
+def normalize_decimal(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return normalize_text(value)
+    normalized = parsed.normalize()
+    return format(normalized, "f")
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def normalize_timestamp(value: Any) -> str | None:
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        return normalize_text(value)
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def normalize_status(value: Any) -> str | None:
+    text = normalize_text(value, upper=True)
+    if text is None:
+        return None
+    return text.replace("-", "_")
+
+
+def normalize_order(row: dict[str, Any]) -> dict[str, Any]:
+    quantity = first_present(row, "quantity", "requested_qty", "requested_quantity")
+    return {
+        "deployment_id": normalize_text(first_present(row, "deployment_id")),
+        "intent_id": normalize_text(first_present(row, "intent_id")),
+        "order_id": normalize_text(first_present(row, "order_id")),
+        "venue_order_id": normalize_text(first_present(row, "venue_order_id")),
+        "event_id": normalize_text(first_present(row, "event_id", "market_id", "market_slug")),
+        "token_id": normalize_text(first_present(row, "token_id")),
+        "market_side": normalize_text(first_present(row, "market_side", "direction"), upper=True),
+        "order_side": normalize_text(first_present(row, "order_side", "side"), upper=True),
+        "purpose": normalize_text(first_present(row, "purpose", "intent_purpose"), upper=True),
+        "quantity": normalize_decimal(quantity),
+        "requested_qty": normalize_decimal(quantity),
+        "limit_price": normalize_decimal(first_present(row, "limit_price", "entry_price")),
+        "filled_quantity": normalize_decimal(first_present(row, "filled_quantity", "filled_qty")),
+        "avg_fill_price": normalize_decimal(first_present(row, "avg_fill_price", "fill_price")),
+        "status": normalize_status(first_present(row, "status", "state", "fill_status")),
+        "rejection_reason": normalize_text(first_present(row, "rejection_reason", "last_error")),
+        "created_at": normalize_timestamp(first_present(row, "created_at", "recorded_at", "decision_ts", "timestamp")),
+    }
+
+
+def normalize_fill(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "deployment_id": normalize_text(first_present(row, "deployment_id")),
+        "intent_id": normalize_text(first_present(row, "intent_id")),
+        "order_id": normalize_text(first_present(row, "order_id")),
+        "fill_id": normalize_text(first_present(row, "fill_id")),
+        "event_id": normalize_text(first_present(row, "event_id", "market_id", "market_slug")),
+        "token_id": normalize_text(first_present(row, "token_id")),
+        "market_side": normalize_text(first_present(row, "market_side", "direction"), upper=True),
+        "fill_side": normalize_text(first_present(row, "fill_side", "side", "order_side"), upper=True),
+        "purpose": normalize_text(first_present(row, "purpose", "intent_purpose"), upper=True),
+        "quantity": normalize_decimal(first_present(row, "quantity", "filled_qty", "filled_quantity")),
+        "price": normalize_decimal(first_present(row, "price", "fill_price", "avg_fill_price")),
+        "fee": normalize_decimal(first_present(row, "fee", "fees")),
+        "fill_timestamp": normalize_timestamp(first_present(row, "fill_timestamp", "timestamp", "created_at", "recorded_at")),
+    }
+
+
+def extract_list_at_paths(data: Any, paths: list[tuple[str, ...]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        value = get_path(data, *path)
+        if isinstance(value, list):
+            rows.extend(item for item in value if isinstance(item, dict))
+
+    if isinstance(data, dict):
+        strategies = data.get("strategies")
+        if isinstance(strategies, list):
+            for strategy in strategies:
+                if not isinstance(strategy, dict):
+                    continue
+                for path in paths:
+                    value = get_path(strategy, *path)
+                    if isinstance(value, list):
+                        for item in value:
+                            if isinstance(item, dict):
+                                enriched = dict(item)
+                                for identity_key in ("runtime_mode", "strategy_id", "deployment_id", "experiment_label"):
+                                    enriched.setdefault(identity_key, strategy.get(identity_key))
+                                rows.append(enriched)
+    return rows
+
+
+def extract_runtime_orders(data: Any) -> list[dict[str, Any]]:
+    rows = extract_list_at_paths(
+        data,
+        [
+            ("runtime_evidence", "orders"),
+            ("orders",),
+            ("dry_run", "orders"),
+            ("data", "orders"),
+            ("report", "orders"),
+        ],
+    )
+    return [normalize_order(row) for row in rows]
+
+
+def extract_runtime_fills(data: Any) -> list[dict[str, Any]]:
+    rows = extract_list_at_paths(
+        data,
+        [
+            ("runtime_evidence", "fills"),
+            ("fills",),
+            ("dry_run", "fills"),
+            ("data", "fills"),
+            ("report", "fills"),
+        ],
+    )
+    return [normalize_fill(row) for row in rows]
+
+
+def normalized_key(row: dict[str, Any], primary_key: str, fallback_fields: tuple[str, ...]) -> str:
+    primary = row.get(primary_key)
+    if primary:
+        return str(primary)
+    parts = [str(row.get(field) or "") for field in fallback_fields]
+    return "|".join(parts)
+
+
+def index_normalized_rows(
+    rows: list[dict[str, Any]],
+    primary_key: str,
+    fallback_fields: tuple[str, ...],
+) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        key = normalized_key(row, primary_key, fallback_fields)
+        if not key.strip("|"):
+            key = f"row-{index}"
+        indexed[key] = row
+    return indexed
+
+
+def values_match(field: str, left: Any, right: Any) -> bool:
+    if field in NUMERIC_FIELDS:
+        try:
+            return abs(Decimal(str(left)) - Decimal(str(right))) <= NUMERIC_TOLERANCE
+        except (InvalidOperation, ValueError):
+            return left == right
+    if field in TIMESTAMP_FIELDS:
+        left_ts = parse_timestamp(left)
+        right_ts = parse_timestamp(right)
+        if left_ts is None or right_ts is None:
+            return left == right
+        return abs((left_ts - right_ts).total_seconds()) <= TIMESTAMP_TOLERANCE_SECONDS
+    return left == right
+
+
+def compare_normalized_rows(
+    replay_rows: list[dict[str, Any]],
+    dryrun_rows: list[dict[str, Any]],
+    *,
+    row_type: str,
+    primary_key: str,
+    fallback_fields: tuple[str, ...],
+    strict_fields: list[str],
+) -> dict[str, Any]:
+    replay_index = index_normalized_rows(replay_rows, primary_key, fallback_fields)
+    dryrun_index = index_normalized_rows(dryrun_rows, primary_key, fallback_fields)
+    shared_keys = sorted(set(replay_index) & set(dryrun_index))
+    mismatches: list[dict[str, Any]] = []
+    missing_fields = set()
+
+    for key in shared_keys:
+        replay = replay_index[key]
+        dryrun = dryrun_index[key]
+        for field in strict_fields:
+            replay_value = replay.get(field)
+            dryrun_value = dryrun.get(field)
+            if replay_value is None or dryrun_value is None:
+                missing_fields.add(f"{row_type}.{field}")
+                continue
+            if not values_match(field, replay_value, dryrun_value):
+                mismatches.append(
+                    {
+                        "row_type": row_type,
+                        "row_key": key,
+                        "field": field,
+                        "replay": replay_value,
+                        "dryrun": dryrun_value,
+                    }
+                )
+
+    return {
+        "row_type": row_type,
+        "replay_count": len(replay_rows),
+        "dryrun_count": len(dryrun_rows),
+        "shared_count": len(shared_keys),
+        "strict_required_fields": strict_fields,
+        "missing_replay_rows": sorted(set(dryrun_index) - set(replay_index))[:50],
+        "missing_dryrun_rows": sorted(set(replay_index) - set(dryrun_index))[:50],
+        "mismatches": mismatches[:100],
+        "missing_strict_fields": sorted(missing_fields),
+        "strict_parity_ready": bool(shared_keys)
+        and not missing_fields
+        and not mismatches
+        and not (set(dryrun_index) - set(replay_index))
+        and not (set(replay_index) - set(dryrun_index)),
+    }
+
+
+def compare_runtime_evidence(replay: Any, dryrun: Any) -> dict[str, Any]:
+    order_comparison = compare_normalized_rows(
+        extract_runtime_orders(replay),
+        extract_runtime_orders(dryrun),
+        row_type="order",
+        primary_key="order_id",
+        fallback_fields=("deployment_id", "event_id", "token_id", "order_side", "purpose", "created_at"),
+        strict_fields=ORDER_STRICT_FIELDS,
+    )
+    fill_comparison = compare_normalized_rows(
+        extract_runtime_fills(replay),
+        extract_runtime_fills(dryrun),
+        row_type="fill",
+        primary_key="fill_id",
+        fallback_fields=("deployment_id", "event_id", "token_id", "fill_side", "fill_timestamp"),
+        strict_fields=FILL_STRICT_FIELDS,
+    )
+    missing_strict_fields = sorted(
+        set(order_comparison["missing_strict_fields"])
+        | set(fill_comparison["missing_strict_fields"])
+    )
+    mismatches = order_comparison["mismatches"] + fill_comparison["mismatches"]
+    strict_parity_ready = (
+        order_comparison["strict_parity_ready"]
+        and fill_comparison["strict_parity_ready"]
+    )
+    return {
+        "orders": order_comparison,
+        "fills": fill_comparison,
+        "missing_strict_fields": missing_strict_fields,
+        "mismatches": mismatches[:100],
+        "strict_parity_ready": strict_parity_ready,
+    }
+
+
 def compare_events(
     replay_events: list[dict[str, Any]], dryrun_events: list[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -217,7 +539,29 @@ def build_result(replay: Any, dryrun: Any, replay_path: Path, dryrun_path: Path)
     replay_events = extract_events(replay)
     dryrun_events = extract_events(dryrun)
     event_comparison = compare_events(replay_events, dryrun_events)
+    runtime_evidence_comparison = compare_runtime_evidence(replay, dryrun)
     risk_flags: list[str] = []
+
+    if runtime_evidence_comparison["orders"]["replay_count"] == 0:
+        risk_flags.append("replay_has_no_order_level_rows")
+    if runtime_evidence_comparison["orders"]["dryrun_count"] == 0:
+        risk_flags.append("dryrun_has_no_order_level_rows")
+    if runtime_evidence_comparison["fills"]["replay_count"] == 0:
+        risk_flags.append("replay_has_no_fill_level_rows")
+    if runtime_evidence_comparison["fills"]["dryrun_count"] == 0:
+        risk_flags.append("dryrun_has_no_fill_level_rows")
+    if runtime_evidence_comparison["orders"]["missing_dryrun_rows"]:
+        risk_flags.append("orders_present_in_replay_missing_from_dryrun")
+    if runtime_evidence_comparison["orders"]["missing_replay_rows"]:
+        risk_flags.append("orders_present_in_dryrun_missing_from_replay")
+    if runtime_evidence_comparison["fills"]["missing_dryrun_rows"]:
+        risk_flags.append("fills_present_in_replay_missing_from_dryrun")
+    if runtime_evidence_comparison["fills"]["missing_replay_rows"]:
+        risk_flags.append("fills_present_in_dryrun_missing_from_replay")
+    if runtime_evidence_comparison["mismatches"]:
+        risk_flags.append("runtime_evidence_field_mismatches")
+    if runtime_evidence_comparison["missing_strict_fields"]:
+        risk_flags.append("missing_runtime_evidence_strict_fields")
 
     if not replay_events:
         risk_flags.append("replay_has_no_event_level_rows")
@@ -233,7 +577,7 @@ def build_result(replay: Any, dryrun: Any, replay_path: Path, dryrun_path: Path)
         risk_flags.append("missing_strict_parity_fields")
 
     decision = "continue"
-    if not event_comparison["strict_parity_ready"]:
+    if not runtime_evidence_comparison["strict_parity_ready"]:
         decision = "fix-data-or-runtime-mismatch"
 
     return {
@@ -246,6 +590,7 @@ def build_result(replay: Any, dryrun: Any, replay_path: Path, dryrun_path: Path)
         "replay_metrics": extract_metrics(replay),
         "dryrun_metrics": extract_metrics(dryrun),
         "event_comparison": event_comparison,
+        "runtime_evidence_comparison": runtime_evidence_comparison,
         "risk_flags": risk_flags,
         "decision": decision,
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11788,3 +11788,44 @@ Issue: https://github.com/proerror77/ploy/issues/256
   champion signal survives broader train data, but the available validation
   slice is too sparse for promotion. Next step is a longer/fresher snapshot or
   walk-forward split with enough validation opportunities, not dry-run deploy.
+
+# PM5D Dry-run / Backtest Parity Repair (2026-05-02)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: actual dry-run/live entry, exit, fillability, and scoring path.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs`
+  - Owner: shared pure scoring contract to be introduced for runtime and research.
+- `crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
+  - Owner: remove duplicated strategy formulas and call the shared scorer.
+- `crates/ploy-strategy-runtime/src/lib.rs`
+  - Owner: replay output must expose order/fill level evidence for parity.
+- `scripts/replay_dryrun_parity.py`
+  - Owner: compare recorded-feed replay with Tango dry-run rows at event/token/side/price/quantity level.
+- `scripts/export_strategy_runtime_evidence.py`
+  - Owner: export Tango `strategy_runtime_orders` / `strategy_runtime_fills` rows into the same evidence shape used by replay parity.
+- `.github/workflows/replay-dryrun-parity.yml`
+  - Owner: summarize strict runtime evidence parity from order/fill rows, not only event-level placeholders.
+- `tests/test_replay_dryrun_parity.py`
+  - Owner: fixture-level guard for strict order/fill parity and mismatch detection.
+- `config/strategies/02-pm5d-threelayer.*dryrun.toml`
+  - Owner: keep dry-run candidates paused until replay parity and event-level fillability pass.
+
+## Tasks
+
+- [x] Pause all Tango PM5D three-layer dry-run deployments while parity is unresolved.
+- [x] Introduce a shared three-layer scorer so optimizer/backtest and runtime cannot drift.
+- [x] Replace snapshot optimizer-only confirmation formulas with runtime-available inputs, or add runtime trackers for the missing factors before using them.
+- [ ] Make recorded canonical feed capture strategy-independent and long enough for a full dry-run observation window.
+- [x] Emit replay order/fill evidence and compare it against Tango `strategy_runtime_orders` / `strategy_runtime_fills`.
+- [ ] Require the promotion gate: same config, same canonical `MarketUpdate` sequence, same runtime scorer, event-level fillability, and positive after-cost EV.
+
+## Review
+
+- 2026-05-02: Paused `pm5d.threelayer.champion.dryrun`, `pm5d.threelayer.continuation-soft.dryrun`, `pm5d.threelayer.obi-hard.dryrun`, and `pm5d.threelayer.obi-soft.dryrun` on `tango-1-1`. Verified all `pm5d.threelayer.*dryrun` deployments plus `pm5d.threelayer.live` are `desired=Paused observed=Paused`.
+- 2026-05-02: Current mismatch is a strategy-research parity bug, not a reason to keep trying blind parameter sets. Runtime replay on the recorded feed is also negative, while older snapshot/backtest results were positive. Do not promote another candidate until snapshot optimizer, runtime, and recorded replay share the same scoring and executable fillability contract.
+- 2026-05-02: Concrete formula drift found: `obi_soft`/`obi_hard` snapshot scoring uses `obi_persistence_30s_side`, while runtime currently repeats OBI weight and does not track 30s side persistence. `continuation_soft` snapshot scoring uses `cex_continuation_score_side`, while runtime uses a different drift/microprice/trade-imbalance mix. Liquidity scoring also differs: snapshot uses fillability labels as score inputs, while runtime hard-gates ask size and then scores liquidity as `1.0`.
+- 2026-05-02: First repair slice landed locally: added `three_layer_model` as the shared pure scoring contract, moved runtime EV/direction/confirmation/entry-score evaluation through it, and connected `three_layer_snapshot_optimize` to the same model for runtime-backed profiles. Snapshot-only `obi_persistence_30s_side` and `cex_continuation_score_side` no longer drive deployable three-layer profile scoring; `cex_direction_first` remains explicitly research-only.
+- 2026-05-02: Focused verification passed: `CARGO_TARGET_DIR=/tmp/ploy-three-layer-model-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib` (`35 passed`), `CARGO_TARGET_DIR=/tmp/ploy-three-layer-model-test /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-research --example three_layer_snapshot_optimize --no-default-features` (`26 passed`), `cargo check` for `ploy-strategy-bundles --lib` and the optimizer example, plus `git diff --check`.
+- 2026-05-02: Second repair slice added strict order/fill evidence. Replay/backtest output now includes `runtime_evidence.intents/orders/fills` normalized from `TradingRuntimeSnapshot`, including deployment, intent/order/fill ids, event/token ids, side/purpose, quantity, prices, fees, status, and timestamps. `replay_dryrun_parity.py` now compares those rows against Tango exports at order/fill level with numeric and timestamp tolerances, and reports `runtime_evidence_comparison.strict_parity_ready`.

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -1,0 +1,102 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "replay_dryrun_parity.py"
+
+
+def evidence_payload(limit_price="0.42", fill_price="0.41"):
+    return {
+        "runtime_evidence": {
+            "orders": [
+                {
+                    "deployment_id": "pm5d.threelayer.test",
+                    "intent_id": "intent-1",
+                    "order_id": "order-1",
+                    "event_id": "event-1",
+                    "token_id": "token-up",
+                    "order_side": "BUY",
+                    "purpose": "ENTRY",
+                    "quantity": "10",
+                    "limit_price": limit_price,
+                    "filled_quantity": "10.0000000",
+                    "status": "FILLED",
+                    "created_at": "2026-05-02T01:02:03Z",
+                }
+            ],
+            "fills": [
+                {
+                    "deployment_id": "pm5d.threelayer.test",
+                    "intent_id": "intent-1",
+                    "order_id": "order-1",
+                    "fill_id": "fill-1",
+                    "event_id": "event-1",
+                    "token_id": "token-up",
+                    "fill_side": "BUY",
+                    "quantity": "10",
+                    "price": fill_price,
+                    "fee": "0",
+                    "fill_timestamp": "2026-05-02T01:02:04Z",
+                }
+            ],
+        }
+    }
+
+
+class ReplayDryrunParityTests(unittest.TestCase):
+    def run_script(self, replay, dryrun):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            replay_path = tmp_path / "replay.json"
+            dryrun_path = tmp_path / "dryrun.json"
+            output_path = tmp_path / "out" / "parity.json"
+            replay_path.write_text(json.dumps(replay), encoding="utf-8")
+            dryrun_path.write_text(json.dumps(dryrun), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--replay-json",
+                    str(replay_path),
+                    "--dryrun-json",
+                    str(dryrun_path),
+                    "--output-json",
+                    str(output_path),
+                ],
+                check=True,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+            )
+            return json.loads(output_path.read_text(encoding="utf-8"))
+
+    def test_runtime_evidence_parity_ready_for_matching_orders_and_fills(self):
+        result = self.run_script(evidence_payload(), evidence_payload())
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertTrue(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "continue")
+        self.assertEqual(runtime["orders"]["shared_count"], 1)
+        self.assertEqual(runtime["fills"]["shared_count"], 1)
+
+    def test_runtime_evidence_blocks_price_mismatch(self):
+        result = self.run_script(
+            evidence_payload(fill_price="0.41"),
+            evidence_payload(fill_price="0.43"),
+        )
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertFalse(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "fix-data-or-runtime-mismatch")
+        self.assertIn("runtime_evidence_field_mismatches", result["risk_flags"])
+        self.assertEqual(runtime["mismatches"][0]["field"], "price")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- port the unmerged row-level replay/dry-run parity evidence work onto current `main`
- preserve newer stable/reversal research profiles while routing runtime-mapped three-layer profiles through the shared scoring model
- add normalized replay runtime evidence, Tango DB order/fill export, and strict order/fill parity checks

## Verification

- `python3 -m unittest tests.test_replay_dryrun_parity`
- `python3 -m py_compile scripts/replay_dryrun_parity.py scripts/export_strategy_runtime_evidence.py`
- Ruby YAML parse for `.github/workflows/replay-dryrun-parity.yml`
- `rustfmt --edition 2024 --config skip_children=true` on touched Rust files
- `CARGO_TARGET_DIR=/tmp/ploy-parity-port-runtime-replay /opt/homebrew/bin/timeout 180 rtk cargo check -p ploy-strategy-runtime --features replay`
- `CARGO_TARGET_DIR=/tmp/ploy-parity-port-runtime-live /opt/homebrew/bin/timeout 180 rtk cargo check -p ploy-strategy-runtime --features live,db-recorder`
- `CARGO_TARGET_DIR=/tmp/ploy-parity-port-research /opt/homebrew/bin/timeout 180 rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --no-default-features`
- `CARGO_TARGET_DIR=/tmp/ploy-parity-port-bundles /opt/homebrew/bin/timeout 240 rtk cargo test -p ploy-strategy-bundles three_layer --lib`
- `git diff --check HEAD~1..HEAD && git diff --check`

## Operational note

I checked Tango before opening this PR. The canonical recording exists at `/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson`, but the currently deployed main binary still emits only replay `snapshot_counts`, not `runtime_evidence` rows. Public `/api/reports/dry-run` also has zero order/fill rows, so strict parity should wait for this PR to merge and deploy before rerunning replay/export comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime order/fill evidence comparison for enhanced deployment parity validation.
  * New script for exporting strategy runtime evidence for analysis.

* **Improvements**
  * Enhanced dry-run to live parity checks with stricter order and fill field validation.
  * Unified three-layer scoring model for consistent strategy evaluation across all tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->