### PR TITLE
Fix replay event evidence enrichment

### DIFF
--- a/scripts/enrich_replay_runtime_evidence.py
+++ b/scripts/enrich_replay_runtime_evidence.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
+
+
+ENTRY_INTENT_RE = re.compile(r"^tl_[a-z0-9]+_(up|down)_([^_]+)_(\d+)$", re.IGNORECASE)
+SETTLEMENT_INTENT_RE = re.compile(r"^tl_settle_([^_]+)_(up|down)$", re.IGNORECASE)
 
 
 def load_settlement_prices(path: Path) -> dict[tuple[str, str], str]:
@@ -35,10 +41,140 @@ def is_open_settlement(value: Any) -> bool:
     return str(value).strip().lower() in {"", "open"}
 
 
+def infer_from_intent_id(intent_id: Any) -> tuple[str | None, str | None, str | None]:
+    if intent_id is None:
+        return None, None, None
+    text = str(intent_id)
+    if match := ENTRY_INTENT_RE.match(text):
+        market_side, event_id, millis = match.groups()
+        return event_id, market_side.upper(), millis
+    if match := SETTLEMENT_INTENT_RE.match(text):
+        event_id, market_side = match.groups()
+        return event_id, market_side.upper(), None
+    return None, None, None
+
+
+def iso_from_millis(millis: str | None) -> str | None:
+    if millis is None:
+        return None
+    try:
+        value = int(millis)
+    except ValueError:
+        return None
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(value / 1000, timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def runtime_rows_by_intent(payload: dict[str, Any], row_name: str) -> dict[str, dict[str, Any]]:
+    runtime = payload.get("runtime_evidence") or {}
+    rows = runtime.get(row_name) or []
+    if not isinstance(rows, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        intent_id = row.get("intent_id")
+        if intent_id is not None:
+            indexed[str(intent_id)] = row
+    return indexed
+
+
+def event_cashflow_by_event_token(payload: dict[str, Any]) -> dict[tuple[str, str], str]:
+    totals: dict[tuple[str, str], Decimal] = {}
+    runtime = payload.get("runtime_evidence") or {}
+    fills = runtime.get("fills") or []
+    if not isinstance(fills, list):
+        return {}
+    for fill in fills:
+        if not isinstance(fill, dict):
+            continue
+        intent_id = fill.get("intent_id")
+        event_id = fill.get("event_id") or fill.get("market_id")
+        if event_id is None:
+            event_id, _, _ = infer_from_intent_id(intent_id)
+        token_id = fill.get("token_id")
+        if event_id is None or token_id is None:
+            continue
+        try:
+            quantity = Decimal(str(fill.get("quantity", "0")))
+            price = Decimal(str(fill.get("price", "0")))
+            fee = Decimal(str(fill.get("fee", "0")))
+        except InvalidOperation:
+            continue
+        side = str(fill.get("fill_side") or fill.get("side") or "").upper()
+        signed = quantity * price
+        if side == "BUY":
+            signed = -signed
+        elif side != "SELL":
+            continue
+        key = (str(event_id), str(token_id))
+        totals[key] = totals.get(key, Decimal("0")) + signed - fee
+    return {key: format(value.normalize(), "f") for key, value in totals.items()}
+
+
+def backfill_replay_event_identity(payload: dict[str, Any]) -> int:
+    runtime = payload.get("runtime_evidence") or {}
+    events = runtime.get("events") or []
+    if not isinstance(events, list):
+        return 0
+    fills_by_intent = runtime_rows_by_intent(payload, "fills")
+    orders_by_intent = runtime_rows_by_intent(payload, "orders")
+    cashflow_by_event_token = event_cashflow_by_event_token(payload)
+    changed = 0
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        intent_id = event.get("intent_id")
+        fill = fills_by_intent.get(str(intent_id)) if intent_id is not None else None
+        order = orders_by_intent.get(str(intent_id)) if intent_id is not None else None
+        inferred_event_id, inferred_market_side, inferred_millis = infer_from_intent_id(intent_id)
+
+        event_id = event.get("event_id") or event.get("market_id") or inferred_event_id
+        if event.get("event_id") in (None, "") and event_id is not None:
+            event["event_id"] = str(event_id)
+            changed += 1
+        if event.get("market_id") in (None, "") and event_id is not None:
+            event["market_id"] = str(event_id)
+            changed += 1
+        if event.get("market_side") in (None, "") and inferred_market_side is not None:
+            event["market_side"] = inferred_market_side
+            changed += 1
+
+        side = event.get("side")
+        fill_side = (fill or {}).get("fill_side") or (order or {}).get("order_side")
+        if (side is None or str(side).upper() == "UNKNOWN") and fill_side is not None:
+            event["side"] = str(fill_side).upper()
+            changed += 1
+
+        if event.get("decision_ts") in (None, ""):
+            decision_ts = (order or {}).get("created_at") or (fill or {}).get("fill_timestamp") or iso_from_millis(
+                inferred_millis
+            )
+            if decision_ts is not None:
+                event["decision_ts"] = decision_ts
+                changed += 1
+
+        token_id = event.get("token_id")
+        if event_id is not None and token_id is not None and str(event.get("side", "")).upper() == "BUY":
+            total_pnl = cashflow_by_event_token.get((str(event_id), str(token_id)))
+            if total_pnl is not None:
+                event["pnl"] = total_pnl
+                changed += 1
+
+    return changed
+
+
 def enrich_payload(payload: dict[str, Any], prices: dict[tuple[str, str], str]) -> dict[str, int]:
+    backfilled = backfill_replay_event_identity(payload)
     events = ((payload.get("runtime_evidence") or {}).get("events") or [])
     stats = {
         "runtime_events": 0,
+        "runtime_events_identity_backfilled": backfilled,
         "runtime_events_open": 0,
         "runtime_events_settlement_enriched": 0,
         "settlement_price_count": len(prices),
@@ -52,6 +188,8 @@ def enrich_payload(payload: dict[str, Any], prices: dict[tuple[str, str], str]) 
         if not is_open_settlement(event.get("settlement")):
             continue
         stats["runtime_events_open"] += 1
+        if str(event.get("side") or "").upper() == "SELL":
+            continue
         event_id = event.get("event_id") or event.get("market_id")
         token_id = event.get("token_id")
         if event_id is None or token_id is None:

--- a/tests/test_enrich_replay_runtime_evidence.py
+++ b/tests/test_enrich_replay_runtime_evidence.py
@@ -92,6 +92,82 @@ class EnrichReplayRuntimeEvidenceTests(unittest.TestCase):
         self.assertEqual(output["runtime_evidence"]["events"][1]["settlement"], "open")
         self.assertEqual(report["runtime_events_settlement_enriched"], 0)
 
+    def test_backfills_replay_event_identity_from_intent_and_fills(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "token_id": "token-up",
+                        "decision_ts": None,
+                        "event_id": None,
+                        "market_id": None,
+                        "side": "UNKNOWN",
+                        "settlement": "open",
+                        "pnl": "-15.1080000000",
+                    },
+                    {
+                        "intent_id": "tl_settle_2221812_up",
+                        "token_id": "token-up",
+                        "decision_ts": None,
+                        "event_id": None,
+                        "market_id": None,
+                        "side": "UNKNOWN",
+                        "settlement": "open",
+                        "pnl": "23.4375",
+                    },
+                ],
+                "orders": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "created_at": None,
+                    },
+                    {
+                        "intent_id": "tl_settle_2221812_up",
+                        "created_at": None,
+                    },
+                ],
+                "fills": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "token_id": "token-up",
+                        "fill_side": "BUY",
+                        "quantity": "23.4375",
+                        "price": "0.64",
+                        "fee": "0.1080000000",
+                        "fill_timestamp": "2026-05-11T11:48:12.316Z",
+                    },
+                    {
+                        "intent_id": "tl_settle_2221812_up",
+                        "token_id": "token-up",
+                        "fill_side": "SELL",
+                        "quantity": "23.4375",
+                        "price": "1",
+                        "fee": "0",
+                        "fill_timestamp": "2026-05-11T11:50:00Z",
+                    },
+                ],
+            }
+        }
+        output, report = self.run_script(
+            payload,
+            [{"event_id": "2221812", "token_id": "token-up", "settlement": "1.00000000000000000000"}],
+        )
+
+        entry, settlement = output["runtime_evidence"]["events"]
+        self.assertEqual(entry["event_id"], "2221812")
+        self.assertEqual(entry["market_id"], "2221812")
+        self.assertEqual(entry["market_side"], "UP")
+        self.assertEqual(entry["side"], "BUY")
+        self.assertEqual(entry["decision_ts"], "2026-05-11T11:48:12.316Z")
+        self.assertEqual(entry["settlement"], "1.00000000000000000000")
+        self.assertEqual(entry["pnl"], "8.3295")
+        self.assertEqual(settlement["side"], "SELL")
+        self.assertEqual(settlement["decision_ts"], "2026-05-11T11:50:00Z")
+        self.assertEqual(settlement["settlement"], "open")
+        self.assertEqual(report["runtime_events_settlement_enriched"], 1)
+        self.assertGreaterEqual(report["runtime_events_identity_backfilled"], 8)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- backfill replay event evidence identity from PM5D intent ids and matching fill/order rows
- enrich entry event settlement while preserving settlement-order rows as open for dry-run parity
- add regression coverage for settlement-probability replay event evidence

## Verification
- python3 -m unittest tests.test_enrich_replay_runtime_evidence tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/enrich_replay_runtime_evidence.py tests/test_enrich_replay_runtime_evidence.py
- git diff --check
- Replayed artifact from run 25668326806 locally: runtime events/orders/fills strict parity ready, decision=continue, blocking_risk_flags=[]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backfilling of missing replay event identity fields (event identifiers, market side, decision timestamps, and profit/loss) with intelligent inference from available data sources.
  * Enhanced derived field computation for improved event enrichment accuracy.

* **Bug Fixes**
  * Improved settlement enrichment logic to correctly handle sell-side events.

* **Tests**
  * Added test coverage for replay event identity backfilling functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/413)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->