### PR TITLE
Diagnose PM5D inverted edge stability

### DIFF
--- a/scripts/analyze_edge_matrix_artifact.py
+++ b/scripts/analyze_edge_matrix_artifact.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Summarize PM5D strategy edge-matrix artifacts.
+
+This is intentionally artifact-only: it reads the CSV/JSON outputs from
+`strategy-research-matrix.yml` and produces a compact decision report without
+rerunning research or touching live/dry-run services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEPLOYABLE_MIN_TRADES = 80
+MAX_EV_GAP = 0.30
+MIN_POSITIVE_DAY_RATE = 0.70
+MIN_FILL_RATE = 0.95
+
+
+@dataclass
+class Aggregate:
+    rows: int = 0
+    trades: int = 0
+    net_pnl: float = 0.0
+    positive_rows: int = 0
+    deployable_rows: int = 0
+
+    def add(self, row: dict[str, str]) -> None:
+        self.rows += 1
+        self.trades += int(row["trades"])
+        pnl = float(row["net_pnl"])
+        self.net_pnl += pnl
+        self.positive_rows += int(pnl > 0.0)
+        self.deployable_rows += int(row["deployable_candidate"] == "true")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "rows": self.rows,
+            "trades": self.trades,
+            "net_pnl": round(self.net_pnl, 6),
+            "positive_rows": self.positive_rows,
+            "deployable_rows": self.deployable_rows,
+        }
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def load_summary(path: Path) -> dict[str, Any]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def artifact_file(root: Path, name: str) -> Path:
+    candidates = sorted(root.rglob(name))
+    if not candidates:
+        raise SystemExit(f"missing artifact file: {name} under {root}")
+    return candidates[0]
+
+
+def blockers(row: dict[str, str]) -> list[str]:
+    out: list[str] = []
+    trades = int(row["trades"])
+    ev_gap = float(row["expectancy_calibration_gap"])
+    fill_rate = float(row["fill_rate"])
+    positive_day = float(row["positive_day_rate"])
+    net_pnl = float(row["net_pnl"])
+    realized = float(row["avg_realized_return_per_stake"])
+    if trades < DEPLOYABLE_MIN_TRADES:
+        out.append(f"sample_power:{trades}<{DEPLOYABLE_MIN_TRADES}")
+    if net_pnl <= 0.0:
+        out.append("nonpositive_pnl")
+    if fill_rate < MIN_FILL_RATE:
+        out.append(f"fill_rate:{fill_rate:.3f}<{MIN_FILL_RATE:.2f}")
+    if realized <= 0.0:
+        out.append("nonpositive_realized_return_per_stake")
+    if ev_gap > MAX_EV_GAP:
+        out.append(f"ev_gap:{ev_gap:.3f}>{MAX_EV_GAP:.2f}")
+    if positive_day < MIN_POSITIVE_DAY_RATE:
+        out.append(f"positive_day:{positive_day:.3f}<{MIN_POSITIVE_DAY_RATE:.2f}")
+    if float(row["positive_symbol_rate"]) < MIN_POSITIVE_DAY_RATE:
+        out.append(f"positive_symbol:{float(row['positive_symbol_rate']):.3f}<{MIN_POSITIVE_DAY_RATE:.2f}")
+    return out
+
+
+def aggregate(rows: list[dict[str, str]], fields: tuple[str, ...]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, Aggregate] = defaultdict(Aggregate)
+    for row in rows:
+        key = " | ".join(row[field] for field in fields)
+        grouped[key].add(row)
+    return {key: value.as_dict() for key, value in sorted(grouped.items())}
+
+
+def top_rows(rows: list[dict[str, str]], limit: int = 12) -> list[dict[str, Any]]:
+    ordered = sorted(
+        rows,
+        key=lambda row: (
+            row["deployable_candidate"] == "true",
+            int(row["trades"]),
+            float(row["net_pnl"]),
+        ),
+        reverse=True,
+    )
+    out = []
+    for row in ordered[:limit]:
+        out.append(
+            {
+                "hypothesis": row["hypothesis"],
+                "direction_mode": row["direction_mode"],
+                "fill_mode": row["fill_mode"],
+                "pm_mode": row["pm_mode"],
+                "trades": int(row["trades"]),
+                "net_pnl": round(float(row["net_pnl"]), 6),
+                "fill_rate": round(float(row["fill_rate"]), 6),
+                "ev_gap": round(float(row["expectancy_calibration_gap"]), 6),
+                "positive_day_rate": round(float(row["positive_day_rate"]), 6),
+                "positive_symbol_rate": round(float(row["positive_symbol_rate"]), 6),
+                "deployable_candidate": row["deployable_candidate"] == "true",
+                "blockers": blockers(row),
+            }
+        )
+    return out
+
+
+def selection_status(rows: list[dict[str, str]]) -> dict[str, dict[str, int]]:
+    grouped: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in rows:
+        grouped[row["direction_mode"]][row["selection_status"]] += 1
+    return {key: dict(value) for key, value in sorted(grouped.items())}
+
+
+def gate_trace(rows: list[dict[str, str]], hypothesis: str) -> list[dict[str, Any]]:
+    out = []
+    for row in rows:
+        if row["split"] != "validation" or row["hypothesis"] != hypothesis:
+            continue
+        out.append(
+            {
+                "gate_index": int(row["gate_index"]),
+                "gate": row["gate"],
+                "rows": int(row["rows"]),
+                "event_sides": int(row["event_sides"]),
+                "entry_fill_rate": round(float(row["entry_fill_rate"]), 6),
+                "roundtrip_fill_rate": round(float(row["roundtrip_fill_rate"]), 6),
+                "total_executable_pnl": round(float(row["total_executable_pnl"]), 6),
+                "avg_executable_pnl": round(float(row["avg_executable_pnl"]), 6),
+            }
+        )
+    return out
+
+
+def build_report(root: Path, run_id: str | None) -> dict[str, Any]:
+    matrix_rows = read_csv(artifact_file(root, "strategy-matrix-results.csv"))
+    audit_rows = read_csv(artifact_file(root, "selection-audit.csv"))
+    gate_rows = read_csv(artifact_file(root, "gate-attrition.csv"))
+    summary = load_summary(artifact_file(root, "edge-matrix-summary.json"))
+    validation_rows = [row for row in matrix_rows if row["split"] == "validation"]
+    top = top_rows(validation_rows)
+    run_threshold_candidate_count = sum(
+        1 for row in validation_rows if row["deployable_candidate"] == "true"
+    )
+    strict_candidate_count = sum(1 for row in validation_rows if not blockers(row))
+    top_hypothesis = top[0]["hypothesis"] if top else None
+    matrix_min_trades = int(summary.get("min_trades") or 0)
+    result = {
+        "artifact_type": "edge_matrix_diagnostic_report",
+        "run_id": run_id,
+        "snapshot_hash": summary.get("snapshot_hash"),
+        "source_rows": summary.get("source_rows"),
+        "v2_rows": summary.get("v2_rows"),
+        "train_window": {"start": summary.get("train_start"), "end": summary.get("train_end")},
+        "validation_window": {"start": summary.get("val_start"), "end": summary.get("val_end")},
+        "symbols": summary.get("symbols"),
+        "hypothesis_count": summary.get("hypothesis_count"),
+        "matrix_min_trades": matrix_min_trades,
+        "validation_row_count": len(validation_rows),
+        "run_threshold_validation_candidates": run_threshold_candidate_count,
+        "strict_deployable_validation_candidates": strict_candidate_count,
+        "top_validation_rows": top,
+        "aggregate_by_direction": aggregate(validation_rows, ("direction_mode",)),
+        "aggregate_by_direction_pm": aggregate(validation_rows, ("direction_mode", "pm_mode")),
+        "aggregate_by_direction_fill": aggregate(validation_rows, ("direction_mode", "fill_mode")),
+        "selection_status_by_direction": selection_status(
+            [row for row in audit_rows if row["split"] == "validation"]
+        ),
+        "top_hypothesis_gate_trace": gate_trace(gate_rows, top_hypothesis) if top_hypothesis else [],
+        "decision": (
+            "review-strict-candidates"
+            if strict_candidate_count > 0 and matrix_min_trades >= DEPLOYABLE_MIN_TRADES
+            else "diagnostic-only-continue-research"
+        ),
+    }
+    return result
+
+
+def markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# PM5D Edge Matrix Diagnostic",
+        "",
+        f"- Run: `{report.get('run_id') or 'unknown'}`",
+        f"- Snapshot hash: `{report.get('snapshot_hash')}`",
+        f"- Train: `{report['train_window']['start']} -> {report['train_window']['end']}`",
+        f"- Validation: `{report['validation_window']['start']} -> {report['validation_window']['end']}`",
+        f"- Symbols: `{','.join(report.get('symbols') or [])}`",
+        f"- Matrix min trades: `{report['matrix_min_trades']}`",
+        f"- Run-threshold validation candidates: `{report['run_threshold_validation_candidates']}`",
+        f"- Strict deployable validation candidates: `{report['strict_deployable_validation_candidates']}`",
+        f"- Decision: `{report['decision']}`",
+        "",
+        "## Direction Aggregate",
+        "",
+        "| Direction | Rows | Trades | Net PnL | Positive Rows | Run-Threshold Rows |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for direction, data in report["aggregate_by_direction"].items():
+        lines.append(
+            f"| {direction} | {data['rows']} | {data['trades']} | "
+            f"{data['net_pnl']:.2f} | {data['positive_rows']} | {data['deployable_rows']} |"
+        )
+    lines.extend(["", "## Top Validation Rows", ""])
+    for row in report["top_validation_rows"][:8]:
+        lines.append(
+            f"- `{row['hypothesis']}`: trades `{row['trades']}`, PnL `{row['net_pnl']:.2f}`, "
+            f"fill `{row['fill_rate']:.3f}`, EV gap `{row['ev_gap']:.3f}`, "
+            f"positive-day `{row['positive_day_rate']:.3f}`, blockers `{', '.join(row['blockers']) or 'none'}`"
+        )
+    lines.extend(["", "## Top Hypothesis Gate Trace", ""])
+    for row in report["top_hypothesis_gate_trace"]:
+        lines.append(
+            f"- `{row['gate_index']}:{row['gate']}` rows `{row['rows']}`, "
+            f"event_sides `{row['event_sides']}`, entry_fill `{row['entry_fill_rate']:.3f}`, "
+            f"roundtrip_fill `{row['roundtrip_fill_rate']:.3f}`, "
+            f"total executable PnL `{row['total_executable_pnl']:.2f}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "- The old `Model` direction remains negative in aggregate, while `Inverted` remains positive.",
+            "- The best inverted row is still not deployable because sample power, calibration, and daily stability gates are not all satisfied.",
+            "- Runs with matrix min trades below 80 are diagnostic only; they can identify candidate behavior but cannot authorize dry-run/live restoration.",
+            "- This supports a focused inverted/regime-calibration research lane, not dry-run/live restoration.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md", required=True)
+    args = parser.parse_args()
+
+    report = build_report(Path(args.artifact_dir), args.run_id or None)
+    json_path = Path(args.output_json)
+    md_path = Path(args.output_md)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(markdown(report), encoding="utf-8")
+    print(json.dumps({"decision": report["decision"], "output_json": str(json_path), "output_md": str(md_path)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/edge_matrix_rolling_20260502.md
+++ b/tasks/edge_matrix_rolling_20260502.md
@@ -1,0 +1,40 @@
+# PM5D Rolling Edge Matrix Diagnostic
+
+Generated from current-main strategy matrix runs over snapshot `25204438461`
+after the replay/dry-run parity matcher fix.
+
+## Inputs
+
+- Snapshot hash: `fb338e1f202c3bda`
+- Symbols: `BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT`
+- Diagnostic min trades: `20`
+- Strict deployability floor used by the analysis report: `80`
+
+## Runs
+
+| Run | Validation Window | Status | Run-Threshold Candidates | Strict Candidates | Top Row | Trades | PnL | Main Blocker |
+| --- | --- | --- | ---: | ---: | --- | ---: | ---: | --- |
+| `25242614746` | `2026-04-27` | success | 45 | 0 | `inverted_entry_only_pm_none_wide_ev0.05` | 77 | 3144.84 | sample power below 80 |
+| `25242615468` | `2026-04-28` | success | 9 | 0 | `inverted_entry_only_pm_none_wide_ev0.05` | 27 | 844.04 | sample power below 80 |
+| `25242616093` | `2026-04-29` | success | 5 | 0 | `inverted_entry_only_pm_none_wide_ev0.05` | 26 | 291.30 | sample power below 80 |
+| `25242616810` | `2026-04-30` | success | 2 | 0 | `inverted_entry_only_pm_none_middle_ev0.05` | 21 | 425.35 | sample power below 80 |
+| `25242617585` | `2026-05-01` | fail-closed | 0 | 0 | `inverted_entry_only_pm_none_wide_ev0.05` | 11 | -50.26 | sample power, negative PnL, calibration, day/symbol stability |
+
+## Interpretation
+
+- The first four single-day validation windows support the inverted-direction
+  hypothesis as a research lane, especially with no PM-dynamics hard filter and
+  entry-only executable fillability.
+- The last validation day fails closed and is negative, so this is not stable
+  enough to restore dry-run.
+- Even the strongest one-day run reaches only `77` trades, below the strict
+  `80`-trade floor. The current evidence is diagnostic, not deployable.
+- The next useful research step is not to tune the old model selector. It is to
+  build a narrower inverted/regime-calibration candidate and then test it on a
+  longer or fresher snapshot with the strict `80`-trade gate restored.
+
+## Decision
+
+`diagnostic-only-continue-research`
+
+No PM5D dry-run or live strategy should be restored from these results.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -25,6 +25,7 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Audit UP/DOWN side-label generation for obvious sign reversal.
 - [x] Add row-level selection audit output to diagnose whether `inverted` is a true contrarian edge or a probability semantics error.
 - [x] Rerun strict matrix with `selection-audit.csv` artifacts.
+- [x] Run current-main single-day rolling diagnostics for the inverted edge.
 
 ## Review
 
@@ -38,6 +39,7 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - 2026-05-01: Side-label audit found no obvious UP/DOWN settlement reversal in `FactorObservationV2`: UP rows use `model_prob_up`, `pm_up_ask`, and `settlement_up`; DOWN rows use `1 - model_prob_up`, `pm_down_ask`, and `1 - settlement_up`. The suspicious part is the matrix `Inverted` mode itself: it uses `1 - side_model_prob` while still buying the same side, so it is a contrarian same-side probability transform rather than an opposite-side trade.
 - 2026-05-01: Added `selection-audit.csv` to the matrix artifacts. It records raw side probability, transformed probability, calibrated probability, side, settlement win, executable PnL, and selection status for rows after all gates. This is needed to decide whether the inverted family is a real contrarian/PM-lag edge or just a probability-semantics bug.
 - 2026-05-02: Re-ran the strict 7-day edge matrix on current `main` after parity fixes. Workflow run `25241818848` used snapshot `25204438461` / hash `fb338e1f202c3bda`, train `2026-04-24 -> 2026-04-28`, validation `2026-04-29 -> 2026-05-01`, six symbols, stake `15`, and `min_trades=80`. The run failed closed with zero deployable validation candidates and uploaded `strategy-matrix-results.csv`, `gate-attrition.csv`, `selection-audit.csv`, `edge-matrix-summary.json`, and `report.txt`. Validation still favors inverted direction over model direction (`Inverted` total validation PnL `+$20,538.21` across 2,022 accepted trades; `Model` `-$3,460.54` across 1,543 accepted trades), but the best row `inverted_entry_only_pm_none_wide_ev0.05` remains blocked by sample power (`65 < 80` trades), EV calibration gap (`0.348 > 0.30`), and positive-day stability (`66.7% < 70%`). This confirms the current evidence supports continued systematic research, not dry-run/live restoration.
+- 2026-05-02: Added `scripts/analyze_edge_matrix_artifact.py` and generated local ignored reports under `reports/strategy/edge-matrix-*.{json,md}` so matrix artifacts can be interpreted consistently without treating low-threshold diagnostics as deployable gates. Current-main single-day rolling diagnostics used `min_trades=20` only as a research probe. Runs `25242614746`, `25242615468`, `25242616093`, and `25242616810` found positive inverted/no-PM candidates on validation days `2026-04-27` through `2026-04-30`, but all remained below the strict `80`-trade floor. Run `25242617585` for `2026-05-01` failed closed with negative top-row PnL. The durable tracked conclusion is in `tasks/edge_matrix_rolling_20260502.md`: inverted direction is a real research lane, but daily stability is not good enough to restore dry-run/live.
 
 # Stable Reversal Fillability Snapshot Research (2026-05-01)
 

--- a/tests/test_edge_matrix_artifact_analysis.py
+++ b/tests/test_edge_matrix_artifact_analysis.py
@@ -1,0 +1,125 @@
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.analyze_edge_matrix_artifact import build_report
+
+
+def write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+class EdgeMatrixArtifactAnalysisTests(unittest.TestCase):
+    def test_min_trades_below_strict_threshold_stays_diagnostic_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "edge-matrix-summary.json").write_text(
+                json.dumps(
+                    {
+                        "snapshot_hash": "hash",
+                        "source_rows": 10,
+                        "v2_rows": 20,
+                        "train_start": "2026-04-24T00:00:00Z",
+                        "train_end": "2026-04-27T00:00:00Z",
+                        "val_start": "2026-04-27T00:00:00Z",
+                        "val_end": "2026-04-28T00:00:00Z",
+                        "symbols": ["BTCUSDT"],
+                        "hypothesis_count": 1,
+                        "min_trades": 20,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            write_csv(
+                root / "strategy-matrix-results.csv",
+                [
+                    {
+                        "hypothesis": "inverted_entry_only_pm_none_wide_ev0.05",
+                        "split": "validation",
+                        "direction_mode": "Inverted",
+                        "fill_mode": "EntryOnlyExecutable",
+                        "pm_mode": "None",
+                        "trades": 21,
+                        "selected": 21,
+                        "trade_attempts_after_throttle": 21,
+                        "rejected_duplicate": 0,
+                        "rejected_cooldown": 0,
+                        "rejected_non_executable": 0,
+                        "net_pnl": 100,
+                        "selection_rate": 1,
+                        "fill_rate": 1,
+                        "duplicate_rate": 0,
+                        "cooldown_rate": 0,
+                        "non_executable_rate": 0,
+                        "win_rate": 1,
+                        "avg_realized_return_per_stake": 0.3,
+                        "avg_expected_value_per_stake": 0.4,
+                        "expectancy_calibration_gap": 0.1,
+                        "positive_day_rate": 1,
+                        "positive_symbol_rate": 1,
+                        "underpowered": "false",
+                        "deployable_candidate": "true",
+                    }
+                ],
+            )
+            write_csv(
+                root / "selection-audit.csv",
+                [
+                    {
+                        "hypothesis": "inverted_entry_only_pm_none_wide_ev0.05",
+                        "split": "validation",
+                        "direction_mode": "Inverted",
+                        "fill_mode": "EntryOnlyExecutable",
+                        "pm_mode": "None",
+                        "event_id": "event",
+                        "symbol": "BTCUSDT",
+                        "tick_ts": "2026-04-27T00:00:00Z",
+                        "side": "UP",
+                        "raw_side_model_prob": 0.4,
+                        "transformed_probability": 0.6,
+                        "calibrated_probability": 0.56,
+                        "entry_ask": 0.5,
+                        "expected_value_per_stake": 0.4,
+                        "side_distance_over_sigma": 1,
+                        "settlement_win": 1,
+                        "executable_pnl_15u": 10,
+                        "selection_status": "accepted",
+                    }
+                ],
+            )
+            write_csv(
+                root / "gate-attrition.csv",
+                [
+                    {
+                        "hypothesis": "inverted_entry_only_pm_none_wide_ev0.05",
+                        "split": "validation",
+                        "gate_index": 0,
+                        "gate": "base",
+                        "rows": 1,
+                        "event_sides": 1,
+                        "executable_pnl_rows": 1,
+                        "full_depth_pnl_rows": 1,
+                        "entry_fill_rate": 1,
+                        "roundtrip_fill_rate": 1,
+                        "total_executable_pnl": 10,
+                        "avg_executable_pnl": 10,
+                    }
+                ],
+            )
+
+            report = build_report(root, "run")
+
+        self.assertEqual(report["run_threshold_validation_candidates"], 1)
+        self.assertEqual(report["strict_deployable_validation_candidates"], 0)
+        self.assertEqual(report["decision"], "diagnostic-only-continue-research")
+        self.assertIn("sample_power:21<80", report["top_validation_rows"][0]["blockers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an artifact-only PM5D edge matrix analyzer for strategy-research-matrix outputs
- distinguish low min_trades diagnostic candidates from strict 80-trade deployability
- record current-main single-day rolling matrix results for the inverted edge

## Research evidence
- Strict 7-day run: 25241818848
- Daily diagnostic runs: 25242614746, 25242615468, 25242616093, 25242616810, 25242617585
- Result: inverted/no-PM remains a real research lane, but one day failed closed and no daily window reached the strict 80-trade floor
- Decision: no dry-run/live restoration

## Verification
- python3 -m unittest tests.test_edge_matrix_artifact_analysis
- python3 -m py_compile scripts/analyze_edge_matrix_artifact.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line tool for analyzing strategy matrix artifacts, generating JSON and Markdown diagnostic reports with deployability metrics and decision summaries.

* **Tests**
  * Added comprehensive test coverage for artifact analysis, including threshold validation and decision logic.

* **Chores**
  * Updated task documentation with diagnostic findings and deployment decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->