### PR TITLE
Fix replay parity artifact option parsing

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -135,6 +135,13 @@ jobs:
                   allowed = ", ".join(sorted(choices[key]))
                   raise SystemExit(f"options_json value for {key} must be one of: {allowed}")
 
+          if ":" in values["replay_parity_run_id"] and not values["replay_parity_artifact_name"]:
+              run_id, artifact_name = values["replay_parity_run_id"].split(":", 1)
+              if not run_id or not artifact_name:
+                  raise SystemExit("replay_parity_run_id must be <run-id>:<artifact-name>")
+              values["replay_parity_run_id"] = run_id
+              values["replay_parity_artifact_name"] = artifact_name
+
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
               for key, value in values.items():
                   if "\n" in value:

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -335,6 +335,31 @@ fn hosted_factor_walk_forward_uploads_alpha_chain_summary() {
 }
 
 #[test]
+fn hosted_factor_walk_forward_splits_replay_parity_artifact_suffix() {
+    let workflow = workflow_contents(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "replay_parity_run_id",
+        "replay_parity_artifact_name",
+        "split(\":\", 1)",
+        "replay_parity_run_id must be <run-id>:<artifact-name>",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!(
+                "factor-walk-forward-v2-hosted-artifact.yml: missing `{needle}`"
+            ));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "hosted factor walk-forward replay parity artifact split guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn tango_deploy_keeps_pm5d_live_paused() {
     let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
     let cloud_assist = workflow_contents("scripts/ci/deploy_tango_cloud_assist.py");


### PR DESCRIPTION
## Summary
- make hosted factor walk-forward split options_json replay_parity_run_id values of the documented <run-id>:<artifact-name> form
- keep the existing explicit replay_parity_artifact_name option working
- add workflow security coverage for the split contract

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "workflow yaml ok"'
- CARGO_TARGET_DIR=/tmp/ploy-replay-parity-split /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security hosted_factor_walk_forward_splits_replay_parity_artifact_suffix
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced replay parity configuration to support combined run ID and artifact name in a single parameter using colon-separated format.

* **Tests**
  * Added validation test for replay parity artifact naming behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->