### PR TITLE
Fix market data audit runner gating

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -29,6 +29,14 @@ on:
           - critical
           - warn
           - never
+      gate_mode:
+        description: "Gate mode: freshness for collector health, coverage for retained-window research quality"
+        type: choice
+        required: true
+        default: "freshness"
+        options:
+          - freshness
+          - coverage
   schedule:
     - cron: "*/30 * * * *"
     - cron: "17 */6 * * *"
@@ -48,7 +56,7 @@ env:
 jobs:
   audit:
     name: Audit Tango market-data gaps
-    runs-on: [self-hosted, tango-1-1]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: tango-1-1
 
@@ -99,6 +107,7 @@ jobs:
           INPUT_BUCKET_MINUTES: ${{ inputs.bucket_minutes }}
           INPUT_SYMBOLS: ${{ inputs.symbols }}
           INPUT_FAIL_ON: ${{ inputs.fail_on }}
+          INPUT_GATE_MODE: ${{ inputs.gate_mode }}
         run: |
           set -euo pipefail
 
@@ -113,6 +122,7 @@ jobs:
           bucket_minutes="${INPUT_BUCKET_MINUTES:-5}"
           symbols="${INPUT_SYMBOLS:-${DEFAULT_SYMBOLS}}"
           fail_on="${INPUT_FAIL_ON:-critical}"
+          gate_mode="${INPUT_GATE_MODE:-freshness}"
 
           case "${run_full}" in
             true|false) ;;
@@ -122,6 +132,10 @@ jobs:
             critical|warn|never) ;;
             *) echo "invalid fail_on value: ${fail_on}" >&2; exit 1 ;;
           esac
+          case "${gate_mode}" in
+            freshness|coverage) ;;
+            *) echo "invalid gate_mode value: ${gate_mode}" >&2; exit 1 ;;
+          esac
 
           {
             echo "run_full=${run_full}"
@@ -129,6 +143,7 @@ jobs:
             echo "bucket_minutes=${bucket_minutes}"
             echo "symbols=${symbols}"
             echo "fail_on=${fail_on}"
+            echo "gate_mode=${gate_mode}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Run remote gap audits
@@ -137,6 +152,7 @@ jobs:
           FULL_LOOKBACK_HOURS: ${{ steps.scope.outputs.lookback_hours }}
           BUCKET_MINUTES: ${{ steps.scope.outputs.bucket_minutes }}
           SYMBOLS: ${{ steps.scope.outputs.symbols }}
+          GATE_MODE: ${{ steps.scope.outputs.gate_mode }}
         run: |
           set -euo pipefail
           mkdir -p artifacts/market-data-gap-audit
@@ -150,7 +166,7 @@ jobs:
 
             # shellcheck disable=SC2029
             ssh tango-1-1 \
-              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
+              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
           set -euo pipefail
           mkdir -p "$(dirname "${REMOTE_FILE}")"
           test -x "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py"
@@ -158,6 +174,7 @@ jobs:
             --lookback-hours "${LOOKBACK_HOURS}" \
             --bucket-minutes "${BUCKET_MINUTES}" \
             --symbols "${SYMBOLS}" \
+            --gate-mode "${GATE_MODE}" \
             --statement-timeout-seconds 20 \
             --psql-timeout-seconds 30 \
             --format json \
@@ -178,6 +195,7 @@ jobs:
         env:
           FAIL_ON: ${{ steps.scope.outputs.fail_on }}
           RUN_FULL: ${{ steps.scope.outputs.run_full }}
+          GATE_MODE: ${{ steps.scope.outputs.gate_mode }}
         run: |
           set -euo pipefail
           python3 <<'PY'
@@ -203,26 +221,34 @@ jobs:
               "## Market Data Gap Audit",
               "",
               f"- Gate: `{fail_on}`",
+              f"- Gate mode: `{os.environ['GATE_MODE']}`",
               f"- Full audit requested: `{os.environ['RUN_FULL']}`",
               "",
-              "| Audit | Overall | Lookback | Bucket | Non-OK sources |",
-              "| --- | --- | ---: | ---: | --- |",
+              "| Audit | Overall | Lookback | Bucket | Non-OK sources | Coverage caveats |",
+              "| --- | --- | ---: | ---: | --- | --- |",
           ]
           for name, _path, payload in reports:
               status = payload.get("overall_status", "unknown")
               if status_order.get(status, 2) > status_order[worst]:
                   worst = status
               non_ok = []
+              coverage_caveats = []
               for item in payload.get("gap_audits", []) + payload.get("window_audits", []):
                   item_status = item.get("status", "unknown")
                   if item_status != "ok":
                       source = item.get("source_id", "unknown")
                       reason = "; ".join(item.get("reasons") or [])
                       non_ok.append(f"`{source}` {item_status}: {reason}")
+                  coverage_status = item.get("coverage_status")
+                  if coverage_status and coverage_status != "ok":
+                      source = item.get("source_id", "unknown")
+                      reason = "; ".join(item.get("coverage_reasons") or [])
+                      coverage_caveats.append(f"`{source}` {coverage_status}: {reason}")
               lines.append(
                   f"| {name} | `{status}` | {payload.get('lookback_hours', 'n/a')}h "
                   f"| {payload.get('bucket_minutes', 'n/a')}m | "
-                  f"{'<br>'.join(non_ok) if non_ok else 'none'} |"
+                  f"{'<br>'.join(non_ok) if non_ok else 'none'} | "
+                  f"{'<br>'.join(coverage_caveats) if coverage_caveats else 'none'} |"
               )
 
           should_fail = False

--- a/crates/ploy-platform-runtime/src/bootstrap.rs
+++ b/crates/ploy-platform-runtime/src/bootstrap.rs
@@ -45,38 +45,44 @@ mod tests {
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::thread;
     use std::time::Duration as StdDuration;
 
-    fn test_working_directory() -> PathBuf {
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn test_id() -> String {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
+        let sequence = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        format!("{}-{unique}-{sequence}", std::process::id())
+    }
+
+    fn test_working_directory() -> PathBuf {
         let path = std::env::temp_dir().join(format!(
-            "ploy-platform-bootstrap-workdir-{}-{unique}",
-            std::process::id()
+            "ploy-platform-bootstrap-workdir-{}",
+            test_id()
         ));
         fs::create_dir_all(&path).expect("create test working directory");
         path
     }
 
     fn test_runner_binary() -> PathBuf {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "ploy-platform-bootstrap-test-runner-{}-{unique}.sh",
-            std::process::id()
+            "ploy-platform-bootstrap-test-runner-{}.sh",
+            test_id()
         ));
-        fs::write(&path, "#!/bin/sh\nsleep 30\n").expect("write test runner");
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, "#!/bin/sh\nsleep 30\n").expect("write test runner");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755))
                 .expect("chmod test runner");
         }
+        fs::rename(&tmp_path, &path).expect("publish test runner");
         path
     }
 

--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -196,38 +196,44 @@ mod tests {
     use rust_decimal_macros::dec;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::thread;
     use std::time::Duration as StdDuration;
 
-    fn test_working_directory() -> PathBuf {
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn test_id() -> String {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
+        let sequence = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        format!("{}-{unique}-{sequence}", std::process::id())
+    }
+
+    fn test_working_directory() -> PathBuf {
         let path = std::env::temp_dir().join(format!(
-            "ploy-platform-runtime-workdir-{}-{unique}",
-            std::process::id()
+            "ploy-platform-runtime-workdir-{}",
+            test_id()
         ));
         fs::create_dir_all(&path).expect("create test working directory");
         path
     }
 
     fn test_runner_binary() -> PathBuf {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "ploy-platform-runtime-test-runner-{}-{unique}.sh",
-            std::process::id()
+            "ploy-platform-runtime-test-runner-{}.sh",
+            test_id()
         ));
-        fs::write(&path, "#!/bin/sh\nsleep 30\n").expect("write test runner");
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, "#!/bin/sh\nsleep 30\n").expect("write test runner");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755))
                 .expect("chmod test runner");
         }
+        fs::rename(&tmp_path, &path).expect("publish test runner");
         path
     }
 

--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -221,6 +221,20 @@ SELECT json_build_object(
 
 
 def classify_gap(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]]:
+    freshness_status, freshness_reasons = classify_freshness(row, target)
+    coverage_status, coverage_reasons = classify_coverage(row, target)
+    status = worst_status([freshness_status, coverage_status])
+    reasons = []
+    if freshness_status != "ok":
+        reasons.extend(freshness_reasons)
+    if coverage_status != "ok":
+        reasons.extend(coverage_reasons)
+    if not reasons:
+        reasons.append("coverage within thresholds")
+    return status, reasons
+
+
+def classify_freshness(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]]:
     reasons: list[str] = []
     status = "ok"
 
@@ -231,6 +245,15 @@ def classify_gap(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]
     if latest_lag is not None and latest_lag > target.stale_after_seconds:
         status = "critical"
         reasons.append(f"latest lag {latest_lag}s > {target.stale_after_seconds}s")
+
+    if not reasons:
+        reasons.append("freshness within threshold")
+    return status, reasons
+
+
+def classify_coverage(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    status = "ok"
 
     if not target.ignore_max_gap:
         max_gap_minutes = int(row.get("max_gap_minutes") or 0)
@@ -256,6 +279,36 @@ def classify_gap(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]
     return status, reasons
 
 
+def classify_gap_for_gate(
+    row: dict[str, Any], target: GapTarget, gate_mode: str
+) -> tuple[str, list[str], str, list[str], str, list[str]]:
+    freshness_status, freshness_reasons = classify_freshness(row, target)
+    coverage_status, coverage_reasons = classify_coverage(row, target)
+    if gate_mode == "freshness":
+        status = freshness_status
+        reasons = list(freshness_reasons)
+        if coverage_status != "ok":
+            reasons.extend(f"coverage not enforced: {reason}" for reason in coverage_reasons)
+    else:
+        status, reasons = classify_gap(row, target)
+    return (
+        status,
+        reasons,
+        freshness_status,
+        freshness_reasons,
+        coverage_status,
+        coverage_reasons,
+    )
+
+
+def worst_status(statuses: Iterable[str]) -> str:
+    status = "ok"
+    for candidate in statuses:
+        if STATUS_ORDER.get(candidate, STATUS_ORDER["unknown"]) > STATUS_ORDER[status]:
+            status = candidate
+    return status
+
+
 def audit_gap_target(
     target: GapTarget,
     *,
@@ -264,6 +317,7 @@ def audit_gap_target(
     recent_minutes: int,
     statement_timeout_seconds: int,
     psql_timeout_seconds: int,
+    gate_mode: str,
 ) -> dict[str, Any]:
     started = time.monotonic()
     try:
@@ -277,9 +331,20 @@ def audit_gap_target(
             ),
             psql_timeout_seconds,
         )
-        status, reasons = classify_gap(row, target)
+        (
+            status,
+            reasons,
+            freshness_status,
+            freshness_reasons,
+            coverage_status,
+            coverage_reasons,
+        ) = classify_gap_for_gate(row, target, gate_mode)
         row["status"] = status
         row["reasons"] = reasons
+        row["freshness_status"] = freshness_status
+        row["freshness_reasons"] = freshness_reasons
+        row["coverage_status"] = coverage_status
+        row["coverage_reasons"] = coverage_reasons
     except Exception as exc:  # noqa: BLE001 - this is an operator diagnostic.
         row = {
             "source_id": target.source_id,
@@ -291,6 +356,10 @@ def audit_gap_target(
             "bucket_minutes": bucket_minutes,
             "status": "unknown",
             "reasons": [str(exc)],
+            "freshness_status": "unknown",
+            "freshness_reasons": [str(exc)],
+            "coverage_status": "unknown",
+            "coverage_reasons": [str(exc)],
         }
     row["query_ms"] = round((time.monotonic() - started) * 1000)
     return row
@@ -524,6 +593,15 @@ def main() -> int:
         default="critical",
         help="exit non-zero on critical, warn-or-higher, unknown-or-critical, or never",
     )
+    parser.add_argument(
+        "--gate-mode",
+        choices=("coverage", "freshness"),
+        default=os.environ.get("PLOY_AUDIT_GATE_MODE", "coverage"),
+        help=(
+            "coverage enforces historical bucket/max-gap checks plus freshness; "
+            "freshness enforces only latest-row staleness while still reporting coverage"
+        ),
+    )
     args = parser.parse_args()
 
     if args.lookback_hours <= 0:
@@ -546,6 +624,7 @@ def main() -> int:
             recent_minutes=args.recent_minutes,
             statement_timeout_seconds=args.statement_timeout_seconds,
             psql_timeout_seconds=args.psql_timeout_seconds,
+            gate_mode=args.gate_mode,
         )
         for target in selected_gap_targets
     ]
@@ -569,6 +648,7 @@ def main() -> int:
         "lookback_hours": args.lookback_hours,
         "bucket_minutes": args.bucket_minutes,
         "recent_minutes": args.recent_minutes,
+        "gate_mode": args.gate_mode,
         "symbols": symbols,
         "required_sources": source_requirements,
         "overall_status": overall_status(items),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,6 +19,9 @@ there is an unrecoverable historical outage from roughly `2026-05-06 03:10` to
 coverage statuses. The collector-health workflow defaults to freshness gating
 on GitHub-hosted runners, while strict coverage mode remains the script default
 for research/data-quality callers.
+PR CI exposed an unrelated `ploy-platform-runtime` test race where temporary
+runner scripts could collide or be executed while published. The test helper now
+uses an atomic per-process sequence and temp-file rename before execution.
 
 ## Tango Deploy Transport Repair (2026-05-06)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10,7 +10,7 @@
   gaps.
 - [x] Apply the smallest repo/remote fix that restores actionable Binance audit
   behavior without relaxing Polymarket freshness gates or reviving `ploy-ci-1`.
-- [ ] Verify locally and through GitHub Actions / remote audit evidence, then
+- [x] Verify locally and through GitHub Actions / remote audit evidence, then
   merge the fix back to `main`.
 
 Result so far: the Binance collectors are active and writing fresh rows, but
@@ -22,6 +22,12 @@ for research/data-quality callers.
 PR CI exposed an unrelated `ploy-platform-runtime` test race where temporary
 runner scripts could collide or be executed while published. The test helper now
 uses an atomic per-process sequence and temp-file rename before execution.
+Verification: local `python3 -m unittest
+tests.test_audit_market_data_gaps tests.test_ploy_maintenance_defaults`, local
+`CARGO_TARGET_DIR=/tmp/ploy-platform-runtime-ci-fix rtk cargo test -p
+ploy-platform-runtime --lib`, workflow YAML parse, and `git diff --check` all
+passed. PR #381 CI run `25592707685` passed after the runtime test helper
+hardening commit.
 
 ## Tango Deploy Transport Repair (2026-05-06)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,25 @@
 # PM5D Settlement Probability PRD Execution Plan (2026-05-05)
 
+## Market Data Audit Runner And Binance Gap Repair (2026-05-09)
+
+- [x] Move `market-data-gap-audit.yml` off the self-hosted `tango-1-1`
+  runner so scheduled/manual audit jobs can run while `ploy-ci-1` remains
+  intentionally offline.
+- [x] Diagnose the current Binance price / agg trade / LOB audit gaps on
+  `tango-1-1` and distinguish collector freshness from historical coverage
+  gaps.
+- [x] Apply the smallest repo/remote fix that restores actionable Binance audit
+  behavior without relaxing Polymarket freshness gates or reviving `ploy-ci-1`.
+- [ ] Verify locally and through GitHub Actions / remote audit evidence, then
+  merge the fix back to `main`.
+
+Result so far: the Binance collectors are active and writing fresh rows, but
+there is an unrecoverable historical outage from roughly `2026-05-06 03:10` to
+`2026-05-08 18:30` CST. The audit script now reports separate freshness and
+coverage statuses. The collector-health workflow defaults to freshness gating
+on GitHub-hosted runners, while strict coverage mode remains the script default
+for research/data-quality callers.
+
 ## Tango Deploy Transport Repair (2026-05-06)
 
 - [x] Diagnose repeated GitHub deploy failure at SSH banner exchange.

--- a/tests/test_audit_market_data_gaps.py
+++ b/tests/test_audit_market_data_gaps.py
@@ -1,0 +1,89 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_market_data_gaps.py"
+SPEC = importlib.util.spec_from_file_location("audit_market_data_gaps", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = audit
+SPEC.loader.exec_module(audit)
+
+
+class AuditMarketDataGapsTests(unittest.TestCase):
+    def test_freshness_gate_allows_historical_gap_but_reports_it(self):
+        target = audit.GapTarget(
+            "binance_price/BTCUSDT",
+            "binance_price_ticks",
+            "trade_time",
+            600,
+        )
+        row = {
+            "latest_at": "2026-05-09T13:05:00+08:00",
+            "latest_lag_seconds": 2,
+            "max_gap_minutes": 3800,
+            "missing_buckets": 1120,
+        }
+
+        status, reasons, freshness_status, _, coverage_status, coverage_reasons = (
+            audit.classify_gap_for_gate(row, target, "freshness")
+        )
+
+        self.assertEqual(status, "ok")
+        self.assertEqual(freshness_status, "ok")
+        self.assertEqual(coverage_status, "critical")
+        self.assertIn("max gap 3800m >= 15m", coverage_reasons)
+        self.assertTrue(any(reason.startswith("coverage not enforced") for reason in reasons))
+
+    def test_coverage_gate_keeps_historical_gap_critical(self):
+        target = audit.GapTarget(
+            "binance_lob/BTCUSDT",
+            "binance_lob_ticks",
+            "event_time",
+            900,
+        )
+        row = {
+            "latest_at": "2026-05-09T13:05:00+08:00",
+            "latest_lag_seconds": 1,
+            "max_gap_minutes": 3800,
+            "missing_buckets": 1120,
+        }
+
+        status, reasons, freshness_status, _, coverage_status, _ = audit.classify_gap_for_gate(
+            row, target, "coverage"
+        )
+
+        self.assertEqual(status, "critical")
+        self.assertEqual(freshness_status, "ok")
+        self.assertEqual(coverage_status, "critical")
+        self.assertIn("max gap 3800m >= 15m", reasons)
+
+    def test_freshness_gate_still_blocks_stale_source(self):
+        target = audit.GapTarget(
+            "binance_agg_trades/BTCUSDT",
+            "binance_agg_trade_ticks",
+            "trade_time",
+            600,
+        )
+        row = {
+            "latest_at": "2026-05-09T12:00:00+08:00",
+            "latest_lag_seconds": 1200,
+            "max_gap_minutes": 0,
+            "missing_buckets": 0,
+        }
+
+        status, reasons, freshness_status, _, coverage_status, _ = audit.classify_gap_for_gate(
+            row, target, "freshness"
+        )
+
+        self.assertEqual(status, "critical")
+        self.assertEqual(freshness_status, "critical")
+        self.assertEqual(coverage_status, "ok")
+        self.assertIn("latest lag 1200s > 600s", reasons)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move the market-data gap audit workflow to GitHub-hosted runners while keeping Tango access through the protected environment SSH path
- add an explicit audit gate mode so collector-health runs can enforce freshness while still reporting retained-window coverage gaps
- keep strict coverage as the script default for research/data-quality callers and add unit coverage for both modes

## Verification
- python3 -m py_compile scripts/audit_market_data_gaps.py tests/test_audit_market_data_gaps.py
- python3 -m unittest tests.test_audit_market_data_gaps tests.test_ploy_maintenance_defaults
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "all-workflow-yaml-ok"'\n- git diff --check\n- remote temp run on tango-1-1: freshness gate returned overall_status=ok while coverage_status remained critical for the 2026-05-06 03:10 to 2026-05-08 18:30 CST Binance outage\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable audit gate mode to select between freshness-based (collector health) or coverage-based (historical data quality) gap detection.
  * Audit reports now separately report freshness and coverage metrics with an expanded summary table including coverage caveats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->