### PR TITLE
Refresh market data audit concurrency

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -42,8 +42,8 @@ on:
     - cron: "17 */6 * * *"
 
 concurrency:
-  group: market-data-gap-audit
-  cancel-in-progress: false
+  group: market-data-gap-audit-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,6 +28,11 @@ tests.test_audit_market_data_gaps tests.test_ploy_maintenance_defaults`, local
 ploy-platform-runtime --lib`, workflow YAML parse, and `git diff --check` all
 passed. PR #381 CI run `25592707685` passed after the runtime test helper
 hardening commit.
+After PR #381 deployed, manual audit run `25593275239` and retry `25593324839`
+still stayed `pending` with `jobs=[]`. The remaining workflow fix changes the
+audit concurrency group from the old global key to a ref-scoped key and cancels
+older in-progress audit runs so cancelled historical scheduled runs cannot keep
+new GitHub-hosted audit runs queued.
 
 ## Tango Deploy Transport Repair (2026-05-06)
 


### PR DESCRIPTION
## Summary
- scope the market-data audit concurrency group by ref
- cancel older in-progress audit runs so stale scheduled runs cannot hold the queue
- record the post-PR #381 pending/no-jobs evidence in tasks/todo.md

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/market-data-gap-audit.yml"); puts "workflow-yaml-ok"'\n- git diff --check\n