### PR TITLE
Surface active dry-run deployment in UI

### DIFF
--- a/ploy-frontend/src/pages/DryRunReport.tsx
+++ b/ploy-frontend/src/pages/DryRunReport.tsx
@@ -81,6 +81,8 @@ type StrategySurfaceRow = {
   latestClosedAt: string | null;
   latestAgeHours: number | null;
   observedState: string;
+  desiredState: string;
+  isActive: boolean;
   strategy?: DryRunStrategyReport;
   deployment?: DeploymentSummary;
   snapshot?: TradingStateSnapshot;
@@ -148,6 +150,22 @@ function shouldShowUnreportedDryRunDeployment(deployment: DeploymentSummary, sna
     deployment.observed_state === 'starting' ||
     deployment.observed_state === 'degraded'
   );
+}
+
+function isActiveDeployment(deployment?: DeploymentSummary) {
+  return deployment?.desired_state === 'running' || deployment?.observed_state === 'running';
+}
+
+function statusBadge(row: StrategySurfaceRow) {
+  if (row.observedState === 'running') return 'success' as const;
+  if (row.observedState === 'failed' || row.observedState === 'degraded') return 'destructive' as const;
+  if (row.observedState === 'starting' || row.desiredState === 'running') return 'warning' as const;
+  return 'secondary' as const;
+}
+
+function statusLabel(row: StrategySurfaceRow) {
+  if (!row.deployment) return 'report only';
+  return `${row.desiredState}/${row.observedState}`;
 }
 
 function isDryRunSnapshot(snapshot: TradingStateSnapshot) {
@@ -566,6 +584,8 @@ export function DryRunReport() {
         latestClosedAt: strategy.summary.latest_closed_at ?? null,
         latestAgeHours: latestAge,
         observedState: deployment?.observed_state ?? 'unknown',
+        desiredState: deployment?.desired_state ?? 'unknown',
+        isActive: isActiveDeployment(deployment),
         strategy,
         deployment,
         snapshot,
@@ -611,6 +631,8 @@ export function DryRunReport() {
           latestClosedAt: null,
           latestAgeHours: null,
           observedState: deployment.observed_state,
+          desiredState: deployment.desired_state,
+          isActive: isActiveDeployment(deployment),
           deployment,
           snapshot,
         };
@@ -618,7 +640,12 @@ export function DryRunReport() {
       });
 
     return [...reported, ...missing].sort((a, b) => {
-      return a.attentionRank - b.attentionRank || toNumber(a.todayPnl) - toNumber(b.todayPnl) || b.todayClosedTrades - a.todayClosedTrades;
+      return (
+        Number(b.isActive) - Number(a.isActive) ||
+        a.attentionRank - b.attentionRank ||
+        toNumber(a.todayPnl) - toNumber(b.todayPnl) ||
+        b.todayClosedTrades - a.todayClosedTrades
+      );
     });
   }, [currentDay, deploymentById, dryRunDeployments, snapshotByDeployment, strategies]);
 
@@ -672,6 +699,7 @@ export function DryRunReport() {
   const greenTodayStrategies = strategyRows.filter((row) => row.todayClosedTrades > 0 && row.todayPnl > 0).length;
   const watchStrategies = strategyRows.filter((row) => row.health === 'watch' || row.health === 'degraded').length;
   const emptyStrategyCount = strategyRows.filter((row) => row.health === 'empty').length;
+  const activeStrategyCount = strategyRows.filter((row) => row.isActive).length;
   const portfolioPnl = toNumber(summary?.realized_pnl);
   const todayPortfolioPnl = toNumber(todayPortfolio?.net_pnl);
   const todayPortfolioClosed = todayPortfolio?.closed_trade_count ?? 0;
@@ -722,6 +750,7 @@ export function DryRunReport() {
               </h1>
               {selectedRow ? <Badge variant={healthBadge(selectedRow)}>{selectedRow.health}</Badge> : null}
               {selectedRow ? <Badge variant={performanceBadge(selectedRow)}>{selectedRow.performance}</Badge> : null}
+              {selectedRow ? <Badge variant={statusBadge(selectedRow)}>{statusLabel(selectedRow)}</Badge> : null}
             </div>
             <div className="mt-1 text-sm text-muted-foreground">
               {selectedRow?.strategyId ?? 'unknown'} · {selectedRow?.deploymentId ?? 'unknown'} · generated{' '}
@@ -734,8 +763,10 @@ export function DryRunReport() {
               <div>runtime</div>
             </div>
             <div className="rounded-md border bg-white px-3 py-2">
-              <div className="font-medium text-foreground">{selectedRow?.deployment?.observed_state ?? '-'}</div>
-              <div>observed</div>
+              <div className="font-medium text-foreground">
+                {selectedRow ? statusLabel(selectedRow) : '-'}
+              </div>
+              <div>state</div>
             </div>
             <div className="rounded-md border bg-white px-3 py-2">
               <div className="font-medium text-foreground">{formatShortTime(selectedRow?.latestClosedAt)}</div>
@@ -866,6 +897,9 @@ export function DryRunReport() {
         <div>
           <div className="mb-2 flex items-center gap-2">
             <Badge variant="outline">Dry-run</Badge>
+            <Badge variant={activeStrategyCount > 0 ? 'success' : 'secondary'}>
+              {activeStrategyCount} active
+            </Badge>
             <Badge variant={report.pairing.mixed_event_groups > 0 ? 'warning' : 'success'}>
               {report.pairing.mixed_event_groups} mixed events
             </Badge>
@@ -877,8 +911,8 @@ export function DryRunReport() {
         </div>
         <div className="grid grid-cols-4 gap-2 text-right text-xs text-muted-foreground">
           <div className="rounded-md border bg-white px-3 py-2">
-            <div className="font-medium text-foreground">{strategyRows.length}</div>
-            <div>strategies</div>
+            <div className="font-medium text-foreground">{activeStrategyCount}/{strategyRows.length}</div>
+            <div>active/report</div>
           </div>
           <div className="rounded-md border bg-white px-3 py-2">
             <div className="font-medium text-foreground">{greenTodayStrategies}</div>
@@ -973,7 +1007,12 @@ export function DryRunReport() {
                           <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: row.color }} />
                           <span className="truncate font-medium">{row.label}</span>
                         </div>
-                        <div className="truncate text-xs text-muted-foreground">{row.strategyId} · {row.runtimeMode}</div>
+                        <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                          <Badge variant={statusBadge(row)} className="shrink-0">
+                            {statusLabel(row)}
+                          </Badge>
+                          <span className="truncate">{row.strategyId} · {row.runtimeMode}</span>
+                        </div>
                       </div>
                       <Badge variant={healthBadge(row)} className="w-fit">{row.health}</Badge>
                       <span>{row.todayClosedTrades}</span>

--- a/ploy-frontend/src/pages/OperatorCockpit.tsx
+++ b/ploy-frontend/src/pages/OperatorCockpit.tsx
@@ -121,6 +121,29 @@ function shouldShowUnreportedDryRunDeployment(deployment: DeploymentSummary, sna
   );
 }
 
+function isActiveDeployment(deployment?: DeploymentSummary) {
+  return deployment?.desired_state === 'running' || deployment?.observed_state === 'running';
+}
+
+function deploymentStatusBadge(deployment?: DeploymentSummary) {
+  if (!deployment) return 'secondary' as const;
+  if (deployment.observed_state === 'running') return 'success' as const;
+  if (deployment.observed_state === 'failed') return 'destructive' as const;
+  if (
+    deployment.observed_state === 'degraded' ||
+    deployment.observed_state === 'starting' ||
+    deployment.desired_state === 'running'
+  ) {
+    return 'warning' as const;
+  }
+  return 'secondary' as const;
+}
+
+function deploymentStatusLabel(deployment?: DeploymentSummary) {
+  if (!deployment) return 'report only';
+  return `${deployment.desired_state}/${deployment.observed_state}`;
+}
+
 function compactTime(timestamp?: string | null) {
   if (!timestamp) return '-';
   return new Date(timestamp).toLocaleTimeString('zh-CN', {
@@ -458,11 +481,19 @@ export function OperatorCockpit() {
   }, [dryRunEquityCurve, dryRunStrategies]);
   const rankedStrategies = useMemo(() => {
     return [...dryRunStrategies].sort(
-      (a, b) =>
-        toNumber(b.summary.realized_pnl) - toNumber(a.summary.realized_pnl) ||
-        b.summary.closed_trades - a.summary.closed_trades
+      (a, b) => {
+        const aDeployment = dryRunDeployments.find((deployment) => deployment.deployment_id === a.deployment_id);
+        const bDeployment = dryRunDeployments.find((deployment) => deployment.deployment_id === b.deployment_id);
+        const aActive = isActiveDeployment(aDeployment) ? 0 : 1;
+        const bActive = isActiveDeployment(bDeployment) ? 0 : 1;
+        return (
+          aActive - bActive ||
+          toNumber(b.summary.realized_pnl) - toNumber(a.summary.realized_pnl) ||
+          b.summary.closed_trades - a.summary.closed_trades
+        );
+      }
     );
-  }, [dryRunStrategies]);
+  }, [dryRunDeployments, dryRunStrategies]);
   const dryRunStrategyByDeployment = useMemo(() => {
     const byDeployment = new Map<string, DryRunStrategyReport>();
     for (const strategy of dryRunStrategies) {
@@ -481,6 +512,13 @@ export function OperatorCockpit() {
       !dryRunStrategyByDeployment.has(deployment.deployment_id) &&
       shouldShowUnreportedDryRunDeployment(deployment, tradingByDeployment.get(deployment.deployment_id))
   );
+  const activeDryRunStrategyCount =
+    dryRunStrategies.filter((strategy) =>
+      isActiveDeployment(
+        dryRunDeployments.find((deployment) => deployment.deployment_id === strategy.deployment_id)
+      )
+    ).length +
+    unreportedDryRunDeployments.filter(isActiveDeployment).length;
 
   const eventAge = lastEventAt == null ? null : Math.max(0, Math.round((Date.now() - lastEventAt) / 1000));
   const cpuPressure =
@@ -608,8 +646,8 @@ export function OperatorCockpit() {
                 <FileText className="h-5 w-5" />
                 Dry-run Strategy Report
               </CardTitle>
-              <Badge variant={dryRunStrategies.length > 1 ? 'success' : 'secondary'}>
-                {dryRunStrategies.length} strategies
+              <Badge variant={activeDryRunStrategyCount > 0 ? 'success' : 'secondary'}>
+                {activeDryRunStrategyCount} active / {dryRunStrategies.length} report rows
               </Badge>
             </div>
           </CardHeader>
@@ -709,6 +747,9 @@ export function OperatorCockpit() {
                     <>
                       {rankedStrategies.map((strategy) => {
                         const pnl = toNumber(strategy.summary.realized_pnl);
+                        const deployment = dryRunDeployments.find(
+                          (entry) => entry.deployment_id === strategy.deployment_id
+                        );
                         return (
                           <div
                             key={`${strategy.runtime_mode}:${strategy.strategy_id}:${strategy.deployment_id}`}
@@ -716,8 +757,13 @@ export function OperatorCockpit() {
                           >
                             <div className="min-w-0">
                               <div className="truncate font-medium">{compactStrategyLabel(strategy)}</div>
-                              <div className="truncate text-xs text-muted-foreground">
-                                {strategy.deployment_id || strategy.strategy_id || 'unknown'} · {strategy.runtime_mode || 'unknown'}
+                              <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                                <Badge variant={deploymentStatusBadge(deployment)} className="shrink-0">
+                                  {deploymentStatusLabel(deployment)}
+                                </Badge>
+                                <span className="truncate">
+                                  {strategy.deployment_id || strategy.strategy_id || 'unknown'} · {strategy.runtime_mode || 'unknown'}
+                                </span>
                               </div>
                             </div>
                             <div>{strategy.summary.closed_trades}</div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,27 @@
+# Dry-Run Active UI Wiring (2026-05-02)
+
+## Files
+
+- `ploy-frontend/src/pages/OperatorCockpit.tsx`
+  - Owner: cockpit dry-run report attribution and deployment/runtime state display.
+- `ploy-frontend/src/pages/DryRunReport.tsx`
+  - Owner: public dry-run report ranking and strategy status display.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Confirm the live API has the champion deployment and report row.
+- [x] Make active/running dry-run deployments sort ahead of stopped historical report rows.
+- [x] Label report rows with deployment status so stopped history is not confused with the running strategy.
+- [ ] Deploy the updated public UI.
+
+## Review
+
+- 2026-05-02: Live API check confirmed `pm5d.threelayer.champion.dryrun` is the only PM5D dry-run in `running/running`; `pm5d.threelayer.live` remains `paused/paused`, and stopped historical dry-run strategies remain stopped. The dry-run report contains the champion row and refreshed to 24 closed trades with realized PnL `-$94.40`.
+- 2026-05-02: Updated the frontend so dry-run report rows are joined back to deployment state, active/running deployments sort ahead of stopped historical report rows, and both the operator cockpit and dry-run report display active/report counts plus `desired/observed` status badges.
+- 2026-05-02: Local frontend verification passed: `npm run lint`, `npm run contracts:check`, `npm run build`, and `git diff --check`.
+
 # PM5D Factor Stability Multi-Window Extension (2026-05-02)
 
 ## Files


### PR DESCRIPTION
## Summary
- sort active dry-run deployments ahead of stopped historical report rows
- show active/report counts and desired/observed status badges in DryRunReport and OperatorCockpit
- record live API/UI wiring evidence in tasks/todo.md

## Verification
- npm run lint
- npm run contracts:check
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strategy status badges now display combined desired/observed state in detail headers and ranking lists
  * Added active strategy counters to dry-run strategy overview summary
  * Strategy ranking prioritized to surface active strategies first
  * Deployment status and labels now visible in strategy attribution table rows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->