### PR TITLE
Move Event ML config promotion onto hosted artifacts

### DIFF
--- a/.github/workflows/event-ml-rolling-evidence.yml
+++ b/.github/workflows/event-ml-rolling-evidence.yml
@@ -40,18 +40,19 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name, handoff runtime/parity gates"
+        description: "Advanced options JSON: sampling, entry/tolerance, logistic search grid, source_dataset_artifact_name, handoff runtime/parity gates, PR-only config promotion"
         required: false
-        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":"","required_strategy_profile":"event_ml_supervised_tabular","runtime_score":"","replay_parity_ready":"false","create_handoff_issue":"false"}'
+        default: '{"lob_sample_secs":30,"max_quote_age_secs":30,"entry_secs":60,"tolerance_secs":30,"search_l2":"0,0.001,0.01","search_min_edge":"0,0.02,0.05","search_learning_rate":"0.03,0.05","search_epochs":500,"source_dataset_artifact_name":"","required_strategy_profile":"event_ml_supervised_tabular","runtime_score":"","replay_parity_ready":"false","create_handoff_issue":"false","create_config_pr":"false","strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","model_artifact_path":""}'
 
 concurrency:
   group: event-ml-rolling-evidence-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   issues: write
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -175,6 +176,9 @@ jobs:
               "runtime_score": "",
               "replay_parity_ready": "false",
               "create_handoff_issue": "false",
+              "create_config_pr": "false",
+              "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+              "model_artifact_path": "",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -247,6 +251,20 @@ jobs:
             --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
             "${handoff_args[@]}" \
             | tee artifacts/event-ml/reports/rolling_workflow.txt
+
+      - name: Skip config PR on legacy DB branch
+        if: always()
+        run: |
+          set -euo pipefail
+          case "${EVENT_ML_CREATE_CONFIG_PR:-false}" in
+            true|True|1|yes|YES)
+              echo "create_config_pr is only supported by the GitHub-hosted artifact branch."
+              echo "Upload the dataset artifact, then rerun with source_dataset_run_id so promotion does not run on ploy-ci-1."
+              ;;
+            *)
+              echo "create_config_pr is not true; skipping config PR creation."
+              ;;
+          esac
 
       - name: Collect compact reports
         if: always()
@@ -424,6 +442,9 @@ jobs:
               "runtime_score": "",
               "replay_parity_ready": "false",
               "create_handoff_issue": "false",
+              "create_config_pr": "false",
+              "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+              "model_artifact_path": "",
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -511,6 +532,97 @@ jobs:
             --search-epochs "${EVENT_ML_SEARCH_EPOCHS}" \
             "${handoff_args[@]}" \
             | tee artifacts/event-ml/reports/rolling_workflow.txt
+
+      - name: Create config PR from ready Event ML handoff
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.inputs.git_ref }}
+        run: |
+          set -euo pipefail
+          case "${EVENT_ML_CREATE_CONFIG_PR:-false}" in
+            true|True|1|yes|YES) ;;
+            *)
+              echo "create_config_pr is not true; skipping config PR creation."
+              exit 0
+              ;;
+          esac
+          handoff_json="$(find artifacts/event-ml/rolling_workflow -path '*/walk_forward/event_ml_strategy_handoff.json' 2>/dev/null | sort | tail -1 || true)"
+          if [ -z "${handoff_json}" ] || [ ! -f "${handoff_json}" ]; then
+            echo "Event ML handoff JSON missing; skipping config PR creation."
+            exit 0
+          fi
+          status="$(HANDOFF_JSON="${handoff_json}" python3 - <<'PY'
+          import json
+          import os
+          with open(os.environ["HANDOFF_JSON"], encoding="utf-8") as handle:
+              print(json.load(handle).get("status", "blocked"))
+          PY
+          )"
+          if [ "${status}" != "ready" ]; then
+            echo "Event ML handoff status is ${status}; no config PR will be created."
+            exit 0
+          fi
+          case "${EVENT_ML_STRATEGY_CONFIG}" in
+            config/strategies/*.toml) ;;
+            *)
+              echo "strategy_config must be a config/strategies/*.toml path" >&2
+              exit 2
+              ;;
+          esac
+          if [ -z "${EVENT_ML_MODEL_ARTIFACT_PATH}" ]; then
+            echo "options_json.model_artifact_path is required when create_config_pr=true and handoff is ready" >&2
+            exit 2
+          fi
+
+          mkdir -p artifacts/event-ml/reports/event-ml-config-handoff
+          python3 scripts/apply_event_ml_handoff_to_config.py \
+            --handoff-json "${handoff_json}" \
+            --config "${EVENT_ML_STRATEGY_CONFIG}" \
+            --model-path "${EVENT_ML_MODEL_ARTIFACT_PATH}" \
+            --output-json artifacts/event-ml/reports/event-ml-config-handoff/config-handoff.json \
+            --output-md artifacts/event-ml/reports/event-ml-config-handoff/config-handoff.md
+          changed="$(python3 - <<'PY'
+          import json
+          with open("artifacts/event-ml/reports/event-ml-config-handoff/config-handoff.json", encoding="utf-8") as handle:
+              print("true" if json.load(handle).get("changed") else "false")
+          PY
+          )"
+          if [ "${changed}" != "true" ]; then
+            echo "Config already matches selected Event ML handoff; no PR will be created."
+            exit 0
+          fi
+
+          branch="event-ml/hosted-handoff-${GITHUB_RUN_ID}"
+          git switch -c "${branch}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "${EVENT_ML_STRATEGY_CONFIG}"
+          git commit \
+            -m "Promote hosted Event ML handoff into dry-run config" \
+            -m "A hosted Event ML rolling evidence run produced a ready dry-run handoff whose runtime model differs from the checked-in dry-run config. This applies only the runtime score and reviewed model artifact path, leaving execution, risk, and kill-switch settings unchanged." \
+            -m "Constraint: Generated from hosted Event ML artifact status=ready" \
+            -m "Constraint: Dry-run config only; no deploy or live order path" \
+            -m "Rejected: Direct deployment from Event ML research workflow | config changes must pass PR review and CI first" \
+            -m "Confidence: medium" \
+            -m "Scope-risk: narrow" \
+            -m "Tested: event-ml-rolling-evidence.yml create_config_pr path" \
+            -m "Not-tested: dry-run deployment/replay after config change"
+          git push origin "${branch}"
+
+          {
+            cat artifacts/event-ml/reports/event-ml-config-handoff/config-handoff.md
+            echo ""
+            echo "Source hosted Event ML run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "Source dataset run: ${{ github.event.inputs.source_dataset_run_id }}"
+            echo ""
+            echo "This PR is generated from a ready hosted Event ML handoff artifact. It does not deploy and does not enable live trading."
+          } > artifacts/event-ml/reports/event-ml-config-handoff/pr-body.md
+          gh pr create \
+            --base "${BASE_REF}" \
+            --head "${branch}" \
+            --title "Promote hosted Event ML handoff into dry-run config" \
+            --body-file artifacts/event-ml/reports/event-ml-config-handoff/pr-body.md
 
       - name: Collect compact reports
         if: always()

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -454,6 +454,25 @@ evidence artifact by design. The `create_handoff_issue` option is also
 fail-closed: it creates an issue only when the generated handoff JSON reports
 `status=ready`.
 
+For the final PR-only dry-run config handoff, keep the same hosted artifact
+path and add `create_config_pr=true` plus the reviewed runtime model path:
+
+```bash
+gh workflow run event-ml-rolling-evidence.yml \
+  -f git_ref=main \
+  -f source_dataset_run_id=<run-id-with-event-ml-rolling-datasets-artifact> \
+  -f options_json='{"runtime_score":"event_ml_model:baseline_v1","replay_parity_ready":"true","create_config_pr":"true","model_artifact_path":"/opt/ploy/models/event_ml/baseline_metrics.json","strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"}'
+```
+
+`create_config_pr=true` is supported only on the GitHub-hosted artifact branch.
+The legacy `ploy-ci-1` branch may still export fresh private-DB datasets, but it
+will not open config PRs. The generated PR updates only
+`three_layer_autofactor_runtime_score` and `three_layer_event_ml_model_path` in
+the dry-run strategy config; it does not deploy and does not enable live
+trading. The config step fails closed unless the handoff is `ready`, replay
+parity is marked ready, the runtime score starts with `event_ml_model:`, and
+`model_artifact_path` is supplied.
+
 The legacy self-hosted phase performs:
 
 1. `factor_research --export-event-dataset`

--- a/scripts/apply_event_ml_handoff_to_config.py
+++ b/scripts/apply_event_ml_handoff_to_config.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Apply a ready Event ML dry-run handoff to a strategy TOML config.
+
+This is intentionally narrower than deployment. It updates only the runtime
+score and model artifact path needed by the existing three-layer dry-run
+strategy to load an Event ML probability model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+RUNTIME_SCORE_RE = re.compile(
+    r'^(\s*three_layer_autofactor_runtime_score\s*=\s*)".*"\s*$'
+)
+MODEL_PATH_RE = re.compile(r'^(\s*three_layer_event_ml_model_path\s*=\s*)".*"\s*$')
+PROFILE_RE = re.compile(r'^\s*three_layer_strategy_profile\s*=\s*"([^"]+)"\s*$')
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def select_strategy(handoff: dict[str, Any]) -> dict[str, Any]:
+    if handoff.get("status") != "ready":
+        raise SystemExit(f"handoff status is {handoff.get('status', 'missing')}; expected ready")
+    strategy = handoff.get("strategy")
+    if not isinstance(strategy, dict):
+        raise SystemExit("handoff has no ready strategy")
+    if handoff.get("replay_parity_ready") is not True:
+        raise SystemExit("handoff replay_parity_ready is not true")
+    return strategy
+
+
+def replace_or_insert_field(
+    lines: list[str],
+    *,
+    regex: re.Pattern[str],
+    new_line: str,
+    insert_after_index: int,
+) -> tuple[str | None, str]:
+    previous: str | None = None
+    for index, line in enumerate(lines):
+        if regex.match(line.rstrip("\n")):
+            previous = line.split("=", 1)[1].strip().strip('"')
+            lines[index] = new_line
+            return previous, "updated"
+    lines.insert(insert_after_index + 1, new_line)
+    return None, "inserted"
+
+
+def replace_or_insert_event_ml_config(
+    config_text: str,
+    *,
+    runtime_score: str,
+    model_path: str,
+    expected_config_profile: str,
+) -> tuple[str, dict[str, str | None]]:
+    lines = config_text.splitlines(keepends=True)
+    profile_index: int | None = None
+    observed_profile: str | None = None
+
+    for index, line in enumerate(lines):
+        profile_match = PROFILE_RE.match(line.rstrip("\n"))
+        if profile_match:
+            profile_index = index
+            observed_profile = profile_match.group(1)
+
+    if expected_config_profile and observed_profile != expected_config_profile:
+        raise SystemExit(
+            "strategy config profile mismatch: "
+            f"observed={observed_profile!r} expected={expected_config_profile!r}"
+        )
+    if profile_index is None:
+        raise SystemExit("cannot insert Event ML config: three_layer_strategy_profile not found")
+
+    previous_score, score_action = replace_or_insert_field(
+        lines,
+        regex=RUNTIME_SCORE_RE,
+        new_line=f'three_layer_autofactor_runtime_score = "{runtime_score}"\n',
+        insert_after_index=profile_index,
+    )
+    score_index = next(
+        index
+        for index, line in enumerate(lines)
+        if RUNTIME_SCORE_RE.match(line.rstrip("\n"))
+    )
+    previous_model_path, model_path_action = replace_or_insert_field(
+        lines,
+        regex=MODEL_PATH_RE,
+        new_line=f'three_layer_event_ml_model_path = "{model_path}"\n',
+        insert_after_index=score_index,
+    )
+
+    return "".join(lines), {
+        "previous_runtime_score": previous_score,
+        "runtime_score_action": score_action,
+        "previous_model_path": previous_model_path,
+        "model_path_action": model_path_action,
+    }
+
+
+def render_summary_markdown(summary: dict[str, Any]) -> str:
+    strategy = summary["selected_strategy"]
+    return "\n".join(
+        [
+            "# Event ML Config Handoff",
+            "",
+            f"- Status: `{summary['status']}`",
+            f"- Config: `{summary['config_path']}`",
+            f"- Changed: `{str(summary['changed']).lower()}`",
+            f"- Runtime score action: `{summary['runtime_score_action']}`",
+            f"- Model path action: `{summary['model_path_action']}`",
+            "- Previous runtime score: "
+            f"`{summary.get('previous_runtime_score') or 'none'}`",
+            f"- New runtime score: `{summary['runtime_score']}`",
+            f"- Previous model path: `{summary.get('previous_model_path') or 'none'}`",
+            f"- New model path: `{summary['model_path']}`",
+            f"- Handoff strategy profile: `{strategy['strategy_profile']}`",
+            f"- Selection rule: `{strategy['selection_rule']}`",
+            f"- Test trades: `{strategy['test_trades']}`",
+            f"- Test PnL: `{strategy['test_pnl']}`",
+            f"- Test ROI: `{strategy['test_roi']}`",
+            "",
+        ]
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handoff-json", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--expected-handoff-profile", default="event_ml_supervised_tabular")
+    parser.add_argument("--expected-config-profile", default="settlement_probability")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output-json", default="")
+    parser.add_argument("--output-md", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    handoff_path = Path(args.handoff_json)
+    config_path = Path(args.config)
+    handoff = load_json(handoff_path)
+    strategy = select_strategy(handoff)
+
+    runtime_score = str(strategy.get("runtime_score") or "")
+    strategy_profile = str(strategy.get("strategy_profile") or "")
+    model_path = args.model_path.strip()
+    if not runtime_score.startswith("event_ml_model:"):
+        raise SystemExit(f"unsupported runtime_score for Event ML config handoff: {runtime_score!r}")
+    if args.expected_handoff_profile and strategy_profile != args.expected_handoff_profile:
+        raise SystemExit(
+            "handoff strategy profile mismatch: "
+            f"observed={strategy_profile!r} expected={args.expected_handoff_profile!r}"
+        )
+    if not model_path:
+        raise SystemExit("model_path is required for Event ML config handoff")
+    if "\n" in model_path or "\r" in model_path:
+        raise SystemExit("model_path must be single-line")
+
+    original = config_path.read_text(encoding="utf-8")
+    updated, actions = replace_or_insert_event_ml_config(
+        original,
+        runtime_score=runtime_score,
+        model_path=model_path,
+        expected_config_profile=args.expected_config_profile,
+    )
+    changed = updated != original
+    if changed and not args.dry_run:
+        config_path.write_text(updated, encoding="utf-8")
+
+    summary = {
+        "kind": "event_ml_config_handoff",
+        "status": "ready",
+        "changed": changed,
+        "dry_run": bool(args.dry_run),
+        "config_path": str(config_path),
+        "handoff_json": str(handoff_path),
+        "runtime_score": runtime_score,
+        "model_path": model_path,
+        "selected_strategy": strategy,
+        **actions,
+    }
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.output_md:
+        Path(args.output_md).write_text(render_summary_markdown(summary), encoding="utf-8")
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -319,6 +319,12 @@ evidence comes from Polymarket full CLOB depth, not top book.
   migration shape as AutoFactor: use `ploy-ci-1` only for private DB export,
   then run artifact-backed coverage/attribution/baseline/walk-forward evidence
   on `ubuntu-latest`.
+- 2026-05-06: Added PR-only Event ML config promotion on the hosted artifact
+  branch. `options_json.create_config_pr=true` now opens a dry-run config PR
+  from a ready `event_ml_strategy_handoff.json`, but only when
+  `source_dataset_run_id` is used on GitHub-hosted runners and an explicit
+  `model_artifact_path` is supplied. The legacy `ploy-ci-1` branch now skips
+  config promotion and remains only a fresh private-DB export fallback.
 - 2026-05-06: Added the Event ML dry-run handoff contract in Rust. The handoff
   artifact is intentionally blocked unless walk-forward readiness passes,
   aggregate test PnL is positive, at least half of test windows are positive, a

--- a/tests/test_apply_event_ml_handoff_to_config.py
+++ b/tests/test_apply_event_ml_handoff_to_config.py
@@ -1,0 +1,161 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "apply_event_ml_handoff_to_config.py"
+
+
+READY_HANDOFF = {
+    "status": "ready",
+    "required_strategy_profile": "event_ml_supervised_tabular",
+    "runtime_score": "event_ml_model:baseline_v1",
+    "replay_parity_ready": True,
+    "blocked_gate_ids": [],
+    "strategy": {
+        "strategy_profile": "event_ml_supervised_tabular",
+        "runtime_score": "event_ml_model:baseline_v1",
+        "selection_rule": "best_validation_roi",
+        "window_count": 3,
+        "test_trades": 42,
+        "test_pnl": 12.5,
+        "test_roi": 0.071,
+        "weighted_avg_entry": 0.62,
+        "max_window_drawdown": -4.0,
+    },
+}
+
+
+BASE_CONFIG = """[strategy]
+symbols = ["BTCUSDT", "ETHUSDT"]
+three_layer_strategy_profile = "settlement_probability"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
+three_layer_min_entry_score = 0.25
+"""
+
+
+class ApplyEventMlHandoffToConfigTests(unittest.TestCase):
+    def run_script(self, handoff, config_text=BASE_CONFIG, *extra_args, check=True):
+        with tempfile.TemporaryDirectory() as tmp:
+            handoff_path = Path(tmp) / "handoff.json"
+            config_path = Path(tmp) / "strategy.toml"
+            summary_path = Path(tmp) / "summary.json"
+            handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+            config_path.write_text(config_text, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--handoff-json",
+                    str(handoff_path),
+                    "--config",
+                    str(config_path),
+                    "--model-path",
+                    "/opt/ploy/models/event_ml/baseline_metrics.json",
+                    "--output-json",
+                    str(summary_path),
+                    *extra_args,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=check,
+            )
+            summary = (
+                json.loads(summary_path.read_text(encoding="utf-8"))
+                if summary_path.exists()
+                else None
+            )
+            return result, config_path.read_text(encoding="utf-8"), summary
+
+    def test_updates_runtime_score_and_inserts_model_path(self):
+        _, config_text, summary = self.run_script(READY_HANDOFF)
+
+        self.assertIn(
+            'three_layer_autofactor_runtime_score = "event_ml_model:baseline_v1"',
+            config_text,
+        )
+        self.assertIn(
+            'three_layer_event_ml_model_path = "/opt/ploy/models/event_ml/baseline_metrics.json"',
+            config_text,
+        )
+        self.assertTrue(summary["changed"])
+        self.assertEqual(summary["runtime_score_action"], "updated")
+        self.assertEqual(summary["model_path_action"], "inserted")
+
+    def test_updates_existing_model_path(self):
+        config_with_model_path = (
+            BASE_CONFIG
+            + 'three_layer_event_ml_model_path = "/old/model.json"\n'
+        )
+
+        _, config_text, summary = self.run_script(READY_HANDOFF, config_with_model_path)
+
+        self.assertNotIn("/old/model.json", config_text)
+        self.assertEqual(summary["previous_model_path"], "/old/model.json")
+        self.assertEqual(summary["model_path_action"], "updated")
+
+    def test_unchanged_config_reports_changed_false(self):
+        current_config = """[strategy]
+three_layer_strategy_profile = "settlement_probability"
+three_layer_autofactor_runtime_score = "event_ml_model:baseline_v1"
+three_layer_event_ml_model_path = "/opt/ploy/models/event_ml/baseline_metrics.json"
+"""
+
+        _, _, summary = self.run_script(READY_HANDOFF, current_config)
+
+        self.assertFalse(summary["changed"])
+
+    def test_blocks_non_ready_handoff(self):
+        result, _, _ = self.run_script(
+            {"status": "blocked", "strategy": None, "replay_parity_ready": True},
+            BASE_CONFIG,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected ready", result.stderr)
+
+    def test_blocks_missing_replay_parity(self):
+        handoff = dict(READY_HANDOFF, replay_parity_ready=False)
+
+        result, _, _ = self.run_script(handoff, BASE_CONFIG, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("replay_parity_ready is not true", result.stderr)
+
+    def test_blocks_non_event_ml_runtime_score(self):
+        handoff = json.loads(json.dumps(READY_HANDOFF))
+        handoff["strategy"]["runtime_score"] = "autofactor_formula:edge"
+
+        result, _, _ = self.run_script(handoff, BASE_CONFIG, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported runtime_score", result.stderr)
+
+    def test_blocks_handoff_profile_mismatch(self):
+        handoff = json.loads(json.dumps(READY_HANDOFF))
+        handoff["strategy"]["strategy_profile"] = "settlement_probability"
+
+        result, _, _ = self.run_script(handoff, BASE_CONFIG, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("handoff strategy profile mismatch", result.stderr)
+
+    def test_blocks_config_profile_mismatch(self):
+        result, _, _ = self.run_script(
+            READY_HANDOFF,
+            BASE_CONFIG.replace("settlement_probability", "repricing_momentum", 1),
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("strategy config profile mismatch", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -119,7 +119,12 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
         "--runtime-score",
         "--replay-parity-ready",
         "create_handoff_issue",
+        "create_config_pr",
+        "model_artifact_path",
+        "Skip config PR on legacy DB branch",
+        "Create config PR from ready Event ML handoff",
         "issues: write",
+        "pull-requests: write",
         "Event ML handoff status is ${status}; no dry-run issue will be created.",
     ] {
         if !workflow.contains(needle) {
@@ -142,6 +147,8 @@ fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
         "runtime_score",
         "replay_parity_ready",
         "create_handoff_issue",
+        "create_config_pr",
+        "model_artifact_path",
         "workflow stays within GitHub's 10-input dispatch limit",
     ] {
         if !runbook.contains(needle) {


### PR DESCRIPTION
## Summary
- add a fail-closed Event ML handoff-to-config script for dry-run runtime score + model path updates
- wire event-ml-rolling-evidence hosted artifact runs to open PR-only config promotions
- keep the legacy ploy-ci-1 branch as fresh DB export only and skip config PR creation there
- document the GitHub-hosted runner promotion path and guard it in workflow tests

## Verification
- python3 -m unittest tests.test_apply_event_ml_handoff_to_config tests.test_apply_autofactor_handoff_to_config
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/event-ml-rolling-evidence.yml
- CARGO_TARGET_DIR=/tmp/ploy-event-ml-config-promotion rtk cargo test --test workflow_security -- --nocapture
- git diff --check

## Safety
This is PR-only. It does not deploy, does not enable live trading, and requires source_dataset_run_id plus model_artifact_path before a hosted Event ML run can open a dry-run config PR.