### PR TITLE
Add fail-closed Event ML strategy handoff

### DIFF
--- a/crates/ploy-research/examples/event_ml_walk_forward.rs
+++ b/crates/ploy-research/examples/event_ml_walk_forward.rs
@@ -3,7 +3,10 @@ use std::fs::{self, File};
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
-use ploy_research::{build_walk_forward_report, walk_forward_report_markdown, WalkForwardConfig};
+use ploy_research::{
+    build_event_ml_strategy_handoff, build_walk_forward_report, event_ml_strategy_handoff_markdown,
+    walk_forward_report_markdown, EventMlStrategyHandoffConfig, WalkForwardConfig,
+};
 
 fn main() -> Result<()> {
     let config = Config::parse(env::args().skip(1))?;
@@ -33,6 +36,27 @@ fn main() -> Result<()> {
     fs::write(&markdown_path, markdown)
         .with_context(|| format!("write {}", markdown_path.display()))?;
 
+    let handoff = build_event_ml_strategy_handoff(
+        &report,
+        &EventMlStrategyHandoffConfig {
+            required_strategy_profile: config.required_strategy_profile.clone(),
+            runtime_score: config.runtime_score.clone(),
+            replay_parity_ready: config.replay_parity_ready,
+            source_report_path: Some(json_path.display().to_string()),
+        },
+    );
+    let handoff_json_path = output_dir.join("event_ml_strategy_handoff.json");
+    let handoff_md_path = output_dir.join("event_ml_strategy_handoff.md");
+    let handoff_file = File::create(&handoff_json_path)
+        .with_context(|| format!("create {}", handoff_json_path.display()))?;
+    serde_json::to_writer_pretty(handoff_file, &handoff)
+        .with_context(|| format!("write {}", handoff_json_path.display()))?;
+    fs::write(
+        &handoff_md_path,
+        event_ml_strategy_handoff_markdown(&handoff),
+    )
+    .with_context(|| format!("write {}", handoff_md_path.display()))?;
+
     eprintln!("artifact_walk_forward_report={}", json_path.display());
     eprintln!(
         "artifact_walk_forward_report_md={}",
@@ -43,6 +67,20 @@ fn main() -> Result<()> {
         "walk_forward_ready_for_dl_rl={}",
         report.readiness.ready_for_dl_rl
     );
+    eprintln!(
+        "artifact_event_ml_strategy_handoff={}",
+        handoff_json_path.display()
+    );
+    eprintln!(
+        "event_ml_strategy_handoff_status={}",
+        handoff.status.as_str()
+    );
+    if !handoff.blocked_gate_ids.is_empty() {
+        eprintln!(
+            "event_ml_strategy_handoff_blockers={}",
+            handoff.blocked_gate_ids.join(",")
+        );
+    }
     if !report.readiness.missing_gate_ids.is_empty() {
         eprintln!(
             "walk_forward_missing_gates={}",
@@ -58,6 +96,9 @@ struct Config {
     output_dir: Option<PathBuf>,
     min_windows: usize,
     min_test_trades_per_window: usize,
+    required_strategy_profile: String,
+    runtime_score: Option<String>,
+    replay_parity_ready: bool,
 }
 
 impl Config {
@@ -91,8 +132,15 @@ impl Config {
         let min_windows = parse_usize_flag(&args, "--min-windows", 3)?;
         let min_test_trades_per_window =
             parse_usize_flag(&args, "--min-test-trades-per-window", 1)?;
+        let required_strategy_profile = flag_value(&args, "--required-strategy-profile")
+            .unwrap_or_else(|| "event_ml_supervised_tabular".to_string());
+        let runtime_score = flag_value(&args, "--runtime-score");
+        let replay_parity_ready = has_flag(&args, "--replay-parity-ready");
         if min_windows == 0 {
             bail!("--min-windows must be positive");
+        }
+        if required_strategy_profile.trim().is_empty() {
+            bail!("--required-strategy-profile must not be empty");
         }
 
         Ok(Config {
@@ -100,6 +148,9 @@ impl Config {
             output_dir,
             min_windows,
             min_test_trades_per_window,
+            required_strategy_profile,
+            runtime_score,
+            replay_parity_ready,
         })
     }
 }
@@ -146,6 +197,9 @@ Options:
   --output-dir <dir>                 Output artifact directory. Default: <first-run-dir>/walk_forward.
   --min-windows <n>                  Minimum windows required for DL/RL readiness. Default: 3.
   --min-test-trades-per-window <n>   Minimum test trades per window. Default: 1.
+  --required-strategy-profile <id>   Dry-run handoff profile. Default: event_ml_supervised_tabular.
+  --runtime-score <id>               Runtime scorer identifier. Required for a ready handoff.
+  --replay-parity-ready              Mark replay/runtime parity as ready for dry-run handoff.
   -h, --help                         Show this help.
 "#
     );

--- a/crates/ploy-research/src/event_ml/mod.rs
+++ b/crates/ploy-research/src/event_ml/mod.rs
@@ -5,9 +5,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 pub use walk_forward::{
-    build_walk_forward_report, walk_forward_report_markdown, WalkForwardAggregate,
-    WalkForwardConfig, WalkForwardGate, WalkForwardGateStatus, WalkForwardMetric,
-    WalkForwardReadiness, WalkForwardReport, WalkForwardWindow, WALK_FORWARD_REPORT_VERSION,
+    build_event_ml_strategy_handoff, build_walk_forward_report, event_ml_strategy_handoff_markdown,
+    walk_forward_report_markdown, EventMlStrategyCandidate, EventMlStrategyHandoff,
+    EventMlStrategyHandoffConfig, EventMlStrategyHandoffStatus, EventMlStrategyPromotionGate,
+    WalkForwardAggregate, WalkForwardConfig, WalkForwardGate, WalkForwardGateStatus,
+    WalkForwardMetric, WalkForwardReadiness, WalkForwardReport, WalkForwardWindow,
+    EVENT_ML_STRATEGY_HANDOFF_VERSION, WALK_FORWARD_REPORT_VERSION,
 };
 
 pub const EVENT_ML_ARCHITECTURE_VERSION: &str = "event-ml-architecture.v1";
@@ -344,7 +347,11 @@ fn canonical_phases() -> Vec<WorkflowPhase> {
             "Walk-forward and executable-price backtest",
             "Prove the result is not one lucky split and report bankroll risk.",
             &["selected model config", "multi-day event-root data"],
-            &["walk_forward_report.json", "backtest_report.json"],
+            &[
+                "walk_forward_report.json",
+                "event_ml_strategy_handoff.json",
+                "backtest_report.json",
+            ],
             "Stop if validation improvement does not survive rolling windows or executable accounting.",
         ),
         phase(
@@ -371,7 +378,11 @@ fn canonical_phases() -> Vec<WorkflowPhase> {
             "Dry-run strategy handoff",
             "Package the model and evidence for dry-run without changing live behavior.",
             &["research artifacts", "backtest evidence"],
-            &["strategy_handoff.md", "model version metadata"],
+            &[
+                "event_ml_strategy_handoff.json",
+                "event_ml_strategy_handoff.md",
+                "model version metadata",
+            ],
             "Stop if model version, feature schema, entry window, and monitoring requirements are absent.",
         ),
     ]
@@ -520,7 +531,7 @@ fn canonical_artifacts() -> Vec<ArchitectureArtifact> {
         ),
         artifact(
             "strategy_handoff",
-            "strategy_handoff.md",
+            "event_ml_strategy_handoff.{json,md}",
             PhaseId::DryRunHandoff,
             &[],
             "Research-to-dry-run packet with model version, schema, entry window, and monitoring requirements.",
@@ -686,7 +697,8 @@ fn canonical_readiness_gates() -> Vec<ReadinessGate> {
             "Dry-run handoff packet contains model, schema, entry, evidence, and monitoring.",
             &[LearningLaneId::DryRunStrategy],
             &[
-                "strategy_handoff.md",
+                "event_ml_strategy_handoff.json",
+                "event_ml_strategy_handoff.md",
                 "model metadata",
                 "monitoring checklist",
             ],

--- a/crates/ploy-research/src/event_ml/walk_forward.rs
+++ b/crates/ploy-research/src/event_ml/walk_forward.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 pub const WALK_FORWARD_REPORT_VERSION: &str = "event-ml-walk-forward.v1";
+pub const EVENT_ML_STRATEGY_HANDOFF_VERSION: &str = "event-ml-strategy-handoff.v1";
 
 #[derive(Debug, Clone)]
 pub struct WalkForwardConfig {
@@ -96,6 +97,75 @@ pub struct WalkForwardMetric {
     pub avg_entry: f64,
     pub logloss: f64,
     pub auc: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EventMlStrategyHandoffStatus {
+    Ready,
+    Blocked,
+}
+
+impl EventMlStrategyHandoffStatus {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            EventMlStrategyHandoffStatus::Ready => "ready",
+            EventMlStrategyHandoffStatus::Blocked => "blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EventMlStrategyHandoffConfig {
+    pub required_strategy_profile: String,
+    pub runtime_score: Option<String>,
+    pub replay_parity_ready: bool,
+    pub source_report_path: Option<String>,
+}
+
+impl Default for EventMlStrategyHandoffConfig {
+    fn default() -> Self {
+        Self {
+            required_strategy_profile: "event_ml_supervised_tabular".to_string(),
+            runtime_score: None,
+            replay_parity_ready: false,
+            source_report_path: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EventMlStrategyHandoff {
+    pub version: String,
+    pub status: EventMlStrategyHandoffStatus,
+    pub recommended_action: String,
+    pub required_strategy_profile: String,
+    pub runtime_score: Option<String>,
+    pub replay_parity_ready: bool,
+    pub blocked_gate_ids: Vec<String>,
+    pub promotion_gate: EventMlStrategyPromotionGate,
+    pub strategy: Option<EventMlStrategyCandidate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EventMlStrategyPromotionGate {
+    pub walk_forward_status: WalkForwardGateStatus,
+    pub source_report_path: Option<String>,
+    pub aggregate: WalkForwardAggregate,
+    pub missing_walk_forward_gate_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EventMlStrategyCandidate {
+    pub strategy_profile: String,
+    pub runtime_score: String,
+    pub selection_rule: String,
+    pub window_count: usize,
+    pub test_trades: usize,
+    pub test_pnl: f64,
+    pub test_roi: f64,
+    pub weighted_avg_entry: f64,
+    pub max_window_drawdown: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -259,6 +329,157 @@ pub fn walk_forward_report_markdown(report: &WalkForwardReport) -> String {
     out.push_str("\n## Notes\n\n");
     for note in &report.notes {
         out.push_str(&format!("- {note}\n"));
+    }
+
+    out
+}
+
+pub fn build_event_ml_strategy_handoff(
+    report: &WalkForwardReport,
+    config: &EventMlStrategyHandoffConfig,
+) -> EventMlStrategyHandoff {
+    let runtime_score = config
+        .runtime_score
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let mut blocked_gate_ids = report.readiness.missing_gate_ids.clone();
+    if report.aggregate.total_test_pnl <= 0.0 {
+        blocked_gate_ids.push("positive_total_test_pnl_missing".to_string());
+    }
+    if report.aggregate.positive_test_windows * 2 < report.aggregate.window_count {
+        blocked_gate_ids.push("positive_test_window_majority_missing".to_string());
+    }
+    if runtime_score.is_none() {
+        blocked_gate_ids.push("runtime_score_missing".to_string());
+    }
+    if !config.replay_parity_ready {
+        blocked_gate_ids.push("replay_parity_missing".to_string());
+    }
+
+    let status = if blocked_gate_ids.is_empty() {
+        EventMlStrategyHandoffStatus::Ready
+    } else {
+        EventMlStrategyHandoffStatus::Blocked
+    };
+    let strategy = match (&status, &runtime_score) {
+        (EventMlStrategyHandoffStatus::Ready, Some(runtime_score)) => {
+            Some(EventMlStrategyCandidate {
+                strategy_profile: config.required_strategy_profile.clone(),
+                runtime_score: runtime_score.clone(),
+                selection_rule: report.selection_rule.clone(),
+                window_count: report.aggregate.window_count,
+                test_trades: report.aggregate.total_test_trades,
+                test_pnl: report.aggregate.total_test_pnl,
+                test_roi: report.aggregate.total_test_roi,
+                weighted_avg_entry: report.aggregate.weighted_avg_entry,
+                max_window_drawdown: report.aggregate.max_window_drawdown,
+            })
+        }
+        _ => None,
+    };
+
+    EventMlStrategyHandoff {
+        version: EVENT_ML_STRATEGY_HANDOFF_VERSION.to_string(),
+        recommended_action: if status == EventMlStrategyHandoffStatus::Ready {
+            "create_dry_run_handoff".to_string()
+        } else {
+            "do_not_promote".to_string()
+        },
+        required_strategy_profile: config.required_strategy_profile.clone(),
+        runtime_score,
+        replay_parity_ready: config.replay_parity_ready,
+        blocked_gate_ids,
+        promotion_gate: EventMlStrategyPromotionGate {
+            walk_forward_status: report.readiness.status,
+            source_report_path: config.source_report_path.clone(),
+            aggregate: report.aggregate.clone(),
+            missing_walk_forward_gate_ids: report.readiness.missing_gate_ids.clone(),
+        },
+        status,
+        strategy,
+    }
+}
+
+pub fn event_ml_strategy_handoff_markdown(handoff: &EventMlStrategyHandoff) -> String {
+    let mut out = String::new();
+    out.push_str("# Event ML Dry-Run Strategy Handoff\n\n");
+    out.push_str(&format!("Version: `{}`\n\n", handoff.version));
+    out.push_str(&format!("Status: `{}`\n\n", handoff.status.as_str()));
+    out.push_str(&format!(
+        "Recommended action: `{}`\n\n",
+        handoff.recommended_action
+    ));
+    out.push_str(&format!(
+        "- Required strategy profile: `{}`\n",
+        handoff.required_strategy_profile
+    ));
+    out.push_str(&format!(
+        "- Runtime score: `{}`\n",
+        handoff.runtime_score.as_deref().unwrap_or("missing")
+    ));
+    out.push_str(&format!(
+        "- Replay parity ready: `{}`\n",
+        handoff.replay_parity_ready
+    ));
+    out.push_str(&format!(
+        "- Walk-forward status: `{}`\n\n",
+        handoff.promotion_gate.walk_forward_status.as_str()
+    ));
+
+    if handoff.status != EventMlStrategyHandoffStatus::Ready {
+        out.push_str(
+            "No dry-run handoff issue or config should be created from this artifact.\n\n",
+        );
+        out.push_str("## Blockers\n\n");
+        for gate_id in &handoff.blocked_gate_ids {
+            out.push_str(&format!("- `{gate_id}`\n"));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Evidence\n\n");
+    out.push_str(&format!(
+        "- windows: `{}`\n",
+        handoff.promotion_gate.aggregate.window_count
+    ));
+    out.push_str(&format!(
+        "- test trades: `{}`\n",
+        handoff.promotion_gate.aggregate.total_test_trades
+    ));
+    out.push_str(&format!(
+        "- test PnL: `{:.4}`\n",
+        handoff.promotion_gate.aggregate.total_test_pnl
+    ));
+    out.push_str(&format!(
+        "- test ROI: `{:.4}`\n",
+        handoff.promotion_gate.aggregate.total_test_roi
+    ));
+    out.push_str(&format!(
+        "- weighted avg entry: `{:.4}`\n",
+        handoff.promotion_gate.aggregate.weighted_avg_entry
+    ));
+    out.push_str(&format!(
+        "- max window drawdown: `{:.4}`\n\n",
+        handoff.promotion_gate.aggregate.max_window_drawdown
+    ));
+
+    if let Some(strategy) = &handoff.strategy {
+        out.push_str("## Dry-Run Config Contract\n\n");
+        out.push_str("```toml\n");
+        out.push_str("[event_ml_strategy_handoff]\n");
+        out.push_str(&format!(
+            "strategy_profile = \"{}\"\n",
+            strategy.strategy_profile
+        ));
+        out.push_str(&format!("runtime_score = \"{}\"\n", strategy.runtime_score));
+        out.push_str("promotion_status = \"ready_for_dry_run_handoff\"\n");
+        out.push_str("```\n\n");
+        out.push_str("## Monitoring Requirements\n\n");
+        out.push_str("- Confirm runtime/replay scorer parity before deployment.\n");
+        out.push_str("- Confirm live dry-run quote availability matches research assumptions.\n");
+        out.push_str("- Keep live trading disabled until a separate operator approval gate.\n");
     }
 
     out
@@ -622,5 +843,113 @@ mod tests {
                 .to_string();
 
         assert!(error.contains("duplicate walk-forward run dir"));
+    }
+
+    #[test]
+    fn event_ml_handoff_is_blocked_without_runtime_and_replay_parity() {
+        let windows = vec![
+            window(1, 1.0, 2.0, 10, 0.4),
+            window(2, 1.0, 2.0, 10, 0.4),
+            window(3, 1.0, 2.0, 10, 0.4),
+        ];
+        let report = WalkForwardReport {
+            version: WALK_FORWARD_REPORT_VERSION.to_string(),
+            selection_rule: "test rule".to_string(),
+            readiness: WalkForwardReadiness {
+                ready_for_dl_rl: true,
+                status: WalkForwardGateStatus::Ready,
+                missing_gate_ids: vec![],
+            },
+            gates: vec![],
+            aggregate: aggregate_windows(&windows),
+            windows,
+            notes: vec![],
+        };
+
+        let handoff =
+            build_event_ml_strategy_handoff(&report, &EventMlStrategyHandoffConfig::default());
+
+        assert_eq!(handoff.status, EventMlStrategyHandoffStatus::Blocked);
+        assert_eq!(handoff.recommended_action, "do_not_promote");
+        assert!(handoff.strategy.is_none());
+        assert!(handoff
+            .blocked_gate_ids
+            .contains(&"runtime_score_missing".to_string()));
+        assert!(handoff
+            .blocked_gate_ids
+            .contains(&"replay_parity_missing".to_string()));
+    }
+
+    #[test]
+    fn event_ml_handoff_treats_blank_runtime_score_as_missing() {
+        let windows = vec![
+            window(1, 1.0, 2.0, 10, 0.4),
+            window(2, 1.0, 1.0, 10, 0.4),
+            window(3, 1.0, 1.0, 10, 0.4),
+        ];
+        let report = WalkForwardReport {
+            version: WALK_FORWARD_REPORT_VERSION.to_string(),
+            selection_rule: "validation pnl".to_string(),
+            readiness: WalkForwardReadiness {
+                ready_for_dl_rl: true,
+                status: WalkForwardGateStatus::Ready,
+                missing_gate_ids: vec![],
+            },
+            gates: vec![],
+            aggregate: aggregate_windows(&windows),
+            windows,
+            notes: vec![],
+        };
+        let config = EventMlStrategyHandoffConfig {
+            runtime_score: Some("   ".to_string()),
+            replay_parity_ready: true,
+            ..EventMlStrategyHandoffConfig::default()
+        };
+
+        let handoff = build_event_ml_strategy_handoff(&report, &config);
+
+        assert_eq!(handoff.status, EventMlStrategyHandoffStatus::Blocked);
+        assert!(handoff.runtime_score.is_none());
+        assert!(handoff
+            .blocked_gate_ids
+            .contains(&"runtime_score_missing".to_string()));
+    }
+
+    #[test]
+    fn event_ml_handoff_is_ready_only_after_all_strategy_gates() {
+        let windows = vec![
+            window(1, 1.0, 2.0, 10, 0.4),
+            window(2, 1.0, 1.0, 10, 0.4),
+            window(3, 1.0, 1.0, 10, 0.4),
+        ];
+        let report = WalkForwardReport {
+            version: WALK_FORWARD_REPORT_VERSION.to_string(),
+            selection_rule: "validation pnl".to_string(),
+            readiness: WalkForwardReadiness {
+                ready_for_dl_rl: true,
+                status: WalkForwardGateStatus::Ready,
+                missing_gate_ids: vec![],
+            },
+            gates: vec![],
+            aggregate: aggregate_windows(&windows),
+            windows,
+            notes: vec![],
+        };
+        let config = EventMlStrategyHandoffConfig {
+            runtime_score: Some("event_ml_model:baseline_v1".to_string()),
+            replay_parity_ready: true,
+            source_report_path: Some("walk_forward_report.json".to_string()),
+            ..EventMlStrategyHandoffConfig::default()
+        };
+
+        let handoff = build_event_ml_strategy_handoff(&report, &config);
+
+        assert_eq!(handoff.status, EventMlStrategyHandoffStatus::Ready);
+        assert_eq!(handoff.recommended_action, "create_dry_run_handoff");
+        assert!(handoff.blocked_gate_ids.is_empty());
+        let strategy = handoff.strategy.expect("ready handoff has strategy");
+        assert_eq!(strategy.runtime_score, "event_ml_model:baseline_v1");
+        assert_eq!(strategy.window_count, 3);
+        assert_eq!(strategy.test_trades, 30);
     }
 }

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -37,12 +37,15 @@ pub use deribit::{
     DeribitFeatureLoadResult,
 };
 pub use event_ml::{
-    build_walk_forward_report, canonical_event_ml_architecture, event_ml_architecture_markdown,
-    gate_matrix, walk_forward_report_markdown, ArchitectureArtifact, EventMlArchitecture,
-    LaneReadiness, LaneStatus, LearningLane, LearningLaneId, PhaseId, ReadinessGate,
-    WalkForwardAggregate, WalkForwardConfig, WalkForwardGate, WalkForwardGateStatus,
-    WalkForwardMetric, WalkForwardReadiness, WalkForwardReport, WalkForwardWindow, WorkflowPhase,
-    EVENT_ML_ARCHITECTURE_VERSION, WALK_FORWARD_REPORT_VERSION,
+    build_event_ml_strategy_handoff, build_walk_forward_report, canonical_event_ml_architecture,
+    event_ml_architecture_markdown, event_ml_strategy_handoff_markdown, gate_matrix,
+    walk_forward_report_markdown, ArchitectureArtifact, EventMlArchitecture,
+    EventMlStrategyCandidate, EventMlStrategyHandoff, EventMlStrategyHandoffConfig,
+    EventMlStrategyHandoffStatus, EventMlStrategyPromotionGate, LaneReadiness, LaneStatus,
+    LearningLane, LearningLaneId, PhaseId, ReadinessGate, WalkForwardAggregate, WalkForwardConfig,
+    WalkForwardGate, WalkForwardGateStatus, WalkForwardMetric, WalkForwardReadiness,
+    WalkForwardReport, WalkForwardWindow, WorkflowPhase, EVENT_ML_ARCHITECTURE_VERSION,
+    EVENT_ML_STRATEGY_HANDOFF_VERSION, WALK_FORWARD_REPORT_VERSION,
 };
 pub use factors::{
     aggregate_factor_metrics, build_event_summaries, build_factor_observations,

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -107,8 +107,13 @@ phase consumes that whitelist automatically. The runner also writes
 The hyperparameter phase writes candidate-level `baseline_metrics.json` files
 plus `hyperparameter_search.json` and `hyperparameter_search.md`.
 The walk-forward phase writes `walk_forward_report.json` and
-`walk_forward_report.md`. With only one workflow run, the report is expected to
-mark DL/RL readiness as `blocked`; that is a useful gate, not a runner failure.
+`walk_forward_report.md`. It also writes a fail-closed
+`event_ml_strategy_handoff.json` / `.md`. The handoff stays `blocked` unless
+walk-forward gates pass, total test PnL is positive, a majority of test windows
+are positive, a runtime score is explicitly supplied, and replay parity is
+marked ready. With only one workflow run, the report is expected to mark DL/RL
+and dry-run handoff readiness as `blocked`; that is a useful gate, not a runner
+failure.
 
 ## AutoFactor Strategy Promotion Gate
 
@@ -688,6 +693,8 @@ The gate writes:
 
 - `walk_forward_report.json`
 - `walk_forward_report.md`
+- `event_ml_strategy_handoff.json`
+- `event_ml_strategy_handoff.md`
 
 Default readiness gates:
 
@@ -697,6 +704,18 @@ Default readiness gates:
 - executable entry accounting is present: cost, ROI, and average entry
 - window-level drawdown is reported
 - validation/test direction agreement is reported
+
+Dry-run handoff gates:
+
+- walk-forward readiness is `ready`
+- total test PnL is positive
+- at least half of test windows are positive
+- `--runtime-score` is supplied by a runtime-integrated scorer
+- `--replay-parity-ready` is supplied only after recorded replay/runtime parity
+  evidence has passed
+
+Without those handoff gates, the generated handoff artifact is still useful,
+but it must say `status=blocked` and `recommended_action=do_not_promote`.
 
 The workflow runner calls this gate automatically for its current run. A
 single-run report should remain `blocked` for DL/RL because it lacks rolling

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -171,6 +171,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   downloads the retained event-root dataset artifact and runs dataset splitting
   plus the canonical rolling ML workflow on `ubuntu-latest`; `ploy-ci-1`
   remains only for the fresh DB export branch.
+- [x] Add a fail-closed Event ML dry-run strategy handoff artifact so rolling
+  Event ML evidence cannot become a dry-run strategy unless walk-forward,
+  positive executable PnL, runtime scorer mapping, and replay parity gates all
+  pass. `event_ml_walk_forward` now writes
+  `event_ml_strategy_handoff.{json,md}` alongside the walk-forward report.
 
 ## Review
 
@@ -274,6 +279,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   migration shape as AutoFactor: use `ploy-ci-1` only for private DB export,
   then run artifact-backed coverage/attribution/baseline/walk-forward evidence
   on `ubuntu-latest`.
+- 2026-05-06: Added the Event ML dry-run handoff contract in Rust. The handoff
+  artifact is intentionally blocked unless walk-forward readiness passes,
+  aggregate test PnL is positive, at least half of test windows are positive, a
+  runtime score is supplied, and recorded replay/runtime parity is marked
+  ready. Verification passed with targeted rustfmt, `event_ml_handoff` unit
+  tests, `event_ml_walk_forward` cargo check, and `git diff --check`.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable


### PR DESCRIPTION
## Summary
- add machine-readable Event ML dry-run handoff artifacts from event_ml_walk_forward
- keep handoff fail-closed until walk-forward, positive executable PnL, positive-window, runtime-score, and replay-parity gates pass
- document the handoff contract in the Event ML AutoML runbook and task tracker

## Verification
- rustfmt --edition 2021 --check crates/ploy-research/src/event_ml/walk_forward.rs crates/ploy-research/src/event_ml/mod.rs crates/ploy-research/examples/event_ml_walk_forward.rs
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-handoff rtk cargo test -p ploy-research event_ml_handoff --lib -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-handoff rtk cargo check -p ploy-research --example event_ml_walk_forward
- git diff --check

## Safety
- no live trading path changed
- no deployment workflow triggered
- blocked handoffs explicitly recommend do_not_promote