### PR TITLE
Route settlement PRD gates through hosted snapshots

### DIFF
--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -21,6 +21,10 @@ on:
         description: "Fixed notional used by executable labels"
         required: true
         default: "15"
+      snapshot_run_id:
+        description: "Existing run id with a full research-snapshot artifact; skips legacy ploy-ci-1 snapshot build"
+        required: false
+        default: ""
       issue_number:
         description: "Issue number for posting gate evidence; leave empty to skip comments"
         required: false
@@ -33,12 +37,8 @@ on:
         description: "Optional Replay Dry-run Parity run id"
         required: false
         default: ""
-      replay_parity_artifact_name:
-        description: "Optional replay parity artifact name; defaults to replay-dryrun-parity-<run-id>"
-        required: false
-        default: ""
       no_wait:
-        description: "Dispatch the strict snapshot only and return"
+        description: "Dispatch the next evidence workflow and return"
         required: true
         default: "false"
         type: boolean
@@ -70,9 +70,9 @@ jobs:
           END_DATE: ${{ github.event.inputs.end_date }}
           SYMBOLS: ${{ github.event.inputs.symbols }}
           STAKE_USD: ${{ github.event.inputs.stake_usd }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
           ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
           REPLAY_PARITY_RUN_ID: ${{ github.event.inputs.replay_parity_run_id }}
-          REPLAY_PARITY_ARTIFACT_NAME: ${{ github.event.inputs.replay_parity_artifact_name }}
           NO_WAIT: ${{ github.event.inputs.no_wait }}
         run: |
           set -euo pipefail
@@ -99,11 +99,11 @@ jobs:
             --audit-lookback-hours "${audit_lookback_hours}"
             --data-quality-mode "${data_quality_mode}"
           )
+          if [ -n "${SNAPSHOT_RUN_ID}" ]; then
+            args+=(--snapshot-run-id "${SNAPSHOT_RUN_ID}")
+          fi
           if [ -n "${REPLAY_PARITY_RUN_ID}" ]; then
             args+=(--replay-parity-run-id "${REPLAY_PARITY_RUN_ID}")
-          fi
-          if [ -n "${REPLAY_PARITY_ARTIFACT_NAME}" ]; then
-            args+=(--replay-parity-artifact-name "${REPLAY_PARITY_ARTIFACT_NAME}")
           fi
           if [ "${NO_WAIT}" = "true" ]; then
             args+=(--no-wait)
@@ -120,6 +120,8 @@ jobs:
             echo "- Window: \`${{ github.event.inputs.start_date }}..${{ github.event.inputs.end_date }}\`"
             echo "- Symbols: \`${{ github.event.inputs.symbols }}\`"
             echo "- Stake: \`${{ github.event.inputs.stake_usd }}u\`"
+            echo "- Snapshot source run: \`${{ github.event.inputs.snapshot_run_id || 'legacy-build' }}\`"
+            echo "- Walk-forward runner: \`ubuntu-latest\` via \`factor-walk-forward-v2-hosted-artifact.yml\`"
             audit_lookback_hours="${{ github.event.inputs.audit_lookback_hours }}"
             data_quality_mode="strict-continuous"
             case "${audit_lookback_hours}" in
@@ -143,7 +145,7 @@ jobs:
             echo "- Data profile: \`pm5d-vol\`"
             echo "- Audit lookback: \`${audit_lookback_hours}h\`"
             echo "- Replay parity run: \`${{ github.event.inputs.replay_parity_run_id || 'none' }}\`"
-            echo "- Replay parity artifact: \`${{ github.event.inputs.replay_parity_artifact_name || 'default' }}\`"
+            echo "- Replay parity artifact: \`default\`"
             echo ""
             echo "A failed workflow can be the correct outcome: the orchestrator exits non-zero when the PRD promotion gate is blocked."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -217,6 +217,28 @@ within the GitHub Actions 10-input limit. Defaults are
 `allowed_target=full_depth_settlement_executable_pnl`,
 `create_handoff_issue=false`, and `fail_if_blocked=false`.
 
+For the full settlement-probability PRD gate, prefer passing an existing full
+snapshot artifact into the orchestrator so downstream AutoFactor mining and
+promotion run on GitHub-hosted runners:
+
+```bash
+gh workflow run settlement-probability-prd-gate.yml \
+  -f git_ref=main \
+  -f snapshot_run_id=<full-snapshot-run-id> \
+  -f start_date=2026-05-01 \
+  -f end_date=2026-05-05 \
+  -f symbols=BTCUSDT,ETHUSDT \
+  -f stake_usd=15 \
+  -f audit_lookback_hours=168:event-complete \
+  -f replay_parity_run_id=<optional-replay-parity-run-id>
+```
+
+With `snapshot_run_id` set, the gate skips the legacy `ploy-ci-1` snapshot
+build and dispatches `factor-walk-forward-v2-hosted-artifact.yml` on
+`ubuntu-latest`. If `snapshot_run_id` is omitted, the orchestrator still falls
+back to `research-snapshot.yml`; that path remains a legacy DB-adjacent path
+until snapshot export is moved to a hosted-safe data source.
+
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.
 

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -185,11 +185,17 @@ different.
   (`TANGO_1_1_KNOWN_HOSTS` and `PLOY_TRADE_1_KNOWN_HOSTS`). Entries should be
   keyed by the workflow aliases `tango-1-1` and `ploy-trade-1` because the deploy
   SSH config sets `HostKeyAlias`.
-- Remote data and heavy research belong on `ploy-ci-1`, `tango-1-1`, ACK, or
-  CI-built artifacts, not local PostgreSQL assumptions.
-- `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub Actions
-  secrets `PLOY_RESEARCH_DATABASE_URL` and `PLOY_DB_URL`; verify the private
-  endpoint with Aliyun CLI before changing those secrets.
+- Artifact-backed PM5D/PM15D research should default to GitHub-hosted runners.
+  Use `factor-walk-forward-v2-hosted-artifact.yml` directly, or
+  `settlement-probability-prd-gate.yml` with `snapshot_run_id`, when a retained
+  full research snapshot artifact already exists.
+- `ploy-ci-1` is now a legacy DB-adjacent fallback for compiling fresh research
+  snapshots from Tango PostgreSQL. Do not route AutoFactor mining,
+  walk-forward promotion, or dry-run handoff checks to `ploy-ci-1` when a full
+  snapshot artifact can be reused on `ubuntu-latest`.
+- Legacy `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub
+  Actions secrets `PLOY_RESEARCH_DATABASE_URL` and `PLOY_DB_URL`; verify the
+  private endpoint with Aliyun CLI before changing those secrets.
 - DB-mode research workflows must fail closed unless the research database URL
   targets Tango's private VPC endpoint `172.16.0.204`. A public Tango endpoint
   can turn large backtest query results into billable公网出流量.

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -3,8 +3,11 @@
 
 The default gate is intentionally strict:
 
-1. Build a portable pm5d-vol research snapshot with a critical data audit.
-2. Feed that snapshot into Factor Walk-Forward V2.
+1. Reuse a retained full research snapshot artifact when --snapshot-run-id is
+   supplied, or build a portable pm5d-vol research snapshot as a legacy
+   fallback.
+2. Feed that snapshot artifact into the GitHub-hosted Factor Walk-Forward V2
+   artifact workflow.
 3. Optionally attach a replay/dry-run parity artifact to the promotion gate.
 
 For PM 5m/15m event research, use --data-quality-mode event-complete when a
@@ -32,7 +35,7 @@ from typing import Any
 
 
 RESEARCH_SNAPSHOT_WORKFLOW = "research-snapshot.yml"
-WALK_FORWARD_WORKFLOW = "factor-walk-forward-v2.yml"
+HOSTED_WALK_FORWARD_WORKFLOW = "factor-walk-forward-v2-hosted-artifact.yml"
 
 
 @dataclass(frozen=True)
@@ -257,6 +260,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end-date", required=True, help="Research window end date, YYYY-MM-DD")
     parser.add_argument("--symbols", default="BTCUSDT,ETHUSDT,SOLUSDT")
     parser.add_argument("--stake-usd", default="15")
+    parser.add_argument(
+        "--snapshot-run-id",
+        default="",
+        help=(
+            "Existing workflow run id that owns a full research-snapshot artifact. "
+            "When supplied, skip the legacy ploy-ci-1 snapshot workflow and run "
+            "the hosted artifact-only walk-forward path."
+        ),
+    )
+    parser.add_argument(
+        "--snapshot-artifact-name",
+        default="",
+        help="Optional snapshot artifact name; defaults to research-snapshot-<snapshot-run-id>",
+    )
     parser.add_argument("--issue-number", default="321")
     parser.add_argument("--audit-lookback-hours", default="168")
     parser.add_argument(
@@ -292,70 +309,79 @@ def main() -> int:
     rust_data_quality_mode = args.data_quality_mode.replace("-", "_")
     snapshot_data_gate = "critical" if args.data_quality_mode == "strict-continuous" else "never"
 
-    snapshot_options = {
-        "lob_sample_secs": int(args.lob_sample_secs),
-        "observation_sample_secs": int(args.observation_sample_secs),
-        "max_quote_age_secs": int(args.max_quote_age_secs),
-        "optimizer_data_dir": "/tmp/ploy-parquet",
-        "data_profile": "pm5d-vol",
-        "custom_required_sources": "",
-        "audit_lookback_hours": int(args.audit_lookback_hours),
-        "data_gate": snapshot_data_gate,
-        "snapshot_registry_dir": "",
-        "upload_full_snapshot": True,
-    }
-    snapshot_fields = {
-        "git_ref": git_ref,
-        "start_date": args.start_date,
-        "end_date": args.end_date,
-        "symbols": args.symbols,
-        "stake_usd": args.stake_usd,
-        "options_json": compact_json(snapshot_options),
-    }
-
-    print(
-        f"Dispatching pm5d-vol research snapshot gate data_quality_mode={args.data_quality_mode} "
-        f"snapshot_data_gate={snapshot_data_gate}.",
-        flush=True,
-    )
-    snapshot_run = dispatch_workflow(
-        RESEARCH_SNAPSHOT_WORKFLOW,
-        snapshot_fields,
-        workflow_ref=git_ref,
-        dry_run=args.dry_run,
-    )
-    if args.dry_run:
-        return 0
-    if snapshot_run is None:
-        raise RuntimeError("snapshot dispatch did not return a run")
-    print(f"snapshot_run_id={snapshot_run.database_id} url={snapshot_run.url}", flush=True)
-    if args.no_wait:
-        return 0
-
-    snapshot_result = wait_for_run(
-        snapshot_run,
-        timeout_minutes=args.snapshot_timeout_minutes,
-        poll_seconds=args.poll_seconds,
-    )
-    if snapshot_result.conclusion != "success":
-        issue_comment(
-            args.issue_number,
-            "\n".join(
-                [
-                    "Settlement probability PRD gate blocked at strict snapshot:",
-                    "",
-                    f"- Snapshot run: {snapshot_result.url}",
-                    f"- Conclusion: `{snapshot_result.conclusion}`",
-                    f"- Data profile: `pm5d-vol`",
-                    f"- Data quality mode: `{args.data_quality_mode}`",
-                    f"- Snapshot data gate: `{snapshot_data_gate}`",
-                    f"- Lookback: `{args.audit_lookback_hours}h`",
-                    "- Decision: inspect snapshot compilation/data coverage before promotion.",
-                ]
-            ),
-            dry_run=False,
+    if args.snapshot_run_id:
+        snapshot_result = refresh_run(int(args.snapshot_run_id))
+        print(
+            "Using existing full research snapshot artifact "
+            f"snapshot_run_id={snapshot_result.database_id} url={snapshot_result.url}.",
+            flush=True,
         )
-        return 1
+    else:
+        snapshot_options = {
+            "lob_sample_secs": int(args.lob_sample_secs),
+            "observation_sample_secs": int(args.observation_sample_secs),
+            "max_quote_age_secs": int(args.max_quote_age_secs),
+            "optimizer_data_dir": "/tmp/ploy-parquet",
+            "data_profile": "pm5d-vol",
+            "custom_required_sources": "",
+            "audit_lookback_hours": int(args.audit_lookback_hours),
+            "data_gate": snapshot_data_gate,
+            "snapshot_registry_dir": "",
+            "upload_full_snapshot": True,
+        }
+        snapshot_fields = {
+            "git_ref": git_ref,
+            "start_date": args.start_date,
+            "end_date": args.end_date,
+            "symbols": args.symbols,
+            "stake_usd": args.stake_usd,
+            "options_json": compact_json(snapshot_options),
+        }
+
+        print(
+            "No snapshot_run_id supplied; dispatching legacy pm5d-vol research "
+            f"snapshot gate data_quality_mode={args.data_quality_mode} "
+            f"snapshot_data_gate={snapshot_data_gate}.",
+            flush=True,
+        )
+        snapshot_run = dispatch_workflow(
+            RESEARCH_SNAPSHOT_WORKFLOW,
+            snapshot_fields,
+            workflow_ref=git_ref,
+            dry_run=args.dry_run,
+        )
+        if args.dry_run:
+            return 0
+        if snapshot_run is None:
+            raise RuntimeError("snapshot dispatch did not return a run")
+        print(f"snapshot_run_id={snapshot_run.database_id} url={snapshot_run.url}", flush=True)
+        if args.no_wait:
+            return 0
+
+        snapshot_result = wait_for_run(
+            snapshot_run,
+            timeout_minutes=args.snapshot_timeout_minutes,
+            poll_seconds=args.poll_seconds,
+        )
+        if snapshot_result.conclusion != "success":
+            issue_comment(
+                args.issue_number,
+                "\n".join(
+                    [
+                        "Settlement probability PRD gate blocked at legacy snapshot build:",
+                        "",
+                        f"- Snapshot run: {snapshot_result.url}",
+                        f"- Conclusion: `{snapshot_result.conclusion}`",
+                        f"- Data profile: `pm5d-vol`",
+                        f"- Data quality mode: `{args.data_quality_mode}`",
+                        f"- Snapshot data gate: `{snapshot_data_gate}`",
+                        f"- Lookback: `{args.audit_lookback_hours}h`",
+                        "- Decision: provide an existing full snapshot artifact or inspect snapshot compilation/data coverage before promotion.",
+                    ]
+                ),
+                dry_run=False,
+            )
+            return 1
 
     walk_options = {
         "train_window_days": int(args.train_window_days),
@@ -368,42 +394,43 @@ def main() -> int:
         "min_observations": int(args.min_observations),
         "top_quantile": float(args.top_quantile),
         "factor_name_filter": "",
-        "compile_snapshot": False,
-        "allow_direct_db_debug": False,
-        "optimizer_data_dir": "/tmp/ploy-parquet",
-        "data_profile": "pm5d-vol",
-        "custom_required_sources": "",
-        "audit_lookback_hours": int(args.audit_lookback_hours),
-        "data_gate": snapshot_data_gate,
         "data_quality_mode": rust_data_quality_mode,
         "min_event_complete_events": int(args.min_event_complete_events),
         "min_event_complete_rows": int(args.min_event_complete_rows),
-        "issue_number": args.issue_number,
-        "snapshot_registry_dir": "",
         "replay_parity_json": "",
         "replay_parity_run_id": args.replay_parity_run_id,
         "replay_parity_artifact_name": args.replay_parity_artifact_name,
+        "required_strategy_profile": "settlement_probability",
+        "allowed_target": "full_depth_settlement_executable_pnl",
+        "issue_number": args.issue_number,
+        "create_handoff_issue": False,
+        "fail_if_blocked": False,
     }
     walk_fields = {
         "git_ref": git_ref,
+        "snapshot_run_id": str(snapshot_result.database_id),
+        "snapshot_artifact_name": args.snapshot_artifact_name,
         "start_date": args.start_date,
         "end_date": args.end_date,
         "symbols": args.symbols,
         "stake_usd": args.stake_usd,
-        "snapshot_run_id": str(snapshot_result.database_id),
         "options_json": compact_json(walk_options),
     }
 
-    print("Dispatching settlement probability promotion gate.", flush=True)
+    print("Dispatching hosted settlement probability promotion gate.", flush=True)
     walk_run = dispatch_workflow(
-        WALK_FORWARD_WORKFLOW,
+        HOSTED_WALK_FORWARD_WORKFLOW,
         walk_fields,
         workflow_ref=git_ref,
-        dry_run=False,
+        dry_run=args.dry_run,
     )
+    if args.dry_run:
+        return 0
     if walk_run is None:
         raise RuntimeError("walk-forward dispatch did not return a run")
     print(f"walk_forward_run_id={walk_run.database_id} url={walk_run.url}", flush=True)
+    if args.no_wait:
+        return 0
     walk_result = wait_for_run(
         walk_run,
         timeout_minutes=args.walk_timeout_minutes,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -144,6 +144,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   `auto_settlement_*` formula factors so candidates that pass the
   `full_depth_settlement_executable_pnl` target can reach the handoff contract
   once the surrounding PRD gate, including recorded replay parity, is ready.
+- [x] Make the settlement PRD gate prefer GitHub-hosted artifact execution when
+  a retained full snapshot artifact is available. `snapshot_run_id` now skips
+  the legacy `ploy-ci-1` snapshot build and dispatches the hosted
+  `factor-walk-forward-v2-hosted-artifact.yml` path for AutoFactor mining and
+  promotion.
 
 ## Review
 
@@ -212,6 +217,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   settlement-native candidates are blocked only by `promotion_gate_not_ready`
   instead of missing runtime mappings; the remaining hard blocker is recorded
   replay parity evidence.
+- 2026-05-06: Updated the PRD gate orchestration so future settlement
+  probability / AutoFactor runs can avoid `ploy-ci-1` when a full snapshot
+  artifact already exists. The workflow now stays within the 10-input GitHub
+  Actions limit by adding `snapshot_run_id` and relying on default replay
+  artifact naming, then calls the hosted artifact-only walk-forward workflow on
+  `ubuntu-latest`.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary

- add `snapshot_run_id` to `settlement-probability-prd-gate.yml` so retained full snapshot artifacts skip the legacy `ploy-ci-1` snapshot build
- route downstream PRD gate walk-forward / AutoFactor promotion through `factor-walk-forward-v2-hosted-artifact.yml` on `ubuntu-latest`
- document GitHub-hosted artifact execution as the default PM5D/PM15D AutoFactor path and keep `ploy-ci-1` as a legacy fresh-snapshot fallback

## Verification

- `python3 -m py_compile scripts/run_settlement_probability_prd_gate.py`
- workflow YAML parse and workflow_dispatch input-count check
- `python3 scripts/run_settlement_probability_prd_gate.py --git-ref main --snapshot-run-id 25385618701 --start-date 2026-05-01 --end-date 2026-05-05 --symbols BTCUSDT,ETHUSDT --stake-usd 15 --audit-lookback-hours 168 --data-quality-mode event-complete --replay-parity-run-id 25379165698 --dry-run`
- `python3 -m unittest tests.test_autofactor_strategy_promotion`
- `git diff --check`

## Notes

This intentionally does not move DB-adjacent fresh snapshot compilation to GitHub-hosted runners yet. That still needs a hosted-safe data export path; artifact-backed AutoFactor and promotion work now use hosted runners by default.
