### PR TITLE
Promote ready AutoFactor settlement handoff

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_full_depth_settlement_edge"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30


### PR DESCRIPTION
## Summary
- updates the settlement-probability BTC/ETH dry-run config to the ready hosted AutoFactor handoff score
- generated by factor-walk-forward-v2-hosted-artifact run 25687766026
- uses recorded replay parity run 25687392088, artifact recorded-replay-parity-25687392088

## Evidence
- handoff status: ready
- recommended action: create_dry_run_handoff
- selected runtime score: autofactor_formula:auto_settlement_conservative_settlement_edge
- promotion gate: replay_parity_ready=true, event_complete_events=292, event_complete_rows=468
- parity run 25687392088: runtime/event strict ready, blocking=[]

## Tests in generator
- python3 -m unittest tests.test_apply_autofactor_handoff_to_config tests.test_factor_walk_forward_sweep
- cargo test -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib

This is config-only and does not deploy or enable live trading.