### PR TITLE
Move Event ML artifact evidence onto hosted runners

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -35,10 +35,14 @@ on:
         description: "Upload raw event-root Parquet datasets as artifacts"
         required: false
         default: "false"
-      options_json:
-        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid"
+      source_dataset_run_id:
+        description: "Existing event-ml-rolling-datasets artifact run id; skips ploy-ci-1 export and runs artifact-backed evidence on GitHub-hosted runner"
         required: false
-        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500}'
+        default: ""
+      options_json:
+        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name"
+        required: false
+        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":""}'
 
 concurrency:
   group: event-ml-rolling-evidence-${{ github.ref }}
@@ -46,6 +50,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -117,7 +122,8 @@ jobs:
           retention-days: 3
 
   event-ml:
-    name: Generate event ML rolling evidence on ploy-ci-1
+    name: Generate event ML rolling evidence from DB on ploy-ci-1
+    if: ${{ github.event.inputs.source_dataset_run_id == '' }}
     runs-on: [self-hosted, ploy-ci-1]
     needs: build-event-ml-examples
     timeout-minutes: 150
@@ -163,6 +169,7 @@ jobs:
               "search_min_edge": "0,0.02,0.05",
               "search_learning_rate": "0.03,0.05",
               "search_epochs": "500",
+              "source_dataset_artifact_name": "",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -304,3 +311,193 @@ jobs:
             artifacts/event-ml/source_event_root/
             artifacts/event-ml/rolling_datasets/
           retention-days: 3
+
+  hosted-event-ml-from-artifact:
+    name: Generate event ML rolling evidence from artifact on GitHub-hosted runner
+    if: ${{ github.event.inputs.source_dataset_run_id != '' }}
+    runs-on: ubuntu-latest
+    needs: build-event-ml-examples
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Download event ML binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: event-ml-example-binaries-${{ github.run_id }}
+          path: artifacts/event-ml-bin
+
+      - name: Prepare event ML binaries
+        run: chmod +x artifacts/event-ml-bin/*
+
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "lob_sample_secs": "30",
+              "max_quote_age_secs": "30",
+              "entry_secs": "60",
+              "tolerance_secs": "30",
+              "search_l2": "0,0.001,0.01",
+              "search_min_edge": "0,0.02,0.05",
+              "search_learning_rate": "0.03,0.05",
+              "search_epochs": "500",
+              "source_dataset_artifact_name": "",
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+          values = dict(defaults)
+          values.update({key: str(value) for key, value in data.items()})
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"EVENT_ML_{key.upper()}={value}\n")
+          PY
+
+      - name: Download source event-root dataset artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_DATASET_RUN_ID: ${{ github.event.inputs.source_dataset_run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/event-ml artifacts/event-ml-source
+          mkdir -p artifacts/event-ml
+
+          artifact_name="${EVENT_ML_SOURCE_DATASET_ARTIFACT_NAME}"
+          if [ -z "${artifact_name}" ]; then
+            artifact_name="event-ml-rolling-datasets-${SOURCE_DATASET_RUN_ID}"
+          fi
+
+          python3 scripts/download_github_artifact.py \
+            --run-id "${SOURCE_DATASET_RUN_ID}" \
+            --name "${artifact_name}" \
+            --output-dir artifacts/event-ml-source
+
+          if [ -d artifacts/event-ml-source/source_event_root ]; then
+            cp -a artifacts/event-ml-source/. artifacts/event-ml/
+          elif [ -d artifacts/event-ml-source/artifacts/event-ml/source_event_root ]; then
+            cp -a artifacts/event-ml-source/artifacts/event-ml/. artifacts/event-ml/
+          else
+            echo "Dataset artifact must contain source_event_root/event_manifest.json" >&2
+            find artifacts/event-ml-source -maxdepth 4 -type f -print >&2
+            exit 2
+          fi
+
+          test -f artifacts/event-ml/source_event_root/event_manifest.json
+
+      - name: Split source dataset into rolling windows
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/event-ml/rolling_datasets
+          mkdir -p artifacts/event-ml/reports
+
+          artifacts/event-ml-bin/event_dataset_rolling_windows \
+            --dataset artifacts/event-ml/source_event_root \
+            --window-events "${{ github.event.inputs.child_window_events }}" \
+            --output-root artifacts/event-ml/rolling_datasets \
+            | tee artifacts/event-ml/reports/rolling_dataset_split.txt
+
+      - name: Run canonical rolling ML workflow
+        if: ${{ github.event.inputs.run_workflow == 'true' }}
+        run: |
+          set -euo pipefail
+
+          DATASETS="$(paste -sd, artifacts/event-ml/rolling_datasets/rolling_datasets.txt)"
+          artifacts/event-ml-bin/event_ml_rolling_workflow \
+            --datasets "${DATASETS}" \
+            --output-root artifacts/event-ml/rolling_workflow \
+            --entry-secs "${EVENT_ML_ENTRY_SECS}" \
+            --tolerance-secs "${EVENT_ML_TOLERANCE_SECS}" \
+            --search-l2 "${EVENT_ML_SEARCH_L2}" \
+            --search-min-edge "${EVENT_ML_SEARCH_MIN_EDGE}" \
+            --search-learning-rate "${EVENT_ML_SEARCH_LEARNING_RATE}" \
+            --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
+            | tee artifacts/event-ml/reports/rolling_workflow.txt
+
+      - name: Collect compact reports
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/event-ml artifacts/event-ml-report-bundle
+          find artifacts/event-ml -type f \
+            \( -name '*.json' -o -name '*.md' -o -name '*.txt' \) \
+            ! -path '*/observations_*.parquet' \
+            ! -path '*/event_summaries_*.parquet' \
+            ! -path '*/event_index.parquet' \
+            ! -path '*/split_assignments.parquet' \
+            -print0 > /tmp/event-ml-report-files
+          if [ -s /tmp/event-ml-report-files ]; then
+            tar --null -T /tmp/event-ml-report-files -czf artifacts/event-ml-report-bundle/event-ml-reports.tar.gz
+          else
+            echo "No event ML reports were produced." > artifacts/event-ml-report-bundle/NO_REPORTS.txt
+          fi
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Event ML rolling evidence"
+            echo ""
+            echo "- Runner: \`ubuntu-latest\`"
+            echo "- Source dataset run: \`${{ github.event.inputs.source_dataset_run_id }}\`"
+            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Symbols: ${{ github.event.inputs.symbols }}"
+            echo "- Source windows: artifact-backed"
+            echo "- Child window events: ${{ github.event.inputs.child_window_events }}"
+            echo "- Run workflow: ${{ github.event.inputs.run_workflow }}"
+            echo ""
+
+            if [ -f artifacts/event-ml/source_event_root/event_manifest.json ]; then
+              echo "### Source dataset"
+              echo '```json'
+              jq '.stats' artifacts/event-ml/source_event_root/event_manifest.json || true
+              echo '```'
+            fi
+
+            if [ -f artifacts/event-ml/rolling_datasets/rolling_datasets_report.json ]; then
+              echo "### Rolling dataset split"
+              echo '```json'
+              jq '{exported_windows, skipped_events, windows: [.windows[] | {id, events, events_per_split}]}' artifacts/event-ml/rolling_datasets/rolling_datasets_report.json || true
+              echo '```'
+            fi
+
+            if [ -f artifacts/event-ml/rolling_workflow/rolling_workflow_report.json ]; then
+              echo "### Rolling workflow"
+              echo '```json'
+              jq '{dataset_count, min_windows, final_walk_forward_report, windows: [.windows[] | {id, status, prior_run_dirs: (.prior_run_dirs | length)}]}' artifacts/event-ml/rolling_workflow/rolling_workflow_report.json || true
+              echo '```'
+            fi
+
+            FINAL_WALK_FORWARD_REPORT="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/walk_forward_report.json' 2>/dev/null | sort | tail -1 || true)"
+            if [ -n "${FINAL_WALK_FORWARD_REPORT}" ] && [ -f "${FINAL_WALK_FORWARD_REPORT}" ]; then
+              echo "### Final walk-forward readiness"
+              echo '```json'
+              jq '.readiness' "${FINAL_WALK_FORWARD_REPORT}" || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload compact report bundle
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: event-ml-rolling-reports-${{ github.run_id }}
+          path: artifacts/event-ml-report-bundle/
+          retention-days: 14

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -372,11 +372,35 @@ gh workflow run event-ml-rolling-evidence.yml \
 ```
 
 The workflow builds the required Rust examples on a GitHub-hosted Ubuntu
-runner first, uploads those binaries as an artifact, then runs the DB-adjacent
-evidence phase on `ploy-ci-1`. `ploy-ci-1` should only download and execute
-the prebuilt binaries while reading the remote research database at
-`172.16.0.204`; do not reintroduce `cargo build` or `cargo run` steps there.
-The self-hosted phase performs:
+runner first, uploads those binaries as an artifact, then chooses one of two
+execution paths:
+
+- if `source_dataset_run_id` is set, it downloads the existing
+  `event-ml-rolling-datasets-<run-id>` artifact and runs the split plus
+  canonical rolling ML workflow entirely on `ubuntu-latest`;
+- if `source_dataset_run_id` is empty, it uses the legacy DB-adjacent
+  `ploy-ci-1` phase only to export the source event-root dataset from the
+  private research database.
+
+Prefer the hosted artifact path whenever a retained dataset artifact is
+available:
+
+```bash
+gh workflow run event-ml-rolling-evidence.yml \
+  -f git_ref=main \
+  -f source_dataset_run_id=<run-id-with-event-ml-rolling-datasets-artifact> \
+  -f start_date=2026-04-24 \
+  -f end_date=2026-04-25 \
+  -f symbols=BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT,BNBUSDT,XRPUSDT \
+  -f child_window_events=150 \
+  -f run_workflow=true
+```
+
+If the dataset artifact has a non-default name, pass it through
+`options_json.source_dataset_artifact_name`. Keep it inside `options_json` so
+the workflow stays within GitHub's 10-input dispatch limit.
+
+The legacy self-hosted phase performs:
 
 1. `factor_research --export-event-dataset`
 2. `event_dataset_rolling_windows`
@@ -384,7 +408,8 @@ The self-hosted phase performs:
 
 `event_ml_rolling_workflow` also expects the sibling `event_ml_workflow`
 binary to be present next to it in the downloaded artifact, so rolling windows
-do not spawn nested Cargo builds on `ploy-ci-1`.
+do not spawn nested Cargo builds on either `ploy-ci-1` or GitHub-hosted
+runners.
 
 It uploads a compact report artifact by default and deliberately avoids
 uploading raw Parquet datasets unless `upload_parquet_datasets=true` is passed.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -51,7 +51,7 @@ mismatch is understood and tracked as a follow-up issue.
 | Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
 | Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
 | Recorded replay/dry-run parity | `.github/workflows/recorded-replay-parity.yml` | Replay a canonical MarketUpdate recording on `tango-1-1` with the deployed binary, then compare against the matching dry-run report slice |
-| Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports |
+| Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports; use `source_dataset_run_id` for the GitHub-hosted artifact path |
 | Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
 | Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |
 | ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` environment |
@@ -189,6 +189,10 @@ different.
   Use `factor-walk-forward-v2-hosted-artifact.yml` directly, or
   `settlement-probability-prd-gate.yml` with `snapshot_run_id`, when a retained
   full research snapshot artifact already exists.
+- Event ML rolling evidence should also default to GitHub-hosted runners after
+  the source event-root dataset is artifactized. Pass `source_dataset_run_id`
+  to `event-ml-rolling-evidence.yml`; only the fresh DB export branch should
+  touch `ploy-ci-1`.
 - `ploy-ci-1` is now a legacy DB-adjacent fallback for compiling fresh research
   snapshots from Tango PostgreSQL. Do not route AutoFactor mining,
   walk-forward promotion, or dry-run handoff checks to `ploy-ci-1` when a full

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -166,6 +166,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   a single GitHub-hosted run can go from retained snapshot artifact to
   AutoFactor walk-forward, promotion gate, handoff artifact, and config PR
   when `options_json.create_config_pr=true`.
+- [x] Add a GitHub-hosted artifact path for Event ML rolling evidence. When
+  `event-ml-rolling-evidence.yml` receives `source_dataset_run_id`, it now
+  downloads the retained event-root dataset artifact and runs dataset splitting
+  plus the canonical rolling ML workflow on `ubuntu-latest`; `ploy-ci-1`
+  remains only for the fresh DB export branch.
 
 ## Review
 
@@ -263,6 +268,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   same optional config-PR promotion path, controlled through `options_json`.
   This makes the artifact-backed hosted AutoFactor path a single workflow from
   snapshot consumption through ready-handoff config PR creation.
+- 2026-05-06: Extended `event-ml-rolling-evidence.yml` with
+  `source_dataset_run_id` so retained event-root dataset artifacts can be
+  processed on GitHub-hosted runners. This gives the Event ML workflow the same
+  migration shape as AutoFactor: use `ploy-ci-1` only for private DB export,
+  then run artifact-backed coverage/attribution/baseline/walk-forward evidence
+  on `ubuntu-latest`.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -103,6 +103,52 @@ fn workflow_dispatch_inputs_stay_lintable() {
 }
 
 #[test]
+fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
+    let workflow = workflow_contents(".github/workflows/event-ml-rolling-evidence.yml");
+    let runbook = workflow_contents("docs/runbooks/event-ml-automl-workflow.md");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "source_dataset_run_id:",
+        "actions: read",
+        "Generate event ML rolling evidence from artifact on GitHub-hosted runner",
+        "runs-on: ubuntu-latest",
+        "github.event.inputs.source_dataset_run_id != ''",
+        "scripts/download_github_artifact.py",
+        "event-ml-rolling-datasets-${SOURCE_DATASET_RUN_ID}",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!("event-ml-rolling-evidence.yml: missing `{needle}`"));
+        }
+    }
+
+    if !workflow.contains("github.event.inputs.source_dataset_run_id == ''")
+        || !workflow.contains("Generate event ML rolling evidence from DB on ploy-ci-1")
+    {
+        offenders.push(
+            "event-ml-rolling-evidence.yml: legacy DB export must be explicitly isolated"
+                .to_string(),
+        );
+    }
+
+    for needle in [
+        "Prefer the hosted artifact path",
+        "source_dataset_artifact_name",
+        "workflow stays within GitHub's 10-input dispatch limit",
+    ] {
+        if !runbook.contains(needle) {
+            offenders.push(format!("event-ml-automl-workflow.md: missing `{needle}`"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "event ML hosted artifact lane guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn ack_images_use_immutable_sha_tags() {
     let build = workflow_contents(".github/workflows/build-push-acr.yml");
     let deploy = workflow_contents(".github/workflows/deploy-ack.yml");


### PR DESCRIPTION
## Summary
- add a `source_dataset_run_id` artifact-backed branch to `event-ml-rolling-evidence.yml` that runs split + rolling ML evidence on `ubuntu-latest`
- keep `ploy-ci-1` only for the legacy fresh private-DB event-root export path
- document the hosted path and add a workflow security guard for the migration contract

## Verification
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |p| YAML.load_file(p) }; puts "all workflow yaml ok"'`\n- `CARGO_TARGET_DIR=/tmp/ploy-workflow-security rtk cargo test --test workflow_security -- --nocapture`\n- `git diff --check`\n\n## Notes\n- PR-only research workflow change. No deploy, no live order path.\n- Live workflow_dispatch against a retained event-ml dataset artifact is still untested.