### PR TITLE
Harden hosted AutoFactor config PR workflow

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -291,7 +291,7 @@ jobs:
       - name: Create config PR from ready handoff
         if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PLOY_PR_CREATE_TOKEN || github.token }}
           BASE_REF: ${{ github.event.inputs.git_ref }}
         run: |
           set -euo pipefail
@@ -338,6 +338,12 @@ jobs:
             exit 0
           fi
 
+          python3 -m unittest tests.test_apply_autofactor_handoff_to_config
+          cargo test --locked \
+            -p ploy-strategy-bundles \
+            settlement_probability_config_carries_autofactor_handoff_score \
+            --lib
+
           branch="autofactor/hosted-walk-forward-handoff-${GITHUB_RUN_ID}"
           git switch -c "${branch}"
           git config user.name "github-actions[bot]"
@@ -364,11 +370,33 @@ jobs:
             echo ""
             echo "This PR is generated from a ready hosted handoff artifact. It does not deploy and does not enable live trading."
           } > artifacts/factor-walk-forward-v2/autofactor-config-handoff/pr-body.md
-          gh pr create \
+          pr_url_file="artifacts/factor-walk-forward-v2/autofactor-config-handoff/pr-create-result.txt"
+          if gh pr create \
             --base "${BASE_REF}" \
             --head "${branch}" \
             --title "${title}" \
-            --body-file artifacts/factor-walk-forward-v2/autofactor-config-handoff/pr-body.md
+            --body-file artifacts/factor-walk-forward-v2/autofactor-config-handoff/pr-body.md \
+            | tee "${pr_url_file}"; then
+            echo "Created config PR from ready AutoFactor handoff."
+          else
+            status=$?
+            manual_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/new/${branch}"
+            {
+              echo "Config branch was pushed, but automatic PR creation failed with exit code ${status}."
+              echo "Manual PR URL: ${manual_url}"
+              echo "This commonly happens when repository policy blocks pull requests created by GitHub Actions tokens."
+            } | tee "${pr_url_file}"
+            {
+              echo "### AutoFactor config PR creation"
+              echo ""
+              echo "Config branch was pushed: \`${branch}\`"
+              echo ""
+              echo "Automatic PR creation failed with exit code \`${status}\`."
+              echo "Manual PR URL: ${manual_url}"
+              echo ""
+              echo "The workflow result remains successful because the research artifact and reviewable branch were produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Publish summary
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,17 @@ jobs:
           # RUSTSEC-2025-0021: gix-features 0.39.1 SHA-1 collision; pulled by burn-dataset, no git ops in prod.
           cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104 --ignore RUSTSEC-2025-0021
 
+  python-script-tests:
+    name: Python script tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Python unittest suite
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
+
   rust-control-plane:
     name: Rust control-plane/core
     runs-on: ubuntu-latest

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13487,3 +13487,20 @@ Review:
 - The implementation adds `symbol_count` and `symbol_positive_ratio` to AutoFactor seed reports, preserving window IC/ICIR gates while adding formula-level symbol stability for `autofactor_formula:*` runtime scores.
 - The promotion evaluator still treats data quality, Deribit, executable-depth, calibration, and replay-parity failures as global blockers; it only replaces PRD model-specific `symbol_holdout` / `walk_forward_oos` blockers with formula-specific AutoFactor gates.
 - Local checks: `python3 -m unittest tests.test_autofactor_strategy_promotion`, `rtk cargo test -p ploy-research autofactor --lib`, `rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2`, and `rtk git diff --check` pass.
+
+## 2026-05-11 - Hosted AutoFactor Config PR Fallback
+
+Plan:
+
+- [x] Diagnose why `create_config_pr=true` marked the hosted walk-forward run failed after a ready handoff.
+- [x] Keep the pushed config branch and artifact as success evidence when only `gh pr create` is blocked by repository token policy.
+- [x] Add promotion preflight checks before pushing a generated config branch.
+- [x] Add Python script tests to the PR `Test` workflow.
+- [ ] Validate workflow syntax and merge the CI fix.
+
+Review:
+
+- Hosted config run `25650041859` produced a ready handoff and pushed branch `autofactor/hosted-walk-forward-handoff-25650041859`, but failed at `gh pr create` with `GitHub Actions is not permitted to create or approve pull requests`.
+- The workflow now uses optional `PLOY_PR_CREATE_TOKEN` before falling back to `github.token`, and treats PR creation failure as a manual follow-up after the branch has already been pushed.
+- Generated config branches now run `tests.test_apply_autofactor_handoff_to_config` and the narrow settlement AutoFactor config contract test before commit/push, so stale hard-coded config expectations fail before the generated PR step.
+- The main PR workflow now runs Python unittest discovery, which exposed and fixed an outdated PM5D recording-source contract test that had drifted outside CI coverage.

--- a/tests/test_apply_autofactor_handoff_to_config.py
+++ b/tests/test_apply_autofactor_handoff_to_config.py
@@ -70,9 +70,10 @@ class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
 
     def test_updates_runtime_score_from_ready_handoff(self):
         _, config_text, summary = self.run_script(READY_HANDOFF)
+        runtime_score = READY_HANDOFF["strategies"][0]["runtime_score"]
 
         self.assertIn(
-            'three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"',
+            f'three_layer_autofactor_runtime_score = "{runtime_score}"',
             config_text,
         )
         self.assertTrue(summary["changed"])
@@ -89,10 +90,11 @@ three_layer_min_entry_score = 0.25
 """
 
         _, config_text, summary = self.run_script(READY_HANDOFF, config_without_score)
+        runtime_score = READY_HANDOFF["strategies"][0]["runtime_score"]
 
         self.assertIn(
             'three_layer_strategy_profile = "settlement_probability"\n'
-            'three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"',
+            f'three_layer_autofactor_runtime_score = "{runtime_score}"',
             config_text,
         )
         self.assertTrue(summary["changed"])

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -8,7 +8,7 @@ STRATEGY_DIR = ROOT / "config" / "strategies"
 
 
 class StrategyConfigContractTests(unittest.TestCase):
-    def test_pm5d_threelayer_has_one_bounded_canonical_recording_source(self) -> None:
+    def test_pm5d_threelayer_recording_sources_are_explicit_and_bounded(self) -> None:
         dryrun_configs = sorted(STRATEGY_DIR.glob("02-pm5d-threelayer.*-dryrun.toml"))
         self.assertGreaterEqual(len(dryrun_configs), 4)
 
@@ -22,15 +22,25 @@ class StrategyConfigContractTests(unittest.TestCase):
 
         self.assertEqual(
             [name for name, _ in recorders],
-            ["02-pm5d-threelayer.obi-soft-dryrun.toml"],
+            [
+                "02-pm5d-threelayer.obi-soft-dryrun.toml",
+                "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+            ],
         )
-        runtime = recorders[0][1]
         self.assertEqual(
-            runtime["record_market_updates_to"],
-            "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson",
+            [runtime["record_market_updates_to"] for _, runtime in recorders],
+            [
+                "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson",
+                "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+            ],
         )
-        self.assertGreater(runtime["record_market_updates_max_records"], 0)
-        self.assertGreater(runtime["record_market_updates_max_bytes"], 0)
+        self.assertEqual(
+            len({runtime["record_market_updates_to"] for _, runtime in recorders}),
+            len(recorders),
+        )
+        for _, runtime in recorders:
+            self.assertGreater(runtime["record_market_updates_max_records"], 0)
+            self.assertGreater(runtime["record_market_updates_max_bytes"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- keep hosted AutoFactor config handoff runs successful when the config branch was pushed but repository policy blocks `gh pr create` with the Actions token
- support optional `PLOY_PR_CREATE_TOKEN` for automatic PR creation
- run config handoff Python tests and the narrow settlement AutoFactor config contract before committing a generated config branch
- add Python unittest discovery to the main `Test` workflow
- update existing Python config-contract tests that had drifted outside CI coverage

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py'`\n- `rtk cargo test -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`\n- YAML parse for `.github/workflows/test.yml` and `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml`\n- `rtk git diff --check`\n\nNote: `actionlint` is not installed locally; CI Workflow lint covers it.\n