### PR TITLE
Batch hosted factor walk-forward variants

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -34,6 +34,10 @@ on:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional issue/config handoff"
         required: false
         default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+      sweep_json:
+        description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
+        required: false
+        default: ""
 
 concurrency:
   group: factor-walk-forward-v2-hosted-artifact-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.snapshot_run_id }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
@@ -274,12 +278,21 @@ jobs:
             --features db \
             --example factor_walk_forward_v2
 
-      - name: Run factor walk-forward
+      - name: Run factor walk-forward sweep
+        env:
+          SWEEP_JSON: ${{ github.event.inputs.sweep_json }}
         run: |
           set -euo pipefail
           mkdir -p artifacts/factor-walk-forward-v2
+          replay_parity_json="${WALK_REPLAY_PARITY_JSON}"
+          if [ -z "${replay_parity_json}" ] && [ -f artifacts/replay-parity/parity-evaluation.json ]; then
+            replay_parity_json="artifacts/replay-parity/parity-evaluation.json"
+          fi
           args=(
+            --binary ./target/fast/examples/factor_walk_forward_v2
+            --evaluator scripts/evaluate_autofactor_strategy_promotion.py
             --snapshot-dir artifacts/research-snapshot
+            --output-dir artifacts/factor-walk-forward-v2
             --symbols "${{ github.event.inputs.symbols }}"
             --start-ts "${WALK_START_TS}"
             --end-ts "${WALK_END_TS}"
@@ -297,44 +310,18 @@ jobs:
             --data-quality-mode "${WALK_DATA_QUALITY_MODE}"
             --min-event-complete-events "${WALK_MIN_EVENT_COMPLETE_EVENTS}"
             --min-event-complete-rows "${WALK_MIN_EVENT_COMPLETE_ROWS}"
+            --required-strategy-profile "${WALK_REQUIRED_STRATEGY_PROFILE}"
+            --allowed-target "${WALK_ALLOWED_TARGET}"
+            --sweep-json "${SWEEP_JSON}"
+            --fail-if-all-failed
           )
-          if [ -n "${WALK_FACTOR_NAME_FILTER}" ]; then
-            args+=(--factor-name-filter "${WALK_FACTOR_NAME_FILTER}")
-          fi
-          replay_parity_json="${WALK_REPLAY_PARITY_JSON}"
-          if [ -z "${replay_parity_json}" ] && [ -f artifacts/replay-parity/parity-evaluation.json ]; then
-            replay_parity_json="artifacts/replay-parity/parity-evaluation.json"
-          fi
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
           fi
-          ./target/fast/examples/factor_walk_forward_v2 "${args[@]}" \
-            | tee artifacts/factor-walk-forward-v2/report.txt
-          echo "canonical_result=snapshot_artifact" | tee artifacts/factor-walk-forward-v2/source.txt
-
-      - name: Evaluate AutoFactor strategy promotion
-        if: always()
-        run: |
-          set -euo pipefail
-          if [ ! -f artifacts/factor-walk-forward-v2/report.txt ]; then
-            echo "No factor walk-forward report found; skipping AutoFactor strategy promotion evaluation."
-            exit 0
-          fi
-          args=(
-            --report artifacts/factor-walk-forward-v2/report.txt
-            --output-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json
-            --output-md artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.md
-            --output-registry-json artifacts/factor-walk-forward-v2/autofactor-factor-registry.json
-            --output-handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json
-            --output-handoff-md artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.md
-            --required-strategy-profile "${WALK_REQUIRED_STRATEGY_PROFILE}"
-            --allowed-target "${WALK_ALLOWED_TARGET}"
-          )
           if [ "${WALK_FAIL_IF_BLOCKED}" = "true" ]; then
             args+=(--fail-if-blocked)
           fi
-          python3 scripts/evaluate_autofactor_strategy_promotion.py "${args[@]}" \
-            | tee artifacts/factor-walk-forward-v2/evaluator-output.json
+          python3 scripts/run_factor_walk_forward_sweep.py "${args[@]}"
 
       - name: Create config PR from ready handoff
         if: always()
@@ -448,6 +435,8 @@ jobs:
 
       - name: Publish summary
         if: always()
+        env:
+          SWEEP_JSON: ${{ github.event.inputs.sweep_json }}
         run: |
           {
             echo "## Factor Walk-Forward V2 Hosted Artifact"
@@ -462,14 +451,23 @@ jobs:
             echo "- Required strategy profile: ${WALK_REQUIRED_STRATEGY_PROFILE}"
             echo "- Allowed target: ${WALK_ALLOWED_TARGET}"
             echo "- Factor filter: ${WALK_FACTOR_NAME_FILTER:-<none>}"
+            if [ -n "${SWEEP_JSON}" ]; then
+              echo "- Sweep mode: \`true\`"
+            else
+              echo "- Sweep mode: \`false\`"
+            fi
             if [ -f artifacts/research-snapshot/quality.md ]; then
               echo ""
               echo "### Snapshot Quality"
               cat artifacts/research-snapshot/quality.md
             fi
+            if [ -f artifacts/factor-walk-forward-v2/sweep-summary.md ]; then
+              echo ""
+              cat artifacts/factor-walk-forward-v2/sweep-summary.md
+            fi
             if [ -f artifacts/factor-walk-forward-v2/report.txt ]; then
               echo ""
-              echo "### Walk-Forward Report"
+              echo "### Selected Walk-Forward Report"
               echo '```'
               sed -n '1,160p' artifacts/factor-walk-forward-v2/report.txt
               echo '```'

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Run multiple factor_walk_forward_v2 variants after one artifact download/build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SWEEP_KEYS = {
+    "label",
+    "train_window_days",
+    "test_window_days",
+    "step_days",
+    "lob_sample_secs",
+    "observation_sample_secs",
+    "max_quote_age_secs",
+    "top_n",
+    "min_observations",
+    "top_quantile",
+    "factor_name_filter",
+    "report_suite",
+    "data_quality_mode",
+    "min_event_complete_events",
+    "min_event_complete_rows",
+}
+
+
+@dataclass(frozen=True)
+class Variant:
+    label: str
+    values: dict[str, str]
+
+
+def slugify(raw: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw.strip()).strip("-")
+    return slug[:80] or "variant"
+
+
+def load_sweep(raw: str, base: dict[str, str]) -> list[Variant]:
+    if not raw.strip():
+        return [Variant(label="base", values=dict(base))]
+    payload = json.loads(raw)
+    if isinstance(payload, dict):
+        variants = payload.get("variants")
+    else:
+        variants = payload
+    if not isinstance(variants, list) or not variants:
+        raise SystemExit("sweep_json must be a non-empty JSON array or an object with variants[]")
+
+    parsed: list[Variant] = []
+    for index, item in enumerate(variants, start=1):
+        if not isinstance(item, dict):
+            raise SystemExit(f"sweep variant {index} must be an object")
+        unknown = sorted(set(item) - SWEEP_KEYS)
+        if unknown:
+            raise SystemExit(f"sweep variant {index} has unknown keys: {', '.join(unknown)}")
+        values = dict(base)
+        for key, value in item.items():
+            if key == "label":
+                continue
+            if isinstance(value, (dict, list)):
+                raise SystemExit(f"sweep variant {index} value for {key} must be scalar")
+            values[key] = str(value)
+        label = str(item.get("label") or values.get("factor_name_filter") or f"variant-{index}")
+        parsed.append(Variant(label=slugify(label), values=values))
+    return parsed
+
+
+def factor_args(args: argparse.Namespace, variant: Variant, replay_parity_json: str) -> list[str]:
+    values = variant.values
+    command = [
+        args.binary,
+        "--snapshot-dir",
+        args.snapshot_dir,
+        "--symbols",
+        args.symbols,
+        "--start-ts",
+        args.start_ts,
+        "--end-ts",
+        args.end_ts,
+        "--stake-usd",
+        args.stake_usd,
+        "--train-window-days",
+        values["train_window_days"],
+        "--test-window-days",
+        values["test_window_days"],
+        "--step-days",
+        values["step_days"],
+        "--lob-sample-secs",
+        values["lob_sample_secs"],
+        "--observation-sample-secs",
+        values["observation_sample_secs"],
+        "--max-quote-age-secs",
+        values["max_quote_age_secs"],
+        "--min-observations",
+        values["min_observations"],
+        "--top-quantile",
+        values["top_quantile"],
+        "--top-n",
+        values["top_n"],
+        "--report-suite",
+        values["report_suite"],
+        "--data-quality-mode",
+        values["data_quality_mode"],
+        "--min-event-complete-events",
+        values["min_event_complete_events"],
+        "--min-event-complete-rows",
+        values["min_event_complete_rows"],
+    ]
+    if values.get("factor_name_filter"):
+        command.extend(["--factor-name-filter", values["factor_name_filter"]])
+    if replay_parity_json:
+        command.extend(["--replay-parity-json", replay_parity_json])
+    return command
+
+
+def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) -> list[str]:
+    command = [
+        sys.executable,
+        args.evaluator,
+        "--report",
+        str(report),
+        "--output-json",
+        str(variant_dir / "autofactor-strategy-promotion.json"),
+        "--output-md",
+        str(variant_dir / "autofactor-strategy-promotion.md"),
+        "--output-registry-json",
+        str(variant_dir / "autofactor-factor-registry.json"),
+        "--output-handoff-json",
+        str(variant_dir / "autofactor-strategy-handoff.json"),
+        "--output-handoff-md",
+        str(variant_dir / "autofactor-strategy-handoff.md"),
+        "--required-strategy-profile",
+        args.required_strategy_profile,
+    ]
+    for target in args.allowed_target:
+        command.extend(["--allowed-target", target])
+    return command
+
+
+def best_factor(promotion: dict[str, Any], allowed_targets: set[str]) -> dict[str, Any] | None:
+    evaluated = promotion.get("evaluated_factors") or []
+    candidates: list[dict[str, Any]] = []
+    for item in evaluated:
+        factor = item.get("factor") or {}
+        if factor.get("target") not in allowed_targets:
+            continue
+        candidates.append(
+            {
+                "name": factor.get("name", ""),
+                "target": factor.get("target", ""),
+                "decision": factor.get("decision", ""),
+                "reason": factor.get("reason", ""),
+                "rank": factor.get("rank", 0),
+                "spearman_ic": factor.get("spearman_ic"),
+                "pearson_ic": factor.get("pearson_ic"),
+                "icir": factor.get("icir"),
+                "positive_window_ratio": factor.get("positive_window_ratio"),
+                "symbol_positive_ratio": factor.get("symbol_positive_ratio"),
+                "qualified": bool(item.get("qualified")),
+                "blockers": item.get("blockers") or [],
+            }
+        )
+    if not candidates:
+        return None
+
+    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float]:
+        return (
+            1.0 if item["qualified"] else 0.0,
+            1.0 if item["decision"] == "candidate" else 0.0,
+            float(item.get("positive_window_ratio") or 0.0),
+            float(item.get("symbol_positive_ratio") or 0.0),
+            float(item.get("spearman_ic") or 0.0),
+        )
+
+    return max(candidates, key=score)
+
+
+def write_markdown(summary: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# Factor Walk-Forward Sweep",
+        "",
+        f"- Variants: `{len(summary['variants'])}`",
+        f"- Total elapsed seconds: `{summary['total_elapsed_seconds']:.2f}`",
+        f"- Best variant: `{summary.get('best_variant') or '<none>'}`",
+        "",
+        "| variant | status | decision | qualified | elapsed_s | best factor | best blockers |",
+        "| --- | --- | --- | ---: | ---: | --- | --- |",
+    ]
+    for item in summary["variants"]:
+        best = item.get("best_factor") or {}
+        lines.append(
+            "| {variant} | {status} | {decision} | {qualified} | {elapsed:.2f} | {factor} | {blockers} |".format(
+                variant=item["label"],
+                status=item["status"],
+                decision=item.get("decision") or "",
+                qualified=item.get("qualified_count", 0),
+                elapsed=item.get("elapsed_seconds", 0.0),
+                factor=best.get("name", ""),
+                blockers=", ".join(best.get("blockers") or []),
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def promote_best_variant(best: dict[str, Any] | None, output_dir: Path) -> None:
+    if not best:
+        return
+    source = Path(best["path"])
+    for name in [
+        "report.txt",
+        "autofactor-strategy-promotion.json",
+        "autofactor-strategy-promotion.md",
+        "autofactor-factor-registry.json",
+        "autofactor-strategy-handoff.json",
+        "autofactor-strategy-handoff.md",
+        "evaluator-output.json",
+    ]:
+        src = source / name
+        if src.exists():
+            shutil.copy2(src, output_dir / name)
+    (output_dir / "source.txt").write_text(
+        f"canonical_result=snapshot_artifact_sweep\nbest_variant={best['label']}\n",
+        encoding="utf-8",
+    )
+
+
+def run_variant(
+    args: argparse.Namespace,
+    variant: Variant,
+    index: int,
+    replay_parity_json: str,
+    allowed_targets: set[str],
+) -> dict[str, Any]:
+    variant_dir = Path(args.output_dir) / f"{index:03d}-{variant.label}"
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    (variant_dir / "variant.json").write_text(
+        json.dumps({"label": variant.label, "values": variant.values}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    report_path = variant_dir / "report.txt"
+    command = factor_args(args, variant, replay_parity_json)
+    started = time.monotonic()
+    with report_path.open("w", encoding="utf-8") as report:
+        result = subprocess.run(
+            command,
+            cwd=args.cwd,
+            stdout=report,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    elapsed = time.monotonic() - started
+    item: dict[str, Any] = {
+        "label": variant.label,
+        "path": str(variant_dir),
+        "status": "failed" if result.returncode else "completed",
+        "exit_code": result.returncode,
+        "elapsed_seconds": elapsed,
+        "variant": variant.values,
+    }
+    if result.returncode:
+        return item
+
+    eval_result = subprocess.run(
+        promotion_args(args, report_path, variant_dir),
+        cwd=args.cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    (variant_dir / "evaluator-output.json").write_text(eval_result.stdout, encoding="utf-8")
+    if eval_result.stderr:
+        (variant_dir / "evaluator-stderr.txt").write_text(eval_result.stderr, encoding="utf-8")
+    item["evaluator_exit_code"] = eval_result.returncode
+    if eval_result.returncode not in {0, 3}:
+        item["status"] = "evaluation_failed"
+        return item
+    promotion = json.loads((variant_dir / "autofactor-strategy-promotion.json").read_text(encoding="utf-8"))
+    item["decision"] = promotion.get("decision")
+    item["qualified_count"] = len(promotion.get("qualified_strategies") or [])
+    item["promotion_gate_ready"] = bool((promotion.get("promotion_gate") or {}).get("ready"))
+    item["best_factor"] = best_factor(promotion, allowed_targets)
+    return item
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--evaluator", default="scripts/evaluate_autofactor_strategy_promotion.py")
+    parser.add_argument("--snapshot-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--symbols", required=True)
+    parser.add_argument("--start-ts", required=True)
+    parser.add_argument("--end-ts", required=True)
+    parser.add_argument("--stake-usd", required=True)
+    parser.add_argument("--replay-parity-json", default="")
+    parser.add_argument("--required-strategy-profile", default="settlement_probability")
+    parser.add_argument("--allowed-target", action="append", default=[])
+    parser.add_argument("--sweep-json", default="")
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("--fail-if-all-failed", action="store_true")
+    parser.add_argument("--fail-if-blocked", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    for key in sorted(SWEEP_KEYS - {"label"}):
+        parser.add_argument(f"--{key.replace('_', '-')}", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base = {key: getattr(args, key) for key in sorted(SWEEP_KEYS - {"label"})}
+    variants = load_sweep(args.sweep_json, base)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    allowed_targets = set(args.allowed_target or ["full_depth_settlement_executable_pnl"])
+
+    if args.dry_run:
+        summary = {
+            "schema_version": "factor_walk_forward_sweep_v1",
+            "dry_run": True,
+            "variants": [{"label": variant.label, "variant": variant.values} for variant in variants],
+        }
+        (output_dir / "sweep-summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        return 0
+
+    started = time.monotonic()
+    variant_summaries = [
+        run_variant(args, variant, index, args.replay_parity_json, allowed_targets)
+        for index, variant in enumerate(variants, start=1)
+    ]
+    completed = [item for item in variant_summaries if item["status"] == "completed"]
+    best = None
+    if completed:
+        best = max(
+            completed,
+            key=lambda item: (
+                item.get("qualified_count", 0),
+                float((item.get("best_factor") or {}).get("positive_window_ratio") or 0.0),
+                float((item.get("best_factor") or {}).get("spearman_ic") or 0.0),
+            ),
+        )
+    summary = {
+        "schema_version": "factor_walk_forward_sweep_v1",
+        "total_elapsed_seconds": time.monotonic() - started,
+        "variant_count": len(variants),
+        "completed_count": len(completed),
+        "best_variant": best["label"] if best else None,
+        "variants": variant_summaries,
+    }
+    (output_dir / "sweep-summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    write_markdown(summary, output_dir / "sweep-summary.md")
+    promote_best_variant(best, output_dir)
+    if args.fail_if_all_failed and not completed:
+        return 2
+    if args.fail_if_blocked and (not best or best.get("decision") != "qualified"):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13741,3 +13741,47 @@ loops without hard-coded date windows or unnecessary snapshot re-export.
   `CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_snapshot --lib`,
   `CARGO_TARGET_DIR=/tmp/ploy-window-auto /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2 --example factor_review_v2`,
   and `git diff --check`.
+
+# Factor Search Loop Efficiency (2026-05-11)
+
+## Goal
+
+Reduce factor-search loop overhead by running multiple hosted artifact
+walk-forward variants after a single snapshot download and Rust build.
+
+## Files / Ownership
+
+- `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml`
+  - Owner: accept optional `sweep_json` and route the prepared artifact/binary
+    through the sweep runner.
+- `scripts/run_factor_walk_forward_sweep.py`
+  - Owner: execute variants, evaluate each AutoFactor promotion artifact, choose
+    the best selected variant, and write sweep summary artifacts.
+- `tests/test_factor_walk_forward_sweep.py`
+  - Owner: prove sweep parsing and multi-variant execution without requiring
+    live data or a Rust binary.
+
+## Tasks
+
+- [x] Identify repeated per-candidate overhead in the current hosted artifact
+  path: GitHub job startup, artifact download, cargo build, and single-config
+  evaluation.
+- [x] Add a sweep runner that loops variants inside one prepared job.
+- [x] Preserve backward compatibility: empty `sweep_json` still runs one base
+  variant and promotes root `report.txt` / handoff files for downstream steps.
+- [x] Add tests for dry-run expansion and two-variant execution.
+
+## Review
+
+- 2026-05-11: The workflow now has an optional `sweep_json` input. A single run
+  can test multiple overrides such as `factor_name_filter`, `top_quantile`,
+  `min_observations`, or walk-window sizes after one artifact download/build.
+  The sweep runner writes per-variant reports under numbered directories,
+  `sweep-summary.json`, `sweep-summary.md`, and copies the selected best
+  variant back to the root artifact path so existing promotion/config-PR steps
+  keep working.
+- 2026-05-11: Local verification passed:
+  `python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion`,
+  `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py`,
+  `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`,
+  and `git diff --check`.

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -1,0 +1,146 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run_factor_walk_forward_sweep.py"
+
+
+FAKE_REPORT = r'''
+print("""=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+recorded_replay_parity,true,blocking_flags=<none>
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,2.666226,0.6836,1
+""")
+'''
+
+
+class FactorWalkForwardSweepTests(unittest.TestCase):
+    def base_args(self, tmp: Path, binary: Path) -> list[str]:
+        return [
+            sys.executable,
+            str(SCRIPT),
+            "--binary",
+            str(binary),
+            "--snapshot-dir",
+            str(tmp / "snapshot"),
+            "--output-dir",
+            str(tmp / "out"),
+            "--symbols",
+            "BTCUSDT,ETHUSDT",
+            "--start-ts",
+            "2026-04-24T00:00:00Z",
+            "--end-ts",
+            "2026-05-01T00:00:00Z",
+            "--stake-usd",
+            "15",
+            "--train-window-days",
+            "2",
+            "--test-window-days",
+            "1",
+            "--step-days",
+            "1",
+            "--lob-sample-secs",
+            "30",
+            "--observation-sample-secs",
+            "30",
+            "--max-quote-age-secs",
+            "30",
+            "--top-n",
+            "20",
+            "--min-observations",
+            "20",
+            "--top-quantile",
+            "0.2",
+            "--factor-name-filter",
+            "",
+            "--report-suite",
+            "core",
+            "--data-quality-mode",
+            "event_complete",
+            "--min-event-complete-events",
+            "20",
+            "--min-event-complete-rows",
+            "40",
+            "--cwd",
+            str(ROOT),
+        ]
+
+    def fake_binary(self, tmp: Path) -> Path:
+        binary = tmp / "fake_factor_walk_forward.py"
+        binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            f"{FAKE_REPORT}\n",
+            encoding="utf-8",
+        )
+        binary.chmod(0o755)
+        return binary
+
+    def test_dry_run_expands_sweep_variants(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = self.fake_binary(tmp)
+            sweep_json = json.dumps(
+                [
+                    {"label": "settlement", "factor_name_filter": "auto_settlement"},
+                    {"label": "quantile-10", "top_quantile": 0.1},
+                ]
+            )
+            subprocess.run(
+                [*self.base_args(tmp, binary), "--sweep-json", sweep_json, "--dry-run"],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+
+        self.assertTrue(summary["dry_run"])
+        self.assertEqual([item["label"] for item in summary["variants"]], ["settlement", "quantile-10"])
+        self.assertEqual(summary["variants"][0]["variant"]["factor_name_filter"], "auto_settlement")
+        self.assertEqual(summary["variants"][1]["variant"]["top_quantile"], "0.1")
+
+    def test_runs_variants_once_artifacts_are_prepared(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = self.fake_binary(tmp)
+            sweep_json = json.dumps(
+                [
+                    {"label": "base"},
+                    {"label": "settlement-only", "factor_name_filter": "auto_settlement"},
+                ]
+            )
+            result = subprocess.run(
+                [*self.base_args(tmp, binary), "--sweep-json", sweep_json],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+            summary_md = (tmp / "out" / "sweep-summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(summary["variant_count"], 2)
+        self.assertEqual(summary["completed_count"], 2)
+        self.assertEqual(summary["variants"][0]["decision"], "qualified")
+        self.assertEqual(summary["variants"][0]["qualified_count"], 1)
+        self.assertIn("auto_settlement_conservative_settlement_edge", summary_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `sweep_json` to hosted factor walk-forward so one workflow run can test multiple option variants after one snapshot download/build
- add `scripts/run_factor_walk_forward_sweep.py` to run variants, evaluate promotion outputs, choose the best variant, and keep root artifacts compatible with existing handoff/config PR steps
- add unit coverage for dry-run expansion and multi-variant execution
- record the efficiency plan and verification in `tasks/todo.md`

## Validation
- python3 -m unittest discover tests
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'\n- git diff --check\n\n## Efficiency impact\nThis removes repeated GitHub job startup, artifact download, and Rust build from candidate-factor loops. The remaining per-variant cost is the actual `factor_walk_forward_v2` run plus promotion evaluation.