### PR TITLE
Add recorded replay parity workflow

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -1,0 +1,245 @@
+name: Recorded Replay Dry-run Parity
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_id:
+        description: "Dry-run deployment id to replay and compare"
+        required: true
+        default: "pm5d.threelayer.obi-soft.dryrun"
+      config_path:
+        description: "Remote deployed dry-run config path on tango-1-1"
+        required: true
+        default: "/opt/ploy/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml"
+      recording_path:
+        description: "Remote recorded MarketUpdate NDJSON path on tango-1-1"
+        required: true
+        default: "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson"
+      since:
+        description: "Inclusive ISO-8601 lower timestamp bound for parity rows"
+        required: true
+      until:
+        description: "Inclusive ISO-8601 upper timestamp bound for parity rows"
+        required: true
+      issue_number:
+        description: "Optional GitHub issue number for posting parity evidence"
+        required: false
+        default: "321"
+
+concurrency:
+  group: recorded-replay-parity-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.since }}-${{ github.event.inputs.until }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+
+jobs:
+  parity:
+    name: Replay recorded feed and compare dry-run evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Run recorded replay on tango-1-1
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          CONFIG_PATH: ${{ github.event.inputs.config_path }}
+          RECORDING_PATH: ${{ github.event.inputs.recording_path }}
+          REMOTE_DIR: /opt/ploy/tmp/recorded-replay-parity-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/replay artifacts/dryrun artifacts/parity
+
+          # shellcheck disable=SC2029
+          ssh tango-1-1 /bin/bash -s -- \
+            "${DEPLOYMENT_ID}" \
+            "${CONFIG_PATH}" \
+            "${RECORDING_PATH}" \
+            "${REMOTE_DIR}" <<'EOF'
+          set -euo pipefail
+          deployment_id="$1"
+          config_path="$2"
+          recording_path="$3"
+          remote_dir="$4"
+
+          mkdir -p "${remote_dir}"
+          test -x /opt/ploy/bin/ploy-runner
+          test -r "${config_path}"
+          test -r "${recording_path}"
+
+          replay_config="${remote_dir}/replay.toml"
+          python3 - "${config_path}" "${recording_path}" "${replay_config}" <<'PY'
+          import sys
+          src, recording, dst = sys.argv[1:]
+          lines = []
+          inserted_replay_path = False
+          with open(src, encoding="utf-8") as handle:
+              for raw in handle.read().splitlines():
+                  stripped = raw.strip()
+                  if stripped.startswith("mode = "):
+                      lines.append('mode = "replay"')
+                      lines.append(f'replay_market_updates_from = "{recording}"')
+                      inserted_replay_path = True
+                      continue
+                  if stripped.startswith("record_market_updates_to"):
+                      continue
+                  if stripped.startswith("record_market_updates_max_"):
+                      continue
+                  lines.append(raw)
+          if not inserted_replay_path:
+              raise SystemExit("runtime mode line not found in source config")
+          with open(dst, "w", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          PY
+
+          timeout 600 /opt/ploy/bin/ploy-runner run \
+            --config "${replay_config}" \
+            --deployment-id "${deployment_id}" \
+            --output-json "${remote_dir}/replay-evaluation.json"
+
+          curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
+            -o "${remote_dir}/dryrun-report.json"
+
+          test -s "${remote_dir}/replay-evaluation.json"
+          test -s "${remote_dir}/dryrun-report.json"
+          ls -lh "${remote_dir}/replay-evaluation.json" "${remote_dir}/dryrun-report.json"
+          EOF
+
+          scp tango-1-1:"${REMOTE_DIR}/replay-evaluation.json" artifacts/replay/evaluation.json
+          scp tango-1-1:"${REMOTE_DIR}/dryrun-report.json" artifacts/dryrun/dryrun.json
+
+      - name: Compare replay and dry-run evidence
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          SINCE: ${{ github.event.inputs.since }}
+          UNTIL: ${{ github.event.inputs.until }}
+        run: |
+          set -euo pipefail
+          python3 scripts/replay_dryrun_parity.py \
+            --replay-json artifacts/replay/evaluation.json \
+            --dryrun-json artifacts/dryrun/dryrun.json \
+            --output-json artifacts/parity/parity-evaluation.json \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            --since "${SINCE}" \
+            --until "${UNTIL}"
+
+      - name: Publish parity summary
+        if: always()
+        run: |
+          {
+            echo "## Recorded Replay vs Dry-run Parity"
+            echo ""
+            echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
+            echo "- Config: \`${{ github.event.inputs.config_path }}\`"
+            echo "- Recording: \`${{ github.event.inputs.recording_path }}\`"
+            echo "- Since: \`${{ github.event.inputs.since }}\`"
+            echo "- Until: \`${{ github.event.inputs.until }}\`"
+            if [ -f artifacts/parity/parity-evaluation.json ]; then
+              echo "- Artifact: \`recorded-replay-parity-${{ github.run_id }}\`"
+              echo ""
+              echo '```json'
+              python3 -c 'import json; data=json.load(open("artifacts/parity/parity-evaluation.json")); runtime=data.get("runtime_evidence_comparison") or {}; orders=runtime.get("orders") or {}; fills=runtime.get("fills") or {}; print(json.dumps({"decision": data.get("decision"), "blocking_risk_flags": data.get("blocking_risk_flags"), "advisory_flags": data.get("advisory_flags"), "strict_parity_ready": runtime.get("strict_parity_ready"), "shared_orders": orders.get("shared_count"), "shared_fills": fills.get("shared_count")}, indent=2, sort_keys=True))'
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload parity artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: recorded-replay-parity-${{ github.run_id }}
+          path: artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Comment parity evidence on issue
+        if: ${{ always() && github.event.inputs.issue_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
+            const issue_number = Number("${{ github.event.inputs.issue_number }}");
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let decision = "missing parity artifact";
+            let strictReady = false;
+            let blocking = [];
+            let advisory = [];
+            let sharedOrders = null;
+            let sharedFills = null;
+            if (fs.existsSync("artifacts/parity/parity-evaluation.json")) {
+              const data = JSON.parse(fs.readFileSync("artifacts/parity/parity-evaluation.json", "utf8"));
+              const runtime = data.runtime_evidence_comparison || {};
+              decision = data.decision || decision;
+              strictReady = Boolean(runtime.strict_parity_ready);
+              blocking = data.blocking_risk_flags || data.risk_flags || [];
+              advisory = data.advisory_flags || [];
+              sharedOrders = runtime.orders?.shared_count ?? null;
+              sharedFills = runtime.fills?.shared_count ?? null;
+            }
+            const body = [
+              "Recorded replay/dry-run parity evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Deployment: \`${{ github.event.inputs.deployment_id }}\``,
+              `- Config: \`${{ github.event.inputs.config_path }}\``,
+              `- Recording: \`${{ github.event.inputs.recording_path }}\``,
+              `- Window: \`${{ github.event.inputs.since }} -> ${{ github.event.inputs.until }}\``,
+              `- Artifact: \`recorded-replay-parity-${process.env.GITHUB_RUN_ID}\``,
+              `- Strict parity ready: \`${strictReady}\``,
+              `- Shared orders/fills: \`${sharedOrders ?? "n/a"} / ${sharedFills ?? "n/a"}\``,
+              `- Blocking flags: \`${blocking.join(", ") || "none"}\``,
+              `- Advisory flags: \`${advisory.join(", ") || "none"}\``,
+              `- Decision: ${decision}`
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });
+            const labels = [
+              "evidence:parity",
+              strictReady && blocking.length === 0 ? "parity:ready" : "parity:blocked",
+              ...labelsForDecision(decision)
+            ];
+            if (decision === "missing parity artifact") {
+              labels.push("evidence:missing-artifact");
+            }
+            await applyResearchIssueLabels({ github, context, core, issue_number, labels });

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -50,6 +50,7 @@ mismatch is understood and tracked as a follow-up issue.
 | Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
 | Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
 | Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
+| Recorded replay/dry-run parity | `.github/workflows/recorded-replay-parity.yml` | Replay a canonical MarketUpdate recording on `tango-1-1` with the deployed binary, then compare against the matching dry-run report slice |
 | Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports |
 | Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
 | Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12853,6 +12853,10 @@ Issue: https://github.com/proerror77/ploy/issues/256
   - Owner: uses `run_backtest --output-json`; this now maps to a real artifact writer.
 - `.github/workflows/replay-dryrun-parity.yml`
   - Owner: next evidence gate once fresh replay and dry-run JSON both contain row-level runtime evidence.
+- `.github/workflows/recorded-replay-parity.yml`
+  - Owner: repeatable recorded replay parity artifact from the deployed tango binary and matching dry-run report slice.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: workflow map must show the recorded replay parity evidence path.
 
 ## Tasks
 
@@ -12864,6 +12868,7 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Dispatch a fresh `backtest.yml` or recorded replay run on `main` and verify its artifact has non-empty `runtime_evidence.orders/fills`.
 - [x] Treat event-level parity gaps as advisory only when order/fill runtime evidence is strict-ready.
 - [x] Add deployment/time-window filters to replay/dry-run parity so one recorded replay session can be compared against the matching dry-run report slice.
+- [x] Add a recorded replay parity workflow that runs the deployed `ploy-runner` on `tango-1-1`, downloads replay/dry-run evidence, compares the matching deployment/window, uploads artifacts, and comments on issue #321.
 - [ ] Run `replay-dryrun-parity.yml` against matching replay/dry-run evidence and attach the result to issue #321.
 - [ ] Keep PRD dry-run handoff blocked until clean 168h strict data audit, OOS, and replay parity all pass.
 
@@ -12875,3 +12880,4 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - 2026-05-05: PR #325 merged and deployed from `main`. Tango `/api/reports/dry-run` exposed row-level runtime evidence with `runtime_evidence.orders=360` and `runtime_evidence.fills=349`; `ployd.service` was active with required restart/OOM guardrails and no `cargo`/`rustc` process. Backtest workflow run `25363832497` produced `strategy_backtest_evaluation` with `orders=151`, `fills=151`, no risk flags, and `canonical_result=continue`.
 - 2026-05-05: Recorded replay parity is now reproducible for the same dry-run session/window. Using `/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson` replay output `/tmp/pm5d-obi-soft-replay-evaluation.json` against the filtered dry-run report slice for `pm5d.threelayer.obi-soft.dryrun` from `2026-05-02T01:35:00+08:00` to `2026-05-02T02:20:00+08:00` produced order/fill runtime strict parity: replay/dry-run/shared orders `10/10/10`, fills `10/10/10`, zero mismatches, zero missing strict runtime fields, `blocking_risk_flags=[]`, decision `continue`. Event-level rows remain advisory because replay still lacks event-level rows.
 - 2026-05-05: Added parity comparator filters for `deployment_id`, `since`, and `until`, including a replay-order timestamp fallback through matching fill intents because current replay order rows can carry `created_at=None` while fill rows carry the session timestamp. This lets the GitHub parity workflow compare a recorded replay artifact to the matching dry-run report window instead of incorrectly comparing against the full report.
+- 2026-05-05: Added `.github/workflows/recorded-replay-parity.yml` as the repeatable evidence path for the manual proof above. The workflow SSHes to `tango-1-1`, generates a temporary replay config from the deployed dry-run TOML, runs the already deployed `/opt/ploy/bin/ploy-runner` in replay mode against the canonical recording, fetches `/api/reports/dry-run`, runs `scripts/replay_dryrun_parity.py` with deployment/time filters, uploads replay/dry-run/parity artifacts, and comments/labels issue #321. It intentionally does not build Rust on `tango-1-1` and does not touch live order paths.


### PR DESCRIPTION
## Summary
- add a manual `recorded-replay-parity.yml` workflow that SSHes to tango-1-1, runs the deployed `/opt/ploy/bin/ploy-runner` in replay mode against the canonical MarketUpdate recording, fetches the dry-run report, and generates a parity artifact
- document the new workflow in the strategy research CI/CD runbook
- record the PRD replay gate handoff in `tasks/todo.md`

## Why
The PRD now has a manual proof that recorded replay order/fill rows can match dry-run rows. This PR makes that proof repeatable as a GitHub artifact/comment so the settlement probability gate can consume it.

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/recorded-replay-parity.yml"); puts "recorded yaml ok"'\n- python3 workflow smoke assertion for recorded-replay-parity, ploy-runner run, and replay_dryrun_parity.py\n- git diff --check\n\n## Not tested\n- workflow_dispatch against tango-1-1 secrets until this workflow is on main. The workflow is replay-only and uses the already deployed CI-built binary; it does not build Rust on tango or place live orders.