### PR TITLE
Record PM5D settlement gate rerun decision

### DIFF
--- a/tasks/pm5d_icir_strategy_candidates_20260503.md
+++ b/tasks/pm5d_icir_strategy_candidates_20260503.md
@@ -24,6 +24,25 @@ Both snapshots are scoped PM5D execution evidence:
 - `include_deribit=false`
 - Deribit IV / DVOL is not present in these runs.
 
+Settlement-focused rerun after adding `side_fair_edge`:
+
+- BTC/ETH/SOL settlement gate: GitHub run `25266543999`
+  - Snapshot run `25254380121`
+  - Head SHA `df29ac69fef9e04c06b0246f2a6cde8f8e22e5da`
+  - Local artifact:
+    `/tmp/ploy-settlement-gate-25266543999/factor-walk-forward-v2-25266543999/factor-walk-forward-v2/report.txt`
+  - Health: `snapshot_data_audit_status=critical`, `source_obs=114008`,
+    `v2_rows=228016`, `executable_pnl_rows=50680`, `deribit_rows=0`,
+    `entry_fill_rate=22.23%`, `exit_fill_rate=20.97%`.
+- XRP/DOGE/BNB settlement gate: GitHub run `25266544004`
+  - Snapshot run `25255158983`
+  - Head SHA `df29ac69fef9e04c06b0246f2a6cde8f8e22e5da`
+  - Local artifact:
+    `/tmp/ploy-settlement-gate-25266544004/factor-walk-forward-v2-25266544004/factor-walk-forward-v2/report.txt`
+  - Health: `snapshot_data_audit_status=critical`, `source_obs=108296`,
+    `v2_rows=216592`, `executable_pnl_rows=15828`, `deribit_rows=0`,
+    `entry_fill_rate=7.31%`, `exit_fill_rate=6.50%`.
+
 ## Candidate Lanes
 
 ### 1. Repricing Momentum
@@ -166,12 +185,31 @@ Status:
 - It is closer to a hold-to-expiry strategy than a 10s/30s repricing strategy.
 - It still needs execution/risk filters because wide spreads and poor exits can
   dominate realized results.
+- The direct `side_fair_edge = side_fair_prob - entry_ask - fee` hypothesis did
+  not survive the settlement executable-PnL gate:
+  - BTC/ETH/SOL AutoFactor `settlement_fair_edge -> settlement_executable_pnl`
+    was rejected with Spearman IC `-0.156860`, ICIR `-1.441374`, positive
+    window ratio `0.0593`, and top bucket avg label `-0.955000`.
+  - XRP/DOGE/BNB AutoFactor `settlement_fair_edge -> settlement_executable_pnl`
+    was rejected with Spearman IC `-0.042813`, ICIR `-0.226205`, positive
+    window ratio `0.3874`, and top bucket avg label `-0.661597`.
+- In the same rerun, raw `side_fair_prob` still ranked settlement outcomes and
+  executable settlement PnL strongly:
+  - BTC/ETH/SOL `side_fair_prob -> settlement_executable_pnl`: Spearman IC
+    `0.4624`, ICIR `3.4101`, positive window ratio `1.0000`, top bucket avg
+    PnL `1.1738`.
+  - XRP/DOGE/BNB `side_fair_prob -> settlement_executable_pnl`: Spearman IC
+    `0.5002`, ICIR `3.6109`, positive window ratio `1.0000`, top bucket avg
+    PnL only `0.0403`.
 
 Decision:
 
 - Promote to a settlement-gate research candidate, not directly to dry-run.
-- Required next gate: optimize/edge matrix around
-  `side_fair_prob - executable_price`, time-to-expiry, distance, and liquidity.
+- Do not promote `side_fair_edge` or a naive
+  `side_fair_prob - executable_price` formula.
+- Required next gate: BTC/ETH/SOL-only selector/edge matrix around raw
+  `side_fair_prob`, time-to-expiry, distance, entry ask, spread, depth, and
+  realized executable settlement PnL.
 
 ## Current Ranking
 
@@ -192,15 +230,18 @@ Priority 1: settlement gate around `side_fair_prob`.
 
 - Reason: it has the cleanest IC/ICIR evidence and maps directly to
   hold-to-expiry accounting.
-- Required score: `side_fair_edge = side_fair_prob - entry_ask - fee`.
+- Required score: raw `side_fair_prob` plus explicit execution/risk filters.
+- Rejected score: `side_fair_edge = side_fair_prob - entry_ask - fee`.
 - Required target: `settlement_executable_pnl`.
 - Required filters: time-to-expiry, distance-over-sigma, spread, top-book
   depth, and symbol.
 - Promotion condition: positive OOS executable PnL, powered validation trade
   count, drawdown within risk budget, and no single-symbol/day concentration.
 - Implementation status: the factor review and AutoFactor walk-forward runner
-  now include `side_fair_edge` against `settlement_executable_pnl`; the next
-  step is to run the snapshot-backed workflow and inspect the new IC/ICIR rows.
+  now include `side_fair_edge` against `settlement_executable_pnl`, and the
+  snapshot-backed rerun rejected that formula. The next step is a BTC/ETH/SOL
+  settlement selector that treats price/liquidity as gates and sizing inputs
+  rather than subtracting them into the alpha score.
 
 Priority 2: BTC/ETH/SOL repricing momentum with `spread_adjusted_external_move`.
 
@@ -223,8 +264,8 @@ Priority 3: volatility trigger with `vol_gap`.
 
 Decision rule:
 
-- If settlement gate passes first, build the first small fixed-size dry-run
-  candidate as hold-to-expiry only.
+- If the BTC/ETH/SOL `side_fair_prob` selector passes first, build the first
+  small fixed-size dry-run candidate as hold-to-expiry only.
 - If settlement is too sparse or drawdown-heavy, promote BTC/ETH/SOL repricing
   momentum to strict replay parity.
 - If both fail, keep `vol_gap` as a pre-trade trigger and do not promote it
@@ -232,10 +273,12 @@ Decision rule:
 
 ## Next Engineering Gates
 
-1. Add or run a settlement-focused gate:
-   - score: `side_fair_edge = side_fair_prob - entry_ask - fee`
+1. Add or run a BTC/ETH/SOL settlement selector gate:
+   - score: raw `side_fair_prob`
+   - reject: naive `side_fair_edge = side_fair_prob - entry_ask - fee`
    - target: `settlement_executable_pnl`
-   - regimes: time-to-expiry, distance-over-sigma, liquidity bucket, symbol.
+   - regimes: time-to-expiry, distance-over-sigma, entry ask, spread,
+     liquidity bucket, symbol.
 2. Add or run a volatility-trigger gate:
    - score: `vol_gap` plus near-strike and liquidity state
    - target: `abs_reprice_bid_change_10s/30s` or tradable move

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,7 +19,7 @@ volatility-triggered repricing.
   `side_fair_prob - executable_entry_price` versus
   `settlement_executable_pnl`, bucketed by time-to-expiry, distance, liquidity,
   and symbol.
-- [ ] Run the snapshot-backed settlement-focused gate on BTC/ETH/SOL and
+- [x] Run the snapshot-backed settlement-focused gate on BTC/ETH/SOL and
   XRP/DOGE/BNB.
 - [ ] If settlement passes, create a hold-to-expiry dry-run handoff packet with
   fixed small sizing and strict no-live default.
@@ -50,6 +50,45 @@ volatility-triggered repricing.
   --no-default-features`, and `git diff --check`. The example check emitted
   only pre-existing strategy-bundle dead-code warnings plus the vendor profile
   warning.
+- 2026-05-03: PR #314 merged to `main` as `df29ac69fef9e04c06b0246f2a6cde8f8e22e5da`.
+  Triggered main snapshot-backed settlement gate runs:
+  BTC/ETH/SOL `25266543999` using snapshot `25254380121`, and XRP/DOGE/BNB
+  `25266544004` using snapshot `25255158983`. Both are blocked before execution
+  because GitHub runner `ploy-ci-1` is offline. Aliyun ECS
+  `i-6we7z44sfbfbnosbeymz` / `ploy-ci-1` is `Stopped`, and
+  `aliyun ecs StartInstance --RegionId ap-northeast-1 --InstanceId
+  i-6we7z44sfbfbnosbeymz` failed with `InstanceExpired`:
+  "The postPaid instance has been expired. Please ensure your account have
+  enough balance." Existing GitHub artifacts for snapshots `25254380121` and
+  `25255158983` contain provenance only, not reusable local parquet snapshot
+  data, so the new settlement gate cannot be rerun locally without violating
+  the repo's no-local-DB research rule. Next action after billing/ECS recovery:
+  verify `ploy-ci-1` runner is online and let/retrigger runs `25266543999` and
+  `25266544004`.
+- 2026-05-03: After billing recovery, Aliyun ECS instance
+  `i-6we7z44sfbfbnosbeymz` was started and GitHub runner `ploy-ci-1` returned
+  online. Main snapshot-backed settlement gate runs completed successfully:
+  BTC/ETH/SOL run `25266543999`
+  (`https://github.com/proerror77/ploy/actions/runs/25266543999`) and
+  XRP/DOGE/BNB run `25266544004`
+  (`https://github.com/proerror77/ploy/actions/runs/25266544004`), both on
+  `main` SHA `df29ac69fef9e04c06b0246f2a6cde8f8e22e5da`.
+- 2026-05-03: The direct settlement edge hypothesis failed. AutoFactor
+  `settlement_fair_edge -> settlement_executable_pnl` was rejected in both
+  batches: BTC/ETH/SOL Spearman IC `-0.156860`, ICIR `-1.441374`, positive
+  window ratio `0.0593`, top bucket avg label `-0.955000`; XRP/DOGE/BNB
+  Spearman IC `-0.042813`, ICIR `-0.226205`, positive window ratio `0.3874`,
+  top bucket avg label `-0.661597`. Do not promote
+  `side_fair_prob - entry_ask - fee` as a hold-to-expiry strategy.
+- 2026-05-03: Raw `side_fair_prob` remains the cleanest settlement predictor,
+  but the tradability differs sharply by symbol group. BTC/ETH/SOL
+  `side_fair_prob -> settlement_executable_pnl` had Spearman IC `0.4624`,
+  ICIR `3.4101`, positive window ratio `1.0000`, and top bucket avg PnL
+  `1.1738`. XRP/DOGE/BNB had Spearman IC `0.5002`, ICIR `3.6109`, positive
+  window ratio `1.0000`, but top bucket avg PnL only `0.0403` and much weaker
+  executable coverage. Next fastest gate should be a BTC/ETH/SOL-only
+  settlement selector around `side_fair_prob` plus entry/liquidity/time filters,
+  not the naive fair-minus-price formula.
 
 # Repricing Momentum Snapshot Optimize Selector (2026-05-03)
 


### PR DESCRIPTION
## Summary
- record the successful post-billing settlement gate reruns
- document why `side_fair_edge = side_fair_prob - entry_ask - fee` is rejected
- redirect the fastest strategy path to a BTC/ETH/SOL raw `side_fair_prob` settlement selector

## Evidence
- BTC/ETH/SOL rerun: https://github.com/proerror77/ploy/actions/runs/25266543999
- XRP/DOGE/BNB rerun: https://github.com/proerror77/ploy/actions/runs/25266544004
- Issue evidence comment: https://github.com/proerror77/ploy/issues/305#issuecomment-4365220496

## Tests
- `git diff --check`

## Caveats
- No Deribit rows in these snapshots; this is not Deribit-IV-backed evidence.
- This PR does not promote any dry-run/live strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation & Chores**
  * Updated internal strategy analysis documentation with completed settlement gate testing results and refined evaluation criteria for engineering gates.
  * Updated task tracking records reflecting testing completion status and performance analysis outcomes for algorithm optimization efforts.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->