### PR TITLE
Make hosted factor artifact windows manifest-driven

### DIFF
--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -15,13 +15,13 @@ on:
         required: false
         default: ""
       start_date:
-        description: "Review start date (YYYY-MM-DD)"
+        description: "Review start date (YYYY-MM-DD), or auto to use the snapshot manifest start"
         required: true
-        default: "2026-04-24"
+        default: "auto"
       end_date:
-        description: "Review end date (YYYY-MM-DD)"
+        description: "Review end date (inclusive YYYY-MM-DD), or auto to use the snapshot manifest end"
         required: true
-        default: "2026-04-24"
+        default: "auto"
       symbols:
         description: "Comma-separated Binance symbols"
         required: true
@@ -158,6 +158,51 @@ jobs:
           print("full research snapshot payload present: " + ", ".join(required))
           PY
 
+      - name: Resolve review window
+        env:
+          INPUT_START_DATE: ${{ github.event.inputs.start_date }}
+          INPUT_END_DATE: ${{ github.event.inputs.end_date }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          def parse_manifest_ts(raw):
+              return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+          def parse_start(raw):
+              if raw.lower() == "auto":
+                  return manifest_start
+              return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+          def parse_end(raw):
+              if raw.lower() == "auto":
+                  return manifest_end
+              return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc) + timedelta(days=1)
+
+          def iso_z(ts):
+              return ts.isoformat().replace("+00:00", "Z")
+
+          manifest = json.loads(Path("artifacts/research-snapshot/manifest.json").read_text(encoding="utf-8"))
+          manifest_start = parse_manifest_ts(manifest["start"])
+          manifest_end = parse_manifest_ts(manifest["end"])
+          start = parse_start(os.environ["INPUT_START_DATE"])
+          end = parse_end(os.environ["INPUT_END_DATE"])
+          if start < manifest_start or end > manifest_end or start >= end:
+              raise SystemExit(
+                  "review window must be within snapshot manifest window: "
+                  f"requested {iso_z(start)} -> {iso_z(end)}, "
+                  f"snapshot {iso_z(manifest_start)} -> {iso_z(manifest_end)}"
+              )
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              handle.write(f"FACTOR_START_TS={iso_z(start)}\n")
+              handle.write(f"FACTOR_END_TS={iso_z(end)}\n")
+          print(f"resolved review window: {iso_z(start)} -> {iso_z(end)}")
+          PY
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -180,8 +225,8 @@ jobs:
           ./target/fast/examples/factor_review_v2 \
             --snapshot-dir artifacts/research-snapshot \
             --symbols "${{ github.event.inputs.symbols }}" \
-            --start-date "${{ github.event.inputs.start_date }}" \
-            --end-date "${{ github.event.inputs.end_date }}" \
+            --start-ts "${FACTOR_START_TS}" \
+            --end-ts "${FACTOR_END_TS}" \
             --stake-usd "${{ github.event.inputs.stake_usd }}" \
             --lob-sample-secs "${FACTOR_LOB_SAMPLE_SECS}" \
             --observation-sample-secs "${FACTOR_OBSERVATION_SAMPLE_SECS}" \
@@ -202,7 +247,7 @@ jobs:
             echo "## Factor Review V2 Hosted Artifact"
             echo ""
             echo "- Snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\`"
-            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Window: ${FACTOR_START_TS} -> ${FACTOR_END_TS}"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
             echo "- Runner: \`ubuntu-latest\`"
@@ -322,7 +367,7 @@ jobs:
               `- Workflow: ${context.workflow}`,
               `- Run URL: ${runUrl}`,
               `- Git ref: ${{ github.event.inputs.git_ref }}`,
-              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
+              `- Dataset/window: ${process.env.FACTOR_START_TS} -> ${process.env.FACTOR_END_TS}`,
               `- Symbols: ${{ github.event.inputs.symbols }}`,
               `- Artifact: \`factor-review-v2-${process.env.GITHUB_RUN_ID}\``,
               `- Runner: \`ubuntu-latest\``,

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -15,13 +15,13 @@ on:
         required: false
         default: ""
       start_date:
-        description: "Review start date (YYYY-MM-DD)"
+        description: "Review start date (YYYY-MM-DD), or auto to use the snapshot manifest start"
         required: true
-        default: "2026-04-21"
+        default: "auto"
       end_date:
-        description: "Review end date (YYYY-MM-DD)"
+        description: "Review end date (inclusive YYYY-MM-DD), or auto to use the snapshot manifest end"
         required: true
-        default: "2026-04-25"
+        default: "auto"
       symbols:
         description: "Comma-separated Binance symbols"
         required: true
@@ -194,6 +194,51 @@ jobs:
           print("full research snapshot payload present: " + ", ".join(required))
           PY
 
+      - name: Resolve walk-forward window
+        env:
+          INPUT_START_DATE: ${{ github.event.inputs.start_date }}
+          INPUT_END_DATE: ${{ github.event.inputs.end_date }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          def parse_manifest_ts(raw):
+              return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+          def parse_start(raw):
+              if raw.lower() == "auto":
+                  return manifest_start
+              return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+          def parse_end(raw):
+              if raw.lower() == "auto":
+                  return manifest_end
+              return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc) + timedelta(days=1)
+
+          def iso_z(ts):
+              return ts.isoformat().replace("+00:00", "Z")
+
+          manifest = json.loads(Path("artifacts/research-snapshot/manifest.json").read_text(encoding="utf-8"))
+          manifest_start = parse_manifest_ts(manifest["start"])
+          manifest_end = parse_manifest_ts(manifest["end"])
+          start = parse_start(os.environ["INPUT_START_DATE"])
+          end = parse_end(os.environ["INPUT_END_DATE"])
+          if start < manifest_start or end > manifest_end or start >= end:
+              raise SystemExit(
+                  "walk-forward window must be within snapshot manifest window: "
+                  f"requested {iso_z(start)} -> {iso_z(end)}, "
+                  f"snapshot {iso_z(manifest_start)} -> {iso_z(manifest_end)}"
+              )
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              handle.write(f"WALK_START_TS={iso_z(start)}\n")
+              handle.write(f"WALK_END_TS={iso_z(end)}\n")
+          print(f"resolved walk-forward window: {iso_z(start)} -> {iso_z(end)}")
+          PY
+
       - name: Download replay parity artifact
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -236,8 +281,8 @@ jobs:
           args=(
             --snapshot-dir artifacts/research-snapshot
             --symbols "${{ github.event.inputs.symbols }}"
-            --start-date "${{ github.event.inputs.start_date }}"
-            --end-date "${{ github.event.inputs.end_date }}"
+            --start-ts "${WALK_START_TS}"
+            --end-ts "${WALK_END_TS}"
             --stake-usd "${{ github.event.inputs.stake_usd }}"
             --train-window-days "${WALK_TRAIN_WINDOW_DAYS}"
             --test-window-days "${WALK_TEST_WINDOW_DAYS}"
@@ -408,7 +453,7 @@ jobs:
             echo "## Factor Walk-Forward V2 Hosted Artifact"
             echo ""
             echo "- Snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\`"
-            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
+            echo "- Window: ${WALK_START_TS} -> ${WALK_END_TS}"
             echo "- Train/Test: ${WALK_TRAIN_WINDOW_DAYS}d / ${WALK_TEST_WINDOW_DAYS}d"
             echo "- Symbols: ${{ github.event.inputs.symbols }}"
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
@@ -491,8 +536,8 @@ jobs:
                 runUrl,
                 gitRef: "${{ github.event.inputs.git_ref }}",
                 snapshotRunId: "${{ github.event.inputs.snapshot_run_id }}",
-                startDate: "${{ github.event.inputs.start_date }}",
-                endDate: "${{ github.event.inputs.end_date }}",
+                startDate: process.env.WALK_START_TS,
+                endDate: process.env.WALK_END_TS,
                 symbols: "${{ github.event.inputs.symbols }}",
                 artifactName: `factor-walk-forward-v2-${process.env.GITHUB_RUN_ID}`,
               },

--- a/crates/ploy-research/examples/factor_review_v2.rs
+++ b/crates/ploy-research/examples/factor_review_v2.rs
@@ -27,7 +27,7 @@ use ploy_research::{
     format_factor_review_v2_report, load_deribit_feature_snapshots,
     load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
     load_research_snapshot, review_factors_v2_with_deribit_and_pm_books_filtered,
-    validate_snapshot_request,
+    validate_snapshot_request_coverage,
 };
 use serde::Serialize;
 use sqlx::postgres::PgPoolOptions;
@@ -180,7 +180,7 @@ async fn main() {
         let started = std::time::Instant::now();
         let snapshot =
             load_research_snapshot(&snapshot_dir).expect("load research snapshot failed");
-        validate_snapshot_request(
+        validate_snapshot_request_coverage(
             &snapshot.manifest,
             ResearchSnapshotRequest {
                 symbols: &symbols,
@@ -193,7 +193,7 @@ async fn main() {
                 require_official_settlement: true,
             },
         )
-        .expect("snapshot does not match requested review inputs");
+        .expect("snapshot does not cover requested review inputs");
         let snapshot_hash = snapshot
             .manifest
             .snapshot_hash

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -29,7 +29,7 @@ use ploy_research::{
     load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
     load_research_snapshot, mine_domain_autofactors_from_v2,
     review_fillability_v1_with_deribit_and_pm_books, review_repricing_ic_with_deribit_and_pm_books,
-    review_trade_formation_v1_with_deribit_and_pm_books, validate_snapshot_request,
+    review_trade_formation_v1_with_deribit_and_pm_books, validate_snapshot_request_coverage,
     walk_forward_factor_combo_v1_with_deribit_and_pm_books,
     walk_forward_factors_v2_with_deribit_and_pm_books,
     walk_forward_meta_label_v1_with_deribit_and_pm_books,
@@ -287,7 +287,7 @@ async fn main() {
             std::process::exit(2);
         }
         let validation_symbols = snapshot.manifest.symbols.clone();
-        validate_snapshot_request(
+        validate_snapshot_request_coverage(
             &snapshot.manifest,
             ResearchSnapshotRequest {
                 symbols: &validation_symbols,
@@ -300,7 +300,7 @@ async fn main() {
                 require_official_settlement: true,
             },
         )
-        .expect("snapshot does not match requested walk-forward inputs");
+        .expect("snapshot does not cover requested walk-forward inputs");
         let snapshot_hash = snapshot
             .manifest
             .snapshot_hash

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -64,9 +64,10 @@ pub use replay::replay_fills;
 #[cfg(feature = "db")]
 pub use research_snapshot::{build_research_snapshot_from_database, ResearchSnapshotBuildOptions};
 pub use research_snapshot::{
-    load_research_snapshot, validate_snapshot_request, write_research_snapshot, ResearchSnapshot,
-    ResearchSnapshotArtifacts, ResearchSnapshotManifest, ResearchSnapshotPhaseTiming,
-    ResearchSnapshotRequest, ResearchSnapshotRowCounts, RESEARCH_SNAPSHOT_SCHEMA_VERSION,
+    load_research_snapshot, validate_snapshot_request, validate_snapshot_request_coverage,
+    write_research_snapshot, ResearchSnapshot, ResearchSnapshotArtifacts, ResearchSnapshotManifest,
+    ResearchSnapshotPhaseTiming, ResearchSnapshotRequest, ResearchSnapshotRowCounts,
+    RESEARCH_SNAPSHOT_SCHEMA_VERSION,
 };
 
 pub const CRATE_MARKER: &str = "ploy-research";

--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -199,6 +199,21 @@ pub fn validate_snapshot_request(
     manifest: &ResearchSnapshotManifest,
     request: ResearchSnapshotRequest<'_>,
 ) -> Result<()> {
+    validate_snapshot_request_with_window_mode(manifest, request, true)
+}
+
+pub fn validate_snapshot_request_coverage(
+    manifest: &ResearchSnapshotManifest,
+    request: ResearchSnapshotRequest<'_>,
+) -> Result<()> {
+    validate_snapshot_request_with_window_mode(manifest, request, false)
+}
+
+fn validate_snapshot_request_with_window_mode(
+    manifest: &ResearchSnapshotManifest,
+    request: ResearchSnapshotRequest<'_>,
+    require_exact_window: bool,
+) -> Result<()> {
     let mut requested_symbols = request.symbols.to_vec();
     requested_symbols.sort();
     let mut snapshot_symbols = manifest.symbols.clone();
@@ -210,9 +225,18 @@ pub fn validate_snapshot_request(
             requested_symbols
         );
     }
-    if manifest.start != request.start || manifest.end != request.end {
+    if require_exact_window && (manifest.start != request.start || manifest.end != request.end) {
         anyhow::bail!(
             "snapshot window {} -> {} does not match requested window {} -> {}",
+            manifest.start,
+            manifest.end,
+            request.start,
+            request.end
+        );
+    }
+    if !require_exact_window && (manifest.start > request.start || manifest.end < request.end) {
+        anyhow::bail!(
+            "snapshot window {} -> {} does not cover requested window {} -> {}",
             manifest.start,
             manifest.end,
             request.start,
@@ -646,6 +670,10 @@ mod tests {
             std::process::id(),
             Utc::now().timestamp_nanos_opt().unwrap_or_default()
         ));
+        let start = "2026-04-24T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let end = "2026-05-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let subset_start = "2026-04-25T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let subset_end = "2026-04-27T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let snapshot = ResearchSnapshot {
             manifest: ResearchSnapshotManifest {
                 schema_version: RESEARCH_SNAPSHOT_SCHEMA_VERSION.to_string(),
@@ -653,9 +681,9 @@ mod tests {
                 generated_at: Utc::now(),
                 git_sha: Some("test-sha".to_string()),
                 symbols: vec!["BTCUSDT".to_string()],
-                start: Utc::now(),
-                end: Utc::now(),
-                history_start: Utc::now(),
+                start,
+                end,
+                history_start: start,
                 lob_sample_secs: 30,
                 pm_book_sample_secs: Some(30),
                 observation_sample_secs: 30,
@@ -702,6 +730,34 @@ mod tests {
             },
         )
         .expect("snapshot request validation");
+        validate_snapshot_request_coverage(
+            &loaded.manifest,
+            ResearchSnapshotRequest {
+                symbols: &["BTCUSDT".to_string()],
+                start: subset_start,
+                end: subset_end,
+                lob_sample_secs: loaded.manifest.lob_sample_secs,
+                observation_sample_secs: loaded.manifest.observation_sample_secs,
+                max_quote_age_secs: loaded.manifest.max_quote_age_secs,
+                stake_usd: loaded.manifest.stake_usd,
+                require_official_settlement: loaded.manifest.require_official_settlement,
+            },
+        )
+        .expect("snapshot coverage validation");
+        let exact_subset_result = validate_snapshot_request(
+            &loaded.manifest,
+            ResearchSnapshotRequest {
+                symbols: &["BTCUSDT".to_string()],
+                start: subset_start,
+                end: subset_end,
+                lob_sample_secs: loaded.manifest.lob_sample_secs,
+                observation_sample_secs: loaded.manifest.observation_sample_secs,
+                max_quote_age_secs: loaded.manifest.max_quote_age_secs,
+                stake_usd: loaded.manifest.stake_usd,
+                require_official_settlement: loaded.manifest.require_official_settlement,
+            },
+        );
+        assert!(exact_subset_result.is_err());
         assert_eq!(loaded.manifest.row_counts.observations, 0);
         assert!(root.join("quality.md").exists());
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -269,3 +269,13 @@
   - Before adding non-trivial TS logic, ask whether the behavior can instead live in `ployctl`, `ployd`, or a Rust crate.
   - If TS is temporarily unavoidable, keep it as a thin wrapper over canonical Rust surfaces rather than embedding core logic there.
   - Do not move strategy, execution, or oversight policy deeper into TS just because the sidecar currently runs on Node.
+
+## 2026-05-11
+
+- Pattern: Hosted artifact factor workflows become slow and brittle when they
+  keep hard-coded date defaults that must exactly match a retained research
+  snapshot manifest.
+- Rule: Artifact-backed research loops should resolve default windows from the
+  snapshot manifest and run sub-window searches against the retained artifact.
+  Do not re-export a full snapshot or rely on hidden inclusive-date semantics
+  just to test another factor window.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13683,3 +13683,61 @@ deployment safety or live-runner coverage.
   `ploy-connectivity`, and the default normal-edge tree is 132 lines. Explicit
   `--features full` still includes `ploy-market-data`, `polymarket-client-sdk`,
   `sqlx`, and `ploy-connectivity`, with a 999-line normal-edge tree.
+
+# Hosted Artifact Factor Loop Window Fix (2026-05-11)
+
+## Goal
+
+Make retained research snapshot artifacts usable for repeated factor-search
+loops without hard-coded date windows or unnecessary snapshot re-export.
+
+## Files / Ownership
+
+- `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml`,
+  `.github/workflows/factor-review-v2-hosted-artifact.yml`
+  - Owner: resolve `auto` review/walk-forward windows from snapshot
+    `manifest.json`, and pass timestamp bounds to Rust examples.
+- `crates/ploy-research/src/research_snapshot.rs`, `crates/ploy-research/src/lib.rs`
+  - Owner: keep exact snapshot validation for producers while exposing a
+    coverage validator for artifact-backed consumers.
+- `crates/ploy-research/examples/factor_review_v2.rs`,
+  `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+  - Owner: accept snapshot artifacts that cover the requested sub-window.
+
+## Tasks
+
+- [x] Prove legacy replay parity flags are clean on `main`.
+- [x] Run all-symbol hosted walk-forward from retained snapshot artifact.
+- [x] Diagnose the hard-coded/end-date mismatch that made the first run panic.
+- [x] Replace hard-coded hosted artifact workflow defaults with manifest-backed
+  `auto` window resolution.
+- [x] Allow factor review/walk-forward examples to use snapshot-covered
+  sub-windows instead of requiring exact full-window equality.
+- [x] Validate YAML, focused snapshot tests, and hosted example compilation.
+
+## Review
+
+- 2026-05-11: PR #408 merged as `e8f0fc81`; recorded replay parity run
+  `25665442731` on `main` passed in 1m09s. Runtime evidence strict parity is
+  ready for events/orders/fills with shared counts `1/1/1`; `risk_flags=[]`,
+  `blocking_risk_flags=[]`, and `advisory_flags=[]`. Legacy event drift remains
+  only in `legacy_event_flags`.
+- 2026-05-11: Full snapshot run `25642459432` took 23m12s wall-clock. Snapshot
+  phase timings show the slow path is export/materialization, especially
+  `historical_updates=474666ms`, `pm_book_snapshots=222302ms`,
+  `cex_lob_snapshots=180860ms`, and `factor_observations=159357ms`.
+- 2026-05-11: Hosted artifact walk-forward run `25665802778` reused snapshot
+  `25642459432` plus replay parity `25665442731` and completed in 1m11s. The
+  result is `blocked`: no qualified dry-run handoff. The best settlement-edge
+  family rows remain watchlist only because of `low_icir`, despite positive
+  window ratios around `0.68-0.75` and symbol-positive ratio `1.0`.
+- 2026-05-11: The failed walk-forward run `25665703311` exposed the hard-coded
+  date trap: workflow `end_date=2026-05-01` was interpreted by the Rust example
+  as an inclusive date and converted to the right-open timestamp
+  `2026-05-02T00:00:00Z`, outside the snapshot manifest end
+  `2026-05-01T00:00:00Z`.
+- 2026-05-11: Local verification for the fix passed:
+  `ruby -e 'require "yaml"; %w[.github/workflows/factor-walk-forward-v2-hosted-artifact.yml .github/workflows/factor-review-v2-hosted-artifact.yml].each { |f| YAML.load_file(f); puts f }'`,
+  `CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_snapshot --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2 --example factor_review_v2`,
+  and `git diff --check`.


### PR DESCRIPTION
## Summary
- resolve hosted factor review/walk-forward windows from snapshot manifest by default (`auto`)
- pass explicit UTC timestamp bounds into Rust examples instead of hard-coded date defaults
- allow artifact-backed review/walk-forward examples to use snapshot-covered sub-windows while preserving exact producer validation
- record parity, timing, and factor-search evidence in tasks/lessons

## Validation
- ruby -e 'require "yaml"; %w[.github/workflows/factor-walk-forward-v2-hosted-artifact.yml .github/workflows/factor-review-v2-hosted-artifact.yml].each { |f| YAML.load_file(f); puts f }'\n- CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_snapshot --lib\n- CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2 --example factor_review_v2\n- git diff --check\n\n## Evidence\n- recorded replay parity run 25665442731: strict runtime parity ready, no risk/advisory/blocking flags\n- hosted all-symbol walk-forward run 25665802778: completed in 1m11s from retained snapshot artifact; no qualified dry-run handoff yet