### PR TITLE
Forward empty factor filter to sweep runner

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -306,6 +306,7 @@ jobs:
             --min-observations "${WALK_MIN_OBSERVATIONS}"
             --top-quantile "${WALK_TOP_QUANTILE}"
             --top-n "${WALK_TOP_N}"
+            --factor-name-filter "${WALK_FACTOR_NAME_FILTER}"
             --report-suite "${WALK_REPORT_SUITE}"
             --data-quality-mode "${WALK_DATA_QUALITY_MODE}"
             --min-event-complete-events "${WALK_MIN_EVENT_COMPLETE_EVENTS}"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13785,3 +13785,8 @@ walk-forward variants after a single snapshot download and Rust build.
   `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py`,
   `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`,
   and `git diff --check`.
+- 2026-05-11: Post-merge smoke run `25667022672` exposed a workflow wiring
+  gap: the sweep runner requires `--factor-name-filter` even when the value is
+  empty, but the workflow did not forward `${WALK_FACTOR_NAME_FILTER}`. Added
+  the missing argument and a workflow contract assertion so the empty-filter
+  base variant remains valid.

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "run_factor_walk_forward_sweep.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "factor-walk-forward-v2-hosted-artifact.yml"
 
 
 FAKE_REPORT = r'''
@@ -140,6 +141,12 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(summary["variants"][0]["decision"], "qualified")
         self.assertEqual(summary["variants"][0]["qualified_count"], 1)
         self.assertIn("auto_settlement_conservative_settlement_edge", summary_md)
+
+    def test_hosted_workflow_passes_empty_factor_filter_to_sweep_runner(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("--sweep-json \"${SWEEP_JSON}\"", workflow)
+        self.assertIn("--factor-name-filter \"${WALK_FACTOR_NAME_FILTER}\"", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- pass `WALK_FACTOR_NAME_FILTER` into the hosted factor sweep runner even when it is empty
- add a workflow contract test for the sweep runner argument wiring
- record the failed post-merge smoke and fix in `tasks/todo.md`

## Validation
- python3 -m unittest tests.test_factor_walk_forward_sweep
- python3 -m unittest discover tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'\n- git diff --check