### PR TITLE
Publish AutoFactor promotion artifacts from walk-forward

### DIFF
--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -468,6 +468,19 @@ jobs:
           ./target/release/examples/factor_walk_forward_v2 "${args[@]}" \
             | tee artifacts/factor-walk-forward-v2/report.txt
 
+      - name: Evaluate AutoFactor strategy promotion
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -f artifacts/factor-walk-forward-v2/report.txt ]; then
+            echo "No factor walk-forward report found; skipping AutoFactor strategy promotion evaluation."
+            exit 0
+          fi
+          python3 scripts/evaluate_autofactor_strategy_promotion.py \
+            --report artifacts/factor-walk-forward-v2/report.txt \
+            --output-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json \
+            --output-md artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md
+
       - name: Publish summary
         if: always()
         run: |
@@ -496,6 +509,10 @@ jobs:
               echo '```'
               sed -n '1,160p' artifacts/factor-walk-forward-v2/report.txt
               echo '```'
+            fi
+            if [ -f artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md ]; then
+              echo ""
+              cat artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -108,6 +108,9 @@ evidence comes from Polymarket full CLOB depth, not top book.
   cannot silently become dry-run strategies unless the surrounding PRD gate is
   ready, the executable target is allowed, and the factor has an explicit
   runtime strategy-profile mapping for the requested lane.
+- [x] Wire the AutoFactor strategy-promotion evaluator into
+  `factor-walk-forward-v2.yml` so every walk-forward artifact carries
+  `autofactor-strategy-promotion.{json,md}`.
 
 ## Review
 
@@ -129,6 +132,13 @@ evidence comes from Polymarket full CLOB depth, not top book.
   `repricing_momentum`, not `settlement_probability`; `settlement_fair_edge`
   remains rejected or lacks a runtime scorer. This converts the prior manual
   explanation into a machine-readable gate.
+- 2026-05-06: Wired the AutoFactor promotion evaluator into
+  `.github/workflows/factor-walk-forward-v2.yml`. Every Factor Walk-Forward V2
+  run now evaluates `report.txt` after generation and uploads
+  `autofactor-strategy-promotion.json` plus `.md` inside the existing artifact.
+  The GitHub step summary also includes the AutoFactor strategy-promotion
+  decision, so future research runs show whether mined factors are deployable
+  or blocked by target/profile/runtime-mapping gates.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary
- runs the AutoFactor strategy-promotion evaluator after factor_walk_forward_v2 produces report.txt
- uploads autofactor-strategy-promotion.json and .md in the existing factor-walk-forward artifact
- includes the AutoFactor promotion decision in the GitHub step summary

## Verification
- python3 YAML parse for .github/workflows/factor-walk-forward-v2.yml
- python3 -m unittest tests.test_autofactor_strategy_promotion
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- git diff --check