### PR TITLE
Create AutoFactor handoff issues only when ready

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -26,6 +26,10 @@ on:
         description: "Optional issue number for the promotion summary"
         required: false
         default: ""
+      create_handoff_issue:
+        description: "Create a dry-run handoff issue when autofactor-strategy-handoff.json is ready"
+        required: false
+        default: "false"
       fail_if_blocked:
         description: "Fail workflow when no AutoFactor strategy qualifies"
         required: false
@@ -148,3 +152,35 @@ jobs:
               issue_number,
               body
             });
+
+      - name: Create ready handoff issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CREATE_HANDOFF_ISSUE: ${{ github.event.inputs.create_handoff_issue }}
+        run: |
+          set -euo pipefail
+          if [ "${CREATE_HANDOFF_ISSUE}" != "true" ]; then
+            echo "create_handoff_issue is not true; skipping handoff issue creation."
+            exit 0
+          fi
+          handoff_json="artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json"
+          handoff_md="artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.md"
+          if [ ! -f "${handoff_json}" ] || [ ! -f "${handoff_md}" ]; then
+            echo "Handoff artifacts missing; skipping issue creation."
+            exit 0
+          fi
+          status="$(python3 - <<'PY'
+          import json
+          with open("artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json", encoding="utf-8") as handle:
+              print(json.load(handle).get("status", "blocked"))
+          PY
+          )"
+          if [ "${status}" != "ready" ]; then
+            echo "Handoff status is ${status}; no dry-run issue will be created."
+            exit 0
+          fi
+          title="Promote AutoFactor strategy handoff to dry-run"
+          gh issue create \
+            --title "${title}" \
+            --body-file "${handoff_md}"

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -177,6 +177,11 @@ This downloads `factor-walk-forward-v2-<run-id>`, runs the same evaluator on
 `report.txt`, uploads `autofactor-strategy-promotion-<run-id>` artifacts, and
 can optionally comment on a research issue.
 
+The hosted workflow also has a fail-closed `create_handoff_issue` input. Leave
+it `false` for diagnostics. When set to `true`, the workflow creates a dry-run
+handoff issue only if `autofactor-strategy-handoff.json` reports
+`status=ready`; blocked handoffs are logged and skipped.
+
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -130,6 +130,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   with the machine-readable handoff JSON. Ready handoffs include a dry-run issue
   and config-contract draft; blocked handoffs explicitly say no dry-run handoff
   issue/config should be created.
+- [x] Add optional ready-only dry-run handoff issue creation to the hosted
+  AutoFactor promotion workflow. The `create_handoff_issue` input defaults to
+  `false`; when enabled, it creates an issue only if the handoff JSON is
+  `status=ready`.
 
 ## Review
 
@@ -181,6 +185,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   fail-closed handoff artifact: blocked runs produce a no-handoff message,
   while qualified runs produce a dry-run issue/config-contract draft from the
   same strategy rows as `autofactor-strategy-handoff.json`.
+- 2026-05-06: Extended the hosted `autofactor-strategy-promotion.yml` workflow
+  with optional ready-only handoff issue creation. Diagnostics remain the
+  default; when `create_handoff_issue=true`, the workflow reads
+  `autofactor-strategy-handoff.json` and creates a dry-run handoff issue only
+  for `status=ready`, skipping blocked reports.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary

- add a `create_handoff_issue` input to the hosted AutoFactor promotion workflow
- default issue creation to off for diagnostics
- create a dry-run handoff issue only when `autofactor-strategy-handoff.json` is `status=ready`
- document the fail-closed issue creation contract

## Verification

- ruby YAML parse for .github/workflows/autofactor-strategy-promotion.yml
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- git diff --check