### PR TITLE
Wire Event ML handoff gates through rolling workflows

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name"
+        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name, handoff runtime/parity gates"
         required: false
-        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":""}'
+        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":"","required_strategy_profile":"event_ml_supervised_tabular","runtime_score":"","replay_parity_ready":"false"}'
 
 concurrency:
   group: event-ml-rolling-evidence-${{ github.ref }}
@@ -170,6 +170,9 @@ jobs:
               "search_learning_rate": "0.03,0.05",
               "search_epochs": "500",
               "source_dataset_artifact_name": "",
+              "required_strategy_profile": "event_ml_supervised_tabular",
+              "runtime_score": "",
+              "replay_parity_ready": "false",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -222,6 +225,15 @@ jobs:
           set -euo pipefail
 
           DATASETS="$(paste -sd, artifacts/event-ml/rolling_datasets/rolling_datasets.txt)"
+          handoff_args=(
+            --required-strategy-profile "${EVENT_ML_REQUIRED_STRATEGY_PROFILE}"
+          )
+          if [ -n "${EVENT_ML_RUNTIME_SCORE}" ]; then
+            handoff_args+=(--runtime-score "${EVENT_ML_RUNTIME_SCORE}")
+          fi
+          case "${EVENT_ML_REPLAY_PARITY_READY}" in
+            true|True|1|yes|YES) handoff_args+=(--replay-parity-ready) ;;
+          esac
           artifacts/event-ml-bin/event_ml_rolling_workflow \
             --datasets "${DATASETS}" \
             --output-root artifacts/event-ml/rolling_workflow \
@@ -231,6 +243,7 @@ jobs:
             --search-min-edge "${EVENT_ML_SEARCH_MIN_EDGE}" \
             --search-learning-rate "${EVENT_ML_SEARCH_LEARNING_RATE}" \
             --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
+            "${handoff_args[@]}" \
             | tee artifacts/event-ml/reports/rolling_workflow.txt
 
       - name: Collect compact reports
@@ -281,7 +294,7 @@ jobs:
             if [ -f artifacts/event-ml/rolling_workflow/rolling_workflow_report.json ]; then
               echo "### Rolling workflow"
               echo '```json'
-              jq '{dataset_count, min_windows, final_walk_forward_report, windows: [.windows[] | {id, status, prior_run_dirs: (.prior_run_dirs | length)}]}' artifacts/event-ml/rolling_workflow/rolling_workflow_report.json || true
+              jq '{dataset_count, min_windows, final_walk_forward_report, final_strategy_handoff_report, windows: [.windows[] | {id, status, prior_run_dirs: (.prior_run_dirs | length)}]}' artifacts/event-ml/rolling_workflow/rolling_workflow_report.json || true
               echo '```'
             fi
 
@@ -290,6 +303,14 @@ jobs:
               echo "### Final walk-forward readiness"
               echo '```json'
               jq '.readiness' "${FINAL_WALK_FORWARD_REPORT}" || true
+              echo '```'
+            fi
+
+            FINAL_HANDOFF_REPORT="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.json' 2>/dev/null | sort | tail -1 || true)"
+            if [ -n "${FINAL_HANDOFF_REPORT}" ] && [ -f "${FINAL_HANDOFF_REPORT}" ]; then
+              echo "### Final strategy handoff"
+              echo '```json'
+              jq '{status, recommended_action, blocked_gate_ids, runtime_score, replay_parity_ready}' "${FINAL_HANDOFF_REPORT}" || true
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -353,6 +374,9 @@ jobs:
               "search_learning_rate": "0.03,0.05",
               "search_epochs": "500",
               "source_dataset_artifact_name": "",
+              "required_strategy_profile": "event_ml_supervised_tabular",
+              "runtime_score": "",
+              "replay_parity_ready": "false",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -420,6 +444,15 @@ jobs:
           set -euo pipefail
 
           DATASETS="$(paste -sd, artifacts/event-ml/rolling_datasets/rolling_datasets.txt)"
+          handoff_args=(
+            --required-strategy-profile "${EVENT_ML_REQUIRED_STRATEGY_PROFILE}"
+          )
+          if [ -n "${EVENT_ML_RUNTIME_SCORE}" ]; then
+            handoff_args+=(--runtime-score "${EVENT_ML_RUNTIME_SCORE}")
+          fi
+          case "${EVENT_ML_REPLAY_PARITY_READY}" in
+            true|True|1|yes|YES) handoff_args+=(--replay-parity-ready) ;;
+          esac
           artifacts/event-ml-bin/event_ml_rolling_workflow \
             --datasets "${DATASETS}" \
             --output-root artifacts/event-ml/rolling_workflow \
@@ -429,6 +462,7 @@ jobs:
             --search-min-edge "${EVENT_ML_SEARCH_MIN_EDGE}" \
             --search-learning-rate "${EVENT_ML_SEARCH_LEARNING_RATE}" \
             --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
+            "${handoff_args[@]}" \
             | tee artifacts/event-ml/reports/rolling_workflow.txt
 
       - name: Collect compact reports
@@ -481,7 +515,7 @@ jobs:
             if [ -f artifacts/event-ml/rolling_workflow/rolling_workflow_report.json ]; then
               echo "### Rolling workflow"
               echo '```json'
-              jq '{dataset_count, min_windows, final_walk_forward_report, windows: [.windows[] | {id, status, prior_run_dirs: (.prior_run_dirs | length)}]}' artifacts/event-ml/rolling_workflow/rolling_workflow_report.json || true
+              jq '{dataset_count, min_windows, final_walk_forward_report, final_strategy_handoff_report, windows: [.windows[] | {id, status, prior_run_dirs: (.prior_run_dirs | length)}]}' artifacts/event-ml/rolling_workflow/rolling_workflow_report.json || true
               echo '```'
             fi
 
@@ -490,6 +524,14 @@ jobs:
               echo "### Final walk-forward readiness"
               echo '```json'
               jq '.readiness' "${FINAL_WALK_FORWARD_REPORT}" || true
+              echo '```'
+            fi
+
+            FINAL_HANDOFF_REPORT="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.json' 2>/dev/null | sort | tail -1 || true)"
+            if [ -n "${FINAL_HANDOFF_REPORT}" ] && [ -f "${FINAL_HANDOFF_REPORT}" ]; then
+              echo "### Final strategy handoff"
+              echo '```json'
+              jq '{status, recommended_action, blocked_gate_ids, runtime_score, replay_parity_ready}' "${FINAL_HANDOFF_REPORT}" || true
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/ploy-research/examples/event_ml_rolling_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_rolling_workflow.rs
@@ -76,6 +76,15 @@ fn main() -> Result<()> {
                     .to_string()
             })
             .unwrap_or_default(),
+        final_strategy_handoff_report: prior_run_dirs
+            .last()
+            .map(|dir| {
+                dir.join("walk_forward")
+                    .join("event_ml_strategy_handoff.json")
+                    .display()
+                    .to_string()
+            })
+            .unwrap_or_default(),
     };
     write_report(&config.output_root, &report)?;
 
@@ -109,6 +118,9 @@ struct Config {
     search_epochs: usize,
     walk_forward_min_windows: usize,
     walk_forward_min_test_trades: usize,
+    required_strategy_profile: String,
+    runtime_score: Option<String>,
+    replay_parity_ready: bool,
     dry_run: bool,
 }
 
@@ -134,6 +146,10 @@ impl Config {
         let walk_forward_min_windows = parse_usize_flag(args, "--walk-forward-min-windows", 3)?;
         let walk_forward_min_test_trades =
             parse_usize_flag(args, "--walk-forward-min-test-trades", 1)?;
+        let required_strategy_profile = flag_value(args, "--required-strategy-profile")
+            .unwrap_or_else(|| "event_ml_supervised_tabular".to_string());
+        let runtime_score = flag_value(args, "--runtime-score");
+        let replay_parity_ready = has_flag(args, "--replay-parity-ready");
         let dry_run = has_flag(args, "--dry-run");
 
         if entry_secs < 0 {
@@ -147,6 +163,9 @@ impl Config {
         }
         if walk_forward_min_windows == 0 {
             bail!("--walk-forward-min-windows must be positive");
+        }
+        if required_strategy_profile.trim().is_empty() {
+            bail!("--required-strategy-profile must not be empty");
         }
 
         Ok(Config {
@@ -163,6 +182,9 @@ impl Config {
             search_epochs,
             walk_forward_min_windows,
             walk_forward_min_test_trades,
+            required_strategy_profile,
+            runtime_score,
+            replay_parity_ready,
             dry_run,
         })
     }
@@ -176,6 +198,7 @@ struct RollingWorkflowReport {
     dry_run: bool,
     windows: Vec<RollingWindowRecord>,
     final_walk_forward_report: String,
+    final_strategy_handoff_report: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -250,6 +273,15 @@ fn event_ml_workflow_args(
         args.push("--features".to_string());
         args.push(features.clone());
     }
+    args.push("--required-strategy-profile".to_string());
+    args.push(config.required_strategy_profile.clone());
+    if let Some(runtime_score) = &config.runtime_score {
+        args.push("--runtime-score".to_string());
+        args.push(runtime_score.clone());
+    }
+    if config.replay_parity_ready {
+        args.push("--replay-parity-ready".to_string());
+    }
     for run_dir in prior_run_dirs {
         args.push("--walk-forward-run-dir".to_string());
         args.push(run_dir.display().to_string());
@@ -278,6 +310,12 @@ fn write_report(output_root: &Path, report: &RollingWorkflowReport) -> Result<()
         markdown.push_str(&format!(
             "- final_walk_forward_report: `{}`\n",
             report.final_walk_forward_report
+        ));
+    }
+    if !report.final_strategy_handoff_report.is_empty() {
+        markdown.push_str(&format!(
+            "- final_strategy_handoff_report: `{}`\n",
+            report.final_strategy_handoff_report
         ));
     }
     markdown.push_str("\n## Windows\n\n");
@@ -463,6 +501,9 @@ Options:
   --search-epochs <n>                Epochs for candidates. Default: 500.
   --walk-forward-min-windows <n>     Minimum windows required before DL/RL readiness. Default: 3.
   --walk-forward-min-test-trades <n> Minimum test trades per window. Default: 1.
+  --required-strategy-profile <id>   Dry-run handoff profile. Default: event_ml_supervised_tabular.
+  --runtime-score <id>               Runtime scorer identifier. Required for ready handoff.
+  --replay-parity-ready              Mark recorded replay/runtime parity as passed for handoff.
   --dry-run                          Print and record commands without running windows.
   -h, --help                         Show this help.
 "#
@@ -525,6 +566,9 @@ mod tests {
             "/tmp/rolling",
             "--search-l2",
             "0",
+            "--runtime-score",
+            "event_ml_model:baseline_v1",
+            "--replay-parity-ready",
         ]))
         .unwrap();
         let prior = vec![PathBuf::from("/tmp/rolling/window_001_event_ml")];
@@ -539,5 +583,9 @@ mod tests {
             .windows(2)
             .any(|pair| pair == ["--walk-forward-run-dir", "/tmp/rolling/window_001_event_ml"]));
         assert!(args.windows(2).any(|pair| pair == ["--search-l2", "0"]));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--runtime-score", "event_ml_model:baseline_v1"]));
+        assert!(args.iter().any(|arg| arg == "--replay-parity-ready"));
     }
 }

--- a/crates/ploy-research/examples/event_ml_workflow.rs
+++ b/crates/ploy-research/examples/event_ml_workflow.rs
@@ -67,6 +67,9 @@ struct Config {
     walk_forward_min_windows: usize,
     walk_forward_min_test_trades: usize,
     walk_forward_extra_run_dirs: Vec<PathBuf>,
+    required_strategy_profile: String,
+    runtime_score: Option<String>,
+    replay_parity_ready: bool,
     phases: Vec<Phase>,
     dry_run: bool,
 }
@@ -208,6 +211,10 @@ fn parse_config(args: &[String]) -> Result<Config> {
     let walk_forward_min_windows = parse_usize_flag(args, "--walk-forward-min-windows", 3)?;
     let walk_forward_min_test_trades = parse_usize_flag(args, "--walk-forward-min-test-trades", 1)?;
     let walk_forward_extra_run_dirs = parse_walk_forward_extra_run_dirs(args);
+    let required_strategy_profile = flag_value(args, "--required-strategy-profile")
+        .unwrap_or_else(|| "event_ml_supervised_tabular".to_string());
+    let runtime_score = flag_value(args, "--runtime-score");
+    let replay_parity_ready = has_flag(args, "--replay-parity-ready");
 
     if entry_secs < 0 {
         bail!("--entry-secs must be non-negative");
@@ -233,6 +240,9 @@ fn parse_config(args: &[String]) -> Result<Config> {
     if walk_forward_min_windows == 0 {
         bail!("--walk-forward-min-windows must be positive");
     }
+    if required_strategy_profile.trim().is_empty() {
+        bail!("--required-strategy-profile must not be empty");
+    }
 
     Ok(Config {
         dataset,
@@ -249,6 +259,9 @@ fn parse_config(args: &[String]) -> Result<Config> {
         walk_forward_min_windows,
         walk_forward_min_test_trades,
         walk_forward_extra_run_dirs,
+        required_strategy_profile,
+        runtime_score,
+        replay_parity_ready,
         phases,
         dry_run,
     })
@@ -462,20 +475,7 @@ fn run_walk_forward_phase(config: &Config, state: &mut WorkflowState) -> Result<
         write_workflow_report(config, state)?;
     }
     let output_dir = state.run_dir.join("walk_forward");
-    let mut args = vec![
-        "--run-dir".to_string(),
-        state.run_dir.display().to_string(),
-        "--output-dir".to_string(),
-        output_dir.display().to_string(),
-        "--min-windows".to_string(),
-        config.walk_forward_min_windows.to_string(),
-        "--min-test-trades-per-window".to_string(),
-        config.walk_forward_min_test_trades.to_string(),
-    ];
-    for run_dir in &config.walk_forward_extra_run_dirs {
-        args.push("--run-dir".to_string());
-        args.push(run_dir.display().to_string());
-    }
+    let args = walk_forward_phase_args(config, state, &output_dir);
     let command = shell_command_without_features("event_ml_walk_forward", &args);
     eprintln!();
     eprintln!(
@@ -527,6 +527,37 @@ fn run_walk_forward_phase(config: &Config, state: &mut WorkflowState) -> Result<
         status: report.readiness.status,
     });
     Ok(())
+}
+
+fn walk_forward_phase_args(
+    config: &Config,
+    state: &WorkflowState,
+    output_dir: &Path,
+) -> Vec<String> {
+    let mut args = vec![
+        "--run-dir".to_string(),
+        state.run_dir.display().to_string(),
+        "--output-dir".to_string(),
+        output_dir.display().to_string(),
+        "--min-windows".to_string(),
+        config.walk_forward_min_windows.to_string(),
+        "--min-test-trades-per-window".to_string(),
+        config.walk_forward_min_test_trades.to_string(),
+    ];
+    for run_dir in &config.walk_forward_extra_run_dirs {
+        args.push("--run-dir".to_string());
+        args.push(run_dir.display().to_string());
+    }
+    args.push("--required-strategy-profile".to_string());
+    args.push(config.required_strategy_profile.clone());
+    if let Some(runtime_score) = &config.runtime_score {
+        args.push("--runtime-score".to_string());
+        args.push(runtime_score.clone());
+    }
+    if config.replay_parity_ready {
+        args.push("--replay-parity-ready".to_string());
+    }
+    args
 }
 
 fn run_hyperparameter_phase(config: &Config, state: &mut WorkflowState) -> Result<()> {
@@ -1009,6 +1040,10 @@ Options:
                            Repeat for rolling windows from prior datasets.
   --walk-forward-run-dirs <csv>
                            Add comma-separated completed workflow run dirs.
+  --required-strategy-profile <id>
+                           Dry-run handoff profile. Default: event_ml_supervised_tabular.
+  --runtime-score <id>     Runtime scorer identifier. Required for ready dry-run handoff.
+  --replay-parity-ready    Mark recorded replay/runtime parity as passed for handoff.
   --dry-run                Print commands without running phases.
 "
     );
@@ -1053,6 +1088,9 @@ mod tests {
             "/tmp/run-a",
             "--walk-forward-run-dirs",
             "/tmp/run-b,/tmp/run-c",
+            "--runtime-score",
+            "event_ml_model:baseline_v1",
+            "--replay-parity-ready",
             "--dry-run",
         ]))
         .unwrap();
@@ -1076,6 +1114,11 @@ mod tests {
                 PathBuf::from("/tmp/run-c")
             ]
         );
+        assert_eq!(
+            config.runtime_score.as_deref(),
+            Some("event_ml_model:baseline_v1")
+        );
+        assert!(config.replay_parity_ready);
     }
 
     #[test]
@@ -1134,5 +1177,29 @@ mod tests {
         assert!(phase_args
             .windows(2)
             .any(|pair| pair == ["--features", "fair_prob_up,model_edge_up"]));
+    }
+
+    #[test]
+    fn walk_forward_phase_receives_handoff_gates() {
+        let config = parse_config(&args(&[
+            "--dataset",
+            "/tmp/events",
+            "--runtime-score",
+            "event_ml_model:baseline_v1",
+            "--replay-parity-ready",
+        ]))
+        .unwrap();
+        let state = WorkflowState {
+            run_dir: PathBuf::from("/tmp/run"),
+            governed_features: None,
+            records: Vec::new(),
+        };
+
+        let args = walk_forward_phase_args(&config, &state, Path::new("/tmp/run/walk_forward"));
+
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--runtime-score", "event_ml_model:baseline_v1"]));
+        assert!(args.iter().any(|arg| arg == "--replay-parity-ready"));
     }
 }

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -115,6 +115,17 @@ marked ready. With only one workflow run, the report is expected to mark DL/RL
 and dry-run handoff readiness as `blocked`; that is a useful gate, not a runner
 failure.
 
+When replay/runtime parity evidence exists, pass it explicitly through the
+workflow runner so the same walk-forward phase can produce a ready handoff:
+
+```bash
+rtk cargo run -p ploy-research --example event_ml_workflow \
+  --features polars-export -- \
+  --dataset /tmp/ploy-event-root-5sym-150-20260424 \
+  --runtime-score event_ml_model:baseline_v1 \
+  --replay-parity-ready
+```
+
 ## AutoFactor Strategy Promotion Gate
 
 AutoFactor candidate rows are discovery evidence, not strategy handoff evidence.
@@ -404,6 +415,20 @@ gh workflow run event-ml-rolling-evidence.yml \
 If the dataset artifact has a non-default name, pass it through
 `options_json.source_dataset_artifact_name`. Keep it inside `options_json` so
 the workflow stays within GitHub's 10-input dispatch limit.
+
+To let the hosted rolling workflow produce a ready Event ML strategy handoff
+after replay/runtime parity has passed, include the handoff gates in
+`options_json`:
+
+```bash
+gh workflow run event-ml-rolling-evidence.yml \
+  -f git_ref=main \
+  -f source_dataset_run_id=<run-id-with-event-ml-rolling-datasets-artifact> \
+  -f options_json='{"runtime_score":"event_ml_model:baseline_v1","replay_parity_ready":"true"}'
+```
+
+Without those options, `event_ml_strategy_handoff.json` remains a blocked
+evidence artifact by design.
 
 The legacy self-hosted phase performs:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -176,6 +176,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   positive executable PnL, runtime scorer mapping, and replay parity gates all
   pass. `event_ml_walk_forward` now writes
   `event_ml_strategy_handoff.{json,md}` alongside the walk-forward report.
+- [x] Wire Event ML handoff gate inputs through the workflow stack. The local
+  `event_ml_workflow`, `event_ml_rolling_workflow`, and
+  `event-ml-rolling-evidence.yml` GitHub workflow now pass runtime-score and
+  replay-parity evidence into the final walk-forward phase, so hosted artifact
+  runs can produce a ready handoff only when those gates are explicitly
+  supplied.
 
 ## Review
 
@@ -285,6 +291,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   runtime score is supplied, and recorded replay/runtime parity is marked
   ready. Verification passed with targeted rustfmt, `event_ml_handoff` unit
   tests, `event_ml_walk_forward` cargo check, and `git diff --check`.
+- 2026-05-06: Continued the Event ML promotion automation by wiring handoff
+  gate inputs through both local workflow runners and the hosted rolling
+  evidence workflow. This keeps the default fail-closed behavior, but lets a
+  later replay-verified run carry `runtime_score` and `replay_parity_ready`
+  into `event_ml_strategy_handoff.json` without manual artifact edits.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -116,6 +116,8 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
         "github.event.inputs.source_dataset_run_id != ''",
         "scripts/download_github_artifact.py",
         "event-ml-rolling-datasets-${SOURCE_DATASET_RUN_ID}",
+        "--runtime-score",
+        "--replay-parity-ready",
     ] {
         if !workflow.contains(needle) {
             offenders.push(format!("event-ml-rolling-evidence.yml: missing `{needle}`"));
@@ -134,6 +136,8 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
     for needle in [
         "Prefer the hosted artifact path",
         "source_dataset_artifact_name",
+        "runtime_score",
+        "replay_parity_ready",
         "workflow stays within GitHub's 10-input dispatch limit",
     ] {
         if !runbook.contains(needle) {
@@ -520,9 +524,7 @@ fn research_workflows_require_private_tango_db_endpoint() {
     ) {
         offenders.push("backtest.yml: missing private Tango DB endpoint guard".to_string());
     }
-    if !backtest.contains(
-        "urlparse(os.environ[\"PLOY_RESEARCH_DATABASE_URL\"]).hostname",
-    ) {
+    if !backtest.contains("urlparse(os.environ[\"PLOY_RESEARCH_DATABASE_URL\"]).hostname") {
         offenders.push("backtest.yml: must parse the research DB URL host before use".to_string());
     }
 
@@ -550,7 +552,9 @@ fn optimize_workflow_builds_and_runs_in_one_job() {
     let content = workflow_contents(".github/workflows/optimize.yml");
     let mut offenders = Vec::new();
 
-    if content.contains("download-artifact") || content.contains("optimize_backtest-${{ github.sha }}") {
+    if content.contains("download-artifact")
+        || content.contains("optimize_backtest-${{ github.sha }}")
+    {
         offenders.push(
             "optimize.yml: must not pass optimize_backtest through a binary artifact".to_string(),
         );


### PR DESCRIPTION
## Summary
- pass Event ML runtime-score and replay-parity gates through event_ml_workflow and event_ml_rolling_workflow
- expose the same gates through event-ml-rolling-evidence.yml options_json for GitHub-hosted artifact runs
- include final strategy handoff status in rolling workflow reports and workflow summaries

## Verification
- rustfmt --edition 2021 --check crates/ploy-research/examples/event_ml_workflow.rs crates/ploy-research/examples/event_ml_rolling_workflow.rs tests/workflow_security.rs
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-promotion rtk cargo test -p ploy-research --features polars-export --example event_ml_workflow -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-promotion rtk cargo test -p ploy-research --example event_ml_rolling_workflow -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-promotion rtk cargo test --test workflow_security event_ml_rolling_evidence_has_hosted_artifact_lane -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-promotion rtk cargo check -p ploy-research --features polars-export --example event_ml_workflow --example event_ml_rolling_workflow
- git diff --check

## Safety
- defaults remain fail-closed: runtime_score is empty and replay_parity_ready is false
- no live trading or deploy path changed
- advanced GitHub knobs stay inside options_json to keep workflow_dispatch below the 10-input limit