### PR TITLE
Automate AutoFactor handoff config promotion

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -30,15 +30,24 @@ on:
         description: "Create a dry-run handoff issue when autofactor-strategy-handoff.json is ready"
         required: false
         default: "false"
+      create_config_pr:
+        description: "Create a dry-run config PR from a ready handoff"
+        required: false
+        default: "false"
+      strategy_config:
+        description: "Strategy config path updated by create_config_pr"
+        required: false
+        default: "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
       fail_if_blocked:
         description: "Fail workflow when no AutoFactor strategy qualifies"
         required: false
         default: "false"
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   issues: write
+  pull-requests: write
 
 jobs:
   evaluate:
@@ -184,3 +193,87 @@ jobs:
           gh issue create \
             --title "${title}" \
             --body-file "${handoff_md}"
+
+      - name: Create config PR from ready handoff
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CREATE_CONFIG_PR: ${{ github.event.inputs.create_config_pr }}
+          STRATEGY_CONFIG: ${{ github.event.inputs.strategy_config }}
+          BASE_REF: ${{ github.event.inputs.git_ref }}
+        run: |
+          set -euo pipefail
+          if [ "${CREATE_CONFIG_PR}" != "true" ]; then
+            echo "create_config_pr is not true; skipping config PR creation."
+            exit 0
+          fi
+          handoff_json="artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json"
+          case "${STRATEGY_CONFIG}" in
+            config/strategies/*.toml) ;;
+            *)
+              echo "strategy_config must be a config/strategies/*.toml path" >&2
+              exit 2
+              ;;
+          esac
+          if [ ! -f "${handoff_json}" ]; then
+            echo "Handoff JSON missing; skipping config PR creation."
+            exit 0
+          fi
+          status="$(python3 - <<'PY'
+          import json
+          with open("artifacts/autofactor-strategy-promotion/autofactor-strategy-handoff.json", encoding="utf-8") as handle:
+              print(json.load(handle).get("status", "blocked"))
+          PY
+          )"
+          if [ "${status}" != "ready" ]; then
+            echo "Handoff status is ${status}; no config PR will be created."
+            exit 0
+          fi
+          mkdir -p artifacts/autofactor-config-handoff
+          python3 scripts/apply_autofactor_handoff_to_config.py \
+            --handoff-json "${handoff_json}" \
+            --config "${STRATEGY_CONFIG}" \
+            --output-json artifacts/autofactor-config-handoff/config-handoff.json \
+            --output-md artifacts/autofactor-config-handoff/config-handoff.md
+          changed="$(python3 - <<'PY'
+          import json
+          with open("artifacts/autofactor-config-handoff/config-handoff.json", encoding="utf-8") as handle:
+              print("true" if json.load(handle).get("changed") else "false")
+          PY
+          )"
+          if [ "${changed}" != "true" ]; then
+            echo "Config already matches selected handoff; no PR will be created."
+            exit 0
+          fi
+
+          branch="autofactor/handoff-${GITHUB_RUN_ID}"
+          git switch -c "${branch}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "${STRATEGY_CONFIG}"
+          git commit \
+            -m "Promote AutoFactor handoff into dry-run config" \
+            -m "A ready AutoFactor strategy handoff selected a runtime score that differs from the checked-in dry-run config. This applies only the promoted runtime score and leaves execution, risk, and kill-switch settings under the existing config." \
+            -m "Constraint: Generated from autofactor-strategy-handoff.json status=ready" \
+            -m "Constraint: Dry-run config only; no deploy or live order path" \
+            -m "Rejected: Direct deployment from promotion workflow | config changes must pass PR review and CI first" \
+            -m "Confidence: medium" \
+            -m "Scope-risk: narrow" \
+            -m "Tested: python3 scripts/apply_autofactor_handoff_to_config.py --handoff-json <artifact> --config ${STRATEGY_CONFIG}" \
+            -m "Not-tested: dry-run deployment/replay after config change"
+          git push origin "${branch}"
+
+          title="Promote AutoFactor handoff into dry-run config"
+          {
+            cat artifacts/autofactor-config-handoff/config-handoff.md
+            echo ""
+            echo "Source promotion run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "Source factor walk-forward run: ${{ github.event.inputs.factor_walk_forward_run_id }}"
+            echo ""
+            echo "This PR is generated from a ready handoff artifact. It does not deploy and does not enable live trading."
+          } > artifacts/autofactor-config-handoff/pr-body.md
+          gh pr create \
+            --base "${BASE_REF}" \
+            --head "${branch}" \
+            --title "${title}" \
+            --body-file artifacts/autofactor-config-handoff/pr-body.md

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -188,6 +188,26 @@ it `false` for diagnostics. When set to `true`, the workflow creates a dry-run
 handoff issue only if `autofactor-strategy-handoff.json` reports
 `status=ready`; blocked handoffs are logged and skipped.
 
+For the final config-promotion step, the same hosted workflow can create a
+reviewable PR instead of requiring a manual TOML edit:
+
+```bash
+gh workflow run autofactor-strategy-promotion.yml \
+  -f git_ref=main \
+  -f factor_walk_forward_run_id=<run-id> \
+  -f required_strategy_profile=settlement_probability \
+  -f allowed_target=full_depth_settlement_executable_pnl \
+  -f create_config_pr=true \
+  -f strategy_config=config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+```
+
+`create_config_pr=true` is intentionally PR-only. It reads the ready handoff
+artifact, updates only `three_layer_autofactor_runtime_score` in the target
+dry-run config, and opens a normal CI-gated pull request. It does not deploy,
+does not change execution/risk settings, and does not enable live trading.
+If the handoff is blocked or the config already uses the selected score, no PR
+is created.
+
 When the missing piece is a fresh Factor Walk-Forward V2 report and a full
 research snapshot artifact already exists, use the GitHub-hosted artifact-only
 workflow instead of `ploy-ci-1`:

--- a/scripts/apply_autofactor_handoff_to_config.py
+++ b/scripts/apply_autofactor_handoff_to_config.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Apply a ready AutoFactor dry-run handoff to a strategy TOML config.
+
+This is the final promotion step after the strict evaluator has produced a
+ready `autofactor-strategy-handoff.json`. It intentionally updates only the
+runtime score field so the existing dry-run execution, risk, and kill-switch
+settings remain under reviewable config ownership.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+RUNTIME_SCORE_RE = re.compile(
+    r'^(\s*three_layer_autofactor_runtime_score\s*=\s*)".*"\s*$'
+)
+PROFILE_RE = re.compile(r'^\s*three_layer_strategy_profile\s*=\s*"([^"]+)"\s*$')
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def select_strategy(handoff: dict[str, Any], strategy_name: str) -> dict[str, Any]:
+    if handoff.get("status") != "ready":
+        raise SystemExit(f"handoff status is {handoff.get('status', 'missing')}; expected ready")
+    strategies = handoff.get("strategies")
+    if not isinstance(strategies, list) or not strategies:
+        raise SystemExit("handoff has no qualified strategies")
+    if strategy_name:
+        for strategy in strategies:
+            if strategy.get("name") == strategy_name:
+                return strategy
+        raise SystemExit(f"strategy {strategy_name!r} not found in handoff")
+    return strategies[0]
+
+
+def replace_or_insert_runtime_score(
+    config_text: str,
+    *,
+    runtime_score: str,
+    expected_strategy_profile: str,
+) -> tuple[str, str | None, str]:
+    lines = config_text.splitlines(keepends=True)
+    profile_index: int | None = None
+    observed_profile: str | None = None
+    score_index: int | None = None
+    previous_score: str | None = None
+
+    for index, line in enumerate(lines):
+        profile_match = PROFILE_RE.match(line.rstrip("\n"))
+        if profile_match:
+            profile_index = index
+            observed_profile = profile_match.group(1)
+        score_match = RUNTIME_SCORE_RE.match(line.rstrip("\n"))
+        if score_match:
+            score_index = index
+            previous_score = line.split("=", 1)[1].strip().strip('"')
+
+    if expected_strategy_profile and observed_profile != expected_strategy_profile:
+        raise SystemExit(
+            "strategy config profile mismatch: "
+            f"observed={observed_profile!r} expected={expected_strategy_profile!r}"
+        )
+
+    new_line = f'three_layer_autofactor_runtime_score = "{runtime_score}"\n'
+    if score_index is not None:
+        lines[score_index] = new_line
+        action = "updated"
+    else:
+        if profile_index is None:
+            raise SystemExit("cannot insert runtime score: three_layer_strategy_profile not found")
+        insert_at = profile_index + 1
+        lines.insert(insert_at, new_line)
+        action = "inserted"
+
+    return "".join(lines), previous_score, action
+
+
+def render_summary_markdown(summary: dict[str, Any]) -> str:
+    strategy = summary["selected_strategy"]
+    return "\n".join(
+        [
+            "# AutoFactor Config Handoff",
+            "",
+            f"- Status: `{summary['status']}`",
+            f"- Config: `{summary['config_path']}`",
+            f"- Changed: `{str(summary['changed']).lower()}`",
+            f"- Action: `{summary['action']}`",
+            "- Previous runtime score: "
+            f"`{summary.get('previous_runtime_score') or 'none'}`",
+            f"- New runtime score: `{summary['runtime_score']}`",
+            f"- Strategy: `{strategy['name']}`",
+            f"- Target: `{strategy['target']}`",
+            f"- Strategy profile: `{strategy['strategy_profile']}`",
+            f"- ICIR: `{strategy['metrics']['icir']}`",
+            f"- Top bucket PnL: `{strategy['metrics']['top_bucket_avg_label']}`",
+            "",
+        ]
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handoff-json", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--strategy-name", default="")
+    parser.add_argument("--expected-strategy-profile", default="settlement_probability")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    handoff_path = Path(args.handoff_json)
+    config_path = Path(args.config)
+    handoff = load_json(handoff_path)
+    strategy = select_strategy(handoff, args.strategy_name)
+    runtime_score = str(strategy.get("runtime_score") or "")
+    strategy_profile = str(strategy.get("strategy_profile") or "")
+    if not runtime_score.startswith("autofactor_formula:"):
+        raise SystemExit(f"unsupported runtime_score for config handoff: {runtime_score!r}")
+    if args.expected_strategy_profile and strategy_profile != args.expected_strategy_profile:
+        raise SystemExit(
+            "handoff strategy profile mismatch: "
+            f"observed={strategy_profile!r} expected={args.expected_strategy_profile!r}"
+        )
+
+    original = config_path.read_text(encoding="utf-8")
+    updated, previous_score, action = replace_or_insert_runtime_score(
+        original,
+        runtime_score=runtime_score,
+        expected_strategy_profile=args.expected_strategy_profile,
+    )
+    changed = updated != original
+    if changed and not args.dry_run:
+        config_path.write_text(updated, encoding="utf-8")
+
+    summary = {
+        "kind": "autofactor_config_handoff",
+        "status": "ready",
+        "changed": changed,
+        "dry_run": bool(args.dry_run),
+        "action": action,
+        "config_path": str(config_path),
+        "handoff_json": str(handoff_path),
+        "previous_runtime_score": previous_score,
+        "runtime_score": runtime_score,
+        "selected_strategy": strategy,
+    }
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_md:
+        Path(args.output_md).write_text(render_summary_markdown(summary), encoding="utf-8")
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -158,6 +158,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   dry-run handoff gates should use GitHub-hosted artifact workflows when a
   full research snapshot artifact exists; keep `ploy-ci-1` only as the legacy
   DB-adjacent fallback until fresh snapshot/export work is artifactized.
+- [x] Add an automated config-promotion step so a ready
+  `autofactor-strategy-handoff.json` can update the dry-run config and open a
+  reviewable PR without a manual TOML edit. This should be PR-only, not deploy
+  or live trading.
 
 ## Review
 
@@ -241,6 +245,16 @@ evidence comes from Polymarket full CLOB depth, not top book.
   three-layer model. The dry-run config now uses the top ready handoff score,
   while full-depth/conservative execution gating remains enforced by the
   existing fixed-stake quote-size and execution settings.
+- 2026-05-06: Started the next AutoResearch-factory slice after #360 merged:
+  automate the final handoff-to-config step. The current missing link is no
+  longer promotion evaluation or runtime scoring; it is turning a ready
+  handoff artifact into a CI-gated dry-run config PR without manually editing
+  TOML.
+- 2026-05-06: Added `scripts/apply_autofactor_handoff_to_config.py` and wired
+  `autofactor-strategy-promotion.yml` with optional `create_config_pr=true`.
+  A ready handoff can now update only
+  `three_layer_autofactor_runtime_score` in the dry-run config and open a
+  normal CI-gated PR; blocked handoffs or unchanged configs do not create PRs.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/test_apply_autofactor_handoff_to_config.py
+++ b/tests/test_apply_autofactor_handoff_to_config.py
@@ -1,0 +1,123 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "apply_autofactor_handoff_to_config.py"
+
+
+READY_HANDOFF = {
+    "status": "ready",
+    "strategies": [
+        {
+            "name": "auto_settlement_conservative_settlement_edge_x_near_strike",
+            "target": "full_depth_settlement_executable_pnl",
+            "strategy_profile": "settlement_probability",
+            "strategy_family": "settlement_probability",
+            "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            "metrics": {
+                "icir": 1.044245,
+                "top_bucket_avg_label": 2.631575,
+            },
+        }
+    ],
+}
+
+
+BASE_CONFIG = """[strategy]
+symbols = ["BTCUSDT", "ETHUSDT"]
+three_layer_strategy_profile = "settlement_probability"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
+three_layer_min_entry_score = 0.25
+"""
+
+
+class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
+    def run_script(self, handoff, config_text=BASE_CONFIG, *extra_args, check=True):
+        with tempfile.TemporaryDirectory() as tmp:
+            handoff_path = Path(tmp) / "handoff.json"
+            config_path = Path(tmp) / "strategy.toml"
+            summary_path = Path(tmp) / "summary.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            config_path.write_text(config_text, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--handoff-json",
+                    str(handoff_path),
+                    "--config",
+                    str(config_path),
+                    "--output-json",
+                    str(summary_path),
+                    *extra_args,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=check,
+            )
+            summary = (
+                json.loads(summary_path.read_text(encoding="utf-8"))
+                if summary_path.exists()
+                else None
+            )
+            return result, config_path.read_text(encoding="utf-8"), summary
+
+    def test_updates_runtime_score_from_ready_handoff(self):
+        _, config_text, summary = self.run_script(READY_HANDOFF)
+
+        self.assertIn(
+            'three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"',
+            config_text,
+        )
+        self.assertTrue(summary["changed"])
+        self.assertEqual(summary["action"], "updated")
+        self.assertEqual(
+            summary["previous_runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+
+    def test_inserts_runtime_score_when_config_has_profile_but_no_score(self):
+        config_without_score = """[strategy]
+three_layer_strategy_profile = "settlement_probability"
+three_layer_min_entry_score = 0.25
+"""
+
+        _, config_text, summary = self.run_script(READY_HANDOFF, config_without_score)
+
+        self.assertIn(
+            'three_layer_strategy_profile = "settlement_probability"\n'
+            'three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"',
+            config_text,
+        )
+        self.assertTrue(summary["changed"])
+        self.assertEqual(summary["action"], "inserted")
+
+    def test_blocks_non_ready_handoff(self):
+        result, _, _ = self.run_script(
+            {"status": "blocked", "strategies": []},
+            BASE_CONFIG,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected ready", result.stderr)
+
+    def test_blocks_profile_mismatch(self):
+        result, _, _ = self.run_script(
+            READY_HANDOFF,
+            BASE_CONFIG.replace("settlement_probability", "repricing_momentum", 1),
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("strategy config profile mismatch", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds `scripts/apply_autofactor_handoff_to_config.py` to apply a ready `autofactor-strategy-handoff.json` to a dry-run strategy config
- extends `autofactor-strategy-promotion.yml` with optional `create_config_pr=true`, which opens a PR only when the handoff is ready and the config differs
- documents the final handoff-to-config step in the Event ML / AutoFactor runbook

## Why

The AutoResearch chain still had a manual gap: qualified handoff artifacts could create issues, but turning the selected runtime score into a dry-run config PR was manual. This keeps the step CI-gated and PR-only while avoiding hand-edited TOML for future promoted factors.

## Verification

- `python3 -m unittest tests.test_apply_autofactor_handoff_to_config tests.test_autofactor_strategy_promotion`
- `python3 -m py_compile scripts/apply_autofactor_handoff_to_config.py scripts/evaluate_autofactor_strategy_promotion.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/autofactor-strategy-promotion.yml")'`
- `git diff --check`

## Safety

This does not deploy and does not enable live trading. The generated workflow path only updates `three_layer_autofactor_runtime_score` in `config/strategies/*.toml` and opens a normal PR for CI/review.

Related #361
