### PR TITLE
Fix dry-run event parity evidence

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_full_depth_settlement_edge"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30

--- a/contracts/schemas/dry-run-performance-report.schema.json
+++ b/contracts/schemas/dry-run-performance-report.schema.json
@@ -765,6 +765,11 @@
         "basis": {
           "type": "string"
         },
+        "events": {
+          "default": [],
+          "type": "array",
+          "items": true
+        },
         "fills": {
           "default": [],
           "type": "array",

--- a/crates/ploy-operator-contracts/src/reports.rs
+++ b/crates/ploy-operator-contracts/src/reports.rs
@@ -198,6 +198,8 @@ pub struct DryRunRuntimeEvidence {
     pub schema_version: u32,
     pub basis: String,
     #[serde(default)]
+    pub events: Vec<serde_json::Value>,
+    #[serde(default)]
     pub orders: Vec<serde_json::Value>,
     #[serde(default)]
     pub fills: Vec<serde_json::Value>,
@@ -258,7 +260,7 @@ pub struct DryRunPerformanceReport {
 #[cfg(test)]
 mod tests {
     use super::DryRunPerformanceReport;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     #[test]
     fn dry_run_report_roundtrip_preserves_diagnostics_fields() {
@@ -351,7 +353,11 @@ mod tests {
         );
         assert_eq!(
             roundtripped["runtime_evidence"]["basis"],
-            "strategy_runtime_orders_and_fills"
+            "strategy_runtime_orders_fills_and_events"
+        );
+        assert_eq!(
+            roundtripped["runtime_evidence"]["events"][0]["event_id"],
+            "event-1"
         );
         assert_eq!(
             roundtripped["runtime_evidence"]["orders"][0]["intent_id"],
@@ -417,7 +423,19 @@ mod tests {
     fn runtime_evidence() -> Value {
         json!({
             "schema_version": 1,
-            "basis": "strategy_runtime_orders_and_fills",
+            "basis": "strategy_runtime_orders_fills_and_events",
+            "events": [{
+                "deployment_id": "pm5d-dryrun",
+                "event_id": "event-1",
+                "decision_ts": "2026-05-02T01:02:03Z",
+                "quote": "0.42",
+                "signal_inputs": {"purpose": "ENTRY"},
+                "side": "BUY",
+                "entry_price": "0.42",
+                "fill_status": "FILLED",
+                "settlement": "open",
+                "pnl": "0"
+            }],
             "orders": [{
                 "deployment_id": "pm5d-dryrun",
                 "intent_id": "intent-1",

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -13,12 +13,12 @@
 //! If no --db-url is given, uses synthetic market data.
 
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
+use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    config::FullConfig, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
-    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
-    StrategyLogic, StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy,
+    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
+    RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
+    StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy, config::FullConfig,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -261,6 +261,15 @@ mod tests {
         let evidence = normalized_runtime_evidence(&snapshot);
 
         assert_eq!(evidence["basis"], "trading_runtime_snapshot");
+        assert_eq!(evidence["events"][0]["event_id"], "event-1");
+        assert!(evidence["events"][0]["decision_ts"].as_str().is_some());
+        assert_eq!(evidence["events"][0]["quote"], "0.42");
+        assert_eq!(evidence["events"][0]["signal_inputs"]["purpose"], "ENTRY");
+        assert_eq!(evidence["events"][0]["side"], "BUY");
+        assert_eq!(evidence["events"][0]["entry_price"], "0.41");
+        assert_eq!(evidence["events"][0]["fill_status"], "FILLED");
+        assert_eq!(evidence["events"][0]["settlement"], "open");
+        assert_eq!(evidence["events"][0]["pnl"], "-4.10");
         assert_eq!(evidence["orders"][0]["deployment_id"], "pm5d-test");
         assert_eq!(evidence["orders"][0]["intent_id"], "intent-1");
         assert_eq!(evidence["orders"][0]["status"], "FILLED");
@@ -685,6 +694,7 @@ fn normalized_runtime_evidence(
 
     let mut fill_quantity_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
     let mut fill_notional_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    let mut fill_pnl_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
     for fill in &snapshot.fills {
         *fill_quantity_by_order
             .entry(fill.order_id.as_str())
@@ -692,7 +702,61 @@ fn normalized_runtime_evidence(
         *fill_notional_by_order
             .entry(fill.order_id.as_str())
             .or_default() += fill.quantity * fill.price;
+        let signed_notional = match fill.side {
+            ploy_trading::TradeSide::Buy => -(fill.quantity * fill.price),
+            ploy_trading::TradeSide::Sell => fill.quantity * fill.price,
+        };
+        *fill_pnl_by_order.entry(fill.order_id.as_str()).or_default() += signed_notional - fill.fee;
     }
+
+    let events: Vec<_> = snapshot
+        .orders
+        .iter()
+        .map(|order| {
+            let intent = intents_by_id.get(order.intent_id.as_str()).copied();
+            let fill_quantity = fill_quantity_by_order
+                .get(order.order_id.as_str())
+                .copied()
+                .unwrap_or(order.filled_qty);
+            let avg_fill_price = if fill_quantity == Decimal::ZERO {
+                None
+            } else {
+                fill_notional_by_order
+                    .get(order.order_id.as_str())
+                    .map(|notional| *notional / fill_quantity)
+            };
+            let purpose = intent
+                .map(|intent| intent_purpose_label(intent.purpose))
+                .unwrap_or("ENTRY");
+
+            json!({
+                "deployment_id": empty_to_none(order.deployment_id.as_str())
+                    .or_else(|| intent.and_then(|intent| empty_to_none(intent.deployment_id.as_str()))),
+                "intent_id": order.intent_id.as_str(),
+                "order_id": order.order_id.as_str(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": order.token_id.as_str(),
+                "decision_ts": intent.map(|intent| intent.created_at),
+                "quote": order.limit_price,
+                "signal_inputs": {
+                    "purpose": purpose,
+                    "requested_qty": order.requested_qty,
+                    "limit_price": order.limit_price,
+                },
+                "side": intent
+                    .map(|intent| trade_side_label(intent.side))
+                    .unwrap_or("UNKNOWN"),
+                "entry_price": avg_fill_price.or(order.limit_price),
+                "fill_status": order_state_label(order.state),
+                "settlement": "open",
+                "pnl": fill_pnl_by_order
+                    .get(order.order_id.as_str())
+                    .copied()
+                    .unwrap_or(Decimal::ZERO),
+            })
+        })
+        .collect();
 
     let orders: Vec<_> = snapshot
         .orders
@@ -770,17 +834,14 @@ fn normalized_runtime_evidence(
         "schema_version": 1,
         "basis": "trading_runtime_snapshot",
         "comparison_contract": "Compare these normalized rows against strategy_runtime_orders and strategy_runtime_fills exported from Tango for the same deployment/config/feed window.",
+        "events": events,
         "orders": orders,
         "fills": fills,
     })
 }
 
 fn empty_to_none(value: &str) -> Option<&str> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
+    if value.is_empty() { None } else { Some(value) }
 }
 
 fn trade_side_label(side: ploy_trading::TradeSide) -> &'static str {

--- a/crates/ploy-strategy-runtime/src/lib.rs
+++ b/crates/ploy-strategy-runtime/src/lib.rs
@@ -232,6 +232,7 @@ fn normalized_runtime_evidence(
 
     let mut fill_quantity_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
     let mut fill_notional_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
+    let mut fill_pnl_by_order: BTreeMap<&str, Decimal> = BTreeMap::new();
     for fill in &snapshot.fills {
         *fill_quantity_by_order
             .entry(fill.order_id.as_str())
@@ -239,6 +240,11 @@ fn normalized_runtime_evidence(
         *fill_notional_by_order
             .entry(fill.order_id.as_str())
             .or_default() += fill.quantity * fill.price;
+        let signed_notional = match fill.side {
+            ploy_trading::TradeSide::Buy => -(fill.quantity * fill.price),
+            ploy_trading::TradeSide::Sell => fill.quantity * fill.price,
+        };
+        *fill_pnl_by_order.entry(fill.order_id.as_str()).or_default() += signed_notional - fill.fee;
     }
 
     let intents: Vec<_> = snapshot
@@ -260,6 +266,64 @@ fn normalized_runtime_evidence(
                 "requested_qty": intent.quantity,
                 "limit_price": intent.limit_price,
                 "created_at": intent.created_at,
+            })
+        })
+        .collect();
+
+    let events: Vec<_> = snapshot
+        .orders
+        .iter()
+        .map(|order| {
+            let intent = intents_by_id.get(order.intent_id.as_str()).copied();
+            let deployment_id =
+                evidence_deployment_id(order.deployment_id.as_str(), fallback_deployment_id)
+                    .or_else(|| {
+                        intent.and_then(|intent| {
+                            evidence_deployment_id(
+                                intent.deployment_id.as_str(),
+                                fallback_deployment_id,
+                            )
+                        })
+                    });
+            let fill_quantity = fill_quantity_by_order
+                .get(order.order_id.as_str())
+                .copied()
+                .unwrap_or(order.filled_qty);
+            let avg_fill_price = if fill_quantity.is_zero() {
+                None
+            } else {
+                fill_notional_by_order
+                    .get(order.order_id.as_str())
+                    .map(|notional| *notional / fill_quantity)
+            };
+            let purpose = intent
+                .map(|intent| intent_purpose_label(intent.purpose))
+                .unwrap_or("ENTRY");
+
+            json!({
+                "deployment_id": deployment_id,
+                "intent_id": order.intent_id.as_str(),
+                "order_id": order.order_id.as_str(),
+                "event_id": intent.map(|intent| intent.market_id.as_str()),
+                "market_id": intent.map(|intent| intent.market_id.as_str()),
+                "token_id": order.token_id.as_str(),
+                "decision_ts": intent.map(|intent| intent.created_at),
+                "quote": order.limit_price,
+                "signal_inputs": {
+                    "purpose": purpose,
+                    "requested_qty": order.requested_qty,
+                    "limit_price": order.limit_price,
+                },
+                "side": intent
+                    .map(|intent| trade_side_label(intent.side))
+                    .unwrap_or("UNKNOWN"),
+                "entry_price": avg_fill_price.or(order.limit_price),
+                "fill_status": order_state_label(order.state),
+                "settlement": "open",
+                "pnl": fill_pnl_by_order
+                    .get(order.order_id.as_str())
+                    .copied()
+                    .unwrap_or(Decimal::ZERO),
             })
         })
         .collect();
@@ -360,6 +424,7 @@ fn normalized_runtime_evidence(
         "basis": "trading_runtime_snapshot",
         "comparison_contract": "Compare these normalized rows against strategy_runtime_orders and strategy_runtime_fills exported from Tango for the same deployment/config/feed window.",
         "intents": intents,
+        "events": events,
         "orders": orders,
         "fills": fills,
     })

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -61,7 +61,7 @@ export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_pr
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
-export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
+export interface DryRunRuntimeEvidence { basis: string; events?: JsonValue[]; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
 
 export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -61,7 +61,7 @@ export interface DryRunOpenPositionRow { deployment_id?: string | null; entry_pr
 
 export interface DryRunPairingReport { current_view_rows: number; fills_in_mixed_event_groups: number; mixed_event_groups: number; pair_key: string; side_aware_rows: number; }
 
-export interface DryRunRuntimeEvidence { basis: string; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
+export interface DryRunRuntimeEvidence { basis: string; events?: JsonValue[]; fills?: JsonValue[]; orders?: JsonValue[]; schema_version: number; }
 
 export interface DryRunStrategyReport { by_window: DryRunWindowRow[]; closed_trades: DryRunClosedTradeRow[]; daily: DryRunDailyRow[]; daily_by_window: DryRunDailyWindowRow[]; deployment_id: string; equity_curve: DryRunEquityPoint[]; execution_diagnostics?: DryRunExecutionDiagnostics | null; experiment_label?: string | null; hourly?: DryRunHourlyRow[]; hourly_by_window?: DryRunHourlyWindowRow[]; label: string; metrics: DryRunMetrics; open_positions: DryRunOpenPositionRow[]; recent_closed: DryRunClosedTradeRow[]; runtime_mode: string; strategy_id: string; summary: DryRunSummary; symbols: DryRunSymbolRow[]; symbols_by_window: DryRunSymbolRow[]; }
 

--- a/scripts/check_dryrun_report_contract.py
+++ b/scripts/check_dryrun_report_contract.py
@@ -61,6 +61,7 @@ def main() -> int:
                 "total_trades": nested_value(payload, "summary.total_trades"),
                 "sharpe_basis": nested_value(payload, "metrics.sharpe_basis"),
                 "execution_diagnostics": nested_value(payload, "execution_diagnostics.basis"),
+                "runtime_evidence_events": len(nested_value(payload, "runtime_evidence.events") or []),
                 "runtime_evidence_orders": len(nested_value(payload, "runtime_evidence.orders") or []),
                 "runtime_evidence_fills": len(nested_value(payload, "runtime_evidence.fills") or []),
             },

--- a/scripts/export_strategy_runtime_evidence.py
+++ b/scripts/export_strategy_runtime_evidence.py
@@ -60,7 +60,58 @@ SELECT jsonb_build_object(
   'deployment_ids', to_jsonb({sql_array(args.deployment_id) if args.deployment_id else "ARRAY[]::text[]"}),
   'runtime_evidence', jsonb_build_object(
     'schema_version', 1,
-    'basis', 'strategy_runtime_orders_and_fills',
+    'basis', 'strategy_runtime_orders_fills_and_events',
+    'events', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'deployment_id', o.deployment_id,
+        'intent_id', o.intent_id,
+        'order_id', o.order_id,
+        'event_id', o.event_id,
+        'market_id', o.event_id,
+        'token_id', o.token_id,
+        'market_side', o.market_side,
+        'side', o.order_side,
+        'decision_ts', o.recorded_at,
+        'quote', COALESCE(o.limit_price, o.avg_fill_price),
+        'signal_inputs', jsonb_build_object(
+          'purpose', 'ENTRY',
+          'requested_qty', o.quantity,
+          'limit_price', o.limit_price
+        ),
+        'entry_price', COALESCE(fill.avg_fill_price, o.avg_fill_price, o.limit_price),
+        'fill_status', o.status,
+        'settlement', CASE
+          WHEN COALESCE(track.is_closed, false)
+            THEN COALESCE(track.avg_exit_price::text, 'closed')
+          ELSE 'open'
+        END,
+        'pnl', COALESCE(track.net_pnl, fill.pnl, 0)
+      ) ORDER BY o.recorded_at, o.order_id)
+      FROM strategy_runtime_orders o
+      LEFT JOIN LATERAL (
+        SELECT
+          CASE
+            WHEN COALESCE(SUM(f.quantity), 0) > 0
+              THEN SUM(f.quantity * f.price) / SUM(f.quantity)
+            ELSE NULL
+          END AS avg_fill_price,
+          SUM(
+            CASE
+              WHEN f.fill_side = 'SELL' THEN f.quantity * f.price
+              ELSE -(f.quantity * f.price)
+            END - f.fee
+          ) AS pnl
+        FROM strategy_runtime_fills f
+        WHERE f.runtime_mode = o.runtime_mode
+          AND f.deployment_id = o.deployment_id
+          AND f.order_id = o.order_id
+      ) fill ON true
+      LEFT JOIN strategy_runtime_event_track_record track
+        ON track.runtime_mode = o.runtime_mode
+        AND track.deployment_id = o.deployment_id
+        AND track.intent_id = o.intent_id
+      WHERE {order_where}
+    ), '[]'::jsonb),
     'orders', COALESCE((
       SELECT jsonb_agg(jsonb_build_object(
         'deployment_id', o.deployment_id,

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -69,9 +69,12 @@ NUMERIC_FIELDS = {
     "avg_fill_price",
     "price",
     "fee",
+    "quote",
+    "entry_price",
+    "pnl",
 }
 
-TIMESTAMP_FIELDS = {"created_at", "fill_timestamp"}
+TIMESTAMP_FIELDS = {"created_at", "fill_timestamp", "decision_ts"}
 
 NUMERIC_TOLERANCE = Decimal("0.000001")
 TIMESTAMP_TOLERANCE_SECONDS = 1.0
@@ -88,14 +91,12 @@ FILL_KEY_CANDIDATES = (
     ("deployment_id", "token_id", "fill_side", "quantity", "price", "fee", "fill_timestamp"),
 )
 
-EVENT_ONLY_RISK_FLAGS = {
-    "replay_has_no_event_level_rows",
-    "dryrun_has_no_event_level_rows",
-    "events_present_in_replay_missing_from_dryrun",
-    "events_present_in_dryrun_missing_from_replay",
-    "strict_field_mismatches",
-    "missing_strict_parity_fields",
-}
+EVENT_KEY_CANDIDATES = (
+    ("deployment_id", "event_id", "token_id", "side"),
+    ("event_id", "token_id", "side"),
+    ("deployment_id", "event_id", "side"),
+    ("event_id", "side"),
+)
 
 
 def filter_summary(
@@ -160,6 +161,7 @@ def extract_events(data: Any) -> list[dict[str, Any]]:
         return []
     events: list[dict[str, Any]] = []
     for path in [
+        ("runtime_evidence", "events"),
         ("events",),
         ("trades",),
         ("fills",),
@@ -428,6 +430,43 @@ def normalize_fill(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def normalize_signal_inputs(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {str(key): normalize_signal_inputs(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        return [normalize_signal_inputs(item) for item in value]
+    text = normalize_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return normalize_decimal(text) or text
+    if isinstance(parsed, (dict, list)):
+        return normalize_signal_inputs(parsed)
+    return normalize_decimal(parsed) or parsed
+
+
+def normalize_event(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "deployment_id": normalize_text(first_present(row, "deployment_id")),
+        "intent_id": normalize_text(first_present(row, "intent_id")),
+        "order_id": normalize_text(first_present(row, "order_id")),
+        "event_id": normalize_text(first_present(row, "event_id", "market_id", "market_slug", "token_id")),
+        "token_id": normalize_text(first_present(row, "token_id")),
+        "decision_ts": normalize_timestamp(canonical_field(row, "decision_ts")),
+        "quote": normalize_decimal(canonical_field(row, "quote")),
+        "signal_inputs": normalize_signal_inputs(canonical_field(row, "signal_inputs")),
+        "side": normalize_text(canonical_field(row, "side"), upper=True),
+        "entry_price": normalize_decimal(canonical_field(row, "entry_price")),
+        "fill_status": normalize_status(canonical_field(row, "fill_status")),
+        "settlement": normalize_text(canonical_field(row, "settlement"), upper=True),
+        "pnl": normalize_decimal(canonical_field(row, "pnl")),
+    }
+
+
 def extract_list_at_paths(data: Any, paths: list[tuple[str, ...]]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for path in paths:
@@ -479,6 +518,16 @@ def extract_runtime_fills(data: Any) -> list[dict[str, Any]]:
         ],
     )
     return [normalize_fill(row) for row in rows]
+
+
+def extract_runtime_events(data: Any) -> list[dict[str, Any]]:
+    rows = extract_list_at_paths(
+        data,
+        [
+            ("runtime_evidence", "events"),
+        ],
+    )
+    return [normalize_event(row) for row in rows]
 
 
 def normalized_key(row: dict[str, Any], key_candidates: tuple[tuple[str, ...], ...]) -> str:
@@ -577,6 +626,13 @@ def compare_runtime_evidence(
     since: datetime | None,
     until: datetime | None,
 ) -> dict[str, Any]:
+    replay_events = filter_rows(
+        extract_runtime_events(replay),
+        deployment_id=deployment_id,
+        since=since,
+        until=until,
+        timestamp_keys=("decision_ts",),
+    )
     replay_fills = filter_rows(
         extract_runtime_fills(replay),
         deployment_id=deployment_id,
@@ -605,6 +661,20 @@ def compare_runtime_evidence(
         since=since,
         until=until,
     )
+    dryrun_events = filter_rows(
+        extract_runtime_events(dryrun),
+        deployment_id=deployment_id,
+        since=since,
+        until=until,
+        timestamp_keys=("decision_ts",),
+    )
+    event_comparison = compare_normalized_rows(
+        replay_events,
+        dryrun_events,
+        row_type="event",
+        key_candidates=EVENT_KEY_CANDIDATES,
+        strict_fields=STRICT_FIELDS,
+    )
     order_comparison = compare_normalized_rows(
         replay_orders,
         dryrun_orders,
@@ -620,15 +690,18 @@ def compare_runtime_evidence(
         strict_fields=FILL_STRICT_FIELDS,
     )
     missing_strict_fields = sorted(
-        set(order_comparison["missing_strict_fields"])
+        set(event_comparison["missing_strict_fields"])
+        | set(order_comparison["missing_strict_fields"])
         | set(fill_comparison["missing_strict_fields"])
     )
-    mismatches = order_comparison["mismatches"] + fill_comparison["mismatches"]
+    mismatches = event_comparison["mismatches"] + order_comparison["mismatches"] + fill_comparison["mismatches"]
     strict_parity_ready = (
-        order_comparison["strict_parity_ready"]
+        event_comparison["strict_parity_ready"]
+        and order_comparison["strict_parity_ready"]
         and fill_comparison["strict_parity_ready"]
     )
     return {
+        "events": event_comparison,
         "orders": order_comparison,
         "fills": fill_comparison,
         "missing_strict_fields": missing_strict_fields,
@@ -716,6 +789,14 @@ def build_result(
     )
     risk_flags: list[str] = []
 
+    if runtime_evidence_comparison["events"]["replay_count"] == 0:
+        risk_flags.append("replay_has_no_event_level_rows")
+    if runtime_evidence_comparison["events"]["dryrun_count"] == 0:
+        risk_flags.append("dryrun_has_no_event_level_rows")
+    if runtime_evidence_comparison["events"]["missing_dryrun_rows"]:
+        risk_flags.append("events_present_in_replay_missing_from_dryrun")
+    if runtime_evidence_comparison["events"]["missing_replay_rows"]:
+        risk_flags.append("events_present_in_dryrun_missing_from_replay")
     if runtime_evidence_comparison["orders"]["replay_count"] == 0:
         risk_flags.append("replay_has_no_order_level_rows")
     if runtime_evidence_comparison["orders"]["dryrun_count"] == 0:
@@ -737,38 +818,34 @@ def build_result(
     if runtime_evidence_comparison["missing_strict_fields"]:
         risk_flags.append("missing_runtime_evidence_strict_fields")
 
-    if not replay_events:
-        risk_flags.append("replay_has_no_event_level_rows")
-    if not dryrun_events:
-        risk_flags.append("dryrun_has_no_event_level_rows")
-    if event_comparison["missing_dryrun_events"]:
-        risk_flags.append("events_present_in_replay_missing_from_dryrun")
-    if event_comparison["missing_replay_events"]:
-        risk_flags.append("events_present_in_dryrun_missing_from_replay")
+    if not replay_events and runtime_evidence_comparison["events"]["replay_count"] == 0:
+        risk_flags.append("replay_has_no_legacy_event_level_rows")
+    if not dryrun_events and runtime_evidence_comparison["events"]["dryrun_count"] == 0:
+        risk_flags.append("dryrun_has_no_legacy_event_level_rows")
+    if (
+        event_comparison["missing_dryrun_events"]
+        and not runtime_evidence_comparison["events"]["missing_dryrun_rows"]
+    ):
+        risk_flags.append("legacy_events_present_in_replay_missing_from_dryrun")
+    if (
+        event_comparison["missing_replay_events"]
+        and not runtime_evidence_comparison["events"]["missing_replay_rows"]
+    ):
+        risk_flags.append("legacy_events_present_in_dryrun_missing_from_replay")
     if event_comparison["mismatches"]:
-        risk_flags.append("strict_field_mismatches")
+        risk_flags.append("legacy_event_strict_field_mismatches")
     if event_comparison["missing_strict_fields"]:
-        risk_flags.append("missing_strict_parity_fields")
+        risk_flags.append("legacy_event_missing_strict_parity_fields")
 
     decision = "continue"
     if not runtime_evidence_comparison["strict_parity_ready"]:
         decision = "fix-data-or-runtime-mismatch"
-    blocking_risk_flags = [
-        flag
-        for flag in risk_flags
-        if not (
-            runtime_evidence_comparison["strict_parity_ready"]
-            and flag in EVENT_ONLY_RISK_FLAGS
-        )
-    ]
     advisory_flags = [
         flag
         for flag in risk_flags
-        if (
-            runtime_evidence_comparison["strict_parity_ready"]
-            and flag in EVENT_ONLY_RISK_FLAGS
-        )
+        if flag.startswith("legacy_event_")
     ]
+    blocking_risk_flags = [flag for flag in risk_flags if flag not in advisory_flags]
 
     return {
         "schema_version": 1,

--- a/scripts/report_dryrun_summary.py
+++ b/scripts/report_dryrun_summary.py
@@ -202,7 +202,62 @@ FROM (
 RUNTIME_EVIDENCE_QUERY = f"""
 SELECT jsonb_build_object(
   'schema_version', 1,
-  'basis', 'strategy_runtime_orders_and_fills',
+  'basis', 'strategy_runtime_orders_fills_and_events',
+  'events', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'runtime_mode', o.runtime_mode,
+      'strategy_id', o.strategy_id,
+      'deployment_id', o.deployment_id,
+      'event_id', o.event_id,
+      'market_id', o.event_id,
+      'intent_id', o.intent_id,
+      'order_id', o.order_id,
+      'token_id', o.token_id,
+      'market_side', o.market_side,
+      'side', o.order_side,
+      'decision_ts', o.recorded_at,
+      'quote', COALESCE(o.limit_price, o.avg_fill_price),
+      'signal_inputs', jsonb_build_object(
+        'purpose', COALESCE(o.context ->> 'purpose', 'ENTRY'),
+        'requested_qty', o.quantity,
+        'limit_price', o.limit_price
+      ),
+      'entry_price', COALESCE(fill.avg_fill_price, o.avg_fill_price, o.limit_price),
+      'fill_status', o.status,
+      'settlement', CASE
+        WHEN COALESCE(track.is_closed, false)
+          THEN COALESCE(track.avg_exit_price::text, 'closed')
+        ELSE 'open'
+      END,
+      'pnl', COALESCE(track.net_pnl, fill.pnl, 0)
+    ) ORDER BY o.recorded_at, o.order_id)
+    FROM strategy_runtime_orders o
+    LEFT JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN COALESCE(SUM(f.quantity), 0) > 0
+            THEN SUM(f.quantity * f.price) / SUM(f.quantity)
+          ELSE NULL
+        END AS avg_fill_price,
+        SUM(
+          CASE
+            WHEN f.fill_side = 'SELL' THEN f.quantity * f.price
+            ELSE -(f.quantity * f.price)
+          END - f.fee
+        ) AS pnl
+      FROM strategy_runtime_fills f
+      WHERE f.runtime_mode = o.runtime_mode
+        AND f.strategy_id = o.strategy_id
+        AND f.deployment_id = o.deployment_id
+        AND f.order_id = o.order_id
+    ) fill ON true
+    LEFT JOIN strategy_runtime_event_track_record track
+      ON track.runtime_mode = o.runtime_mode
+      AND track.strategy_id = o.strategy_id
+      AND track.deployment_id = o.deployment_id
+      AND track.intent_id = o.intent_id
+    WHERE o.runtime_mode IN ({MODE_FILTER})
+  ), '[]'::jsonb),
   'orders', COALESCE((
     SELECT jsonb_agg(jsonb_build_object(
       'runtime_mode', o.runtime_mode,
@@ -804,7 +859,8 @@ def empty_payload():
         "execution_diagnostics": build_execution_diagnostics([]),
         "runtime_evidence": {
             "schema_version": 1,
-            "basis": "strategy_runtime_orders_and_fills",
+            "basis": "strategy_runtime_orders_fills_and_events",
+            "events": [],
             "orders": [],
             "fills": [],
         },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,20 @@
+# Dry-Run Conservative Factor And Event-Level Replay Parity (2026-05-11)
+
+## Plan
+
+- [x] Switch the BTC/ETH settlement-probability dry-run config to the conservative AutoFactor handoff score from the hosted artifact evidence.
+- [x] Extend dry-run runtime evidence with event-level rows carrying `event_id`, `decision_ts`, `quote`, `signal_inputs`, `side`, `entry_price`, `fill_status`, `settlement`, and `pnl`.
+- [x] Extend replay/backtest runtime evidence with the same event-level contract.
+- [x] Make replay/dry-run parity require event-level runtime evidence, not treat missing event rows as advisory once orders/fills match.
+- [x] Verify focused Python/Rust contract tests and diff hygiene before PR/merge/deploy.
+
+## Review
+
+- Implemented the dry-run config handoff to `autofactor_formula:auto_settlement_conservative_settlement_edge`.
+- Added `runtime_evidence.events` to dry-run report/export and replay/backtest artifacts. The event contract uses a stable executable subset for `signal_inputs` so replay and dry-run can compare the same fields without relying on opaque DB-only context.
+- Replay parity now requires event, order, and fill runtime evidence to pass before `strict_parity_ready=true`; missing event rows are blocking.
+- Verification passed: `python3 -m unittest tests.test_replay_dryrun_parity tests.test_dryrun_report_contracts`, focused `run_backtest` example evidence test, focused `ploy-operator-contracts` report roundtrip/schema tests, generated schema/type contract checks, `rtk cargo check -p ploy-strategy-runtime`, and `git diff --check`.
+
 # PM5D Settlement Probability PRD Execution Plan (2026-05-05)
 
 ## Factor Walk-Forward Core Report Suite (2026-05-11)

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -111,19 +111,24 @@ class DryRunReportContractTests(unittest.TestCase):
         payload = summary.empty_payload()
 
         self.assertEqual(payload["runtime_evidence"]["schema_version"], 1)
-        self.assertEqual(payload["runtime_evidence"]["basis"], "strategy_runtime_orders_and_fills")
+        self.assertEqual(payload["runtime_evidence"]["basis"], "strategy_runtime_orders_fills_and_events")
+        self.assertEqual(payload["runtime_evidence"]["events"], [])
         self.assertEqual(payload["runtime_evidence"]["orders"], [])
         self.assertEqual(payload["runtime_evidence"]["fills"], [])
 
-    def test_runtime_evidence_query_exports_order_and_fill_rows(self) -> None:
+    def test_runtime_evidence_query_exports_event_order_and_fill_rows(self) -> None:
         script = SUMMARY_SCRIPT.read_text()
 
         self.assertIn("RUNTIME_EVIDENCE_QUERY", script)
         self.assertIn('"runtime_evidence"', script)
         self.assertIn("FROM strategy_runtime_orders o", script)
+        self.assertIn("LEFT JOIN strategy_runtime_event_track_record track", script)
+        self.assertIn("FROM strategy_runtime_orders o", script)
         self.assertIn("FROM strategy_runtime_fills f", script)
+        self.assertIn("'events'", script)
         self.assertIn("'orders'", script)
         self.assertIn("'fills'", script)
+        self.assertIn("'signal_inputs'", script)
         self.assertIn("'context', o.context", script)
 
     def test_report_contract_checker_accepts_clean_empty_dryrun(self) -> None:
@@ -136,7 +141,8 @@ class DryRunReportContractTests(unittest.TestCase):
             "execution_diagnostics": {"basis": "strategy_runtime_orders"},
             "runtime_evidence": {
                 "schema_version": 1,
-                "basis": "strategy_runtime_orders_and_fills",
+                "basis": "strategy_runtime_orders_fills_and_events",
+                "events": [],
                 "orders": [],
                 "fills": [],
             },

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -22,9 +22,32 @@ def evidence_payload(
     deployment_id="pm5d.threelayer.test",
     created_at="2026-05-02T01:02:03Z",
     fill_timestamp="2026-05-02T01:02:04Z",
+    event_side="BUY",
 ):
+    event_pnl = f"-{DecimalString.mul('10', fill_price)}"
     return {
         "runtime_evidence": {
+            "events": [
+                {
+                    "deployment_id": deployment_id,
+                    "intent_id": intent_id,
+                    "order_id": order_id,
+                    "event_id": "event-1",
+                    "token_id": "token-up",
+                    "decision_ts": created_at,
+                    "quote": limit_price,
+                    "signal_inputs": {
+                        "purpose": "ENTRY",
+                        "requested_qty": "10",
+                        "limit_price": limit_price,
+                    },
+                    "side": event_side,
+                    "entry_price": fill_price,
+                    "fill_status": "FILLED",
+                    "settlement": "open",
+                    "pnl": event_pnl,
+                }
+            ],
             "orders": [
                 {
                     "deployment_id": deployment_id,
@@ -60,6 +83,14 @@ def evidence_payload(
     }
 
 
+class DecimalString:
+    @staticmethod
+    def mul(left, right):
+        from decimal import Decimal
+
+        return format((Decimal(str(left)) * Decimal(str(right))).normalize(), "f")
+
+
 class ReplayDryrunParityTests(unittest.TestCase):
     def run_script(self, replay, dryrun, extra_args=None):
         with tempfile.TemporaryDirectory() as tmp:
@@ -91,16 +122,17 @@ class ReplayDryrunParityTests(unittest.TestCase):
             )
             return json.loads(output_path.read_text(encoding="utf-8"))
 
-    def test_runtime_evidence_parity_ready_for_matching_orders_and_fills(self):
+    def test_runtime_evidence_parity_ready_for_matching_events_orders_and_fills(self):
         result = self.run_script(evidence_payload(), evidence_payload())
 
         runtime = result["runtime_evidence_comparison"]
         self.assertTrue(runtime["strict_parity_ready"])
         self.assertEqual(result["decision"], "continue")
+        self.assertEqual(runtime["events"]["shared_count"], 1)
         self.assertEqual(runtime["orders"]["shared_count"], 1)
         self.assertEqual(runtime["fills"]["shared_count"], 1)
         self.assertEqual(result["blocking_risk_flags"], [])
-        self.assertIn("replay_has_no_event_level_rows", result["advisory_flags"])
+        self.assertEqual(result["advisory_flags"], [])
 
     def test_runtime_evidence_matches_semantic_rows_with_different_generated_ids(self):
         result = self.run_script(
@@ -111,6 +143,7 @@ class ReplayDryrunParityTests(unittest.TestCase):
         runtime = result["runtime_evidence_comparison"]
         self.assertTrue(runtime["strict_parity_ready"])
         self.assertEqual(result["decision"], "continue")
+        self.assertEqual(runtime["events"]["shared_count"], 1)
         self.assertEqual(runtime["orders"]["shared_count"], 1)
         self.assertEqual(runtime["fills"]["shared_count"], 1)
 
@@ -125,7 +158,7 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertEqual(result["decision"], "fix-data-or-runtime-mismatch")
         self.assertIn("runtime_evidence_field_mismatches", result["risk_flags"])
         self.assertIn("runtime_evidence_field_mismatches", result["blocking_risk_flags"])
-        self.assertEqual(runtime["mismatches"][0]["field"], "price")
+        self.assertIn(runtime["mismatches"][0]["field"], {"entry_price", "pnl", "price"})
 
     def test_runtime_evidence_blocks_fill_side_mismatch(self):
         result = self.run_script(
@@ -165,6 +198,7 @@ class ReplayDryrunParityTests(unittest.TestCase):
         )
         dryrun["runtime_evidence"]["orders"].extend(extra["runtime_evidence"]["orders"])
         dryrun["runtime_evidence"]["fills"].extend(extra["runtime_evidence"]["fills"])
+        dryrun["runtime_evidence"]["events"].extend(extra["runtime_evidence"]["events"])
 
         result = self.run_script(
             replay,
@@ -181,9 +215,23 @@ class ReplayDryrunParityTests(unittest.TestCase):
 
         runtime = result["runtime_evidence_comparison"]
         self.assertTrue(runtime["strict_parity_ready"])
+        self.assertEqual(runtime["events"]["dryrun_count"], 1)
         self.assertEqual(runtime["orders"]["dryrun_count"], 1)
         self.assertEqual(runtime["fills"]["dryrun_count"], 1)
         self.assertEqual(result["filters"]["deployment_id"], "pm5d.threelayer.test")
+
+    def test_runtime_evidence_blocks_missing_event_rows(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        replay["runtime_evidence"]["events"] = []
+
+        result = self.run_script(replay, dryrun)
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertFalse(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "fix-data-or-runtime-mismatch")
+        self.assertIn("replay_has_no_event_level_rows", result["blocking_risk_flags"])
+        self.assertEqual(runtime["events"]["replay_count"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch BTC/ETH settlement-probability dry-run config to the conservative AutoFactor score
- export event-level runtime evidence from dry-run reports, DB evidence export, and replay/backtest artifacts
- require event-level runtime evidence in replay/dry-run parity instead of treating missing events as advisory

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity tests.test_dryrun_report_contracts
- rtk cargo test -p ploy-strategy-bundles --example run_backtest normalized_runtime_evidence_exposes_order_and_fill_rows
- rtk cargo test -p ploy-operator-contracts dry_run_report_roundtrip_preserves_diagnostics_fields
- rtk cargo check -p ploy-strategy-runtime
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-level data to runtime evidence, including decision timestamps, quotes, signal inputs, entry prices, fill status, settlement info, and per-order P&L metrics.
  * Expanded parity checking to validate event-level rows alongside orders and fills.

* **Improvements**
  * Updated settlement probability strategy configuration to use conservative settlement factor formula for more risk-averse behavior.

* **Documentation**
  * Updated task tracking with completed event-level runtime evidence and parity validation work.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/400)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->