### PR TITLE
Make promoted AutoFactor settlement score executable

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,6 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30

--- a/config/strategies/REGISTRY.md
+++ b/config/strategies/REGISTRY.md
@@ -92,7 +92,7 @@ numeric ID used as filename prefix.
 | `02-pm5d-threelayer.obi-hard-dryrun.toml` | **UNIFIED** | Snapshot-profile dry-run candidate; profile `obi_hard` with hard OBI confirmation |
 | `02-pm5d-threelayer.continuation-soft-dryrun.toml` | **UNIFIED** | Holistic snapshot-profile dry-run candidate; profile `continuation_soft` |
 | `02-pm5d-threelayer.repricing-momentum-dryrun.toml` | **UNIFIED** | BTC/ETH/SOL-only full-depth dry-run candidate; profile `repricing_momentum` |
-| `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` | **UNIFIED** | BTC/ETH-only PRD dry-run handoff candidate; profile `settlement_probability` |
+| `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` | **UNIFIED** | BTC/ETH-only AutoFactor PRD dry-run handoff candidate; profile `settlement_probability`, runtime score `auto_settlement_conservative_settlement_edge` |
 
 ### S03 — Pattern Memory
 | File | Format | Notes |

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -41,7 +41,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use optimizer::prelude::*;
 use ploy_feed_loaders::{
-    load_from_database_with_options, HistoricalLoadOptions as DbHistoricalLoadOptions,
+    HistoricalLoadOptions as DbHistoricalLoadOptions, load_from_database_with_options,
 };
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
@@ -1266,6 +1266,7 @@ fn make_directional_config(
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     }
 }
 
@@ -1337,6 +1338,7 @@ fn make_reversal_config(symbols: &[String], params: &ReversalSearchParams) -> Di
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     }
 }
 

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -102,8 +102,8 @@ fn generate_synthetic_data(symbols: &[&str], duration_mins: u64) -> Vec<MarketUp
                 ts: window_start + Duration::seconds(5),
                 bid_size: None,
                 ask_size: None,
-            bid_levels: Vec::new(),
-            ask_levels: Vec::new(),
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
             });
             updates.push(MarketUpdate::Quote {
                 token_id: Arc::clone(&dn_token),
@@ -112,8 +112,8 @@ fn generate_synthetic_data(symbols: &[&str], duration_mins: u64) -> Vec<MarketUp
                 ts: window_start + Duration::seconds(5),
                 bid_size: None,
                 ask_size: None,
-            bid_levels: Vec::new(),
-            ask_levels: Vec::new(),
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
             });
 
             // Spot ticks showing the drift
@@ -149,8 +149,8 @@ fn generate_synthetic_data(symbols: &[&str], duration_mins: u64) -> Vec<MarketUp
                 ts: window_start + Duration::seconds(55),
                 bid_size: None,
                 ask_size: None,
-            bid_levels: Vec::new(),
-            ask_levels: Vec::new(),
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
             });
             updates.push(MarketUpdate::Quote {
                 token_id: dn_token,
@@ -159,8 +159,8 @@ fn generate_synthetic_data(symbols: &[&str], duration_mins: u64) -> Vec<MarketUp
                 ts: window_start + Duration::seconds(55),
                 bid_size: None,
                 ask_size: None,
-            bid_levels: Vec::new(),
-            ask_levels: Vec::new(),
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
             });
 
             // Spot at window midpoint (entry zone: 60-300s remaining)
@@ -358,6 +358,7 @@ fn main() {
                     three_layer_stop_distance_pct: 0.020,
                     three_layer_max_pm_lag_secs: 15,
                     three_layer_min_entry_score: 0.30,
+                    three_layer_autofactor_runtime_score: None,
                 },
                 SimulatedExecutorConfig {
                     use_spread: true,

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -5,8 +5,8 @@
 
 use chrono::{DateTime, Utc};
 use ploy_market_contracts::{InstrumentKind, PredictionFamily, VenueKind};
-use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::FromPrimitive;
 use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
@@ -760,6 +760,21 @@ venue = "sportsbook"
                 "{file} must not optimize against spot-fallback settlement"
             );
         }
+    }
+
+    #[test]
+    fn settlement_probability_config_carries_autofactor_handoff_score() {
+        let path = strategy_config_dir()
+            .join("02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml");
+        let config = FullConfig::from_file(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            config
+                .strategy
+                .three_layer_autofactor_runtime_score
+                .as_deref(),
+            Some("autofactor_formula:auto_settlement_conservative_settlement_edge")
+        );
     }
 
     fn strategy_config_dir() -> PathBuf {

--- a/crates/ploy-strategy-bundles/src/strategies/directional.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/directional.rs
@@ -13,8 +13,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
@@ -209,6 +209,10 @@ pub struct DirectionalConfig {
     /// Scoring model: minimum total score to enter (0.0-1.0).
     #[serde(default = "default_tl_min_entry_score")]
     pub three_layer_min_entry_score: f64,
+
+    /// Optional AutoFactor formula score promoted from the research handoff.
+    #[serde(default)]
+    pub three_layer_autofactor_runtime_score: Option<String>,
 
     // Timing
     #[serde(default = "default_min_time")]
@@ -1832,6 +1836,7 @@ mod tests {
             three_layer_stop_distance_pct: 0.020,
             three_layer_max_pm_lag_secs: 15,
             three_layer_min_entry_score: 0.30,
+            three_layer_autofactor_runtime_score: None,
             min_time_remaining_secs: 60,
             max_time_remaining_secs: 300,
             cooldown_secs: 0,

--- a/crates/ploy-strategy-bundles/src/strategies/mean_reversion.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/mean_reversion.rs
@@ -11,8 +11,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use tracing::{debug, info, warn};
 
@@ -1068,6 +1068,7 @@ mod tests {
             three_layer_stop_distance_pct: 0.020,
             three_layer_max_pm_lag_secs: 15,
             three_layer_min_entry_score: 0.30,
+            three_layer_autofactor_runtime_score: None,
         }
     }
 

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use ploy_trading::{
     FillRecord, IntentPurpose, OrderLedger, OrderState, PositionLedger, TradeSide, TradingIntent,
 };
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -14,7 +14,8 @@ use super::common::event::EventWindow;
 use super::common::quote::QuoteState;
 use super::common::settlement;
 use super::three_layer_model::{
-    self, BookConfirmationInputs, EntryScoreInputs, ThreeLayerModelConfig,
+    self, AutoSettlementFactorInputs, BookConfirmationInputs, EntryScoreInputs,
+    ThreeLayerModelConfig,
 };
 use super::three_layer_profile::ThreeLayerProfile;
 use crate::strategies::directional::DirectionalConfig;
@@ -50,6 +51,7 @@ pub struct ThreeLayerConfig {
     pub min_entry_price: f64,
     pub max_entry_price: f64,
     pub min_entry_score: f64,
+    pub autofactor_runtime_score: Option<String>,
 }
 
 impl From<DirectionalConfig> for ThreeLayerConfig {
@@ -81,6 +83,7 @@ impl From<DirectionalConfig> for ThreeLayerConfig {
             min_entry_price: c.min_entry_price,
             max_entry_price: c.max_entry_price,
             min_entry_score: c.three_layer_min_entry_score,
+            autofactor_runtime_score: c.three_layer_autofactor_runtime_score,
         }
     }
 }
@@ -450,6 +453,17 @@ fn spread_adjusted_external_move_score(side_external_move_30s: f64, side_spread:
     three_layer_model::spread_adjusted_external_move_score(side_external_move_30s, side_spread)
 }
 
+fn autofactor_formula_entry_score(
+    runtime_score: &str,
+    inputs: AutoSettlementFactorInputs,
+    min_edge: f64,
+) -> Option<(f64, f64)> {
+    let raw = three_layer_model::auto_settlement_formula_score(runtime_score, inputs)?;
+    let normalized =
+        three_layer_model::threshold_score(raw, min_edge.max(0.0), 0.08, false).clamp(-0.50, 1.0);
+    Some((raw, normalized))
+}
+
 // ── ThreeLayerStrategy ─────────────────────────────────────────────
 
 pub struct ThreeLayerStrategy {
@@ -798,22 +812,60 @@ impl ThreeLayerStrategy {
                 continue;
             }
 
+            let entry_capacity_ratio = self
+                .quote_depth
+                .get(token_id)
+                .and_then(|depth| depth.ask_size)
+                .and_then(|ask_size| {
+                    let ask_size_f = ask_size.to_f64()?;
+                    let stake_usd = self.config.stake_usd.to_f64()?;
+                    if entry_price_f > 0.0 && stake_usd.is_finite() {
+                        let entry_shares = stake_usd / entry_price_f;
+                        (entry_shares > 0.0).then_some(ask_size_f / entry_shares)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(f64::NAN);
             let pm_momentum_score = self.pm_momentum_score(token_id, ask, now);
-            let total_score = evaluate_entry_score(
-                &self.config,
-                EntryScoreInputs {
-                    direction_score,
-                    distance_over_sigma,
-                    direction_sign,
-                    edge,
-                    edge_score,
-                    confirmation: confirmation_score,
-                    repricing_score,
-                    drift_30s,
-                    pm_momentum_score,
-                    liquidity_score: 1.0,
-                },
-            );
+            let (autofactor_raw_score, total_score) =
+                if let Some(runtime_score) = self.config.autofactor_runtime_score.as_deref() {
+                    let inputs = AutoSettlementFactorInputs {
+                        settlement_edge: edge,
+                        distance_over_sigma,
+                        direction_sign,
+                        entry_capacity_ratio,
+                        side_spread,
+                        external_pressure: confirmation_score,
+                        iv_change_1m: 0.0,
+                    };
+                    let Some((raw, normalized)) =
+                        autofactor_formula_entry_score(runtime_score, inputs, self.config.min_edge)
+                    else {
+                        self.bump("skip_autofactor_score_unavailable");
+                        continue;
+                    };
+                    (Some(raw), normalized)
+                } else {
+                    (
+                        None,
+                        evaluate_entry_score(
+                            &self.config,
+                            EntryScoreInputs {
+                                direction_score,
+                                distance_over_sigma,
+                                direction_sign,
+                                edge,
+                                edge_score,
+                                confirmation: confirmation_score,
+                                repricing_score,
+                                drift_30s,
+                                pm_momentum_score,
+                                liquidity_score: 1.0,
+                            },
+                        ),
+                    )
+                };
 
             if total_score < self.config.min_entry_score {
                 self.bump("skip_entry_score");
@@ -827,6 +879,8 @@ impl ThreeLayerStrategy {
                     confirmation_score = format!("{:.3}", confirmation_score),
                     repricing_score = format!("{:.3}", repricing_score),
                     pm_momentum_score = format!("{:.3}", pm_momentum_score),
+                    autofactor_runtime_score = self.config.autofactor_runtime_score.as_deref().unwrap_or(""),
+                    autofactor_raw_score = autofactor_raw_score.map(|score| format!("{score:.4}")).unwrap_or_default(),
                     min_entry_score = self.config.min_entry_score,
                     profile = %self.config.profile,
                     regime = regime.as_str(),
@@ -918,6 +972,8 @@ impl ThreeLayerStrategy {
                 confirmation_score = format!("{:.3}", confirmation_score),
                 repricing_score = format!("{:.3}", repricing_score),
                 pm_momentum_score = format!("{:.3}", pm_momentum_score),
+                autofactor_runtime_score = self.config.autofactor_runtime_score.as_deref().unwrap_or(""),
+                autofactor_raw_score = autofactor_raw_score.map(|score| format!("{score:.4}")).unwrap_or_default(),
                 p_hat = effective_p,
                 edge,
                 entry_price = %entry_price,
@@ -1574,6 +1630,7 @@ mod tests {
             min_entry_price: 0.15,
             max_entry_price: 0.85,
             min_entry_score: 0.30,
+            autofactor_runtime_score: None,
         }
     }
 
@@ -2450,6 +2507,32 @@ mod tests {
 
         assert!(strong_edge > weak_edge);
         assert!(strong_edge > config.min_entry_score);
+    }
+
+    #[test]
+    fn autofactor_settlement_formula_can_override_entry_score() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+
+        let inputs = AutoSettlementFactorInputs {
+            settlement_edge: 0.06,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            entry_capacity_ratio: 3.0,
+            side_spread: 0.03,
+            external_pressure: 0.0,
+            iv_change_1m: 0.0,
+        };
+        let (raw, score) = autofactor_formula_entry_score(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+            inputs,
+            config.min_edge,
+        )
+        .expect("settlement formula score");
+
+        assert!((raw - 0.06).abs() < 1e-9);
+        assert!(score > config.min_entry_score);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -49,6 +49,17 @@ pub struct EntryScoreInputs {
     pub liquidity_score: f64,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct AutoSettlementFactorInputs {
+    pub settlement_edge: f64,
+    pub distance_over_sigma: f64,
+    pub direction_sign: f64,
+    pub entry_capacity_ratio: f64,
+    pub side_spread: f64,
+    pub external_pressure: f64,
+    pub iv_change_1m: f64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DirectionScore {
     pub direction_sign: f64,
@@ -83,17 +94,89 @@ pub fn spread_adjusted_external_move_score(side_external_move_30s: f64, side_spr
     side_external_move_30s / (side_spread + 0.01)
 }
 
+pub fn auto_settlement_near_strike_score(distance_over_sigma: f64, direction_sign: f64) -> f64 {
+    if !distance_over_sigma.is_finite() || !direction_sign.is_finite() {
+        return f64::NAN;
+    }
+    let side_distance_over_sigma = distance_over_sigma * direction_sign;
+    (1.0 - side_distance_over_sigma.abs()).clamp(0.0, 1.0)
+}
+
+pub fn auto_settlement_entry_capacity_score(entry_capacity_ratio: f64) -> f64 {
+    if entry_capacity_ratio.is_finite() {
+        (entry_capacity_ratio / 3.0).clamp(0.0, 1.0)
+    } else {
+        f64::NAN
+    }
+}
+
+pub fn auto_settlement_formula_score(
+    runtime_score: &str,
+    inputs: AutoSettlementFactorInputs,
+) -> Option<f64> {
+    let name = runtime_score
+        .strip_prefix("autofactor_formula:")
+        .unwrap_or(runtime_score);
+    let is_full_depth = name.starts_with("auto_settlement_full_depth_settlement_edge");
+    let is_conservative = name.starts_with("auto_settlement_conservative_settlement_edge");
+    if !is_full_depth && !is_conservative {
+        return None;
+    }
+
+    if !inputs.settlement_edge.is_finite() {
+        return None;
+    }
+    let mut score = inputs.settlement_edge;
+    let suffix = if is_full_depth {
+        name.strip_prefix("auto_settlement_full_depth_settlement_edge")
+    } else {
+        name.strip_prefix("auto_settlement_conservative_settlement_edge")
+    }?;
+
+    match suffix {
+        "" => {}
+        "_x_near_strike" => {
+            score *=
+                auto_settlement_near_strike_score(inputs.distance_over_sigma, inputs.direction_sign)
+        }
+        "_x_capacity" => score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio),
+        "_x_near_strike_x_capacity" => {
+            score *= auto_settlement_near_strike_score(
+                inputs.distance_over_sigma,
+                inputs.direction_sign,
+            );
+            score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio);
+        }
+        "_spread_adjusted" => {
+            if !inputs.side_spread.is_finite() || inputs.side_spread < 0.0 {
+                return None;
+            }
+            score /= inputs.side_spread + 0.01;
+        }
+        "_x_external_pressure" => {
+            if !inputs.external_pressure.is_finite() {
+                return None;
+            }
+            score *= inputs.external_pressure;
+        }
+        "_x_iv_change" => {
+            if !inputs.iv_change_1m.is_finite() {
+                return None;
+            }
+            score *= inputs.iv_change_1m;
+        }
+        _ => return None,
+    }
+    score.is_finite().then_some(score)
+}
+
 /// Normal CDF approximation (Abramowitz & Stegun).
 pub fn norm_cdf(x: f64) -> f64 {
     let t = 1.0 / (1.0 + 0.2316419 * x.abs());
     let d = 0.3989422804014327 * (-x * x / 2.0).exp();
     let p =
         d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 {
-        1.0 - p
-    } else {
-        p
-    }
+    if x >= 0.0 { 1.0 - p } else { p }
 }
 
 pub fn calibrate_direction_probability(
@@ -160,11 +243,7 @@ pub fn reward_risk_ratio(entry_price: f64) -> f64 {
     let fee = crypto_fee_cost(entry_price);
     let reward = 1.0 - entry_price - fee;
     let risk = entry_price + fee;
-    if risk <= 0.0 {
-        f64::NAN
-    } else {
-        reward / risk
-    }
+    if risk <= 0.0 { f64::NAN } else { reward / risk }
 }
 
 pub fn evaluate_direction_score(

--- a/crates/ploy-strategy-bundles/tests/backtest_integration.rs
+++ b/crates/ploy-strategy-bundles/tests/backtest_integration.rs
@@ -49,8 +49,8 @@ fn build_scenario() -> Vec<MarketUpdate> {
         ts: now,
         bid_size: None,
         ask_size: None,
-    bid_levels: Vec::new(),
-    ask_levels: Vec::new(),
+        bid_levels: Vec::new(),
+        ask_levels: Vec::new(),
     });
     updates.push(MarketUpdate::Quote {
         token_id: "dn-btc-001".into(),
@@ -59,8 +59,8 @@ fn build_scenario() -> Vec<MarketUpdate> {
         ts: now,
         bid_size: None,
         ask_size: None,
-    bid_levels: Vec::new(),
-    ask_levels: Vec::new(),
+        bid_levels: Vec::new(),
+        ask_levels: Vec::new(),
     });
 
     // 4. BTC trends up over several updates so realized vol has a usable estimate.
@@ -218,6 +218,7 @@ async fn backtest_full_loop_produces_entry() {
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     };
 
     let strategy = DirectionalStrategy::new(config);
@@ -357,6 +358,7 @@ async fn empty_feed_produces_zero_trades() {
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     };
 
     let strategy = DirectionalStrategy::new(config);
@@ -434,6 +436,7 @@ async fn recorded_updates_replay_to_the_same_runtime_result() {
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     };
     let sim_config = SimulatedExecutorConfig {
         use_spread: true,
@@ -561,6 +564,7 @@ async fn sports_updates_round_trip_without_changing_crypto_runtime_behavior() {
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     };
     let sim_config = SimulatedExecutorConfig {
         use_spread: true,
@@ -681,6 +685,7 @@ async fn reference_updates_round_trip_without_changing_crypto_runtime_behavior()
         three_layer_stop_distance_pct: 0.020,
         three_layer_max_pm_lag_secs: 15,
         three_layer_min_entry_score: 0.30,
+        three_layer_autofactor_runtime_score: None,
     };
     let sim_config = SimulatedExecutorConfig {
         use_spread: true,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -94,6 +94,13 @@
   - After boot, use Cloud Assistant if needed to run `systemctl enable --now actions.runner.proerror77-ploy.ploy-ci-1.service`.
   - Confirm queued workflow runs move to `in_progress` before assuming ploy-ci work has actually started.
 
+- Pattern: AutoFactor / settlement-probability PRD downstream evidence does not need a live self-hosted runner once a full research snapshot artifact exists.
+- Rule: Prefer GitHub-hosted `ubuntu-latest` artifact workflows for AutoFactor mining, promotion, and dry-run handoff gates. Treat `ploy-ci-1` as a legacy DB-adjacent fallback only for fresh snapshot/export work that still requires Tango private-network database access.
+- Migration guardrail:
+  - Use `factor-walk-forward-v2-hosted-artifact.yml` or `settlement-probability-prd-gate.yml` with `snapshot_run_id` before dispatching legacy `factor-walk-forward-v2.yml`.
+  - Do not move a DB/private-endpoint workflow to GitHub-hosted runners by changing only `runs-on`; first replace the data source with a portable artifact or a hosted-safe export path.
+  - When a full snapshot artifact exists, do not block strategy promotion on `ploy-ci-1` availability.
+
 ## 2026-03-06
 
 - Pattern: Managed strategy bootstrap can silently drift from the checked-in live strategy template and override production sizing without touching host config files.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -149,6 +149,15 @@ evidence comes from Polymarket full CLOB depth, not top book.
   the legacy `ploy-ci-1` snapshot build and dispatches the hosted
   `factor-walk-forward-v2-hosted-artifact.yml` path for AutoFactor mining and
   promotion.
+- [x] Wire the first promoted AutoFactor settlement formula into the dry-run
+  runtime config and shared three-layer scorer. The BTC/ETH settlement
+  probability dry-run config now points at
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`, matching
+  the top ready handoff strategy from issue #359.
+- [x] Record the runner migration rule: AutoFactor mining, promotion, and
+  dry-run handoff gates should use GitHub-hosted artifact workflows when a
+  full research snapshot artifact exists; keep `ploy-ci-1` only as the legacy
+  DB-adjacent fallback until fresh snapshot/export work is artifactized.
 
 ## Review
 
@@ -227,6 +236,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   `run_id:artifact_name`, so recorded replay parity artifacts with names like
   `recorded-replay-parity-<run_id>` can still be consumed without adding an
   eleventh GitHub workflow input.
+- 2026-05-06: Began issue #359 implementation by adding runtime support for
+  settlement-native `autofactor_formula:auto_settlement_*` scores in the shared
+  three-layer model. The dry-run config now uses the top ready handoff score,
+  while full-depth/conservative execution gating remains enforced by the
+  existing fixed-stake quote-size and execution settings.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary

- implements the promoted settlement-native AutoFactor formula family in the shared three-layer runtime scorer
- wires the BTC/ETH settlement-probability dry-run config to the top ready handoff score from #359
- records the runner policy: AutoFactor mining/promotion/handoff should use GitHub-hosted artifact workflows when a full snapshot artifact exists, with `ploy-ci-1` kept as the legacy DB-adjacent fallback

## Verification

- `rustfmt --edition 2024 <touched Rust files>`
- `git diff --check`
- `cargo test -p ploy-strategy-bundles autofactor_settlement_formula_can_override_entry_score --lib`
- `cargo test -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`
- `cargo test -p ploy-strategy-bundles --lib three_layer`
- `cargo check -p ploy-strategy-bundles --lib`

## Notes

This is a dry-run handoff only. It does not deploy and does not enable live order paths.

Closes #359
