### PR TITLE
Accept nullable snapshot factor fields

### DIFF
--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -142,11 +142,27 @@ pub struct FactorObservation {
     pub reward_risk_down: f64,
     pub obi: f64,
     pub spread_bps: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub microprice_offset_bps: f64,
     pub bid_depth_near: f64,
     pub ask_depth_near: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub depth_ratio: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub depth_imbalance: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub depth_far_ratio: f64,
     #[serde(
         default = "nan_f64",
@@ -203,8 +219,20 @@ pub struct FactorObservation {
     pub cum_mprice_drift_5m: f64,
     pub cum_trade_imbalance_5m: f64,
     pub cex_bar_return_30s: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub cex_bar_return_60s: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub cex_bar_volume_ratio_30s: f64,
+    #[serde(
+        default = "nan_f64",
+        deserialize_with = "deserialize_nullable_f64_as_nan"
+    )]
     pub cex_bar_volume_trend_3: f64,
     #[serde(
         default = "nan_f64",
@@ -2525,6 +2553,10 @@ mod tests {
         observation.model_edge_up = f64::NAN;
         observation.reward_risk_up = f64::NAN;
         observation.reward_risk_down = f64::NAN;
+        observation.microprice_offset_bps = f64::NAN;
+        observation.depth_ratio = f64::NAN;
+        observation.depth_imbalance = f64::NAN;
+        observation.depth_far_ratio = f64::NAN;
         observation.depth_acceleration = f64::NAN;
         observation.pm_up_bid = f64::NAN;
         observation.pm_up_ask = f64::NAN;
@@ -2534,13 +2566,19 @@ mod tests {
         observation.pm_down_ask = f64::NAN;
         observation.pm_down_bid_size = f64::NAN;
         observation.pm_down_ask_size = f64::NAN;
+        observation.cex_bar_return_60s = f64::NAN;
+        observation.cex_bar_volume_ratio_30s = f64::NAN;
+        observation.cex_bar_volume_trend_3 = f64::NAN;
         observation.cex_signed_volume_ratio_30s = f64::NAN;
         observation.cex_breakout_volume_score = f64::NAN;
         observation.future_up_ask_change_60s = None;
 
         let json = serde_json::to_string(&observation).expect("serialize observation");
         assert!(json.contains("\"flip_age_secs\":null"));
+        assert!(json.contains("\"microprice_offset_bps\":null"));
+        assert!(json.contains("\"depth_ratio\":null"));
         assert!(json.contains("\"depth_acceleration\":null"));
+        assert!(json.contains("\"cex_bar_volume_ratio_30s\":null"));
         assert!(json.contains("\"pm_up_bid_size\":null"));
 
         let decoded: FactorObservation =
@@ -2554,6 +2592,10 @@ mod tests {
         assert!(decoded.model_edge_up.is_nan());
         assert!(decoded.reward_risk_up.is_nan());
         assert!(decoded.reward_risk_down.is_nan());
+        assert!(decoded.microprice_offset_bps.is_nan());
+        assert!(decoded.depth_ratio.is_nan());
+        assert!(decoded.depth_imbalance.is_nan());
+        assert!(decoded.depth_far_ratio.is_nan());
         assert!(decoded.depth_acceleration.is_nan());
         assert!(decoded.pm_up_bid.is_nan());
         assert!(decoded.pm_up_ask.is_nan());
@@ -2563,6 +2605,9 @@ mod tests {
         assert!(decoded.pm_down_ask.is_nan());
         assert!(decoded.pm_down_bid_size.is_nan());
         assert!(decoded.pm_down_ask_size.is_nan());
+        assert!(decoded.cex_bar_return_60s.is_nan());
+        assert!(decoded.cex_bar_volume_ratio_30s.is_nan());
+        assert!(decoded.cex_bar_volume_trend_3.is_nan());
         assert!(decoded.cex_signed_volume_ratio_30s.is_nan());
         assert!(decoded.cex_breakout_volume_score.is_nan());
         assert_eq!(decoded.future_up_ask_change_60s, None);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13460,10 +13460,14 @@ Plan:
 - [x] Diagnose why the 6-symbol, 7-day `pm5d-vol` research snapshot timed out.
 - [x] Add independent PM book sampling so CEX/observation sampling can stay at 30s while PM book lookups use a coarser cadence.
 - [x] Validate the code/workflow change locally.
-- [ ] Open PR, merge, deploy, and rerun the full snapshot.
+- [x] Open PR, merge, deploy, and rerun the full snapshot.
+- [ ] Fix hosted walk-forward snapshot parsing for nullable LOB/CEX derived fields, merge, and rerun the walk-forward.
 
 Review:
 
 - Run `25632454419` reached `lob snapshot rows: 87349` and then timed out with compile status `124` during PM book snapshot loading.
 - The failing window has 14,334 PM events, 28,668 token-side rows, about 509,504 generated 30s PM book buckets, and 8,663,685 raw matching orderbook rows in the 73GB `clob_orderbook_snapshots` table.
 - Local checks: `rtk cargo check -p ploy-research --features db,polars-export --example research_snapshot_compile`, YAML parse, `actionlint -color .github/workflows/research-snapshot.yml`, and `rtk git diff --check` all pass.
+- PR #390 merged as `68928d98` and deployed by run `25642258988`.
+- Full `pm5d-vol` snapshot run `25642459432` succeeded with `pm_book_sample_secs=300`, `compile_status=0`, artifact `research-snapshot-25642459432` size `339071681` bytes, and row counts: observations `81645`, Deribit snapshots `16049`, PM book snapshots `46906`.
+- Hosted walk-forward run `25642965148` proved the snapshot artifact is complete but failed while parsing `observations.json`: `invalid type: null, expected f64` for nullable LOB/CEX derived fields that were not yet covered by the nullable-as-NaN serde compatibility path.


### PR DESCRIPTION
## Summary
- Treat nullable LOB/CEX-derived FactorObservation fields as NaN when reading retained research snapshots
- Extend the existing snapshot-null deserialization regression test
- Record the snapshot and hosted walk-forward evidence in tasks/todo.md

## Verification
- rtk cargo test -p ploy-research factor_observation_deserializes_snapshot_nulls_as_nan --features db --lib
- rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2
- rustfmt --edition 2021 crates/ploy-research/src/factors.rs
- rtk git diff --check

Context: hosted walk-forward run 25642965148 failed on research-snapshot-25642459432 because observations.json can contain null for microprice/depth/CEX derived fields.