### PR TITLE
Add BTC/ETH settlement probability dry-run profile

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -1,0 +1,68 @@
+# Three-layer settlement-probability dry-run config
+# PRD gate run 25369614389, snapshot 25367212009 / 69e259f6b4469392.
+# Dry-run handoff candidate only: BTC/ETH passed current full-depth,
+# conservative, OOS, symbol-holdout, anti-overfit, and recorded replay parity
+# gates. This is not a live config.
+
+[runtime]
+strategy_variant = "three_layer"
+mode = "dryrun"
+throttle_hz = 10
+
+[strategy]
+symbols = ["BTCUSDT", "ETHUSDT"]
+
+vol_floor = 0.001
+min_probability = 0.51
+min_z_score = 0.20
+
+min_entry_price = 0.10
+max_entry_price = 0.95
+no_trade_zone_min = 0.45
+no_trade_zone_max = 0.55
+
+min_edge = 0.0
+
+min_time_remaining_secs = 30
+max_time_remaining_secs = 180
+cooldown_secs = 30
+
+stake_usd = 15.0
+max_positions = 4
+max_daily_trades = 50
+allowed_window_secs = [300, 900]
+
+three_layer_strategy_profile = "settlement_probability"
+three_layer_min_entry_score = 0.25
+three_layer_min_direction_prob = 0.56
+three_layer_min_distance_over_sigma = 0.30
+three_layer_min_confirmation_score = 0.0
+three_layer_require_confirmation = false
+three_layer_min_drift_confirmation = 0.0
+three_layer_min_edge = 0.02
+three_layer_min_reward_risk = 0.0
+three_layer_alpha_contrarian = false
+three_layer_cex_contrarian = false
+three_layer_probability_shrink = 1.0
+three_layer_probability_haircut = 0.0
+three_layer_take_profit_ask = 0.99
+three_layer_stop_distance_pct = 0.030
+three_layer_max_pm_lag_secs = 15
+
+[execution]
+use_spread = true
+spread_pct = 0.08
+enable_partial_fills = false
+min_fill_pct = 0.5
+enable_market_impact = true
+impact_coefficient = 0.1
+default_depth_shares = 500
+require_lob_liquidity = true
+
+[reference_data]
+capture_sports_state = false
+
+[backtest_data]
+include_reference_prices = false
+include_sports_state = false
+require_official_settlement = true

--- a/config/strategies/REGISTRY.md
+++ b/config/strategies/REGISTRY.md
@@ -92,6 +92,7 @@ numeric ID used as filename prefix.
 | `02-pm5d-threelayer.obi-hard-dryrun.toml` | **UNIFIED** | Snapshot-profile dry-run candidate; profile `obi_hard` with hard OBI confirmation |
 | `02-pm5d-threelayer.continuation-soft-dryrun.toml` | **UNIFIED** | Holistic snapshot-profile dry-run candidate; profile `continuation_soft` |
 | `02-pm5d-threelayer.repricing-momentum-dryrun.toml` | **UNIFIED** | BTC/ETH/SOL-only full-depth dry-run candidate; profile `repricing_momentum` |
+| `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` | **UNIFIED** | BTC/ETH-only PRD dry-run handoff candidate; profile `settlement_probability` |
 
 ### S03 — Pattern Memory
 | File | Format | Notes |

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -739,6 +739,7 @@ venue = "sportsbook"
         for file in [
             "02-pm5d-threelayer.unified.toml",
             "02-pm5d-threelayer.live.toml",
+            "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
         ] {
             let path = config_dir.join(file);
             let config = FullConfig::from_file(path.to_str().unwrap()).unwrap();

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -1490,6 +1490,11 @@ mod tests {
             serde_json::from_str(r#"{"strategy_profile":"repricing_momentum"}"#).unwrap();
         let tlc: ThreeLayerConfig = dc.into();
         assert_eq!(tlc.profile, ThreeLayerProfile::RepricingMomentum);
+
+        let dc: DirectionalConfig =
+            serde_json::from_str(r#"{"strategy_profile":"settlement_probability"}"#).unwrap();
+        let tlc: ThreeLayerConfig = dc.into();
+        assert_eq!(tlc.profile, ThreeLayerProfile::SettlementProbability);
     }
 
     #[test]
@@ -2395,6 +2400,47 @@ mod tests {
 
         assert!(strong > weak);
         assert!(strong > config.min_entry_score);
+    }
+
+    #[test]
+    fn settlement_probability_profile_rewards_probability_edge_not_repricing() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_entry_score = 0.25;
+
+        let weak_edge = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.45,
+                distance_over_sigma: 0.35,
+                direction_sign: 1.0,
+                edge: 0.01,
+                edge_score: 0.05,
+                confirmation: 1.0,
+                repricing_score: 1.0,
+                drift_30s: 0.0,
+                pm_momentum_score: 1.0,
+                liquidity_score: 1.0,
+            },
+        );
+        let strong_edge = evaluate_entry_score(
+            &config,
+            EntryScoreInputs {
+                direction_score: 0.45,
+                distance_over_sigma: 0.35,
+                direction_sign: 1.0,
+                edge: 0.08,
+                edge_score: 0.90,
+                confirmation: -1.0,
+                repricing_score: -1.0,
+                drift_30s: 0.0,
+                pm_momentum_score: -1.0,
+                liquidity_score: 1.0,
+            },
+        );
+
+        assert!(strong_edge > weak_edge);
+        assert!(strong_edge > config.min_entry_score);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -286,7 +286,7 @@ pub fn profile_confirmation_score(
                 ((inputs.signed_trade_imbalance / 50.0) * inputs.direction_sign).clamp(-1.0, 1.0);
             0.50 * drift_continuation + 0.30 * microprice + 0.20 * trade_imbalance
         }
-        ThreeLayerProfile::RepricingMomentum => 0.0,
+        ThreeLayerProfile::RepricingMomentum | ThreeLayerProfile::SettlementProbability => 0.0,
     }
 }
 
@@ -399,6 +399,12 @@ pub fn evaluate_entry_score(config: &ThreeLayerModelConfig, inputs: EntryScoreIn
                 + 0.30 * repricing_score
                 + 0.10 * inputs.pm_momentum_score
                 + 0.08 * inputs.liquidity_score
+        }
+        ThreeLayerProfile::SettlementProbability => {
+            0.35 * inputs.direction_score
+                + 0.15 * distance_score
+                + 0.40 * edge_score
+                + 0.10 * inputs.liquidity_score
         }
         ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),
     }

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_profile.rs
@@ -19,6 +19,8 @@ pub enum ThreeLayerProfile {
     ContinuationSoft,
     /// Candidate Strategy D: external CEX repricing pressure adjusted by PM spread.
     RepricingMomentum,
+    /// PRD settlement-probability lane: probability edge first, no repricing alpha gate.
+    SettlementProbability,
 }
 
 impl Default for ThreeLayerProfile {
@@ -36,6 +38,7 @@ impl ThreeLayerProfile {
             Self::ObiHard => "obi_hard",
             Self::ContinuationSoft => "continuation_soft",
             Self::RepricingMomentum => "repricing_momentum",
+            Self::SettlementProbability => "settlement_probability",
         }
     }
 
@@ -62,8 +65,11 @@ impl FromStr for ThreeLayerProfile {
             | "repricing_momentum"
             | "reprice_momentum"
             | "spread_adjusted_external_move" => Ok(Self::RepricingMomentum),
+            "settlement" | "settlement_probability" | "settlement_prob" | "probability_edge" => {
+                Ok(Self::SettlementProbability)
+            }
             other => Err(format!(
-                "unknown three_layer_strategy_profile {other:?}; expected mixed, champion, obi_soft, obi_hard, continuation_soft, or repricing_momentum"
+                "unknown three_layer_strategy_profile {other:?}; expected mixed, champion, obi_soft, obi_hard, continuation_soft, repricing_momentum, or settlement_probability"
             )),
         }
     }
@@ -116,6 +122,22 @@ mod tests {
         assert_eq!(
             ThreeLayerProfile::RepricingMomentum.as_str(),
             "repricing_momentum"
+        );
+    }
+
+    #[test]
+    fn parses_settlement_probability_aliases() {
+        assert_eq!(
+            ThreeLayerProfile::from_str("settlement_probability").unwrap(),
+            ThreeLayerProfile::SettlementProbability
+        );
+        assert_eq!(
+            ThreeLayerProfile::from_str("probability_edge").unwrap(),
+            ThreeLayerProfile::SettlementProbability
+        );
+        assert_eq!(
+            ThreeLayerProfile::SettlementProbability.as_str(),
+            "settlement_probability"
         );
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12932,3 +12932,11 @@ Issue: https://github.com/proerror77/ploy/issues/256
   BTC/ETH settlement probability dry-run handoff candidate. This is not live
   approval; next work is a dedicated BTC/ETH settlement dry-run config/scorer
   parity slice with kill switches and audit logging.
+- 2026-05-05: Started the first BTC/ETH settlement dry-run implementation
+  slice from issue #332. Added a dedicated `settlement_probability`
+  three-layer profile that weights probability edge instead of repricing
+  pressure, plus a BTC/ETH-only dry-run config
+  `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`. This is a
+  dry-run handoff config only; runtime still uses top-of-book quote size for
+  live fillability, so full-depth runtime parity remains a blocker before any
+  live promotion.


### PR DESCRIPTION
## Summary

- adds a dedicated `settlement_probability` three-layer profile so BTC/ETH settlement dry-run does not reuse repricing-momentum semantics
- adds `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` scoped to BTCUSDT/ETHUSDT
- records the implementation slice and remaining full-depth runtime parity blocker in `tasks/todo.md`

## PRD evidence

- Handoff issue: #332
- BTC/ETH walk-forward gate: 25369614389
- Snapshot: 25367212009 / 69e259f6b4469392
- Recorded replay parity: 25366831381

## Important limitation

This is dry-run handoff only, not live approval. Runtime still uses observed quote size rather than research full-depth sweep labels, so live promotion remains blocked on scorer parity, full-depth runtime capacity, kill switches, and observed dry-run evidence.

## Verification

- `rustfmt --edition 2021 --check` on strategy bundle files
- `CARGO_TARGET_DIR=/tmp/ploy-settlement-dryrun-profile /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-strategy-bundles three_layer --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-settlement-dryrun-profile /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-strategy-bundles threelayer_configs_require_official_settlement_for_backtests --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-settlement-dryrun-profile /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-strategy-bundles parses_settlement_probability_aliases --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-settlement-dryrun-profile /opt/homebrew/bin/timeout 300 rtk cargo check -p ploy-strategy-bundles --lib`
- `git diff --check`
