### PR TITLE
Require event replay parity for alpha promotion

### DIFF
--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -141,7 +141,7 @@ fn replay_parity_evidence(path: &str) -> (bool, String) {
         .get("decision")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("<missing>");
-    let ready = runtime_ready && risk_flags.is_empty() && decision == "continue";
+    let ready = runtime_ready && event_ready && risk_flags.is_empty() && decision == "continue";
     let evidence = format!(
         "replay_parity_json={} runtime_ready={} event_ready={} blocking_flags={} advisory_flags={} decision={}",
         path,
@@ -160,6 +160,60 @@ fn replay_parity_evidence(path: &str) -> (bool, String) {
         decision,
     );
     (ready, evidence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replay_parity_evidence;
+    use std::fs;
+
+    fn write_parity_fixture(name: &str, payload: &str) -> String {
+        let path = std::env::temp_dir().join(format!(
+            "ploy-factor-walk-forward-{name}-{}-{}.json",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        fs::write(&path, payload).expect("write parity fixture");
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn replay_parity_requires_runtime_and_event_strict_readiness() {
+        let path = write_parity_fixture(
+            "event-not-ready",
+            r#"{
+              "decision": "continue",
+              "blocking_risk_flags": [],
+              "runtime_evidence_comparison": {"strict_parity_ready": true},
+              "event_comparison": {"strict_parity_ready": false}
+            }"#,
+        );
+
+        let (ready, evidence) = replay_parity_evidence(&path);
+
+        assert!(!ready);
+        assert!(evidence.contains("runtime_ready=true"));
+        assert!(evidence.contains("event_ready=false"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn replay_parity_accepts_runtime_and_event_strict_readiness() {
+        let path = write_parity_fixture(
+            "ready",
+            r#"{
+              "decision": "continue",
+              "blocking_risk_flags": [],
+              "runtime_evidence_comparison": {"strict_parity_ready": true},
+              "event_comparison": {"strict_parity_ready": true}
+            }"#,
+        );
+
+        let (ready, evidence) = replay_parity_evidence(&path);
+
+        assert!(ready, "{evidence}");
+        let _ = fs::remove_file(path);
+    }
 }
 
 fn alpha_search_plan_factor_names(path: &str) -> Vec<String> {
@@ -705,7 +759,10 @@ async fn main() {
                             summary.output_dir
                         ),
                         Err(err) => {
-                            eprintln!("alpha search artifact write failed for {}: {err}", target.as_str());
+                            eprintln!(
+                                "alpha search artifact write failed for {}: {err}",
+                                target.as_str()
+                            );
                         }
                     }
                 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Alpha Promotion Parity Gate Hardening (2026-05-11)
+
+## Goal
+
+Make the hosted alpha/factor promotion path fail closed unless the supplied
+recorded replay parity artifact proves both runtime evidence parity and
+event-level parity.
+
+## Plan
+
+- [x] Confirm the current promotion blocker remains replay/dry-run parity, not
+  additional MCTS search depth.
+- [x] Require `event_comparison.strict_parity_ready=true` when
+  `factor_walk_forward_v2` converts a parity artifact into the
+  `recorded_replay_parity` promotion gate.
+- [x] Add focused coverage proving runtime-only parity is insufficient.
+- [x] Run focused verification and diff hygiene checks.
+
+## Review
+
+- 2026-05-11: Hardened `factor_walk_forward_v2` so
+  `recorded_replay_parity` requires both
+  `runtime_evidence_comparison.strict_parity_ready` and
+  `event_comparison.strict_parity_ready`, with no blocking flags and
+  `decision=continue`.
+- 2026-05-11: Verification passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-factor-parity-gate /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --features db --example factor_walk_forward_v2 replay_parity`
+  and `rtk git diff --check`.
+
 # Alpha Search Promotion Blocker: Current Replay/Dry-Run Parity (2026-05-11)
 
 ## Evidence


### PR DESCRIPTION
## Summary
- require factor_walk_forward_v2 replay parity evidence to have both runtime and event strict readiness before the recorded_replay_parity gate passes
- add focused example tests proving runtime-only parity is insufficient
- record the hardening slice in tasks/todo.md

## Tests
- CARGO_TARGET_DIR=/tmp/ploy-factor-parity-gate /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --features db --example factor_walk_forward_v2 replay_parity
- rtk git diff --check

## Notes
This does not deploy to tango-1-1. The current strategy promotion remains blocked until current main is deployed to dry-run, a fresh sample is collected, and recorded replay parity passes.