### PR TITLE
Scope market data audit to collector sources

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -52,6 +52,7 @@ env:
   DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
   DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
   DEFAULT_SYMBOLS: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT
+  REQUIRED_SOURCES: pm5d-vol
 
 jobs:
   audit:
@@ -166,14 +167,16 @@ jobs:
 
             # shellcheck disable=SC2029
             ssh tango-1-1 \
-              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
+              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REQUIRED_SOURCES='${REQUIRED_SOURCES}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
           set -euo pipefail
           mkdir -p "$(dirname "${REMOTE_FILE}")"
           test -x "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py"
+          # Keep this workflow on collector health; research metadata is tracked separately.
           "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py" \
             --lookback-hours "${LOOKBACK_HOURS}" \
             --bucket-minutes "${BUCKET_MINUTES}" \
             --symbols "${SYMBOLS}" \
+            --required-sources "${REQUIRED_SOURCES}" \
             --gate-mode "${GATE_MODE}" \
             --statement-timeout-seconds 20 \
             --psql-timeout-seconds 30 \

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12617,7 +12617,7 @@ Review:
 - [x] Confirm the GitHub-hosted audit runner is the active path, not `ploy-ci-1`.
 - [x] Narrow the default workflow scope to collector-health sources only.
 - [x] Add a regression check so `research_valid_windows` stays out of the default gate.
-- [ ] Verify the workflow and merge the fix.
+- [x] Verify the workflow and merge the fix.
 
 ## Review
 
@@ -12626,6 +12626,8 @@ Review:
   which caused the summary to fail even when the collectors were healthy. The
   fix now keeps the workflow on collector-health scope and leaves research
   metadata for explicit use elsewhere.
+- 2026-05-10: PR #383 checks passed on GitHub-hosted runners; `ploy-ci-1` was
+  not used for this fix.
 # Data-Requirement Scoped Research Workflows (2026-04-28)
 
 ## Files

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12609,6 +12609,23 @@ Review:
   in 28s. Post-merge workflow run `25041205036` verified quick + full retained
   window reporting with `fail_on=never` and completed successfully in 1m49s;
   `summary.md`, `quick.json`, and `full.json` were uploaded as artifacts.
+
+# Market Data Audit Scope Fix (2026-05-10)
+
+## Tasks
+
+- [x] Confirm the GitHub-hosted audit runner is the active path, not `ploy-ci-1`.
+- [x] Narrow the default workflow scope to collector-health sources only.
+- [x] Add a regression check so `research_valid_windows` stays out of the default gate.
+- [ ] Verify the workflow and merge the fix.
+
+## Review
+
+- 2026-05-10: The remaining failure was policy, not dispatch. The hosted audit
+  workflow still treated `research_valid_windows` as part of the default gate,
+  which caused the summary to fail even when the collectors were healthy. The
+  fix now keeps the workflow on collector-health scope and leaves research
+  metadata for explicit use elsewhere.
 # Data-Requirement Scoped Research Workflows (2026-04-28)
 
 ## Files

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -1,0 +1,53 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_SCRIPT = ROOT / "scripts" / "audit_market_data_gaps.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "market-data-gap-audit.yml"
+
+
+def load_audit_module():
+    spec = importlib.util.spec_from_file_location("audit_market_data_gaps", AUDIT_SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class MarketDataGapAuditScopeTests(unittest.TestCase):
+    def test_collector_profiles_exclude_research_valid_windows(self) -> None:
+        audit = load_audit_module()
+        collector_profiles = ("pm5d-core", "pm5d-execution", "pm5d-vol")
+
+        for profile in collector_profiles:
+            with self.subTest(profile=profile):
+                requirements = audit.parse_source_requirements(profile)
+                self.assertNotIn("research_valid_windows", requirements)
+
+                research_window_target = {
+                    "source_id": "research_valid_windows",
+                    "table_name": "research_valid_windows",
+                }
+                self.assertFalse(
+                    audit.source_is_required(research_window_target, requirements),
+                    f"{profile} must stay scoped to market-data collectors",
+                )
+
+    def test_research_windows_remain_explicitly_auditable(self) -> None:
+        audit = load_audit_module()
+        requirements = audit.parse_source_requirements("research-windows")
+        self.assertEqual(requirements, ["research_valid_windows"])
+
+    def test_scheduled_workflow_uses_collector_scope(self) -> None:
+        workflow = WORKFLOW.read_text()
+        self.assertIn("REQUIRED_SOURCES: pm5d-vol", workflow)
+        self.assertIn("--required-sources \"${REQUIRED_SOURCES}\"", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the scheduled market-data gap workflow on the pm5d-vol collector source profile
- pass --required-sources through the remote Tango audit invocation
- add regression coverage so research_valid_windows stays out of collector profiles while remaining explicitly auditable

## Verification
- python3 -m unittest tests.test_market_data_gap_audit_scope
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/market-data-gap-audit.yml"); puts "yaml ok"'
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for market data audit scope to validate source requirement handling across different profiles and workflow configurations.

* **Chores**
  * Updated market data audit workflow to support configurable required data sources.
  * Updated project documentation with audit scope implementation details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/383)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->