### PR TITLE
Speed hosted factor walk-forward reports

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -81,6 +81,7 @@ jobs:
               "min_observations": "20",
               "top_quantile": "0.2",
               "factor_name_filter": "",
+              "report_suite": "core",
               "data_quality_mode": "event_complete",
               "min_event_complete_events": "20",
               "min_event_complete_rows": "40",
@@ -97,6 +98,7 @@ jobs:
           }
           bool_keys = {"create_handoff_issue", "create_config_pr", "fail_if_blocked"}
           choices = {
+              "report_suite": {"core", "full"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
           }
           raw = os.environ.get("OPTIONS_JSON", "").strip()
@@ -246,6 +248,7 @@ jobs:
             --min-observations "${WALK_MIN_OBSERVATIONS}"
             --top-quantile "${WALK_TOP_QUANTILE}"
             --top-n "${WALK_TOP_N}"
+            --report-suite "${WALK_REPORT_SUITE}"
             --data-quality-mode "${WALK_DATA_QUALITY_MODE}"
             --min-event-complete-events "${WALK_MIN_EVENT_COMPLETE_EVENTS}"
             --min-event-complete-rows "${WALK_MIN_EVENT_COMPLETE_ROWS}"
@@ -410,6 +413,7 @@ jobs:
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
             echo "- Data quality mode: ${WALK_DATA_QUALITY_MODE}"
+            echo "- Report suite: ${WALK_REPORT_SUITE}"
             echo "- Required strategy profile: ${WALK_REQUIRED_STRATEGY_PROFILE}"
             echo "- Allowed target: ${WALK_ALLOWED_TARGET}"
             echo "- Factor filter: ${WALK_FACTOR_NAME_FILTER:-<none>}"

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -81,6 +81,7 @@ jobs:
               "min_observations",
               "top_quantile",
               "factor_name_filter",
+              "report_suite",
               "data_quality_mode",
               "min_event_complete_events",
               "min_event_complete_rows",
@@ -176,6 +177,7 @@ jobs:
               "min_observations": "20",
               "top_quantile": "0.2",
               "factor_name_filter": "",
+              "report_suite": "full",
               "compile_snapshot": "true",
               "allow_direct_db_debug": "false",
               "optimizer_data_dir": "/tmp/ploy-parquet",
@@ -194,6 +196,7 @@ jobs:
           }
           bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
           choices = {
+              "report_suite": {"core", "full"},
               "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
               "data_gate": {"critical", "warn", "never"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
@@ -531,6 +534,7 @@ jobs:
             --min-observations "${WALK_MIN_OBSERVATIONS}"
             --top-quantile "${WALK_TOP_QUANTILE}"
             --top-n "${WALK_TOP_N}"
+            --report-suite "${WALK_REPORT_SUITE}"
             --data-quality-mode "${WALK_DATA_QUALITY_MODE}"
             --min-event-complete-events "${WALK_MIN_EVENT_COMPLETE_EVENTS}"
             --min-event-complete-rows "${WALK_MIN_EVENT_COMPLETE_ROWS}"
@@ -574,6 +578,7 @@ jobs:
             echo "- Train/Test: ${WALK_TRAIN_WINDOW_DAYS}d / ${WALK_TEST_WINDOW_DAYS}d"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
+            echo "- Report suite: ${WALK_REPORT_SUITE}"
             echo "- Factor filter: ${WALK_FACTOR_NAME_FILTER:-<none>}"
             if [ -f artifacts/factor-walk-forward-v2/source.txt ]; then
               echo "- Source: $(cat artifacts/factor-walk-forward-v2/source.txt)"

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -5,9 +5,16 @@
 //! scores executable PnL after PM CLOB fillability.
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
+    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
+    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
+    FillabilityReviewOptions, FullDepthExecutionMatrixOptions, LiquidityGateV1Options,
+    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, RepricingIcOptions,
+    ResearchSnapshotRequest, SettlementProbabilityDataQualityMode,
+    SettlementProbabilityPromotionGateOptions, SettlementProbabilityReportOptions,
+    SettlementProbabilityWalkForwardOptions, TradeFormationReviewOptions,
     build_factor_observations_v2_with_deribit_and_pm_books,
     build_factor_observations_with_lob_sampled, build_factor_stability_report,
     build_full_depth_execution_matrix, build_settlement_probability_promotion_gate_report,
@@ -25,13 +32,7 @@ use ploy_research::{
     review_trade_formation_v1_with_deribit_and_pm_books, validate_snapshot_request,
     walk_forward_factor_combo_v1_with_deribit_and_pm_books,
     walk_forward_factors_v2_with_deribit_and_pm_books,
-    walk_forward_meta_label_v1_with_deribit_and_pm_books, AutoFactorOptions, AutoFactorV2Target,
-    FactorComboV1Options, FactorObservation, FactorReviewOptions, FactorStabilityOptions,
-    FactorWalkForwardOptions, FillabilityReviewOptions, FullDepthExecutionMatrixOptions,
-    LiquidityGateV1Options, LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions,
-    RepricingIcOptions, ResearchSnapshotRequest, SettlementProbabilityDataQualityMode,
-    SettlementProbabilityPromotionGateOptions, SettlementProbabilityReportOptions,
-    SettlementProbabilityWalkForwardOptions, TradeFormationReviewOptions,
+    walk_forward_meta_label_v1_with_deribit_and_pm_books,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashSet;
@@ -74,6 +75,29 @@ fn parse_data_quality_mode(raw: Option<String>) -> SettlementProbabilityDataQual
         }
         "event_complete" | "event-complete" => SettlementProbabilityDataQualityMode::EventComplete,
         value => panic!("invalid --data-quality-mode: {value}"),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReportSuite {
+    Core,
+    Full,
+}
+
+impl ReportSuite {
+    fn parse(raw: Option<String>) -> Self {
+        match raw.as_deref().unwrap_or("full") {
+            "core" => Self::Core,
+            "full" => Self::Full,
+            value => panic!("invalid --report-suite: {value}"),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Core => "core",
+            Self::Full => "full",
+        }
     }
 }
 
@@ -204,9 +228,10 @@ async fn main() {
             .unwrap_or(20),
         factor_name_filter: flag_value(&args, "--factor-name-filter"),
     };
+    let report_suite = ReportSuite::parse(flag_value(&args, "--report-suite"));
 
     eprintln!(
-        "factor_walk_forward_v2: {} -> {} for {:?}, stake_usd={:.2}, train_days={}, test_days={}, observation_sample_secs={}, factor_name_filter={}",
+        "factor_walk_forward_v2: {} -> {} for {:?}, stake_usd={:.2}, train_days={}, test_days={}, observation_sample_secs={}, factor_name_filter={}, report_suite={}",
         start,
         end,
         symbols,
@@ -214,7 +239,8 @@ async fn main() {
         options.train_window_days,
         options.test_window_days,
         observation_sample_secs,
-        options.factor_name_filter.as_deref().unwrap_or("<none>")
+        options.factor_name_filter.as_deref().unwrap_or("<none>"),
+        report_suite.as_str()
     );
 
     let snapshot_dir = flag_value(&args, "--snapshot-dir");
@@ -506,19 +532,21 @@ async fn main() {
         "{}",
         format_full_depth_execution_matrix_report(&conservative_execution_matrix, options.top_n)
     );
-    let repricing_ic_report = review_repricing_ic_with_deribit_and_pm_books(
-        &observations,
-        &deribit_snapshots,
-        &all_pm_book_snapshots,
-        RepricingIcOptions {
-            review: options.review.clone(),
-            ..Default::default()
-        },
-    );
-    println!(
-        "{}",
-        format_repricing_ic_report(&repricing_ic_report, options.top_n)
-    );
+    if report_suite == ReportSuite::Full {
+        let repricing_ic_report = review_repricing_ic_with_deribit_and_pm_books(
+            &observations,
+            &deribit_snapshots,
+            &all_pm_book_snapshots,
+            RepricingIcOptions {
+                review: options.review.clone(),
+                ..Default::default()
+            },
+        );
+        println!(
+            "{}",
+            format_repricing_ic_report(&repricing_ic_report, options.top_n)
+        );
+    }
     let autofactor_rows = build_factor_observations_v2_with_deribit_and_pm_books(
         &observations,
         &deribit_snapshots,
@@ -620,6 +648,9 @@ async fn main() {
                 );
             }
         }
+    }
+    if report_suite == ReportSuite::Core {
+        return;
     }
     let fillability_report = review_fillability_v1_with_deribit_and_pm_books(
         &observations,

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -274,7 +274,12 @@ within the GitHub Actions 10-input limit. Defaults are
 `required_strategy_profile=settlement_probability`,
 `allowed_target=full_depth_settlement_executable_pnl`,
 `create_handoff_issue=false`, `create_config_pr=false`, and
-`fail_if_blocked=false`.
+`fail_if_blocked=false`. The GitHub-hosted artifact workflow defaults
+`report_suite=core`, which keeps the walk-forward report, full-depth execution
+matrices, settlement-probability reports, PRD promotion gate, and AutoFactor
+mining needed for handoff while skipping slower diagnostic-only sections. Pass
+`"report_suite":"full"` when reviewing fillability, liquidity-gated alpha,
+trade formation, meta-label, stability, or combo diagnostics.
 
 To make the hosted walk-forward workflow run the final PR-only config promotion
 step in the same run, pass `create_config_pr=true` inside `options_json`:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,32 @@
 # PM5D Settlement Probability PRD Execution Plan (2026-05-05)
 
+## Factor Walk-Forward Core Report Suite (2026-05-11)
+
+- [x] Confirm BTC/ETH hosted artifact factor search succeeds from
+  `main@77151171` without using `ploy-ci-1`.
+- [x] Add `--report-suite core|full` to `factor_walk_forward_v2`, keeping the
+  binary default at `full` for existing CLI behavior.
+- [x] Keep the `core` suite large enough for AutoFactor promotion/handoff:
+  walk-forward, full-depth execution matrices, settlement probability reports,
+  PRD promotion gate, and AutoFactor mining.
+- [x] Make the hosted artifact workflow default to `report_suite=core` while
+  leaving the legacy/direct workflow default at `full`.
+- [x] Verify Rust formatting, workflow YAML parsing, example compilation, and
+  diff hygiene.
+
+Review:
+- Verification passed with `rustfmt --edition 2024
+  crates/ploy-research/examples/factor_walk_forward_v2.rs`, Ruby YAML parsing
+  for both factor walk-forward workflows, `rtk cargo build --profile fast
+  --locked -p ploy-research --features db --example factor_walk_forward_v2`,
+  and `git diff --check`.
+- The BTC/ETH hosted artifact search run `25654032760` completed on
+  `main@77151171` and produced a ready handoff. The strongest immediately
+  usable runtime score is
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`; the
+  `*_x_capacity` branch is a high-ICIR near miss but remains blocked by symbol
+  holdout instability.
+
 ## AutoFactor Walk-Forward Evidence Output Repair (2026-05-11)
 
 - [x] Reproduce the current hosted `factor-walk-forward-v2` behavior on

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -59,6 +59,22 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 3,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,-0.301991,0.4785,3
 """
 
+CORE_SUITE_REPORT = f"""
+# Snapshot
+snapshot_schema=1
+snapshot_data_audit_status=critical
+
+=== Factor Walk-Forward V2 ===
+factor,target,decision
+
+=== Full Depth Execution Matrix ===
+candidate,bucket,count
+
+{READY_GATE}
+
+{AUTOFACTOR_SETTLEMENT_AUTO_REPORT}
+"""
+
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
     def run_script(self, report, *extra_args, check=True):
@@ -156,6 +172,22 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
         self.assertFalse(rejected["qualified"])
         self.assertIn("autofactor_not_candidate:reject:nonpositive_rank_ic", rejected["blockers"])
+
+    def test_core_suite_report_is_sufficient_for_handoff_evaluation(self):
+        self.assertNotIn("=== Fillability Review V1 Data Health ===", CORE_SUITE_REPORT)
+        self.assertNotIn("=== Liquidity Gate V1 ===", CORE_SUITE_REPORT)
+        self.assertNotIn("=== Meta Label Walk-Forward V1 ===", CORE_SUITE_REPORT)
+
+        _, payload, registry, handoff, handoff_md = self.run_script(CORE_SUITE_REPORT)
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(
+            handoff["strategies"][0]["runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+        self.assertIn("Promote AutoFactor strategy handoff to dry-run", handoff_md)
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
         _, payload, registry, handoff, handoff_md = self.run_script(


### PR DESCRIPTION
## Summary
- add a core/full report suite switch to factor_walk_forward_v2
- default hosted artifact factor searches to the core suite while preserving full CLI/self-hosted behavior
- document the report-suite behavior and record BTC/ETH factor-search evidence

## Verification
- rustfmt --edition 2024 crates/ploy-research/examples/factor_walk_forward_v2.rs
- ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/factor-walk-forward-v2.yml .github/workflows/factor-walk-forward-v2-hosted-artifact.yml
- rtk cargo build --profile fast --locked -p ploy-research --features db --example factor_walk_forward_v2
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--report-suite` option to factor walk-forward analysis, allowing selection between `core` (faster, essential reports) and `full` (comprehensive diagnostics).

* **Documentation**
  * Updated workflow documentation to explain report-suite behavior and default configurations across deployment environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/399)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->