### PR TITLE
Run artifact factor review on GitHub-hosted runners

### DIFF
--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -1,0 +1,346 @@
+name: Factor Review V2 Hosted Artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref"
+        required: true
+        default: "main"
+      snapshot_run_id:
+        description: "Research Snapshot or downstream run id that owns a full research snapshot artifact"
+        required: true
+      snapshot_artifact_name:
+        description: "Snapshot artifact name; defaults to research-snapshot-<snapshot_run_id>"
+        required: false
+        default: ""
+      start_date:
+        description: "Review start date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-24"
+      end_date:
+        description: "Review end date (YYYY-MM-DD)"
+        required: true
+        default: "2026-04-24"
+      symbols:
+        description: "Comma-separated Binance symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT,BNBUSDT,XRPUSDT"
+      stake_usd:
+        description: "Fixed notional per candidate"
+        required: true
+        default: "15"
+      options_json:
+        description: "Advanced options JSON: sampling, top_n, factor filters, issue_number"
+        required: false
+        default: '{"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":50,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","issue_number":""}'
+
+concurrency:
+  group: factor-review-v2-hosted-artifact-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.snapshot_run_id }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  review:
+    name: Run factor review from snapshot artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "lob_sample_secs": "30",
+              "observation_sample_secs": "30",
+              "max_quote_age_secs": "30",
+              "top_n": "50",
+              "min_observations": "20",
+              "top_quantile": "0.2",
+              "factor_name_filter": "",
+              "issue_number": "",
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          values.update({key: str(value) for key, value in data.items()})
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"FACTOR_{key.upper()}={value}\n")
+          PY
+
+      - name: Download research snapshot artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
+          SNAPSHOT_ARTIFACT_NAME: ${{ github.event.inputs.snapshot_artifact_name }}
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/research-snapshot
+          artifact_name="${SNAPSHOT_ARTIFACT_NAME}"
+          if [ -z "${artifact_name}" ]; then
+            artifact_name="research-snapshot-${SNAPSHOT_RUN_ID}"
+          fi
+          if python3 scripts/download_github_artifact.py \
+            --run-id "${SNAPSHOT_RUN_ID}" \
+            --name "${artifact_name}" \
+            --output-dir artifacts/research-snapshot \
+            --require manifest.json \
+            --require quality.md; then
+            echo "Downloaded research snapshot artifact ${artifact_name}."
+          else
+            echo "Standalone snapshot artifact ${artifact_name} not found or incomplete; trying embedded downstream artifacts."
+            python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-review-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md \
+            || python3 scripts/download_github_artifact.py \
+              --run-id "${SNAPSHOT_RUN_ID}" \
+              --name "factor-walk-forward-v2-${SNAPSHOT_RUN_ID}" \
+              --strip-prefix research-snapshot \
+              --output-dir artifacts/research-snapshot \
+              --require manifest.json \
+              --require quality.md
+          fi
+
+      - name: Validate full snapshot payload
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("artifacts/research-snapshot")
+          manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+          artifacts = manifest.get("artifacts") or {}
+          required = [
+              artifacts.get("observations_json", "observations.json"),
+              artifacts.get("deribit_snapshots_json", "deribit_snapshots.json"),
+              artifacts.get("pm_book_snapshots_json", "pm_book_snapshots.json"),
+              artifacts.get("quality_markdown", "quality.md"),
+          ]
+          missing = [path for path in required if not path or not (root / path).exists()]
+          if missing:
+              raise SystemExit(
+                  "research snapshot artifact has manifest/quality but is missing full payload: "
+                  + ", ".join(missing)
+              )
+          print("full research snapshot payload present: " + ", ".join(required))
+          PY
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-targets: "true"
+          key: factor-review-v2-hosted-artifact-${{ hashFiles('crates/ploy-research/**', 'crates/ploy-feed-loaders/**', 'Cargo.lock') }}
+
+      - name: Build factor review
+        run: |
+          set -euo pipefail
+          cargo build --release --locked \
+            -p ploy-research \
+            --features db \
+            --example factor_review_v2
+
+      - name: Run factor review
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/factor-review-v2
+          ./target/release/examples/factor_review_v2 \
+            --snapshot-dir artifacts/research-snapshot \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --start-date "${{ github.event.inputs.start_date }}" \
+            --end-date "${{ github.event.inputs.end_date }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --lob-sample-secs "${FACTOR_LOB_SAMPLE_SECS}" \
+            --observation-sample-secs "${FACTOR_OBSERVATION_SAMPLE_SECS}" \
+            --max-quote-age-secs "${FACTOR_MAX_QUOTE_AGE_SECS}" \
+            --min-observations "${FACTOR_MIN_OBSERVATIONS}" \
+            --top-quantile "${FACTOR_TOP_QUANTILE}" \
+            --top-n "${FACTOR_TOP_N}" \
+            --factor-name-filter "${FACTOR_FACTOR_NAME_FILTER}" \
+            --git-ref "${{ github.event.inputs.git_ref }}" \
+            --output-json artifacts/factor-review-v2/evaluation.json \
+            | tee artifacts/factor-review-v2/report.txt
+          echo "canonical_result=snapshot_artifact" | tee artifacts/factor-review-v2/source.txt
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Factor Review V2 Hosted Artifact"
+            echo ""
+            echo "- Snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\`"
+            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Symbols: ${{ github.event.inputs.symbols }}"
+            echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            echo "- Runner: \`ubuntu-latest\`"
+            echo "- Factor filter: ${FACTOR_FACTOR_NAME_FILTER:-<none>}"
+            if [ -f artifacts/research-snapshot/quality.md ]; then
+              echo ""
+              echo "### Snapshot Quality"
+              cat artifacts/research-snapshot/quality.md
+            fi
+            if [ -f artifacts/factor-review-v2/evaluation.json ]; then
+              echo ""
+              echo "### Evaluation"
+              echo '```json'
+              python3 - <<'PY'
+          import json
+          data = json.load(open("artifacts/factor-review-v2/evaluation.json", encoding="utf-8"))
+          report = data.get("report") or {}
+          buckets = report.get("executable_ev_buckets") or []
+          supported = [b for b in buckets if b.get("statistically_supported")]
+          positive = [b for b in buckets if b.get("positive_ev") and not b.get("underpowered")]
+          headline = {
+              "canonical_result": data.get("canonical_result"),
+              "risk_flags": data.get("risk_flags") or [],
+              "bucket_counts": {
+                  "total": len(buckets),
+                  "positive_non_underpowered": len(positive),
+                  "statistically_supported": len(supported),
+              },
+              "best_supported_buckets": supported[:5],
+          }
+          print(json.dumps(headline, indent=2, sort_keys=True))
+          PY
+              echo '```'
+            fi
+            if [ -f artifacts/factor-review-v2/report.txt ]; then
+              echo ""
+              echo "### Report"
+              echo '```'
+              sed -n '1,120p' artifacts/factor-review-v2/report.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stage report artifact
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf artifacts/factor-review-v2-upload
+          mkdir -p artifacts/factor-review-v2-upload
+          if [ -d artifacts/factor-review-v2 ]; then
+            cp -R artifacts/factor-review-v2 artifacts/factor-review-v2-upload/
+          fi
+          mkdir -p artifacts/factor-review-v2-upload/snapshot-provenance
+          {
+            echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
+            echo "producer_run_id=${GITHUB_RUN_ID}"
+            echo "full_snapshot_embedded=false"
+            echo "runner=ubuntu-latest"
+          } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
+          for file in manifest.json quality.md data-gap-audit.md data-gap-audit.json compile.log; do
+            if [ -f "artifacts/research-snapshot/${file}" ]; then
+              cp "artifacts/research-snapshot/${file}" \
+                "artifacts/factor-review-v2-upload/snapshot-provenance/${file}"
+            fi
+          done
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: factor-review-v2-${{ github.run_id }}
+          path: artifacts/factor-review-v2-upload/
+          compression-level: 0
+          retention-days: 14
+
+      - name: Comment factor evidence on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
+            const issueNumberRaw = process.env.FACTOR_ISSUE_NUMBER || "";
+            if (!issueNumberRaw) {
+              core.info("No issue_number configured in options_json; skipping issue comment.");
+              return;
+            }
+            const issue_number = Number(issueNumberRaw);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let decision = "fix-workflow-or-artifact";
+            let riskFlags = ["missing_evaluation_artifact"];
+            let bucketSummary = "unavailable";
+            if (fs.existsSync("artifacts/factor-review-v2/evaluation.json")) {
+              const data = JSON.parse(fs.readFileSync("artifacts/factor-review-v2/evaluation.json", "utf8"));
+              riskFlags = data.risk_flags || [];
+              const buckets = data.report?.executable_ev_buckets || [];
+              const positive = buckets.filter((bucket) => bucket.positive_ev && !bucket.underpowered);
+              const supported = buckets.filter((bucket) => bucket.statistically_supported);
+              const best = [...supported].sort((a, b) => (b.avg_pnl_15u || 0) - (a.avg_pnl_15u || 0)).slice(0, 3);
+              bucketSummary = JSON.stringify({
+                total: buckets.length,
+                positive_non_underpowered: positive.length,
+                statistically_supported: supported.length,
+                best_supported: best.map((bucket) => ({
+                  dimension: bucket.dimension,
+                  bucket: bucket.bucket,
+                  pnl_rows: bucket.pnl_rows,
+                  avg_pnl_15u: bucket.avg_pnl_15u,
+                  t_stat: bucket.t_stat
+                }))
+              });
+              decision = supported.length > 0 ? "candidate-for-oos-replay-gate" : "no-deploy-factor-review-only";
+            }
+            const body = [
+              "Factor review evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Git ref: ${{ github.event.inputs.git_ref }}`,
+              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
+              `- Symbols: ${{ github.event.inputs.symbols }}`,
+              `- Artifact: \`factor-review-v2-${process.env.GITHUB_RUN_ID}\``,
+              `- Runner: \`ubuntu-latest\``,
+              `- Source snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\``,
+              `- Executable EV buckets: \`${bucketSummary}\``,
+              `- Risk flags: \`${riskFlags.join(", ") || "none"}\``,
+              `- Decision: ${decision}`
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });
+            await applyResearchIssueLabels({
+              github,
+              context,
+              core,
+              issue_number,
+              labels: ["evidence:factor-review", ...labelsForDecision(decision), ...(riskFlags.includes("missing_evaluation_artifact") ? ["evidence:missing-artifact"] : [])]
+            });

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -45,7 +45,8 @@ mismatch is understood and tracked as a follow-up issue.
 | --- | --- | --- |
 | PR validation | `.github/workflows/test.yml` | Required Platform CI gate for code, contracts, frontend, integration, dependency audit, and workflow lint |
 | Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
-| Factor diagnostics | `.github/workflows/factor-review-v2.yml` | Snapshot-backed factor review on `ploy-ci-1` |
+| Factor diagnostics | `.github/workflows/factor-review-v2-hosted-artifact.yml` | GitHub-hosted factor review from a retained full research snapshot artifact |
+| Legacy factor diagnostics | `.github/workflows/factor-review-v2.yml` | Fresh DB/snapshot fallback on `ploy-ci-1`; avoid when a full snapshot artifact already exists |
 | Walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Rolling factor validation across train/test windows |
 | Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
 | Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
@@ -186,7 +187,8 @@ different.
   keyed by the workflow aliases `tango-1-1` and `ploy-trade-1` because the deploy
   SSH config sets `HostKeyAlias`.
 - Artifact-backed PM5D/PM15D research should default to GitHub-hosted runners.
-  Use `factor-walk-forward-v2-hosted-artifact.yml` directly, or
+  Use `factor-review-v2-hosted-artifact.yml`,
+  `factor-walk-forward-v2-hosted-artifact.yml`, or
   `settlement-probability-prd-gate.yml` with `snapshot_run_id`, when a retained
   full research snapshot artifact already exists.
 - Event ML rolling evidence should also default to GitHub-hosted runners after

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -187,6 +187,11 @@ evidence comes from Polymarket full CLOB depth, not top book.
   switch defaults to false and creates an issue only when
   `event_ml_strategy_handoff.json` is `status=ready`; blocked artifacts still
   produce no promotion issue.
+- [x] Add a GitHub-hosted artifact-only Factor Review V2 workflow. When a full
+  research snapshot artifact exists, factor diagnostics can now run on
+  `ubuntu-latest` via `factor-review-v2-hosted-artifact.yml`; the legacy
+  `factor-review-v2.yml` path remains only for fresh DB/snapshot fallback work
+  that still needs `ploy-ci-1`.
 
 ## Review
 


### PR DESCRIPTION
## Summary

- add a GitHub-hosted, artifact-only Factor Review V2 workflow
- validate retained full research snapshot payloads before building/running factor_review_v2
- update the research CI runbook and task tracker so artifact-backed factor diagnostics no longer wait for ploy-ci-1

## Verification

- Ruby YAML parse for .github/workflows/factor-review-v2-hosted-artifact.yml
- git diff --check

## Notes

The legacy factor-review-v2.yml workflow remains the fresh DB/snapshot fallback because that path still depends on Tango private-network DB access through ploy-ci-1.