### PR TITLE
Enable BTC/ETH settlement probability dry-run deployment

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -170,6 +170,7 @@ jobs:
           cp config/strategies/02-pm5d-threelayer.champion-dryrun.toml dist/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml dist/config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml dist/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
+          cp config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml dist/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
           cp config/deployments/*.json dist/config/deployments/
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
@@ -418,6 +419,7 @@ jobs:
             install -m 0644 ./config/strategies/02-pm5d-threelayer.champion-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
+            install -m 0644 ./config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
             install -m 0644 ./config/deployments/*.json ${DEPLOY_ROOT}/config/deployments/
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py

--- a/config/deployments/README.md
+++ b/config/deployments/README.md
@@ -13,6 +13,9 @@ Current examples:
 - `example.live.dry-run.json`
   - remote live-host readiness drill
   - still uses `runtime_mode: "paper"` so the drill never touches real funds
+- `pm5d.threelayer.settlement-probability-btc-eth.dryrun.json`
+  - BTC/ETH-only PM5D/PM15D settlement-probability dry-run handoff candidate
+  - paper runtime only; not live approval
 
 Each manifest includes:
 

--- a/config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json
+++ b/config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json
@@ -1,0 +1,8 @@
+{
+  "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+  "bundle_id": "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun",
+  "account_id": "acct-pm5d-dryrun",
+  "max_gross_exposure": "5.00",
+  "runtime_mode": "paper",
+  "desired_state": "running"
+}

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -26,6 +26,7 @@ EXPERIMENT_LABELS = {
     "pm5d.threelayer.obi-soft.dryrun": "TL v3 OBI-soft EVCal",
     "pm5d.threelayer.obi-hard.dryrun": "TL v4 OBI-hard EVCal",
     "pm5d.threelayer.continuation-soft.dryrun": "TL v5 Continuation-soft EVCal",
+    "pm5d.threelayer.settlement-probability-btc-eth.dryrun": "TL Settlement Probability BTC/ETH",
 }
 
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12940,3 +12940,19 @@ Issue: https://github.com/proerror77/ploy/issues/256
   dry-run handoff config only; runtime still uses top-of-book quote size for
   live fillability, so full-depth runtime parity remains a blocker before any
   live promotion.
+- 2026-05-05: Continuing the PRD handoff after BTC/ETH-only gates passed and
+  PR #334 added the `settlement_probability` strategy profile/config. Current
+  slice: add deployment support only. Planned files are
+  `.github/workflows/deploy-tango-1-1.yml`,
+  `config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json`,
+  `config/deployments/README.md`, and `scripts/report_dryrun_summary.py`.
+  Acceptance for this slice: the new BTC/ETH dry-run config is bundled and
+  installed by the tango deploy workflow, has a paper-mode deployment manifest,
+  and appears with an explicit settlement-probability label in dry-run reports.
+- 2026-05-05: Implemented the BTC/ETH settlement dry-run deployment support
+  slice. Added the paper deployment manifest, wired the tango deploy bundle to
+  copy/install the settlement-probability strategy TOML, documented the
+  manifest as dry-run-only, and added an explicit report label. Verification
+  passed: `python3 -m json.tool` on the new manifest, `python3 -m py_compile
+  scripts/report_dryrun_summary.py`, a manifest-to-config/workflow path
+  consistency check, report-label smoke import, and `git diff --check`.


### PR DESCRIPTION
## Summary

- add a paper deployment manifest for the BTC/ETH settlement-probability dry-run candidate from issue #332
- bundle and install the new settlement-probability strategy TOML in the tango deploy workflow
- add an explicit dry-run report label and deployment README note

## Scope

Dry-run deployment support only. This does not approve or enable live trading; live remains blocked on full-depth runtime parity and observed dry-run evidence.

## Verification

- `python3 -m json.tool config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json >/dev/null`
- `python3 -m py_compile scripts/report_dryrun_summary.py`
- manifest/config/workflow path consistency smoke
- report label smoke import
- `git diff --check`

Related: #332