### PR TITLE
Forward replay parity artifact name through PRD gate

### DIFF
--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -33,6 +33,10 @@ on:
         description: "Optional Replay Dry-run Parity run id"
         required: false
         default: ""
+      replay_parity_artifact_name:
+        description: "Optional replay parity artifact name; defaults to replay-dryrun-parity-<run-id>"
+        required: false
+        default: ""
       no_wait:
         description: "Dispatch the strict snapshot only and return"
         required: true
@@ -69,6 +73,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
           AUDIT_LOOKBACK_HOURS: ${{ github.event.inputs.audit_lookback_hours }}
           REPLAY_PARITY_RUN_ID: ${{ github.event.inputs.replay_parity_run_id }}
+          REPLAY_PARITY_ARTIFACT_NAME: ${{ github.event.inputs.replay_parity_artifact_name }}
           NO_WAIT: ${{ github.event.inputs.no_wait }}
         run: |
           set -euo pipefail
@@ -84,6 +89,9 @@ jobs:
           )
           if [ -n "${REPLAY_PARITY_RUN_ID}" ]; then
             args+=(--replay-parity-run-id "${REPLAY_PARITY_RUN_ID}")
+          fi
+          if [ -n "${REPLAY_PARITY_ARTIFACT_NAME}" ]; then
+            args+=(--replay-parity-artifact-name "${REPLAY_PARITY_ARTIFACT_NAME}")
           fi
           if [ "${NO_WAIT}" = "true" ]; then
             args+=(--no-wait)
@@ -104,6 +112,7 @@ jobs:
             echo "- Data profile: \`pm5d-vol\`"
             echo "- Audit lookback: \`${{ github.event.inputs.audit_lookback_hours }}h\`"
             echo "- Replay parity run: \`${{ github.event.inputs.replay_parity_run_id || 'none' }}\`"
+            echo "- Replay parity artifact: \`${{ github.event.inputs.replay_parity_artifact_name || 'default' }}\`"
             echo ""
             echo "A failed workflow can be the correct outcome: the orchestrator exits non-zero when the PRD promotion gate is blocked."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12855,6 +12855,8 @@ Issue: https://github.com/proerror77/ploy/issues/256
   - Owner: next evidence gate once fresh replay and dry-run JSON both contain row-level runtime evidence.
 - `.github/workflows/recorded-replay-parity.yml`
   - Owner: repeatable recorded replay parity artifact from the deployed tango binary and matching dry-run report slice.
+- `.github/workflows/settlement-probability-prd-gate.yml`
+  - Owner: wrapper inputs must forward replay parity run and artifact name into the walk-forward gate.
 - `docs/runbooks/strategy-research-cicd.md`
   - Owner: workflow map must show the recorded replay parity evidence path.
 
@@ -12869,6 +12871,7 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - [x] Treat event-level parity gaps as advisory only when order/fill runtime evidence is strict-ready.
 - [x] Add deployment/time-window filters to replay/dry-run parity so one recorded replay session can be compared against the matching dry-run report slice.
 - [x] Add a recorded replay parity workflow that runs the deployed `ploy-runner` on `tango-1-1`, downloads replay/dry-run evidence, compares the matching deployment/window, uploads artifacts, and comments on issue #321.
+- [x] Expose `replay_parity_artifact_name` on the settlement PRD gate workflow so recorded parity artifacts named `recorded-replay-parity-*` can be consumed.
 - [ ] Run `replay-dryrun-parity.yml` against matching replay/dry-run evidence and attach the result to issue #321.
 - [ ] Keep PRD dry-run handoff blocked until clean 168h strict data audit, OOS, and replay parity all pass.
 
@@ -12881,3 +12884,4 @@ Issue: https://github.com/proerror77/ploy/issues/256
 - 2026-05-05: Recorded replay parity is now reproducible for the same dry-run session/window. Using `/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson` replay output `/tmp/pm5d-obi-soft-replay-evaluation.json` against the filtered dry-run report slice for `pm5d.threelayer.obi-soft.dryrun` from `2026-05-02T01:35:00+08:00` to `2026-05-02T02:20:00+08:00` produced order/fill runtime strict parity: replay/dry-run/shared orders `10/10/10`, fills `10/10/10`, zero mismatches, zero missing strict runtime fields, `blocking_risk_flags=[]`, decision `continue`. Event-level rows remain advisory because replay still lacks event-level rows.
 - 2026-05-05: Added parity comparator filters for `deployment_id`, `since`, and `until`, including a replay-order timestamp fallback through matching fill intents because current replay order rows can carry `created_at=None` while fill rows carry the session timestamp. This lets the GitHub parity workflow compare a recorded replay artifact to the matching dry-run report window instead of incorrectly comparing against the full report.
 - 2026-05-05: Added `.github/workflows/recorded-replay-parity.yml` as the repeatable evidence path for the manual proof above. The workflow SSHes to `tango-1-1`, generates a temporary replay config from the deployed dry-run TOML, runs the already deployed `/opt/ploy/bin/ploy-runner` in replay mode against the canonical recording, fetches `/api/reports/dry-run`, runs `scripts/replay_dryrun_parity.py` with deployment/time filters, uploads replay/dry-run/parity artifacts, and comments/labels issue #321. It intentionally does not build Rust on `tango-1-1` and does not touch live order paths.
+- 2026-05-05: First attempt to feed recorded parity run `25365401498` into `settlement-probability-prd-gate.yml` failed at walk-forward artifact download because the gate wrapper only forwarded the run id and the downstream workflow defaulted to artifact name `replay-dryrun-parity-25365401498`. The recorded workflow correctly uploaded `recorded-replay-parity-25365401498`, so the wrapper now exposes and forwards `replay_parity_artifact_name`.


### PR DESCRIPTION
## Summary
- expose `replay_parity_artifact_name` on `settlement-probability-prd-gate.yml`
- forward the artifact name into `scripts/run_settlement_probability_prd_gate.py` so walk-forward can download non-default parity artifact names
- record the failed first attempt and fix in `tasks/todo.md`

## Why
Recorded replay parity uploads `recorded-replay-parity-<run-id>`, while the existing downstream default is `replay-dryrun-parity-<run-id>`. The PRD gate needs to pass the explicit artifact name to consume the recorded parity evidence.

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/settlement-probability-prd-gate.yml"); puts "gate yaml ok"'\n- python3 scripts/run_settlement_probability_prd_gate.py --git-ref main --start-date 2026-05-05 --end-date 2026-05-05 --replay-parity-run-id 25365401498 --replay-parity-artifact-name recorded-replay-parity-25365401498 --dry-run\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional parameter to the settlement probability gate workflow for specifying replay parity artifact names, enabling flexible artifact configuration.

* **Documentation**
  * Updated task documentation to clarify artifact forwarding requirements and workflow ownership responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->