### PR TITLE
Use dry-run settlement evidence for replay parity

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -95,6 +95,8 @@ jobs:
             tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
           scp scripts/enrich_replay_runtime_evidence.py \
             tango-1-1:"${REMOTE_DIR}/enrich_replay_runtime_evidence.py"
+          scp scripts/extract_dryrun_settlement_evidence.py \
+            tango-1-1:"${REMOTE_DIR}/extract_dryrun_settlement_evidence.py"
 
           # shellcheck disable=SC2029
           ssh tango-1-1 /bin/bash -s -- \
@@ -118,14 +120,18 @@ jobs:
           test -r "${recording_path}"
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
           test -r "${remote_dir}/enrich_replay_runtime_evidence.py"
+          test -r "${remote_dir}/extract_dryrun_settlement_evidence.py"
 
           set -a
           . /opt/ploy/.env
           set +a
 
           settlements_json="${remote_dir}/official-settlements.json"
+          dryrun_report="${remote_dir}/dryrun-report.json"
           enriched_recording="${remote_dir}/recording-official-settlement.ndjson"
           enrichment_report="${remote_dir}/recording-enrichment.json"
+          curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
+            -o "${dryrun_report}"
           if [ -n "${PLOY_DATABASE__URL:-}" ]; then
             PSQL=(psql "${PLOY_DATABASE__URL}" -v ON_ERROR_STOP=1 -t -A)
           else
@@ -184,6 +190,13 @@ jobs:
           FROM unambiguous;
           SQL
 
+          python3 "${remote_dir}/extract_dryrun_settlement_evidence.py" \
+            --dryrun-json "${dryrun_report}" \
+            --output-json "${settlements_json}" \
+            --deployment-id "${deployment_id}" \
+            --since "${since_ts}" \
+            --until "${until_ts}"
+
           python3 "${remote_dir}/enrich_recording_official_settlement.py" \
             --input "${recording_path}" \
             --output "${enriched_recording}" \
@@ -226,9 +239,6 @@ jobs:
             --output-json "${remote_dir}/replay-evaluation.json" \
             --settlements-json "${settlements_json}" \
             --report-json "${remote_dir}/replay-evidence-enrichment.json"
-
-          curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
-            -o "${remote_dir}/dryrun-report.json"
 
           test -s "${remote_dir}/replay-evaluation.json"
           test -s "${remote_dir}/dryrun-report.json"

--- a/scripts/extract_dryrun_settlement_evidence.py
+++ b/scripts/extract_dryrun_settlement_evidence.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Extract replay settlement evidence from the dry-run report being compared."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+ENTRY_INTENT_RE = re.compile(r"^tl_[a-z0-9]+_(up|down)_([^_]+)_(\d+)$", re.IGNORECASE)
+SETTLEMENT_INTENT_RE = re.compile(r"^tl_settle_([^_]+)_(up|down)$", re.IGNORECASE)
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def infer_market_side(intent_id: Any) -> str | None:
+    if intent_id is None:
+        return None
+    text = str(intent_id)
+    if match := ENTRY_INTENT_RE.match(text):
+        return match.group(1).upper()
+    if match := SETTLEMENT_INTENT_RE.match(text):
+        return match.group(2).upper()
+    return None
+
+
+def is_open(value: Any) -> bool:
+    if value is None:
+        return True
+    return str(value).strip().lower() in {"", "open"}
+
+
+def resolved_up_won(market_side: str, settlement: Any) -> bool | None:
+    try:
+        price = Decimal(str(settlement))
+    except InvalidOperation:
+        return None
+    side = market_side.upper()
+    if side == "UP" and price >= Decimal("0.99"):
+        return True
+    if side == "UP" and price <= Decimal("0.01"):
+        return False
+    if side == "DOWN" and price >= Decimal("0.99"):
+        return False
+    if side == "DOWN" and price <= Decimal("0.01"):
+        return True
+    return None
+
+
+def iter_runtime_events(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    rows = ((payload.get("runtime_evidence") or {}).get("events") or [])
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def extract_settlements(
+    payload: Any,
+    *,
+    deployment_id: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> list[dict[str, Any]]:
+    settlements: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in iter_runtime_events(payload):
+        if deployment_id and row.get("deployment_id") != deployment_id:
+            continue
+        ts = parse_ts(str(row.get("decision_ts"))) if row.get("decision_ts") is not None else None
+        if since and (ts is None or ts < since):
+            continue
+        if until and (ts is None or ts > until):
+            continue
+        if str(row.get("side") or "").upper() == "SELL":
+            continue
+        event_id = row.get("event_id") or row.get("market_id")
+        token_id = row.get("token_id")
+        settlement = row.get("settlement")
+        if event_id is None or token_id is None or is_open(settlement):
+            continue
+        market_side = row.get("market_side") or infer_market_side(row.get("intent_id"))
+        if market_side is None:
+            continue
+        resolved = resolved_up_won(str(market_side), settlement)
+        if resolved is None:
+            continue
+        key = (str(event_id), str(token_id))
+        settlements[key] = {
+            "event_id": str(event_id),
+            "token_id": str(token_id),
+            "settlement": str(settlement),
+            "resolved_up_won": resolved,
+        }
+    return sorted(settlements.values(), key=lambda item: (item["event_id"], item["token_id"]))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dryrun-json", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--deployment-id", default="")
+    parser.add_argument("--since", default="")
+    parser.add_argument("--until", default="")
+    args = parser.parse_args()
+
+    with Path(args.dryrun_json).open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    settlements = extract_settlements(
+        payload,
+        deployment_id=args.deployment_id or None,
+        since=parse_ts(args.since),
+        until=parse_ts(args.until),
+    )
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(settlements, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(json.dumps({"settlement_event_count": len(settlements)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_dryrun_settlement_evidence.py
+++ b/tests/test_extract_dryrun_settlement_evidence.py
@@ -1,0 +1,127 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "extract_dryrun_settlement_evidence.py"
+
+
+class ExtractDryrunSettlementEvidenceTests(unittest.TestCase):
+    def run_script(self, payload, extra_args=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "dryrun.json"
+            output_path = tmp_path / "settlements.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+            args = [
+                sys.executable,
+                str(SCRIPT),
+                "--dryrun-json",
+                str(input_path),
+                "--output-json",
+                str(output_path),
+            ]
+            if extra_args:
+                args.extend(extra_args)
+            subprocess.run(args, cwd=ROOT, check=True, capture_output=True, text=True)
+            return json.loads(output_path.read_text(encoding="utf-8"))
+
+    def test_extracts_buy_event_settlement_for_replay_enrichment(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {
+                        "deployment_id": "pm5d.threelayer.test",
+                        "decision_ts": "2026-05-11T19:48:12.316+08:00",
+                        "event_id": "2221812",
+                        "token_id": "token-up",
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "market_side": "UP",
+                        "side": "BUY",
+                        "settlement": "1.00000000000000000000",
+                    },
+                    {
+                        "deployment_id": "pm5d.threelayer.test",
+                        "decision_ts": "2026-05-11T19:50:00+08:00",
+                        "event_id": "2221812",
+                        "token_id": "token-up",
+                        "intent_id": "tl_settle_2221812_up",
+                        "market_side": "UP",
+                        "side": "SELL",
+                        "settlement": "open",
+                    },
+                ]
+            }
+        }
+
+        settlements = self.run_script(
+            payload,
+            [
+                "--deployment-id",
+                "pm5d.threelayer.test",
+                "--since",
+                "2026-05-11T19:47:00+08:00",
+                "--until",
+                "2026-05-11T19:50:30+08:00",
+            ],
+        )
+
+        self.assertEqual(
+            settlements,
+            [
+                {
+                    "event_id": "2221812",
+                    "token_id": "token-up",
+                    "settlement": "1.00000000000000000000",
+                    "resolved_up_won": True,
+                }
+            ],
+        )
+
+    def test_filters_outside_window_and_open_rows(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {
+                        "deployment_id": "pm5d.threelayer.test",
+                        "decision_ts": "2026-05-11T19:46:59+08:00",
+                        "event_id": "before",
+                        "token_id": "token",
+                        "market_side": "UP",
+                        "side": "BUY",
+                        "settlement": "1",
+                    },
+                    {
+                        "deployment_id": "pm5d.threelayer.test",
+                        "decision_ts": "2026-05-11T19:48:00+08:00",
+                        "event_id": "open",
+                        "token_id": "token",
+                        "market_side": "UP",
+                        "side": "BUY",
+                        "settlement": "open",
+                    },
+                ]
+            }
+        }
+
+        settlements = self.run_script(
+            payload,
+            [
+                "--deployment-id",
+                "pm5d.threelayer.test",
+                "--since",
+                "2026-05-11T19:47:00+08:00",
+                "--until",
+                "2026-05-11T19:50:30+08:00",
+            ],
+        )
+
+        self.assertEqual(settlements, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch the dry-run report before recorded replay parity replays the recording
- extract settlement evidence from the same dry-run report/window being compared
- use that report-derived settlement evidence for recording/replay enrichment so parity does not drift against a separate DB view

## Verification
- python3 -m unittest tests.test_extract_dryrun_settlement_evidence tests.test_enrich_replay_runtime_evidence tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/extract_dryrun_settlement_evidence.py scripts/enrich_replay_runtime_evidence.py tests/test_extract_dryrun_settlement_evidence.py tests/test_enrich_replay_runtime_evidence.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/recorded-replay-parity.yml"); puts "ok"'\n- git diff --check