### PR TITLE
Preserve replay artifact overrides in hosted PRD gate

### DIFF
--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -34,7 +34,7 @@ on:
         required: true
         default: "168"
       replay_parity_run_id:
-        description: "Optional Replay Dry-run Parity run id"
+        description: "Optional replay parity run id, or run_id:artifact_name for non-default artifact names"
         required: false
         default: ""
       no_wait:
@@ -145,7 +145,7 @@ jobs:
             echo "- Data profile: \`pm5d-vol\`"
             echo "- Audit lookback: \`${audit_lookback_hours}h\`"
             echo "- Replay parity run: \`${{ github.event.inputs.replay_parity_run_id || 'none' }}\`"
-            echo "- Replay parity artifact: \`default\`"
+            echo "- Replay parity artifact: \`default unless encoded as run_id:artifact_name\`"
             echo ""
             echo "A failed workflow can be the correct outcome: the orchestrator exits non-zero when the PRD promotion gate is blocked."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -238,6 +238,9 @@ build and dispatches `factor-walk-forward-v2-hosted-artifact.yml` on
 `ubuntu-latest`. If `snapshot_run_id` is omitted, the orchestrator still falls
 back to `research-snapshot.yml`; that path remains a legacy DB-adjacent path
 until snapshot export is moved to a hosted-safe data source.
+When replay parity evidence uses a non-default artifact name, encode the input
+as `replay_parity_run_id=<run-id>:<artifact-name>` so the workflow stays within
+GitHub's 10-input dispatch limit.
 
 Use `--output-dir <dir>` to choose the artifact directory. Without it, the
 runner writes under `<dataset>/workflow_runs/event_ml_<timestamp>`.

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -190,6 +190,23 @@ def compact_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, separators=(",", ":"), sort_keys=True)
 
 
+def split_replay_parity_input(value: str, artifact_name: str) -> tuple[str, str]:
+    """Parse workflow-friendly replay parity input.
+
+    GitHub workflow_dispatch is limited to 10 inputs, so the workflow accepts a
+    compact replay input of either "<run_id>" or "<run_id>:<artifact_name>".
+    Direct CLI callers can still use --replay-parity-artifact-name.
+    """
+
+    stripped = value.strip()
+    if not stripped or artifact_name:
+        return stripped, artifact_name
+    if ":" not in stripped:
+        return stripped, artifact_name
+    run_id, artifact = stripped.split(":", 1)
+    return run_id.strip(), artifact.strip()
+
+
 def parse_promotion_gate(report_text: str) -> PromotionGateEvaluation:
     ready: bool | None = None
     blocked_gates: list[str] = []
@@ -308,6 +325,10 @@ def main() -> int:
     git_ref = args.git_ref or git_branch()
     rust_data_quality_mode = args.data_quality_mode.replace("-", "_")
     snapshot_data_gate = "critical" if args.data_quality_mode == "strict-continuous" else "never"
+    replay_parity_run_id, replay_parity_artifact_name = split_replay_parity_input(
+        args.replay_parity_run_id,
+        args.replay_parity_artifact_name,
+    )
 
     if args.snapshot_run_id:
         snapshot_result = refresh_run(int(args.snapshot_run_id))
@@ -398,8 +419,8 @@ def main() -> int:
         "min_event_complete_events": int(args.min_event_complete_events),
         "min_event_complete_rows": int(args.min_event_complete_rows),
         "replay_parity_json": "",
-        "replay_parity_run_id": args.replay_parity_run_id,
-        "replay_parity_artifact_name": args.replay_parity_artifact_name,
+        "replay_parity_run_id": replay_parity_run_id,
+        "replay_parity_artifact_name": replay_parity_artifact_name,
         "required_strategy_profile": "settlement_probability",
         "allowed_target": "full_depth_settlement_executable_pnl",
         "issue_number": args.issue_number,
@@ -468,7 +489,8 @@ def main() -> int:
             f"- Snapshot run: {snapshot_result.url}",
             f"- Walk-forward run: {walk_result.url}",
             f"- Walk-forward conclusion: `{walk_result.conclusion}`",
-            f"- Replay parity run supplied: `{args.replay_parity_run_id or 'none'}`",
+            f"- Replay parity run supplied: `{replay_parity_run_id or 'none'}`",
+            f"- Replay parity artifact supplied: `{replay_parity_artifact_name or 'default'}`",
             f"- Data quality mode: `{args.data_quality_mode}`",
             f"- Gate: `{gate.evidence}`",
             f"- Decision: {decision}",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -223,6 +223,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   Actions limit by adding `snapshot_run_id` and relying on default replay
   artifact naming, then calls the hosted artifact-only walk-forward workflow on
   `ubuntu-latest`.
+- 2026-05-06: Follow-up compatibility fix: `replay_parity_run_id` now accepts
+  `run_id:artifact_name`, so recorded replay parity artifacts with names like
+  `recorded-replay-parity-<run_id>` can still be consumed without adding an
+  eleventh GitHub workflow input.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary

- allow `replay_parity_run_id` to carry either `<run_id>` or `<run_id>:<artifact_name>`
- keep `settlement-probability-prd-gate.yml` at the GitHub Actions 10-input limit after adding `snapshot_run_id`
- document the encoded artifact-name form for recorded replay parity evidence

## Verification

- `python3 -m py_compile scripts/run_settlement_probability_prd_gate.py`
- workflow YAML parse and workflow_dispatch input-count check
- `python3 scripts/run_settlement_probability_prd_gate.py --git-ref main --snapshot-run-id 25385618701 --start-date 2026-05-01 --end-date 2026-05-05 --symbols BTCUSDT,ETHUSDT --stake-usd 15 --audit-lookback-hours 168 --data-quality-mode event-complete --replay-parity-run-id 25379165698:recorded-replay-parity-25379165698 --dry-run`
- `python3 -m unittest tests.test_autofactor_strategy_promotion`
- `git diff --check`
