### PR TITLE
Hide legacy event drift from parity flags

### DIFF
--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -818,30 +818,31 @@ def build_result(
     if runtime_evidence_comparison["missing_strict_fields"]:
         risk_flags.append("missing_runtime_evidence_strict_fields")
 
+    legacy_event_flags: list[str] = []
     if not replay_events and runtime_evidence_comparison["events"]["replay_count"] == 0:
-        risk_flags.append("replay_has_no_legacy_event_level_rows")
+        legacy_event_flags.append("replay_has_no_legacy_event_level_rows")
     if not dryrun_events and runtime_evidence_comparison["events"]["dryrun_count"] == 0:
-        risk_flags.append("dryrun_has_no_legacy_event_level_rows")
+        legacy_event_flags.append("dryrun_has_no_legacy_event_level_rows")
     if (
         event_comparison["missing_dryrun_events"]
         and not runtime_evidence_comparison["events"]["missing_dryrun_rows"]
     ):
-        risk_flags.append("legacy_events_present_in_replay_missing_from_dryrun")
+        legacy_event_flags.append("legacy_events_present_in_replay_missing_from_dryrun")
     if (
         event_comparison["missing_replay_events"]
         and not runtime_evidence_comparison["events"]["missing_replay_rows"]
     ):
-        risk_flags.append("legacy_events_present_in_dryrun_missing_from_replay")
+        legacy_event_flags.append("legacy_events_present_in_dryrun_missing_from_replay")
     if event_comparison["mismatches"]:
-        risk_flags.append("legacy_event_strict_field_mismatches")
+        legacy_event_flags.append("legacy_event_strict_field_mismatches")
     if event_comparison["missing_strict_fields"]:
-        risk_flags.append("legacy_event_missing_strict_parity_fields")
+        legacy_event_flags.append("legacy_event_missing_strict_parity_fields")
 
     decision = "continue"
     if not runtime_evidence_comparison["strict_parity_ready"]:
         decision = "fix-data-or-runtime-mismatch"
-    advisory_flags = [flag for flag in risk_flags if flag.startswith("legacy_")]
-    blocking_risk_flags = [flag for flag in risk_flags if flag not in advisory_flags]
+    advisory_flags: list[str] = []
+    blocking_risk_flags = list(risk_flags)
 
     return {
         "schema_version": 1,
@@ -855,6 +856,7 @@ def build_result(
         "dryrun_metrics": extract_metrics(dryrun),
         "event_comparison": event_comparison,
         "runtime_evidence_comparison": runtime_evidence_comparison,
+        "legacy_event_flags": legacy_event_flags,
         "risk_flags": risk_flags,
         "blocking_risk_flags": blocking_risk_flags,
         "advisory_flags": advisory_flags,

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -233,7 +233,7 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertIn("replay_has_no_event_level_rows", result["blocking_risk_flags"])
         self.assertEqual(runtime["events"]["replay_count"], 0)
 
-    def test_legacy_event_drift_is_advisory_when_runtime_evidence_is_strict_ready(self):
+    def test_legacy_event_drift_is_diagnostic_when_runtime_evidence_is_strict_ready(self):
         replay = evidence_payload()
         dryrun = evidence_payload()
         dryrun["events"] = [
@@ -254,7 +254,12 @@ class ReplayDryrunParityTests(unittest.TestCase):
 
         self.assertTrue(result["runtime_evidence_comparison"]["strict_parity_ready"])
         self.assertEqual(result["blocking_risk_flags"], [])
-        self.assertIn("legacy_events_present_in_dryrun_missing_from_replay", result["advisory_flags"])
+        self.assertEqual(result["advisory_flags"], [])
+        self.assertEqual(result["risk_flags"], [])
+        self.assertIn(
+            "legacy_events_present_in_dryrun_missing_from_replay",
+            result["legacy_event_flags"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep legacy top-level event comparison as diagnostic JSON only
- stop surfacing legacy event drift in risk_flags/advisory_flags once strict runtime evidence is available
- update parity tests to assert clean flags with legacy_event_flags retained

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity
- python3 -m unittest discover tests
- python3 -m py_compile scripts/replay_dryrun_parity.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected legacy event drift classification to "diagnostic" status.

* **Refactor**
  * Restructured output to separately track legacy event indicators from general risk flags for improved clarity.

* **Tests**
  * Updated test validation to align with refined output schema and corrected classification behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->