### PR TITLE
Create Event ML handoff issues only from ready artifacts

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -42,7 +42,7 @@ on:
       options_json:
         description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name, handoff runtime/parity gates"
         required: false
-        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":"","required_strategy_profile":"event_ml_supervised_tabular","runtime_score":"","replay_parity_ready":"false"}'
+        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":"","required_strategy_profile":"event_ml_supervised_tabular","runtime_score":"","replay_parity_ready":"false","create_handoff_issue":"false"}'
 
 concurrency:
   group: event-ml-rolling-evidence-${{ github.ref }}
@@ -51,6 +51,7 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -173,6 +174,7 @@ jobs:
               "required_strategy_profile": "event_ml_supervised_tabular",
               "runtime_score": "",
               "replay_parity_ready": "false",
+              "create_handoff_issue": "false",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -315,6 +317,50 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Create ready Event ML handoff issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${EVENT_ML_CREATE_HANDOFF_ISSUE:-false}" in
+            true|True|1|yes|YES) ;;
+            *)
+              echo "create_handoff_issue is not true; skipping handoff issue creation."
+              exit 0
+              ;;
+          esac
+
+          handoff_json="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.json' 2>/dev/null | sort | tail -1 || true)"
+          handoff_md="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.md' 2>/dev/null | sort | tail -1 || true)"
+          if [ -z "${handoff_json}" ] || [ -z "${handoff_md}" ] || [ ! -f "${handoff_json}" ] || [ ! -f "${handoff_md}" ]; then
+            echo "Event ML handoff artifacts missing; skipping issue creation."
+            exit 0
+          fi
+          status="$(HANDOFF_JSON="${handoff_json}" python3 - <<'PY'
+          import json
+          import os
+          with open(os.environ["HANDOFF_JSON"], encoding="utf-8") as handle:
+              print(json.load(handle).get("status", "blocked"))
+          PY
+          )"
+          if [ "${status}" != "ready" ]; then
+            echo "Event ML handoff status is ${status}; no dry-run issue will be created."
+            exit 0
+          fi
+
+          mkdir -p artifacts/event-ml/reports
+          {
+            cat "${handoff_md}"
+            echo ""
+            echo "Source Event ML rolling evidence run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo ""
+            echo "This issue is generated from a ready Event ML handoff artifact. It does not deploy and does not enable live trading."
+          } > artifacts/event-ml/reports/event_ml_handoff_issue.md
+          gh issue create \
+            --title "Promote Event ML strategy handoff to dry-run" \
+            --body-file artifacts/event-ml/reports/event_ml_handoff_issue.md
+
       - name: Upload compact report bundle
         if: always()
         uses: actions/upload-artifact@v7
@@ -377,6 +423,7 @@ jobs:
               "required_strategy_profile": "event_ml_supervised_tabular",
               "runtime_score": "",
               "replay_parity_ready": "false",
+              "create_handoff_issue": "false",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -535,6 +582,50 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create ready Event ML handoff issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${EVENT_ML_CREATE_HANDOFF_ISSUE:-false}" in
+            true|True|1|yes|YES) ;;
+            *)
+              echo "create_handoff_issue is not true; skipping handoff issue creation."
+              exit 0
+              ;;
+          esac
+
+          handoff_json="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.json' 2>/dev/null | sort | tail -1 || true)"
+          handoff_md="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.md' 2>/dev/null | sort | tail -1 || true)"
+          if [ -z "${handoff_json}" ] || [ -z "${handoff_md}" ] || [ ! -f "${handoff_json}" ] || [ ! -f "${handoff_md}" ]; then
+            echo "Event ML handoff artifacts missing; skipping issue creation."
+            exit 0
+          fi
+          status="$(HANDOFF_JSON="${handoff_json}" python3 - <<'PY'
+          import json
+          import os
+          with open(os.environ["HANDOFF_JSON"], encoding="utf-8") as handle:
+              print(json.load(handle).get("status", "blocked"))
+          PY
+          )"
+          if [ "${status}" != "ready" ]; then
+            echo "Event ML handoff status is ${status}; no dry-run issue will be created."
+            exit 0
+          fi
+
+          mkdir -p artifacts/event-ml/reports
+          {
+            cat "${handoff_md}"
+            echo ""
+            echo "Source Event ML rolling evidence run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo ""
+            echo "This issue is generated from a ready Event ML handoff artifact. It does not deploy and does not enable live trading."
+          } > artifacts/event-ml/reports/event_ml_handoff_issue.md
+          gh issue create \
+            --title "Promote Event ML strategy handoff to dry-run" \
+            --body-file artifacts/event-ml/reports/event_ml_handoff_issue.md
 
       - name: Upload compact report bundle
         if: always()

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -424,11 +424,13 @@ after replay/runtime parity has passed, include the handoff gates in
 gh workflow run event-ml-rolling-evidence.yml \
   -f git_ref=main \
   -f source_dataset_run_id=<run-id-with-event-ml-rolling-datasets-artifact> \
-  -f options_json='{"runtime_score":"event_ml_model:baseline_v1","replay_parity_ready":"true"}'
+  -f options_json='{"runtime_score":"event_ml_model:baseline_v1","replay_parity_ready":"true","create_handoff_issue":"true"}'
 ```
 
 Without those options, `event_ml_strategy_handoff.json` remains a blocked
-evidence artifact by design.
+evidence artifact by design. The `create_handoff_issue` option is also
+fail-closed: it creates an issue only when the generated handoff JSON reports
+`status=ready`.
 
 The legacy self-hosted phase performs:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -182,6 +182,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   replay-parity evidence into the final walk-forward phase, so hosted artifact
   runs can produce a ready handoff only when those gates are explicitly
   supplied.
+- [x] Add ready-only Event ML handoff issue creation to
+  `event-ml-rolling-evidence.yml`. The `options_json.create_handoff_issue`
+  switch defaults to false and creates an issue only when
+  `event_ml_strategy_handoff.json` is `status=ready`; blocked artifacts still
+  produce no promotion issue.
 
 ## Review
 
@@ -296,6 +301,10 @@ evidence comes from Polymarket full CLOB depth, not top book.
   evidence workflow. This keeps the default fail-closed behavior, but lets a
   later replay-verified run carry `runtime_score` and `replay_parity_ready`
   into `event_ml_strategy_handoff.json` without manual artifact edits.
+- 2026-05-06: Added the first downstream Event ML handoff action: ready-only
+  issue creation from `event-ml-rolling-evidence.yml`. This deliberately stops
+  short of config PR automation because the checked-in dry-run config currently
+  supports AutoFactor runtime scores, not a live Event ML runtime scorer.
 - 2026-05-05: Implemented the first settlement-probability research slice in
   `crates/ploy-research/src/factors_v2.rs` and wired it into
   `factor_walk_forward_v2`. The new report uses full-depth entry-fillable

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -118,6 +118,9 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
         "event-ml-rolling-datasets-${SOURCE_DATASET_RUN_ID}",
         "--runtime-score",
         "--replay-parity-ready",
+        "create_handoff_issue",
+        "issues: write",
+        "Event ML handoff status is ${status}; no dry-run issue will be created.",
     ] {
         if !workflow.contains(needle) {
             offenders.push(format!("event-ml-rolling-evidence.yml: missing `{needle}`"));
@@ -138,6 +141,7 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
         "source_dataset_artifact_name",
         "runtime_score",
         "replay_parity_ready",
+        "create_handoff_issue",
         "workflow stays within GitHub's 10-input dispatch limit",
     ] {
         if !runbook.contains(needle) {


### PR DESCRIPTION
## Summary
- add ready-only Event ML handoff issue creation to event-ml-rolling-evidence.yml
- keep issue creation off by default via options_json.create_handoff_issue=false
- require event_ml_strategy_handoff.json status=ready before opening a promotion issue

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-issue rtk cargo test --test workflow_security event_ml_rolling_evidence_has_hosted_artifact_lane -- --nocapture
- rustfmt --edition 2021 --check tests/workflow_security.rs
- git diff --check

## Safety
- no live trading or deploy path changed
- no config PR automation for Event ML yet because runtime scorer support is not implemented
- blocked/missing handoff artifacts skip issue creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated GitHub issue creation when Event ML handoff reaches ready status. New `create_handoff_issue` option is disabled by default, providing controlled handoff tracking without disrupting existing workflows.

* **Documentation**
  * Updated workflow documentation with details on the new handoff issue creation feature and its activation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->