### PR TITLE
Keep repricing dry-run deployable on tango

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -169,6 +169,7 @@ jobs:
           cp config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml dist/config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.champion-dryrun.toml dist/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml dist/config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml
+          cp config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml dist/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
           cp config/deployments/*.json dist/config/deployments/
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
@@ -416,6 +417,7 @@ jobs:
             install -m 0644 ./config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.champion-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml
+            install -m 0644 ./config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
             install -m 0644 ./config/deployments/*.json ${DEPLOY_ROOT}/config/deployments/
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -120,6 +120,12 @@ volatility-triggered repricing.
   ploy-strategy-bundles --lib`, and `git diff --check`. Cargo emitted only
   pre-existing warnings from unrelated strategy modules and the vendor profile
   warning.
+- 2026-05-03: After PR #317 merged, found the tango deploy workflow still
+  copied three-layer strategy TOMLs through an explicit allowlist. Added the
+  repricing-momentum dry-run TOML to both the bundle staging copy and the
+  remote install list in `.github/workflows/deploy-tango-1-1.yml`; otherwise
+  the new deployment manifest would arrive on tango without its strategy
+  bundle.
 
 # Full-Depth Execution Label Repair (2026-05-03)
 


### PR DESCRIPTION
## Summary
- include the repricing-momentum dry-run strategy TOML in deploy-tango bundle staging
- install the same TOML on tango alongside the existing three-layer dry-run configs
- record the deploy allowlist follow-up in tasks/todo.md

## Verification
- Ruby YAML parse for .github/workflows/deploy-tango-1-1.yml
- git diff --check

## Why
PR #317 added the deployment manifest and strategy config, but deploy-tango uses explicit strategy TOML copies. Without this, the manifest would arrive remotely without its bundle.