### PR TITLE
Allow tango deploy build-only smoke

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -55,7 +55,7 @@ jobs:
     name: Build and deploy to tango-1-1
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    environment: tango-1-1
+    environment: ${{ inputs.deploy && 'tango-1-1' || 'tango-1-1-build-only' }}
 
     steps:
       - name: Checkout code

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,31 @@
+# Tango Deploy Build-Only Environment (2026-05-11)
+
+## Goal
+
+Allow `deploy-tango-1-1.yml` to run `deploy=false` bundle-smoke validation
+without requiring protected `tango-1-1` environment approval, while preserving
+the protected environment for real deployments.
+
+## Plan
+
+- [x] Confirm `deploy=false` run `25680756036` waited on the protected
+  `tango-1-1` environment without executing steps, then cancel it.
+- [x] Make the workflow choose `tango-1-1` only for `deploy=true`, and
+  `tango-1-1-build-only` for build-only smoke runs.
+- [x] Add workflow security coverage for the conditional environment.
+- [x] Validate workflow syntax, focused tests, and diff hygiene.
+
+## Review
+
+- 2026-05-11: Changed `deploy-tango-1-1.yml` so real deploys still use the
+  protected `tango-1-1` environment, while `deploy=false` bundle-smoke runs use
+  `tango-1-1-build-only`. This should let CI validate deploy bundle construction
+  and bundle-time guards without requesting runtime deployment approval.
+- 2026-05-11: Verification passed:
+  Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-deploy-build-only-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  and `rtk git diff --check`.
+
 # Tango Cloud Assistant Live-Paused Guard (2026-05-11)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -262,6 +262,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     let mut offenders = Vec::new();
 
     for needle in [
+        "environment: ${{ inputs.deploy && 'tango-1-1' || 'tango-1-1-build-only' }}",
         "Verify live deployment remains paused in bundle",
         "pm5d.threelayer.live.json",
         "desired_state=paused",


### PR DESCRIPTION
## Summary
- make deploy-tango-1-1.yml use the protected tango-1-1 environment only when deploy=true
- route deploy=false bundle-smoke runs to tango-1-1-build-only so they can validate bundle construction without runtime approval
- extend workflow security coverage and record the slice in tasks/todo.md

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'\n- CARGO_TARGET_DIR=/tmp/ploy-deploy-build-only-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused\n- rtk git diff --check\n\n## Notes\nThis preserves the protected tango-1-1 environment for real deployments. It only unblocks deploy=false no-runtime bundle validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline efficiency: deployment workflow now dynamically selects between a protected production environment for deployments and an unprotected build-only environment for validation-only runs, eliminating unnecessary approval waits.

* **Tests**
  * Extended workflow security tests to validate conditional environment selection based on deployment input flags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/424)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->