### PR TITLE
Run settlement PRD gate from GitHub Actions

### DIFF
--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -1,0 +1,109 @@
+name: Settlement Probability PRD Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Branch or tag used for the downstream snapshot and walk-forward workflows"
+        required: true
+        default: "main"
+      start_date:
+        description: "Research window start date (YYYY-MM-DD)"
+        required: true
+      end_date:
+        description: "Research window end date (YYYY-MM-DD)"
+        required: true
+      symbols:
+        description: "Comma-separated Binance symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT"
+      stake_usd:
+        description: "Fixed notional used by executable labels"
+        required: true
+        default: "15"
+      issue_number:
+        description: "Issue number for posting gate evidence; leave empty to skip comments"
+        required: false
+        default: "321"
+      audit_lookback_hours:
+        description: "Strict data-audit lookback hours"
+        required: true
+        default: "168"
+      replay_parity_run_id:
+        description: "Optional Replay Dry-run Parity run id"
+        required: false
+        default: ""
+      no_wait:
+        description: "Dispatch the strict snapshot only and return"
+        required: true
+        default: "false"
+        type: boolean
+
+concurrency:
+  group: settlement-probability-prd-gate-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+jobs:
+  gate:
+    name: Run settlement probability PRD gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout orchestration code
+        uses: actions/checkout@v6
+
+      - name: Run strict settlement probability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GIT_REF: ${{ github.event.inputs.git_ref }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+          SYMBOLS: ${{ github.event.inputs.symbols }}
+          STAKE_USD: ${{ github.event.inputs.stake_usd }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
+          REPLAY_PARITY_RUN_ID: ${{ github.event.inputs.replay_parity_run_id }}
+          NO_WAIT: ${{ github.event.inputs.no_wait }}
+        run: |
+          set -euo pipefail
+          args=(
+            scripts/run_settlement_probability_prd_gate.py
+            --git-ref "${GIT_REF}"
+            --start-date "${START_DATE}"
+            --end-date "${END_DATE}"
+            --symbols "${SYMBOLS}"
+            --stake-usd "${STAKE_USD}"
+            --issue-number "${ISSUE_NUMBER}"
+            --audit-lookback-hours "${AUDIT_LOOKBACK_HOURS}"
+          )
+          if [ -n "${REPLAY_PARITY_RUN_ID}" ]; then
+            args+=(--replay-parity-run-id "${REPLAY_PARITY_RUN_ID}")
+          fi
+          if [ "${NO_WAIT}" = "true" ]; then
+            args+=(--no-wait)
+          fi
+          "${args[@]}"
+
+      - name: Write gate summary
+        if: always()
+        run: |
+          {
+            echo "## Settlement Probability PRD Gate"
+            echo ""
+            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
+            echo "- Window: \`${{ github.event.inputs.start_date }}..${{ github.event.inputs.end_date }}\`"
+            echo "- Symbols: \`${{ github.event.inputs.symbols }}\`"
+            echo "- Stake: \`${{ github.event.inputs.stake_usd }}u\`"
+            echo "- Data gate: \`critical\`"
+            echo "- Data profile: \`pm5d-vol\`"
+            echo "- Audit lookback: \`${{ github.event.inputs.audit_lookback_hours }}h\`"
+            echo "- Replay parity run: \`${{ github.event.inputs.replay_parity_run_id || 'none' }}\`"
+            echo ""
+            echo "A failed workflow can be the correct outcome: the orchestrator exits non-zero when the PRD promotion gate is blocked."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tasks/settlement_probability_prd_audit_20260505.md
+++ b/tasks/settlement_probability_prd_audit_20260505.md
@@ -59,6 +59,7 @@ snapshot-backed full-depth execution labels and probability-model validation.
 | PRD promotion gate | `=== Settlement Probability PRD Promotion Gate ===` | Run `25359476569` prints `ready_for_dry_run_handoff=false`, `walk_forward_oos=false`, and `recorded_replay_parity=false` | Complete as a blocker gate |
 | Replay parity artifact input | `factor_walk_forward_v2 --replay-parity-json`, workflow `options_json.replay_parity_json`, `options_json.replay_parity_run_id` | The report can now consume `scripts/replay_dryrun_parity.py` JSON either from a runner path or from a downloaded `replay-dryrun-parity-*` artifact | Code complete; no passing parity artifact yet |
 | Repeatable PRD gate runner | `scripts/run_settlement_probability_prd_gate.py` | Script dispatches strict `pm5d-vol` snapshot with `data_gate=critical` / `upload_full_snapshot=true`, waits, then dispatches snapshot-backed `factor-walk-forward-v2` with optional replay parity artifact linkage | Complete as orchestration; decision-grade data still pending |
+| Manual CI PRD gate entrypoint | `.github/workflows/settlement-probability-prd-gate.yml` | Workflow-dispatch wrapper runs the same strict orchestrator from GitHub Actions and fails closed when the promotion gate is blocked | Complete as orchestration; decision-grade data still pending |
 | Official settlement fidelity | Snapshot manifest `require_official_settlement=true` | Provenance for snapshots `25254380121` and `25255158983` confirms official settlement required | Partial evidence |
 | Data quality / coverage | `data-gap-audit.md` | Strict `pm5d-vol` run `25354264444` failed at `Audit required market data`; every required source had critical max gaps around `1700m` | Failing / blocks promotion |
 | Deribit / vol inputs | `data_profile=pm5d-vol` or `include_deribit=true` snapshot | Short-window snapshot `25356726430` includes Deribit; strict retained 168h snapshot still fails coverage | Partial; full retained evidence missing |
@@ -341,6 +342,11 @@ scripts/run_settlement_probability_prd_gate.py \
   Promotion Gate`, comments the exact blocked gates, and exits blocked when
   `ready_for_dry_run_handoff=false`. A successful workflow run is no longer
   treated as a successful promotion gate by itself.
+- `.github/workflows/settlement-probability-prd-gate.yml` is now the canonical
+  manual GitHub Actions entrypoint for running the same strict gate from CI.
+  It accepts the retained data window, symbols, stake, and optional replay
+  parity artifact run id. A failed workflow can be a correct PRD result when
+  the downstream promotion gate remains blocked.
 
 Interpretation:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -94,6 +94,9 @@ evidence comes from Polymarket full CLOB depth, not top book.
 - [x] Add a repeatable PRD gate orchestrator so the remaining strict
   snapshot -> walk-forward -> replay-parity evidence chain can be run without
   manual workflow stitching.
+- [x] Add a manual GitHub Actions wrapper for the repeatable PRD gate so the
+  strict retained-window evidence chain can run from CI without relying on a
+  local terminal session.
 - [ ] Only after the above gates pass, create a settlement dry-run handoff with
   fixed small stake, strict kill switch, and shared scorer parity.
 
@@ -457,6 +460,18 @@ evidence comes from Polymarket full CLOB depth, not top book.
   artifact, found the intended blockers:
   `anti_overfit_diagnostics`, `walk_forward_oos`, and
   `recorded_replay_parity`.
+- 2026-05-05: Added `.github/workflows/settlement-probability-prd-gate.yml` as
+  the manual CI entrypoint for the strict settlement-probability PRD evidence
+  chain. The workflow invokes `scripts/run_settlement_probability_prd_gate.py`,
+  dispatches the `pm5d-vol` / `data_gate=critical` snapshot, then dispatches the
+  snapshot-backed Factor Walk-Forward V2 promotion gate with optional replay
+  parity artifact linkage. It intentionally fails the workflow when
+  `ready_for_dry_run_handoff=false`, so a blocked promotion remains visible in
+  GitHub Actions. Verification passed: `python3 -m py_compile
+  scripts/run_settlement_probability_prd_gate.py`, YAML parse for the new
+  workflow, `scripts/run_settlement_probability_prd_gate.py --git-ref main
+  --start-date 2026-05-05 --end-date 2026-05-05 --audit-lookback-hours 1
+  --dry-run`, and `git diff --check`.
 
 # PM5D High ICIR Strategy Discovery Plan (2026-05-03)
 


### PR DESCRIPTION
## Summary
- add a manual Settlement Probability PRD Gate workflow that invokes the existing strict orchestrator
- keep the gate fail-closed when the downstream promotion report is blocked
- record the new CI entrypoint in the PRD task/audit docs

## Verification
- python3 -m py_compile scripts/run_settlement_probability_prd_gate.py
- YAML parse for .github/workflows/settlement-probability-prd-gate.yml
- scripts/run_settlement_probability_prd_gate.py --git-ref main --start-date 2026-05-05 --end-date 2026-05-05 --audit-lookback-hours 1 --dry-run
- git diff --check