### PR TITLE
Emit AutoFactor dry-run handoff draft

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -78,6 +78,7 @@ jobs:
             --output-md artifacts/autofactor-strategy-promotion/autofactor-strategy-promotion.md
             --output-registry-json artifacts/autofactor-strategy-promotion/autofactor-factor-registry.json
             --output-handoff-json artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json
+            --output-handoff-md artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.md
             --required-strategy-profile "${{ github.event.inputs.required_strategy_profile }}"
             --allowed-target "${{ github.event.inputs.allowed_target }}"
           )

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -481,7 +481,8 @@ jobs:
             --output-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json \
             --output-md artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md \
             --output-registry-json artifacts/factor-walk-forward-v2/autofactor-factor-registry.json \
-            --output-handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json
+            --output-handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json \
+            --output-handoff-md artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.md
 
       - name: Publish summary
         if: always()

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -122,7 +122,8 @@ python3 scripts/evaluate_autofactor_strategy_promotion.py \
   --output-json /tmp/autofactor-strategy-promotion.json \
   --output-md /tmp/autofactor-strategy-promotion.md \
   --output-registry-json /tmp/autofactor-factor-registry.json \
-  --output-handoff-json /tmp/autofactor-strategy-handoff.json
+  --output-handoff-json /tmp/autofactor-strategy-handoff.json \
+  --output-handoff-md /tmp/autofactor-strategy-handoff.md
 ```
 
 The evaluator requires all of the following:
@@ -149,6 +150,9 @@ corresponding output paths are provided:
 - `autofactor-strategy-handoff.json`: only qualified strategy rows. When no
   row qualifies, this manifest is intentionally `status=blocked` and
   `recommended_action=do_not_promote`.
+- `autofactor-strategy-handoff.md`: a dry-run handoff issue/config draft only
+  when the handoff is ready. In blocked runs it explicitly says no dry-run
+  handoff issue or config should be created.
 
 Factor Walk-Forward V2 also includes a constrained settlement-native generator
 for the `full_depth_settlement_executable_pnl` target. It automatically expands

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -328,6 +328,89 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def render_handoff_markdown(handoff: dict[str, Any]) -> str:
+    lines = [
+        "# AutoFactor Dry-Run Strategy Handoff",
+        "",
+        f"Status: `{handoff['status']}`",
+        f"Recommended action: `{handoff['recommended_action']}`",
+        f"Required strategy profile: `{handoff['required_strategy_profile']}`",
+        f"Allowed targets: `{', '.join(handoff['allowed_targets'])}`",
+        "",
+    ]
+    if handoff["status"] != "ready":
+        lines.extend(
+            [
+                "No dry-run handoff issue or config should be created from this artifact.",
+                "",
+                f"Blocked factor count: `{handoff['blocked_factor_count']}`",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "## Draft Issue",
+            "",
+            "Title: Promote AutoFactor strategy handoff to dry-run",
+            "",
+            "## Qualified Strategies",
+            "",
+            "| factor | target | strategy profile | runtime score | icir | top bucket pnl |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for strategy in handoff["strategies"]:
+        metrics = strategy["metrics"]
+        lines.append(
+            "| {name} | {target} | {profile} | {runtime_score} | {icir:.6f} | {pnl:.6f} |".format(
+                name=strategy["name"],
+                target=strategy["target"],
+                profile=strategy["strategy_profile"],
+                runtime_score=strategy["runtime_score"],
+                icir=metrics["icir"],
+                pnl=metrics["top_bucket_avg_label"],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Dry-Run Config Contract",
+            "",
+            "```toml",
+        ]
+    )
+    for idx, strategy in enumerate(handoff["strategies"], start=1):
+        lines.extend(
+            [
+                f"[[autofactor_strategy_handoff]] # {idx}",
+                f'name = "{strategy["name"]}"',
+                f'target = "{strategy["target"]}"',
+                f'strategy_profile = "{strategy["strategy_profile"]}"',
+                f'strategy_family = "{strategy["strategy_family"]}"',
+                f'runtime_score = "{strategy["runtime_score"]}"',
+                'promotion_status = "ready_for_dry_run_handoff"',
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "```",
+            "",
+            "## Acceptance Criteria",
+            "",
+            "- Confirm the runtime score is implemented in the shared scorer.",
+            "- Confirm the dry-run config uses the same full-depth execution gates as research.",
+            "- Confirm replay parity remains ready for the source report.",
+            "- Start with small fixed stake and the existing kill switch.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def render_markdown(result: dict[str, Any]) -> str:
     lines = [
         "# AutoFactor Strategy Promotion Report",
@@ -382,6 +465,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-md", default="")
     parser.add_argument("--output-registry-json", default="")
     parser.add_argument("--output-handoff-json", default="")
+    parser.add_argument("--output-handoff-md", default="")
     parser.add_argument("--runtime-mapping-json", default="")
     parser.add_argument(
         "--allowed-target",
@@ -413,6 +497,7 @@ def main() -> int:
         output = Path(args.output_md)
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(render_markdown(result), encoding="utf-8")
+    handoff = build_strategy_handoff(result)
     if args.output_registry_json:
         output = Path(args.output_registry_json)
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -424,9 +509,13 @@ def main() -> int:
         output = Path(args.output_handoff_json)
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(
-            json.dumps(build_strategy_handoff(result), indent=2, sort_keys=True) + "\n",
+            json.dumps(handoff, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+    if args.output_handoff_md:
+        output = Path(args.output_handoff_md)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(render_handoff_markdown(handoff), encoding="utf-8")
 
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result["decision"] == "qualified" or not args.fail_if_blocked else 3

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -126,6 +126,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   candidates with near-strike, capacity, spread, external-pressure, and
   short-IV-change interactions. These generated rows remain discovery evidence
   until the promotion evaluator and runtime mapping gates qualify them.
+- [x] Add `autofactor-strategy-handoff.md` as the human handoff draft paired
+  with the machine-readable handoff JSON. Ready handoffs include a dry-run issue
+  and config-contract draft; blocked handoffs explicitly say no dry-run handoff
+  issue/config should be created.
 
 ## Review
 
@@ -172,6 +176,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   and conservative settlement edge, near-strike state, entry capacity, spread,
   external pressure, and IV change. Repricing targets intentionally do not
   receive these generated settlement candidates.
+- 2026-05-06: Extended the AutoFactor promotion evaluator with
+  `autofactor-strategy-handoff.md`. This gives downstream automation a
+  fail-closed handoff artifact: blocked runs produce a no-handoff message,
+  while qualified runs produce a dry-run issue/config-contract draft from the
+  same strategy rows as `autofactor-strategy-handoff.json`.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -47,6 +47,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             output_json = Path(tmp) / "promotion.json"
             output_registry = Path(tmp) / "registry.json"
             output_handoff = Path(tmp) / "handoff.json"
+            output_handoff_md = Path(tmp) / "handoff.md"
             report_path.write_text(report, encoding="utf-8")
             result = subprocess.run(
                 [
@@ -60,6 +61,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     str(output_registry),
                     "--output-handoff-json",
                     str(output_handoff),
+                    "--output-handoff-md",
+                    str(output_handoff_md),
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -70,15 +73,19 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             payload = json.loads(output_json.read_text(encoding="utf-8"))
             registry = json.loads(output_registry.read_text(encoding="utf-8"))
             handoff = json.loads(output_handoff.read_text(encoding="utf-8"))
-            return result, payload, registry, handoff
+            handoff_md = output_handoff_md.read_text(encoding="utf-8")
+            return result, payload, registry, handoff, handoff_md
 
     def test_blocks_candidate_when_runtime_profile_is_not_required_profile(self):
-        _, payload, registry, handoff = self.run_script(READY_GATE + AUTOFACTOR_REPORT)
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_REPORT
+        )
 
         self.assertEqual(payload["decision"], "blocked")
         self.assertEqual(registry["decision"], "blocked")
         self.assertEqual(handoff["status"], "blocked")
         self.assertEqual(handoff["recommended_action"], "do_not_promote")
+        self.assertIn("No dry-run handoff issue or config", handoff_md)
         spread = next(
             item
             for item in payload["evaluated_factors"]
@@ -91,7 +98,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
-        _, payload, registry, handoff = self.run_script(
+        _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
             "full_depth_reprice_pnl_10s",
@@ -107,13 +114,15 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             handoff["strategies"][0]["runtime_score"],
             "spread_adjusted_external_move_score",
         )
+        self.assertIn("Promote AutoFactor strategy handoff to dry-run", handoff_md)
+        self.assertIn("spread_adjusted_external_move_score", handoff_md)
         self.assertEqual(
             payload["qualified_strategies"][0]["factor"]["name"],
             "spread_adjusted_external_move",
         )
 
     def test_blocks_when_promotion_gate_is_not_ready(self):
-        result, payload, _, handoff = self.run_script(
+        result, payload, _, handoff, _ = self.run_script(
             BLOCKED_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
             "full_depth_reprice_pnl_10s",


### PR DESCRIPTION
## Summary

- add `autofactor-strategy-handoff.md` alongside the handoff JSON
- render blocked runs as explicit no-handoff/no-config artifacts
- render qualified runs as a dry-run issue and config-contract draft from the same qualified strategy rows
- wire the markdown handoff artifact into both AutoFactor promotion workflows

## Verification

- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- ruby YAML parse for .github/workflows/autofactor-strategy-promotion.yml and .github/workflows/factor-walk-forward-v2.yml
- git diff --check
- retained-report evaluator run emitted blocked no-handoff markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AutoFactor strategy promotion now generates human-readable Markdown handoff artifacts in addition to existing JSON outputs for improved accessibility.

* **Documentation**
  * Updated workflow documentation to describe the new Markdown handoff artifact output format and behavior for ready and blocked runs.

* **Tests**
  * Expanded test coverage to validate Markdown handoff generation, content accuracy, and behavior across different run scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->