### PR TITLE
Fix backtest LOB loader sampling

### DIFF
--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -110,6 +110,35 @@ const BINANCE_AGG_TRADE_SAMPLED_QUERY: &str = r#"
         ORDER BY agg.trade_time
         "#;
 
+const BINANCE_LOB_SAMPLED_QUERY: &str = r#"
+        WITH buckets AS (
+            SELECT s.symbol, bucket_start
+            FROM unnest($1::text[]) AS s(symbol)
+            CROSS JOIN generate_series(
+                $2::timestamptz,
+                $3::timestamptz,
+                make_interval(secs => $4::int)
+            ) AS bucket_start
+        )
+        SELECT lob.event_time, lob.symbol,
+               COALESCE(lob.obi_5, 0.0) as obi,
+               COALESCE(lob.spread_bps, 0)::int as spread_bps,
+               COALESCE(lob.bid_volume_5, 0) as bid_volume_5,
+               COALESCE(lob.ask_volume_5, 0) as ask_volume_5
+        FROM buckets
+        JOIN LATERAL (
+            SELECT event_time, symbol, obi_5, spread_bps, bid_volume_5, ask_volume_5
+            FROM binance_lob_ticks
+            WHERE symbol = buckets.symbol
+              AND event_time >= buckets.bucket_start
+              AND event_time < buckets.bucket_start + make_interval(secs => $4::int)
+              AND event_time <= $3
+            ORDER BY event_time DESC
+            LIMIT 1
+        ) AS lob ON true
+        ORDER BY lob.event_time
+        "#;
+
 /// Historical research backtests only trust canonical historical PM quote captures.
 ///
 /// Older `ploy_runner_live` rows were synthetic midpoint quotes; newer rows carry
@@ -827,21 +856,7 @@ async fn load_l2_data(
 ) -> Result<(), sqlx::Error> {
     let sample_secs = sample_secs.max(1) as i64;
     let rows: Vec<(DateTime<Utc>, String, Decimal, i32, Decimal, Decimal)> = match sqlx::query_as(
-        r#"
-        SELECT DISTINCT ON (symbol, date_trunc('second', event_time) - INTERVAL '1 second' * (EXTRACT(EPOCH FROM event_time)::bigint % $4))
-               event_time, symbol,
-               COALESCE(obi_5, 0.0) as obi,
-               COALESCE(spread_bps, 0)::int as spread_bps,
-               COALESCE(bid_volume_5, 0) as bid_volume_5,
-               COALESCE(ask_volume_5, 0) as ask_volume_5
-        FROM binance_lob_ticks
-        WHERE symbol = ANY($1)
-          AND event_time >= $2
-          AND event_time <= $3
-        ORDER BY symbol,
-                 date_trunc('second', event_time) - INTERVAL '1 second' * (EXTRACT(EPOCH FROM event_time)::bigint % $4),
-                 event_time DESC
-        "#,
+        BINANCE_LOB_SAMPLED_QUERY,
     )
     .bind(symbols)
     .bind(from)
@@ -1152,7 +1167,7 @@ mod tests {
 
     use super::{
         build_event_updates, l2_updates_from_book, near_depth, EventMetadataRow, MarketUpdate,
-        BINANCE_AGG_TRADE_SAMPLED_QUERY, BINANCE_PRICE_SAMPLED_QUERY,
+        BINANCE_AGG_TRADE_SAMPLED_QUERY, BINANCE_LOB_SAMPLED_QUERY, BINANCE_PRICE_SAMPLED_QUERY,
         SYNC_RECORDS_SPOT_SAMPLED_QUERY,
     };
 
@@ -1162,6 +1177,7 @@ mod tests {
             SYNC_RECORDS_SPOT_SAMPLED_QUERY,
             BINANCE_PRICE_SAMPLED_QUERY,
             BINANCE_AGG_TRADE_SAMPLED_QUERY,
+            BINANCE_LOB_SAMPLED_QUERY,
         ] {
             assert!(
                 query.contains("generate_series"),
@@ -1184,6 +1200,8 @@ mod tests {
         assert!(BINANCE_PRICE_SAMPLED_QUERY.contains("trade_time >= buckets.bucket_start"));
         assert!(BINANCE_PRICE_SAMPLED_QUERY.contains("ORDER BY trade_time DESC"));
         assert!(BINANCE_AGG_TRADE_SAMPLED_QUERY.contains("ORDER BY trade_time ASC"));
+        assert!(BINANCE_LOB_SAMPLED_QUERY.contains("event_time >= buckets.bucket_start"));
+        assert!(BINANCE_LOB_SAMPLED_QUERY.contains("ORDER BY event_time DESC"));
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/optimize_backtest.rs
@@ -1734,7 +1734,8 @@ fn main() {
 
         eprintln!(
             "Loading training data into db-eager replay ({} → {})...",
-            train_start, train_end
+            train_start_ts.as_deref().unwrap_or(&train_start),
+            train_end_ts.as_deref().unwrap_or(&train_end)
         );
         let train_load_started = Instant::now();
         let train = rt
@@ -1759,7 +1760,8 @@ fn main() {
 
         eprintln!(
             "Loading validation data into db-eager replay ({} → {})...",
-            val_start, val_end
+            val_start_ts.as_deref().unwrap_or(&val_start),
+            val_end_ts.as_deref().unwrap_or(&val_end)
         );
         let val_load_started = Instant::now();
         let val = rt

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,26 @@
 # PM5D Settlement Probability PRD Execution Plan (2026-05-05)
 
+## PM5D Backtest LOB Loader Repair (2026-05-10)
+
+- [x] Confirm `backtest.yml` still targets `ploy-ci-1` and avoid dispatching it.
+- [x] Start the BTC/ETH settlement-probability strategy backtest from the
+  deployed `tango-1-1` artifact path.
+- [x] Stop the long direct-DB debug run after it reached the heavy
+  `binance_lob_ticks` scan.
+- [x] Replace the DB L2 loader's computed-bucket `DISTINCT ON` query with
+  bucketed index lookups.
+- [x] Fix `optimize-backtest` DB loader logs so timestamp windows are printed
+  accurately.
+- [x] Verify locally.
+- [ ] Open/merge PR, deploy to `tango-1-1`, then rerun a bounded
+  strategy backtest.
+
+Review:
+- Local verification passed with `rtk cargo test -p ploy-feed-loaders
+  binance_samplers_use_bucketed_index_lookups --lib`,
+  `rtk cargo test -p ploy-strategy-bundles --example optimize_backtest
+  --no-run`, and `git diff --check`.
+
 ## Market Data Audit Runner And Binance Gap Repair (2026-05-09)
 
 - [x] Move `market-data-gap-audit.yml` off the self-hosted `tango-1-1`


### PR DESCRIPTION
## Summary
- replace DB eager Binance LOB sampling with bucketed lateral index lookups
- fix optimize-backtest DB loader logs to show timestamp windows when provided
- record the PM5D backtest repair plan and local verification

## Verification
- rtk cargo test -p ploy-feed-loaders binance_samplers_use_bucketed_index_lookups --lib
- rtk cargo test -p ploy-strategy-bundles --example optimize_backtest --no-run
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized L2 orderbook data loading from Binance with improved database query execution for faster, more efficient market data retrieval.

* **Improvements**
  * Backtest logging now clearly displays timestamp parameter values, automatically falling back to date-based parameters when overrides are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/387)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->