### PR TITLE
Align prediction-shift anti-overfit gate with PRD

### DIFF
--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -8024,7 +8024,7 @@ fn build_probability_anti_overfit_rows(
             perturbed_edge_win_rank_ic: prediction_shift_rank_ic,
             observed_top_edge_avg_full_depth_settlement_pnl: observed_top_pnl,
             perturbed_top_edge_avg_full_depth_settlement_pnl: prediction_shift_top_pnl,
-            pass: anti_overfit_pass(
+            pass: anti_overfit_no_improvement_pass(
                 observed_rank_ic,
                 prediction_shift_rank_ic,
                 observed_top_pnl,
@@ -8114,6 +8114,22 @@ fn anti_overfit_pass(
         || !perturbed_top_pnl.is_finite()
         || observed_top_pnl <= 0.0
         || perturbed_top_pnl <= observed_top_pnl * 0.5;
+    ic_ok && pnl_ok
+}
+
+fn anti_overfit_no_improvement_pass(
+    observed_rank_ic: f64,
+    perturbed_rank_ic: f64,
+    observed_top_pnl: f64,
+    perturbed_top_pnl: f64,
+) -> bool {
+    let eps = 1e-9;
+    let ic_ok = !observed_rank_ic.is_finite()
+        || !perturbed_rank_ic.is_finite()
+        || perturbed_rank_ic.abs() <= observed_rank_ic.abs() + eps;
+    let pnl_ok = !observed_top_pnl.is_finite()
+        || !perturbed_top_pnl.is_finite()
+        || perturbed_top_pnl <= observed_top_pnl + eps;
     ic_ok && pnl_ok
 }
 
@@ -9558,6 +9574,19 @@ mod tests {
     use chrono::Utc;
 
     use super::*;
+
+    #[test]
+    fn prediction_shift_anti_overfit_passes_when_not_better() {
+        assert!(anti_overfit_no_improvement_pass(0.18, 0.16, 2.12, 2.05));
+        assert!(!anti_overfit_no_improvement_pass(0.18, 0.20, 2.12, 2.05));
+        assert!(!anti_overfit_no_improvement_pass(0.18, 0.16, 2.12, 2.20));
+    }
+
+    #[test]
+    fn label_perturbation_anti_overfit_still_requires_decay() {
+        assert!(anti_overfit_pass(0.18, 0.03, 2.12, 0.90));
+        assert!(!anti_overfit_pass(0.18, 0.16, 2.12, 2.05));
+    }
 
     fn base_obs() -> FactorObservation {
         FactorObservation {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12893,3 +12893,22 @@ Issue: https://github.com/proerror77/ploy/issues/256
   preserves raw replay/dry-run inputs in a separate
   `recorded-replay-inputs-*` artifact, so the PRD gate can consume recorded
   replay parity without special casing nested paths.
+- 2026-05-05: PR #329 fixed the recorded parity artifact layout and main run
+  `25366831381` proved the artifact contract: `parity-evaluation.json` is now
+  at the artifact root, runtime order/fill strict parity is ready
+  (`10/10/10` shared orders and fills), and blocking flags are empty. The
+  one-day PRD gate `25366891903` then passed data quality, Deribit, full-depth
+  capacity, conservative capacity, probability calibration, settlement edge,
+  conservative edge, and recorded replay parity, but correctly blocked dry-run
+  handoff because walk-forward OOS had no non-empty windows and deterministic
+  anti-overfit still failed.
+- 2026-05-05: A wider available-window PRD gate `25367205869`
+  (`2026-04-29..2026-05-05`, BTC/ETH/SOL, 15u) produced snapshot
+  `25367212009` and walk-forward `25368373695`. Walk-forward OOS now passes
+  for `q_market_midpoint` with 4 windows, positive window ratio `1.0000`, and
+  min test top-edge full-depth PnL `1.3664`, while dry-run handoff remains
+  blocked by anti-overfit semantics and symbol holdout: SOLUSDT top-edge PnL is
+  still slightly negative for both market midpoint and existing fair
+  probability. The next code correction is to align prediction one-step
+  time-shift with the PRD rule "should not become better" while preserving the
+  stricter decay requirement for label shift/permutation tests.


### PR DESCRIPTION
## Summary
- split prediction one-step shift from label perturbation anti-overfit semantics
- keep label cyclic/permutation checks strict, requiring signal decay
- make prediction time-shift pass when shifted performance is not stronger than observed, matching the PRD leakage rule
- record the one-day and seven-day PRD gate evidence in tasks/todo.md

## Verification
- rustfmt --edition 2021 --check crates/ploy-research/src/factors_v2.rs
- CARGO_TARGET_DIR=/tmp/ploy-anti-overfit-semantics /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-research anti_overfit --lib
- CARGO_TARGET_DIR=/tmp/ploy-anti-overfit-semantics /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-research settlement_probability --lib
- git diff --check

## Notes
The seven-day gate remains blocked after this conceptually by symbol holdout, especially SOLUSDT. This PR fixes an over-strict diagnostic, not a dry-run promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented stricter validation criteria for model diagnostics, requiring both metric improvements and performance consistency checks
  * Added comprehensive test coverage for new validation logic, including edge cases and existing functionality verification

* **Documentation**
  * Updated documentation reflecting recent artifact layout improvements and current walk-forward testing status with progress notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->