### PR TITLE
Emit AutoFactor repricing seed reports

### DIFF
--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -8,22 +8,23 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
-    FactorWalkForwardOptions, FillabilityReviewOptions, LiquidityGateV1Options,
-    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, ResearchSnapshotRequest,
-    RepricingIcOptions, TradeFormationReviewOptions, build_factor_observations_with_lob_sampled,
-    build_factor_stability_report, format_factor_combo_v1_report, format_factor_stability_report,
+    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
+    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
+    FillabilityReviewOptions, LiquidityGateV1Options, LiquidityGatedAlphaV1Options,
+    MetaLabelWalkForwardOptions, RepricingIcOptions, ResearchSnapshotRequest,
+    TradeFormationReviewOptions, build_factor_observations_v2_with_deribit_and_pm_books,
+    build_factor_observations_with_lob_sampled, build_factor_stability_report,
+    format_autofactor_reports, format_factor_combo_v1_report, format_factor_stability_report,
     format_factor_walk_forward_v2_report, format_fillability_review_v1_report,
     format_liquidity_gate_v1_report, format_liquidity_gated_alpha_v1_report,
     format_meta_label_walk_forward_v1_report, format_repricing_ic_report,
-    format_trade_formation_v1_report,
-    liquidity_gate_v1_with_deribit, liquidity_gated_alpha_v1_with_deribit,
-    load_deribit_feature_snapshots, load_research_lob_snapshots_sampled,
-    load_research_pm_book_snapshots_sampled, load_research_snapshot,
-    review_fillability_v1_with_deribit, review_repricing_ic_with_deribit_and_pm_books,
-    review_trade_formation_v1_with_deribit, validate_snapshot_request,
-    walk_forward_factor_combo_v1_with_deribit, walk_forward_factors_v2_with_deribit_and_pm_books,
-    walk_forward_meta_label_v1_with_deribit,
+    format_trade_formation_v1_report, liquidity_gate_v1_with_deribit,
+    liquidity_gated_alpha_v1_with_deribit, load_deribit_feature_snapshots,
+    load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
+    load_research_snapshot, mine_domain_autofactors_from_v2, review_fillability_v1_with_deribit,
+    review_repricing_ic_with_deribit_and_pm_books, review_trade_formation_v1_with_deribit,
+    validate_snapshot_request, walk_forward_factor_combo_v1_with_deribit,
+    walk_forward_factors_v2_with_deribit_and_pm_books, walk_forward_meta_label_v1_with_deribit,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -356,6 +357,34 @@ async fn main() {
         "{}",
         format_repricing_ic_report(&repricing_ic_report, options.top_n)
     );
+    let autofactor_rows = build_factor_observations_v2_with_deribit_and_pm_books(
+        &observations,
+        &deribit_snapshots,
+        &all_pm_book_snapshots,
+        &options.review,
+    );
+    let autofactor_options = AutoFactorOptions {
+        min_observations: options.review.min_observations.max(50),
+        min_window_observations: options.review.min_observations.max(20),
+        ..Default::default()
+    };
+    for target in [
+        AutoFactorV2Target::RepricePnl10s,
+        AutoFactorV2Target::RepricePnl30s,
+    ] {
+        match mine_domain_autofactors_from_v2(&autofactor_rows, target, &autofactor_options) {
+            Ok(reports) => {
+                println!("# AutoFactor target={}", target.as_str());
+                println!("{}", format_autofactor_reports(&reports, options.top_n));
+            }
+            Err(err) => {
+                eprintln!(
+                    "autofactor seed report failed for {}: {err}",
+                    target.as_str()
+                );
+            }
+        }
+    }
     let fillability_report = review_fillability_v1_with_deribit(
         &observations,
         &deribit_snapshots,

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -215,6 +215,7 @@ impl AutoFactorDecision {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutoFactorReport {
     pub name: String,
+    pub target: Option<String>,
     pub expr: FactorExpr,
     pub n: usize,
     pub pearson_ic: f64,
@@ -353,6 +354,7 @@ pub fn evaluate_named_factor(
 
     Ok(AutoFactorReport {
         name: factor.name.clone(),
+        target: factor.target.clone(),
         expr: factor.expr.clone(),
         n: scored.len(),
         pearson_ic: pearson,
@@ -409,6 +411,38 @@ pub fn mine_autofactors(
             })
     });
     Ok(reports)
+}
+
+pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> String {
+    let mut out = String::new();
+    out.push_str("=== AutoFactor Seed Candidate Report ===\n");
+    out.push_str(
+        "target labels are side-aligned executable repricing PnL; reports are candidate discovery gates, not deploy decisions.\n",
+    );
+    out.push_str(
+        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity\n",
+    );
+    for (idx, report) in reports.iter().take(top_n).enumerate() {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{:.4},{:.6},{:.4},{}\n",
+            idx + 1,
+            report.name,
+            report.target.as_deref().unwrap_or("<unspecified>"),
+            report.decision.as_str(),
+            report.reason,
+            report.n,
+            report.spearman_ic,
+            report.pearson_ic,
+            report.window_count,
+            report.icir,
+            report.positive_window_ratio,
+            report.monotonicity_score,
+            report.top_bucket_avg_label,
+            report.top_bucket_positive_label_rate,
+            report.complexity,
+        ));
+    }
+    out
 }
 
 pub fn mine_domain_autofactors_from_v2(

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -84,7 +84,8 @@ pub use autofactor::{
     AutoFactorDecision, AutoFactorError, AutoFactorMatrix, AutoFactorOptions, AutoFactorReport,
     AutoFactorV2Target, FactorExpr, NamedFactorExpr, autofactor_labels_from_v2,
     autofactor_matrix_from_v2, autofactor_windows_from_v2, domain_seed_candidates,
-    evaluate_named_factor, mine_autofactors, mine_domain_autofactors_from_v2,
+    evaluate_named_factor, format_autofactor_reports, mine_autofactors,
+    mine_domain_autofactors_from_v2,
 };
 pub use backtest::{BacktestMetrics, SimulatedFill, run_binary_backtest};
 pub use factors_new::{

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# AutoFactor Repricing Runner (2026-05-03)
+
+## Files
+
+- `crates/ploy-research/src/autofactor.rs`
+  - Owner: report formatting and V2 seed-candidate mining adapter.
+- `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+  - Owner: emit AutoFactor seed reports from the existing snapshot-backed walk-forward workflow.
+- `crates/ploy-research/src/lib.rs`
+  - Owner: public exports for the AutoFactor report runner.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Add a text report formatter for AutoFactor seed candidate results.
+- [x] Wire `factor_walk_forward_v2` to emit `reprice_pnl_10s` and `reprice_pnl_30s` AutoFactor seed reports.
+- [x] Run focused local verification.
+- [x] Commit and open PR.
+
+## Review
+
+- 2026-05-03: Wired the existing snapshot-backed `factor_walk_forward_v2` example to build `FactorObservationV2` rows once, run AutoFactor domain seed candidates against `reprice_pnl_10s` and `reprice_pnl_30s`, and print a CSV-style seed candidate gate report after the Repricing IC section.
+- 2026-05-03: Added `format_autofactor_reports` so the workflow output includes decision, reason, IC, ICIR, positive-window ratio, bucket monotonicity, top-bucket executable label, and complexity for each seed formula. Local verification passed: `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runner rtk cargo test -p ploy-research autofactor --lib`, `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runner rtk cargo check -p ploy-research --example factor_walk_forward_v2 --features db --no-default-features`, and `git diff --check`. The example check emitted only pre-existing strategy-bundle dead-code warnings and the vendor profile warning.
+- 2026-05-03: Opened PR `#308` (`Emit AutoFactor repricing seed reports`). This PR reuses the existing factor walk-forward workflow and does not promote any factor to dry-run/live.
+
 # Rust Native AutoFactor Engine (2026-05-03)
 
 ## Files


### PR DESCRIPTION
## Summary
- emit AutoFactor seed candidate reports from the existing snapshot-backed `factor_walk_forward_v2` workflow
- score seed formulas against side-aligned `reprice_pnl_10s` and `reprice_pnl_30s` labels
- include IC/ICIR, positive-window ratio, monotonicity, top-bucket label, and decision reason in report output

## Verification
- `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runner rtk cargo test -p ploy-research autofactor --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runner rtk cargo check -p ploy-research --example factor_walk_forward_v2 --features db --no-default-features`
- `git diff --check`

## Notes
- This reuses the existing factor walk-forward workflow; it does not promote any factor to dry-run/live.