### PR TITLE
Slim runner CI feature graph

### DIFF
--- a/.github/workflows/build-push-acr.yml
+++ b/.github/workflows/build-push-acr.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
+            --features full \
             -p new-ploy-runner
           strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
 

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
+            --features new-ploy-runner/full \
             -p new-ployd \
             -p new-ploy-runner
           strip "target/${PLATFORM_TARGET}/release/new-ployd" || true

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -117,6 +117,7 @@ jobs:
         run: |
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
+            --features full \
             -p new-ploy-runner
           strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
           (cd "target/${PLATFORM_TARGET}/release" && sha256sum new-ploy-runner > new-ploy-runner.sha256)

--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Build factor review
         run: |
           set -euo pipefail
-          cargo build --release --locked \
+          cargo build --profile fast --locked \
             -p ploy-research \
             --features db \
             --example factor_review_v2
@@ -177,7 +177,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/factor-review-v2
-          ./target/release/examples/factor_review_v2 \
+          ./target/fast/examples/factor_review_v2 \
             --snapshot-dir artifacts/research-snapshot \
             --symbols "${{ github.event.inputs.symbols }}" \
             --start-date "${{ github.event.inputs.start_date }}" \

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Build factor walk-forward
         run: |
           set -euo pipefail
-          cargo build --release --locked \
+          cargo build --profile fast --locked \
             -p ploy-research \
             --features db \
             --example factor_walk_forward_v2
@@ -260,7 +260,7 @@ jobs:
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
           fi
-          ./target/release/examples/factor_walk_forward_v2 "${args[@]}" \
+          ./target/fast/examples/factor_walk_forward_v2 "${args[@]}" \
             | tee artifacts/factor-walk-forward-v2/report.txt
           echo "canonical_result=snapshot_artifact" | tee artifacts/factor-walk-forward-v2/source.txt
 

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -87,6 +87,7 @@ jobs:
           # binary names used by existing hosts and systemd units.
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
+            --features new-ploy-runner/full \
             -p new-ployd \
             -p ployctl \
             -p ploytui \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,20 +267,6 @@ jobs:
     name: Rust runner live/default
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_USER: ploy
-          POSTGRES_PASSWORD: ploy
-          POSTGRES_DB: ploy_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -293,7 +279,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld
+          sudo apt-get install -y pkg-config libssl-dev clang lld
           sudo apt-get install -y sccache || cargo install sccache --locked
 
       - name: Cache Rust dependencies
@@ -310,33 +296,12 @@ jobs:
             ${{ runner.os }}-sccache-runner-live-
             ${{ runner.os }}-sccache-
 
-      - name: Install SQLx CLI
-        run: |
-          cargo install sqlx-cli \
-            --locked \
-            --version "${SQLX_CLI_VERSION}" \
-            --no-default-features \
-            --features rustls,postgres
-
-      - name: Prepare database schema
+      - name: Check runner slim/default and full/live contracts
         env:
-          DATABASE_URL: postgres://ploy:ploy@localhost:5432/ploy_test
-        run: sqlx migrate run
-
-      - name: Build and test runner live/default lane
-        env:
-          DATABASE_URL: postgres://ploy:ploy@localhost:5432/ploy_test
           RUSTC_WRAPPER: sccache
         run: |
           set -euo pipefail
           SECONDS=0
-          cargo build --locked \
-            -p new-ploy-runner \
-            -p ploy-backtest \
-            -p ploy-runner-host \
-            -p ploy-strategy-runtime \
-            -p ploy-strategy-bundles \
-            -p ploy-connectivity
           cargo test --locked \
             -p new-ploy-runner \
             -p ploy-backtest \
@@ -344,6 +309,16 @@ jobs:
             -p ploy-strategy-runtime \
             -p ploy-strategy-bundles \
             -p ploy-connectivity
+          cargo check --locked \
+            -p new-ploy-runner \
+            --features full
+          cargo check --locked \
+            -p ploy-backtest \
+            -p ploy-runner-host \
+            -p ploy-strategy-runtime \
+            -p ploy-strategy-bundles \
+            -p ploy-connectivity \
+            --features ploy-runner-host/full,ploy-strategy-runtime/full
           echo "### Rust runner live/default lane" >> "$GITHUB_STEP_SUMMARY"
           echo "Elapsed seconds: ${SECONDS}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -397,7 +372,7 @@ jobs:
         run: |
           set -euo pipefail
           SECONDS=0
-          cargo check --locked -p ploy-market-data --lib
+          cargo check --locked -p ploy-market-data --features live --lib
           echo "### Rust market-data ops lane" >> "$GITHUB_STEP_SUMMARY"
           echo "Elapsed seconds: ${SECONDS}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo run -p ployctl -- deployments list
 cargo run -p ployctl -- deployments inspect example.paper
 cargo run -p ployctl -- trading cancel example.live <order-id>
 cargo run -p ploytui
-cargo run -p new-ploy-runner -- run --config config/strategies/02-pm5d.unified.toml --dry-run
+cargo run -p new-ploy-runner --features full -- run --config config/strategies/02-pm5d.unified.toml --dry-run
 # realtime operator stream
 curl -N http://127.0.0.1:8081/api/events/stream
 rtk cargo test --test platform_smoke -- --nocapture
@@ -128,12 +128,14 @@ Use `new-ploy-runner -- run --config ...` for:
 
 - local backtests
 - local dry-run debugging
+- full live/dry-run mode requires the explicit Cargo feature:
+  `cargo run -p new-ploy-runner --features full -- run --config ...`
 - one-off manual strategy inspection
 
 Example:
 
 ```bash
-cargo run -p new-ploy-runner -- run --config config/strategies/02-pm5d.v4-dryrun.toml --dry-run
+cargo run -p new-ploy-runner --features full -- run --config config/strategies/02-pm5d.v4-dryrun.toml --dry-run
 ```
 
 Use deployment manifests when you want the platform daemon to own lifecycle and supervision.
@@ -583,7 +585,7 @@ cargo run -p ployctl -- deployments apply config/deployments/example.paper.json
 cargo run -p ployctl -- deployments list
 cargo run -p ployctl -- deployments inspect example.paper
 cargo run -p ploytui
-cargo run -p new-ploy-runner -- run --config config/strategies/02-pm5d.unified.toml --dry-run
+cargo run -p new-ploy-runner --features full -- run --config config/strategies/02-pm5d.unified.toml --dry-run
 curl -N http://127.0.0.1:8081/api/events/stream
 rtk cargo check -p new-ployd         # Fast daemon type-check loop
 rtk cargo check -p new-ploy-runner   # Fast runner type-check loop
@@ -593,7 +595,7 @@ rtk cargo test --test platform_smoke platform_smoke_registers_and_starts_one_dep
 cargo fmt --check                    # Check formatting
 cargo clippy -- -D warnings          # Lint
 rtk cargo build -p new-ployd         # Build the daemon binary
-rtk cargo build -p new-ploy-runner   # Build the runner binary
+rtk cargo build -p new-ploy-runner --features full   # Build the full runner binary
 rtk cargo build -p ployctl           # Build the operator client binary
 rtk cargo build -p ploytui           # Build the terminal console binary
 ```

--- a/apps/new-ploy-runner/Cargo.toml
+++ b/apps/new-ploy-runner/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Bootstrap shell for the next-generation Ploy strategy runner"
 
 [features]
-default = ["full"]
+default = ["lean-replay"]
 full = ["ploy-runner-host/full"]
 lean-backtest = ["ploy-runner-host/lean-backtest"]
 lean-replay = ["ploy-runner-host/lean-replay"]

--- a/crates/ploy-market-data/Cargo.toml
+++ b/crates/ploy-market-data/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Market-data collection, discovery, and scanning infrastructure for Ploy"
 
 [features]
-default = ["live"]
+default = []
 live = [
     "dep:futures",
     "dep:polymarket-client-sdk",

--- a/crates/ploy-runner-host/Cargo.toml
+++ b/crates/ploy-runner-host/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "CLI host crate for the Ploy strategy runner"
 
 [features]
-default = ["full"]
+default = ["lean-replay"]
 full = ["ops", "run-full"]
 lean-backtest = ["ploy-strategy-runtime/backtest-db"]
 lean-replay = ["ploy-strategy-runtime/replay"]

--- a/crates/ploy-strategy-runtime/Cargo.toml
+++ b/crates/ploy-strategy-runtime/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Next-generation strategy runtime ownership boundary for Ploy"
 
 [features]
-default = ["full"]
+default = ["replay"]
 full = ["backtest-db", "db-recorder", "live", "live-execution", "replay"]
 backtest-db = ["dep:ploy-feed-loaders", "dep:sqlx"]
 db-recorder = ["dep:sqlx"]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,7 +23,8 @@ cargo build -p new-ployd -p new-ploy-runner -p ployctl -p ploytui
 
 # Focused daemon / runner loops
 cargo build -p new-ployd
-cargo build -p new-ploy-runner
+cargo build -p new-ploy-runner  # slim default replay runner
+cargo build -p new-ploy-runner --features full  # full live/dry-run runner
 ```
 
 ### Environment

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13504,3 +13504,63 @@ Review:
 - The workflow now uses optional `PLOY_PR_CREATE_TOKEN` before falling back to `github.token`, and treats PR creation failure as a manual follow-up after the branch has already been pushed.
 - Generated config branches now run `tests.test_apply_autofactor_handoff_to_config` and the narrow settlement AutoFactor config contract test before commit/push, so stale hard-coded config expectations fail before the generated PR step.
 - The main PR workflow now runs Python unittest discovery, which exposed and fixed an outdated PM5D recording-source contract test that had drifted outside CI coverage.
+# CI Speed Issue #396 Plan (2026-05-11)
+
+## Goal
+
+Reduce required PR CI wall-clock for the runner/research lanes without weakening
+deployment safety or live-runner coverage.
+
+## Files / Ownership
+
+- `apps/new-ploy-runner/Cargo.toml`, `crates/ploy-runner-host/Cargo.toml`,
+  `crates/ploy-strategy-runtime/Cargo.toml`, `crates/ploy-market-data/Cargo.toml`
+  - Owner: slim default feature graph; keep full/live behind explicit features.
+- `.github/workflows/test.yml`
+  - Owner: required runner CI lane; avoid duplicate build+test and keep full/live
+    compile contract.
+- `.github/workflows/deploy-tango-1-1.yml`,
+  `.github/workflows/build-push-acr.yml`,
+  `.github/workflows/release-platform.yml`, `.github/workflows/deploy-trade.yml`
+  - Owner: production/release runner builds must request `new-ploy-runner/full`
+    explicitly.
+- `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml`,
+  `.github/workflows/factor-review-v2-hosted-artifact.yml`
+  - Owner: hosted artifact evidence builds use the existing `fast` profile
+    instead of release LTO/profile settings.
+
+## Tasks
+
+- [x] Move runner and market-data defaults away from live/ops/full feature graphs.
+- [x] Update required runner CI to test slim defaults once and check full/live
+  contracts explicitly.
+- [x] Keep deployment/release workflows on explicit full runner builds.
+- [x] Move hosted artifact evidence builds from release to fast profile paths.
+- [x] Validate workflow syntax, slim/full Cargo feature checks, and dependency
+  tree exclusions.
+
+## Review
+
+- 2026-05-11: Implemented #396 CI speed slice. The default `new-ploy-runner`
+  graph now uses lean replay only, `ploy-market-data` has no live default, and
+  full live/dry-run dependencies are requested explicitly by release/deploy
+  workflows. The required runner CI lane now avoids separate build+test
+  duplicate compilation, removes Postgres/SQLx setup from that lane, tests the
+  slim default packages once, and checks full/live contracts explicitly.
+  Hosted artifact factor review/walk-forward workflows now build examples with
+  the workspace `fast` profile and run them from `target/fast/examples`.
+- 2026-05-11: Verification passed:
+  `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts f }'`,
+  `git diff --check`, `cargo metadata --locked --no-deps --format-version 1`,
+  `CARGO_TARGET_DIR=/tmp/ploy-ci-speed-slim /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner -p ploy-runner-host -p ploy-strategy-runtime -p ploy-market-data`,
+  `CARGO_TARGET_DIR=/tmp/ploy-ci-speed-full /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner --features full`,
+  `CARGO_TARGET_DIR=/tmp/ploy-ci-speed-market /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-market-data --features live --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-ci-speed-slim /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p new-ploy-runner -p ploy-backtest -p ploy-runner-host -p ploy-strategy-runtime -p ploy-strategy-bundles -p ploy-connectivity`,
+  `CARGO_TARGET_DIR=/tmp/ploy-ci-speed-full /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-backtest -p ploy-runner-host -p ploy-strategy-runtime -p ploy-strategy-bundles -p ploy-connectivity --features ploy-runner-host/full,ploy-strategy-runtime/full`,
+  and fast-profile hosted example builds for `factor_review_v2` and
+  `factor_walk_forward_v2`.
+- 2026-05-11: Dependency evidence: default `cargo tree -p new-ploy-runner`
+  no longer contains `polymarket-client-sdk`, `sqlx`, `ploy-market-data`, or
+  `ploy-connectivity`, and the default normal-edge tree is 132 lines. Explicit
+  `--features full` still includes `ploy-market-data`, `polymarket-client-sdk`,
+  `sqlx`, and `ploy-connectivity`, with a 999-line normal-edge tree.


### PR DESCRIPTION
## Summary
- make runner and market-data defaults slim so PR defaults no longer pull live/ops SDK dependencies
- keep deploy/release builds on explicit full runner features
- remove duplicate build+test work and Postgres/SQLx setup from the required runner CI lane
- use the existing fast profile for hosted artifact factor review/walk-forward example builds

Fixes #396

## Verification
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts f }'\n- git diff --check\n- cargo metadata --locked --no-deps --format-version 1\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-slim /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner -p ploy-runner-host -p ploy-strategy-runtime -p ploy-market-data\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-full /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner --features full\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-market /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-market-data --features live --lib\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-slim /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p new-ploy-runner -p ploy-backtest -p ploy-runner-host -p ploy-strategy-runtime -p ploy-strategy-bundles -p ploy-connectivity\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-full /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-backtest -p ploy-runner-host -p ploy-strategy-runtime -p ploy-strategy-bundles -p ploy-connectivity --features ploy-runner-host/full,ploy-strategy-runtime/full\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-research /opt/homebrew/bin/timeout 300 rtk cargo build --profile fast --locked -p ploy-research --features db --example factor_review_v2\n- CARGO_TARGET_DIR=/tmp/ploy-ci-speed-research /opt/homebrew/bin/timeout 300 rtk cargo build --profile fast --locked -p ploy-research --features db --example factor_walk_forward_v2\n\n## Evidence\n- default new-ploy-runner normal-edge tree: 132 lines and no polymarket-client-sdk/sqlx/ploy-market-data/ploy-connectivity\n- explicit --features full tree still includes ploy-market-data, polymarket-client-sdk, sqlx, and ploy-connectivity\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations to require explicit `--features full` flag for accessing full functionality; default builds now use lighter feature sets
  * Optimized CI/CD workflows for improved build performance

* **Documentation**
  * Updated build instructions and examples to document the `--features full` requirement for running with full capabilities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/397)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->