### PR TITLE
Enrich replay runtime evidence settlement

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -93,6 +93,8 @@ jobs:
           EOF
           scp scripts/enrich_recording_official_settlement.py \
             tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
+          scp scripts/enrich_replay_runtime_evidence.py \
+            tango-1-1:"${REMOTE_DIR}/enrich_replay_runtime_evidence.py"
 
           # shellcheck disable=SC2029
           ssh tango-1-1 /bin/bash -s -- \
@@ -115,6 +117,7 @@ jobs:
           test -r "${config_path}"
           test -r "${recording_path}"
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
+          test -r "${remote_dir}/enrich_replay_runtime_evidence.py"
 
           set -a
           . /opt/ploy/.env
@@ -136,6 +139,8 @@ jobs:
           WITH row_outcomes AS (
             SELECT
               event_id,
+              token_id,
+              avg_exit_price::text AS settlement,
               CASE
                 WHEN market_side = 'UP' AND avg_exit_price >= 0.99 THEN 1
                 WHEN market_side = 'UP' AND avg_exit_price <= 0.01 THEN 0
@@ -153,20 +158,26 @@ jobs:
           unambiguous AS (
             SELECT
               event_id,
-              MIN(outcome_int) AS outcome_int
+              token_id,
+              MIN(outcome_int) AS outcome_int,
+              MIN(settlement) AS settlement
             FROM row_outcomes
             WHERE event_id IS NOT NULL
+              AND token_id IS NOT NULL
               AND outcome_int IS NOT NULL
-            GROUP BY event_id
+              AND settlement IS NOT NULL
+            GROUP BY event_id, token_id
             HAVING MIN(outcome_int) = MAX(outcome_int)
           )
           SELECT COALESCE(
             jsonb_agg(
               jsonb_build_object(
                 'event_id', event_id,
+                'token_id', token_id,
+                'settlement', settlement,
                 'resolved_up_won', outcome_int = 1
               )
-              ORDER BY event_id
+              ORDER BY event_id, token_id
             ),
             '[]'::jsonb
           )::text
@@ -210,16 +221,23 @@ jobs:
             --deployment-id "${deployment_id}" \
             --output-json "${remote_dir}/replay-evaluation.json"
 
+          python3 "${remote_dir}/enrich_replay_runtime_evidence.py" \
+            --input-json "${remote_dir}/replay-evaluation.json" \
+            --output-json "${remote_dir}/replay-evaluation.json" \
+            --settlements-json "${settlements_json}" \
+            --report-json "${remote_dir}/replay-evidence-enrichment.json"
+
           curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
             -o "${remote_dir}/dryrun-report.json"
 
           test -s "${remote_dir}/replay-evaluation.json"
           test -s "${remote_dir}/dryrun-report.json"
-          ls -lh "${remote_dir}/replay-evaluation.json" "${remote_dir}/dryrun-report.json" "${enrichment_report}"
+          ls -lh "${remote_dir}/replay-evaluation.json" "${remote_dir}/dryrun-report.json" "${enrichment_report}" "${remote_dir}/replay-evidence-enrichment.json"
           EOF
 
           scp tango-1-1:"${REMOTE_DIR}/replay-evaluation.json" artifacts/replay/evaluation.json
           scp tango-1-1:"${REMOTE_DIR}/recording-enrichment.json" artifacts/replay/recording-enrichment.json
+          scp tango-1-1:"${REMOTE_DIR}/replay-evidence-enrichment.json" artifacts/replay/replay-evidence-enrichment.json
           scp tango-1-1:"${REMOTE_DIR}/dryrun-report.json" artifacts/dryrun/dryrun.json
 
       - name: Compare replay and dry-run evidence

--- a/scripts/enrich_replay_runtime_evidence.py
+++ b/scripts/enrich_replay_runtime_evidence.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Attach official settlement prices to replay runtime evidence events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_settlement_prices(path: Path) -> dict[tuple[str, str], str]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict):
+        payload = payload.get("settlements", [])
+    prices: dict[tuple[str, str], str] = {}
+    if not isinstance(payload, list):
+        return prices
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        event_id = item.get("event_id")
+        token_id = item.get("token_id")
+        settlement = item.get("settlement")
+        if event_id is None or token_id is None or settlement is None:
+            continue
+        prices[(str(event_id), str(token_id))] = str(settlement)
+    return prices
+
+
+def is_open_settlement(value: Any) -> bool:
+    if value is None:
+        return True
+    return str(value).strip().lower() in {"", "open"}
+
+
+def enrich_payload(payload: dict[str, Any], prices: dict[tuple[str, str], str]) -> dict[str, int]:
+    events = ((payload.get("runtime_evidence") or {}).get("events") or [])
+    stats = {
+        "runtime_events": 0,
+        "runtime_events_open": 0,
+        "runtime_events_settlement_enriched": 0,
+        "settlement_price_count": len(prices),
+    }
+    if not isinstance(events, list):
+        return stats
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        stats["runtime_events"] += 1
+        if not is_open_settlement(event.get("settlement")):
+            continue
+        stats["runtime_events_open"] += 1
+        event_id = event.get("event_id") or event.get("market_id")
+        token_id = event.get("token_id")
+        if event_id is None or token_id is None:
+            continue
+        settlement = prices.get((str(event_id), str(token_id)))
+        if settlement is None:
+            continue
+        event["settlement"] = settlement
+        stats["runtime_events_settlement_enriched"] += 1
+    runtime_evidence = payload.setdefault("runtime_evidence", {})
+    if isinstance(runtime_evidence, dict):
+        runtime_evidence["settlement_enrichment"] = stats
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-json", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--settlements-json", required=True)
+    parser.add_argument("--report-json", required=True)
+    args = parser.parse_args()
+
+    input_path = Path(args.input_json)
+    with input_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"{input_path}: expected JSON object")
+
+    stats = enrich_payload(payload, load_settlement_prices(Path(args.settlements_json)))
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    report_path = Path(args.report_json)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("w", encoding="utf-8") as handle:
+        json.dump(stats, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(json.dumps(stats, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,7 +8,8 @@
 - [x] Verify Python tests, workflow YAML, shell syntax, and diff hygiene.
 - [x] Open PR, wait for CI, merge, then rerun strict recorded replay parity.
 - [x] Fix the post-merge `psql -c` variable-substitution failure and rerun strict recorded replay parity.
-- [ ] Fix settlement lookup runtime-mode mismatch and rerun strict recorded replay parity.
+- [x] Fix settlement lookup runtime-mode mismatch and rerun strict recorded replay parity.
+- [ ] Backfill replay artifact event-level settlement from the same official map and rerun strict recorded replay parity.
 
 ## Review
 
@@ -32,6 +33,12 @@
   replay run `25662126098` completed but still blocked because the settlement
   lookup used `runtime_mode = 'dryrun'` while current dry-run evidence is stored
   as `dry_run`; the follow-up lookup accepts both spellings.
+- PR #405 merged as `63552cd05c84573d3e3c2f3ad546f581ce5302eb`. Replay run
+  `25662486505` enriched one `event_expired` row and found one settlement row,
+  but strict parity still blocked because the replay JSON `runtime_evidence`
+  event kept `settlement=open`. The next follow-up uses the same official
+  settlement map to backfill replay artifact event-level settlement by
+  `event_id + token_id`, without relaxing parity comparison.
 
 # Dry-Run Conservative Factor And Event-Level Replay Parity (2026-05-11)
 

--- a/tests/test_enrich_replay_runtime_evidence.py
+++ b/tests/test_enrich_replay_runtime_evidence.py
@@ -1,0 +1,97 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "enrich_replay_runtime_evidence.py"
+
+
+class EnrichReplayRuntimeEvidenceTests(unittest.TestCase):
+    def run_script(self, payload, settlements):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "replay.json"
+            output_path = tmp_path / "replay-enriched.json"
+            settlements_path = tmp_path / "settlements.json"
+            report_path = tmp_path / "report.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+            settlements_path.write_text(json.dumps(settlements), encoding="utf-8")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--input-json",
+                    str(input_path),
+                    "--output-json",
+                    str(output_path),
+                    "--settlements-json",
+                    str(settlements_path),
+                    "--report-json",
+                    str(report_path),
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return (
+                json.loads(output_path.read_text(encoding="utf-8")),
+                json.loads(report_path.read_text(encoding="utf-8")),
+            )
+
+    def test_enriches_matching_open_event_settlement_price(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {
+                        "event_id": "evt-1",
+                        "token_id": "token-up",
+                        "settlement": "open",
+                    }
+                ]
+            }
+        }
+        output, report = self.run_script(
+            payload,
+            [
+                {
+                    "event_id": "evt-1",
+                    "token_id": "token-up",
+                    "settlement": "0.00000000000000000000",
+                }
+            ],
+        )
+
+        event = output["runtime_evidence"]["events"][0]
+        self.assertEqual(event["settlement"], "0.00000000000000000000")
+        self.assertEqual(report["runtime_events_settlement_enriched"], 1)
+        self.assertEqual(
+            output["runtime_evidence"]["settlement_enrichment"]["settlement_price_count"],
+            1,
+        )
+
+    def test_preserves_closed_or_unmatched_event_settlement(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {"event_id": "evt-1", "token_id": "token-up", "settlement": "0.5"},
+                    {"event_id": "evt-2", "token_id": "token-up", "settlement": "open"},
+                ]
+            }
+        }
+        output, report = self.run_script(
+            payload,
+            [{"event_id": "evt-1", "token_id": "token-up", "settlement": "1"}],
+        )
+
+        self.assertEqual(output["runtime_evidence"]["events"][0]["settlement"], "0.5")
+        self.assertEqual(output["runtime_evidence"]["events"][1]["settlement"], "open")
+        self.assertEqual(report["runtime_events_settlement_enriched"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add replay runtime-evidence enrichment that fills open event settlement from the official event_id + token_id settlement map
- extend recorded-replay-parity to emit token settlement prices, enrich the temporary recording, and enrich the replay evaluation artifact before parity compare
- add focused tests for replay event settlement enrichment

## Verification
- python3 -m unittest tests.test_enrich_recording_official_settlement tests.test_enrich_replay_runtime_evidence tests.test_replay_dryrun_parity
- python3 -m unittest discover tests
- python3 -m py_compile scripts/enrich_recording_official_settlement.py scripts/enrich_replay_runtime_evidence.py scripts/replay_dryrun_parity.py
- ruby YAML parse for .github/workflows/recorded-replay-parity.yml
- bash -n on the recorded replay workflow run step
- git diff --check

Follow-up to PR #403/#404/#405. Run 25662486505 proved recording enrichment works, but the replay JSON event row still carried settlement=open.