### PR TITLE
Retry market data audit SSH transport

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -164,10 +164,12 @@ jobs:
             local remote_dir="${DEPLOY_ROOT}/reports/market-data-gap-audit"
             local remote_file="${remote_dir}/${audit_kind}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
             local local_file="artifacts/market-data-gap-audit/${audit_kind}.json"
+            local attempt
 
-            # shellcheck disable=SC2029
-            ssh tango-1-1 \
-              "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REQUIRED_SOURCES='${REQUIRED_SOURCES}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
+            for attempt in 1 2 3; do
+              # shellcheck disable=SC2029
+              if ssh tango-1-1 \
+                "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REQUIRED_SOURCES='${REQUIRED_SOURCES}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
           set -euo pipefail
           mkdir -p "$(dirname "${REMOTE_FILE}")"
           test -x "${DEPLOY_ROOT}/scripts/audit_market_data_gaps.py"
@@ -184,8 +186,27 @@ jobs:
             --fail-on never > "${REMOTE_FILE}"
           cp "${REMOTE_FILE}" "${DEPLOY_ROOT}/reports/market-data-gap-audit/${AUDIT_KIND}-latest.json"
           EOF
+              then
+                break
+              fi
 
-            scp "tango-1-1:${remote_file}" "${local_file}"
+              if [ "${attempt}" -eq 3 ]; then
+                echo "remote ${audit_kind} audit failed after ${attempt} attempts" >&2
+                return 1
+              fi
+              sleep "$((attempt * 15))"
+            done
+
+            for attempt in 1 2 3; do
+              if scp "tango-1-1:${remote_file}" "${local_file}"; then
+                break
+              fi
+              if [ "${attempt}" -eq 3 ]; then
+                echo "copying ${audit_kind} audit report failed after ${attempt} attempts" >&2
+                return 1
+              fi
+              sleep "$((attempt * 15))"
+            done
           }
 
           run_remote_audit quick 1

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12628,6 +12628,11 @@ Review:
   metadata for explicit use elsewhere.
 - 2026-05-10: PR #383 checks passed on GitHub-hosted runners; `ploy-ci-1` was
   not used for this fix.
+- 2026-05-10: Post-merge manual audit run `25618785890` reached a GitHub-hosted
+  job after environment approval, then failed before the audit query because
+  Tango SSH timed out during banner exchange. Added bounded SSH/SCP retry so a
+  transient public SSH timeout does not fail the collector-health audit on the
+  first attempt.
 # Data-Requirement Scoped Research Workflows (2026-04-28)
 
 ## Files

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -47,6 +47,11 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         workflow = WORKFLOW.read_text()
         self.assertIn("REQUIRED_SOURCES: pm5d-vol", workflow)
         self.assertIn("--required-sources \"${REQUIRED_SOURCES}\"", workflow)
+        self.assertIn("remote ${audit_kind} audit failed after ${attempt} attempts", workflow)
+        self.assertIn(
+            "copying ${audit_kind} audit report failed after ${attempt} attempts",
+            workflow,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry remote Tango audit SSH execution and SCP report download up to three times
- keep failures bounded and explicit after the final attempt
- extend the market-data audit regression test to cover the retry guard

## Verification
- python3 -m unittest tests.test_market_data_gap_audit_scope
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/market-data-gap-audit.yml"); puts "yaml ok"'
- bash -n on the embedded Run remote gap audits shell step
- git diff --check