### PR TITLE
Fix recorded replay psql variable expansion

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -132,7 +132,7 @@ jobs:
             -v deployment_id="${deployment_id}" \
             -v since_ts="${since_ts}" \
             -v until_ts="${until_ts}" \
-            -c "
+            > "${settlements_json}" <<'SQL'
           WITH row_outcomes AS (
             SELECT
               event_id,
@@ -171,7 +171,7 @@ jobs:
             '[]'::jsonb
           )::text
           FROM unambiguous;
-          " > "${settlements_json}"
+          SQL
 
           python3 "${remote_dir}/enrich_recording_official_settlement.py" \
             --input "${recording_path}" \

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,8 @@
 - [x] Add a temporary replay enrichment helper that fills only `event_expired.resolved_up_won` from official runtime settlement evidence.
 - [x] Wire `recorded-replay-parity.yml` to build the enriched recording on `tango-1-1` before replay without mutating the source recording.
 - [x] Verify Python tests, workflow YAML, shell syntax, and diff hygiene.
-- [ ] Open PR, wait for CI, merge, then rerun strict recorded replay parity.
+- [x] Open PR, wait for CI, merge, then rerun strict recorded replay parity.
+- [ ] Fix the post-merge `psql -c` variable-substitution failure and rerun strict recorded replay parity.
 
 ## Review
 
@@ -21,6 +22,11 @@
 - Verification passed: focused Python parity/enrichment tests, full Python
   unittest discovery, workflow YAML parse, recorded replay step `bash -n`,
   workflow input-count guard, Python `py_compile`, and `git diff --check`.
+- PR #403 merged as `306433258429e6ce67251abab25625446b555042`. The first
+  post-merge recorded replay run `25661788361` failed before replay because
+  psql variables were not expanded inside `-c`; the follow-up fix feeds SQL on
+  stdin so `:'deployment_id'`, `:'since_ts'`, and `:'until_ts'` are expanded by
+  psql before execution.
 
 # Dry-Run Conservative Factor And Event-Level Replay Parity (2026-05-11)
 


### PR DESCRIPTION
## Summary
- feed the settlement lookup SQL to psql on stdin so psql variables expand correctly
- record the failed post-merge replay run and follow-up in tasks/todo.md

## Verification
- python3 -m unittest tests.test_enrich_recording_official_settlement tests.test_replay_dryrun_parity
- ruby YAML parse for .github/workflows/recorded-replay-parity.yml
- bash -n on the recorded replay workflow run step
- git diff --check

Follow-up to PR #403. The first post-merge run failed before replay because psql did not expand :\'deployment_id\' inside -c.