### PR TITLE
Add alpha search CI/CD artifacts

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -711,6 +711,7 @@ jobs:
           PY
           next_options="$(cat artifacts/factor-walk-forward-v2/next-options.json)"
           gh workflow run factor-walk-forward-v2-hosted-artifact.yml \
+            --ref "${{ github.ref_name }}" \
             -f git_ref="${{ github.event.inputs.git_ref }}" \
             -f snapshot_run_id="${{ github.event.inputs.snapshot_run_id }}" \
             -f snapshot_artifact_name="${{ github.event.inputs.snapshot_artifact_name }}" \

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -33,7 +33,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -45,7 +45,7 @@ concurrency:
 
 permissions:
   contents: write
-  actions: read
+  actions: write
   issues: write
   pull-requests: write
 
@@ -92,6 +92,13 @@ jobs:
               "replay_parity_json": "",
               "replay_parity_run_id": "",
               "replay_parity_artifact_name": "",
+              "alpha_search_plan_json": "",
+              "alpha_search_plan_run_id": "",
+              "alpha_search_plan_artifact_name": "",
+              "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
+              "alpha_search_min_reward_improvement": "0.0",
+              "chain_next_run": "false",
+              "chain_remaining": "0",
               "required_strategy_profile": "settlement_probability",
               "allowed_target": "full_depth_settlement_executable_pnl",
               "issue_number": "",
@@ -100,7 +107,7 @@ jobs:
               "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
               "fail_if_blocked": "false",
           }
-          bool_keys = {"create_handoff_issue", "create_config_pr", "fail_if_blocked"}
+          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "fail_if_blocked"}
           choices = {
               "report_suite": {"core", "full"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
@@ -263,6 +270,27 @@ jobs:
             --output-dir artifacts/replay-parity \
             --require parity-evaluation.json
 
+      - name: Download alpha search plan artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WALK_ALPHA_SEARCH_PLAN_JSON}" ] || [ -z "${WALK_ALPHA_SEARCH_PLAN_RUN_ID}" ]; then
+            echo "No alpha search plan artifact download requested."
+            exit 0
+          fi
+          rm -rf artifacts/alpha-search-plan
+          artifact_name="${WALK_ALPHA_SEARCH_PLAN_ARTIFACT_NAME}"
+          if [ -z "${artifact_name}" ]; then
+            artifact_name="factor-walk-forward-v2-${WALK_ALPHA_SEARCH_PLAN_RUN_ID}"
+          fi
+          python3 scripts/download_github_artifact.py \
+            --run-id "${WALK_ALPHA_SEARCH_PLAN_RUN_ID}" \
+            --name "${artifact_name}" \
+            --strip-prefix "factor-walk-forward-v2/alpha-search/${WALK_ALPHA_SEARCH_PLAN_TARGET}" \
+            --output-dir artifacts/alpha-search-plan \
+            --require mcts-expansion-plan.json
+
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
@@ -315,9 +343,17 @@ jobs:
             --allowed-target "${WALK_ALLOWED_TARGET}"
             --sweep-json "${SWEEP_JSON}"
             --fail-if-all-failed
+            --alpha-search-output-dir artifacts/factor-walk-forward-v2/alpha-search
           )
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
+          fi
+          alpha_search_plan_json="${WALK_ALPHA_SEARCH_PLAN_JSON}"
+          if [ -z "${alpha_search_plan_json}" ] && [ -f artifacts/alpha-search-plan/mcts-expansion-plan.json ]; then
+            alpha_search_plan_json="artifacts/alpha-search-plan/mcts-expansion-plan.json"
+          fi
+          if [ -n "${alpha_search_plan_json}" ]; then
+            args+=(--alpha-search-plan-json "${alpha_search_plan_json}")
           fi
           if [ "${WALK_FAIL_IF_BLOCKED}" = "true" ]; then
             args+=(--fail-if-blocked)
@@ -503,6 +539,116 @@ jobs:
             fi
           done
 
+      - name: Prepare alpha search chain decision
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/factor-walk-forward-v2-upload/alpha-search-chain
+          python3 - <<'PY'
+          import json
+          import math
+          import os
+          from pathlib import Path
+
+          target = os.environ.get("WALK_ALPHA_SEARCH_PLAN_TARGET", "")
+          decision = {
+              "should_dispatch": False,
+              "reason": "disabled",
+              "target": target,
+              "current_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "next_remaining": None,
+              "handoff_status": None,
+              "selected_node_count": None,
+              "current_best_reward": None,
+              "previous_best_reward": None,
+              "min_reward_improvement": None,
+          }
+
+          chain_next = os.environ.get("WALK_CHAIN_NEXT_RUN", "").lower() == "true"
+          raw_remaining = os.environ.get("WALK_CHAIN_REMAINING", "")
+          if not chain_next:
+              decision["reason"] = "chain_next_run_false"
+          else:
+              try:
+                  remaining = int(raw_remaining)
+                  if remaining < 0:
+                      raise ValueError
+              except ValueError:
+                  decision["reason"] = "invalid_chain_remaining"
+                  decision["error"] = f"chain_remaining must be a non-negative integer: {raw_remaining!r}"
+              else:
+                  decision["next_remaining"] = max(0, remaining - 1)
+                  if remaining <= 0:
+                      decision["reason"] = "chain_remaining_exhausted"
+                  else:
+                      handoff = Path("artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json")
+                      if handoff.exists():
+                          payload = json.loads(handoff.read_text(encoding="utf-8"))
+                          decision["handoff_status"] = payload.get("status")
+                          if payload.get("status") == "ready":
+                              decision["reason"] = "ready_handoff"
+
+                      if decision["reason"] == "disabled":
+                          plan = Path("artifacts/factor-walk-forward-v2/alpha-search") / target / "mcts-expansion-plan.json"
+                          if not plan.exists():
+                              decision["reason"] = "missing_mcts_expansion_plan"
+                          else:
+                              payload = json.loads(plan.read_text(encoding="utf-8"))
+                              selected_nodes = payload.get("selected_nodes") or []
+                              decision["selected_node_count"] = len(selected_nodes)
+                              if not selected_nodes:
+                                  decision["reason"] = "no_selected_nodes"
+                              else:
+                                  try:
+                                      min_reward_improvement = float(os.environ.get("WALK_ALPHA_SEARCH_MIN_REWARD_IMPROVEMENT", "0.0"))
+                                  except ValueError:
+                                      decision["reason"] = "invalid_min_reward_improvement"
+                                      decision["error"] = "alpha_search_min_reward_improvement must be numeric"
+                                  else:
+                                      if not math.isfinite(min_reward_improvement) or min_reward_improvement < 0:
+                                          decision["reason"] = "invalid_min_reward_improvement"
+                                          decision["error"] = "alpha_search_min_reward_improvement must be a finite non-negative number"
+                                      else:
+                                          decision["min_reward_improvement"] = min_reward_improvement
+                                          current_feedback = Path("artifacts/factor-walk-forward-v2/alpha-search") / target / "search-feedback.json"
+                                          previous_feedback = Path("artifacts/alpha-search-plan/search-feedback.json")
+                                          if previous_feedback.exists():
+                                              if not current_feedback.exists():
+                                                  decision["reason"] = "missing_current_search_feedback"
+                                              else:
+                                                  current = json.loads(current_feedback.read_text(encoding="utf-8"))
+                                                  previous = json.loads(previous_feedback.read_text(encoding="utf-8"))
+                                                  decision["current_best_reward"] = current.get("best_reward")
+                                                  decision["previous_best_reward"] = previous.get("best_reward")
+                                                  current_reward = current.get("best_reward")
+                                                  previous_reward = previous.get("best_reward")
+                                                  if current_reward is None or previous_reward is None:
+                                                      decision["reason"] = "missing_best_reward"
+                                                  else:
+                                                      try:
+                                                          current_reward = float(current_reward)
+                                                          previous_reward = float(previous_reward)
+                                                      except ValueError:
+                                                          decision["reason"] = "invalid_best_reward"
+                                                      else:
+                                                          if not math.isfinite(current_reward) or not math.isfinite(previous_reward):
+                                                              decision["reason"] = "invalid_best_reward"
+                                                          elif current_reward <= previous_reward + min_reward_improvement:
+                                                              decision["reason"] = "reward_stagnation"
+                                                          else:
+                                                              decision["reason"] = "continue"
+                                                              decision["should_dispatch"] = True
+                                          else:
+                                              decision["reason"] = "continue"
+                                              decision["should_dispatch"] = True
+
+          output = Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json")
+          output.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          print(json.dumps(decision, sort_keys=True))
+          if decision["reason"] in {"invalid_chain_remaining", "invalid_min_reward_improvement"}:
+              raise SystemExit(2)
+          PY
+
       - name: Upload report artifact
         if: always()
         uses: actions/upload-artifact@v7
@@ -511,6 +657,77 @@ jobs:
           path: artifacts/factor-walk-forward-v2-upload/
           compression-level: 0
           retention-days: 14
+
+      - name: Dispatch chained alpha search run
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          decision_path="artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json"
+          if [ ! -f "${decision_path}" ]; then
+            echo "Missing alpha search chain decision artifact; skipping chained dispatch."
+            exit 0
+          fi
+          should_dispatch="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json").read_text(encoding="utf-8"))
+          print("true" if payload.get("should_dispatch") else "false")
+          PY
+          )"
+          if [ "${should_dispatch}" != "true" ]; then
+            reason="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json").read_text(encoding="utf-8"))
+          print(payload.get("reason", "unknown"))
+          PY
+          )"
+            echo "Alpha search chain decision is ${reason}; skipping chained dispatch."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          data["alpha_search_plan_json"] = ""
+          data["alpha_search_plan_run_id"] = os.environ["GITHUB_RUN_ID"]
+          data["alpha_search_plan_artifact_name"] = f"factor-walk-forward-v2-{os.environ['GITHUB_RUN_ID']}"
+          data["alpha_search_plan_target"] = os.environ["WALK_ALPHA_SEARCH_PLAN_TARGET"]
+          remaining = max(0, int(os.environ["WALK_CHAIN_REMAINING"]) - 1)
+          data["chain_remaining"] = remaining
+          data["chain_next_run"] = remaining > 0
+          Path("artifacts/factor-walk-forward-v2/next-options.json").write_text(
+              json.dumps(data, separators=(",", ":"), sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          next_options="$(cat artifacts/factor-walk-forward-v2/next-options.json)"
+          gh workflow run factor-walk-forward-v2-hosted-artifact.yml \
+            -f git_ref="${{ github.event.inputs.git_ref }}" \
+            -f snapshot_run_id="${{ github.event.inputs.snapshot_run_id }}" \
+            -f snapshot_artifact_name="${{ github.event.inputs.snapshot_artifact_name }}" \
+            -f start_date="${{ github.event.inputs.start_date }}" \
+            -f end_date="${{ github.event.inputs.end_date }}" \
+            -f symbols="${{ github.event.inputs.symbols }}" \
+            -f stake_usd="${{ github.event.inputs.stake_usd }}" \
+            -f options_json="${next_options}"
+          next_remaining="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json").read_text(encoding="utf-8"))
+          print(payload.get("next_remaining", 0))
+          PY
+          )"
+          echo "Dispatched chained alpha search run with chain_remaining=${next_remaining}."
 
       - name: Comment walk-forward evidence on issue
         if: always()

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -30,7 +30,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings, local snapshot registry, optional replay parity artifact"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":""}'
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl"}'
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
@@ -193,6 +193,10 @@ jobs:
               "replay_parity_json": "",
               "replay_parity_run_id": "",
               "replay_parity_artifact_name": "",
+              "alpha_search_plan_json": "",
+              "alpha_search_plan_run_id": "",
+              "alpha_search_plan_artifact_name": "",
+              "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
           }
           bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
           choices = {
@@ -425,6 +429,27 @@ jobs:
             --output-dir artifacts/replay-parity \
             --require parity-evaluation.json
 
+      - name: Download alpha search plan artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WALK_ALPHA_SEARCH_PLAN_JSON}" ] || [ -z "${WALK_ALPHA_SEARCH_PLAN_RUN_ID}" ]; then
+            echo "No alpha search plan artifact download requested."
+            exit 0
+          fi
+          rm -rf artifacts/alpha-search-plan
+          artifact_name="${WALK_ALPHA_SEARCH_PLAN_ARTIFACT_NAME}"
+          if [ -z "${artifact_name}" ]; then
+            artifact_name="factor-walk-forward-v2-${WALK_ALPHA_SEARCH_PLAN_RUN_ID}"
+          fi
+          python3 scripts/download_github_artifact.py \
+            --run-id "${WALK_ALPHA_SEARCH_PLAN_RUN_ID}" \
+            --name "${artifact_name}" \
+            --strip-prefix "factor-walk-forward-v2/alpha-search/${WALK_ALPHA_SEARCH_PLAN_TARGET}" \
+            --output-dir artifacts/alpha-search-plan \
+            --require mcts-expansion-plan.json
+
       - name: Cache cargo build
         if: ${{ github.event.inputs.snapshot_run_id == '' }}
         uses: Swatinem/rust-cache@v2
@@ -538,6 +563,7 @@ jobs:
             --data-quality-mode "${WALK_DATA_QUALITY_MODE}"
             --min-event-complete-events "${WALK_MIN_EVENT_COMPLETE_EVENTS}"
             --min-event-complete-rows "${WALK_MIN_EVENT_COMPLETE_ROWS}"
+            --alpha-search-output-dir artifacts/factor-walk-forward-v2/alpha-search
           )
           if [ -n "${WALK_FACTOR_NAME_FILTER}" ]; then
             args+=(--factor-name-filter "${WALK_FACTOR_NAME_FILTER}")
@@ -548,6 +574,13 @@ jobs:
           fi
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
+          fi
+          alpha_search_plan_json="${WALK_ALPHA_SEARCH_PLAN_JSON}"
+          if [ -z "${alpha_search_plan_json}" ] && [ -f artifacts/alpha-search-plan/mcts-expansion-plan.json ]; then
+            alpha_search_plan_json="artifacts/alpha-search-plan/mcts-expansion-plan.json"
+          fi
+          if [ -n "${alpha_search_plan_json}" ]; then
+            args+=(--alpha-search-plan-json "${alpha_search_plan_json}")
           fi
           ./target/release/examples/factor_walk_forward_v2 "${args[@]}" \
             | tee artifacts/factor-walk-forward-v2/report.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,18 @@ ci/<short-description>        — CI/workflow changes
 
 ### Research Issue Workflow
 
+- Before any PM5D, event ML, factor research, replay, backtest, dry-run
+  candidate, live-prep, or strategy-promotion task, read
+  [docs/PROJECT_SEMANTICS.md](docs/PROJECT_SEMANTICS.md) and name the evidence
+  stage being produced.
+- Treat `docs/PROJECT_SEMANTICS.md` as the source of truth for project
+  semantics. Memory and prior chat can provide historical context, but they do
+  not override the repo-local semantic contract.
+- For human-readable research/backtest results, use
+  [tasks/research_evidence/TEMPLATE.md](tasks/research_evidence/TEMPLATE.md)
+  unless a workflow already emits a stricter machine-readable artifact.
+- If evidence conflicts with the semantic contract, mark the result as a caveat
+  or blocker instead of promoting it.
 - Strategy research ideas should be captured as GitHub issues instead of staying
   only in chat, local notes, or one-off scripts.
 - Follow `docs/runbooks/strategy-research-cicd.md` for the canonical research

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,18 @@ ci/<short-description>        — CI/workflow changes
 
 ### Research Issue Workflow
 
+- Before any PM5D, event ML, factor research, replay, backtest, dry-run
+  candidate, live-prep, or strategy-promotion task, read
+  [docs/PROJECT_SEMANTICS.md](docs/PROJECT_SEMANTICS.md) and name the evidence
+  stage being produced.
+- Treat `docs/PROJECT_SEMANTICS.md` as the source of truth for project
+  semantics. Memory and prior chat can provide historical context, but they do
+  not override the repo-local semantic contract.
+- For human-readable research/backtest results, use
+  [tasks/research_evidence/TEMPLATE.md](tasks/research_evidence/TEMPLATE.md)
+  unless a workflow already emits a stricter machine-readable artifact.
+- If evidence conflicts with the semantic contract, mark the result as a caveat
+  or blocker instead of promoting it.
 - Strategy research ideas should be captured as GitHub issues instead of staying
   only in chat, local notes, or one-off scripts.
 - Follow `docs/runbooks/strategy-research-cicd.md` for the canonical research

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -15,7 +15,7 @@ use ploy_research::{
     ResearchSnapshotRequest, SettlementProbabilityDataQualityMode,
     SettlementProbabilityPromotionGateOptions, SettlementProbabilityReportOptions,
     SettlementProbabilityWalkForwardOptions, TradeFormationReviewOptions,
-    build_factor_observations_v2_with_deribit_and_pm_books,
+    autofactor_matrix_from_v2, build_factor_observations_v2_with_deribit_and_pm_books,
     build_factor_observations_with_lob_sampled, build_factor_stability_report,
     build_full_depth_execution_matrix, build_settlement_probability_promotion_gate_report,
     format_autofactor_reports, format_factor_combo_v1_report, format_factor_stability_report,
@@ -27,12 +27,12 @@ use ploy_research::{
     format_trade_formation_v1_report, liquidity_gate_v1_with_deribit_and_pm_books,
     liquidity_gated_alpha_v1_with_deribit_and_pm_books, load_deribit_feature_snapshots,
     load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
-    load_research_snapshot, mine_domain_autofactors_from_v2,
+    load_research_snapshot, mine_domain_autofactors_from_v2_with_mcts_plan,
     review_fillability_v1_with_deribit_and_pm_books, review_repricing_ic_with_deribit_and_pm_books,
     review_trade_formation_v1_with_deribit_and_pm_books, validate_snapshot_request_coverage,
     walk_forward_factor_combo_v1_with_deribit_and_pm_books,
     walk_forward_factors_v2_with_deribit_and_pm_books,
-    walk_forward_meta_label_v1_with_deribit_and_pm_books,
+    walk_forward_meta_label_v1_with_deribit_and_pm_books, write_alpha_search_artifacts,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashSet;
@@ -162,6 +162,24 @@ fn replay_parity_evidence(path: &str) -> (bool, String) {
     (ready, evidence)
 }
 
+fn alpha_search_plan_factor_names(path: &str) -> Vec<String> {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("read alpha search plan JSON {path} failed: {err}"));
+    let json: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|err| panic!("parse alpha search plan JSON {path} failed: {err}"));
+    json.get("selected_nodes")
+        .and_then(serde_json::Value::as_array)
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|node| node.get("factor_name"))
+                .filter_map(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
 fn slice_by_time<T, F>(items: &[T], start: DateTime<Utc>, end: DateTime<Utc>, ts_fn: F) -> &[T]
 where
     F: Fn(&T) -> DateTime<Utc>,
@@ -245,6 +263,8 @@ async fn main() {
 
     let snapshot_dir = flag_value(&args, "--snapshot-dir");
     let replay_parity_json = flag_value(&args, "--replay-parity-json");
+    let alpha_search_output_dir = flag_value(&args, "--alpha-search-output-dir");
+    let alpha_search_plan_json = flag_value(&args, "--alpha-search-plan-json");
     let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
     let data_quality_mode = parse_data_quality_mode(flag_value(&args, "--data-quality-mode"));
     let min_event_complete_events = flag_value(&args, "--min-event-complete-events")
@@ -631,15 +651,64 @@ async fn main() {
         min_window_observations: options.review.min_observations.max(20),
         ..Default::default()
     };
+    let alpha_search_input_names = alpha_search_output_dir.as_ref().and_then(|_| {
+        autofactor_matrix_from_v2(&autofactor_rows)
+            .map(|matrix| matrix.input_names().into_iter().collect::<Vec<_>>())
+            .map_err(|err| {
+                eprintln!("alpha search matrix build failed: {err}");
+                err
+            })
+            .ok()
+    });
+    let alpha_search_plan_names = alpha_search_plan_json
+        .as_deref()
+        .map(alpha_search_plan_factor_names)
+        .unwrap_or_default();
+    if let Some(path) = alpha_search_plan_json.as_deref() {
+        eprintln!(
+            "alpha search MCTS plan loaded: {} selected nodes from {}",
+            alpha_search_plan_names.len(),
+            path
+        );
+    }
     for target in [
         AutoFactorV2Target::FullDepthRepricePnl10s,
         AutoFactorV2Target::FullDepthRepricePnl30s,
         AutoFactorV2Target::FullDepthSettlementExecutablePnl,
     ] {
-        match mine_domain_autofactors_from_v2(&autofactor_rows, target, &autofactor_options) {
+        match mine_domain_autofactors_from_v2_with_mcts_plan(
+            &autofactor_rows,
+            target,
+            &autofactor_options,
+            &alpha_search_plan_names,
+        ) {
             Ok(reports) => {
                 println!("# AutoFactor target={}", target.as_str());
                 println!("{}", format_autofactor_reports(&reports, options.top_n));
+                if let (Some(output_dir), Some(input_names)) = (
+                    alpha_search_output_dir.as_deref(),
+                    alpha_search_input_names.as_ref(),
+                ) {
+                    match write_alpha_search_artifacts(
+                        output_dir,
+                        target.as_str(),
+                        input_names,
+                        &reports,
+                        &autofactor_options,
+                    ) {
+                        Ok(summary) => eprintln!(
+                            "alpha search artifacts written target={} candidates={} rejected={} best={} dir={}",
+                            summary.target,
+                            summary.candidate_count,
+                            summary.rejected_count,
+                            summary.best_candidate.as_deref().unwrap_or("<none>"),
+                            summary.output_dir
+                        ),
+                        Err(err) => {
+                            eprintln!("alpha search artifact write failed for {}: {err}", target.as_str());
+                        }
+                    }
+                }
             }
             Err(err) => {
                 eprintln!(

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -1,0 +1,629 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::autofactor::{AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr};
+
+const ALPHA_SEARCH_ARTIFACT_VERSION: &str = "alpha_search_artifacts_v1";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AlphaSearchArtifactSummary {
+    pub target: String,
+    pub output_dir: String,
+    pub candidate_count: usize,
+    pub rejected_count: usize,
+    pub best_candidate: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum AlphaSearchArtifactError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for AlphaSearchArtifactError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "alpha search artifact I/O failed: {err}"),
+            Self::Json(err) => write!(f, "alpha search artifact JSON failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for AlphaSearchArtifactError {}
+
+impl From<std::io::Error> for AlphaSearchArtifactError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for AlphaSearchArtifactError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SearchSpaceArtifact {
+    version: &'static str,
+    mode: &'static str,
+    target: String,
+    feature_pool: Vec<String>,
+    constant_pool: Vec<f64>,
+    operator_pool: Vec<&'static str>,
+    limits: SearchLimits,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchLimits {
+    min_observations: usize,
+    min_window_observations: usize,
+    bucket_count: usize,
+    min_spearman_ic: f64,
+    min_icir: f64,
+    min_positive_window_ratio: f64,
+    min_top_bucket_avg_label: f64,
+    min_monotonicity_score: f64,
+    max_complexity: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct LlmPriorArtifact {
+    version: &'static str,
+    mode: &'static str,
+    target: String,
+    hypotheses: Vec<PriorHypothesis>,
+    allowed_mutation_types: Vec<&'static str>,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct PriorHypothesis {
+    id: &'static str,
+    hypothesis: &'static str,
+    expected_mechanism: &'static str,
+    required_surfaces: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct CandidateExpression {
+    name: String,
+    target: Option<String>,
+    source: &'static str,
+    complexity: usize,
+    root_gene: String,
+    expr: FactorExpr,
+}
+
+#[derive(Debug, Serialize)]
+struct RejectedExpression {
+    name: String,
+    target: Option<String>,
+    root_gene: String,
+    reason: String,
+    complexity: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TreeTraceArtifact {
+    version: &'static str,
+    mode: &'static str,
+    target: String,
+    nodes: Vec<TreeTraceNode>,
+}
+
+#[derive(Debug, Serialize)]
+struct TreeTraceNode {
+    id: String,
+    parent: Option<String>,
+    factor_name: String,
+    mutation: &'static str,
+    selected_dimension: String,
+    reward: f64,
+    visits: usize,
+    decision: String,
+}
+
+#[derive(Debug, Serialize)]
+struct NodeMetric {
+    id: String,
+    factor_name: String,
+    target: Option<String>,
+    decision: String,
+    reason: String,
+    selected_dimension: String,
+    effectiveness: f64,
+    stability: f64,
+    diversity: f64,
+    execution_cost: f64,
+    overfit_risk: f64,
+    runtime_readiness: f64,
+    reward: f64,
+    spearman_ic: f64,
+    icir: f64,
+    positive_window_ratio: f64,
+    top_bucket_avg_label: f64,
+    monotonicity_score: f64,
+    complexity: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct AvoidedSubtree {
+    root_gene: String,
+    count: usize,
+    action: &'static str,
+    reason: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchFeedbackArtifact {
+    version: &'static str,
+    mode: &'static str,
+    target: String,
+    candidate_count: usize,
+    rejected_count: usize,
+    watchlist_count: usize,
+    passed_count: usize,
+    best_candidate: Option<String>,
+    best_reward: Option<f64>,
+    interpretation: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct MctsExpansionPlan {
+    version: &'static str,
+    mode: &'static str,
+    target: String,
+    exploration_weight: f64,
+    selected_nodes: Vec<MctsSelectedNode>,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct MctsSelectedNode {
+    node_id: String,
+    factor_name: String,
+    selected_dimension: String,
+    proposed_mutation: &'static str,
+    reward: f64,
+    ucb_priority: f64,
+}
+
+pub fn write_alpha_search_artifacts(
+    output_root: impl AsRef<Path>,
+    target: &str,
+    input_names: &[String],
+    reports: &[AutoFactorReport],
+    options: &AutoFactorOptions,
+) -> Result<AlphaSearchArtifactSummary, AlphaSearchArtifactError> {
+    let output_dir = output_root.as_ref().join(target);
+    std::fs::create_dir_all(&output_dir)?;
+
+    let feature_pool = {
+        let mut values = input_names.to_vec();
+        values.sort();
+        values
+    };
+    write_json(
+        &output_dir.join("search-space.json"),
+        &SearchSpaceArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION,
+            mode: "deterministic_seed_search",
+            target: target.to_string(),
+            feature_pool,
+            constant_pool: vec![
+                0.001, 0.005, 0.01, 0.02, 0.05, 0.10, 1.0, 2.0, 3.0, 5.0, 10.0, 30.0, 60.0, 300.0,
+            ],
+            operator_pool: vec![
+                "Input",
+                "Const",
+                "Add",
+                "Sub",
+                "Mul",
+                "SafeDiv",
+                "Max",
+                "Min",
+                "Tanh",
+                "Log1pAbs",
+                "SqrtAbs",
+                "Clip",
+                "Delta",
+                "RollingMean",
+                "RollingStd",
+                "ZScore",
+            ],
+            limits: SearchLimits {
+                min_observations: options.min_observations,
+                min_window_observations: options.min_window_observations,
+                bucket_count: options.bucket_count,
+                min_spearman_ic: options.min_spearman_ic,
+                min_icir: options.min_icir,
+                min_positive_window_ratio: options.min_positive_window_ratio,
+                min_top_bucket_avg_label: options.min_top_bucket_avg_label,
+                min_monotonicity_score: options.min_monotonicity_score,
+                max_complexity: options.max_complexity,
+            },
+        },
+    )?;
+
+    write_json(
+        &output_dir.join("llm-priors.json"),
+        &LlmPriorArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION,
+            mode: "deterministic_domain_prior_placeholder",
+            target: target.to_string(),
+            hypotheses: default_hypotheses(target),
+            allowed_mutation_types: vec![
+                "add_feature_gate",
+                "replace_denominator",
+                "add_spread_penalty",
+                "add_capacity_gate",
+                "add_near_strike_interaction",
+                "change_time_window",
+                "clip_or_squash",
+                "invert_or_contrarian",
+                "remove_component",
+            ],
+            note: "External LLM expansion is not invoked in this artifact. This file records the machine-checkable prior schema used by deterministic seed search.",
+        },
+    )?;
+
+    let candidates = reports
+        .iter()
+        .map(|report| CandidateExpression {
+            name: report.name.clone(),
+            target: report.target.clone(),
+            source: candidate_source(&report.name),
+            complexity: report.complexity,
+            root_gene: root_gene(&report.expr),
+            expr: report.expr.clone(),
+        })
+        .collect::<Vec<_>>();
+    write_json(&output_dir.join("candidate-expressions.json"), &candidates)?;
+
+    let rejected = reports
+        .iter()
+        .filter(|report| report.decision == AutoFactorDecision::Reject)
+        .map(|report| RejectedExpression {
+            name: report.name.clone(),
+            target: report.target.clone(),
+            root_gene: root_gene(&report.expr),
+            reason: report.reason.clone(),
+            complexity: report.complexity,
+        })
+        .collect::<Vec<_>>();
+    write_json(&output_dir.join("rejected-expressions.json"), &rejected)?;
+
+    let node_metrics = reports
+        .iter()
+        .enumerate()
+        .map(|(idx, report)| node_metric(idx, report))
+        .collect::<Vec<_>>();
+    write_json(&output_dir.join("node-metrics.json"), &node_metrics)?;
+    write_json(
+        &output_dir.join("mcts-expansion-plan.json"),
+        &mcts_expansion_plan(target, &node_metrics),
+    )?;
+
+    write_json(
+        &output_dir.join("tree-trace.json"),
+        &TreeTraceArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION,
+            mode: "single_depth_seed_tree",
+            target: target.to_string(),
+            nodes: reports
+                .iter()
+                .enumerate()
+                .map(|(idx, report)| TreeTraceNode {
+                    id: format!("node-{idx}"),
+                    parent: None,
+                    factor_name: report.name.clone(),
+                    mutation: "seed",
+                    selected_dimension: selected_dimension(report),
+                    reward: reward(report),
+                    visits: 1,
+                    decision: report.decision.as_str().to_string(),
+                })
+                .collect(),
+        },
+    )?;
+
+    write_json(
+        &output_dir.join("avoided-subtrees.json"),
+        &avoided_subtrees(reports),
+    )?;
+
+    let best = node_metrics
+        .iter()
+        .max_by(|lhs, rhs| lhs.reward.total_cmp(&rhs.reward));
+    let feedback = SearchFeedbackArtifact {
+        version: ALPHA_SEARCH_ARTIFACT_VERSION,
+        mode: "deterministic_seed_search",
+        target: target.to_string(),
+        candidate_count: reports.len(),
+        rejected_count: rejected.len(),
+        watchlist_count: reports
+            .iter()
+            .filter(|report| report.decision == AutoFactorDecision::Watchlist)
+            .count(),
+        passed_count: reports
+            .iter()
+            .filter(|report| report.decision == AutoFactorDecision::Candidate)
+            .count(),
+        best_candidate: best.map(|metric| metric.factor_name.clone()),
+        best_reward: best.map(|metric| metric.reward),
+        interpretation: "Search feedback is discovery evidence only. Promotion still requires the AutoFactor strategy-promotion gate and replay/runtime parity.",
+    };
+    write_json(&output_dir.join("search-feedback.json"), &feedback)?;
+
+    Ok(AlphaSearchArtifactSummary {
+        target: target.to_string(),
+        output_dir: output_dir.display().to_string(),
+        candidate_count: reports.len(),
+        rejected_count: rejected.len(),
+        best_candidate: feedback.best_candidate,
+    })
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<(), AlphaSearchArtifactError> {
+    let raw = serde_json::to_string_pretty(value)?;
+    std::fs::write(path, raw)?;
+    Ok(())
+}
+
+fn default_hypotheses(target: &str) -> Vec<PriorHypothesis> {
+    if target == "full_depth_settlement_executable_pnl" {
+        vec![
+            PriorHypothesis {
+                id: "settlement_edge_after_execution_cost",
+                hypothesis: "Settlement probability edge is valuable only after full-depth executable entry cost and PM fee are deducted.",
+                expected_mechanism: "True q minus sweep price should rank event-side decisions when depth and quote freshness are adequate.",
+                required_surfaces: vec!["polymarket_full_clob_depth", "official_settlement", "probability_state"],
+            },
+            PriorHypothesis {
+                id: "capacity_and_near_strike_gate",
+                hypothesis: "Settlement edge should be gated by near-strike state and executable capacity.",
+                expected_mechanism: "Near-strike contracts are more sensitive to small external moves, but only deployable when the book can absorb the stake.",
+                required_surfaces: vec!["event_geometry", "polymarket_full_clob_depth"],
+            },
+        ]
+    } else {
+        vec![PriorHypothesis {
+            id: "repricing_after_pm_lag",
+            hypothesis: "External market movement is more valuable when Polymarket quotes are stale or spread-adjusted friction is low.",
+            expected_mechanism: "CEX movement can predict short-horizon PM quote repricing before the book updates.",
+            required_surfaces: vec!["binance_price", "binance_l2", "polymarket_quote_ticks"],
+        }]
+    }
+}
+
+fn candidate_source(name: &str) -> &'static str {
+    if name.starts_with("mut_") {
+        "deterministic_mutation"
+    } else if name.starts_with("auto_settlement_") {
+        "settlement_native_generator"
+    } else {
+        "domain_seed"
+    }
+}
+
+fn node_metric(idx: usize, report: &AutoFactorReport) -> NodeMetric {
+    NodeMetric {
+        id: format!("node-{idx}"),
+        factor_name: report.name.clone(),
+        target: report.target.clone(),
+        decision: report.decision.as_str().to_string(),
+        reason: report.reason.clone(),
+        selected_dimension: selected_dimension(report),
+        effectiveness: normalized_positive(report.top_bucket_avg_label),
+        stability: report.positive_window_ratio.clamp(0.0, 1.0),
+        diversity: 1.0 / report.complexity.max(1) as f64,
+        execution_cost: if report.name.contains("capacity") || report.name.contains("spread") {
+            1.0
+        } else {
+            0.5
+        },
+        overfit_risk: 1.0 / report.complexity.max(1) as f64,
+        runtime_readiness: if report.name.starts_with("auto_settlement_") {
+            1.0
+        } else {
+            0.5
+        },
+        reward: reward(report),
+        spearman_ic: finite_or_zero(report.spearman_ic),
+        icir: finite_or_zero(report.icir),
+        positive_window_ratio: finite_or_zero(report.positive_window_ratio),
+        top_bucket_avg_label: finite_or_zero(report.top_bucket_avg_label),
+        monotonicity_score: finite_or_zero(report.monotonicity_score),
+        complexity: report.complexity,
+    }
+}
+
+fn mcts_expansion_plan(target: &str, metrics: &[NodeMetric]) -> MctsExpansionPlan {
+    let exploration_weight = 0.75;
+    let total_visits = metrics.len().max(1) as f64;
+    let mut selected = metrics
+        .iter()
+        .filter(|metric| metric.decision != "reject")
+        .map(|metric| {
+            let visits = 1.0_f64;
+            let ucb_priority =
+                metric.reward + exploration_weight * (total_visits.ln() / visits).sqrt();
+            MctsSelectedNode {
+                node_id: metric.id.clone(),
+                factor_name: metric.factor_name.clone(),
+                selected_dimension: metric.selected_dimension.clone(),
+                proposed_mutation: proposed_mutation(&metric.selected_dimension),
+                reward: metric.reward,
+                ucb_priority,
+            }
+        })
+        .collect::<Vec<_>>();
+    selected.sort_by(|lhs, rhs| rhs.ucb_priority.total_cmp(&lhs.ucb_priority));
+    selected.truncate(12);
+
+    MctsExpansionPlan {
+        version: ALPHA_SEARCH_ARTIFACT_VERSION,
+        mode: "single_run_ucb_planner",
+        target: target.to_string(),
+        exploration_weight,
+        selected_nodes: selected,
+        note: "This is the first MCTS control artifact. It selects branches for the next search run from node metrics, but does not yet execute multi-run backpropagation.",
+    }
+}
+
+fn proposed_mutation(selected_dimension: &str) -> &'static str {
+    match selected_dimension {
+        "sample_power" => "do_not_expand_collect_more_data",
+        "stability" => "add_feature_gate",
+        "effectiveness" => "replace_denominator",
+        "monotonicity" => "clip_or_squash",
+        "overfit_risk" => "remove_component",
+        "exploit" => "add_capacity_gate",
+        _ => "clip_or_squash",
+    }
+}
+
+fn reward(report: &AutoFactorReport) -> f64 {
+    let decision_bonus = match report.decision {
+        AutoFactorDecision::Candidate => 1.0,
+        AutoFactorDecision::Watchlist => 0.25,
+        AutoFactorDecision::Reject => -0.5,
+    };
+    decision_bonus
+        + finite_or_zero(report.icir).tanh()
+        + finite_or_zero(report.spearman_ic).tanh()
+        + finite_or_zero(report.positive_window_ratio)
+        + normalized_positive(report.top_bucket_avg_label)
+        + finite_or_zero(report.monotonicity_score)
+        - (report.complexity as f64 / 32.0)
+}
+
+fn selected_dimension(report: &AutoFactorReport) -> String {
+    match report.reason.as_str() {
+        "too_few_observations" | "no_powered_windows" => "sample_power",
+        "low_icir" | "unstable_positive_windows" => "stability",
+        "nonpositive_top_bucket_label" | "nonpositive_rank_ic" => "effectiveness",
+        "nonmonotonic_buckets" => "monotonicity",
+        "too_complex" => "overfit_risk",
+        "passed" => "exploit",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn avoided_subtrees(reports: &[AutoFactorReport]) -> Vec<AvoidedSubtree> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for report in reports {
+        *counts.entry(root_gene(&report.expr)).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .filter(|(_, count)| *count > 2)
+        .map(|(root_gene, count)| AvoidedSubtree {
+            root_gene,
+            count,
+            action: "penalize",
+            reason: "root_gene_crowding",
+        })
+        .collect()
+}
+
+fn root_gene(expr: &FactorExpr) -> String {
+    match expr {
+        FactorExpr::Input(_) => "Input",
+        FactorExpr::Const(_) => "Const",
+        FactorExpr::Add(_, _) => "Add",
+        FactorExpr::Sub(_, _) => "Sub",
+        FactorExpr::Mul(_, _) => "Mul",
+        FactorExpr::SafeDiv(_, _) => "SafeDiv",
+        FactorExpr::Max(_, _) => "Max",
+        FactorExpr::Min(_, _) => "Min",
+        FactorExpr::Tanh(_) => "Tanh",
+        FactorExpr::Log1pAbs(_) => "Log1pAbs",
+        FactorExpr::SqrtAbs(_) => "SqrtAbs",
+        FactorExpr::Clip { .. } => "Clip",
+        FactorExpr::Delta { .. } => "Delta",
+        FactorExpr::RollingMean { .. } => "RollingMean",
+        FactorExpr::RollingStd { .. } => "RollingStd",
+        FactorExpr::ZScore { .. } => "ZScore",
+    }
+    .to_string()
+}
+
+fn normalized_positive(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value.tanh()
+    } else {
+        0.0
+    }
+}
+
+fn finite_or_zero(value: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::autofactor::{AutoFactorDecision, FactorExpr};
+
+    #[test]
+    fn writes_search_artifact_bundle() {
+        let tmp =
+            std::env::temp_dir().join(format!("ploy-alpha-search-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let report = AutoFactorReport {
+            name: "auto_settlement_conservative_settlement_edge".to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Input("conservative_settlement_edge".to_string()),
+            n: 100,
+            pearson_ic: 0.2,
+            spearman_ic: 0.25,
+            window_count: 3,
+            window_ic_mean: 0.2,
+            icir: 1.2,
+            positive_window_ratio: 1.0,
+            symbol_count: 2,
+            symbol_ic_mean: 0.18,
+            symbol_icir: 1.0,
+            symbol_positive_ratio: 1.0,
+            bucket_avg_labels: vec![-0.1, 0.0, 0.2],
+            bottom_bucket_n: 20,
+            bottom_bucket_avg_label: -0.1,
+            top_bucket_n: 20,
+            top_bucket_avg_label: 0.2,
+            top_bucket_positive_label_rate: 0.7,
+            monotonicity_score: 1.0,
+            complexity: 1,
+            decision: AutoFactorDecision::Candidate,
+            reason: "passed".to_string(),
+        };
+        let summary = write_alpha_search_artifacts(
+            &tmp,
+            "full_depth_settlement_executable_pnl",
+            &["conservative_settlement_edge".to_string()],
+            &[report],
+            &AutoFactorOptions::default(),
+        )
+        .expect("write artifacts");
+        assert_eq!(summary.candidate_count, 1);
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/search-space.json")
+            .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/tree-trace.json")
+            .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
+            .exists());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -9,6 +9,8 @@ use crate::factors::{pearson_ic, spearman_ic};
 use crate::factors_v2::FactorObservationV2;
 
 const EPS: f64 = 1e-9;
+const MAX_DETERMINISTIC_MUTATION_DEPTH: usize = 2;
+const MAX_DETERMINISTIC_MUTATION_CANDIDATES: usize = 160;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FactorExpr {
@@ -503,18 +505,31 @@ pub fn mine_domain_autofactors_from_v2(
     target: AutoFactorV2Target,
     options: &AutoFactorOptions,
 ) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
+    mine_domain_autofactors_from_v2_with_mcts_plan(rows, target, options, &[])
+}
+
+pub fn mine_domain_autofactors_from_v2_with_mcts_plan(
+    rows: &[FactorObservationV2],
+    target: AutoFactorV2Target,
+    options: &AutoFactorOptions,
+    mcts_selected_factor_names: &[String],
+) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
     let matrix = autofactor_matrix_from_v2(rows)?;
     let labels = autofactor_labels_from_v2(rows, target);
     let windows = autofactor_windows_from_v2(rows);
     let symbols = autofactor_symbols_from_v2(rows);
     let target_name = target.as_str().to_string();
-    let candidates = domain_candidates_for_target(&matrix.input_names(), target)
-        .into_iter()
-        .map(|mut factor| {
-            factor.target = Some(target_name.clone());
-            factor
-        })
-        .collect::<Vec<_>>();
+    let candidates = domain_candidates_for_target_with_mcts(
+        &matrix.input_names(),
+        target,
+        mcts_selected_factor_names,
+    )
+    .into_iter()
+    .map(|mut factor| {
+        factor.target = Some(target_name.clone());
+        factor
+    })
+    .collect::<Vec<_>>();
     mine_autofactors(&candidates, &matrix, &labels, &windows, &symbols, options)
 }
 
@@ -756,15 +771,166 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
     out
 }
 
-fn domain_candidates_for_target(
+fn domain_candidates_for_target_with_mcts(
     input_names: &BTreeSet<String>,
     target: AutoFactorV2Target,
+    mcts_selected_factor_names: &[String],
 ) -> Vec<NamedFactorExpr> {
     let mut out = domain_seed_candidates(input_names);
     if target == AutoFactorV2Target::FullDepthSettlementExecutablePnl {
         out.extend(settlement_native_generated_candidates(input_names));
     }
+    out.extend(deterministic_mutation_candidates(input_names, &out, target));
+    if !mcts_selected_factor_names.is_empty() {
+        let selected = out
+            .iter()
+            .filter(|candidate| mcts_selected_factor_names.contains(&candidate.name))
+            .cloned()
+            .collect::<Vec<_>>();
+        out.extend(
+            deterministic_mutation_layer(input_names, &selected, target, 3)
+                .into_iter()
+                .map(|mut candidate| {
+                    candidate.name = candidate.name.replacen("mut2_", "mcts_", 1);
+                    candidate.name = candidate.name.replacen("mut_", "mcts_", 1);
+                    candidate.notes.push(
+                        "MCTS-guided expansion from prior mcts-expansion-plan.json selection."
+                            .to_string(),
+                    );
+                    candidate
+                }),
+        );
+    }
     out
+}
+
+fn deterministic_mutation_candidates(
+    input_names: &BTreeSet<String>,
+    seeds: &[NamedFactorExpr],
+    target: AutoFactorV2Target,
+) -> Vec<NamedFactorExpr> {
+    let mut out = Vec::new();
+    let mut frontier = seeds.to_vec();
+    for depth in 1..=MAX_DETERMINISTIC_MUTATION_DEPTH {
+        if out.len() >= MAX_DETERMINISTIC_MUTATION_CANDIDATES {
+            break;
+        }
+        let next = deterministic_mutation_layer(input_names, &frontier, target, depth);
+        for candidate in next.iter().cloned() {
+            if out.len() >= MAX_DETERMINISTIC_MUTATION_CANDIDATES {
+                break;
+            }
+            out.push(candidate);
+        }
+        frontier = next;
+        if frontier.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+fn deterministic_mutation_layer(
+    input_names: &BTreeSet<String>,
+    seeds: &[NamedFactorExpr],
+    target: AutoFactorV2Target,
+    depth: usize,
+) -> Vec<NamedFactorExpr> {
+    let mut out = Vec::new();
+    let settlement_target = matches!(
+        target,
+        AutoFactorV2Target::SettlementExecutablePnl
+            | AutoFactorV2Target::FullDepthSettlementExecutablePnl
+    );
+
+    for seed in seeds {
+        push_mutation(
+            &mut out,
+            seed,
+            depth,
+            "squashed",
+            FactorExpr::Tanh(Box::new(seed.expr.clone())),
+            "clip_or_squash: bound the seed score so one extreme observation cannot dominate search feedback.",
+        );
+
+        if input_names.contains("side_spread") {
+            push_mutation(
+                &mut out,
+                seed,
+                depth,
+                "spread_adjusted",
+                safe_div_expr(
+                    seed.expr.clone(),
+                    FactorExpr::Add(
+                        Box::new(input("side_spread")),
+                        Box::new(FactorExpr::Const(0.01)),
+                    ),
+                ),
+                "add_spread_penalty: scale the seed by executable Polymarket spread plus epsilon.",
+            );
+        }
+
+        if input_names.contains("near_strike_score") {
+            push_mutation(
+                &mut out,
+                seed,
+                depth,
+                "near_strike",
+                mul(seed.expr.clone(), input("near_strike_score")),
+                "add_near_strike_interaction: emphasize event states where small external moves matter more.",
+            );
+        }
+
+        if settlement_target && input_names.contains("entry_capacity_score") {
+            push_mutation(
+                &mut out,
+                seed,
+                depth,
+                "capacity",
+                mul(seed.expr.clone(), input("entry_capacity_score")),
+                "add_capacity_gate: penalize alpha that cannot be executed at the configured stake.",
+            );
+        }
+
+        if !settlement_target && input_names.contains("poly_quote_age") {
+            push_mutation(
+                &mut out,
+                seed,
+                depth,
+                "pm_lag_gate",
+                mul(
+                    seed.expr.clone(),
+                    FactorExpr::Tanh(Box::new(safe_div_expr(
+                        input("poly_quote_age"),
+                        FactorExpr::Const(3.0),
+                    ))),
+                ),
+                "add_feature_gate: repricing alpha should strengthen when the Polymarket quote is stale.",
+            );
+        }
+    }
+    out
+}
+
+fn push_mutation(
+    out: &mut Vec<NamedFactorExpr>,
+    seed: &NamedFactorExpr,
+    depth: usize,
+    suffix: &str,
+    expr: FactorExpr,
+    note: impl Into<String>,
+) {
+    let prefix = if depth <= 1 { "mut" } else { "mut2" };
+    out.push(NamedFactorExpr {
+        name: format!("{prefix}_{}_{}", seed.name, suffix),
+        expr,
+        target: seed.target.clone(),
+        notes: vec![format!(
+            "Deterministic alpha-search depth-{depth} mutation from `{}`. {}",
+            seed.name,
+            note.into()
+        )],
+    });
 }
 
 fn settlement_native_generated_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactorExpr> {
@@ -1526,6 +1692,13 @@ mod tests {
         assert!(reports
             .iter()
             .any(|report| report.name == "poly_lag_pressure"));
+        assert!(reports
+            .iter()
+            .any(|report| report.name == "mut_spread_adjusted_external_move_pm_lag_gate"));
+        assert!(reports
+            .iter()
+            .any(|report| report.name
+                == "mut2_mut_spread_adjusted_external_move_pm_lag_gate_squashed"));
     }
 
     #[test]
@@ -1586,6 +1759,15 @@ mod tests {
         assert!(reports.iter().any(|report| {
             report.name == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity"
         }));
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name
+                    == "mut_auto_settlement_full_depth_settlement_edge_capacity")
+        );
+        assert!(reports
+            .iter()
+            .any(|report| report.name.starts_with("mut2_")));
     }
 
     #[test]

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -581,6 +581,18 @@ pub fn autofactor_matrix_from_v2(
         rows,
         |row| row.cex_bar_return_30s * row.side.multiplier(),
     );
+    insert_column(&mut columns, "cex_return_30s_side", rows, |row| {
+        row.cex_bar_return_30s * row.side.multiplier()
+    });
+    insert_column(&mut columns, "cex_return_60s_side", rows, |row| {
+        row.cex_bar_return_60s * row.side.multiplier()
+    });
+    insert_column(&mut columns, "sigma_horizon_pos", rows, |row| {
+        positive_or_nan(row.sigma_horizon)
+    });
+    insert_column(&mut columns, "vol_gap_pos", rows, |row| {
+        positive_or_nan(row.vol_gap)
+    });
     insert_column(&mut columns, "poly_quote_age", rows, |row| {
         row.pm_lag_secs.max(0.0)
     });
@@ -766,6 +778,34 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             ),
             target: Some("reprice_pnl_10s".to_string()),
             notes: vec!["External move must clear the side spread to be tradable.".to_string()],
+        });
+    }
+    if has_all(input_names, &["cex_return_30s_side", "sigma_horizon_pos"]) {
+        out.push(NamedFactorExpr {
+            name: "amplitude_weighted_momentum_30s_sigma".to_string(),
+            expr: mul(
+                input("cex_return_30s_side"),
+                FactorExpr::Log1pAbs(Box::new(input("sigma_horizon_pos"))),
+            ),
+            target: Some("reprice_pnl_10s".to_string()),
+            notes: vec![
+                "Side-aligned 30s CEX return weighted by current event volatility amplitude."
+                    .to_string(),
+            ],
+        });
+    }
+    if has_all(input_names, &["cex_return_30s_side", "vol_gap_pos"]) {
+        out.push(NamedFactorExpr {
+            name: "amplitude_weighted_momentum_30s_vol_gap".to_string(),
+            expr: mul(
+                input("cex_return_30s_side"),
+                FactorExpr::Log1pAbs(Box::new(input("vol_gap_pos"))),
+            ),
+            target: Some("reprice_pnl_10s".to_string()),
+            notes: vec![
+                "Side-aligned 30s CEX return weighted by positive volatility shock versus implied baseline."
+                    .to_string(),
+            ],
         });
     }
     out
@@ -1478,7 +1518,7 @@ mod tests {
             drift_30s: 0.0,
             post_flip_drift: 0.0,
             sigma_horizon: 1.0,
-            vol_gap: 0.0,
+            vol_gap: score + 1.0,
             obi_10: score + 1.0,
             depth_imbalance: 0.0,
             depth_acceleration: 0.0,
@@ -1692,6 +1732,12 @@ mod tests {
         assert!(reports
             .iter()
             .any(|report| report.name == "poly_lag_pressure"));
+        assert!(reports
+            .iter()
+            .any(|report| report.name == "amplitude_weighted_momentum_30s_sigma"));
+        assert!(reports
+            .iter()
+            .any(|report| report.name == "amplitude_weighted_momentum_30s_vol_gap"));
         assert!(reports
             .iter()
             .any(|report| report.name == "mut_spread_adjusted_external_move_pm_lag_gate"));

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alpha_search;
 pub mod attribution;
 pub mod autofactor;
 pub mod backtest;
@@ -81,12 +82,16 @@ pub fn crate_marker() -> &'static str {
 // Keep `Regime` as a single root-level export from operator contracts. The
 // factor registry uses the same type internally, but does not re-export its own
 // `factors_new::Regime` alias.
+pub use alpha_search::{
+    write_alpha_search_artifacts, AlphaSearchArtifactError, AlphaSearchArtifactSummary,
+};
 pub use attribution::{factor_pnl, regime_pnl, AttributionReport, RegimePnl};
 pub use autofactor::{
     autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_windows_from_v2,
     domain_seed_candidates, evaluate_named_factor, format_autofactor_reports, mine_autofactors,
-    mine_domain_autofactors_from_v2, AutoFactorDecision, AutoFactorError, AutoFactorMatrix,
-    AutoFactorOptions, AutoFactorReport, AutoFactorV2Target, FactorExpr, NamedFactorExpr,
+    mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_mcts_plan,
+    AutoFactorDecision, AutoFactorError, AutoFactorMatrix, AutoFactorOptions, AutoFactorReport,
+    AutoFactorV2Target, FactorExpr, NamedFactorExpr,
 };
 pub use backtest::{run_binary_backtest, BacktestMetrics, SimulatedFill};
 pub use factors_new::{
@@ -137,9 +142,8 @@ pub use factors_v2::{
     SettlementProbabilityReportOptions, SettlementProbabilitySymbolHoldoutRow,
     SettlementProbabilityWalkForwardAggregate, SettlementProbabilityWalkForwardOptions,
     SettlementProbabilityWalkForwardReport, SettlementProbabilityWalkForwardWindow,
-    SingleFactorReview, ThreeLayerArchive,
-    TradeFormationPathRow, TradeFormationReviewOptions, TradeFormationReviewReport,
-    TradeFormationRuleRow,
+    SingleFactorReview, ThreeLayerArchive, TradeFormationPathRow, TradeFormationReviewOptions,
+    TradeFormationReviewReport, TradeFormationRuleRow,
 };
 #[cfg(feature = "rl")]
 pub use model::rl::{BinaryEventEnv, DqnAgent, Environment, ReplayBuffer};

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -1,0 +1,372 @@
+# Alpha Factor Search CI/CD Contract
+
+This document defines Ploy's CI/CD method for mining alpha factors with a
+two-layer search architecture:
+
+```text
+LLM semantic prior layer
+  -> MCTS/systematic search layer
+  -> CI backtest feedback layer
+  -> promotion/handoff gate
+```
+
+It complements `docs/PROJECT_SEMANTICS.md`; it does not bypass settlement,
+execution, runtime-parity, or dry-run/live promotion gates.
+
+## Paper Basis
+
+The design is grounded in these research patterns:
+
+- `Navigating the Alpha Jungle`: combine LLM symbolic formula generation with
+  MCTS exploration, backtest feedback, and frequent-subtree avoidance for
+  interpretable formulaic factor mining.
+- `RiskMiner`: formulate alpha mining as a reward-dense MDP and solve it with
+  risk-seeking MCTS so the search uses the structure of the discrete formula
+  space instead of treating candidate generation as a flat neural policy.
+- `Alpha-GPT`: use LLMs as an interactive bridge from human trading ideas to
+  symbolic alpha expressions and iterative modification suggestions.
+- `QuantaAlpha`: preserve semantic consistency between hypothesis, expression,
+  and executable code, and reuse high-reward trajectory segments through
+  controlled evolution.
+
+For Ploy, these are architecture inputs, not permission to skip repo gates.
+The useful pattern is LLM-guided symbolic priors plus machine-checked
+exploration and CI evidence.
+
+## Current State
+
+The repo already has the downstream half of the factory:
+
+- `factor-walk-forward-v2.yml`: self-hosted research path for fresh DB-adjacent
+  snapshot and walk-forward evidence.
+- `factor-walk-forward-v2-hosted-artifact.yml`: GitHub-hosted path that consumes
+  a retained full research snapshot artifact.
+- `autofactor-strategy-promotion.yml`: evaluator for existing
+  `factor-walk-forward-v2-*` artifacts.
+- `scripts/evaluate_autofactor_strategy_promotion.py`: fail-closed promotion
+  gate from discovered factor rows to strategy handoff artifacts.
+- `scripts/apply_autofactor_handoff_to_config.py`: ready-only config PR bridge.
+- `crates/ploy-research/src/autofactor.rs`: Rust `FactorExpr` DSL, safe
+  operators, seed candidates, settlement-native generated candidates, and
+  candidate/watchlist/reject scoring.
+
+That means the repo can already do:
+
+```text
+research snapshot
+  -> factor walk-forward
+  -> AutoFactor promotion evaluation
+  -> blocked/ready handoff artifact
+  -> optional dry-run config PR
+```
+
+The missing layer is the upstream search controller:
+
+```text
+semantic hypothesis + formula prior
+  -> feature pool + constant pool + operator pool
+  -> MCTS candidate expansion
+  -> multi-dimensional backtest feedback
+  -> search trace artifacts
+  -> factor walk-forward rows
+```
+
+Until that layer is implemented, AutoFactor is a constrained generator plus
+promotion gate, not a full alpha-search engine.
+
+## Architecture
+
+### 1. LLM Semantic Prior Layer
+
+The LLM should produce a prior, not final truth. Its job is to translate a
+market intuition into a typed, reviewable search seed:
+
+- natural-language hypothesis
+- expected edge mechanism
+- applicable strategy lane, such as `settlement_probability` or `repricing`
+- required data surfaces
+- candidate feature families
+- initial symbolic `FactorExpr` formulas
+- suggested constants and bounded ranges
+- suggested local modifications
+- invalid assumptions and expected failure modes
+
+The LLM output must be machine-checkable before it enters search. Invalid
+features, unsupported operators, unbounded constants, future-looking columns,
+or missing data surfaces are rejected before any backtest.
+
+Required artifact:
+
+- `llm-priors.json`
+- `llm-priors.md`
+
+### 2. MCTS Search Layer
+
+MCTS owns exploration and exploitation over the formula space. Each node is a
+candidate formula state:
+
+```text
+node = {
+  factor_expr,
+  hypothesis_ref,
+  parent,
+  mutation,
+  selected_dimension,
+  metrics,
+  visits,
+  reward,
+  blockers
+}
+```
+
+The search loop:
+
+```text
+select node
+  -> choose weak dimension
+  -> expand with allowed mutation
+  -> evaluate candidate
+  -> backpropagate multi-dimensional reward
+  -> penalize crowded or invalid subtrees
+```
+
+MCTS may use the LLM as an expansion policy, but only inside the declared DSL.
+The LLM can propose modifications like "gate by quote freshness" or "scale by
+capacity", but the Rust layer must compile them into `FactorExpr` using allowed
+features, constants, and operators.
+
+Required artifacts:
+
+- `tree-trace.json`
+- `node-metrics.json`
+- `candidate-expressions.json`
+- `rejected-expressions.json`
+- `avoided-subtrees.json`
+
+### 3. CI Backtest Feedback Layer
+
+Backtest feedback is the scoring signal for MCTS. It must be produced by the
+same CI evidence path used for promotion:
+
+- snapshot provenance
+- walk-forward windows
+- executable target labels
+- data-surface audit
+- fillability/capacity assumptions
+- settlement or exit accounting
+- promotion-gate readiness
+
+The reward should not be a single PnL number. It should combine:
+
+- effectiveness: executable target score, PnL, IC/ICIR, top-bucket label
+- stability: positive-window ratio, window decay, symbol holdout behavior
+- diversity: novelty versus accepted/watchlisted factor expressions
+- execution cost: spread, capacity, fillability, quote age, turnover-like churn
+- overfit risk: complexity, parameter count, train/test decay, permutation and
+  time-shift sensitivity
+- runtime readiness: explicit profile mapping and scorer support
+
+Required artifact:
+
+- `search-feedback.json`
+- `search-feedback.md`
+
+### 4. Promotion/Handoff Layer
+
+Only this layer can produce a dry-run handoff or config PR. The LLM and MCTS
+layers can generate candidates, but they cannot promote them.
+
+The existing fail-closed path remains:
+
+```text
+factor-walk-forward-v2/report.txt
+  -> scripts/evaluate_autofactor_strategy_promotion.py
+  -> autofactor-factor-registry.json
+  -> autofactor-strategy-handoff.json
+  -> optional ready-only handoff issue or config PR
+```
+
+## Search-Space Contract
+
+Every alpha-search run must declare its search space in machine-readable form.
+
+### Feature Pool
+
+Features should be grouped by data meaning, not only by column name:
+
+- external price movement: Binance spot / aggTrade moves, velocity, acceleration
+- external microstructure: L2 imbalance, OFI, depth, thinness, pressure
+- Polymarket quote state: side ask/bid, spread, quote age, PM lag
+- full-depth execution: sweep price, capacity, conservative depth assumptions
+- event geometry: time remaining, distance to strike, near-strike score
+- probability state: q estimates, market prior, EventVolSurface prior
+- volatility state: realized/IV/DVOL primitives when present and audited
+- risk/friction: fees, slippage, fillability, capacity, turnover proxies
+
+A feature absent from the snapshot must fail closed for generated candidates
+that require it. Do not silently substitute a different data surface.
+
+### Constant Pool
+
+Constants are part of the hypothesis. They must be declared, bounded, and
+reported. Initial safe pools:
+
+- additive epsilons: `0.001`, `0.005`, `0.01`, `0.02`
+- spread/capacity thresholds: `0.01`, `0.02`, `0.05`, `0.10`
+- time windows or lags: `1`, `3`, `5`, `10`, `30`, `60`, `300`
+- clipping bounds: `[-5, 5]`, `[-3, 3]`, `[0, 1]`
+- nonlinear scales: `1`, `2`, `3`, `5`, `10`
+
+Constants discovered by search are not automatically runtime constants. A
+runtime handoff must show the selected constants, their source run, and why they
+survived walk-forward and anti-overfit gates.
+
+### Operator Pool
+
+Operators must be safe, deterministic, and supported by replay/runtime parity.
+The current `FactorExpr` foundation already supports:
+
+- inputs and constants
+- `Add`, `Sub`, `Mul`
+- `SafeDiv`
+- `Max`, `Min`
+- `Tanh`, `Log1pAbs`, `SqrtAbs`
+- `Clip`
+- `Delta`
+- `RollingMean`, `RollingStd`, `ZScore`
+
+New operators require deterministic semantics, finite-value handling,
+complexity accounting, serialization compatibility, test coverage, and a
+runtime/replay parity plan if the operator can reach strategy handoff.
+
+## LLM Modification Types
+
+LLM proposals must compile into one of these bounded mutation types:
+
+- `add_feature_gate`: multiply by a bounded regime, capacity, or freshness score
+- `replace_denominator`: change a normalization term with safe division
+- `add_spread_penalty`: subtract or divide by executable friction
+- `add_capacity_gate`: penalize candidates that only work at unavailable depth
+- `add_near_strike_interaction`: condition on event geometry
+- `change_time_window`: swap among declared lag/window constants
+- `clip_or_squash`: add `Clip`, `Tanh`, or `Log1pAbs` for robustness
+- `invert_or_contrarian`: test opposite sign only when semantically justified
+- `remove_component`: ablate a subtree to reduce overfit risk
+
+Free-form code generation is not allowed in the search loop. LLM output is
+advice until it is parsed into typed mutations.
+
+## Frequent-Subtree Avoidance
+
+The search layer must track repeated expression structures. A subtree can be
+penalized or blocked when it repeats a crowded root gene without improving the
+selected weak dimension.
+
+Examples:
+
+- repeated `safe_div(external_move, spread + eps)` variants
+- repeated `edge * near_strike_score` variants
+- repeated stale-quote gates with only epsilon changes
+
+Avoidance is not a hard ban forever. It is a diversity control: a crowded
+subtree can be revisited only when the candidate improves a declared weak
+dimension such as capacity, stability, or overfit risk.
+
+## Workflow Roles
+
+- `factor-walk-forward-v2-hosted-artifact.yml` should be the default efficient
+  search surface once a full snapshot artifact exists.
+- `factor-walk-forward-v2.yml` should be used when a fresh DB-adjacent snapshot
+  or data audit is required.
+- `autofactor-strategy-promotion.yml` should be used to re-evaluate an existing
+  walk-forward artifact without rerunning search.
+- `event-ml-rolling-evidence.yml` is the supervised event-ML lane, not the
+  formula-search lane, though it may consume factor registries later.
+
+## Required Search Artifact Bundle
+
+Every complete CI/CD alpha-search run should upload:
+
+- `search-space.json`: feature pool, constants, operators, targets, limits
+- `llm-priors.json`: hypotheses, symbolic seeds, suggested modifications
+- `candidate-expressions.json`: all generated `FactorExpr` candidates
+- `rejected-expressions.json`: invalid or blocked expressions and reasons
+- `tree-trace.json`: parent/child expansions, selected weak dimension, rewards
+- `node-metrics.json`: multi-dimensional scores per node
+- `mcts-expansion-plan.json`: UCB-style branch selection for the next search
+  run, including selected weak dimension and proposed mutation type
+- `avoided-subtrees.json`: repeated subtrees blocked or penalized
+- `search-feedback.json`: backtest feedback used by MCTS
+- `alpha-search-chain/chain-decision.json`: hosted-workflow continuation
+  decision, including whether the next run was dispatched and why the chain
+  stopped when it did not continue
+- `factor-walk-forward-v2/report.txt`: existing walk-forward report
+- `autofactor-factor-registry.json`: evaluated factor rows and blockers
+- `autofactor-strategy-handoff.json`: ready/blocked handoff manifest
+
+If any of the search artifacts are missing, the run can still be diagnostic,
+but it is not a complete alpha-search run.
+
+## Completion Criteria
+
+The method is fully defined only when CI exposes all of the following:
+
+- LLM prior artifact with machine-checkable hypotheses and formulas
+- declared feature pool, constant pool, and operator pool
+- typed mutation schema from LLM suggestions to `FactorExpr`
+- MCTS controller with selection, expansion, evaluation, and backpropagation
+- multi-dimensional node scoring from CI backtest feedback
+- frequent-subtree/root-gene avoidance
+- full search artifact bundle
+- existing walk-forward and promotion gates
+- ready-only issue/config PR creation
+
+Current implementation status:
+
+- Implemented: deterministic seed-search artifact bundle from
+  `factor_walk_forward_v2` via `--alpha-search-output-dir`.
+- Implemented: bounded deterministic multi-depth mutations over existing domain
+  seeds, including squashing, spread adjustment, near-strike interaction,
+  capacity gating, and PM-lag gating. The current depth is capped at `2`, with
+  a candidate cap to keep CI runs bounded.
+- Implemented: workflow upload path for the artifact bundle through both
+  Factor Walk-Forward V2 workflows.
+- Implemented: first MCTS control artifact,
+  `mcts-expansion-plan.json`, which ranks non-rejected nodes with a UCB-style
+  priority and proposes the next mutation family from each node's weakest
+  dimension.
+- Implemented: `factor_walk_forward_v2 --alpha-search-plan-json <path>` can
+  consume a prior `mcts-expansion-plan.json` and generate extra `mcts_*`
+  guided mutations for selected branches. The Factor Walk-Forward workflows
+  expose this as `options_json.alpha_search_plan_json`.
+- Implemented: the Factor Walk-Forward workflows can download a prior plan from
+  a previous run with `options_json.alpha_search_plan_run_id`,
+  `alpha_search_plan_artifact_name`, and `alpha_search_plan_target`.
+- Implemented: the hosted artifact workflow can dispatch the next search
+  iteration automatically with `options_json.chain_next_run=true` and bounded
+  `chain_remaining`.
+- Implemented: the hosted chain stops early when the current run already
+  produces `autofactor-strategy-handoff.json status=ready` or when the current
+  MCTS plan has no selected nodes.
+- Implemented: hosted chained runs request `actions: write` and publish
+  `alpha-search-chain/chain-decision.json` before dispatch, so CI artifacts
+  record `continue`, `ready_handoff`, `no_selected_nodes`,
+  `chain_remaining_exhausted`, or other stop reasons instead of relying only on
+  workflow logs.
+- Implemented: the hosted chain compares the current
+  `search-feedback.json.best_reward` with the prior plan artifact's
+  `search-feedback.json.best_reward` and stops with `reward_stagnation` when
+  the configured `alpha_search_min_reward_improvement` threshold is not met.
+- Implemented as placeholder artifact: `llm-priors.json` records the typed prior
+  schema without calling an external LLM.
+- Not yet implemented: live LLM expansion policy, typed mutation parser from
+  LLM proposals, full multi-run MCTS visit/reward backpropagation beyond the
+  current artifact-to-artifact feedback loop.
+
+The current system is enough to start systematizing alpha discovery in CI: every
+walk-forward run can now expand interpretable bounded multi-depth mutations,
+download or consume a prior MCTS expansion plan, and preserve search space,
+candidates, rejected expressions, node metrics, tree trace, MCTS expansion plan,
+subtree crowding, and feedback artifacts. Hosted artifact runs can also dispatch
+bounded chained follow-up runs with ready-handoff, empty-plan, and reward
+stagnation stop criteria.

--- a/docs/PROJECT_SEMANTICS.md
+++ b/docs/PROJECT_SEMANTICS.md
@@ -1,0 +1,131 @@
+# Ploy Project Semantics
+
+This file is the repository-level semantic contract for Ploy. Read it before
+PM5D, event ML, factor research, replay, backtest, dry-run, live-prep, or
+deployment-promotion work.
+
+## What Ploy Is
+
+Ploy is a multi-crate trading platform for prediction-market strategies, not a
+single bot script. The current canonical runtime path is:
+
+- `apps/new-ployd`: daemon and HTTP control-plane surface
+- `apps/ployctl`: operator client for system, trading, and deployment control
+- `apps/new-ploy-runner`: strategy runner using unified strategy configs
+- `crates/ploy-trading`: canonical trading lifecycle
+- `crates/ploy-strategy-bundles`: signal-to-intent strategy logic
+- `crates/ploy-strategy-runtime`: strategy dispatch and runtime ownership
+- `crates/ploy-research`: replay, factor research, backtest, and evidence
+  generation
+
+Archived or compatibility commands in older docs are not the default operating
+surface unless a task explicitly targets legacy code.
+
+## Trading Lifecycle
+
+The platform lifecycle is:
+
+```text
+market data -> signal -> intent -> order -> ack -> fill -> position -> pnl -> risk
+```
+
+Research, replay, dry-run, and live work must say which lifecycle segment is
+being tested. A result about signal quality is not evidence that execution,
+fills, settlement accounting, or risk behavior is ready.
+
+## PM5D Strategy Semantics
+
+PM5D / five-minute crypto event work is event-rooted binary-options trading.
+The strategy question is not only whether a short-horizon price move predicts a
+quote move. It is which of these lanes is being evaluated:
+
+- `settlement_probability`: estimate the probability that the event settles on
+  a side, then compare that probability with executable entry cost.
+- `repricing`: exploit short-horizon Polymarket quote movement before
+  settlement.
+- `runtime_parity`: prove replay, dry-run, and runtime use the same scorer,
+  input sequence, and accounting semantics.
+- `execution_quality`: prove quote freshness, depth, fillability, slippage,
+  queue priority, and venue constraints are modeled conservatively.
+
+Default promotion priority is settlement-probability evidence. Repricing
+evidence can stay valuable as a diagnostic lane, but it must not silently become
+the main dry-run or live promotion path.
+
+Executable PM5D accounting is one event, one decision, one trade lifecycle
+unless a task explicitly defines a multi-entry strategy. Entry-grid diagnostics
+that evaluate many timestamps from the same event are research diagnostics, not
+deployable trade counts.
+
+## Evidence Stages
+
+Use these stage names consistently in reports, issues, and handoff artifacts:
+
+- `diagnostic`: explores signal shape or data behavior. Not deployable.
+- `factor_attribution`: measures factor direction, stability, IC/ICIR, or
+  bucket behavior. Not deployable by itself.
+- `executable_replay`: uses executable prices, realistic fill assumptions,
+  event-level accounting, and settlement or exit labels.
+- `walk_forward`: separates train/validation/test windows and blocks leakage.
+- `runtime_parity`: proves research and runtime scorers/configs produce the
+  same decisions on the same input sequence.
+- `dry_run_candidate`: has passed the required gates and can be tested with
+  fixed small stake and kill switches.
+- `live_candidate`: dry-run evidence plus operator, risk, balance, settlement,
+  claim/redeem, and deployment guardrail evidence.
+
+Do not collapse these stages. A positive diagnostic or factor result is a reason
+to continue research, not a reason to deploy.
+
+## Data Semantics
+
+Reports must name the data surfaces used and the surfaces missing:
+
+- Binance spot or trade ticks: external price movement.
+- Binance L2 / LOB: depth, pressure, and short-term execution context.
+- Polymarket quote ticks: top-of-book PM market state.
+- Polymarket full CLOB depth: executable sweep, capacity, and conservative
+  fillability.
+- Official settlement: final binary outcome for settlement-probability
+  accounting.
+- Dry-run/runtime fills: observed execution behavior, not a substitute for
+  official settlement labels.
+
+If full-depth CLOB, official settlement, replay parity, or runtime scorer parity
+is missing, mark promotion as blocked unless the task explicitly targets an
+earlier diagnostic stage.
+
+## Promotion Gates
+
+A PM5D or event-ML strategy may move toward dry-run only when the evidence names
+and passes the relevant gates:
+
+- hypothesis and expected edge mechanism are explicit
+- data window, symbols, snapshot/run ID, git ref, and artifacts are recorded
+- data audit status and missing surfaces are listed
+- executable price and fillability assumptions are conservative
+- settlement or exit label matches the intended strategy lane
+- train/test or walk-forward split prevents leakage
+- replay/dry-run parity is present for runtime handoff
+- runtime scorer/config mapping is explicit
+- risk, stake, kill switch, and daily loss limits are stated
+- caveats and next decision are recorded
+
+If any required gate is missing, the decision should be `continue`, `revise`, or
+`reject`, not `promote to dry-run` or `promote to live`.
+
+## Agent Operating Rule
+
+Before running or interpreting research/backtest/promotion work, an agent must:
+
+1. Read this file and the relevant runbook under `docs/runbooks/`.
+   For CI/CD alpha-factor search, also read
+   `docs/ALPHA_FACTOR_SEARCH_CICD.md`.
+2. State the evidence stage being produced.
+3. Write results using `tasks/research_evidence/TEMPLATE.md` or a stricter
+   machine-readable artifact when a workflow already provides one.
+4. Treat conflicts with this semantic contract as blockers or caveats.
+
+Subagents working on Ploy research must receive this file path in their task
+prompt. Memory can provide historical context, but this file is the project
+source of truth for current semantics.

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -120,6 +120,10 @@ def factor_args(args: argparse.Namespace, variant: Variant, replay_parity_json: 
         command.extend(["--factor-name-filter", values["factor_name_filter"]])
     if replay_parity_json:
         command.extend(["--replay-parity-json", replay_parity_json])
+    if args.alpha_search_output_dir:
+        command.extend(["--alpha-search-output-dir", args.alpha_search_output_dir])
+    if args.alpha_search_plan_json:
+        command.extend(["--alpha-search-plan-json", args.alpha_search_plan_json])
     return command
 
 
@@ -304,6 +308,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end-ts", required=True)
     parser.add_argument("--stake-usd", required=True)
     parser.add_argument("--replay-parity-json", default="")
+    parser.add_argument("--alpha-search-output-dir", default="")
+    parser.add_argument("--alpha-search-plan-json", default="")
     parser.add_argument("--required-strategy-profile", default="settlement_probability")
     parser.add_argument("--allowed-target", action="append", default=[])
     parser.add_argument("--sweep-json", default="")

--- a/tasks/research_evidence/TEMPLATE.md
+++ b/tasks/research_evidence/TEMPLATE.md
@@ -1,0 +1,79 @@
+# Research Evidence: <topic> - <YYYY-MM-DD>
+
+## Decision
+
+Status: `<continue | revise | reject | promote-to-dry-run | promote-to-live>`
+
+One-line decision:
+
+## Semantic Context
+
+- Strategy lane: `<settlement_probability | repricing | runtime_parity | execution_quality | other>`
+- Evidence stage: `<diagnostic | factor_attribution | executable_replay | walk_forward | runtime_parity | dry_run_candidate | live_candidate>`
+- Lifecycle segment tested: `<signal | intent | order | fill | position | pnl | risk | end-to-end>`
+- Promotion target, if any: `<none | dry-run | live>`
+
+## Hypothesis
+
+- Claim:
+- Expected edge mechanism:
+- Failure criteria:
+- Next decision this evidence should unlock:
+
+## Inputs
+
+- Git ref:
+- Workflow run:
+- Snapshot or artifact:
+- Dataset/window:
+- Symbols/events:
+- Config:
+- Local/remote artifact paths:
+
+## Data Surface Audit
+
+- Binance spot/trade ticks: `<present | missing | not applicable>`
+- Binance L2/LOB: `<present | missing | not applicable>`
+- Polymarket quote ticks: `<present | missing | not applicable>`
+- Polymarket full CLOB depth: `<present | missing | not applicable>`
+- Official settlement: `<present | missing | not applicable>`
+- Runtime/dry-run fills: `<present | missing | not applicable>`
+- Data audit status:
+- Missing surfaces and impact:
+
+## Accounting Semantics
+
+- Event accounting: `<one-event-one-trade | multi-entry-defined | diagnostic-entry-grid>`
+- Entry price model:
+- Exit or settlement label:
+- Fillability assumption:
+- Fees/slippage/latency assumption:
+- Capacity or stake assumption:
+
+## Results
+
+- Headline metrics:
+- Stability metrics:
+- Calibration or bucket behavior:
+- Fill rate/capacity:
+- PnL/ROI:
+- Drawdown/risk:
+
+## Promotion Gate Check
+
+- Hypothesis explicit: `<pass | fail | n/a>`
+- Data provenance recorded: `<pass | fail | n/a>`
+- Executable pricing conservative: `<pass | fail | n/a>`
+- Settlement/exit label matches lane: `<pass | fail | n/a>`
+- Walk-forward or leakage guard: `<pass | fail | n/a>`
+- Replay/runtime parity: `<pass | fail | n/a>`
+- Runtime scorer/config mapping: `<pass | fail | n/a>`
+- Risk/stake/kill switch stated: `<pass | fail | n/a>`
+
+## Caveats
+
+- 
+
+## Follow-Up
+
+- 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -972,6 +972,32 @@ evidence comes from Polymarket full CLOB depth, not top book.
   `anti_overfit_diagnostics`, `walk_forward_oos`, and
   `recorded_replay_parity`.
 
+# Amplitude-Weighted Momentum Factor Check (2026-05-11)
+
+## Goal
+
+Verify whether amplitude-weighted CEX momentum is useful for PM5D binary
+options as `factor_attribution` evidence. This is not a dry-run or live
+promotion task.
+
+## Plan
+
+- [x] Add narrow AutoFactor candidates for amplitude-weighted momentum using
+  existing Factor V2 fields only.
+- [x] Run focused local checks that avoid local DB/backtest execution.
+- [ ] Dispatch hosted factor walk-forward evidence from existing research
+  snapshot artifacts.
+- [ ] Record whether the factor is useful for settlement probability,
+  repricing, or neither.
+
+## Review
+
+- 2026-05-11: Added `amplitude_weighted_momentum_30s_sigma` and
+  `amplitude_weighted_momentum_30s_vol_gap` as AutoFactor research candidates
+  only. Local verification passed: `rustfmt --edition 2021 --check
+  crates/ploy-research/src/autofactor.rs` and `CARGO_TARGET_DIR=/tmp/ploy-awm-autofactor
+  rtk cargo test -p ploy-research autofactor --lib` with 8 tests passing.
+
 # PM5D High ICIR Strategy Discovery Plan (2026-05-03)
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Alpha Search CI/CD Clean Port (2026-05-11)
+
+## Goal
+
+Port the systematic alpha discovery layer onto a clean `main`-based branch so
+CI can generate, evaluate, chain, and preserve factor candidates without
+bypassing replay/runtime parity or dry-run promotion gates.
+
+## Plan
+
+- [x] Preserve the current hosted factor walk-forward sweep wrapper instead of
+  reverting to a direct binary-only workflow.
+- [x] Add alpha-search artifact output and prior MCTS plan passthrough to the
+  sweep path.
+- [ ] Finish the clean cherry-pick, resolve conflicts, and verify workflow
+  YAML/Python/Rust compile surfaces.
+- [ ] Open a focused PR for the alpha-search CI/CD artifact layer.
+
+Review:
+- The intended search shape is `semantic prior -> typed formula candidates ->
+  deterministic/MCTS-guided expansion -> CI walk-forward feedback -> promotion
+  evaluator -> blocked-or-ready handoff`.
+- This work is candidate discovery infrastructure. It does not claim a
+  profitable deployable strategy until walk-forward, replay/runtime parity,
+  and dry-run handoff gates produce ready evidence.
+
 # Recorded Replay Official Settlement Enrichment (2026-05-11)
 
 ## Follow-up: Settlement Parity Classifier (2026-05-11)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,6 +23,11 @@ Review:
 - This work is candidate discovery infrastructure. It does not claim a
   profitable deployable strategy until walk-forward, replay/runtime parity,
   and dry-run handoff gates produce ready evidence.
+- Old-branch CI smoke evidence showed the chain can improve candidate search
+  rewards (`25672175576` best_reward `4.81954070569323`, chained run
+  `25672625360` best_reward `4.894975850946932`), but those results are
+  research/search evidence only and must be rerun from this clean branch before
+  promotion.
 
 # Recorded Replay Official Settlement Enrichment (2026-05-11)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,7 +12,7 @@ bypassing replay/runtime parity or dry-run promotion gates.
   reverting to a direct binary-only workflow.
 - [x] Add alpha-search artifact output and prior MCTS plan passthrough to the
   sweep path.
-- [ ] Finish the clean cherry-pick, resolve conflicts, and verify workflow
+- [x] Finish the clean cherry-pick, resolve conflicts, and verify workflow
   YAML/Python/Rust compile surfaces.
 - [ ] Open a focused PR for the alpha-search CI/CD artifact layer.
 
@@ -28,6 +28,13 @@ Review:
   `25672625360` best_reward `4.894975850946932`), but those results are
   research/search evidence only and must be rerun from this clean branch before
   promotion.
+- Clean-branch local verification passed: `python3 -m py_compile
+  scripts/run_factor_walk_forward_sweep.py`, Ruby YAML parse for both factor
+  workflows, `CARGO_TARGET_DIR=/tmp/ploy-alpha-clean rtk cargo check -p
+  ploy-research --features db --example factor_walk_forward_v2`,
+  `CARGO_TARGET_DIR=/tmp/ploy-alpha-clean-test rtk cargo test -p
+  ploy-research alpha_search --lib`, `CARGO_TARGET_DIR=/tmp/ploy-autofactor-clean-test
+  rtk cargo test -p ploy-research autofactor --lib`, and `git diff --check`.
 
 # Recorded Replay Official Settlement Enrichment (2026-05-11)
 


### PR DESCRIPTION
## Summary
- add repo-local project semantics and research evidence template for PM5D/event research work
- add alpha-search artifact generation for AutoFactor candidates, including search space, priors, node metrics, tree trace, feedback, and MCTS expansion plan
- wire factor walk-forward workflows and sweep wrapper to emit alpha-search artifacts, consume prior MCTS plans, and support bounded chained hosted exploration
- add amplitude-weighted momentum candidate mutations while preserving promotion gates

## Verification
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); YAML.load_file(".github/workflows/factor-walk-forward-v2.yml")'
- CARGO_TARGET_DIR=/tmp/ploy-alpha-clean rtk cargo check -p ploy-research --features db --example factor_walk_forward_v2
- CARGO_TARGET_DIR=/tmp/ploy-alpha-clean-test rtk cargo test -p ploy-research alpha_search --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-clean-test rtk cargo test -p ploy-research autofactor --lib
- git diff --check

## Notes
This PR adds systematic candidate discovery and CI artifacts. It does not promote a strategy to dry-run/live; replay/runtime parity and promotion handoff gates remain required.