### PR TITLE
Expose parity evidence for settlement PRD gates

### DIFF
--- a/contracts/schemas/dry-run-performance-report.schema.json
+++ b/contracts/schemas/dry-run-performance-report.schema.json
@@ -81,6 +81,17 @@
         "$ref": "#/definitions/DryRunClosedTradeRow"
       }
     },
+    "runtime_evidence": {
+      "default": null,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DryRunRuntimeEvidence"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "strategies": {
       "type": "array",
       "items": {
@@ -625,6 +636,33 @@
         "side_aware_rows": {
           "type": "integer",
           "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunRuntimeEvidence": {
+      "type": "object",
+      "required": [
+        "basis",
+        "schema_version"
+      ],
+      "properties": {
+        "basis": {
+          "type": "string"
+        },
+        "fills": {
+          "default": [],
+          "type": "array",
+          "items": true
+        },
+        "orders": {
+          "default": [],
+          "type": "array",
+          "items": true
+        },
+        "schema_version": {
+          "type": "integer",
+          "format": "uint32",
           "minimum": 0.0
         }
       }

--- a/crates/ploy-operator-contracts/src/lib.rs
+++ b/crates/ploy-operator-contracts/src/lib.rs
@@ -14,11 +14,11 @@ pub use deployments::{
     DeploymentSummary, DesiredState, ObservedState,
 };
 pub use diagnostics::{
-    compute_oversight_report, AgentRunRecord, DeploymentDiagnosticsMetrics,
-    DeploymentDiagnosticsReport, DiagnosticsEvidence, DiagnosticsFinding,
-    OversightRecommendedAction, OversightReport, OversightSignal, OversightSnapshotEvent,
-    PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest, ProposalDecisionRequest,
-    ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
+    AgentRunRecord, DeploymentDiagnosticsMetrics, DeploymentDiagnosticsReport, DiagnosticsEvidence,
+    DiagnosticsFinding, OversightRecommendedAction, OversightReport, OversightSignal,
+    OversightSnapshotEvent, PlatformDiagnosticsReport, ProposalActionKind, ProposalCreateRequest,
+    ProposalDecisionRequest, ProposalSnapshotEvent, ProposalStatus, SafetyProposal,
+    compute_oversight_report,
 };
 pub use errors::ControlPlaneErrorResponse;
 pub use events::{
@@ -28,8 +28,8 @@ pub use events::{
 pub use reports::{
     DryRunClosedTradeRow, DryRunDailyRow, DryRunDailyWindowRow, DryRunEquityPoint,
     DryRunExecutionDiagnostics, DryRunMetrics, DryRunOpenPositionRow, DryRunPairingReport,
-    DryRunPerformanceReport, DryRunStrategyReport, DryRunSummary, DryRunSymbolRow, DryRunWindowRow,
-    NumberOrText,
+    DryRunPerformanceReport, DryRunRuntimeEvidence, DryRunStrategyReport, DryRunSummary,
+    DryRunSymbolRow, DryRunWindowRow, NumberOrText,
 };
 pub use system::{
     ActiveAlert, AlertKind, AlertSeverity, HeartbeatState, HeartbeatStatus, PlatformMetrics,

--- a/crates/ploy-operator-contracts/src/reports.rs
+++ b/crates/ploy-operator-contracts/src/reports.rs
@@ -170,6 +170,16 @@ pub struct DryRunExecutionDiagnostics {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunRuntimeEvidence {
+    pub schema_version: u32,
+    pub basis: String,
+    #[serde(default)]
+    pub orders: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub fills: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DryRunStrategyReport {
     pub runtime_mode: String,
     pub strategy_id: String,
@@ -209,12 +219,14 @@ pub struct DryRunPerformanceReport {
     pub pairing: DryRunPairingReport,
     #[serde(default)]
     pub execution_diagnostics: Option<DryRunExecutionDiagnostics>,
+    #[serde(default)]
+    pub runtime_evidence: Option<DryRunRuntimeEvidence>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::DryRunPerformanceReport;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     #[test]
     fn dry_run_report_roundtrip_preserves_diagnostics_fields() {
@@ -256,7 +268,8 @@ mod tests {
                 "current_view_rows": 0,
                 "side_aware_rows": 0
             },
-            "execution_diagnostics": diagnostics()
+            "execution_diagnostics": diagnostics(),
+            "runtime_evidence": runtime_evidence()
         });
 
         let report: DryRunPerformanceReport = serde_json::from_value(raw).unwrap();
@@ -281,6 +294,14 @@ mod tests {
         assert_eq!(
             roundtripped["execution_diagnostics"]["summary"]["rejected_buy_orders"],
             2
+        );
+        assert_eq!(
+            roundtripped["runtime_evidence"]["basis"],
+            "strategy_runtime_orders_and_fills"
+        );
+        assert_eq!(
+            roundtripped["runtime_evidence"]["orders"][0]["intent_id"],
+            "intent-1"
         );
     }
 
@@ -333,6 +354,35 @@ mod tests {
                 "deployment_id": "pm5d-dryrun",
                 "buy_orders": 5,
                 "rejected_buy_orders": 2
+            }]
+        })
+    }
+
+    fn runtime_evidence() -> Value {
+        json!({
+            "schema_version": 1,
+            "basis": "strategy_runtime_orders_and_fills",
+            "orders": [{
+                "deployment_id": "pm5d-dryrun",
+                "intent_id": "intent-1",
+                "order_id": "order-1",
+                "token_id": "token-up",
+                "quantity": "10",
+                "limit_price": "0.42",
+                "filled_quantity": "10",
+                "status": "FILLED"
+            }],
+            "fills": [{
+                "deployment_id": "pm5d-dryrun",
+                "intent_id": "intent-1",
+                "order_id": "order-1",
+                "fill_id": "fill-1",
+                "token_id": "token-up",
+                "fill_side": "BUY",
+                "quantity": "10",
+                "price": "0.42",
+                "fee": "0",
+                "fill_timestamp": "2026-05-02T01:02:03Z"
             }]
         })
     }

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -13,12 +13,12 @@
 //! If no --db-url is given, uses synthetic market data.
 
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    config::FullConfig, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
-    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
-    StrategyLogic, StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy,
+    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
+    RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
+    StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy, config::FullConfig,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -206,6 +206,59 @@ mod tests {
         assert_eq!(config.max_updates, Some(123));
         assert!(!config.skip_settlement_exits);
     }
+
+    #[test]
+    fn normalized_runtime_evidence_exposes_order_and_fill_rows() {
+        let timestamp = Utc::now();
+        let snapshot = ploy_trading::TradingRuntimeSnapshot {
+            intents: vec![ploy_trading::TradingIntent {
+                intent_id: "intent-1".to_string(),
+                deployment_id: "pm5d-test".to_string(),
+                market_id: "event-1".to_string(),
+                token_id: "token-up".to_string(),
+                side: ploy_trading::TradeSide::Buy,
+                quantity: dec!(10),
+                limit_price: Some(dec!(0.42)),
+                purpose: ploy_trading::IntentPurpose::Entry,
+                created_at: timestamp,
+            }],
+            orders: vec![ploy_trading::OrderRecord {
+                order_id: "order-1".to_string(),
+                intent_id: "intent-1".to_string(),
+                deployment_id: "pm5d-test".to_string(),
+                token_id: "token-up".to_string(),
+                requested_qty: dec!(10),
+                limit_price: Some(dec!(0.42)),
+                venue_order_id: Some("venue-1".to_string()),
+                venue_order_history: vec![],
+                revision: 0,
+                state: ploy_trading::OrderState::Filled,
+                filled_qty: dec!(10),
+                rejection_reason: None,
+                last_error: None,
+            }],
+            fills: vec![ploy_trading::FillRecord {
+                fill_id: "fill-1".to_string(),
+                order_id: "order-1".to_string(),
+                token_id: "token-up".to_string(),
+                side: ploy_trading::TradeSide::Buy,
+                quantity: dec!(10),
+                price: dec!(0.41),
+                fee: Decimal::ZERO,
+                timestamp,
+            }],
+            ..Default::default()
+        };
+
+        let evidence = normalized_runtime_evidence(&snapshot);
+
+        assert_eq!(evidence["basis"], "trading_runtime_snapshot");
+        assert_eq!(evidence["orders"][0]["deployment_id"], "pm5d-test");
+        assert_eq!(evidence["orders"][0]["intent_id"], "intent-1");
+        assert_eq!(evidence["orders"][0]["status"], "FILLED");
+        assert_eq!(evidence["fills"][0]["fill_id"], "fill-1");
+        assert_eq!(evidence["fills"][0]["fill_side"], "BUY");
+    }
 }
 
 fn main() {
@@ -219,6 +272,7 @@ fn main() {
     let start_date = flag_value(&args, "--start-date");
     let end_date = flag_value(&args, "--end-date");
     let timing_json = flag_value(&args, "--timing-json");
+    let output_json = flag_value(&args, "--output-json");
 
     let (strategy_variant, strategy_config, sim_config, runtime_config, backtest_options) =
         if let Some(ref path) = config_path {
@@ -413,6 +467,15 @@ fn main() {
                 }),
             );
             print_results(&result, &snapshot, stake_usd);
+            write_backtest_evaluation_json(
+                output_json.as_deref(),
+                &strategy_variant,
+                config_path.as_deref(),
+                start_date.as_deref(),
+                end_date.as_deref(),
+                &result,
+                &snapshot,
+            );
         }
     } else {
         let eager_source_load_secs;
@@ -496,6 +559,241 @@ fn main() {
             }),
         );
         print_results(&result, &snapshot, stake_usd);
+        write_backtest_evaluation_json(
+            output_json.as_deref(),
+            &strategy_variant,
+            config_path.as_deref(),
+            start_date.as_deref(),
+            end_date.as_deref(),
+            &result,
+            &snapshot,
+        );
+    }
+}
+
+fn write_backtest_evaluation_json(
+    path: Option<&str>,
+    strategy_variant: &str,
+    config_path: Option<&str>,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+    result: &ploy_strategy_bundles::RuntimeResult,
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+) {
+    let Some(path) = path else {
+        return;
+    };
+    let artifact = build_backtest_evaluation_artifact(
+        strategy_variant,
+        config_path,
+        start_date,
+        end_date,
+        result,
+        snapshot,
+    );
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            eprintln!(
+                "warning: failed to create output json dir {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    match serde_json::to_string_pretty(&artifact) {
+        Ok(body) => {
+            if let Err(error) = fs::write(path, format!("{body}\n")) {
+                eprintln!("warning: failed to write output json {path}: {error}");
+            }
+        }
+        Err(error) => eprintln!("warning: failed to encode output json {path}: {error}"),
+    }
+}
+
+fn build_backtest_evaluation_artifact(
+    strategy_variant: &str,
+    config_path: Option<&str>,
+    start_date: Option<&str>,
+    end_date: Option<&str>,
+    result: &ploy_strategy_bundles::RuntimeResult,
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+) -> serde_json::Value {
+    let cashflow = snapshot.fill_cashflow_summary();
+    let mut risk_flags = Vec::new();
+    if snapshot.orders.is_empty() {
+        risk_flags.push("no_order_level_rows");
+    }
+    if snapshot.fills.is_empty() {
+        risk_flags.push("no_fill_level_rows");
+    }
+
+    json!({
+        "schema_version": 1,
+        "artifact_type": "strategy_backtest_evaluation",
+        "producer": "run_backtest",
+        "generated_at": Utc::now().to_rfc3339(),
+        "replay_mode": "backtest",
+        "canonical_result": if risk_flags.is_empty() { "continue" } else { "fix-workflow-or-data-source" },
+        "strategy_variant": strategy_variant,
+        "config_path": config_path,
+        "window": {
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+        "metrics": {
+            "updates_processed": result.updates_processed,
+            "intents_submitted": result.intents_submitted,
+            "orders": snapshot.orders.len(),
+            "fills_recorded": result.fills_recorded,
+            "fills": snapshot.fills.len(),
+            "realized_pnl": result.pnl.realized_pnl,
+            "unrealized_pnl": result.pnl.unrealized_pnl,
+            "total_fees": result.pnl.total_fees,
+            "net_pnl": result.pnl.net_pnl(),
+            "deployed_capital": cashflow.deployed_capital(),
+            "gross_sell_proceeds": cashflow.gross_sell_proceeds,
+            "elapsed_secs": result.elapsed_secs,
+        },
+        "risk_flags": risk_flags,
+        "runtime_evidence": normalized_runtime_evidence(snapshot),
+    })
+}
+
+fn normalized_runtime_evidence(
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+) -> serde_json::Value {
+    let intents_by_id: BTreeMap<&str, &ploy_trading::TradingIntent> = snapshot
+        .intents
+        .iter()
+        .map(|intent| (intent.intent_id.as_str(), intent))
+        .collect();
+    let orders_by_id: BTreeMap<&str, &ploy_trading::OrderRecord> = snapshot
+        .orders
+        .iter()
+        .map(|order| (order.order_id.as_str(), order))
+        .collect();
+
+    let mut fill_quantity_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    let mut fill_notional_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    for fill in &snapshot.fills {
+        *fill_quantity_by_order
+            .entry(fill.order_id.as_str())
+            .or_default() += fill.quantity;
+        *fill_notional_by_order
+            .entry(fill.order_id.as_str())
+            .or_default() += fill.quantity * fill.price;
+    }
+
+    let orders: Vec<_> = snapshot
+        .orders
+        .iter()
+        .map(|order| {
+            let intent = intents_by_id.get(order.intent_id.as_str()).copied();
+            let fill_quantity = fill_quantity_by_order
+                .get(order.order_id.as_str())
+                .copied()
+                .unwrap_or(order.filled_qty);
+            let avg_fill_price = if fill_quantity == Decimal::ZERO {
+                None
+            } else {
+                fill_notional_by_order
+                    .get(order.order_id.as_str())
+                    .map(|notional| *notional / fill_quantity)
+            };
+
+            json!({
+                "deployment_id": empty_to_none(order.deployment_id.as_str())
+                    .or_else(|| intent.and_then(|intent| empty_to_none(intent.deployment_id.as_str()))),
+                "intent_id": order.intent_id.as_str(),
+                "order_id": order.order_id.as_str(),
+                "venue_order_id": order.venue_order_id.as_deref(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": order.token_id.as_str(),
+                "market_side": None::<String>,
+                "order_side": intent
+                    .map(|intent| trade_side_label(intent.side))
+                    .unwrap_or("UNKNOWN"),
+                "purpose": intent.map(|intent| intent_purpose_label(intent.purpose)),
+                "quantity": order.requested_qty,
+                "requested_qty": order.requested_qty,
+                "limit_price": order.limit_price,
+                "filled_quantity": fill_quantity,
+                "avg_fill_price": avg_fill_price,
+                "status": order_state_label(order.state),
+                "rejection_reason": order.rejection_reason.as_deref(),
+                "last_error": order.last_error.as_deref(),
+                "created_at": intent.map(|intent| intent.created_at),
+            })
+        })
+        .collect();
+
+    let fills: Vec<_> = snapshot
+        .fills
+        .iter()
+        .map(|fill| {
+            let order = orders_by_id.get(fill.order_id.as_str()).copied();
+            let intent =
+                order.and_then(|order| intents_by_id.get(order.intent_id.as_str()).copied());
+            json!({
+                "deployment_id": order
+                    .and_then(|order| empty_to_none(order.deployment_id.as_str()))
+                    .or_else(|| intent.and_then(|intent| empty_to_none(intent.deployment_id.as_str()))),
+                "intent_id": order.map(|order| order.intent_id.as_str()),
+                "order_id": fill.order_id.as_str(),
+                "fill_id": fill.fill_id.as_str(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": fill.token_id.as_str(),
+                "market_side": None::<String>,
+                "fill_side": trade_side_label(fill.side),
+                "purpose": intent.map(|intent| intent_purpose_label(intent.purpose)),
+                "quantity": fill.quantity,
+                "price": fill.price,
+                "fee": fill.fee,
+                "fill_timestamp": fill.timestamp,
+            })
+        })
+        .collect();
+
+    json!({
+        "schema_version": 1,
+        "basis": "trading_runtime_snapshot",
+        "comparison_contract": "Compare these normalized rows against strategy_runtime_orders and strategy_runtime_fills exported from Tango for the same deployment/config/feed window.",
+        "orders": orders,
+        "fills": fills,
+    })
+}
+
+fn empty_to_none(value: &str) -> Option<&str> {
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn trade_side_label(side: ploy_trading::TradeSide) -> &'static str {
+    match side {
+        ploy_trading::TradeSide::Buy => "BUY",
+        ploy_trading::TradeSide::Sell => "SELL",
+    }
+}
+
+fn intent_purpose_label(purpose: ploy_trading::IntentPurpose) -> &'static str {
+    match purpose {
+        ploy_trading::IntentPurpose::Entry => "ENTRY",
+        ploy_trading::IntentPurpose::Exit => "EXIT",
+        ploy_trading::IntentPurpose::Reduce => "REDUCE",
+        ploy_trading::IntentPurpose::Hedge => "HEDGE",
+        ploy_trading::IntentPurpose::Cancel => "CANCEL",
+    }
+}
+
+fn order_state_label(state: ploy_trading::OrderState) -> &'static str {
+    match state {
+        ploy_trading::OrderState::Pending => "PENDING",
+        ploy_trading::OrderState::Acknowledged => "ACKNOWLEDGED",
+        ploy_trading::OrderState::PartiallyFilled => "PARTIALLY_FILLED",
+        ploy_trading::OrderState::Filled => "FILLED",
+        ploy_trading::OrderState::Canceled => "CANCELED",
+        ploy_trading::OrderState::Rejected => "REJECTED",
     }
 }
 

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -57,6 +57,8 @@ export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_pr
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
+export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
+
 export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
@@ -67,7 +69,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -57,6 +57,8 @@ export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_pr
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
+export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
+
 export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
@@ -67,7 +69,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 

--- a/scripts/check_dryrun_report_contract.py
+++ b/scripts/check_dryrun_report_contract.py
@@ -61,6 +61,8 @@ def main() -> int:
                 "total_trades": nested_value(payload, "summary.total_trades"),
                 "sharpe_basis": nested_value(payload, "metrics.sharpe_basis"),
                 "execution_diagnostics": nested_value(payload, "execution_diagnostics.basis"),
+                "runtime_evidence_orders": len(nested_value(payload, "runtime_evidence.orders") or []),
+                "runtime_evidence_fills": len(nested_value(payload, "runtime_evidence.fills") or []),
             },
             sort_keys=True,
         )

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -184,6 +184,59 @@ FROM (
 ) d;
 """
 
+RUNTIME_EVIDENCE_QUERY = f"""
+SELECT jsonb_build_object(
+  'schema_version', 1,
+  'basis', 'strategy_runtime_orders_and_fills',
+  'orders', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'runtime_mode', o.runtime_mode,
+      'strategy_id', o.strategy_id,
+      'deployment_id', o.deployment_id,
+      'intent_id', o.intent_id,
+      'order_id', o.order_id,
+      'venue_order_id', o.venue_order_id,
+      'event_id', o.event_id,
+      'market_id', o.event_id,
+      'token_id', o.token_id,
+      'market_side', o.market_side,
+      'order_side', o.order_side,
+      'quantity', o.quantity,
+      'requested_qty', o.quantity,
+      'limit_price', o.limit_price,
+      'filled_quantity', o.filled_quantity,
+      'avg_fill_price', o.avg_fill_price,
+      'status', o.status,
+      'rejection_reason', o.rejection_reason,
+      'created_at', o.recorded_at
+    ) ORDER BY o.recorded_at, o.order_id)
+    FROM strategy_runtime_orders o
+    WHERE o.runtime_mode IN ({MODE_FILTER})
+  ), '[]'::jsonb),
+  'fills', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'runtime_mode', f.runtime_mode,
+      'strategy_id', f.strategy_id,
+      'deployment_id', f.deployment_id,
+      'intent_id', f.intent_id,
+      'order_id', f.order_id,
+      'fill_id', f.fill_id,
+      'event_id', f.event_id,
+      'market_id', f.event_id,
+      'token_id', f.token_id,
+      'market_side', f.market_side,
+      'fill_side', f.fill_side,
+      'quantity', f.quantity,
+      'price', f.price,
+      'fee', f.fee,
+      'fill_timestamp', f.fill_timestamp
+    ) ORDER BY f.fill_timestamp, f.fill_id)
+    FROM strategy_runtime_fills f
+    WHERE f.runtime_mode IN ({MODE_FILTER})
+  ), '[]'::jsonb)
+)::text;
+"""
+
 
 def run_json_query(query: str, timeout: int = 30):
     result = subprocess.run(
@@ -660,6 +713,12 @@ def empty_payload():
             "side_aware_rows": 0,
         },
         "execution_diagnostics": build_execution_diagnostics([]),
+        "runtime_evidence": {
+            "schema_version": 1,
+            "basis": "strategy_runtime_orders_and_fills",
+            "orders": [],
+            "fills": [],
+        },
     }
 
 
@@ -668,12 +727,14 @@ def main() -> int:
     daily_rows = run_json_query(DAILY_QUERY) or []
     pairing = run_json_query(PAIRING_QUERY) or empty_payload()["pairing"]
     order_diagnostics = run_json_query(ORDER_DIAGNOSTICS_QUERY) or []
+    runtime_evidence = run_json_query(RUNTIME_EVIDENCE_QUERY) or empty_payload()["runtime_evidence"]
 
     payload = empty_payload()
     payload["generated_at"] = datetime.now(timezone.utc).isoformat()
     payload.update(build_report_slice(events, daily_rows))
     payload["pairing"] = pairing
     payload["execution_diagnostics"] = build_execution_diagnostics(order_diagnostics)
+    payload["runtime_evidence"] = runtime_evidence
 
     events_by_strategy = defaultdict(list)
     for event in events:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12836,3 +12836,37 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - 2026-05-02: Second repair slice added strict order/fill evidence. Replay/backtest output now includes `runtime_evidence.intents/orders/fills` normalized from `TradingRuntimeSnapshot`, including deployment, intent/order/fill ids, event/token ids, side/purpose, quantity, prices, fees, status, and timestamps. `replay_dryrun_parity.py` now compares those rows against Tango exports at order/fill level with numeric and timestamp tolerances, and reports `runtime_evidence_comparison.strict_parity_ready`.
 - 2026-05-02: Semantic row matching fixed the post-deploy parity false negative. The comparator now keys runtime orders/fills by stable semantic identity, led by `deployment_id + intent_id`, and treats replay-generated `order_id` / `fill_id` as diagnostic rather than strict parity fields. Real Tango artifact check passed against `/opt/ploy/data/parity/postdeploy-20260502T022934Z`: orders `10/10` shared, fills `10/10` shared, zero row mismatches, zero missing runtime strict fields, `runtime_evidence_comparison.strict_parity_ready=true`, decision `continue`. Event-level rows are still absent on both sides, so this proves order/fill runtime parity only; dry-run/live restoration remains blocked on the broader promotion gate.
 - 2026-05-02: Factor stability probe `25243415961` used snapshot `25204438461` / hash `fb338e1f202c3bda`, train `2026-04-24 -> 2026-04-29`, validation `2026-04-29 -> 2026-05-02`, six symbols, and `min_observations=80`. Raw single-factor walk-forward was mixed and should not be promoted directly: raw `side_model_prob` and `side_distance_over_sigma` were positive in train but negative in validation. After the liquidity gate, those same alpha factors became strongly positive on validation (`side_model_prob` `+5990.4034`, `side_distance_over_sigma` `+5997.9890`) with `100%` fill, symbol-positive, and time-bucket-positive rates. The workflow still marked them `watchlist` because there is only one validation window (`too_few_windows_positive_pnl`) and the snapshot data audit is `critical`. Durable record: [tasks/pm5d_factor_stability_20260502.md](/Users/proerror/Documents/ploy/tasks/pm5d_factor_stability_20260502.md).
+
+# Settlement Probability PRD Continuation (2026-05-05)
+
+## Files
+
+- `scripts/report_dryrun_summary.py`
+  - Owner: dry-run report must expose top-level row-level `runtime_evidence.orders/fills` from `strategy_runtime_orders` and `strategy_runtime_fills`.
+- `crates/ploy-operator-contracts/src/reports.rs`
+  - Owner: operator report contract must preserve optional runtime evidence for API clients and parity workflows.
+- `crates/ploy-strategy-bundles/examples/run_backtest.rs`
+  - Owner: `backtest.yml` artifact `artifacts/backtest/evaluation.json` must exist and include replay/backtest order/fill evidence.
+- `scripts/replay_dryrun_parity.py`
+  - Owner: strict parity comparator; already consumes `runtime_evidence.orders/fills`.
+- `.github/workflows/backtest.yml`
+  - Owner: uses `run_backtest --output-json`; this now maps to a real artifact writer.
+- `.github/workflows/replay-dryrun-parity.yml`
+  - Owner: next evidence gate once fresh replay and dry-run JSON both contain row-level runtime evidence.
+
+## Tasks
+
+- [x] Add row-level dry-run `runtime_evidence.orders/fills` to `/api/reports/dry-run` payload generation.
+- [x] Add optional `DryRunRuntimeEvidence` to the Rust operator contract and regenerate schema/TypeScript contracts.
+- [x] Make `run_backtest --output-json` write `evaluation.json` with headline metrics and normalized order/fill runtime evidence.
+- [x] Preserve strict replay/dry-run comparator semantics: row matching still uses stable semantic identity, not generated order/fill ids.
+- [ ] Deploy the updated dry-run report script/daemon via CI from `main`, then pull `/api/reports/dry-run` from `tango-1-1` and verify non-empty `runtime_evidence.orders/fills`.
+- [ ] Dispatch a fresh `backtest.yml` or recorded replay run on `main` and verify its artifact has non-empty `runtime_evidence.orders/fills`.
+- [ ] Run `replay-dryrun-parity.yml` against matching replay/dry-run evidence and attach the result to issue #321.
+- [ ] Keep PRD dry-run handoff blocked until clean 168h strict data audit, OOS, and replay parity all pass.
+
+## Review
+
+- 2026-05-05: Fixed the current PRD parity evidence gap instead of mining new factors. The dry-run report now queries `strategy_runtime_orders` and `strategy_runtime_fills` into a top-level `runtime_evidence` object with `schema_version=1`, `basis=strategy_runtime_orders_and_fills`, `orders`, and `fills`. The report contract checker also reports runtime evidence row counts.
+- 2026-05-05: Fixed the backtest workflow artifact path. `run_backtest` now parses `--output-json` and writes `strategy_backtest_evaluation` with headline metrics, risk flags for missing order/fill rows, and normalized `runtime_evidence.orders/fills` from `TradingRuntimeSnapshot`. This is the artifact shape expected by replay/dry-run parity.
+- 2026-05-05: Local verification passed: `python3 -m unittest tests.test_dryrun_report_contracts tests.test_replay_dryrun_parity`; `CARGO_TARGET_DIR=/tmp/ploy-prd-contracts rtk cargo test -p ploy-operator-contracts dry_run_report_roundtrip_preserves_diagnostics_fields --lib`; `CARGO_TARGET_DIR=/tmp/ploy-prd-backtest-example rtk cargo test -p ploy-strategy-bundles --example run_backtest`; `CARGO_TARGET_DIR=/tmp/ploy-prd-contracts rtk cargo run --locked -p ploy-operator-contracts --example export_schemas -- --check`; `node scripts/export_operator_contract_types.mjs --check`; `git diff --check`.

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -76,6 +76,25 @@ class DryRunReportContractTests(unittest.TestCase):
         self.assertEqual(diagnostics["summary"]["rejected_buy_orders"], 1)
         self.assertEqual(diagnostics["summary"]["buy_fill_rate_pct"], 50)
 
+    def test_empty_payload_exposes_runtime_evidence_contract(self) -> None:
+        summary = load_summary_module()
+        payload = summary.empty_payload()
+
+        self.assertEqual(payload["runtime_evidence"]["schema_version"], 1)
+        self.assertEqual(payload["runtime_evidence"]["basis"], "strategy_runtime_orders_and_fills")
+        self.assertEqual(payload["runtime_evidence"]["orders"], [])
+        self.assertEqual(payload["runtime_evidence"]["fills"], [])
+
+    def test_runtime_evidence_query_exports_order_and_fill_rows(self) -> None:
+        script = SUMMARY_SCRIPT.read_text()
+
+        self.assertIn("RUNTIME_EVIDENCE_QUERY", script)
+        self.assertIn('"runtime_evidence"', script)
+        self.assertIn("FROM strategy_runtime_orders o", script)
+        self.assertIn("FROM strategy_runtime_fills f", script)
+        self.assertIn("'orders'", script)
+        self.assertIn("'fills'", script)
+
     def test_report_contract_checker_accepts_clean_empty_dryrun(self) -> None:
         payload = {
             "summary": {"total_trades": 0},
@@ -84,6 +103,12 @@ class DryRunReportContractTests(unittest.TestCase):
                 "daily_sharpe_basis": "daily_net_pnl_sqrt_365",
             },
             "execution_diagnostics": {"basis": "strategy_runtime_orders"},
+            "runtime_evidence": {
+                "schema_version": 1,
+                "basis": "strategy_runtime_orders_and_fills",
+                "orders": [],
+                "fills": [],
+            },
             "strategies": [],
         }
 


### PR DESCRIPTION
## Summary
- add top-level dry-run report runtime_evidence orders/fills from strategy_runtime_orders and strategy_runtime_fills
- preserve optional DryRunRuntimeEvidence in Rust/TS operator contracts and schema
- make run_backtest --output-json write evaluation.json with metrics and normalized order/fill runtime evidence
- record the PRD continuation state in tasks/todo.md

## Verification
- python3 -m unittest tests.test_dryrun_report_contracts tests.test_replay_dryrun_parity
- CARGO_TARGET_DIR=/tmp/ploy-prd-contracts rtk cargo test -p ploy-operator-contracts dry_run_report_roundtrip_preserves_diagnostics_fields --lib
- CARGO_TARGET_DIR=/tmp/ploy-prd-backtest-example rtk cargo test -p ploy-strategy-bundles --example run_backtest
- CARGO_TARGET_DIR=/tmp/ploy-prd-contracts rtk cargo run --locked -p ploy-operator-contracts --example export_schemas -- --check
- node scripts/export_operator_contract_types.mjs --check
- git diff --check

## Notes
This does not promote a strategy or enable live trading. It only repairs the evidence path needed by the settlement probability PRD gates.