### PR TITLE
Add alpha-search chain summarizer

### DIFF
--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -321,6 +321,21 @@ Every complete CI/CD alpha-search run should upload:
 If any of the search artifacts are missing, the run can still be diagnostic,
 but it is not a complete alpha-search run.
 
+For a quick review across multiple downloaded hosted runs, use:
+
+```bash
+python3 scripts/summarize_alpha_search_chain.py \
+  /tmp/ploy-alpha-run-25683730944 \
+  /tmp/ploy-alpha-run-25683858420 \
+  --output-json /tmp/alpha-search-chain-summary.json \
+  --output-md /tmp/alpha-search-chain-summary.md
+```
+
+The summary reports candidate counts, passed counts, best reward, selected MCTS
+factor, handoff status, recommended action, and chain stop reason per run. It
+is a review aid only; it does not replace the promotion evaluator or replay
+parity gate.
+
 ## Completion Criteria
 
 The method is fully defined only when CI exposes all of the following:

--- a/scripts/summarize_alpha_search_chain.py
+++ b/scripts/summarize_alpha_search_chain.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Summarize downloaded Factor Walk-Forward V2 alpha-search artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+RUN_ID_RE = re.compile(r"(\d{8,})")
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def optional_json(path: Path) -> Any:
+    if not path.exists():
+        return None
+    return load_json(path)
+
+
+def artifact_root(path: Path) -> Path:
+    if (path / "factor-walk-forward-v2").is_dir():
+        return path / "factor-walk-forward-v2"
+    return path
+
+
+def infer_run_id(path: Path) -> str | None:
+    for part in reversed(path.parts):
+        if match := RUN_ID_RE.search(part):
+            return match.group(1)
+    return None
+
+
+def selected_factor(plan: Any) -> str | None:
+    if not isinstance(plan, dict):
+        return None
+    selected = plan.get("selected_nodes")
+    if not isinstance(selected, list) or not selected:
+        return None
+    first = selected[0]
+    if not isinstance(first, dict):
+        return None
+    value = first.get("factor_name")
+    return str(value) if value is not None else None
+
+
+def summarize_artifact(path: Path) -> dict[str, Any]:
+    root = artifact_root(path)
+    target = "full_depth_settlement_executable_pnl"
+    feedback = optional_json(root / "alpha-search" / target / "search-feedback.json") or {}
+    plan = optional_json(root / "alpha-search" / target / "mcts-expansion-plan.json") or {}
+    handoff = optional_json(root / "autofactor-strategy-handoff.json") or {}
+    promotion = optional_json(root / "autofactor-strategy-promotion.json") or {}
+    chain = optional_json(path / "alpha-search-chain" / "chain-decision.json")
+    if chain is None:
+        chain = optional_json(root.parent / "alpha-search-chain" / "chain-decision.json") or {}
+
+    return {
+        "artifact": str(path),
+        "run_id": str(chain.get("current_run_id") or infer_run_id(path) or ""),
+        "target": str(feedback.get("target") or target),
+        "candidate_count": feedback.get("candidate_count"),
+        "passed_count": feedback.get("passed_count"),
+        "best_reward": feedback.get("best_reward"),
+        "best_selected_factor": selected_factor(plan),
+        "handoff_status": handoff.get("status"),
+        "recommended_action": handoff.get("recommended_action"),
+        "qualified_strategy_count": len(handoff.get("qualified_strategies") or []),
+        "promotion_decision": promotion.get("decision"),
+        "chain_reason": chain.get("reason"),
+        "chain_should_dispatch": chain.get("should_dispatch"),
+        "chain_next_remaining": chain.get("next_remaining"),
+        "chain_previous_best_reward": chain.get("previous_best_reward"),
+        "chain_current_best_reward": chain.get("current_best_reward"),
+    }
+
+
+def write_markdown(summary: dict[str, Any], path: Path) -> None:
+    rows = summary["runs"]
+    lines = [
+        "# Alpha Search Chain Summary",
+        "",
+        f"- Run count: `{len(rows)}`",
+        f"- Best run: `{summary.get('best_run_id') or 'n/a'}`",
+        f"- Best reward: `{summary.get('best_reward') if summary.get('best_reward') is not None else 'n/a'}`",
+        f"- Ready handoff count: `{summary.get('ready_handoff_count')}`",
+        "",
+        "| Run | Candidates | Passed | Best reward | Best selected factor | Handoff | Action | Chain |",
+        "| --- | ---: | ---: | ---: | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {run} | {candidates} | {passed} | {reward} | {factor} | {handoff} | {action} | {chain} |".format(
+                run=row.get("run_id") or "n/a",
+                candidates=row.get("candidate_count") if row.get("candidate_count") is not None else "n/a",
+                passed=row.get("passed_count") if row.get("passed_count") is not None else "n/a",
+                reward=row.get("best_reward") if row.get("best_reward") is not None else "n/a",
+                factor=row.get("best_selected_factor") or "n/a",
+                handoff=row.get("handoff_status") or "n/a",
+                action=row.get("recommended_action") or "n/a",
+                chain=row.get("chain_reason") or "n/a",
+            )
+        )
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def build_summary(paths: list[Path]) -> dict[str, Any]:
+    runs = [summarize_artifact(path) for path in paths]
+    best = max(
+        (row for row in runs if isinstance(row.get("best_reward"), int | float)),
+        key=lambda row: row["best_reward"],
+        default=None,
+    )
+    return {
+        "run_count": len(runs),
+        "best_run_id": best.get("run_id") if best else None,
+        "best_reward": best.get("best_reward") if best else None,
+        "best_selected_factor": best.get("best_selected_factor") if best else None,
+        "ready_handoff_count": sum(1 for row in runs if row.get("handoff_status") == "ready"),
+        "blocked_handoff_count": sum(1 for row in runs if row.get("handoff_status") == "blocked"),
+        "runs": runs,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact_dir", nargs="+", help="Downloaded factor-walk-forward artifact directory")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md", required=True)
+    args = parser.parse_args()
+
+    summary = build_summary([Path(value) for value in args.artifact_dir])
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with output_json.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    write_markdown(summary, Path(args.output_md))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,30 @@
+# Alpha Search Chain Summary Tool (2026-05-12)
+
+## Goal
+
+Make hosted alpha-search chain evidence machine-readable without manually
+inspecting each downloaded artifact directory.
+
+## Plan
+
+- [x] Add a script that summarizes one or more downloaded
+  `factor-walk-forward-v2-*` artifacts.
+- [x] Include candidate counts, passed counts, best reward, selected MCTS
+  factor, handoff status, recommended action, and chain decision per run.
+- [x] Add focused tests with tiny fixture directories.
+- [x] Validate tests, syntax, diff hygiene, then land as a focused PR.
+
+## Review
+
+- 2026-05-12: Added `scripts/summarize_alpha_search_chain.py` to summarize
+  downloaded hosted Factor Walk-Forward V2 artifacts into JSON and Markdown.
+  The summary records per-run candidate counts, passed counts, best reward,
+  selected MCTS factor, handoff status/action, promotion decision, and chain
+  decision fields, then highlights the best run and ready/blocked handoff
+  counts.
+- 2026-05-12: Added focused fixture tests and documented the review command in
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`.
+
 # Alpha Search Current-State Semantics (2026-05-12)
 
 ## Goal

--- a/tests/test_summarize_alpha_search_chain.py
+++ b/tests/test_summarize_alpha_search_chain.py
@@ -1,0 +1,144 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import summarize_alpha_search_chain as summary
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class AlphaSearchChainSummaryTest(unittest.TestCase):
+    def make_artifact(
+        self,
+        root: Path,
+        run_id: str,
+        *,
+        best_reward: float,
+        candidates: int,
+        passed: int,
+        factor: str,
+        handoff_status: str,
+        action: str,
+        chain_reason: str,
+    ) -> Path:
+        artifact = root / f"factor-walk-forward-v2-{run_id}"
+        inner = artifact / "factor-walk-forward-v2"
+        target = "full_depth_settlement_executable_pnl"
+        write_json(
+            inner / "alpha-search" / target / "search-feedback.json",
+            {
+                "target": target,
+                "candidate_count": candidates,
+                "passed_count": passed,
+                "best_reward": best_reward,
+            },
+        )
+        write_json(
+            inner / "alpha-search" / target / "mcts-expansion-plan.json",
+            {"selected_nodes": [{"factor_name": factor}]},
+        )
+        write_json(
+            inner / "autofactor-strategy-handoff.json",
+            {
+                "status": handoff_status,
+                "recommended_action": action,
+                "qualified_strategies": [{}] if handoff_status == "ready" else [],
+            },
+        )
+        write_json(inner / "autofactor-strategy-promotion.json", {"decision": handoff_status})
+        write_json(
+            artifact / "alpha-search-chain" / "chain-decision.json",
+            {
+                "current_run_id": run_id,
+                "reason": chain_reason,
+                "should_dispatch": chain_reason == "continue",
+                "next_remaining": 0,
+                "current_best_reward": best_reward,
+            },
+        )
+        return artifact
+
+    def test_build_summary_selects_best_run_and_counts_handoffs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = self.make_artifact(
+                root,
+                "11111111",
+                best_reward=1.5,
+                candidates=10,
+                passed=3,
+                factor="base_edge",
+                handoff_status="blocked",
+                action="do_not_promote",
+                chain_reason="continue",
+            )
+            second = self.make_artifact(
+                root,
+                "22222222",
+                best_reward=2.25,
+                candidates=12,
+                passed=5,
+                factor="mcts_edge",
+                handoff_status="ready",
+                action="create_dry_run_handoff",
+                chain_reason="ready_handoff",
+            )
+
+            result = summary.build_summary([first, second])
+
+            self.assertEqual(result["run_count"], 2)
+            self.assertEqual(result["best_run_id"], "22222222")
+            self.assertEqual(result["best_reward"], 2.25)
+            self.assertEqual(result["best_selected_factor"], "mcts_edge")
+            self.assertEqual(result["ready_handoff_count"], 1)
+            self.assertEqual(result["blocked_handoff_count"], 1)
+            self.assertEqual(result["runs"][0]["candidate_count"], 10)
+            self.assertEqual(result["runs"][1]["recommended_action"], "create_dry_run_handoff")
+
+    def test_main_writes_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = self.make_artifact(
+                root,
+                "33333333",
+                best_reward=3.0,
+                candidates=20,
+                passed=8,
+                factor="mcts_branch",
+                handoff_status="blocked",
+                action="do_not_promote",
+                chain_reason="chain_next_run_false",
+            )
+            output_json = root / "summary.json"
+            output_md = root / "summary.md"
+
+            summary.main_args = None
+            import sys
+
+            old_argv = sys.argv
+            try:
+                sys.argv = [
+                    "summarize_alpha_search_chain.py",
+                    str(artifact),
+                    "--output-json",
+                    str(output_json),
+                    "--output-md",
+                    str(output_md),
+                ]
+                summary.main()
+            finally:
+                sys.argv = old_argv
+
+            data = json.loads(output_json.read_text(encoding="utf-8"))
+            markdown = output_md.read_text(encoding="utf-8")
+            self.assertEqual(data["best_run_id"], "33333333")
+            self.assertIn("Alpha Search Chain Summary", markdown)
+            self.assertIn("mcts_branch", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/summarize_alpha_search_chain.py` for downloaded Factor Walk-Forward V2 artifacts
- summarize per-run candidate counts, passed counts, best reward, selected MCTS factor, handoff/action, and chain decision
- document the command in `docs/ALPHA_FACTOR_SEARCH_CICD.md` and track the work in `tasks/todo.md`

## Verification
- python3 -m unittest tests.test_summarize_alpha_search_chain
- python3 -m py_compile scripts/summarize_alpha_search_chain.py tests/test_summarize_alpha_search_chain.py
- python3 scripts/summarize_alpha_search_chain.py /tmp/ploy-alpha-run-25683730944 /tmp/ploy-alpha-run-25683858420 /tmp/ploy-alpha-run-25683945041 --output-json /tmp/ploy-alpha-chain-summary.json --output-md /tmp/ploy-alpha-chain-summary.md
- rtk git diff --check

## Notes
- Tooling/docs only. No deploy or runtime mutation.