### PR TITLE
Avoid Cloud Assistant command size limits

### DIFF
--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import base64
 import json
 import os
+from pathlib import Path
 import shlex
 import subprocess
 import sys
 import time
+import tempfile
 
 
 def require_env(name: str) -> str:
@@ -25,9 +27,25 @@ def require_env(name: str) -> str:
     return value
 
 
+def run_text(args: list[str]) -> str:
+    completed = subprocess.run(args, text=True, capture_output=True)
+    if completed.returncode != 0:
+        if completed.stdout:
+            print(completed.stdout, file=sys.stderr)
+        if completed.stderr:
+            print(completed.stderr, file=sys.stderr)
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            args[0],
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    return completed.stdout
+
+
 def run_json(args: list[str]) -> dict:
-    completed = subprocess.run(args, check=True, text=True, capture_output=True)
-    return json.loads(completed.stdout)
+    completed = run_text(args)
+    return json.loads(completed)
 
 
 def shell_quote(value: str) -> str:
@@ -290,11 +308,86 @@ fi
 """
 
 
+def bootstrap_script(script_object: str) -> str:
+    deploy_root = require_env("DEPLOY_ROOT")
+    github_sha = require_env("GITHUB_SHA")
+    oss_region = require_env("DEPLOY_OSS_REGION")
+    oss_bucket = require_env("ALIYUN_OSS_BUCKET")
+    oss_key_id = require_env("ALIYUN_OSS_ACCESS_KEY_ID")
+    oss_key_secret = require_env("ALIYUN_OSS_ACCESS_KEY_SECRET")
+
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_ROOT={shell_quote(deploy_root)}
+GITHUB_SHA={shell_quote(github_sha)}
+WORKDIR="${{DEPLOY_ROOT}}/tmp/deploy-${{GITHUB_SHA}}-cloud-assist-bootstrap"
+
+ensure_ossutil() {{
+  export PATH="/usr/local/bin:/usr/bin:/bin:${{PATH}}"
+  if command -v ossutil >/dev/null 2>&1; then
+    return 0
+  fi
+  curl -fsSL https://gosspublic.alicdn.com/ossutil/install.sh | bash
+  export PATH="/usr/local/bin:/usr/bin:/bin:${{PATH}}"
+  command -v ossutil >/dev/null 2>&1
+}}
+
+mkdir -p "${{WORKDIR}}"
+ensure_ossutil
+export OSS_ACCESS_KEY_ID={shell_quote(oss_key_id)}
+export OSS_ACCESS_KEY_SECRET={shell_quote(oss_key_secret)}
+export OSS_REGION={shell_quote(oss_region)}
+export OSS_ENDPOINT="https://oss-{oss_region}-internal.aliyuncs.com"
+OSS_BUCKET={shell_quote(oss_bucket)}
+SCRIPT_OBJECT={shell_quote(script_object)}
+
+ossutil cp "oss://${{OSS_BUCKET}}/${{SCRIPT_OBJECT}}" "${{WORKDIR}}/cloud-assist-deploy.sh" \\
+  -i "${{OSS_ACCESS_KEY_ID}}" -k "${{OSS_ACCESS_KEY_SECRET}}" -e "${{OSS_ENDPOINT}}"
+chmod 0700 "${{WORKDIR}}/cloud-assist-deploy.sh"
+exec /bin/bash "${{WORKDIR}}/cloud-assist-deploy.sh"
+"""
+
+
+def upload_remote_script(script: str) -> str:
+    region = require_env("DEPLOY_OSS_REGION")
+    bucket = require_env("ALIYUN_OSS_BUCKET")
+    prefix = require_env("DEPLOY_OSS_PREFIX")
+    github_sha = require_env("GITHUB_SHA")
+    key_id = require_env("ALIYUN_OSS_ACCESS_KEY_ID")
+    key_secret = require_env("ALIYUN_OSS_ACCESS_KEY_SECRET")
+
+    script_object = f"{prefix}/{github_sha}/cloud-assist-deploy.sh"
+    script_path = Path(tempfile.gettempdir()) / f"ploy-cloud-assist-deploy-{github_sha[:12]}.sh"
+    script_path.write_text(script, encoding="utf-8")
+    run_text(
+        [
+            "ossutil",
+            "cp",
+            str(script_path),
+            f"oss://{bucket}/{script_object}",
+            "-i",
+            key_id,
+            "-k",
+            key_secret,
+            "-e",
+            f"https://oss-{region}.aliyuncs.com",
+        ]
+    )
+    return script_object
+
+
 def main() -> int:
     region = require_env("DEPLOY_OSS_REGION")
     instance_id = require_env("TANGO_1_1_INSTANCE_ID")
     command_name = f"ploy-cloud-assist-deploy-{os.environ.get('GITHUB_SHA', 'unknown')[:12]}"
-    command_content = f"/bin/bash -lc {shell_quote(remote_script())}"
+    script = remote_script()
+    script_object = upload_remote_script(script)
+    command_content = f"/bin/bash -lc {shell_quote(bootstrap_script(script_object))}"
+    print(
+        f"Uploaded Cloud Assistant deploy script oss://{require_env('ALIYUN_OSS_BUCKET')}/{script_object} "
+        f"({len(script.encode('utf-8'))} bytes); bootstrap is {len(command_content.encode('utf-8'))} bytes"
+    )
 
     run_result = run_json(
         [

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13348,3 +13348,11 @@ Issue: https://github.com/proerror77/ploy/issues/256
   as `unknown` windows when event metadata exists. The report also emits hourly
   and hourly-by-window rows with trade count, PnL, cumulative PnL, and drawdown
   so the soak can be reviewed directly by hour and by 5m/15m window.
+- 2026-05-06: PR #377 merged the first `deploy-tango-1-1.yml` Cloud Assistant
+  fallback, but the first main deploy run (`25439072337`) failed while
+  submitting `RunCommand`, before the remote script started. The fallback now
+  uploads the full remote deploy script to the same OSS deployment prefix and
+  sends Cloud Assistant only a small bootstrap command that downloads and
+  executes that script. This keeps CI-built artifacts as the source of truth
+  while avoiding Cloud Assistant command-content length limits and printing
+  Aliyun CLI stdout/stderr on future submission failures.


### PR DESCRIPTION
## Summary\n- Upload the full tango Cloud Assistant deploy script to OSS instead of inlining it into RunCommand.\n- Submit only a short bootstrap command that downloads and executes the script on tango-1-1.\n- Print Aliyun CLI stdout/stderr on submission failures so the next failure is diagnosable.\n\n## Verification\n- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py\n- git diff --check\n- bootstrap size smoke: full script 10924 bytes, bootstrap command 1086 bytes\n\n## Context\nMain deploy run 25439072337 reached the fallback path but failed before remote execution, while submitting RunCommand. This patch keeps CI-built artifacts and deployment semantics unchanged; it only changes Cloud Assistant transport packaging.