### PR TITLE
docs refresh alpha parity blocker

### DIFF
--- a/tasks/alpha_search_completion_audit_20260512.md
+++ b/tasks/alpha_search_completion_audit_20260512.md
@@ -23,14 +23,33 @@ The hard blocker is recorded replay/dry-run parity for:
 
 `pm5d.threelayer.settlement-probability-btc-eth.dryrun`
 
-Current parity run:
+Latest parity runs:
 
 - run: `25683379408`
 - workflow: `recorded-replay-parity.yml`
-- status: `waiting`
-- reason: protected `tango-1-1` environment approval is required before SSH
-  secrets can be used
-- deploy impact: none; this run is a replay comparison, not a deploy
+- status: `completed`
+- result: workflow success, strict parity failed
+- resolved auto window: `2026-05-11T13:46:06Z` ->
+  `2026-05-11T16:56:00Z`
+- reason: the auto window selected dry-run rows outside the available recording
+  coverage, so replay produced no shared event/order/fill rows
+- deploy impact: none; this run was a replay comparison, not a deploy
+
+- run: `25685537480`
+- workflow: `recorded-replay-parity.yml`
+- status: `completed`
+- result: workflow success, strict parity failed
+- manual window: `2026-05-11T19:47:00+08:00` ->
+  `2026-05-11T21:12:00+08:00`
+- shared orders/fills: `18 / 18`
+- blocking flags:
+  `events_present_in_dryrun_missing_from_replay`,
+  `orders_present_in_dryrun_missing_from_replay`,
+  `runtime_evidence_field_mismatches`,
+  `settlement_exit_price_mismatches`
+- interpretation: the window mismatch is no longer the only issue. The current
+  dry-run evidence still contains entry/settlement behavior that current replay
+  cannot reproduce, so promotion remains correctly blocked.
 
 ## Prompt-To-Artifact Checklist
 
@@ -42,7 +61,7 @@ Current parity run:
 | System summarizes search-chain evidence | `scripts/summarize_alpha_search_chain.py`, `alpha-search-chain/summary.json`, `alpha-search-chain/summary.md` | `ready` | PR #428 added the script. PR #429 wired it into the hosted workflow. Run `25684811262` proves the summary files are uploaded. |
 | Search found a stronger candidate branch | run `25683858420` | `partial` | Best reward improved to `4.894975850946932` with `mcts_mcts_auto_settlement_conservative_settlement_edge_x_near_strike_near_strike_near_strike`. |
 | Promotion gate blocks unsafe candidates | `autofactor-strategy-handoff.json` | `ready` | Recent runs report `status=blocked`, `recommended_action=do_not_promote`, and `ready_handoff_count=0`. This is correct behavior, not a search failure. |
-| Replay/dry-run parity is ready | `recorded-replay-parity.yml` artifact | `blocked` | Run `25683379408` is waiting for protected environment approval. No ready parity artifact exists for the current target lane. |
+| Replay/dry-run parity is ready | `recorded-replay-parity.yml` artifact | `blocked` | Runs `25683379408` and `25685537480` completed, but no ready parity artifact exists for the current target lane. The latest manual-window run has shared rows, yet still reports runtime field mismatches and settlement-exit mismatches. |
 | A dry-run config PR can be generated from ready handoff | `create_config_pr=true` path in hosted workflow | `blocked` | The path exists, but it is fail-closed until handoff status is `ready`. |
 | A profitable strategy has been produced | ready handoff plus parity plus dry-run/executable evidence | `not ready` | No artifact currently proves executable profitability with replay/dry-run parity. |
 
@@ -77,13 +96,18 @@ All runs used:
 
 ## Remaining Actions
 
-1. Approve `tango-1-1` protected environment for run `25683379408`.
-2. Inspect the resulting recorded replay parity artifact.
-3. If parity is ready, rerun hosted alpha-search/promotion with
+1. With explicit operator approval, deploy current `main` to the protected
+   `tango-1-1` dry-run path while keeping live paused.
+2. Collect a fresh settlement-probability BTC/ETH dry-run sample from the
+   newly deployed binary/config.
+3. Rerun `recorded-replay-parity.yml` against that fresh sample. Use `auto`
+   only after confirming the recording and dry-run coverage overlap; otherwise
+   use the explicit fresh recording window.
+4. If parity is ready, rerun hosted alpha-search/promotion with
    `replay_parity_run_id=<ready-run>`.
-4. If handoff becomes `ready`, create the dry-run config PR through the
+5. If handoff becomes `ready`, create the dry-run config PR through the
    existing `create_config_pr=true` path.
-5. Only after dry-run/replay parity and executable evidence remain clean should
+6. Only after dry-run/replay parity and executable evidence remain clean should
    any live deployment discussion start.
 
 ## Completion Rule

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Alpha Search Parity Blocker Refresh (2026-05-12)
+
+## Goal
+
+Record the completed recorded replay parity evidence and keep the alpha-search
+system from treating a blocked handoff as a profitable strategy.
+
+## Plan
+
+- [x] Inspect manual-window recorded replay parity run `25685537480`.
+- [x] Update the completion audit from "waiting for approval" to the current
+  strict parity failure.
+- [x] Preserve the next action as an explicit dry-run deploy approval gate
+  instead of silently mutating `tango-1-1`.
+- [ ] After approval, deploy current `main` to the protected dry-run path,
+  collect a fresh sample, and rerun recorded replay parity.
+
+## Review
+
+- 2026-05-12: Run `25685537480` completed successfully as a workflow but
+  reported `strict_parity_ready=false`. It improved over the prior auto-window
+  run by finding `18 / 18` shared orders/fills, but still blocked promotion with
+  missing dry-run-only entry rows, runtime field mismatches, and
+  settlement-exit price mismatches. No candidate should be promoted until a
+  fresh main dry-run sample produces ready parity.
+
 # Alpha Search Completion Audit (2026-05-12)
 
 ## Goal


### PR DESCRIPTION
## Summary
- record completed recorded replay parity runs 25683379408 and 25685537480
- update the alpha-search completion audit from waiting-for-approval to strict parity blocked
- keep fresh main dry-run redeploy as the explicit next approval gate

## Verification
- rtk git diff --check -- tasks/alpha_search_completion_audit_20260512.md tasks/todo.md