### PR TITLE
Make repricing momentum replayable

### DIFF
--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -15,11 +15,11 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_research::{
-    FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest, build_data_health_report,
-    build_factor_observations_v2_with_deribit_and_pm_books, load_research_snapshot,
+    build_data_health_report, build_factor_observations_v2_with_deribit_and_pm_books,
+    load_research_snapshot, FactorObservationV2, FactorReviewOptions, ResearchSnapshotManifest,
 };
-use ploy_strategy_bundles::ThreeLayerProfile;
 use ploy_strategy_bundles::strategies::three_layer_model as tl_model;
+use ploy_strategy_bundles::ThreeLayerProfile;
 use serde::Serialize;
 
 const OPTIMIZER_MIN_DIRECTION_PROB: f64 = 0.515;
@@ -434,7 +434,11 @@ fn validate_snapshot_scope(
 }
 
 fn finite_or_zero(value: f64) -> f64 {
-    if value.is_finite() { value } else { 0.0 }
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
 }
 
 fn reward_risk_ratio(entry_price: f64) -> f64 {
@@ -722,6 +726,10 @@ fn three_layer_entry_score(
             edge,
             edge_score,
             confirmation,
+            repricing_score: tl_model::spread_adjusted_external_move_score(
+                row.cex_bar_return_30s * row.side.multiplier(),
+                row.pm_spread_bps / 10_000.0,
+            ),
             drift_30s: row.drift_30s,
             pm_momentum_score,
             liquidity_score: 1.0,
@@ -2083,10 +2091,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        OPTIMIZER_MAX_DIRECTION_PROB, OPTIMIZER_MIN_DIRECTION_PROB,
-        STABLE_DIRECTION_MIN_DIRECTION_PROB, STABLE_REVERSAL_FILLABLE_MIN_DIRECTION_PROB,
-        STABLE_REVERSAL_SOFT_MIN_DIRECTION_PROB, SnapshotObjectiveMetrics,
-        SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
         calibrate_direction_probability, calibrated_model_probability,
         calibrated_profile_probability, cex_direction_probability, compounded_log_growth,
         default_min_trades_from_coverage, direction_alpha_probability,
@@ -2097,6 +2101,10 @@ mod tests {
         row_passes_gates, sample_power_multiplier, stable_compounding_objective,
         stable_direction_confirmation_score, stable_reversal_confirmation_score,
         stable_reversal_soft_confirmation_score, trade_sharpe, transformed_model_probability,
+        SnapshotObjectiveMetrics, SnapshotThreeLayerParams, StableObjectiveInputs, StrategyProfile,
+        OPTIMIZER_MAX_DIRECTION_PROB, OPTIMIZER_MIN_DIRECTION_PROB,
+        STABLE_DIRECTION_MIN_DIRECTION_PROB, STABLE_REVERSAL_FILLABLE_MIN_DIRECTION_PROB,
+        STABLE_REVERSAL_SOFT_MIN_DIRECTION_PROB,
     };
     use chrono::{TimeZone, Utc};
     use ploy_research::{FactorObservationV2, Regime, ReviewSide};

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, OrderState, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -446,6 +446,10 @@ fn evaluate_edge_score(
     ))
 }
 
+fn spread_adjusted_external_move_score(side_external_move_30s: f64, side_spread: f64) -> f64 {
+    three_layer_model::spread_adjusted_external_move_score(side_external_move_30s, side_spread)
+}
+
 // ── ThreeLayerStrategy ─────────────────────────────────────────────
 
 pub struct ThreeLayerStrategy {
@@ -737,6 +741,7 @@ impl ThreeLayerStrategy {
                 self.bump("skip_no_pm_ask");
                 continue;
             };
+            let bid = quote.bid.and_then(|price| price.to_f64());
             let quote_age = (now - quote.ts).num_seconds();
             if quote_age > self.config.max_pm_lag_secs as i64 {
                 self.bump("skip_stale_pm_quote");
@@ -764,6 +769,23 @@ impl ThreeLayerStrategy {
                 continue;
             }
 
+            let side_spread = bid
+                .filter(|bid| bid.is_finite() && ask.is_finite() && ask > 0.0)
+                .map(|bid| ((ask - bid).max(0.0)) / ask)
+                .unwrap_or(f64::NAN);
+            let repricing_score =
+                spread_adjusted_external_move_score(drift_30s * direction_sign, side_spread);
+            if self.config.profile == ThreeLayerProfile::RepricingMomentum {
+                if !repricing_score.is_finite() {
+                    self.bump("skip_repricing_score_unavailable");
+                    continue;
+                }
+                if repricing_score < self.config.min_confirmation_score {
+                    self.bump("skip_repricing_score");
+                    continue;
+                }
+            }
+
             // Layer 3: Edge score
             let Some((entry_price_f, edge, rr, edge_score)) =
                 evaluate_edge_score(effective_p, ask, regime, &self.config)
@@ -786,6 +808,7 @@ impl ThreeLayerStrategy {
                     edge,
                     edge_score,
                     confirmation: confirmation_score,
+                    repricing_score,
                     drift_30s,
                     pm_momentum_score,
                     liquidity_score: 1.0,
@@ -802,6 +825,7 @@ impl ThreeLayerStrategy {
                     direction_score = format!("{:.3}", direction_score),
                     edge_score = format!("{:.3}", edge_score),
                     confirmation_score = format!("{:.3}", confirmation_score),
+                    repricing_score = format!("{:.3}", repricing_score),
                     pm_momentum_score = format!("{:.3}", pm_momentum_score),
                     min_entry_score = self.config.min_entry_score,
                     profile = %self.config.profile,
@@ -892,6 +916,7 @@ impl ThreeLayerStrategy {
                 direction_score = format!("{:.3}", direction_score),
                 edge_score = format!("{:.3}", edge_score),
                 confirmation_score = format!("{:.3}", confirmation_score),
+                repricing_score = format!("{:.3}", repricing_score),
                 pm_momentum_score = format!("{:.3}", pm_momentum_score),
                 p_hat = effective_p,
                 edge,
@@ -1460,6 +1485,11 @@ mod tests {
             serde_json::from_str(r#"{"strategy_profile":"obi_hard"}"#).unwrap();
         let tlc: ThreeLayerConfig = dc.into();
         assert_eq!(tlc.profile, ThreeLayerProfile::ObiHard);
+
+        let dc: DirectionalConfig =
+            serde_json::from_str(r#"{"strategy_profile":"repricing_momentum"}"#).unwrap();
+        let tlc: ThreeLayerConfig = dc.into();
+        assert_eq!(tlc.profile, ThreeLayerProfile::RepricingMomentum);
     }
 
     #[test]
@@ -1974,6 +2004,77 @@ mod tests {
     }
 
     #[test]
+    fn repricing_momentum_profile_gates_on_spread_adjusted_external_move() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::RepricingMomentum;
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        config.min_confirmation_score = 0.05;
+        config.min_entry_score = 0.0;
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        let mut strategy = ThreeLayerStrategy::new(config.clone());
+        discover_test_event(&mut strategy, now);
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        assert!(decisions.is_empty());
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("skip_repricing_score"), Some(&1));
+
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        for i in 0..30 {
+            strategy.on_update(
+                &MarketUpdate::SpotPrice {
+                    symbol: Arc::from("BTCUSDT"),
+                    price: Decimal::from(99_400 + i * 20),
+                    ts: now - chrono::Duration::seconds(30 - i as i64),
+                },
+                &positions,
+                &orders,
+            );
+        }
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            matches!(decisions.as_slice(), [StrategyDecision::Enter { .. }]),
+            "positive side external move should pass repricing gate, got {decisions:?}"
+        );
+    }
+
+    #[test]
     fn balance_pause_blocks_entries_but_not_take_profit_exit() {
         use chrono::TimeZone;
 
@@ -2160,6 +2261,7 @@ mod tests {
                 edge: 0.01,
                 edge_score: 0.20,
                 confirmation: -1.0,
+                repricing_score: 0.0,
                 drift_30s: 0.0,
                 pm_momentum_score: 0.0,
                 liquidity_score: 1.0,
@@ -2174,6 +2276,7 @@ mod tests {
                 edge: 0.01,
                 edge_score: 0.20,
                 confirmation: 1.0,
+                repricing_score: 0.0,
                 drift_30s: 0.0,
                 pm_momentum_score: 0.0,
                 liquidity_score: 1.0,
@@ -2228,6 +2331,7 @@ mod tests {
                 edge: 0.06,
                 edge_score: 0.70,
                 confirmation: 0.0,
+                repricing_score: 0.0,
                 drift_30s: 0.0,
                 pm_momentum_score: 0.0,
                 liquidity_score: 1.0,
@@ -2238,6 +2342,59 @@ mod tests {
             soft_score > soft_config.min_entry_score,
             "OBI-soft should still be able to score weak confirmation instead of hard rejecting"
         );
+    }
+
+    #[test]
+    fn spread_adjusted_external_move_matches_autofactor_formula() {
+        let side_external_move_30s = 0.004;
+        let side_spread = 0.03;
+        let score = spread_adjusted_external_move_score(side_external_move_30s, side_spread);
+
+        assert!((score - 0.10).abs() < 1e-9);
+        assert!(spread_adjusted_external_move_score(0.004, f64::NAN).is_nan());
+        assert!(spread_adjusted_external_move_score(0.004, -0.01).is_nan());
+    }
+
+    #[test]
+    fn repricing_momentum_profile_rewards_spread_adjusted_external_move() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::RepricingMomentum;
+        config.min_confirmation_score = 0.05;
+        config.min_entry_score = 0.25;
+
+        let weak = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.20,
+                distance_over_sigma: 0.20,
+                direction_sign: 1.0,
+                edge: 0.04,
+                edge_score: 0.20,
+                confirmation: 0.0,
+                repricing_score: 0.01,
+                drift_30s: 0.0,
+                pm_momentum_score: 0.0,
+                liquidity_score: 1.0,
+            },
+        );
+        let strong = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.20,
+                distance_over_sigma: 0.20,
+                direction_sign: 1.0,
+                edge: 0.04,
+                edge_score: 0.20,
+                confirmation: 0.0,
+                repricing_score: 0.20,
+                drift_30s: 0.0,
+                pm_momentum_score: 0.0,
+                liquidity_score: 1.0,
+            },
+        );
+
+        assert!(strong > weak);
+        assert!(strong > config.min_entry_score);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -43,6 +43,7 @@ pub struct EntryScoreInputs {
     pub edge: f64,
     pub edge_score: f64,
     pub confirmation: f64,
+    pub repricing_score: f64,
     pub drift_30s: f64,
     pub pm_momentum_score: f64,
     pub liquidity_score: f64,
@@ -75,13 +76,24 @@ pub fn threshold_score(value: f64, threshold: f64, scale: f64, contrarian: bool)
     (signed / scale).clamp(-0.50, 1.0)
 }
 
+pub fn spread_adjusted_external_move_score(side_external_move_30s: f64, side_spread: f64) -> f64 {
+    if !side_external_move_30s.is_finite() || !side_spread.is_finite() || side_spread < 0.0 {
+        return f64::NAN;
+    }
+    side_external_move_30s / (side_spread + 0.01)
+}
+
 /// Normal CDF approximation (Abramowitz & Stegun).
 pub fn norm_cdf(x: f64) -> f64 {
     let t = 1.0 / (1.0 + 0.2316419 * x.abs());
     let d = 0.3989422804014327 * (-x * x / 2.0).exp();
     let p =
         d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 { 1.0 - p } else { p }
+    if x >= 0.0 {
+        1.0 - p
+    } else {
+        p
+    }
 }
 
 pub fn calibrate_direction_probability(
@@ -148,7 +160,11 @@ pub fn reward_risk_ratio(entry_price: f64) -> f64 {
     let fee = crypto_fee_cost(entry_price);
     let reward = 1.0 - entry_price - fee;
     let risk = entry_price + fee;
-    if risk <= 0.0 { f64::NAN } else { reward / risk }
+    if risk <= 0.0 {
+        f64::NAN
+    } else {
+        reward / risk
+    }
 }
 
 pub fn evaluate_direction_score(
@@ -270,6 +286,7 @@ pub fn profile_confirmation_score(
                 ((inputs.signed_trade_imbalance / 50.0) * inputs.direction_sign).clamp(-1.0, 1.0);
             0.50 * drift_continuation + 0.30 * microprice + 0.20 * trade_imbalance
         }
+        ThreeLayerProfile::RepricingMomentum => 0.0,
     }
 }
 
@@ -348,6 +365,12 @@ pub fn evaluate_entry_score(config: &ThreeLayerModelConfig, inputs: EntryScoreIn
         0.50,
         config.cex_contrarian,
     );
+    let repricing_score = threshold_score(
+        inputs.repricing_score,
+        config.min_confirmation_score,
+        0.10,
+        false,
+    );
 
     match config.profile {
         ThreeLayerProfile::Champion => {
@@ -367,6 +390,14 @@ pub fn evaluate_entry_score(config: &ThreeLayerModelConfig, inputs: EntryScoreIn
                 + 0.15 * confirmation_score
                 + 0.10 * drift_score
                 + 0.12 * inputs.pm_momentum_score
+                + 0.08 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::RepricingMomentum => {
+            0.20 * inputs.direction_score
+                + 0.12 * distance_score
+                + 0.20 * edge_score
+                + 0.30 * repricing_score
+                + 0.10 * inputs.pm_momentum_score
                 + 0.08 * inputs.liquidity_score
         }
         ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
@@ -1,6 +1,6 @@
 //! Runtime profile selector for the PM5D three-layer strategy.
 
-use serde::{Deserialize, Deserializer, Serialize, de};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
@@ -17,6 +17,8 @@ pub enum ThreeLayerProfile {
     ObiHard,
     /// Snapshot Strategy C: Champion plus CEX continuation soft score.
     ContinuationSoft,
+    /// Candidate Strategy D: external CEX repricing pressure adjusted by PM spread.
+    RepricingMomentum,
 }
 
 impl Default for ThreeLayerProfile {
@@ -33,6 +35,7 @@ impl ThreeLayerProfile {
             Self::ObiSoft => "obi_soft",
             Self::ObiHard => "obi_hard",
             Self::ContinuationSoft => "continuation_soft",
+            Self::RepricingMomentum => "repricing_momentum",
         }
     }
 
@@ -55,8 +58,12 @@ impl FromStr for ThreeLayerProfile {
             "continuation" | "continuation_soft" | "c" | "cex_continuation" => {
                 Ok(Self::ContinuationSoft)
             }
+            "repricing"
+            | "repricing_momentum"
+            | "reprice_momentum"
+            | "spread_adjusted_external_move" => Ok(Self::RepricingMomentum),
             other => Err(format!(
-                "unknown three_layer_strategy_profile {other:?}; expected mixed, champion, obi_soft, obi_hard, or continuation_soft"
+                "unknown three_layer_strategy_profile {other:?}; expected mixed, champion, obi_soft, obi_hard, continuation_soft, or repricing_momentum"
             )),
         }
     }
@@ -94,5 +101,21 @@ mod tests {
             ThreeLayerProfile::ObiHard
         );
         assert_eq!(ThreeLayerProfile::ObiHard.as_str(), "obi_hard");
+    }
+
+    #[test]
+    fn parses_repricing_momentum_aliases() {
+        assert_eq!(
+            ThreeLayerProfile::from_str("repricing_momentum").unwrap(),
+            ThreeLayerProfile::RepricingMomentum
+        );
+        assert_eq!(
+            ThreeLayerProfile::from_str("spread_adjusted_external_move").unwrap(),
+            ThreeLayerProfile::RepricingMomentum
+        );
+        assert_eq!(
+            ThreeLayerProfile::RepricingMomentum.as_str(),
+            "repricing_momentum"
+        );
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,30 @@
+# Repricing Momentum Runtime Scorer (2026-05-03)
+
+## Files
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs`
+  - Owner: add a replay-only candidate profile selector for repricing momentum.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs`
+  - Owner: pure scorer for the IC-gated `spread_adjusted_external_move` formula.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: runtime wiring for the repricing scorer without enabling live/dry-run deployment.
+- `crates/ploy-research/examples/three_layer_snapshot_optimize.rs`
+  - Owner: keep snapshot optimizer scoring parity with the shared model inputs.
+- `tasks/todo.md`
+  - Owner: plan and verification evidence.
+
+## Tasks
+
+- [x] Add a `repricing_momentum` profile and pure `spread_adjusted_external_move` scorer.
+- [x] Wire the scorer into three-layer runtime entry scoring with a profile-specific gate.
+- [x] Keep research optimizer calls compiling against the shared input contract.
+- [x] Add focused tests for profile parsing, formula parity, and scoring behavior.
+- [x] Run focused local verification and open PR.
+
+## Review
+
+- 2026-05-03: Added the `repricing_momentum` three-layer profile and shared `spread_adjusted_external_move_score(side_external_move_30s, side_spread)` helper so the IC-gated AutoFactor seed can be evaluated in the runtime/replay path. Runtime wiring computes the formula from available 30s log drift (`drift_30s * direction_sign`) and executable side spread, gates the profile on `three_layer_min_confirmation_score`, and records the score in entry-signal logs. The snapshot optimizer passes the same formula shape from `cex_bar_return_30s * side / (pm_spread_bps / 10000 + 0.01)`, preserving a shared scoring function while keeping source-specific primitives explicit. Local verification passed: `rustfmt --edition 2021 --check` on touched Rust files, `CARGO_TARGET_DIR=/tmp/ploy-repricing-scorer rtk cargo test -p ploy-strategy-bundles three_layer --lib`, `CARGO_TARGET_DIR=/tmp/ploy-repricing-scorer rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --features db --no-default-features`, and `git diff --check`. The research example check emitted only pre-existing strategy-bundle dead-code warnings and the vendor profile warning. Opened PR #312.
+
 # AutoFactor Target Metadata Fix (2026-05-03)
 
 ## Files


### PR DESCRIPTION
## Summary
- add a research-gated repricing_momentum three-layer profile
- add the shared spread_adjusted_external_move_score helper behind the IC-gated candidate formula
- wire runtime entry scoring and snapshot optimizer scoring through the shared input contract
- add focused tests for parsing, formula parity, entry gating, and profile scoring

## Evidence
Remote factor-walk-forward reruns on current main after PR #311:
- BTC/ETH/SOL run 25262768330: spread_adjusted_external_move candidate for 10s and 30s repricing labels
- XRP/DOGE/BNB run 25262865237: spread_adjusted_external_move candidate for 10s and 30s repricing labels

## Verification
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/strategies/three_layer.rs crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs crates/ploy-research/examples/three_layer_snapshot_optimize.rs
- CARGO_TARGET_DIR=/tmp/ploy-repricing-scorer rtk cargo test -p ploy-strategy-bundles three_layer --lib
- CARGO_TARGET_DIR=/tmp/ploy-repricing-scorer rtk cargo check -p ploy-research --example three_layer_snapshot_optimize --features db --no-default-features
- git diff --check

## Risk
Research/replay handoff only. This PR does not add a deployment config and does not enable dry-run/live trading.