### PR TITLE
Guard Cloud Assistant deploy live paused state

### DIFF
--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -82,6 +82,19 @@ service_exists() {{
   systemctl cat "$1" >/dev/null 2>&1
 }}
 
+require_pm5d_live_paused() {{
+  local live_status
+  live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live)"
+  echo "${{live_status}}"
+  case "${{live_status}}" in
+    *"desired=Paused"*"observed=Paused"*) ;;
+    *)
+      echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+      exit 1
+      ;;
+  esac
+}}
+
 require_service_guardrails() {{
   local unit="$1"
   test "$(systemctl show -P Restart "${{unit}}")" = "always"
@@ -257,6 +270,8 @@ if service_exists ployd.service; then
   systemctl is-active --quiet ployd.service
   curl -fsS http://127.0.0.1:8081/health
   curl -fsS http://127.0.0.1:8081/api/reports/dry-run | "${{DEPLOY_ROOT}}/scripts/check_dryrun_report_contract.py"
+  "${{DEPLOY_ROOT}}/bin/ployctl" deployments list
+  require_pm5d_live_paused
 fi
 
 wait_for_recent_rows \\

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Tango Cloud Assistant Live-Paused Guard (2026-05-11)
+
+## Goal
+
+Make the Cloud Assistant fallback deployment path enforce the same
+`pm5d.threelayer.live` paused postflight as the primary SSH path before the next
+approved dry-run parity deployment.
+
+## Plan
+
+- [x] Inspect `scripts/ci/deploy_tango_cloud_assist.py` for post-deploy
+  `ployctl` checks.
+- [x] Add a Cloud Assistant remote-script guard requiring
+  `pm5d.threelayer.live` to report `desired=Paused observed=Paused`.
+- [x] Extend workflow security coverage so both SSH and Cloud Assistant deploy
+  paths must keep the live-paused guard.
+- [x] Validate Python syntax, focused tests, and diff hygiene.
+
+## Review
+
+- 2026-05-11: Added `require_pm5d_live_paused` to the Cloud Assistant fallback
+  remote script and call it after `ployd` health/dry-run report checks. The
+  fallback now fails closed if `pm5d.threelayer.live` is not
+  `desired=Paused observed=Paused`.
+- 2026-05-11: Verification passed:
+  `python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py`,
+  `CARGO_TARGET_DIR=/tmp/ploy-cloud-assist-paused-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  and `rtk git diff --check`.
+
 # Tango Dry-Run Deploy Live-Paused Guard (2026-05-11)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -258,6 +258,7 @@ fn replay_dryrun_parity_reports_strict_readiness() {
 #[test]
 fn tango_deploy_keeps_pm5d_live_paused() {
     let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
+    let cloud_assist = workflow_contents("scripts/ci/deploy_tango_cloud_assist.py");
     let mut offenders = Vec::new();
 
     for needle in [
@@ -270,6 +271,19 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     ] {
         if !workflow.contains(needle) {
             offenders.push(format!("deploy-tango-1-1.yml: missing `{needle}`"));
+        }
+    }
+
+    for needle in [
+        "require_pm5d_live_paused",
+        "deployments inspect pm5d.threelayer.live",
+        "desired=Paused",
+        "observed=Paused",
+    ] {
+        if !cloud_assist.contains(needle) {
+            offenders.push(format!(
+                "deploy_tango_cloud_assist.py: missing `{needle}`"
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary
- add the same pm5d.threelayer.live desired=Paused observed=Paused postflight to the Cloud Assistant fallback deploy script
- extend workflow security coverage so both SSH and Cloud Assistant paths keep the live-paused guard
- record the fallback hardening slice in tasks/todo.md

## Tests
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- CARGO_TARGET_DIR=/tmp/ploy-cloud-assist-paused-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- rtk git diff --check

## Notes
This does not deploy to tango-1-1. It closes the fallback-path gap before the next approved dry-run parity deployment.