### PR TITLE
Show true AutoFactor repricing targets

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -444,7 +444,14 @@ pub fn mine_domain_autofactors_from_v2(
     let matrix = autofactor_matrix_from_v2(rows)?;
     let labels = autofactor_labels_from_v2(rows, target);
     let windows = autofactor_windows_from_v2(rows);
-    let candidates = domain_seed_candidates(&matrix.input_names());
+    let target_name = target.as_str().to_string();
+    let candidates = domain_seed_candidates(&matrix.input_names())
+        .into_iter()
+        .map(|mut factor| {
+            factor.target = Some(target_name.clone());
+            factor
+        })
+        .collect::<Vec<_>>();
     mine_autofactors(&candidates, &matrix, &labels, &windows, options)
 }
 
@@ -1271,5 +1278,29 @@ mod tests {
         assert!(reports
             .iter()
             .any(|report| report.name == "poly_lag_pressure"));
+    }
+
+    #[test]
+    fn mines_domain_candidates_from_v2_uses_requested_target_metadata() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+
+        let reports =
+            mine_domain_autofactors_from_v2(&rows, AutoFactorV2Target::RepricePnl30s, &options)
+                .expect("reports");
+
+        assert!(!reports.is_empty());
+        assert!(reports
+            .iter()
+            .all(|report| report.target.as_deref() == Some("reprice_pnl_30s")));
+
+        let formatted = format_autofactor_reports(&reports, reports.len());
+        assert!(formatted.contains("reprice_pnl_30s"));
+        assert!(!formatted.contains("reprice_pnl_10s"));
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,23 @@
+# AutoFactor Target Metadata Fix (2026-05-03)
+
+## Files
+
+- `crates/ploy-research/src/autofactor.rs`
+  - Owner: ensure V2 AutoFactor seed reports display the actual target label used for evaluation.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Fix V2 AutoFactor report target metadata for `reprice_pnl_30s`.
+- [x] Add a focused regression test for requested target metadata.
+- [x] Run focused local verification.
+- [ ] Commit, PR, merge, and rerun the snapshot-backed factor workflow.
+
+## Review
+
+- 2026-05-03: Fixed V2 AutoFactor seed reports so every report row displays the target label actually used by `mine_domain_autofactors_from_v2` (`reprice_pnl_10s` or `reprice_pnl_30s`) instead of the seed candidate's default 10s metadata. Added a regression test that mines 30s labels and verifies formatted output contains only `reprice_pnl_30s`. Local verification passed: `rustfmt --edition 2021 --check crates/ploy-research/src/autofactor.rs`, `CARGO_TARGET_DIR=/tmp/ploy-autofactor-target rtk cargo test -p ploy-research autofactor --lib`, `CARGO_TARGET_DIR=/tmp/ploy-autofactor-target rtk cargo check -p ploy-research --example factor_walk_forward_v2 --features db --no-default-features`, and `git diff --check`. The example check emitted only pre-existing strategy-bundle dead-code warnings and the vendor profile warning.
+
 # AutoFactor Repricing Runner (2026-05-03)
 
 ## Files


### PR DESCRIPTION
## Summary
- override V2 AutoFactor seed report metadata with the actual requested repricing target
- add a 30s regression test so formatted reports do not show stale 10s labels
- record focused verification in tasks/todo.md

## Verification
- rustfmt --edition 2021 --check crates/ploy-research/src/autofactor.rs
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-target rtk cargo test -p ploy-research autofactor --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-target rtk cargo check -p ploy-research --example factor_walk_forward_v2 --features db --no-default-features
- git diff --check

## Risk
Research/reporting only. This does not promote any factor to dry-run or live.