### PR TITLE
Map settlement AutoFactors to handoff profiles

### DIFF
--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -161,6 +161,12 @@ formula candidates with near-strike, capacity, spread, external-pressure, and
 short-IV-change interactions. These rows are still discovery evidence only:
 they must pass the same promotion evaluator and runtime mapping gates before
 becoming a dry-run handoff.
+The built-in promotion evaluator maps the generated `auto_settlement_*`
+formula family to the `settlement_probability` strategy profile with
+`autofactor_formula:<factor_name>` runtime score identifiers. That mapping only
+removes the profile/mapping blocker; it does not override the PRD promotion
+gate. Recorded replay parity and the other settlement gates must still be
+ready before a handoff issue/config is created.
 
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -25,6 +25,11 @@ from typing import Any
 
 DEFAULT_ALLOWED_TARGETS = ("full_depth_settlement_executable_pnl",)
 
+SETTLEMENT_RUNTIME_MAPPING = {
+    "strategy_profile": "settlement_probability",
+    "strategy_family": "settlement_probability",
+}
+
 BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
     "spread_adjusted_external_move": {
         "strategy_profile": "repricing_momentum",
@@ -40,6 +45,62 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
         "strategy_profile": "",
         "strategy_family": "settlement_probability",
         "runtime_score": "",
+    },
+    "auto_settlement_full_depth_settlement_edge": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_near_strike": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_capacity": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_capacity",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity",
+    },
+    "auto_settlement_full_depth_settlement_edge_spread_adjusted": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_spread_adjusted",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_external_pressure": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_external_pressure",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_iv_change": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_iv_change",
+    },
+    "auto_settlement_conservative_settlement_edge": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+    },
+    "auto_settlement_conservative_settlement_edge_x_near_strike": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+    },
+    "auto_settlement_conservative_settlement_edge_x_capacity": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_capacity",
+    },
+    "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity",
+    },
+    "auto_settlement_conservative_settlement_edge_spread_adjusted": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_spread_adjusted",
+    },
+    "auto_settlement_conservative_settlement_edge_x_external_pressure": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_external_pressure",
+    },
+    "auto_settlement_conservative_settlement_edge_x_iv_change": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_iv_change",
     },
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -140,6 +140,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   it does not access the DB, does not compile a fresh snapshot, and fails fast
   when the artifact contains only provenance instead of the full snapshot
   payload.
+- [x] Add built-in runtime strategy-profile mappings for the settlement-native
+  `auto_settlement_*` formula factors so candidates that pass the
+  `full_depth_settlement_executable_pnl` target can reach the handoff contract
+  once the surrounding PRD gate, including recorded replay parity, is ready.
 
 ## Review
 
@@ -202,6 +206,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   the manifest plus full payload files, builds only `factor_walk_forward_v2`,
   runs the same snapshot-backed report and AutoFactor promotion evaluator, and
   preserves the ready-only dry-run handoff issue guard.
+- 2026-05-06: Added runtime mapping coverage for the generated
+  `auto_settlement_*` factors in the AutoFactor promotion evaluator. Re-running
+  the evaluator locally on hosted run `25409441265` now shows the qualifying
+  settlement-native candidates are blocked only by `promotion_gate_not_ready`
+  instead of missing runtime mappings; the remaining hard blocker is recorded
+  replay parity evidence.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -39,6 +39,16 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 1,spread_adjusted_external_move,full_depth_reprice_pnl_10s,candidate,passed,49789,0.327294,0.123771,40,3.301626,1.0000,0.5000,1.625037,0.5354,5
 """
 
+AUTOFACTOR_SETTLEMENT_AUTO_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,1.0000,2.666226,0.6836,1
+2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,1.0000,2.631575,0.6790,3
+3,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,0.5000,-0.301991,0.4785,3
+"""
+
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
     def run_script(self, report, *extra_args, check=True):
@@ -96,6 +106,44 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "runtime_profile_mismatch:repricing_momentum!=settlement_probability",
             spread["blockers"],
         )
+        fair_edge = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "settlement_fair_edge"
+            and item["factor"]["target"] == "full_depth_settlement_executable_pnl"
+        )
+        self.assertIn("autofactor_not_candidate:reject:nonpositive_rank_ic", fair_edge["blockers"])
+        self.assertIn("empty_runtime_strategy_profile", fair_edge["blockers"])
+
+    def test_qualifies_settlement_native_auto_factors_when_gate_is_ready(self):
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(handoff["blocked_factor_count"], 1)
+        self.assertEqual(len(handoff["strategies"]), 2)
+        self.assertEqual(
+            handoff["strategies"][0]["runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+        self.assertEqual(
+            handoff["strategies"][0]["strategy_profile"],
+            "settlement_probability",
+        )
+        self.assertIn(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            handoff_md,
+        )
+        rejected = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "auto_settlement_full_depth_settlement_edge_x_external_pressure"
+        )
+        self.assertFalse(rejected["qualified"])
+        self.assertIn("autofactor_not_candidate:reject:nonpositive_rank_ic", rejected["blockers"])
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
         _, payload, registry, handoff, handoff_md = self.run_script(


### PR DESCRIPTION
## Summary
- add explicit settlement_probability runtime mappings for generated auto_settlement_* formula factors
- keep repricing factors and rejected settlement_fair_edge blocked from settlement promotion
- document that mapping removes only the runtime-mapping blocker; replay parity and PRD gates still decide handoff readiness

## Verification
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- YAML parse for factor-walk-forward-v2-hosted-artifact.yml and autofactor-strategy-promotion.yml
- local evaluator replay on hosted report 25409441265 shows auto_settlement candidates now blocked only by promotion_gate_not_ready
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced AutoFactor Strategy Promotion Gate documentation with clearer explanation of settlement-related runtime mapping identifiers and promotion gate conditions.

* **Tests**
  * Expanded test coverage for settlement-focused AutoFactor scenarios, validating blocker conditions, ranking metrics, and runtime profile requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->