### PR TITLE
Measure PM5D settlement edge directly

### DIFF
--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -5,14 +5,10 @@
 //! scores executable PnL after PM CLOB fillability.
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
-    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
-    FillabilityReviewOptions, LiquidityGateV1Options, LiquidityGatedAlphaV1Options,
-    MetaLabelWalkForwardOptions, RepricingIcOptions, ResearchSnapshotRequest,
-    TradeFormationReviewOptions, build_factor_observations_v2_with_deribit_and_pm_books,
+    build_factor_observations_v2_with_deribit_and_pm_books,
     build_factor_observations_with_lob_sampled, build_factor_stability_report,
     format_autofactor_reports, format_factor_combo_v1_report, format_factor_stability_report,
     format_factor_walk_forward_v2_report, format_fillability_review_v1_report,
@@ -25,6 +21,11 @@ use ploy_research::{
     review_repricing_ic_with_deribit_and_pm_books, review_trade_formation_v1_with_deribit,
     validate_snapshot_request, walk_forward_factor_combo_v1_with_deribit,
     walk_forward_factors_v2_with_deribit_and_pm_books, walk_forward_meta_label_v1_with_deribit,
+    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
+    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
+    FillabilityReviewOptions, LiquidityGateV1Options, LiquidityGatedAlphaV1Options,
+    MetaLabelWalkForwardOptions, RepricingIcOptions, ResearchSnapshotRequest,
+    TradeFormationReviewOptions,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::time::Duration;
@@ -371,6 +372,7 @@ async fn main() {
     for target in [
         AutoFactorV2Target::RepricePnl10s,
         AutoFactorV2Target::RepricePnl30s,
+        AutoFactorV2Target::SettlementExecutablePnl,
     ] {
         match mine_domain_autofactors_from_v2(&autofactor_rows, target, &autofactor_options) {
             Ok(reports) => {

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -240,6 +240,7 @@ pub struct AutoFactorReport {
 pub enum AutoFactorV2Target {
     RepricePnl10s,
     RepricePnl30s,
+    SettlementExecutablePnl,
 }
 
 impl AutoFactorV2Target {
@@ -247,6 +248,7 @@ impl AutoFactorV2Target {
         match self {
             AutoFactorV2Target::RepricePnl10s => "reprice_pnl_10s",
             AutoFactorV2Target::RepricePnl30s => "reprice_pnl_30s",
+            AutoFactorV2Target::SettlementExecutablePnl => "settlement_executable_pnl",
         }
     }
 
@@ -254,6 +256,7 @@ impl AutoFactorV2Target {
         match self {
             AutoFactorV2Target::RepricePnl10s => row.label_future_exit_pnl_10s,
             AutoFactorV2Target::RepricePnl30s => row.label_future_exit_pnl_30s,
+            AutoFactorV2Target::SettlementExecutablePnl => row.label_executable_pnl_15u,
         }
         .unwrap_or(f64::NAN)
     }
@@ -462,6 +465,16 @@ pub fn autofactor_matrix_from_v2(
     insert_column(&mut columns, "side_model_edge", rows, |row| {
         row.side_model_edge
     });
+    insert_column(&mut columns, "side_fair_prob", rows, |row| {
+        row.side_fair_prob
+    });
+    insert_column(&mut columns, "side_fair_edge", rows, |row| {
+        if valid_pm_price(row.entry_ask) && row.side_fair_prob.is_finite() {
+            row.side_fair_prob - row.entry_ask - pm_fee_cost(row.entry_ask)
+        } else {
+            f64::NAN
+        }
+    });
     insert_column(&mut columns, "repricing_gap_side_10s", rows, |row| {
         row.side_model_edge
     });
@@ -530,6 +543,14 @@ pub fn autofactor_windows_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
         .collect()
 }
 
+fn valid_pm_price(value: f64) -> bool {
+    value.is_finite() && value > 0.0 && value < 1.0
+}
+
+fn pm_fee_cost(entry_price: f64) -> f64 {
+    0.02 * entry_price * (1.0 - entry_price)
+}
+
 pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactorExpr> {
     let mut out = Vec::new();
     if input_names.contains("repricing_gap_side_10s") {
@@ -538,6 +559,14 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             expr: input("repricing_gap_side_10s"),
             target: Some("reprice_pnl_10s".to_string()),
             notes: vec!["Side-aligned fair-minus-entry gap proxy.".to_string()],
+        });
+    }
+    if input_names.contains("side_fair_edge") {
+        out.push(NamedFactorExpr {
+            name: "settlement_fair_edge".to_string(),
+            expr: input("side_fair_edge"),
+            target: Some("settlement_executable_pnl".to_string()),
+            notes: vec!["Settlement fair probability minus executable ask and fee.".to_string()],
         });
     }
     if has_all(input_names, &["ofi_l5", "depth_top5"]) {
@@ -1076,7 +1105,7 @@ mod tests {
             regime: Regime::Middle,
             side: ReviewSide::Up,
             side_model_prob: 0.5,
-            side_fair_prob: 0.5,
+            side_fair_prob: (0.50 + score * 0.01).clamp(0.01, 0.99),
             side_model_edge: score * 0.01,
             side_distance_over_sigma: 0.25,
             abs_distance_to_beat: 10.0,
@@ -1278,6 +1307,34 @@ mod tests {
         assert!(reports
             .iter()
             .any(|report| report.name == "poly_lag_pressure"));
+    }
+
+    #[test]
+    fn mines_domain_candidates_from_v2_settlement_rows() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+        let reports = mine_domain_autofactors_from_v2(
+            &rows,
+            AutoFactorV2Target::SettlementExecutablePnl,
+            &options,
+        )
+        .expect("reports");
+        let fair_edge = reports
+            .iter()
+            .find(|report| report.name == "settlement_fair_edge")
+            .expect("settlement fair-edge report");
+
+        assert_eq!(fair_edge.decision, AutoFactorDecision::Candidate);
+        assert_eq!(
+            fair_edge.target.as_deref(),
+            Some("settlement_executable_pnl")
+        );
+        assert!(fair_edge.spearman_ic > 0.95);
     }
 
     #[test]

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -1037,6 +1037,18 @@ pub fn factor_v2_descriptors() -> Vec<FactorV2Descriptor> {
             |r| r.side_fair_prob,
         ),
         descriptor(
+            "side_fair_edge",
+            FactorFamily::Alpha,
+            ThreeLayerArchive::DirectionProbabilityEdge,
+            |r| {
+                if valid_price(r.entry_ask) && r.side_fair_prob.is_finite() {
+                    r.side_fair_prob - r.entry_ask - crypto_fee_cost(r.entry_ask)
+                } else {
+                    f64::NAN
+                }
+            },
+        ),
+        descriptor(
             "side_distance_over_sigma",
             FactorFamily::Alpha,
             ThreeLayerArchive::DirectionProbabilityEdge,
@@ -7420,6 +7432,10 @@ mod tests {
             .reviews
             .iter()
             .any(|review| review.factor == "side_model_edge"));
+        assert!(report
+            .reviews
+            .iter()
+            .any(|review| review.factor == "side_fair_edge"));
     }
 
     #[test]

--- a/tasks/pm5d_icir_strategy_candidates_20260503.md
+++ b/tasks/pm5d_icir_strategy_candidates_20260503.md
@@ -1,0 +1,253 @@
+# PM5D ICIR Strategy Candidates - 2026-05-03
+
+Purpose: keep the strategy-discovery lane centered on IC/ICIR evidence before
+promoting any PM5D strategy to dry-run or live.
+
+## Source Artifacts
+
+- BTC/ETH/SOL factor walk-forward: GitHub run `25262768330`
+  - Snapshot run `25254380121`
+  - Snapshot hash `762ae7751ad08a21`
+  - Window `2026-04-21T00:00:00Z -> 2026-05-02T00:00:00Z`
+  - Local artifact:
+    `/tmp/ploy-factor-wf-25262768330/factor-walk-forward-v2-25262768330/factor-walk-forward-v2/report.txt`
+- XRP/DOGE/BNB factor walk-forward: GitHub run `25262865237`
+  - Snapshot run `25255158983`
+  - Snapshot hash `6e858cf3c0a607f0`
+  - Window `2026-04-21T00:00:00Z -> 2026-05-02T00:00:00Z`
+  - Local artifact:
+    `/tmp/ploy-factor-wf-25262865237/factor-walk-forward-v2-25262865237/factor-walk-forward-v2/report.txt`
+
+Both snapshots are scoped PM5D execution evidence:
+
+- `data_audit_status=critical`
+- `include_deribit=false`
+- Deribit IV / DVOL is not present in these runs.
+
+## Candidate Lanes
+
+### 1. Repricing Momentum
+
+Goal: trade short-horizon Polymarket repricing, not necessarily final outcome.
+
+Primary factor:
+
+- `spread_adjusted_external_move`
+
+Evidence:
+
+- BTC/ETH/SOL, `reprice_pnl_10s`
+  - Spearman IC `0.093937`
+  - ICIR `0.761164`
+  - positive window ratio `0.8204`
+  - top bucket avg executable label `0.257310`
+- BTC/ETH/SOL, `reprice_pnl_30s`
+  - Spearman IC `0.080748`
+  - ICIR `0.872932`
+  - positive window ratio `0.8389`
+  - top bucket avg executable label `0.278328`
+- XRP/DOGE/BNB, `reprice_pnl_10s`
+  - Spearman IC `0.166884`
+  - ICIR `1.544933`
+  - positive window ratio `0.9146`
+  - top bucket avg executable label `0.384413`
+- XRP/DOGE/BNB, `reprice_pnl_30s`
+  - Spearman IC `0.149044`
+  - ICIR `2.012613`
+  - positive window ratio `0.9851`
+  - top bucket avg executable label `0.387410`
+
+Status:
+
+- Strongest current IC/ICIR repricing candidate.
+- Runtime scorer exists as `repricing_momentum`.
+- Snapshot optimize evidence is mixed:
+  - BTC/ETH/SOL optimize run `25263475705` passed validation with 124 trades and `+$2032.78`.
+  - XRP/DOGE/BNB optimize run `25263476561` stayed positive but failed closed with only 25 validation trades versus `min_trades=80`.
+
+Decision:
+
+- Continue as BTC/ETH/SOL-first candidate.
+- Do not promote all-six-symbol dry-run/live.
+- Next gate is strict replay/runtime parity for BTC/ETH/SOL.
+
+### 2. Volatility / Tradable Move
+
+Goal: predict whether either side will move enough to create a tradable
+repricing opportunity.
+
+Primary current factor:
+
+- `vol_gap`
+
+Evidence on BTC/ETH/SOL:
+
+- `abs_reprice_bid_change_5s`
+  - Spearman IC `0.1620`
+  - ICIR `1.3805`
+  - positive window ratio `0.8333`
+  - monotonic buckets: true
+  - top bucket avg `0.1318`
+- `abs_reprice_bid_change_10s`
+  - Spearman IC `0.1621`
+  - ICIR `1.3806`
+  - positive window ratio `0.8333`
+  - monotonic buckets: true
+  - top bucket avg `0.1319`
+- `abs_reprice_bid_change_30s`
+  - Spearman IC `0.1565`
+  - ICIR `1.1636`
+  - positive window ratio `0.8333`
+  - monotonic buckets: true
+  - top bucket avg `0.1468`
+- `abs_reprice_bid_change_60s`
+  - Spearman IC `0.1769`
+  - ICIR `1.2560`
+  - positive window ratio `0.8333`
+  - top bucket avg `0.1862`
+
+Status:
+
+- Good volatility/tradable-move candidate on BTC/ETH/SOL.
+- Current run does not include Deribit IV, so this is not yet the full
+  Deribit-IV volatility regime strategy.
+- XRP/DOGE/BNB report did not show an equally clean alpha-side volatility
+  candidate in the top target rows.
+
+Decision:
+
+- Treat as BTC/ETH/SOL volatility trigger candidate.
+- It should not buy both YES and NO blindly.
+- Runtime shape should be:
+  `vol_trigger -> wait for direction confirmation -> buy the repricing side`.
+
+### 3. Settlement / Hold-to-Expiry
+
+Goal: hold when fair probability strongly predicts final settlement and the
+entry is executable.
+
+Primary factor:
+
+- `side_fair_prob`
+
+Evidence on BTC/ETH/SOL:
+
+- `settlement_win`
+  - Spearman IC `0.5453`
+  - ICIR `5.4045`
+  - positive window ratio `1.0000`
+  - monotonic buckets: true
+  - top bucket win rate `0.8906`
+- `settlement_executable_pnl`
+  - Spearman IC `0.4624`
+  - ICIR `3.4101`
+  - positive window ratio `1.0000`
+  - monotonic buckets: true
+  - top bucket avg PnL `1.1738`
+
+Evidence on XRP/DOGE/BNB:
+
+- `settlement_win`
+  - Spearman IC `0.5737`
+  - ICIR `4.8453`
+  - positive window ratio `1.0000`
+  - monotonic buckets: true
+  - top bucket win rate `0.9040`
+- `settlement_executable_pnl`
+  - Spearman IC `0.5002`
+  - ICIR `3.6109`
+  - positive window ratio `1.0000`
+  - monotonic buckets: true
+  - top bucket avg PnL `0.0403`
+
+Status:
+
+- This is the cleanest high-IC/ICIR settlement lane.
+- It is closer to a hold-to-expiry strategy than a 10s/30s repricing strategy.
+- It still needs execution/risk filters because wide spreads and poor exits can
+  dominate realized results.
+
+Decision:
+
+- Promote to a settlement-gate research candidate, not directly to dry-run.
+- Required next gate: optimize/edge matrix around
+  `side_fair_prob - executable_price`, time-to-expiry, distance, and liquidity.
+
+## Current Ranking
+
+1. Settlement hold-to-expiry: `side_fair_prob`
+   - Highest and most stable IC/ICIR across both symbol batches.
+2. Repricing momentum: `spread_adjusted_external_move`
+   - Best executable short-horizon repricing candidate.
+3. Volatility trigger: `vol_gap`
+   - Good BTC/ETH/SOL tradable-move signal, but needs Deribit-IV enrichment.
+
+## Fastest Path To A Tradable Candidate
+
+The fastest path is not to build the full LOB + Deribit + AutoML stack first.
+The fastest path is to promote one narrowly scoped candidate through the next
+evidence gate while keeping the other lanes as backups.
+
+Priority 1: settlement gate around `side_fair_prob`.
+
+- Reason: it has the cleanest IC/ICIR evidence and maps directly to
+  hold-to-expiry accounting.
+- Required score: `side_fair_edge = side_fair_prob - entry_ask - fee`.
+- Required target: `settlement_executable_pnl`.
+- Required filters: time-to-expiry, distance-over-sigma, spread, top-book
+  depth, and symbol.
+- Promotion condition: positive OOS executable PnL, powered validation trade
+  count, drawdown within risk budget, and no single-symbol/day concentration.
+- Implementation status: the factor review and AutoFactor walk-forward runner
+  now include `side_fair_edge` against `settlement_executable_pnl`; the next
+  step is to run the snapshot-backed workflow and inspect the new IC/ICIR rows.
+
+Priority 2: BTC/ETH/SOL repricing momentum with `spread_adjusted_external_move`.
+
+- Reason: it already has a runtime/replay scorer and BTC/ETH/SOL optimize
+  evidence, so it is closest to a replay-parity handoff.
+- Required next gate: strict replay/runtime parity on BTC/ETH/SOL only.
+- Promotion condition: same scorer/config/MarketUpdate sequence, positive
+  after-cost replay PnL, fill/exit evidence, and acceptable latency/slippage
+  caveats.
+
+Priority 3: volatility trigger with `vol_gap`.
+
+- Reason: `vol_gap` has good IC/ICIR against tradable-move labels, but it is a
+  trigger, not a side selector.
+- Required action model: `vol_trigger -> direction confirmation -> buy side`.
+- Required target: `tradable_move` and side-specific future bid reprice after
+  direction confirmation.
+- Promotion condition: the trigger improves opportunity selection without
+  buying both YES and NO, and survives near-strike/liquidity buckets.
+
+Decision rule:
+
+- If settlement gate passes first, build the first small fixed-size dry-run
+  candidate as hold-to-expiry only.
+- If settlement is too sparse or drawdown-heavy, promote BTC/ETH/SOL repricing
+  momentum to strict replay parity.
+- If both fail, keep `vol_gap` as a pre-trade trigger and do not promote it
+  until direction confirmation has its own executable IC/PnL evidence.
+
+## Next Engineering Gates
+
+1. Add or run a settlement-focused gate:
+   - score: `side_fair_edge = side_fair_prob - entry_ask - fee`
+   - target: `settlement_executable_pnl`
+   - regimes: time-to-expiry, distance-over-sigma, liquidity bucket, symbol.
+2. Add or run a volatility-trigger gate:
+   - score: `vol_gap` plus near-strike and liquidity state
+   - target: `abs_reprice_bid_change_10s/30s` or tradable move
+   - action: direction confirmation before entry.
+3. Keep repricing momentum as BTC/ETH/SOL-first:
+   - run replay/runtime parity before dry-run.
+
+## Do Not Promote Yet
+
+- No live trading.
+- No all-six-symbol dry-run.
+- No direct volatility straddle.
+- No strategy handoff unless replay/runtime uses the same scorer and reports
+  fill, exit, latency, slippage, adverse selection, drawdown, and missed
+  opportunity.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,56 @@
+# PM5D High ICIR Strategy Discovery Plan (2026-05-03)
+
+## Goal
+
+Find the fastest credible path from high IC/ICIR research evidence to one small,
+tradable PM5D strategy candidate. The candidate must be selected from the
+existing evidence lanes: settlement hold-to-expiry, short-horizon repricing, or
+volatility-triggered repricing.
+
+## Plan
+
+- [x] Preserve the current IC/ICIR shortlist in
+  `tasks/pm5d_icir_strategy_candidates_20260503.md`.
+- [x] Rank the lanes by speed to a tradable candidate:
+  1. `side_fair_prob` settlement gate.
+  2. BTC/ETH/SOL `spread_adjusted_external_move` repricing parity gate.
+  3. `vol_gap` volatility trigger with direction confirmation.
+- [x] Implement the settlement-focused factor gate input:
+  `side_fair_prob - executable_entry_price` versus
+  `settlement_executable_pnl`, bucketed by time-to-expiry, distance, liquidity,
+  and symbol.
+- [ ] Run the snapshot-backed settlement-focused gate on BTC/ETH/SOL and
+  XRP/DOGE/BNB.
+- [ ] If settlement passes, create a hold-to-expiry dry-run handoff packet with
+  fixed small sizing and strict no-live default.
+- [ ] If settlement fails or is too sparse, run strict BTC/ETH/SOL replay/runtime
+  parity for `repricing_momentum`.
+- [ ] Keep `vol_gap` as a trigger-only lane until direction confirmation has
+  executable IC/PnL evidence.
+
+## Review
+
+- 2026-05-03: User clarified the original objective: find high IC/ICIR factors
+  first, then decide whether the tradeable strategy is volatility/repricing or
+  hold-to-settlement. Current evidence makes `side_fair_prob` the fastest
+  high-IC settlement candidate, `spread_adjusted_external_move` the closest
+  runtime-backed repricing candidate, and `vol_gap` a volatility trigger rather
+  than a standalone long-vol trade.
+- 2026-05-03: Added a direct settlement edge research input:
+  `side_fair_edge = side_fair_prob - entry_ask - fee`, plus an AutoFactor
+  `settlement_executable_pnl` target. This makes the next snapshot-backed
+  factor walk-forward report evaluate the actual hold-to-expiry edge instead
+  of only the raw fair probability. Focused verification passed:
+  `rustfmt --edition 2021 --check` on touched Rust files,
+  `CARGO_TARGET_DIR=/tmp/ploy-settlement-autofactor rtk cargo test -p
+  ploy-research autofactor --lib`, `CARGO_TARGET_DIR=/tmp/ploy-settlement-factors
+  rtk cargo test -p ploy-research factors_v2 --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-settlement-autofactor-check rtk cargo check -p
+  ploy-research --example factor_walk_forward_v2 --features db
+  --no-default-features`, and `git diff --check`. The example check emitted
+  only pre-existing strategy-bundle dead-code warnings plus the vendor profile
+  warning.
+
 # Repricing Momentum Snapshot Optimize Selector (2026-05-03)
 
 ## Files


### PR DESCRIPTION
## Summary
- add side_fair_edge as side_fair_prob minus executable ask and fee
- add AutoFactor settlement_executable_pnl target to factor_walk_forward_v2
- record the ICIR-first candidate ranking and fastest strategy-discovery path

## Verification
- rustfmt --edition 2021 --check crates/ploy-research/src/factors_v2.rs crates/ploy-research/src/autofactor.rs crates/ploy-research/examples/factor_walk_forward_v2.rs
- CARGO_TARGET_DIR=/tmp/ploy-settlement-autofactor rtk cargo test -p ploy-research autofactor --lib
- CARGO_TARGET_DIR=/tmp/ploy-settlement-factors rtk cargo test -p ploy-research factors_v2 --lib
- CARGO_TARGET_DIR=/tmp/ploy-settlement-autofactor-check rtk cargo check -p ploy-research --example factor_walk_forward_v2 --features db --no-default-features
- git diff --check

## Notes
This is research infrastructure only. It does not promote a dry-run/live strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced RepricingMomentum strategy profile for the three-layer optimizer with configurable directional probability and confirmation scoring parameters
  * Extended settlement analysis with new executable profitability metrics and supporting factors

* **Documentation**
  * Added comprehensive strategy discovery planning documentation with three candidate optimization lanes, validation criteria, promotion rules, and engineering gates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->