### PR TITLE
Fix recorded replay dry-run runtime settlement lookup

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -144,7 +144,7 @@ jobs:
                 ELSE NULL
               END AS outcome_int
             FROM strategy_runtime_event_track_record
-            WHERE runtime_mode = 'dryrun'
+            WHERE runtime_mode IN ('dry_run', 'dryrun')
               AND deployment_id = :'deployment_id'
               AND is_closed
               AND opened_at >= :'since_ts'::timestamptz - INTERVAL '10 minutes'

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,7 +7,8 @@
 - [x] Wire `recorded-replay-parity.yml` to build the enriched recording on `tango-1-1` before replay without mutating the source recording.
 - [x] Verify Python tests, workflow YAML, shell syntax, and diff hygiene.
 - [x] Open PR, wait for CI, merge, then rerun strict recorded replay parity.
-- [ ] Fix the post-merge `psql -c` variable-substitution failure and rerun strict recorded replay parity.
+- [x] Fix the post-merge `psql -c` variable-substitution failure and rerun strict recorded replay parity.
+- [ ] Fix settlement lookup runtime-mode mismatch and rerun strict recorded replay parity.
 
 ## Review
 
@@ -27,6 +28,10 @@
   psql variables were not expanded inside `-c`; the follow-up fix feeds SQL on
   stdin so `:'deployment_id'`, `:'since_ts'`, and `:'until_ts'` are expanded by
   psql before execution.
+- PR #404 merged as `e028a4b61f6b9723410012fb7c21ed48cf58fbaf`. The next
+  replay run `25662126098` completed but still blocked because the settlement
+  lookup used `runtime_mode = 'dryrun'` while current dry-run evidence is stored
+  as `dry_run`; the follow-up lookup accepts both spellings.
 
 # Dry-Run Conservative Factor And Event-Level Replay Parity (2026-05-11)
 


### PR DESCRIPTION
## Summary
- accept both dry_run and dryrun runtime mode spellings in recorded replay settlement lookup
- record the completed-but-still-blocked parity run and root cause in tasks/todo.md

## Verification
- python3 -m unittest tests.test_enrich_recording_official_settlement tests.test_replay_dryrun_parity
- ruby YAML parse for .github/workflows/recorded-replay-parity.yml
- bash -n on the recorded replay workflow run step
- git diff --check

Follow-up to PR #403/#404. Run 25662126098 proved the workflow executes, but settlement_event_count stayed 0 because current runtime evidence uses runtime_mode=dry_run.