### PR TITLE
Report actionable AutoFactor walk-forward decisions

### DIFF
--- a/.github/scripts/autofactor-walk-forward-evidence.js
+++ b/.github/scripts/autofactor-walk-forward-evidence.js
@@ -1,0 +1,142 @@
+const fs = require("fs");
+
+function readJson(path) {
+  if (!fs.existsSync(path)) return null;
+  const raw = fs.readFileSync(path, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const sanitized = raw
+      .replace(/:\s*NaN\b/g, ": null")
+      .replace(/:\s*Infinity\b/g, ": null")
+      .replace(/:\s*-Infinity\b/g, ": null");
+    return JSON.parse(sanitized);
+  }
+}
+
+function stringifyBlockers(blockers, limit = 3) {
+  const values = Array.isArray(blockers) ? blockers.filter(Boolean) : [];
+  if (values.length === 0) return "none";
+  const shown = values.slice(0, limit);
+  const suffix = values.length > shown.length ? `, +${values.length - shown.length} more` : "";
+  return `${shown.join("; ")}${suffix}`;
+}
+
+function decisionFromArtifacts({ promotion, handoff }) {
+  if (!promotion && !handoff) {
+    return {
+      decision: "fix-workflow-or-artifact",
+      reason: "missing AutoFactor promotion and handoff artifacts",
+    };
+  }
+
+  if (handoff && handoff.status === "ready" && Array.isArray(handoff.strategies) && handoff.strategies.length > 0) {
+    return {
+      decision: "promote-to-dry-run",
+      reason: "qualified AutoFactor strategy handoff is ready",
+    };
+  }
+
+  const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
+  const blockedGates = Array.isArray(gate.blocked_gates) ? gate.blocked_gates : [];
+  const blockerText = blockedGates.join(" ").toLowerCase();
+
+  if (blockerText.includes("data_quality") || blockerText.includes("deribit")) {
+    return {
+      decision: "fix-data",
+      reason: stringifyBlockers(blockedGates),
+    };
+  }
+  if (blockerText.includes("replay") || blockerText.includes("runtime") || blockerText.includes("parity")) {
+    return {
+      decision: "fix-runtime",
+      reason: stringifyBlockers(blockedGates),
+    };
+  }
+  if (blockedGates.length > 0) {
+    return {
+      decision: "revise",
+      reason: stringifyBlockers(blockedGates),
+    };
+  }
+
+  if (promotion && promotion.decision === "blocked") {
+    return {
+      decision: "revise",
+      reason: "no AutoFactor row qualified under the requested target/profile",
+    };
+  }
+
+  return {
+    decision: "pending-review",
+    reason: "promotion artifacts were produced but no terminal decision was detected",
+  };
+}
+
+function topStrategies(handoff, limit = 3) {
+  if (!handoff || !Array.isArray(handoff.strategies)) return [];
+  return handoff.strategies.slice(0, limit).map((strategy) => {
+    const metrics = strategy.metrics || {};
+    return [
+      strategy.name || "<unknown>",
+      strategy.runtime_score || "<missing-runtime-score>",
+      `icir=${metrics.icir ?? "n/a"}`,
+      `top_bucket_avg_label=${metrics.top_bucket_avg_label ?? "n/a"}`,
+    ].join(" | ");
+  });
+}
+
+function actionableBlockers({ handoff, promotion }) {
+  const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
+  const blockedGates = Array.isArray(gate.blocked_gates) ? gate.blocked_gates : [];
+  if (handoff && handoff.status === "ready") {
+    return blockedGates.filter((item) => {
+      const value = String(item || "");
+      return !value.startsWith("symbol_holdout:") && !value.startsWith("walk_forward_oos:");
+    });
+  }
+  return blockedGates;
+}
+
+function buildWalkForwardEvidence({ title, metadata, artifactDir, runnerLabel }) {
+  const promotion = readJson(`${artifactDir}/autofactor-strategy-promotion.json`);
+  const handoff = readJson(`${artifactDir}/autofactor-strategy-handoff.json`);
+  const outcome = decisionFromArtifacts({ promotion, handoff });
+  const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
+  const strategies = topStrategies(handoff);
+  const blockers = actionableBlockers({ handoff, promotion });
+
+  const body = [
+    `${title}:`,
+    "",
+    `- Workflow: ${metadata.workflow}`,
+    `- Run URL: ${metadata.runUrl}`,
+    `- Git ref: ${metadata.gitRef}`,
+    `- Source snapshot run: \`${metadata.snapshotRunId}\``,
+    `- Dataset/window: ${metadata.startDate} -> ${metadata.endDate}`,
+    `- Symbols: ${metadata.symbols}`,
+    `- Artifact: \`${metadata.artifactName}\``,
+    `- Handoff status: \`${handoff ? handoff.status : "missing"}\``,
+    `- Promotion decision: \`${promotion ? promotion.decision : "missing"}\``,
+    `- Promotion gate ready: \`${gate.ready === true}\``,
+    `- Actionable blockers: \`${stringifyBlockers(blockers)}\``,
+    `- Decision: ${outcome.decision}`,
+    `- Next action: ${outcome.reason}`,
+  ];
+
+  if (strategies.length > 0) {
+    body.push("", "Qualified strategies:");
+    for (const strategy of strategies) body.push(`- ${strategy}`);
+  }
+
+  return {
+    body: body.join("\n"),
+    decision: outcome.decision,
+    labels: ["evidence:walk-forward", runnerLabel].filter(Boolean),
+  };
+}
+
+module.exports = {
+  buildWalkForwardEvidence,
+  decisionFromArtifacts,
+};

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -469,7 +469,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { applyResearchIssueLabels } = require("./.github/scripts/research-issue-labels.js");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
+            const { buildWalkForwardEvidence } = require("./.github/scripts/autofactor-walk-forward-evidence.js");
             const issueNumberRaw = process.env.WALK_ISSUE_NUMBER || "";
             if (!issueNumberRaw) {
               core.info("No issue_number configured; skipping issue comment.");
@@ -477,30 +478,33 @@ jobs:
             }
             const issue_number = Number(issueNumberRaw);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "Hosted factor walk-forward evidence:",
-              "",
-              `- Workflow: ${context.workflow}`,
-              `- Run URL: ${runUrl}`,
-              `- Git ref: ${{ github.event.inputs.git_ref }}`,
-              `- Source snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\``,
-              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
-              `- Symbols: ${{ github.event.inputs.symbols }}`,
-              `- Artifact: \`factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}\``,
-              "- Decision: pending"
-            ].join("\n");
+            const evidence = buildWalkForwardEvidence({
+              title: "Hosted factor walk-forward evidence",
+              artifactDir: "artifacts/factor-walk-forward-v2",
+              runnerLabel: "runner:hosted",
+              metadata: {
+                workflow: context.workflow,
+                runUrl,
+                gitRef: "${{ github.event.inputs.git_ref }}",
+                snapshotRunId: "${{ github.event.inputs.snapshot_run_id }}",
+                startDate: "${{ github.event.inputs.start_date }}",
+                endDate: "${{ github.event.inputs.end_date }}",
+                symbols: "${{ github.event.inputs.symbols }}",
+                artifactName: `factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}`,
+              },
+            });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number,
-              body
+              body: evidence.body
             });
             await applyResearchIssueLabels({
               github,
               context,
               core,
               issue_number,
-              labels: ["evidence:walk-forward", "runner:hosted", "decision:pending"]
+              labels: [...evidence.labels, ...labelsForDecision(evidence.decision)]
             });
 
       - name: Create ready handoff issue

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -636,7 +636,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { applyResearchIssueLabels } = require("./.github/scripts/research-issue-labels.js");
+            const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
+            const { buildWalkForwardEvidence } = require("./.github/scripts/autofactor-walk-forward-evidence.js");
             const issueNumberRaw = process.env.WALK_ISSUE_NUMBER || "";
             if (!issueNumberRaw) {
               core.info("No issue_number configured in options_json; skipping issue comment.");
@@ -644,27 +645,31 @@ jobs:
             }
             const issue_number = Number(issueNumberRaw);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = [
-              "Factor walk-forward evidence:",
-              "",
-              `- Workflow: ${context.workflow}`,
-              `- Run URL: ${runUrl}`,
-              `- Git ref: ${{ github.event.inputs.git_ref }}`,
-              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
-              `- Symbols: ${{ github.event.inputs.symbols }}`,
-              `- Artifact: \`factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}\``,
-              "- Decision: pending"
-            ].join("\n");
+            const evidence = buildWalkForwardEvidence({
+              title: "Factor walk-forward evidence",
+              artifactDir: "artifacts/factor-walk-forward-v2",
+              runnerLabel: "runner:self-hosted",
+              metadata: {
+                workflow: context.workflow,
+                runUrl,
+                gitRef: "${{ github.event.inputs.git_ref }}",
+                snapshotRunId: "${{ github.event.inputs.snapshot_run_id || 'none' }}",
+                startDate: "${{ github.event.inputs.start_date }}",
+                endDate: "${{ github.event.inputs.end_date }}",
+                symbols: "${{ github.event.inputs.symbols }}",
+                artifactName: `factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}`,
+              },
+            });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number,
-              body
+              body: evidence.body
             });
             await applyResearchIssueLabels({
               github,
               context,
               core,
               issue_number,
-              labels: ["evidence:walk-forward", "decision:pending"]
+              labels: [...evidence.labels, ...labelsForDecision(evidence.decision)]
             });

--- a/scripts/apply_autofactor_handoff_to_config.py
+++ b/scripts/apply_autofactor_handoff_to_config.py
@@ -100,7 +100,7 @@ def render_summary_markdown(summary: dict[str, Any]) -> str:
             f"- Target: `{strategy['target']}`",
             f"- Strategy profile: `{strategy['strategy_profile']}`",
             f"- ICIR: `{strategy['metrics']['icir']}`",
-            f"- Top bucket PnL: `{strategy['metrics']['top_bucket_avg_label']}`",
+            f"- Top bucket avg label: `{strategy['metrics']['top_bucket_avg_label']}`",
             "",
         ]
     )

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -463,20 +463,20 @@ def render_handoff_markdown(handoff: dict[str, Any]) -> str:
             "",
             "## Qualified Strategies",
             "",
-            "| factor | target | strategy profile | runtime score | icir | top bucket pnl |",
+            "| factor | target | strategy profile | runtime score | icir | top bucket avg label |",
             "| --- | --- | --- | --- | --- | --- |",
         ]
     )
     for strategy in handoff["strategies"]:
         metrics = strategy["metrics"]
         lines.append(
-            "| {name} | {target} | {profile} | {runtime_score} | {icir:.6f} | {pnl:.6f} |".format(
+            "| {name} | {target} | {profile} | {runtime_score} | {icir:.6f} | {label:.6f} |".format(
                 name=strategy["name"],
                 target=strategy["target"],
                 profile=strategy["strategy_profile"],
                 runtime_score=strategy["runtime_score"],
                 icir=metrics["icir"],
-                pnl=metrics["top_bucket_avg_label"],
+                label=metrics["top_bucket_avg_label"],
             )
         )
 
@@ -534,18 +534,18 @@ def render_markdown(result: dict[str, Any]) -> str:
         "",
     ]
     if result["qualified_strategies"]:
-        lines.append("| factor | target | runtime profile | icir | top bucket pnl |")
+        lines.append("| factor | target | runtime profile | icir | top bucket avg label |")
         lines.append("| --- | --- | --- | --- | --- |")
         for item in result["qualified_strategies"]:
             factor = item["factor"]
             mapping = item["runtime_mapping"] or {}
             lines.append(
-                "| {name} | {target} | {profile} | {icir:.6f} | {pnl:.6f} |".format(
+                "| {name} | {target} | {profile} | {icir:.6f} | {label:.6f} |".format(
                     name=factor["name"],
                     target=factor["target"],
                     profile=mapping.get("strategy_profile", ""),
                     icir=factor["icir"],
-                    pnl=factor["top_bucket_avg_label"],
+                    label=factor["top_bucket_avg_label"],
                 )
             )
     else:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,32 @@
 # PM5D Settlement Probability PRD Execution Plan (2026-05-05)
 
+## AutoFactor Walk-Forward Evidence Output Repair (2026-05-11)
+
+- [x] Reproduce the current hosted `factor-walk-forward-v2` behavior on
+  `main@76f00c18` and confirm the run succeeds while issue comments still
+  collapse the decision to `pending`.
+- [x] Make walk-forward issue comments read the AutoFactor promotion/handoff
+  artifacts and report terminal decision, handoff status, actionable blockers,
+  and qualified strategy rows.
+- [x] Keep hosted and self-hosted walk-forward comment logic aligned through a
+  shared GitHub Actions helper.
+- [x] Rename promotion/handoff markdown labels from misleading `top bucket PnL`
+  wording to `top bucket avg label`.
+- [x] Verify the Python scripts, workflow YAML, GitHub Actions helper, and diff
+  hygiene.
+
+Review:
+- Verification passed with `python3 -m unittest
+  tests.test_autofactor_strategy_promotion
+  tests.test_apply_autofactor_handoff_to_config`, Ruby YAML parsing for
+  `factor-walk-forward-v2.yml` and
+  `factor-walk-forward-v2-hosted-artifact.yml`, a Node smoke of
+  `.github/scripts/autofactor-walk-forward-evidence.js` against run
+  `25652518730` artifacts, and `git diff --check`.
+- `backtest.yml` still targets `ploy-ci-1`; migrating that workflow to
+  GitHub-hosted runners requires a separate artifact-backed data source because
+  its current DB/Parquet path depends on Tango/private-host access.
+
 ## PM5D Backtest LOB Loader Repair (2026-05-10)
 
 - [x] Confirm `backtest.yml` still targets `ploy-ci-1` and avoid dispatching it.

--- a/tests/test_apply_autofactor_handoff_to_config.py
+++ b/tests/test_apply_autofactor_handoff_to_config.py
@@ -42,6 +42,7 @@ class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
             handoff_path = Path(tmp) / "handoff.json"
             config_path = Path(tmp) / "strategy.toml"
             summary_path = Path(tmp) / "summary.json"
+            summary_md_path = Path(tmp) / "summary.md"
             handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
             config_path.write_text(config_text, encoding="utf-8")
             result = subprocess.run(
@@ -54,6 +55,8 @@ class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
                     str(config_path),
                     "--output-json",
                     str(summary_path),
+                    "--output-md",
+                    str(summary_md_path),
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -66,10 +69,11 @@ class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
                 if summary_path.exists()
                 else None
             )
-            return result, config_path.read_text(encoding="utf-8"), summary
+            summary_md = summary_md_path.read_text(encoding="utf-8") if summary_md_path.exists() else ""
+            return result, config_path.read_text(encoding="utf-8"), summary, summary_md
 
     def test_updates_runtime_score_from_ready_handoff(self):
-        _, config_text, summary = self.run_script(READY_HANDOFF)
+        _, config_text, summary, summary_md = self.run_script(READY_HANDOFF)
         runtime_score = READY_HANDOFF["strategies"][0]["runtime_score"]
 
         self.assertIn(
@@ -82,6 +86,8 @@ class ApplyAutoFactorHandoffToConfigTests(unittest.TestCase):
             summary["previous_runtime_score"],
             "autofactor_formula:auto_settlement_conservative_settlement_edge",
         )
+        self.assertIn("Top bucket avg label", summary_md)
+        self.assertNotIn("Top bucket PnL", summary_md)
 
     def test_inserts_runtime_score_when_config_has_profile_but_no_score(self):
         config_without_score = """[strategy]
@@ -89,7 +95,7 @@ three_layer_strategy_profile = "settlement_probability"
 three_layer_min_entry_score = 0.25
 """
 
-        _, config_text, summary = self.run_script(READY_HANDOFF, config_without_score)
+        _, config_text, summary, _ = self.run_script(READY_HANDOFF, config_without_score)
         runtime_score = READY_HANDOFF["strategies"][0]["runtime_score"]
 
         self.assertIn(
@@ -101,7 +107,7 @@ three_layer_min_entry_score = 0.25
         self.assertEqual(summary["action"], "inserted")
 
     def test_blocks_non_ready_handoff(self):
-        result, _, _ = self.run_script(
+        result, _, _, _ = self.run_script(
             {"status": "blocked", "strategies": []},
             BASE_CONFIG,
             check=False,
@@ -111,7 +117,7 @@ three_layer_min_entry_score = 0.25
         self.assertIn("expected ready", result.stderr)
 
     def test_blocks_profile_mismatch(self):
-        result, _, _ = self.run_script(
+        result, _, _, _ = self.run_script(
             READY_HANDOFF,
             BASE_CONFIG.replace("settlement_probability", "repricing_momentum", 1),
             check=False,

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -147,6 +147,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
             handoff_md,
         )
+        self.assertIn("top bucket avg label", handoff_md)
+        self.assertNotIn("top bucket pnl", handoff_md.lower())
         rejected = next(
             item
             for item in payload["evaluated_factors"]


### PR DESCRIPTION
## Summary

- Replace static `Decision: pending` walk-forward issue comments with AutoFactor promotion/handoff artifact summaries.
- Add a shared GitHub Actions helper that reports handoff status, promotion decision, actionable blockers, and qualified strategy rows for hosted and self-hosted walk-forward workflows.
- Rename misleading `top bucket PnL` markdown labels to `top bucket avg label` so discovery labels are not presented as executable PnL.

## Verification

- `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_apply_autofactor_handoff_to_config`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/factor-walk-forward-v2.yml .github/workflows/factor-walk-forward-v2-hosted-artifact.yml`
- Node smoke of `.github/scripts/autofactor-walk-forward-evidence.js` against run `25652518730` artifacts
- `git diff --check`

## Notes

`backtest.yml` still targets `ploy-ci-1`; migrating it to GitHub-hosted runners needs a separate artifact-backed data source because its current DB/Parquet path depends on Tango/private-host access.
