### PR TITLE
Fix AutoFactor formula promotion gates

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -224,6 +224,10 @@ pub struct AutoFactorReport {
     pub window_ic_mean: f64,
     pub icir: f64,
     pub positive_window_ratio: f64,
+    pub symbol_count: usize,
+    pub symbol_ic_mean: f64,
+    pub symbol_icir: f64,
+    pub symbol_positive_ratio: f64,
     pub bucket_avg_labels: Vec<f64>,
     pub bottom_bucket_n: usize,
     pub bottom_bucket_avg_label: f64,
@@ -287,6 +291,7 @@ pub fn evaluate_named_factor(
     matrix: &AutoFactorMatrix,
     labels: &[f64],
     windows: &[String],
+    symbols: &[String],
     options: &AutoFactorOptions,
 ) -> Result<AutoFactorReport, AutoFactorError> {
     if labels.len() != matrix.len() {
@@ -299,6 +304,12 @@ pub fn evaluate_named_factor(
         return Err(AutoFactorError::WindowLengthMismatch {
             expected: matrix.len(),
             actual: windows.len(),
+        });
+    }
+    if !symbols.is_empty() && symbols.len() != matrix.len() {
+        return Err(AutoFactorError::WindowLengthMismatch {
+            expected: matrix.len(),
+            actual: symbols.len(),
         });
     }
 
@@ -346,6 +357,34 @@ pub fn evaluate_named_factor(
     );
     let window_ic_mean = finite_mean(window_ics.iter().copied());
     let factor_icir = icir(&window_ics);
+    let mut grouped_symbols: BTreeMap<&str, Vec<(f64, f64)>> = BTreeMap::new();
+    for (idx, score, label) in &scored {
+        let key = if symbols.is_empty() {
+            "all"
+        } else {
+            symbols[*idx].as_str()
+        };
+        grouped_symbols
+            .entry(key)
+            .or_default()
+            .push((*score, *label));
+    }
+    let symbol_ics = grouped_symbols
+        .values()
+        .filter(|pairs| pairs.len() >= options.min_window_observations)
+        .map(|pairs| {
+            let xs = pairs.iter().map(|(score, _)| *score).collect::<Vec<_>>();
+            let ys = pairs.iter().map(|(_, label)| *label).collect::<Vec<_>>();
+            spearman_ic(&xs, &ys)
+        })
+        .filter(|ic| ic.is_finite())
+        .collect::<Vec<_>>();
+    let symbol_positive_ratio = ratio(
+        symbol_ics.iter().filter(|ic| **ic > 0.0).count(),
+        symbol_ics.len(),
+    );
+    let symbol_ic_mean = finite_mean(symbol_ics.iter().copied());
+    let symbol_icir = icir(&symbol_ics);
 
     let buckets = build_buckets(&scored, options.bucket_count);
     let bucket_avg_labels = buckets
@@ -379,6 +418,10 @@ pub fn evaluate_named_factor(
         window_ic_mean,
         icir: factor_icir,
         positive_window_ratio,
+        symbol_count: symbol_ics.len(),
+        symbol_ic_mean,
+        symbol_icir,
+        symbol_positive_ratio,
         bucket_avg_labels,
         bottom_bucket_n: bottom.map(|bucket| bucket.n).unwrap_or(0),
         bottom_bucket_avg_label: bottom.map(|bucket| bucket.avg_label).unwrap_or(f64::NAN),
@@ -399,12 +442,13 @@ pub fn mine_autofactors(
     matrix: &AutoFactorMatrix,
     labels: &[f64],
     windows: &[String],
+    symbols: &[String],
     options: &AutoFactorOptions,
 ) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
     let mut reports = Vec::with_capacity(factors.len());
     for factor in factors {
         reports.push(evaluate_named_factor(
-            factor, matrix, labels, windows, options,
+            factor, matrix, labels, windows, symbols, options,
         )?);
     }
     reports.sort_by(|lhs, rhs| {
@@ -427,11 +471,11 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
         "target labels are side-aligned executable PnL for the requested target; reports are candidate discovery gates, not deploy decisions.\n",
     );
     out.push_str(
-        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity\n",
+        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity\n",
     );
     for (idx, report) in reports.iter().take(top_n).enumerate() {
         out.push_str(&format!(
-            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{:.4},{:.6},{:.4},{}\n",
+            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{},{:.4},{:.4},{:.6},{:.4},{}\n",
             idx + 1,
             report.name,
             report.target.as_deref().unwrap_or("<unspecified>"),
@@ -443,6 +487,8 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
             report.window_count,
             report.icir,
             report.positive_window_ratio,
+            report.symbol_count,
+            report.symbol_positive_ratio,
             report.monotonicity_score,
             report.top_bucket_avg_label,
             report.top_bucket_positive_label_rate,
@@ -460,6 +506,7 @@ pub fn mine_domain_autofactors_from_v2(
     let matrix = autofactor_matrix_from_v2(rows)?;
     let labels = autofactor_labels_from_v2(rows, target);
     let windows = autofactor_windows_from_v2(rows);
+    let symbols = autofactor_symbols_from_v2(rows);
     let target_name = target.as_str().to_string();
     let candidates = domain_candidates_for_target(&matrix.input_names(), target)
         .into_iter()
@@ -468,7 +515,7 @@ pub fn mine_domain_autofactors_from_v2(
             factor
         })
         .collect::<Vec<_>>();
-    mine_autofactors(&candidates, &matrix, &labels, &windows, options)
+    mine_autofactors(&candidates, &matrix, &labels, &windows, &symbols, options)
 }
 
 pub fn autofactor_matrix_from_v2(
@@ -570,6 +617,10 @@ pub fn autofactor_windows_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
             )
         })
         .collect()
+}
+
+pub fn autofactor_symbols_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
+    rows.iter().map(|row| row.symbol.clone()).collect()
 }
 
 fn valid_pm_price(value: f64) -> bool {
@@ -1413,8 +1464,9 @@ mod tests {
             ..Default::default()
         };
 
-        let reports =
-            mine_autofactors(&candidates, &matrix, &labels, &windows, &options).expect("reports");
+        let symbols = Vec::new();
+        let reports = mine_autofactors(&candidates, &matrix, &labels, &windows, &symbols, &options)
+            .expect("reports");
         let report = reports
             .iter()
             .find(|item| item.name == "ofi_l5_depth_norm")
@@ -1446,8 +1498,9 @@ mod tests {
             max_complexity: 3,
             ..Default::default()
         };
-        let report =
-            evaluate_named_factor(&factor, &matrix, &labels, &windows, &options).expect("report");
+        let symbols = Vec::new();
+        let report = evaluate_named_factor(&factor, &matrix, &labels, &windows, &symbols, &options)
+            .expect("report");
         assert_eq!(report.decision, AutoFactorDecision::Reject);
         assert_eq!(report.reason, "too_complex");
     }

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -4,10 +4,15 @@
 This is intentionally stricter than the AutoFactor IC/ICIR candidate gate.
 An AutoFactor row is only a qualified strategy when:
 
-1. the surrounding settlement PRD promotion gate is ready;
+1. all global settlement PRD promotion gates are ready;
 2. the row is a `candidate` with reason `passed`;
 3. the target is one of the allowed executable targets; and
 4. the factor has an explicit runtime strategy-profile mapping.
+
+For `autofactor_formula:*` runtime scores, the PRD model-specific
+`symbol_holdout` and `walk_forward_oos` gates are replaced by formula-level
+symbol/window stability from the AutoFactor row. Data quality, Deribit,
+execution-depth, calibration, and replay-parity gates remain global blockers.
 
 The current PM5D/PM15D settlement PRD should not silently promote a good
 repricing factor into the settlement strategy lane.
@@ -125,6 +130,8 @@ class AutoFactorRow:
     window_count: int
     icir: float
     positive_window_ratio: float
+    symbol_count: int
+    symbol_positive_ratio: float
     monotonicity: float
     top_bucket_avg_label: float
     top_bucket_positive_label_rate: float
@@ -148,6 +155,8 @@ def factor_metrics(row: AutoFactorRow) -> dict[str, Any]:
         "window_count": row.window_count,
         "icir": row.icir,
         "positive_window_ratio": row.positive_window_ratio,
+        "symbol_count": row.symbol_count,
+        "symbol_positive_ratio": row.symbol_positive_ratio,
         "monotonicity": row.monotonicity,
         "top_bucket_avg_label": row.top_bucket_avg_label,
         "top_bucket_positive_label_rate": row.top_bucket_positive_label_rate,
@@ -243,6 +252,8 @@ def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
                 window_count=parse_int(item["window_count"]),
                 icir=parse_float(item["icir"]),
                 positive_window_ratio=parse_float(item["positive_window_ratio"]),
+                symbol_count=parse_int(item.get("symbol_count", "0")),
+                symbol_positive_ratio=parse_float(item.get("symbol_positive_ratio", "nan")),
                 monotonicity=parse_float(item["monotonicity"]),
                 top_bucket_avg_label=parse_float(item["top_bucket_avg_label"]),
                 top_bucket_positive_label_rate=parse_float(item["top_bucket_positive_label_rate"]),
@@ -264,6 +275,33 @@ def load_runtime_mappings(path: str | None) -> dict[str, dict[str, str]]:
     return mappings
 
 
+MODEL_SPECIFIC_PRD_GATE_PREFIXES = (
+    "symbol_holdout:",
+    "walk_forward_oos:",
+)
+
+
+def is_autofactor_formula(mapping: dict[str, str] | None) -> bool:
+    if not mapping:
+        return False
+    return mapping.get("runtime_score", "").startswith("autofactor_formula:")
+
+
+def global_gate_blockers(gate: PromotionGate, *, formula_specific: bool) -> list[str]:
+    if gate.ready:
+        return []
+    if not formula_specific:
+        return ["promotion_gate_not_ready"]
+    blockers = [
+        item
+        for item in gate.blocked_gates
+        if not item.startswith(MODEL_SPECIFIC_PRD_GATE_PREFIXES)
+    ]
+    if blockers:
+        return [f"global_promotion_gate_not_ready:{item}" for item in blockers]
+    return []
+
+
 def evaluate(
     report_text: str,
     *,
@@ -277,13 +315,13 @@ def evaluate(
 
     for row in rows:
         blockers: list[str] = []
-        if not gate.ready:
-            blockers.append("promotion_gate_not_ready")
+        mapping = runtime_mappings.get(row.name)
+        formula_specific = is_autofactor_formula(mapping)
+        blockers.extend(global_gate_blockers(gate, formula_specific=formula_specific))
         if row.target not in allowed_targets:
             blockers.append("target_not_allowed")
         if row.decision != "candidate" or row.reason != "passed":
             blockers.append(f"autofactor_not_candidate:{row.decision}:{row.reason}")
-        mapping = runtime_mappings.get(row.name)
         if not mapping:
             blockers.append("missing_runtime_strategy_mapping")
         else:
@@ -293,6 +331,13 @@ def evaluate(
             elif mapped_profile != required_strategy_profile:
                 blockers.append(
                     f"runtime_profile_mismatch:{mapped_profile}!={required_strategy_profile}"
+                )
+        if formula_specific:
+            if row.symbol_count < 2:
+                blockers.append("formula_symbol_holdout_too_few_symbols")
+            elif row.symbol_positive_ratio < 0.60:
+                blockers.append(
+                    f"formula_symbol_holdout_unstable:{row.symbol_positive_ratio:.4f}<0.60"
                 )
         evaluated.append(
             EvaluatedFactor(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13472,3 +13472,18 @@ Review:
 - Full `pm5d-vol` snapshot run `25642459432` succeeded with `pm_book_sample_secs=300`, `compile_status=0`, artifact `research-snapshot-25642459432` size `339071681` bytes, and row counts: observations `81645`, Deribit snapshots `16049`, PM book snapshots `46906`.
 - Hosted walk-forward run `25642965148` proved the snapshot artifact is complete but failed while parsing `observations.json`: `invalid type: null, expected f64` for nullable LOB/CEX derived fields that were not yet covered by the nullable-as-NaN serde compatibility path.
 - PR #391 merged as `0b394616` and hosted walk-forward run `25643191151` succeeded from snapshot `25642459432`. AutoFactor promotion is correctly blocked, not broken: handoff status `blocked`, recommendation `do_not_promote`, with blockers `symbol_holdout` and `walk_forward_oos`; settlement AutoFactor formulas are watchlist only because of `low_icir`.
+
+## 2026-05-11 - AutoFactor Formula Promotion Gate
+
+Plan:
+
+- [x] Add formula-level symbol stability evidence to AutoFactor seed reports.
+- [x] Make the promotion evaluator distinguish global data/parity gates from formula-specific AutoFactor gates.
+- [x] Validate with focused unit/script tests before opening the implementation PR.
+
+Review:
+
+- Strict top-edge hosted run `25649549442` converted leading settlement AutoFactor rows into `candidate/passed`, but the handoff stayed blocked because the evaluator only understood the global PRD model gates.
+- The implementation adds `symbol_count` and `symbol_positive_ratio` to AutoFactor seed reports, preserving window IC/ICIR gates while adding formula-level symbol stability for `autofactor_formula:*` runtime scores.
+- The promotion evaluator still treats data quality, Deribit, executable-depth, calibration, and replay-parity failures as global blockers; it only replaces PRD model-specific `symbol_holdout` / `walk_forward_oos` blockers with formula-specific AutoFactor gates.
+- Local checks: `python3 -m unittest tests.test_autofactor_strategy_promotion`, `rtk cargo test -p ploy-research autofactor --lib`, `rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`, and `rtk git diff --check` pass.

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -24,6 +24,16 @@ data_quality,false,mode=event_complete event_complete_events=0 event_complete_ro
 recorded_replay_parity,false,missing replay parity
 """
 
+MODEL_BLOCKED_GATE = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=292 event_complete_rows=468 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=292 event_complete_rows=468
+deribit_vol_surface,true,require_deribit=true include_deribit=true
+recorded_replay_parity,true,blocking_flags=<none>
+symbol_holdout,false,no non-naive model passes all symbol holdouts
+walk_forward_oos,false,no non-naive model has non-empty OOS windows with positive_window_ratio >= 0.60
+"""
+
 AUTOFACTOR_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
@@ -43,10 +53,10 @@ AUTOFACTOR_SETTLEMENT_AUTO_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
-1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,1.0000,2.666226,0.6836,1
-2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,1.0000,2.631575,0.6790,3
-3,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,0.5000,-0.301991,0.4785,3
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,2.666226,0.6836,1
+2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,6,0.8333,1.0000,2.631575,0.6790,3
+3,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,-0.301991,0.4785,3
 """
 
 
@@ -184,6 +194,33 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(payload["decision"], "blocked")
         self.assertEqual(handoff["status"], "blocked")
         self.assertIn("promotion_gate_not_ready", payload["evaluated_factors"][0]["blockers"])
+
+    def test_formula_candidates_use_formula_specific_model_gates(self):
+        _, payload, _, handoff, _ = self.run_script(
+            MODEL_BLOCKED_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(len(handoff["strategies"]), 2)
+        first = payload["qualified_strategies"][0]["factor"]
+        self.assertEqual(first["symbol_count"], 6)
+        self.assertEqual(first["symbol_positive_ratio"], 0.8333)
+
+    def test_formula_candidates_require_symbol_stability(self):
+        weak_symbol_report = AUTOFACTOR_SETTLEMENT_AUTO_REPORT.replace(
+            ",6,0.8333,",
+            ",6,0.5000,",
+        )
+
+        _, payload, _, handoff, _ = self.run_script(
+            MODEL_BLOCKED_GATE + weak_symbol_report
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertIn("formula_symbol_holdout_unstable:0.5000<0.60", first["blockers"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add symbol-level stability fields to AutoFactor seed reports
- let `autofactor_formula:*` promotion use formula-specific symbol/window gates instead of PRD model-only `symbol_holdout` / `walk_forward_oos` blockers
- keep global data quality, Deribit, executable-depth, calibration, and replay-parity blockers fail-closed

## Evidence

- Strict hosted run `25649549442` found settlement formula candidates, but handoff stayed blocked because the evaluator only understood global PRD model gates.
- This PR adds the missing formula-level evidence and evaluator logic; it does not create a config PR or deploy.

## Verification

- `python3 -m unittest tests.test_autofactor_strategy_promotion`
- `rtk cargo test -p ploy-research autofactor --lib`
- `rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`
- `rtk git diff --check`
