### PR TITLE
Fix alpha parity readiness gates

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -395,6 +395,21 @@ jobs:
               fi
             }
 
+            require_pm5d_live_paused() {
+              local live_status
+              local live_line
+              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
+              echo "\${live_status}"
+              live_line="\$(printf '%s\n' "\${live_status}" | awk '\$1 == "pm5d.threelayer.live" { print; exit }')"
+              case "\${live_line}" in
+                *"desired=Paused"*"observed=Paused"*) ;;
+                *)
+                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+                  exit 1
+                  ;;
+              esac
+            }
+
             service_exists() {
               systemctl cat "\$1" >/dev/null 2>&1
             }
@@ -562,15 +577,7 @@ jobs:
               curl -fsS http://127.0.0.1:8081/health
               curl -fsS http://127.0.0.1:8081/api/reports/dry-run | ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
               ${DEPLOY_ROOT}/bin/ployctl deployments list
-              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
-              echo "\${live_status}"
-              case "\${live_status}" in
-                *"desired=Paused"*"observed=Paused"*) ;;
-                *)
-                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-                  exit 1
-                  ;;
-              esac
+              require_pm5d_live_paused
             fi
 
             wait_for_recent_rows \

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -84,9 +84,11 @@ service_exists() {{
 
 require_pm5d_live_paused() {{
   local live_status
+  local live_line
   live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live)"
   echo "${{live_status}}"
-  case "${{live_status}}" in
+  live_line="$(printf '%s\n' "${{live_status}}" | awk '$1 == "pm5d.threelayer.live" {{ print; exit }}')"
+  case "${{live_line}}" in
     *"desired=Paused"*"observed=Paused"*) ;;
     *)
       echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -771,13 +771,15 @@ def compare_events(
     for key in shared_keys:
         replay = replay_index[key]
         dryrun = dryrun_index[key]
+        normalized_replay = normalize_event(replay)
+        normalized_dryrun = normalize_event(dryrun)
         for field in STRICT_FIELDS:
-            replay_value = canonical_field(replay, field)
-            dryrun_value = canonical_field(dryrun, field)
+            replay_value = normalized_replay.get(field)
+            dryrun_value = normalized_dryrun.get(field)
             if replay_value is None or dryrun_value is None:
                 missing_fields.add(field)
                 continue
-            if replay_value != dryrun_value:
+            if not values_match(field, replay_value, dryrun_value):
                 mismatches.append(
                     {
                         "event_key": key,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -24,6 +24,40 @@ system from treating a blocked handoff as a profitable strategy.
   settlement-exit price mismatches. No candidate should be promoted until a
   fresh main dry-run sample produces ready parity.
 
+# Alpha Search Parity Recovery (2026-05-12)
+
+## Goal
+
+Remove the false deploy guard failure that blocks fresh recorded replay parity,
+then rerun the strict dry-run/replay gate before any alpha-search handoff can
+be treated as promotable.
+
+## Plan
+
+- [x] Inspect failed deploy run `25686133681` and confirm whether live stayed
+  paused.
+- [x] Harden the SSH and Cloud Assistant live-paused checks against multi-line
+  `ployctl` output.
+- [x] Normalize replay/dry-run legacy event comparison for timestamp timezone
+  and numeric representation drift.
+- [x] Verify the guard and parity-normalization changes locally.
+- [x] Confirm remote dry-run state and trigger fresh recorded replay parity.
+- [ ] Use only a strict-ready parity run as input to the hosted alpha-search
+  promotion chain.
+
+## Review
+
+- 2026-05-12: Deploy run `25686133681` shipped the bundle and showed
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun desired=Running
+  observed=Running`; it also showed `pm5d.threelayer.live desired=Paused
+  observed=Paused`. The deploy failed because both SSH and Cloud Assistant
+  guard code misclassified that valid live-paused line.
+- 2026-05-12: Narrow parity run `25686923236` succeeded on `main@2f730b12`.
+  Its runtime evidence was strict-ready, but event comparison was blocked only
+  by representation drift: `+08:00` timestamp versus `Z`, and JSON number
+  versus string values. Recomputing the same artifact with the local
+  normalization fix reports runtime ready, event ready, and no blockers.
+
 # Alpha Search Completion Audit (2026-05-12)
 
 ## Goal

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -265,6 +265,30 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertIn("replay_has_no_event_level_rows", result["blocking_risk_flags"])
         self.assertEqual(runtime["events"]["replay_count"], 0)
 
+    def test_legacy_event_comparison_normalizes_timestamp_and_numeric_shapes(self):
+        replay = evidence_payload(
+            created_at="2026-05-11T17:40:00Z",
+            limit_price="1",
+            fill_price="1",
+        )
+        dryrun = evidence_payload(
+            created_at="2026-05-12T01:40:00+08:00",
+            limit_price=1.0,
+            fill_price=1.0,
+        )
+        dryrun["runtime_evidence"]["events"][0]["signal_inputs"] = {
+            "purpose": "ENTRY",
+            "requested_qty": 10.0,
+            "limit_price": 1.0,
+        }
+
+        result = self.run_script(replay, dryrun)
+
+        self.assertTrue(result["runtime_evidence_comparison"]["strict_parity_ready"])
+        self.assertTrue(result["event_comparison"]["strict_parity_ready"])
+        self.assertEqual(result["event_comparison"]["mismatches"], [])
+        self.assertNotIn("legacy_event_strict_field_mismatches", result["legacy_event_flags"])
+
     def test_legacy_event_drift_is_diagnostic_when_runtime_evidence_is_strict_ready(self):
         replay = evidence_payload()
         dryrun = evidence_payload()


### PR DESCRIPTION
## Summary
- harden tango deploy live-paused postflight checks by matching the inspected live deployment line
- normalize legacy replay/dry-run event comparison for timezone-equivalent timestamps and numeric JSON shape differences
- record the alpha parity recovery evidence in tasks/todo.md

## Tests
- python3 -m unittest tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/replay_dryrun_parity.py scripts/ci/deploy_tango_cloud_assist.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "workflow yaml ok"'
- CARGO_TARGET_DIR=/tmp/ploy-alpha-parity-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- CARGO_TARGET_DIR=/tmp/ploy-alpha-parity-readiness /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security replay_dryrun_parity_reports_strict_readiness
- rtk git diff --check

## Evidence
- recorded replay parity run 25686923236 on main had runtime strict parity ready but event comparison mismatched only timestamp timezone and JSON numeric representation
- recomputing the downloaded artifact locally with this fix reports runtime ready, event ready, and no blockers