### PR TITLE
Fix dry-run window metadata for settlement soak

### DIFF
--- a/contracts/schemas/dry-run-performance-report.schema.json
+++ b/contracts/schemas/dry-run-performance-report.schema.json
@@ -63,6 +63,20 @@
     "generated_at": {
       "type": "string"
     },
+    "hourly": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunHourlyRow"
+      }
+    },
+    "hourly_by_window": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DryRunHourlyWindowRow"
+      }
+    },
     "metrics": {
       "$ref": "#/definitions/DryRunMetrics"
     },
@@ -418,6 +432,107 @@
         }
       }
     },
+    "DryRunHourlyRow": {
+      "type": "object",
+      "required": [
+        "closed_trade_count",
+        "cumulative_pnl",
+        "drawdown",
+        "losses",
+        "net_pnl",
+        "trade_count",
+        "trading_hour_cst",
+        "wins"
+      ],
+      "properties": {
+        "closed_trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "cumulative_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "drawdown": {
+          "type": "number",
+          "format": "double"
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "trading_hour_cst": {
+          "type": "string"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    "DryRunHourlyWindowRow": {
+      "type": "object",
+      "required": [
+        "closed_trade_count",
+        "losses",
+        "net_pnl",
+        "trade_count",
+        "trading_hour_cst",
+        "window_label",
+        "wins"
+      ],
+      "properties": {
+        "closed_trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "losses": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "net_pnl": {
+          "type": "number",
+          "format": "double"
+        },
+        "trade_count": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "trading_hour_cst": {
+          "type": "string"
+        },
+        "window_label": {
+          "type": "string"
+        },
+        "window_secs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "wins": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
     "DryRunMetrics": {
       "type": "object",
       "required": [
@@ -736,6 +851,20 @@
             "string",
             "null"
           ]
+        },
+        "hourly": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunHourlyRow"
+          }
+        },
+        "hourly_by_window": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DryRunHourlyWindowRow"
+          }
         },
         "label": {
           "type": "string"

--- a/crates/ploy-operator-contracts/src/reports.rs
+++ b/crates/ploy-operator-contracts/src/reports.rs
@@ -99,6 +99,30 @@ pub struct DryRunDailyWindowRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunHourlyRow {
+    pub trading_hour_cst: String,
+    pub trade_count: usize,
+    pub closed_trade_count: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub net_pnl: f64,
+    pub cumulative_pnl: f64,
+    pub drawdown: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DryRunHourlyWindowRow {
+    pub trading_hour_cst: String,
+    pub window_secs: Option<i64>,
+    pub window_label: String,
+    pub trade_count: usize,
+    pub closed_trade_count: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub net_pnl: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct DryRunSymbolRow {
     pub symbol: String,
     pub trades: usize,
@@ -192,6 +216,10 @@ pub struct DryRunStrategyReport {
     pub by_window: Vec<DryRunWindowRow>,
     pub daily: Vec<DryRunDailyRow>,
     pub daily_by_window: Vec<DryRunDailyWindowRow>,
+    #[serde(default)]
+    pub hourly: Vec<DryRunHourlyRow>,
+    #[serde(default)]
+    pub hourly_by_window: Vec<DryRunHourlyWindowRow>,
     pub symbols: Vec<DryRunSymbolRow>,
     pub symbols_by_window: Vec<DryRunSymbolRow>,
     pub closed_trades: Vec<DryRunClosedTradeRow>,
@@ -210,6 +238,10 @@ pub struct DryRunPerformanceReport {
     pub by_window: Vec<DryRunWindowRow>,
     pub daily: Vec<DryRunDailyRow>,
     pub daily_by_window: Vec<DryRunDailyWindowRow>,
+    #[serde(default)]
+    pub hourly: Vec<DryRunHourlyRow>,
+    #[serde(default)]
+    pub hourly_by_window: Vec<DryRunHourlyWindowRow>,
     pub symbols: Vec<DryRunSymbolRow>,
     pub symbols_by_window: Vec<DryRunSymbolRow>,
     pub closed_trades: Vec<DryRunClosedTradeRow>,
@@ -226,7 +258,7 @@ pub struct DryRunPerformanceReport {
 #[cfg(test)]
 mod tests {
     use super::DryRunPerformanceReport;
-    use serde_json::{Value, json};
+    use serde_json::{json, Value};
 
     #[test]
     fn dry_run_report_roundtrip_preserves_diagnostics_fields() {
@@ -238,6 +270,26 @@ mod tests {
             "by_window": [],
             "daily": [],
             "daily_by_window": [],
+            "hourly": [{
+                "trading_hour_cst": "2026-04-29T08:00:00+08:00",
+                "trade_count": 2,
+                "closed_trade_count": 1,
+                "wins": 1,
+                "losses": 0,
+                "net_pnl": 1.25,
+                "cumulative_pnl": 1.25,
+                "drawdown": 0.0
+            }],
+            "hourly_by_window": [{
+                "trading_hour_cst": "2026-04-29T08:00:00+08:00",
+                "window_secs": 300,
+                "window_label": "5m",
+                "trade_count": 2,
+                "closed_trade_count": 1,
+                "wins": 1,
+                "losses": 0,
+                "net_pnl": 1.25
+            }],
             "symbols": [],
             "symbols_by_window": [],
             "closed_trades": [],
@@ -254,6 +306,8 @@ mod tests {
                 "by_window": [],
                 "daily": [],
                 "daily_by_window": [],
+                "hourly": [],
+                "hourly_by_window": [],
                 "symbols": [],
                 "symbols_by_window": [],
                 "closed_trades": [],
@@ -303,6 +357,8 @@ mod tests {
             roundtripped["runtime_evidence"]["orders"][0]["intent_id"],
             "intent-1"
         );
+        assert_eq!(roundtripped["hourly"][0]["trade_count"], 2);
+        assert_eq!(roundtripped["hourly_by_window"][0]["window_label"], "5m");
     }
 
     fn summary() -> Value {

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -47,13 +47,13 @@ export interface DryRunDailyRow { closed_trade_count: number; confirmed_pnl: num
 
 export interface DryRunDailyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_day_cst: string; window_label: string; window_secs?: number | null; wins: number; }
 
-export interface DryRunHourlyRow { closed_trade_count: number; cumulative_pnl: number; drawdown: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; wins: number; }
-
-export interface DryRunHourlyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; window_label: string; window_secs?: number | null; wins: number; }
-
 export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
 
 export interface DryRunExecutionDiagnostics { basis: string; partial_buy_threshold_pct: number; strategies: JsonValue[]; summary: { [key: string]: JsonValue }; }
+
+export interface DryRunHourlyRow { closed_trade_count: number; cumulative_pnl: number; drawdown: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; wins: number; }
+
+export interface DryRunHourlyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; window_label: string; window_secs?: number | null; wins: number; }
 
 export interface DryRunMetrics { avg_trade?: number | null; closed_trade_count_for_sharpe?: number | null; daily_sharpe_basis?: string | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; sharpe_basis?: string | null; sharpe_daily_ann?: number | null; sharpe_per_trade?: number | null; }
 

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -47,6 +47,10 @@ export interface DryRunDailyRow { closed_trade_count: number; confirmed_pnl: num
 
 export interface DryRunDailyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_day_cst: string; window_label: string; window_secs?: number | null; wins: number; }
 
+export interface DryRunHourlyRow { closed_trade_count: number; cumulative_pnl: number; drawdown: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; wins: number; }
+
+export interface DryRunHourlyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; window_label: string; window_secs?: number | null; wins: number; }
+
 export interface DryRunEquityPoint { cumulative: number; drawdown: number; index: number; label: string; pnl: number; symbol?: string | null; timestamp?: string | null; }
 
 export interface DryRunExecutionDiagnostics { basis: string; partial_buy_threshold_pct: number; strategies: JsonValue[]; summary: { [key: string]: JsonValue }; }
@@ -59,7 +63,7 @@ export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed
 
 export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
 
-export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
 
@@ -69,7 +73,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 
@@ -128,4 +132,3 @@ export interface TradeResponse { entry_price: number; error_message?: string | n
 export interface TradingSnapshotEvent { trading: TradingStateSnapshot[]; }
 
 export type OperatorEvent = { data: LogEntry; type: "log"; } | { data: TradeResponse; type: "trade"; } | { data: PositionResponse; type: "position"; } | { data: MarketData; type: "market"; } | { data: StatusUpdate; type: "status"; } | { data: SystemSnapshotEvent; type: "system_snapshot"; } | { data: DeploymentSnapshotEvent; type: "deployment_snapshot"; } | { data: TradingSnapshotEvent; type: "trading_snapshot"; } | { data: MetricsSnapshotEvent; type: "metrics_snapshot"; } | { data: AlertSnapshotEvent; type: "alert_snapshot"; } | { data: OversightSnapshotEvent; type: "oversight_snapshot"; } | { data: ProposalSnapshotEvent; type: "proposal_snapshot"; };
-

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -51,6 +51,10 @@ export interface DryRunEquityPoint { cumulative: number; drawdown: number; index
 
 export interface DryRunExecutionDiagnostics { basis: string; partial_buy_threshold_pct: number; strategies: JsonValue[]; summary: { [key: string]: JsonValue }; }
 
+export interface DryRunHourlyRow { closed_trade_count: number; cumulative_pnl: number; drawdown: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; wins: number; }
+
+export interface DryRunHourlyWindowRow { closed_trade_count: number; losses: number; net_pnl: number; trade_count: number; trading_hour_cst: string; window_label: string; window_secs?: number | null; wins: number; }
+
 export interface DryRunMetrics { avg_trade?: number | null; closed_trade_count_for_sharpe?: number | null; daily_sharpe_basis?: string | null; equity_points: number; gross_loss: number; gross_profit: number; max_drawdown: number; profit_factor?: NumberOrText | null; sharpe?: number | null; sharpe_basis?: string | null; sharpe_daily_ann?: number | null; sharpe_per_trade?: number | null; }
 
 export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_price?: number | null; entry_time_remaining_secs?: number | null; event_id?: string | null; experiment_label?: string | null; market_side?: string | null; notional: number; opened_at?: string | null; quantity: number; runtime_mode?: string | null; strategy_id?: string | null; symbol?: string | null; trade_key?: string | null; window_label: string; window_secs?: number | null; }
@@ -59,7 +63,7 @@ export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed
 
 export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
 
-export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface DryRunSummary { closed_trades: number; latest_closed_at?: string | null; latest_opened_at?: string | null; losses: number; open_exposure: number; open_positions: number; realized_pnl: number; total_fees: number; total_trades: number; win_rate_pct: number; wins: number; }
 
@@ -69,7 +73,7 @@ export interface DryRunWindowRow { avg_entry?: number | null; avg_pnl?: number |
 
 export type NumberOrText = number | string;
 
-export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
+export interface DryRunPerformanceReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; generated_at: string; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; pairing: DryRunPairingReport; recent_closed: DryRunClosedTradeRow[]; runtime_evidence?: DryRunRuntimeEvidence | null; strategies: DryRunStrategyReport[]; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 
 export interface SystemStatus { active_alert_count?: number; database_connected: boolean; error_count_1h: number; last_live_reconcile_error?: string | null; last_live_reconcile_success_at?: string | null; last_trade_time?: string | null; live_reconcile_failures?: number; next_live_reconcile_at?: string | null; stale_source_count?: number; status: string; strategy: string; uptime_seconds: number; version: string; websocket_connected: boolean; }
 
@@ -128,4 +132,3 @@ export interface TradeResponse { entry_price: number; error_message?: string | n
 export interface TradingSnapshotEvent { trading: TradingStateSnapshot[]; }
 
 export type OperatorEvent = { data: LogEntry; type: "log"; } | { data: TradeResponse; type: "trade"; } | { data: PositionResponse; type: "position"; } | { data: MarketData; type: "market"; } | { data: StatusUpdate; type: "status"; } | { data: SystemSnapshotEvent; type: "system_snapshot"; } | { data: DeploymentSnapshotEvent; type: "deployment_snapshot"; } | { data: TradingSnapshotEvent; type: "trading_snapshot"; } | { data: MetricsSnapshotEvent; type: "metrics_snapshot"; } | { data: AlertSnapshotEvent; type: "alert_snapshot"; } | { data: OversightSnapshotEvent; type: "oversight_snapshot"; } | { data: ProposalSnapshotEvent; type: "proposal_snapshot"; };
-

--- a/scripts/export_operator_contract_types.mjs
+++ b/scripts/export_operator_contract_types.mjs
@@ -115,7 +115,7 @@ for (const fileName of schemaFiles) {
   emitDefinition(schema.title, schema);
 }
 
-const output = `${lines.join("\n").replace(/[ \t]+$/gm, "")}\n`;
+const output = `${lines.join("\n").replace(/[ \t]+$/gm, "").trimEnd()}\n`;
 const stale = [];
 
 for (const target of targets) {

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -56,25 +56,39 @@ WITH events AS (
     t.is_closed,
     t.open_quantity,
     CASE
-      WHEN m.market_slug IS NOT NULL THEN 'token_settlement_market_metadata'
+      WHEN ms.market_slug IS NOT NULL THEN 'token_settlement_market_metadata'
       WHEN s.market_slug IS NOT NULL THEN 'token_settlement_without_metadata'
-      ELSE 'missing_token_settlement'
+      WHEN me.market_slug IS NOT NULL THEN 'event_track_market_metadata'
+      WHEN mt.market_slug IS NOT NULL THEN 'trade_key_market_metadata'
+      ELSE 'missing_market_metadata'
     END AS metadata_join_status,
+    COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug) AS metadata_market_slug,
     CASE
-      WHEN m.end_time IS NOT NULL AND m.start_time IS NOT NULL
-        THEN ROUND(EXTRACT(EPOCH FROM (m.end_time - m.start_time)))::int
-      WHEN m.market_slug ILIKE '%15m%' OR m.market_slug ILIKE '%15-minute%' THEN 900
-      WHEN m.market_slug ILIKE '%5m%' OR m.market_slug ILIKE '%5-minute%' THEN 300
+      WHEN COALESCE(ms.end_time, me.end_time, mt.end_time) IS NOT NULL
+        AND COALESCE(ms.start_time, me.start_time, mt.start_time) IS NOT NULL
+        THEN ROUND(EXTRACT(EPOCH FROM (
+          COALESCE(ms.end_time, me.end_time, mt.end_time)
+          - COALESCE(ms.start_time, me.start_time, mt.start_time)
+        )))::int
+      WHEN COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug) ILIKE '%15m%'
+        OR COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug) ILIKE '%15-minute%'
+        THEN 900
+      WHEN COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug) ILIKE '%5m%'
+        OR COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug) ILIKE '%5-minute%'
+        THEN 300
       ELSE NULL
     END AS window_secs,
     CASE
-      WHEN m.end_time IS NOT NULL AND t.opened_at IS NOT NULL
-        THEN ROUND(EXTRACT(EPOCH FROM (m.end_time - t.opened_at)))::int
+      WHEN COALESCE(ms.end_time, me.end_time, mt.end_time) IS NOT NULL
+        AND t.opened_at IS NOT NULL
+        THEN ROUND(EXTRACT(EPOCH FROM (COALESCE(ms.end_time, me.end_time, mt.end_time) - t.opened_at)))::int
       ELSE NULL
     END AS entry_time_remaining_secs
   FROM strategy_runtime_event_track_record t
   LEFT JOIN pm_token_settlements s ON s.token_id = t.token_id
-  LEFT JOIN pm_market_metadata m ON m.market_slug = s.market_slug
+  LEFT JOIN pm_market_metadata ms ON ms.market_slug = s.market_slug
+  LEFT JOIN pm_market_metadata me ON me.market_slug = t.event_id
+  LEFT JOIN pm_market_metadata mt ON mt.market_slug = t.trade_key
   WHERE t.runtime_mode IN ({MODE_FILTER})
 )
 SELECT COALESCE(json_agg(row_to_json(e) ORDER BY e.opened_at, e.trade_key), '[]'::json)::text
@@ -341,6 +355,20 @@ def day_from_event(row) -> str | None:
     return parsed.astimezone(timezone(timedelta(hours=8))).date().isoformat()
 
 
+def hour_from_event(row) -> str | None:
+    timestamp = row.get("closed_at") or row.get("last_fill_at") or row.get("opened_at")
+    if not timestamp:
+        return None
+    parsed = parse_timestamp(timestamp)
+    if parsed is None:
+        return str(timestamp)[:13] + ":00"
+    if parsed.tzinfo is None:
+        hour = parsed.replace(minute=0, second=0, microsecond=0)
+    else:
+        hour = parsed.astimezone(timezone(timedelta(hours=8))).replace(minute=0, second=0, microsecond=0)
+    return hour.isoformat()
+
+
 def parse_timestamp(value):
     if not value:
         return None
@@ -527,6 +555,61 @@ def build_daily_by_window(events):
     return sorted(rows, key=lambda row: (row["trading_day_cst"], row["window_secs"] or 0), reverse=True)
 
 
+def build_hourly_rows(events):
+    grouped = defaultdict(list)
+    for event in events:
+        hour = hour_from_event(event)
+        if hour is not None:
+            grouped[hour].append(event)
+
+    cumulative = 0.0
+    peak = 0.0
+    rows = []
+    for hour in sorted(grouped.keys()):
+        hour_events = grouped[hour]
+        closed = [event for event in hour_events if event.get("is_closed")]
+        net_pnl = sum(number(event.get("net_pnl")) for event in closed)
+        cumulative += net_pnl
+        peak = max(peak, cumulative)
+        rows.append(
+            {
+                "trading_hour_cst": hour,
+                "trade_count": len(hour_events),
+                "closed_trade_count": len(closed),
+                "wins": sum(1 for event in closed if number(event.get("net_pnl")) > 0),
+                "losses": sum(1 for event in closed if number(event.get("net_pnl")) <= 0),
+                "net_pnl": rounded(net_pnl),
+                "cumulative_pnl": round(cumulative, 4),
+                "drawdown": round(cumulative - peak, 4),
+            }
+        )
+    return list(reversed(rows))
+
+
+def build_hourly_by_window(events):
+    grouped = defaultdict(list)
+    for event in events:
+        hour = hour_from_event(event)
+        if hour is not None:
+            grouped[(hour, event.get("window_secs"))].append(event)
+    rows = []
+    for (hour, window_secs), window_events in grouped.items():
+        closed = [event for event in window_events if event.get("is_closed")]
+        rows.append(
+            {
+                "trading_hour_cst": hour,
+                "window_secs": window_secs,
+                "window_label": window_label(window_secs),
+                "trade_count": len(window_events),
+                "closed_trade_count": len(closed),
+                "wins": sum(1 for event in closed if number(event.get("net_pnl")) > 0),
+                "losses": sum(1 for event in closed if number(event.get("net_pnl")) <= 0),
+                "net_pnl": rounded(sum(number(event.get("net_pnl")) for event in closed)),
+            }
+        )
+    return sorted(rows, key=lambda row: (row["trading_hour_cst"], row["window_secs"] or 0), reverse=True)
+
+
 def build_symbol_rows(events, include_window=False):
     grouped = defaultdict(list)
     for event in events:
@@ -648,6 +731,8 @@ def build_report_slice(events, daily_rows):
         "by_window": build_window_rows(events),
         "daily": build_daily_rows(daily_rows),
         "daily_by_window": build_daily_by_window(events),
+        "hourly": build_hourly_rows(events),
+        "hourly_by_window": build_hourly_by_window(events),
         "symbols": build_symbol_rows(events),
         "symbols_by_window": build_symbol_rows(events, include_window=True),
         "closed_trades": closed_trades[:250],
@@ -701,6 +786,8 @@ def empty_payload():
         "by_window": [],
         "daily": [],
         "daily_by_window": [],
+        "hourly": [],
+        "hourly_by_window": [],
         "symbols": [],
         "symbols_by_window": [],
         "closed_trades": [],

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13330,3 +13330,10 @@ Issue: https://github.com/proerror77/ploy/issues/256
   handoff. Live trading, all-symbol promotion, strict 168h collector-health
   signoff, and stronger event-level replay parity remain out of scope or
   residual follow-up.
+- 2026-05-06: Fixed the dry-run report metadata path for the settlement
+  probability 24h/48h soak. `report_dryrun_summary.py` now prefers the
+  token-settlement bridge but falls back to event-track and trade-key
+  `pm_market_metadata` joins, so orphaned token-settlement rows should not show
+  as `unknown` windows when event metadata exists. The report also emits hourly
+  and hourly-by-window rows with trade count, PnL, cumulative PnL, and drawdown
+  so the soak can be reviewed directly by hour and by 5m/15m window.

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -27,8 +27,11 @@ class DryRunReportContractTests(unittest.TestCase):
         script = SUMMARY_SCRIPT.read_text()
 
         self.assertIn("LEFT JOIN pm_token_settlements s ON s.token_id = t.token_id", script)
-        self.assertIn("LEFT JOIN pm_market_metadata m ON m.market_slug = s.market_slug", script)
-        self.assertNotIn("m.market_slug = t.event_id", script)
+        self.assertIn("LEFT JOIN pm_market_metadata ms ON ms.market_slug = s.market_slug", script)
+        self.assertIn("LEFT JOIN pm_market_metadata me ON me.market_slug = t.event_id", script)
+        self.assertIn("LEFT JOIN pm_market_metadata mt ON mt.market_slug = t.trade_key", script)
+        self.assertIn("COALESCE(ms.market_slug, me.market_slug, mt.market_slug, s.market_slug)", script)
+        self.assertLess(script.index("LEFT JOIN pm_market_metadata ms"), script.index("LEFT JOIN pm_market_metadata me"))
 
     def test_summary_metrics_expose_explicit_sharpe_basis(self) -> None:
         summary = load_summary_module()
@@ -53,6 +56,33 @@ class DryRunReportContractTests(unittest.TestCase):
             summary.day_from_event({"closed_at": "2026-04-28T17:30:00+00:00"}),
             "2026-04-29",
         )
+
+    def test_summary_hourly_rows_include_pnl_and_drawdown(self) -> None:
+        summary = load_summary_module()
+        events = [
+            {
+                "is_closed": True,
+                "net_pnl": 5.0,
+                "closed_at": "2026-04-28T17:30:00+00:00",
+                "window_secs": 300,
+            },
+            {
+                "is_closed": True,
+                "net_pnl": -8.0,
+                "closed_at": "2026-04-28T18:15:00+00:00",
+                "window_secs": 900,
+            },
+        ]
+
+        hourly = summary.build_hourly_rows(events)
+        hourly_by_window = summary.build_hourly_by_window(events)
+
+        self.assertEqual(hourly[0]["trading_hour_cst"], "2026-04-29T02:00:00+08:00")
+        self.assertEqual(hourly[0]["trade_count"], 1)
+        self.assertEqual(hourly[0]["net_pnl"], -8.0)
+        self.assertEqual(hourly[0]["drawdown"], -8.0)
+        self.assertEqual(hourly[1]["trading_hour_cst"], "2026-04-29T01:00:00+08:00")
+        self.assertEqual(hourly_by_window[0]["window_label"], "15m")
 
     def test_execution_diagnostics_contract(self) -> None:
         summary = load_summary_module()


### PR DESCRIPTION
## Summary
- keep token-settlement metadata as the primary dry-run report join
- add event_id/trade_key metadata fallbacks to remove explainable `unknown` windows
- add hourly and hourly-by-window dry-run report rows for 24h/48h soak review

## Verification
- `python3 -m unittest tests.test_dryrun_report_contracts`
- `rtk cargo test -p ploy-operator-contracts reports::tests::dry_run_report_roundtrip_preserves_diagnostics_fields`
- `rustfmt --check crates/ploy-operator-contracts/src/reports.rs`
- `git diff --check`

## Notes
- `cargo fmt --check` is not clean repo-wide on this branch because existing unrelated files need formatting; this change only checked the touched Rust contract file.
- No strategy scoring, deployment, or live order path is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dry-run reports now include hourly analytics with trade counts, profit/loss, cumulative performance, and drawdown metrics
  * Hourly performance can now be analyzed by specific trading windows for granular insights

* **Bug Fixes**
  * Fixed metadata resolution for settlement data to prevent orphaned windows from appearing as unknown in reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->