### PR TITLE
Fix settlement parity diagnostics and crypto token semantics

### DIFF
--- a/crates/ploy-market-data/src/discovery/crypto.rs
+++ b/crates/ploy-market-data/src/discovery/crypto.rs
@@ -75,8 +75,7 @@ async fn normalize_crypto_market(
     if !matches!(market_window_secs, Some(300 | 900)) {
         return None;
     }
-    let up_token = token_ids[0].to_string();
-    let down_token = token_ids[1].to_string();
+    let (up_token, down_token) = semantic_up_down_tokens(market, token_ids)?;
     let reference_symbol = market_symbol_to_chainlink_symbol(strategy_symbol);
 
     let price_to_beat = latest_reference_price(
@@ -129,6 +128,35 @@ async fn normalize_crypto_market(
         raw_event: event.and_then(event_to_value),
         raw_market: serde_json::to_value(market).ok()?,
     })
+}
+
+fn semantic_up_down_tokens<T: ToString>(
+    market: &Market,
+    token_ids: &[T],
+) -> Option<(String, String)> {
+    if token_ids.len() != 2 {
+        return None;
+    }
+
+    if let Some(outcomes) = market.outcomes.as_ref() {
+        if outcomes.len() == token_ids.len() {
+            let mut up_token = None;
+            let mut down_token = None;
+            for (outcome, token_id) in outcomes.iter().zip(token_ids.iter()) {
+                let outcome = outcome.to_ascii_lowercase();
+                if outcome.contains("up") || outcome.contains("yes") {
+                    up_token = Some(token_id.to_string());
+                } else if outcome.contains("down") || outcome.contains("no") {
+                    down_token = Some(token_id.to_string());
+                }
+            }
+            if let (Some(up), Some(down)) = (up_token, down_token) {
+                return Some((up, down));
+            }
+        }
+    }
+
+    Some((token_ids[0].to_string(), token_ids[1].to_string()))
 }
 
 fn crypto_market_start_time(market: &Market, event: Option<&Event>) -> Option<DateTime<Utc>> {
@@ -307,6 +335,44 @@ mod tests {
         .await;
 
         assert_eq!(discovered.len(), 1, "15-minute markets should be kept");
+    }
+
+    #[tokio::test]
+    async fn maps_crypto_tokens_by_outcome_semantics_not_array_order() {
+        let registry = new_reference_price_registry();
+
+        let market: polymarket_client_sdk::gamma::types::response::Market =
+            serde_json::from_value(json!({
+                "id": "market-reversed",
+                "question": "Will Bitcoin be up or down in 5 minutes?",
+                "slug": "bitcoin-up-or-down-apr-6-0000",
+                "endDate": "2026-04-06T00:05:00Z",
+                "startDate": "2026-04-06T00:00:00Z",
+                "groupItemThreshold": "0",
+                "outcomes": "[\"Down\",\"Up\"]",
+                "clobTokenIds": "[\"111\",\"222\"]",
+                "active": true,
+                "acceptingOrders": true,
+                "events": [{
+                    "id": "event-reversed",
+                    "slug": "bitcoin-up-or-down-apr-6-0000",
+                    "title": "Bitcoin Up Or Down",
+                    "startDate": "2026-04-06T00:00:00Z"
+                }]
+            }))
+            .unwrap();
+
+        let discovered = discover_crypto_markets(
+            &[market],
+            &["BTCUSDT".to_string()],
+            &registry,
+            Utc.with_ymd_and_hms(2026, 4, 6, 0, 0, 30).unwrap(),
+        )
+        .await;
+
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].up_token, "222");
+        assert_eq!(discovered[0].down_token, "111");
     }
 
     #[tokio::test]

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -566,6 +566,19 @@ def values_match(field: str, left: Any, right: Any) -> bool:
     return left == right
 
 
+def runtime_row_summary(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "deployment_id": row.get("deployment_id"),
+        "intent_id": row.get("intent_id"),
+        "event_id": row.get("event_id"),
+        "token_id": row.get("token_id"),
+        "market_side": row.get("market_side"),
+        "order_side": row.get("order_side"),
+        "fill_side": row.get("fill_side"),
+        "purpose": row.get("purpose"),
+    }
+
+
 def compare_normalized_rows(
     replay_rows: list[dict[str, Any]],
     dryrun_rows: list[dict[str, Any]],
@@ -597,6 +610,8 @@ def compare_normalized_rows(
                         "field": field,
                         "replay": replay_value,
                         "dryrun": dryrun_value,
+                        "replay_row": runtime_row_summary(replay),
+                        "dryrun_row": runtime_row_summary(dryrun),
                     }
                 )
 
@@ -616,6 +631,36 @@ def compare_normalized_rows(
         and not (set(dryrun_index) - set(replay_index))
         and not (set(replay_index) - set(dryrun_index)),
     }
+
+
+def is_settlement_exit_row(row: dict[str, Any] | None) -> bool:
+    if not row:
+        return False
+    intent_id = str(row.get("intent_id") or "").lower()
+    purpose = str(row.get("purpose") or "").upper()
+    order_side = str(row.get("order_side") or "").upper()
+    fill_side = str(row.get("fill_side") or "").upper()
+    is_sell_exit = order_side == "SELL" or fill_side == "SELL"
+    return (
+        intent_id.startswith("tl_settle_")
+        or purpose in {"SETTLEMENT", "SETTLEMENT_EXIT"}
+        or ("SETTLE" in intent_id and purpose in {"CLOSE", "EXIT"} and is_sell_exit)
+    )
+
+
+def settlement_exit_price_mismatches(mismatches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    price_fields = {"limit_price", "price", "avg_fill_price"}
+    settlement_mismatches: list[dict[str, Any]] = []
+    for mismatch in mismatches:
+        if mismatch.get("field") not in price_fields:
+            continue
+        if not (
+            is_settlement_exit_row(mismatch.get("replay_row"))
+            or is_settlement_exit_row(mismatch.get("dryrun_row"))
+        ):
+            continue
+        settlement_mismatches.append(mismatch)
+    return settlement_mismatches[:100]
 
 
 def compare_runtime_evidence(
@@ -695,6 +740,7 @@ def compare_runtime_evidence(
         | set(fill_comparison["missing_strict_fields"])
     )
     mismatches = event_comparison["mismatches"] + order_comparison["mismatches"] + fill_comparison["mismatches"]
+    settlement_mismatches = settlement_exit_price_mismatches(mismatches)
     strict_parity_ready = (
         event_comparison["strict_parity_ready"]
         and order_comparison["strict_parity_ready"]
@@ -706,6 +752,7 @@ def compare_runtime_evidence(
         "fills": fill_comparison,
         "missing_strict_fields": missing_strict_fields,
         "mismatches": mismatches[:100],
+        "settlement_exit_mismatches": settlement_mismatches,
         "strict_parity_ready": strict_parity_ready,
     }
 
@@ -815,6 +862,8 @@ def build_result(
         risk_flags.append("fills_present_in_dryrun_missing_from_replay")
     if runtime_evidence_comparison["mismatches"]:
         risk_flags.append("runtime_evidence_field_mismatches")
+    if runtime_evidence_comparison["settlement_exit_mismatches"]:
+        risk_flags.append("settlement_exit_price_mismatches")
     if runtime_evidence_comparison["missing_strict_fields"]:
         risk_flags.append("missing_runtime_evidence_strict_fields")
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,20 @@
 # Recorded Replay Official Settlement Enrichment (2026-05-11)
 
+## Follow-up: Settlement Parity Classifier (2026-05-11)
+
+- [x] Classify settlement-exit order/fill price mismatches as
+  `settlement_exit_price_mismatches` while preserving the generic
+  `runtime_evidence_field_mismatches` blocker.
+- [x] Add focused parity coverage for `tl_settle_*` settlement exits.
+
+Review:
+- Implemented structured
+  `runtime_evidence_comparison.settlement_exit_mismatches` details in
+  `scripts/replay_dryrun_parity.py`.
+- Verification passed on the source branch with `python3 -m unittest
+  tests.test_replay_dryrun_parity`, `python3 -m py_compile
+  scripts/replay_dryrun_parity.py`, and `git diff --check`.
+
 ## Plan
 
 - [x] Confirm strict parity blocker is settlement-only drift between recorded NDJSON and dry-run runtime evidence.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,6 +14,19 @@ Review:
 - Verification passed on the source branch with `python3 -m unittest
   tests.test_replay_dryrun_parity`, `python3 -m py_compile
   scripts/replay_dryrun_parity.py`, and `git diff --check`.
+- 2026-05-11 settlement token semantics fix: The `2221812` artifact showed an
+  internal dry-run contradiction: official track-record accounting marked the
+  UP trade as a loss (`exit_price=0`, `net_pnl=-15.108`), while runtime
+  order/fill evidence recorded the settlement exit at price `1`. Root cause is
+  that crypto discovery treated the raw `clobTokenIds` array order as
+  UP/DOWN semantics; if Gamma returns outcomes in another order, scanner
+  `official_event_outcome` can invert the event result. Updated
+  `crates/ploy-market-data/src/discovery/crypto.rs` to map tokens by the
+  market `outcomes` labels (`Up`/`Down`, `Yes`/`No`) and only fall back to array
+  order when labels are unavailable. Verification passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-market-data-token-map-clean rtk cargo test -p
+  ploy-market-data --features live discovery::crypto --lib`, `python3 -m unittest
+  tests.test_replay_dryrun_parity`, and `git diff --check`.
 
 ## Plan
 

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -23,6 +23,7 @@ def evidence_payload(
     created_at="2026-05-02T01:02:03Z",
     fill_timestamp="2026-05-02T01:02:04Z",
     event_side="BUY",
+    purpose="ENTRY",
 ):
     event_pnl = f"-{DecimalString.mul('10', fill_price)}"
     return {
@@ -56,7 +57,7 @@ def evidence_payload(
                     "event_id": "event-1",
                     "token_id": "token-up",
                     "order_side": order_side,
-                    "purpose": "ENTRY",
+                    "purpose": purpose,
                     "quantity": "10",
                     "limit_price": limit_price,
                     "filled_quantity": "10.0000000",
@@ -73,6 +74,7 @@ def evidence_payload(
                     "event_id": "event-1",
                     "token_id": "token-up",
                     "fill_side": fill_side,
+                    "purpose": purpose,
                     "quantity": "10",
                     "price": fill_price,
                     "fee": "0",
@@ -159,6 +161,36 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertIn("runtime_evidence_field_mismatches", result["risk_flags"])
         self.assertIn("runtime_evidence_field_mismatches", result["blocking_risk_flags"])
         self.assertIn(runtime["mismatches"][0]["field"], {"entry_price", "pnl", "price"})
+
+    def test_runtime_evidence_classifies_settlement_exit_price_mismatch(self):
+        result = self.run_script(
+            evidence_payload(
+                intent_id="tl_settle_event-1_up",
+                order_side="SELL",
+                fill_side="SELL",
+                limit_price="0",
+                fill_price="0",
+                purpose="SETTLEMENT_EXIT",
+            ),
+            evidence_payload(
+                intent_id="tl_settle_event-1_up",
+                order_side="SELL",
+                fill_side="SELL",
+                limit_price="1",
+                fill_price="1",
+                purpose="SETTLEMENT_EXIT",
+            ),
+        )
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertFalse(runtime["strict_parity_ready"])
+        self.assertIn("runtime_evidence_field_mismatches", result["risk_flags"])
+        self.assertIn("settlement_exit_price_mismatches", result["risk_flags"])
+        self.assertIn("settlement_exit_price_mismatches", result["blocking_risk_flags"])
+        self.assertEqual(
+            runtime["settlement_exit_mismatches"][0]["dryrun_row"]["intent_id"],
+            "tl_settle_event-1_up",
+        )
 
     def test_runtime_evidence_blocks_fill_side_mismatch(self):
         result = self.run_script(


### PR DESCRIPTION
## Summary
- Classify settlement-exit price mismatches as a dedicated parity blocker with structured mismatch rows.
- Map crypto UP/DOWN tokens by market outcome labels instead of assuming raw clobTokenIds array order.
- Record the follow-up diagnosis in tasks/todo.md.

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/replay_dryrun_parity.py
- CARGO_TARGET_DIR=/tmp/ploy-market-data-token-map-clean rtk cargo test -p ploy-market-data --features live discovery::crypto --lib
- git diff --check HEAD

## Notes
This is a clean branch from origin/main. It fixes the settlement/parity blocker surfaced by event 2221812, but it does not claim a profitable strategy yet; post-merge deploy and fresh recorded replay parity evidence are still required before any strategy promotion.