### PR TITLE
Emit AutoFactor promotion handoff artifacts

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -76,6 +76,8 @@ jobs:
             --report "${REPORT_PATH}"
             --output-json artifacts/autofactor-strategy-promotion/autofactor-strategy-promotion.json
             --output-md artifacts/autofactor-strategy-promotion/autofactor-strategy-promotion.md
+            --output-registry-json artifacts/autofactor-strategy-promotion/autofactor-factor-registry.json
+            --output-handoff-json artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json
             --required-strategy-profile "${{ github.event.inputs.required_strategy_profile }}"
             --allowed-target "${{ github.event.inputs.allowed_target }}"
           )

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -479,7 +479,9 @@ jobs:
           python3 scripts/evaluate_autofactor_strategy_promotion.py \
             --report artifacts/factor-walk-forward-v2/report.txt \
             --output-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json \
-            --output-md artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md
+            --output-md artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md \
+            --output-registry-json artifacts/factor-walk-forward-v2/autofactor-factor-registry.json \
+            --output-handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json
 
       - name: Publish summary
         if: always()

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -120,7 +120,9 @@ evaluator before creating any dry-run handoff:
 python3 scripts/evaluate_autofactor_strategy_promotion.py \
   --report /tmp/factor-walk-forward-v2/report.txt \
   --output-json /tmp/autofactor-strategy-promotion.json \
-  --output-md /tmp/autofactor-strategy-promotion.md
+  --output-md /tmp/autofactor-strategy-promotion.md \
+  --output-registry-json /tmp/autofactor-factor-registry.json \
+  --output-handoff-json /tmp/autofactor-strategy-handoff.json
 ```
 
 The evaluator requires all of the following:
@@ -138,6 +140,15 @@ wrong lane. For example, `spread_adjusted_external_move` can be a valid
 repricing candidate while still being blocked from settlement-probability
 promotion because its runtime mapping is `repricing_momentum`, not
 `settlement_probability`.
+
+The evaluator also emits two machine-readable downstream artifacts when the
+corresponding output paths are provided:
+
+- `autofactor-factor-registry.json`: every evaluated factor/target row, its
+  AutoFactor status, blockers, runtime mapping, and metrics.
+- `autofactor-strategy-handoff.json`: only qualified strategy rows. When no
+  row qualifies, this manifest is intentionally `status=blocked` and
+  `recommended_action=do_not_promote`.
 
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -78,6 +78,22 @@ class EvaluatedFactor:
     runtime_mapping: dict[str, str] | None
 
 
+def factor_metrics(row: AutoFactorRow) -> dict[str, Any]:
+    return {
+        "rank": row.rank,
+        "n": row.n,
+        "spearman_ic": row.spearman_ic,
+        "pearson_ic": row.pearson_ic,
+        "window_count": row.window_count,
+        "icir": row.icir,
+        "positive_window_ratio": row.positive_window_ratio,
+        "monotonicity": row.monotonicity,
+        "top_bucket_avg_label": row.top_bucket_avg_label,
+        "top_bucket_positive_label_rate": row.top_bucket_positive_label_rate,
+        "complexity": row.complexity,
+    }
+
+
 def parse_float(raw: str) -> float:
     try:
         return float(raw)
@@ -252,6 +268,66 @@ def evaluate(
     }
 
 
+def build_factor_registry(result: dict[str, Any]) -> dict[str, Any]:
+    entries = []
+    for item in result["evaluated_factors"]:
+        factor = item["factor"]
+        mapping = item["runtime_mapping"] or {}
+        entries.append(
+            {
+                "name": factor["name"],
+                "target": factor["target"],
+                "status": "qualified" if item["qualified"] else "blocked",
+                "autofactor_decision": factor["decision"],
+                "autofactor_reason": factor["reason"],
+                "blockers": item["blockers"],
+                "runtime_mapping": mapping,
+                "metrics": factor_metrics(AutoFactorRow(**factor)),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "kind": "autofactor_strategy_registry",
+        "decision": result["decision"],
+        "required_strategy_profile": result["required_strategy_profile"],
+        "allowed_targets": result["allowed_targets"],
+        "promotion_gate": result["promotion_gate"],
+        "entries": entries,
+    }
+
+
+def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
+    strategies = []
+    for item in result["qualified_strategies"]:
+        factor = item["factor"]
+        mapping = item["runtime_mapping"] or {}
+        strategies.append(
+            {
+                "name": factor["name"],
+                "target": factor["target"],
+                "strategy_profile": mapping.get("strategy_profile", ""),
+                "strategy_family": mapping.get("strategy_family", ""),
+                "runtime_score": mapping.get("runtime_score", ""),
+                "promotion_status": "ready_for_dry_run_handoff",
+                "metrics": factor_metrics(AutoFactorRow(**factor)),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "kind": "autofactor_strategy_handoff",
+        "status": "ready" if strategies else "blocked",
+        "recommended_action": "create_dry_run_handoff" if strategies else "do_not_promote",
+        "required_strategy_profile": result["required_strategy_profile"],
+        "allowed_targets": result["allowed_targets"],
+        "promotion_gate": result["promotion_gate"],
+        "strategies": strategies,
+        "blocked_factor_count": sum(
+            1 for item in result["evaluated_factors"] if not item["qualified"]
+        ),
+    }
+
+
 def render_markdown(result: dict[str, Any]) -> str:
     lines = [
         "# AutoFactor Strategy Promotion Report",
@@ -304,6 +380,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--report", required=True, help="factor_walk_forward_v2 report.txt")
     parser.add_argument("--output-json", default="")
     parser.add_argument("--output-md", default="")
+    parser.add_argument("--output-registry-json", default="")
+    parser.add_argument("--output-handoff-json", default="")
     parser.add_argument("--runtime-mapping-json", default="")
     parser.add_argument(
         "--allowed-target",
@@ -335,6 +413,20 @@ def main() -> int:
         output = Path(args.output_md)
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(render_markdown(result), encoding="utf-8")
+    if args.output_registry_json:
+        output = Path(args.output_registry_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(build_factor_registry(result), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_handoff_json:
+        output = Path(args.output_handoff_json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(build_strategy_handoff(result), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result["decision"] == "qualified" or not args.fail_if_blocked else 3

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -114,6 +114,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
 - [x] Add a hosted `autofactor-strategy-promotion.yml` workflow that can
   evaluate existing Factor Walk-Forward V2 artifacts without waiting for
   `ploy-ci-1`.
+- [x] Add machine-readable AutoFactor downstream artifacts:
+  `autofactor-factor-registry.json` for evaluated factor rows and
+  `autofactor-strategy-handoff.json` for qualified dry-run handoff rows. The
+  handoff manifest is deliberately `blocked` when no strategy qualifies, so
+  downstream automation cannot mistake a report-only candidate for a deployable
+  strategy.
 
 ## Review
 
@@ -149,6 +155,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   research runner is offline. It downloads `report.txt`, emits
   `autofactor-strategy-promotion.json` / `.md`, uploads them as a workflow
   artifact, and can comment the result back to a GitHub issue.
+- 2026-05-06: Extended AutoFactor strategy-promotion artifacts with a registry
+  and handoff manifest. The registry preserves every evaluated factor/target
+  row plus blockers and runtime mapping. The handoff manifest is the downstream
+  contract for dry-run automation: it contains only qualified strategy rows, or
+  a blocked/do-not-promote status when none qualify.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -45,6 +45,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             report_path = Path(tmp) / "report.txt"
             output_json = Path(tmp) / "promotion.json"
+            output_registry = Path(tmp) / "registry.json"
+            output_handoff = Path(tmp) / "handoff.json"
             report_path.write_text(report, encoding="utf-8")
             result = subprocess.run(
                 [
@@ -54,6 +56,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     str(report_path),
                     "--output-json",
                     str(output_json),
+                    "--output-registry-json",
+                    str(output_registry),
+                    "--output-handoff-json",
+                    str(output_handoff),
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -62,12 +68,17 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                 check=check,
             )
             payload = json.loads(output_json.read_text(encoding="utf-8"))
-            return result, payload
+            registry = json.loads(output_registry.read_text(encoding="utf-8"))
+            handoff = json.loads(output_handoff.read_text(encoding="utf-8"))
+            return result, payload, registry, handoff
 
     def test_blocks_candidate_when_runtime_profile_is_not_required_profile(self):
-        _, payload = self.run_script(READY_GATE + AUTOFACTOR_REPORT)
+        _, payload, registry, handoff = self.run_script(READY_GATE + AUTOFACTOR_REPORT)
 
         self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(registry["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        self.assertEqual(handoff["recommended_action"], "do_not_promote")
         spread = next(
             item
             for item in payload["evaluated_factors"]
@@ -80,7 +91,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
-        _, payload = self.run_script(
+        _, payload, registry, handoff = self.run_script(
             READY_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
             "full_depth_reprice_pnl_10s",
@@ -89,13 +100,20 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
 
         self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(handoff["recommended_action"], "create_dry_run_handoff")
+        self.assertEqual(
+            handoff["strategies"][0]["runtime_score"],
+            "spread_adjusted_external_move_score",
+        )
         self.assertEqual(
             payload["qualified_strategies"][0]["factor"]["name"],
             "spread_adjusted_external_move",
         )
 
     def test_blocks_when_promotion_gate_is_not_ready(self):
-        result, payload = self.run_script(
+        result, payload, _, handoff = self.run_script(
             BLOCKED_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
             "full_depth_reprice_pnl_10s",
@@ -107,6 +125,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 3)
         self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
         self.assertIn("promotion_gate_not_ready", payload["evaluated_factors"][0]["blockers"])
 
 


### PR DESCRIPTION
## Summary

- add machine-readable AutoFactor factor registry output
- add strategy handoff manifest output for qualified dry-run candidates or blocked/do-not-promote state
- wire both artifacts into factor-walk-forward-v2 and the hosted promotion workflow
- document the downstream artifact contract

## Verification

- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- ruby YAML parse for .github/workflows/autofactor-strategy-promotion.yml and .github/workflows/factor-walk-forward-v2.yml
- git diff --check
- local retained-report evaluator run emitted blocked handoff manifest with 21 blocked factor rows and no strategies
