### PR TITLE
Bound PM book sampling for research snapshots

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -26,7 +26,7 @@ on:
       options_json:
         description: "Advanced options JSON: sampling, optimizer_data_dir, data_profile, audit gate, and optional full snapshot upload"
         required: false
-        default: '{"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
+        default: '{"lob_sample_secs":30,"pm_book_sample_secs":300,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -67,6 +67,7 @@ jobs:
 
           defaults = {
               "lob_sample_secs": "30",
+              "pm_book_sample_secs": "300",
               "observation_sample_secs": "30",
               "max_quote_age_secs": "30",
               "optimizer_data_dir": "/tmp/ploy-parquet",
@@ -300,6 +301,7 @@ jobs:
             "${{ github.event.inputs.end_date }}" \
             "${{ github.event.inputs.stake_usd }}" \
             "${SNAPSHOT_LOB_SAMPLE_SECS}" \
+            "${SNAPSHOT_PM_BOOK_SAMPLE_SECS}" \
             "${SNAPSHOT_OBSERVATION_SAMPLE_SECS}" \
             "${SNAPSHOT_MAX_QUOTE_AGE_SECS}" \
             "${SNAPSHOT_OPTIMIZER_DATA_DIR}" \
@@ -314,12 +316,13 @@ jobs:
           end_date="$5"
           stake_usd="$6"
           lob_sample_secs="$7"
-          observation_sample_secs="$8"
-          max_quote_age_secs="$9"
-          optimizer_data_dir="${10}"
-          required_sources="${11}"
-          data_audit_status="${12}"
-          include_deribit="${13}"
+          pm_book_sample_secs="$8"
+          observation_sample_secs="$9"
+          max_quote_age_secs="${10}"
+          optimizer_data_dir="${11}"
+          required_sources="${12}"
+          data_audit_status="${13}"
+          include_deribit="${14}"
 
           set -a
           . "${deploy_root}/.env"
@@ -340,6 +343,7 @@ jobs:
             --end-date "${end_date}" \
             --stake-usd "${stake_usd}" \
             --lob-sample-secs "${lob_sample_secs}" \
+            --pm-book-sample-secs "${pm_book_sample_secs}" \
             --observation-sample-secs "${observation_sample_secs}" \
             --max-quote-age-secs "${max_quote_age_secs}" \
             --output-dir "${remote_dir}/research-snapshot" \
@@ -390,6 +394,8 @@ jobs:
             echo "- Data profile: ${SNAPSHOT_DATA_PROFILE}"
             echo "- Data requirements: ${{ steps.data_scope.outputs.required_sources }}"
             echo "- Include Deribit: ${{ steps.data_scope.outputs.include_deribit }}"
+            echo "- LOB sample secs: ${SNAPSHOT_LOB_SAMPLE_SECS}"
+            echo "- PM book sample secs: ${SNAPSHOT_PM_BOOK_SAMPLE_SECS}"
             echo ""
             if [ -f artifacts/research-snapshot/data-gap-audit.md ]; then
               cat artifacts/research-snapshot/data-gap-audit.md

--- a/crates/ploy-research/examples/research_snapshot_compile.rs
+++ b/crates/ploy-research/examples/research_snapshot_compile.rs
@@ -72,6 +72,9 @@ async fn main() -> anyhow::Result<()> {
     let lob_sample_secs: i32 = flag_value(&args, "--lob-sample-secs")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(30);
+    let pm_book_sample_secs: i32 = flag_value(&args, "--pm-book-sample-secs")
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(lob_sample_secs);
     let max_quote_age_secs: i64 = flag_value(&args, "--max-quote-age-secs")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(30);
@@ -90,14 +93,15 @@ async fn main() -> anyhow::Result<()> {
     let include_deribit = !flag_present(&args, "--skip-deribit");
 
     eprintln!(
-        "research_snapshot_compile: {} -> {} for {:?}, stake_usd={:.2}, output={}, data_requirements={}, include_deribit={}",
+        "research_snapshot_compile: {} -> {} for {:?}, stake_usd={:.2}, output={}, data_requirements={}, include_deribit={}, pm_book_sample_secs={}",
         start,
         end,
         symbols,
         stake_usd,
         output_dir.display(),
         data_requirements.join(","),
-        include_deribit
+        include_deribit,
+        pm_book_sample_secs
     );
 
     let pool = PgPoolOptions::new()
@@ -113,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
             start,
             end,
             lob_sample_secs,
+            pm_book_sample_secs,
             observation_sample_secs,
             max_quote_age_secs,
             stake_usd,

--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -60,6 +60,8 @@ pub struct ResearchSnapshotManifest {
     pub end: DateTime<Utc>,
     pub history_start: DateTime<Utc>,
     pub lob_sample_secs: i32,
+    #[serde(default)]
+    pub pm_book_sample_secs: Option<i32>,
     pub observation_sample_secs: i64,
     pub max_quote_age_secs: i64,
     pub stake_usd: f64,
@@ -272,6 +274,7 @@ pub struct ResearchSnapshotBuildOptions {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
     pub lob_sample_secs: i32,
+    pub pm_book_sample_secs: i32,
     pub observation_sample_secs: i64,
     pub max_quote_age_secs: i64,
     pub stake_usd: f64,
@@ -340,12 +343,13 @@ pub async fn build_research_snapshot_from_database(
     });
 
     let started = Instant::now();
+    let pm_book_sample_secs = options.pm_book_sample_secs.max(1);
     let all_pm_book_snapshots = load_research_pm_book_snapshots_sampled(
         pool,
         &options.symbols,
         history_start,
         options.end,
-        options.lob_sample_secs,
+        pm_book_sample_secs,
     )
     .await
     .context("load PM book snapshots")?;
@@ -426,6 +430,7 @@ pub async fn build_research_snapshot_from_database(
             end: options.end,
             history_start,
             lob_sample_secs: options.lob_sample_secs,
+            pm_book_sample_secs: Some(pm_book_sample_secs),
             observation_sample_secs: options.observation_sample_secs,
             max_quote_age_secs: options.max_quote_age_secs,
             stake_usd: options.stake_usd,
@@ -493,6 +498,14 @@ fn compute_snapshot_hash(
     update(&mut hash, manifest.end.to_rfc3339().as_bytes());
     update(&mut hash, manifest.symbols.join(",").as_bytes());
     update(&mut hash, manifest.stake_usd.to_string().as_bytes());
+    update(
+        &mut hash,
+        manifest
+            .pm_book_sample_secs
+            .map(|value| value.to_string())
+            .unwrap_or_default()
+            .as_bytes(),
+    );
     update(&mut hash, manifest.data_requirements.join(",").as_bytes());
     update(&mut hash, manifest.include_deribit.to_string().as_bytes());
     update(
@@ -538,6 +551,21 @@ fn write_quality_markdown(path: &Path, manifest: &ResearchSnapshotManifest) -> R
         manifest.start, manifest.end
     ));
     body.push_str(&format!("- Symbols: `{}`\n", manifest.symbols.join(",")));
+    body.push_str(&format!(
+        "- LOB sample secs: `{}`\n",
+        manifest.lob_sample_secs
+    ));
+    body.push_str(&format!(
+        "- PM book sample secs: `{}`\n",
+        manifest
+            .pm_book_sample_secs
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "<same-as-lob>".to_string())
+    ));
+    body.push_str(&format!(
+        "- Observation sample secs: `{}`\n",
+        manifest.observation_sample_secs
+    ));
     body.push_str(&format!(
         "- Immutable input: `{}`\n",
         manifest.immutable_input
@@ -629,6 +657,7 @@ mod tests {
                 end: Utc::now(),
                 history_start: Utc::now(),
                 lob_sample_secs: 30,
+                pm_book_sample_secs: Some(30),
                 observation_sample_secs: 30,
                 max_quote_age_secs: 30,
                 stake_usd: 15.0,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13452,3 +13452,18 @@ Review:
 
 - Local checks so far: YAML parses; `actionlint -color` passes; GitHub workflow `run` blocks pass `bash -n` after expression sanitization; `rtk git diff --check` passes.
 - Remote preflight: `/opt/ploy/.env` sources under bash and exports `PLOY_DATABASE__URL`; `/opt/ploy/scripts/audit_market_data_gaps.py` is executable; `/opt/ploy/bin/research-snapshot-compile` is not deployed yet and must be installed by the next `deploy-tango-1-1.yml` run from `main`.
+
+## 2026-05-11 - PM Book Snapshot Sampling Timeout
+
+Plan:
+
+- [x] Diagnose why the 6-symbol, 7-day `pm5d-vol` research snapshot timed out.
+- [x] Add independent PM book sampling so CEX/observation sampling can stay at 30s while PM book lookups use a coarser cadence.
+- [x] Validate the code/workflow change locally.
+- [ ] Open PR, merge, deploy, and rerun the full snapshot.
+
+Review:
+
+- Run `25632454419` reached `lob snapshot rows: 87349` and then timed out with compile status `124` during PM book snapshot loading.
+- The failing window has 14,334 PM events, 28,668 token-side rows, about 509,504 generated 30s PM book buckets, and 8,663,685 raw matching orderbook rows in the 73GB `clob_orderbook_snapshots` table.
+- Local checks: `rtk cargo check -p ploy-research --features db,polars-export --example research_snapshot_compile`, YAML parse, `actionlint -color .github/workflows/research-snapshot.yml`, and `rtk git diff --check` all pass.


### PR DESCRIPTION
## Summary
- add `--pm-book-sample-secs` to `research_snapshot_compile` so PM orderbook sampling can be coarser than CEX/observation sampling
- record `pm_book_sample_secs` in snapshot manifest/quality output/hash metadata
- default `research-snapshot.yml` PM book sampling to 300s while preserving LOB and observation sampling at 30s

## Diagnosis
The full `pm5d-vol` snapshot run `25632454419` timed out with compile status `124` after logging `lob snapshot rows: 87349`. The next phase is PM book loading. The 6-symbol, 7-day window had 14,334 events, 28,668 token-side rows, about 509,504 generated 30s PM book buckets, and 8,663,685 raw matching orderbook rows in the 73GB `clob_orderbook_snapshots` table.

## Validation
- `rtk cargo check -p ploy-research --features db,polars-export --example research_snapshot_compile`
- YAML parse for `.github/workflows/research-snapshot.yml`
- `actionlint -color .github/workflows/research-snapshot.yml`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable PM book sample seconds parameter to research snapshot compilation, enabling independent control of PM book sampling intervals from other sampling settings.

* **Documentation**
  * Added documentation on PM Book snapshot sampling timeout investigation and mitigation approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/390)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->