### PR TITLE
Keep legacy parity flags advisory

### DIFF
--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -840,11 +840,7 @@ def build_result(
     decision = "continue"
     if not runtime_evidence_comparison["strict_parity_ready"]:
         decision = "fix-data-or-runtime-mismatch"
-    advisory_flags = [
-        flag
-        for flag in risk_flags
-        if flag.startswith("legacy_event_")
-    ]
+    advisory_flags = [flag for flag in risk_flags if flag.startswith("legacy_")]
     blocking_risk_flags = [flag for flag in risk_flags if flag not in advisory_flags]
 
     return {

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -233,6 +233,29 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertIn("replay_has_no_event_level_rows", result["blocking_risk_flags"])
         self.assertEqual(runtime["events"]["replay_count"], 0)
 
+    def test_legacy_event_drift_is_advisory_when_runtime_evidence_is_strict_ready(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        dryrun["events"] = [
+            {
+                "event_id": "legacy-only",
+                "decision_ts": "2026-05-02T01:02:03Z",
+                "quote": "0.42",
+                "signal_inputs": {},
+                "side": "BUY",
+                "entry_price": "0.41",
+                "fill_status": "FILLED",
+                "settlement": "open",
+                "pnl": "0",
+            }
+        ]
+
+        result = self.run_script(replay, dryrun)
+
+        self.assertTrue(result["runtime_evidence_comparison"]["strict_parity_ready"])
+        self.assertEqual(result["blocking_risk_flags"], [])
+        self.assertIn("legacy_events_present_in_dryrun_missing_from_replay", result["advisory_flags"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- keep legacy event drift flags advisory once runtime evidence strict parity is ready
- add regression coverage for top-level legacy event drift alongside strict runtime evidence

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity
- git diff --check