### PR TITLE
Guard tango deploy live paused state

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -213,6 +213,24 @@ jobs:
             -C dist -cf - . | gzip -n > "${DEPLOY_BUNDLE_NAME}"
           sha256sum "${DEPLOY_BUNDLE_NAME}" > "${DEPLOY_BUNDLE_NAME}.sha256"
 
+      - name: Verify live deployment remains paused in bundle
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = Path("dist/config/deployments/pm5d.threelayer.live.json")
+          data = json.loads(manifest.read_text(encoding="utf-8"))
+          if data.get("deployment_id") != "pm5d.threelayer.live":
+              raise SystemExit(f"unexpected live deployment manifest: {data.get('deployment_id')}")
+          if data.get("runtime_mode") != "live":
+              raise SystemExit("pm5d.threelayer.live manifest is not runtime_mode=live")
+          if data.get("desired_state") != "paused":
+              raise SystemExit("pm5d.threelayer.live must remain desired_state=paused")
+          print("pm5d.threelayer.live bundle manifest remains paused")
+          PY
+
       - name: Validate OSS deploy secrets
         if: ${{ inputs.deploy }}
         env:
@@ -544,6 +562,15 @@ jobs:
               curl -fsS http://127.0.0.1:8081/health
               curl -fsS http://127.0.0.1:8081/api/reports/dry-run | ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
               ${DEPLOY_ROOT}/bin/ployctl deployments list
+              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
+              echo "\${live_status}"
+              case "\${live_status}" in
+                *"desired=Paused"*"observed=Paused"*) ;;
+                *)
+                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+                  exit 1
+                  ;;
+              esac
             fi
 
             wait_for_recent_rows \

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Tango Dry-Run Deploy Live-Paused Guard (2026-05-11)
+
+## Goal
+
+Before the next approved dry-run deployment for alpha parity sampling, make the
+protected `deploy-tango-1-1.yml` path prove that `pm5d.threelayer.live` remains
+paused in both the shipped bundle and the post-deploy control-plane state.
+
+## Plan
+
+- [x] Inspect the current tango deploy workflow and PM5D deployment manifests.
+- [x] Add a bundle-time guard requiring
+  `config/deployments/pm5d.threelayer.live.json` to keep
+  `desired_state=paused`.
+- [x] Add a post-deploy `ployctl deployments inspect pm5d.threelayer.live`
+  guard requiring `desired=Paused observed=Paused`.
+- [x] Add workflow security coverage so the guard cannot be removed silently.
+- [x] Validate workflow syntax, focused tests, and diff hygiene.
+
+## Review
+
+- 2026-05-11: Added bundle-time and post-deploy live-paused guards to
+  `deploy-tango-1-1.yml`. The workflow now fails before upload if the shipped
+  `pm5d.threelayer.live` manifest is not `desired_state=paused`, and fails
+  after deploy if `ployctl deployments inspect pm5d.threelayer.live` does not
+  report `desired=Paused observed=Paused`.
+- 2026-05-11: Verification passed:
+  Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-tango-live-paused-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  and `rtk git diff --check`.
+
 # Alpha Promotion Parity Gate Hardening (2026-05-11)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -256,6 +256,31 @@ fn replay_dryrun_parity_reports_strict_readiness() {
 }
 
 #[test]
+fn tango_deploy_keeps_pm5d_live_paused() {
+    let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "Verify live deployment remains paused in bundle",
+        "pm5d.threelayer.live.json",
+        "desired_state=paused",
+        "deployments inspect pm5d.threelayer.live",
+        "desired=Paused",
+        "observed=Paused",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!("deploy-tango-1-1.yml: missing `{needle}`"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "tango deploy live-paused guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn research_issue_workflows_apply_decision_labels() {
     let helper = workflow_contents(".github/scripts/research-issue-labels.js");
     let mut offenders = Vec::new();


### PR DESCRIPTION
## Summary
- add a bundle-time deploy guard that verifies pm5d.threelayer.live remains desired_state=paused
- add a post-deploy ployctl guard requiring pm5d.threelayer.live to report desired=Paused observed=Paused
- add workflow security coverage for the guard and record the slice in tasks/todo.md

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'\n- CARGO_TARGET_DIR=/tmp/ploy-tango-live-paused-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused\n- rtk git diff --check\n\n## Notes\nThis does not deploy to tango-1-1. It makes the next approved dry-run deployment fail closed if the live PM5D deployment is not paused.