### PR TITLE
Gate AutoFactor strategy promotion by runtime mapping

### DIFF
--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -110,6 +110,35 @@ The walk-forward phase writes `walk_forward_report.json` and
 `walk_forward_report.md`. With only one workflow run, the report is expected to
 mark DL/RL readiness as `blocked`; that is a useful gate, not a runner failure.
 
+## AutoFactor Strategy Promotion Gate
+
+AutoFactor candidate rows are discovery evidence, not strategy handoff evidence.
+After a `factor_walk_forward_v2` report is produced, run the strategy-promotion
+evaluator before creating any dry-run handoff:
+
+```bash
+python3 scripts/evaluate_autofactor_strategy_promotion.py \
+  --report /tmp/factor-walk-forward-v2/report.txt \
+  --output-json /tmp/autofactor-strategy-promotion.json \
+  --output-md /tmp/autofactor-strategy-promotion.md
+```
+
+The evaluator requires all of the following:
+
+- the surrounding PRD promotion gate reports `ready_for_dry_run_handoff=true`;
+- the AutoFactor row has `decision=candidate` and `reason=passed`;
+- the target is an allowed executable target, defaulting to
+  `full_depth_settlement_executable_pnl`;
+- the factor has an explicit runtime strategy-profile mapping; and
+- the runtime profile matches the requested promotion lane, defaulting to
+  `settlement_probability`.
+
+This deliberately blocks cases where a factor is statistically good in the
+wrong lane. For example, `spread_adjusted_external_move` can be a valid
+repricing candidate while still being blocked from settlement-probability
+promotion because its runtime mapping is `repricing_momentum`, not
+`settlement_probability`.
+
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.
 

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Evaluate whether AutoFactor report rows can become strategy handoffs.
+
+This is intentionally stricter than the AutoFactor IC/ICIR candidate gate.
+An AutoFactor row is only a qualified strategy when:
+
+1. the surrounding settlement PRD promotion gate is ready;
+2. the row is a `candidate` with reason `passed`;
+3. the target is one of the allowed executable targets; and
+4. the factor has an explicit runtime strategy-profile mapping.
+
+The current PM5D/PM15D settlement PRD should not silently promote a good
+repricing factor into the settlement strategy lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ALLOWED_TARGETS = ("full_depth_settlement_executable_pnl",)
+
+BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
+    "spread_adjusted_external_move": {
+        "strategy_profile": "repricing_momentum",
+        "strategy_family": "repricing",
+        "runtime_score": "spread_adjusted_external_move_score",
+    },
+    "repricing_gap_side_10s": {
+        "strategy_profile": "repricing_momentum",
+        "strategy_family": "repricing",
+        "runtime_score": "repricing_gap_side_10s",
+    },
+    "settlement_fair_edge": {
+        "strategy_profile": "",
+        "strategy_family": "settlement_probability",
+        "runtime_score": "",
+    },
+}
+
+
+@dataclass
+class PromotionGate:
+    ready: bool
+    evidence: str
+    blocked_gates: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AutoFactorRow:
+    rank: int
+    name: str
+    target: str
+    decision: str
+    reason: str
+    n: int
+    spearman_ic: float
+    pearson_ic: float
+    window_count: int
+    icir: float
+    positive_window_ratio: float
+    monotonicity: float
+    top_bucket_avg_label: float
+    top_bucket_positive_label_rate: float
+    complexity: int
+
+
+@dataclass
+class EvaluatedFactor:
+    factor: AutoFactorRow
+    qualified: bool
+    blockers: list[str]
+    runtime_mapping: dict[str, str] | None
+
+
+def parse_float(raw: str) -> float:
+    try:
+        return float(raw)
+    except ValueError:
+        return float("nan")
+
+
+def parse_int(raw: str) -> int:
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def parse_promotion_gate(report_text: str) -> PromotionGate:
+    ready: bool | None = None
+    evidence = ""
+    blocked: list[str] = []
+    in_gate_table = False
+
+    for line in report_text.splitlines():
+        if line.startswith("ready_for_dry_run_handoff="):
+            evidence = line
+            ready = line.split("=", 1)[1].split(maxsplit=1)[0].lower() == "true"
+            continue
+        if line == "gate,passed,evidence":
+            in_gate_table = True
+            continue
+        if in_gate_table:
+            if not line.strip():
+                break
+            parts = line.split(",", 2)
+            if len(parts) != 3:
+                continue
+            gate, passed, gate_evidence = parts
+            if passed.lower() != "true":
+                blocked.append(f"{gate}: {gate_evidence}")
+
+    if ready is None:
+        return PromotionGate(
+            ready=False,
+            evidence="missing ready_for_dry_run_handoff line",
+            blocked_gates=["missing_promotion_gate"],
+        )
+    return PromotionGate(ready=ready, evidence=evidence, blocked_gates=blocked)
+
+
+def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
+    rows: list[AutoFactorRow] = []
+    in_section = False
+    header: list[str] | None = None
+    current_target = ""
+
+    for line in report_text.splitlines():
+        if line.startswith("# AutoFactor target="):
+            current_target = line.split("=", 1)[1].strip()
+            in_section = True
+            header = None
+            continue
+        if not in_section:
+            continue
+        if line.startswith("rank,name,target,"):
+            header = next(csv.reader([line]))
+            continue
+        if not line.strip():
+            in_section = False
+            header = None
+            current_target = ""
+            continue
+        if header is None or line.startswith("===") or line.startswith("target labels"):
+            continue
+        values = next(csv.reader([line]))
+        if len(values) != len(header):
+            continue
+        item = dict(zip(header, values))
+        rows.append(
+            AutoFactorRow(
+                rank=parse_int(item["rank"]),
+                name=item["name"],
+                target=item.get("target") or current_target,
+                decision=item["decision"],
+                reason=item["reason"],
+                n=parse_int(item["n"]),
+                spearman_ic=parse_float(item["spearman_ic"]),
+                pearson_ic=parse_float(item["pearson_ic"]),
+                window_count=parse_int(item["window_count"]),
+                icir=parse_float(item["icir"]),
+                positive_window_ratio=parse_float(item["positive_window_ratio"]),
+                monotonicity=parse_float(item["monotonicity"]),
+                top_bucket_avg_label=parse_float(item["top_bucket_avg_label"]),
+                top_bucket_positive_label_rate=parse_float(item["top_bucket_positive_label_rate"]),
+                complexity=parse_int(item["complexity"]),
+            )
+        )
+
+    return rows
+
+
+def load_runtime_mappings(path: str | None) -> dict[str, dict[str, str]]:
+    mappings = dict(BUILTIN_RUNTIME_MAPPINGS)
+    if not path:
+        return mappings
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    for name, value in payload.items():
+        if isinstance(value, dict):
+            mappings[name] = {str(k): str(v) for k, v in value.items()}
+    return mappings
+
+
+def evaluate(
+    report_text: str,
+    *,
+    allowed_targets: tuple[str, ...],
+    required_strategy_profile: str,
+    runtime_mappings: dict[str, dict[str, str]],
+) -> dict[str, Any]:
+    gate = parse_promotion_gate(report_text)
+    rows = parse_autofactor_rows(report_text)
+    evaluated: list[EvaluatedFactor] = []
+
+    for row in rows:
+        blockers: list[str] = []
+        if not gate.ready:
+            blockers.append("promotion_gate_not_ready")
+        if row.target not in allowed_targets:
+            blockers.append("target_not_allowed")
+        if row.decision != "candidate" or row.reason != "passed":
+            blockers.append(f"autofactor_not_candidate:{row.decision}:{row.reason}")
+        mapping = runtime_mappings.get(row.name)
+        if not mapping:
+            blockers.append("missing_runtime_strategy_mapping")
+        else:
+            mapped_profile = mapping.get("strategy_profile", "")
+            if not mapped_profile:
+                blockers.append("empty_runtime_strategy_profile")
+            elif mapped_profile != required_strategy_profile:
+                blockers.append(
+                    f"runtime_profile_mismatch:{mapped_profile}!={required_strategy_profile}"
+                )
+        evaluated.append(
+            EvaluatedFactor(
+                factor=row,
+                qualified=not blockers,
+                blockers=blockers,
+                runtime_mapping=mapping,
+            )
+        )
+
+    qualified = [item for item in evaluated if item.qualified]
+    return {
+        "schema_version": 1,
+        "decision": "qualified" if qualified else "blocked",
+        "required_strategy_profile": required_strategy_profile,
+        "allowed_targets": list(allowed_targets),
+        "promotion_gate": asdict(gate),
+        "qualified_strategies": [
+            {
+                "factor": asdict(item.factor),
+                "runtime_mapping": item.runtime_mapping,
+            }
+            for item in qualified
+        ],
+        "evaluated_factors": [
+            {
+                "factor": asdict(item.factor),
+                "qualified": item.qualified,
+                "blockers": item.blockers,
+                "runtime_mapping": item.runtime_mapping,
+            }
+            for item in evaluated
+        ],
+    }
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    lines = [
+        "# AutoFactor Strategy Promotion Report",
+        "",
+        f"Decision: `{result['decision']}`",
+        f"Required strategy profile: `{result['required_strategy_profile']}`",
+        f"Allowed targets: `{', '.join(result['allowed_targets'])}`",
+        "",
+        "## Promotion Gate",
+        "",
+        f"- Ready: `{str(result['promotion_gate']['ready']).lower()}`",
+        f"- Evidence: `{result['promotion_gate']['evidence']}`",
+        "",
+        "## Qualified Strategies",
+        "",
+    ]
+    if result["qualified_strategies"]:
+        lines.append("| factor | target | runtime profile | icir | top bucket pnl |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for item in result["qualified_strategies"]:
+            factor = item["factor"]
+            mapping = item["runtime_mapping"] or {}
+            lines.append(
+                "| {name} | {target} | {profile} | {icir:.6f} | {pnl:.6f} |".format(
+                    name=factor["name"],
+                    target=factor["target"],
+                    profile=mapping.get("strategy_profile", ""),
+                    icir=factor["icir"],
+                    pnl=factor["top_bucket_avg_label"],
+                )
+            )
+    else:
+        lines.append("No AutoFactor row qualifies for strategy handoff under the requested profile.")
+
+    lines.extend(["", "## Evaluated Factors", ""])
+    lines.append("| factor | target | decision | blockers |")
+    lines.append("| --- | --- | --- | --- |")
+    for item in result["evaluated_factors"]:
+        factor = item["factor"]
+        blockers = ", ".join(item["blockers"]) if item["blockers"] else "none"
+        lines.append(
+            f"| {factor['name']} | {factor['target']} | {factor['decision']} | {blockers} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", required=True, help="factor_walk_forward_v2 report.txt")
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--runtime-mapping-json", default="")
+    parser.add_argument(
+        "--allowed-target",
+        action="append",
+        default=[],
+        help="Allowed AutoFactor target. May be repeated.",
+    )
+    parser.add_argument("--required-strategy-profile", default="settlement_probability")
+    parser.add_argument("--fail-if-blocked", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report_text = Path(args.report).read_text(encoding="utf-8")
+    allowed_targets = tuple(args.allowed_target or DEFAULT_ALLOWED_TARGETS)
+    result = evaluate(
+        report_text,
+        allowed_targets=allowed_targets,
+        required_strategy_profile=args.required_strategy_profile,
+        runtime_mappings=load_runtime_mappings(args.runtime_mapping_json or None),
+    )
+
+    if args.output_json:
+        output = Path(args.output_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.output_md:
+        output = Path(args.output_md)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(render_markdown(result), encoding="utf-8")
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["decision"] == "qualified" or not args.fail_if_blocked else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,6 +104,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
 - [x] Only after the above gates pass, create a settlement dry-run handoff with
   fixed small stake, strict kill switch, and shared scorer parity. BTC/ETH-only
   dry-run handoff candidate is tracked in GitHub issue #332.
+- [x] Add an AutoFactor strategy-promotion evaluator so IC/ICIR candidate rows
+  cannot silently become dry-run strategies unless the surrounding PRD gate is
+  ready, the executable target is allowed, and the factor has an explicit
+  runtime strategy-profile mapping for the requested lane.
 
 ## Review
 
@@ -113,6 +117,18 @@ evidence comes from Polymarket full CLOB depth, not top book.
   shock, and mean reversion remain secondary research modules. The immediate
   next implementation slice is not another AutoFactor run or dry-run deploy; it
   is a settlement probability report over full-depth executable labels.
+- 2026-05-06: Added `scripts/evaluate_autofactor_strategy_promotion.py` and
+  `tests/test_autofactor_strategy_promotion.py` as the first automation bridge
+  from AutoFactor discovery to strategy handoff. The evaluator reads a
+  `factor_walk_forward_v2` report, checks
+  `ready_for_dry_run_handoff=true`, requires `decision=candidate` /
+  `reason=passed`, restricts the target to executable labels, and requires an
+  explicit runtime profile mapping. Running it on retained artifact
+  `25386935332` correctly reports `decision=blocked` for settlement promotion:
+  `spread_adjusted_external_move` is a strong AutoFactor candidate but maps to
+  `repricing_momentum`, not `settlement_probability`; `settlement_fair_edge`
+  remains rejected or lacks a runtime scorer. This converts the prior manual
+  explanation into a machine-readable gate.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -1,0 +1,114 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "evaluate_autofactor_strategy_promotion.py"
+
+
+READY_GATE = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+recorded_replay_parity,true,blocking_flags=<none>
+"""
+
+BLOCKED_GATE = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=0 event_complete_rows=0 replay_parity_ready=false
+gate,passed,evidence
+data_quality,false,mode=event_complete event_complete_events=0 event_complete_rows=0
+recorded_replay_parity,false,missing replay parity
+"""
+
+AUTOFACTOR_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable repricing PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,63255,0.112526,0.058830,54,0.948193,0.8889,0.5000,1.902254,0.6656,5
+2,settlement_fair_edge,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.208894,-0.007501,45,-2.321308,0.0222,0.5000,-2.981937,0.5035,1
+
+# AutoFactor target=full_depth_reprice_pnl_10s
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable repricing PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,spread_adjusted_external_move,full_depth_reprice_pnl_10s,candidate,passed,49789,0.327294,0.123771,40,3.301626,1.0000,0.5000,1.625037,0.5354,5
+"""
+
+
+class AutoFactorStrategyPromotionTests(unittest.TestCase):
+    def run_script(self, report, *extra_args, check=True):
+        with tempfile.TemporaryDirectory() as tmp:
+            report_path = Path(tmp) / "report.txt"
+            output_json = Path(tmp) / "promotion.json"
+            report_path.write_text(report, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--report",
+                    str(report_path),
+                    "--output-json",
+                    str(output_json),
+                    *extra_args,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=check,
+            )
+            payload = json.loads(output_json.read_text(encoding="utf-8"))
+            return result, payload
+
+    def test_blocks_candidate_when_runtime_profile_is_not_required_profile(self):
+        _, payload = self.run_script(READY_GATE + AUTOFACTOR_REPORT)
+
+        self.assertEqual(payload["decision"], "blocked")
+        spread = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "spread_adjusted_external_move"
+            and item["factor"]["target"] == "full_depth_settlement_executable_pnl"
+        )
+        self.assertIn(
+            "runtime_profile_mismatch:repricing_momentum!=settlement_probability",
+            spread["blockers"],
+        )
+
+    def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
+        _, payload = self.run_script(
+            READY_GATE + AUTOFACTOR_REPORT,
+            "--allowed-target",
+            "full_depth_reprice_pnl_10s",
+            "--required-strategy-profile",
+            "repricing_momentum",
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(
+            payload["qualified_strategies"][0]["factor"]["name"],
+            "spread_adjusted_external_move",
+        )
+
+    def test_blocks_when_promotion_gate_is_not_ready(self):
+        result, payload = self.run_script(
+            BLOCKED_GATE + AUTOFACTOR_REPORT,
+            "--allowed-target",
+            "full_depth_reprice_pnl_10s",
+            "--required-strategy-profile",
+            "repricing_momentum",
+            "--fail-if-blocked",
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 3)
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertIn("promotion_gate_not_ready", payload["evaluated_factors"][0]["blockers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds an AutoFactor strategy-promotion evaluator for factor_walk_forward_v2 reports
- blocks IC/ICIR candidates unless the PRD gate is ready, target is executable, and runtime strategy-profile mapping matches
- documents the new promotion gate in the event ML workflow and records the current retained-report outcome

## Evidence
- Current retained report 25386935332: PRD gate ready, AutoFactor settlement promotion blocked because spread_adjusted_external_move maps to repricing_momentum, not settlement_probability.

## Verification
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- git diff --check