### PR TITLE
Upload alpha-search chain summaries

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -649,6 +649,19 @@ jobs:
               raise SystemExit(2)
           PY
 
+      - name: Summarize alpha search chain evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -d artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2 ]; then
+            echo "No factor-walk-forward-v2 artifact directory found; skipping alpha search chain summary."
+            exit 0
+          fi
+          python3 scripts/summarize_alpha_search_chain.py \
+            artifacts/factor-walk-forward-v2-upload \
+            --output-json artifacts/factor-walk-forward-v2-upload/alpha-search-chain/summary.json \
+            --output-md artifacts/factor-walk-forward-v2-upload/alpha-search-chain/summary.md
+
       - name: Upload report artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# Alpha Search Chain Summary Artifact (2026-05-12)
+
+## Goal
+
+Make each hosted alpha-search run upload its own chain summary artifacts so
+agents and issue comments can review current-run evidence without manual JSON
+inspection after download.
+
+## Plan
+
+- [x] Wire `scripts/summarize_alpha_search_chain.py` into
+  `factor-walk-forward-v2-hosted-artifact.yml` after chain-decision creation.
+- [x] Upload `alpha-search-chain/summary.json` and `summary.md` in the existing
+  walk-forward artifact.
+- [x] Add workflow security coverage so the summary artifact step stays wired.
+- [x] Validate workflow lint/tests/diff hygiene and land a focused PR.
+
+## Review
+
+- 2026-05-12: Wired the hosted Factor Walk-Forward V2 workflow to run
+  `scripts/summarize_alpha_search_chain.py` after writing
+  `alpha-search-chain/chain-decision.json` and before uploading the artifact.
+  Each hosted run now uploads `alpha-search-chain/summary.json` and
+  `alpha-search-chain/summary.md` alongside the existing chain decision.
+
 # Alpha Search Chain Summary Tool (2026-05-12)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -297,6 +297,44 @@ fn recorded_replay_parity_supports_auto_window() {
 }
 
 #[test]
+fn hosted_factor_walk_forward_uploads_alpha_chain_summary() {
+    let workflow = workflow_contents(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "Summarize alpha search chain evidence",
+        "scripts/summarize_alpha_search_chain.py",
+        "artifacts/factor-walk-forward-v2-upload",
+        "alpha-search-chain/summary.json",
+        "alpha-search-chain/summary.md",
+        "Upload report artifact",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!(
+                "factor-walk-forward-v2-hosted-artifact.yml: missing `{needle}`"
+            ));
+        }
+    }
+
+    let summary_index = workflow
+        .find("Summarize alpha search chain evidence")
+        .unwrap_or(usize::MAX);
+    let upload_index = workflow.find("Upload report artifact").unwrap_or(0);
+    if summary_index > upload_index {
+        offenders.push(
+            "factor-walk-forward-v2-hosted-artifact.yml: summary must be generated before upload"
+                .to_string(),
+        );
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "hosted alpha chain summary artifact guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn tango_deploy_keeps_pm5d_live_paused() {
     let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
     let cloud_assist = workflow_contents("scripts/ci/deploy_tango_cloud_assist.py");


### PR DESCRIPTION
## Summary
- run `scripts/summarize_alpha_search_chain.py` inside hosted Factor Walk-Forward V2 after chain decision creation
- upload `alpha-search-chain/summary.json` and `summary.md` with the existing report artifact
- add workflow-security coverage for the hosted summary artifact step

## Verification
- actionlint -color .github/workflows/factor-walk-forward-v2-hosted-artifact.yml
- CARGO_TARGET_DIR=/tmp/ploy-alpha-chain-summary-artifact /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security hosted_factor_walk_forward_uploads_alpha_chain_summary -- --exact
- python3 -m unittest tests.test_summarize_alpha_search_chain
- rtk git diff --check

## Notes
- CI/tooling only. Does not change search scoring, promotion gates, deploy, or runtime state.