### PR TITLE
Record settlement dry-run feed for replay parity

### DIFF
--- a/config/deployments/README.md
+++ b/config/deployments/README.md
@@ -16,6 +16,10 @@ Current examples:
 - `pm5d.threelayer.settlement-probability-btc-eth.dryrun.json`
   - BTC/ETH-only PM5D/PM15D settlement-probability dry-run handoff candidate
   - paper runtime only; not live approval
+  - records its own MarketUpdate stream at
+    `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`
+    so recorded replay parity can use the same deployed strategy and time
+    window
 
 Each manifest includes:
 

--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -8,6 +8,12 @@
 strategy_variant = "three_layer"
 mode = "dryrun"
 throttle_hz = 10
+# Dedicated capture for the settlement-probability dry-run handoff. The
+# replay-parity gate must compare against the same deployed strategy/window,
+# not the older OBI-soft canonical recording.
+record_market_updates_to = "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson"
+record_market_updates_max_records = 300000
+record_market_updates_max_bytes = 268435456
 
 [strategy]
 symbols = ["BTCUSDT", "ETHUSDT"]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12972,3 +12972,15 @@ Issue: https://github.com/proerror77/ploy/issues/256
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-audit-check /opt/homebrew/bin/timeout
   300 rtk cargo check -p ploy-strategy-runtime --lib` with only pre-existing
   warnings.
+- 2026-05-05: Deployed the runtime audit slice from `main` and verified
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun` is running on
+  `tango-1-1` while `pm5d.threelayer.repricing-momentum.dryrun` remains
+  paused. New post-deploy BUY orders in `/api/reports/dry-run` include
+  `signal_p_hat`, `signal_edge`, `signal_entry_price`,
+  `runtime_price_basis=top_book_quote`, and
+  `full_depth_runtime_parity=false`. The next recorded replay parity step is
+  blocked until the settlement deployment records its own MarketUpdate stream:
+  the old canonical recording
+  `/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson` is stale
+  (`mtime=2026-05-02T02:15:13+08:00`) and cannot cover the 2026-05-05
+  settlement dry-run order window.


### PR DESCRIPTION
## Summary
- add a dedicated MarketUpdate recording path to the BTC/ETH settlement-probability dry-run config
- document that this deployment records its own replay-parity feed
- record the deployed audit evidence and stale canonical-recording blocker in tasks/todo.md

## Verification
- python3 TOML parse/assert recording fields
- CARGO_TARGET_DIR=/tmp/ploy-settlement-recording-config /opt/homebrew/bin/timeout 300 rtk cargo test -p ploy-strategy-bundles config --lib
- git diff --check

## Notes
This remains dry-run only. The old canonical recording is stale for the 2026-05-05 settlement order window, so parity should run only after this config is deployed and a fresh settlement window is captured.