### PR TITLE
Expose probability-edge audit context in dry-run evidence

### DIFF
--- a/crates/ploy-strategy-runtime/src/recording.rs
+++ b/crates/ploy-strategy-runtime/src/recording.rs
@@ -173,6 +173,14 @@ impl RuntimeDbRecorder {
         let context_json = json!({
             "runtime_mode": self.mode_label,
             "signal_decision": signal.map(|record| record.decision.as_str()),
+            "signal_strategy": signal.map(|record| record.strategy.as_str()),
+            "signal_symbol": signal.map(|record| record.symbol.as_str()),
+            "signal_direction": signal.map(|record| record.direction.as_str()),
+            "signal_p_hat": signal.map(|record| record.p_hat),
+            "signal_edge": signal.map(|record| record.edge),
+            "signal_entry_price": signal.map(|record| record.entry_price.to_string()),
+            "runtime_price_basis": "top_book_quote",
+            "full_depth_runtime_parity": false,
             "slippage": report.slippage.map(|value| value.to_string()),
             "market_impact": report.market_impact.map(|value| value.to_string()),
         });

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -209,6 +209,7 @@ SELECT jsonb_build_object(
       'avg_fill_price', o.avg_fill_price,
       'status', o.status,
       'rejection_reason', o.rejection_reason,
+      'context', o.context,
       'created_at', o.recorded_at
     ) ORDER BY o.recorded_at, o.order_id)
     FROM strategy_runtime_orders o

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12956,3 +12956,19 @@ Issue: https://github.com/proerror77/ploy/issues/256
   passed: `python3 -m json.tool` on the new manifest, `python3 -m py_compile
   scripts/report_dryrun_summary.py`, a manifest-to-config/workflow path
   consistency check, report-label smoke import, and `git diff --check`.
+- 2026-05-05: Implemented the first runtime audit slice for PRD dry-run
+  evidence. `strategy_runtime_orders.context` now records the signal
+  probability, edge, entry price, signal strategy/symbol/direction, and the
+  explicit runtime price basis `top_book_quote` with
+  `full_depth_runtime_parity=false`. `report_dryrun_summary.py` now exports
+  order `context` under `runtime_evidence.orders`, so dry-run/replay evidence
+  can inspect probability-edge decisions directly while still flagging the
+  remaining full-depth runtime parity blocker. Verification passed:
+  `python3 -m unittest tests.test_dryrun_report_contracts
+  tests.test_replay_dryrun_parity`, `python3 -m py_compile
+  scripts/report_dryrun_summary.py scripts/replay_dryrun_parity.py`,
+  `rustfmt --edition 2021 --check
+  crates/ploy-strategy-runtime/src/recording.rs`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-runtime-audit-check /opt/homebrew/bin/timeout
+  300 rtk cargo check -p ploy-strategy-runtime --lib` with only pre-existing
+  warnings.

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -94,6 +94,7 @@ class DryRunReportContractTests(unittest.TestCase):
         self.assertIn("FROM strategy_runtime_fills f", script)
         self.assertIn("'orders'", script)
         self.assertIn("'fills'", script)
+        self.assertIn("'context', o.context", script)
 
     def test_report_contract_checker_accepts_clean_empty_dryrun(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

- persist existing signal probability/edge/entry-price fields into `strategy_runtime_orders.context`
- mark the current runtime execution basis as `top_book_quote` with `full_depth_runtime_parity=false`
- export order `context` in `runtime_evidence.orders` from the dry-run summary report

## Why

The BTC/ETH settlement-probability dry-run needs per-order q/edge evidence before replay/dry-run parity can explain decisions. This is an audit bridge only; it does not claim full-depth runtime parity.

## Verification

- `python3 -m unittest tests.test_dryrun_report_contracts tests.test_replay_dryrun_parity`
- `python3 -m py_compile scripts/report_dryrun_summary.py scripts/replay_dryrun_parity.py`
- `rustfmt --edition 2021 --check crates/ploy-strategy-runtime/src/recording.rs`
- `CARGO_TARGET_DIR=/tmp/ploy-runtime-audit-check /opt/homebrew/bin/timeout 300 rtk cargo check -p ploy-strategy-runtime --lib`
- `git diff --check`

Related: #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order recording now captures expanded context with signal and runtime parameters for enhanced visibility into trading decisions.
  * Order context details are now included in generated reports, enabling direct inspection of order metadata and decision parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->