### PR TITLE
ci: harden tango live-paused deploy guard

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -400,14 +400,15 @@ jobs:
               local live_line
               live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
               echo "\${live_status}"
-              live_line="\$(printf '%s\n' "\${live_status}" | awk '\$1 == "pm5d.threelayer.live" { print; exit }')"
-              case "\${live_line}" in
-                *"desired=Paused"*"observed=Paused"*) ;;
-                *)
-                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-                  exit 1
-                  ;;
-              esac
+              live_line="\$(printf '%s\n' "\${live_status}" | grep -F "pm5d.threelayer.live " | head -n 1 || true)"
+              if ! printf '%s\n' "\${live_line}" | grep -F "desired=Paused" >/dev/null; then
+                echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+                exit 1
+              fi
+              if ! printf '%s\n' "\${live_line}" | grep -F "observed=Paused" >/dev/null; then
+                echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+                exit 1
+              fi
             }
 
             service_exists() {

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -87,14 +87,15 @@ require_pm5d_live_paused() {{
   local live_line
   live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live)"
   echo "${{live_status}}"
-  live_line="$(printf '%s\n' "${{live_status}}" | awk '$1 == "pm5d.threelayer.live" {{ print; exit }}')"
-  case "${{live_line}}" in
-    *"desired=Paused"*"observed=Paused"*) ;;
-    *)
-      echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-      exit 1
-      ;;
-  esac
+  live_line="$(printf '%s\n' "${{live_status}}" | grep -F "pm5d.threelayer.live " | head -n 1 || true)"
+  if ! printf '%s\n' "${{live_line}}" | grep -F "desired=Paused" >/dev/null; then
+    echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "${{live_line}}" | grep -F "observed=Paused" >/dev/null; then
+    echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+    exit 1
+  fi
 }}
 
 require_service_guardrails() {{

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,51 @@
+# Tango Deploy False-Negative Guard Repair (2026-05-12)
+
+## Goal
+
+Record the protected dry-run deploy outcome and repair the Cloud Assistant
+live-paused guard that failed after the SSH deploy path had already updated
+`tango-1-1`.
+
+## Plan
+
+- [x] Approve and monitor protected deploy run `25690789142`.
+- [x] Independently verify the remote dry-run config, live paused state, and
+  `ployd` guardrails after the workflow failure.
+- [x] Harden both SSH and Cloud Assistant live-paused guard parsing against
+  multi-line `ployctl` output.
+- [x] Run focused workflow/security validation.
+- [ ] Collect enough post-deploy closed dry-run rows and rerun recorded replay
+  parity before claiming profitability.
+
+## Review
+
+- 2026-05-12: Protected deploy run `25690789142` built the release runner,
+  research tools, optimize-backtest, deploy bundle, passed the bundle
+  live-paused guard, uploaded the bundle, and completed the primary SSH
+  `Pull bundle from OSS and restart services` step. The run failed later in
+  the Cloud Assistant fallback live-paused guard even though the output
+  included `pm5d.threelayer.live desired=Paused observed=Paused`.
+- 2026-05-12: Independent read-only remote verification at
+  `2026-05-11T19:18:53Z` confirmed the deployment was actually applied:
+  `pm5d.threelayer.live desired=Paused observed=Paused`,
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun desired=Running
+  observed=Running`, and the remote dry-run config now uses
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`.
+  `ployd` was `ActiveState=active`, `SubState=running`, with
+  `Restart=always`, `OOMPolicy=kill`, and `MemoryMax=1610612736`.
+- 2026-05-12: Fixed both deploy live-paused guards to select the live line via
+  fixed-string `grep -F "pm5d.threelayer.live "` and then check
+  `desired=Paused` and `observed=Paused` separately. Verification passed:
+  `python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py`,
+  Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-tango-live-paused-grep /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  and `rtk git diff --check`.
+- 2026-05-12: First post-deploy closed-row check found only `1` closed row
+  since `2026-05-11T19:18:00Z`, with net PnL `20.4126279478`. This proves the
+  new dry-run is producing evidence, but it is far too small for profitability
+  or parity promotion. Wait for a larger fresh sample before triggering
+  recorded replay parity.
+
 # Alpha Search Post-Handoff Audit Refresh (2026-05-12)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -371,6 +371,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
         "pm5d.threelayer.live.json",
         "desired_state=paused",
         "deployments inspect pm5d.threelayer.live",
+        "grep -F \"pm5d.threelayer.live \"",
         "desired=Paused",
         "observed=Paused",
     ] {
@@ -382,6 +383,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     for needle in [
         "require_pm5d_live_paused",
         "deployments inspect pm5d.threelayer.live",
+        "grep -F \"pm5d.threelayer.live \"",
         "desired=Paused",
         "observed=Paused",
     ] {


### PR DESCRIPTION
## Summary
- harden the SSH and Cloud Assistant tango deploy live-paused guard to match the live deployment line with fixed-string grep
- check desired=Paused and observed=Paused separately so valid multi-line ployctl output is not misclassified
- record deploy run 25690789142 evidence and the remaining fresh dry-run parity gate

## Verification
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "yaml ok"'\n- CARGO_TARGET_DIR=/tmp/ploy-tango-live-paused-grep2 /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused\n- rtk git diff --check -- .github/workflows/deploy-tango-1-1.yml scripts/ci/deploy_tango_cloud_assist.py tests/workflow_security.rs tasks/todo.md\n\n## Notes\n- Deploy run 25690789142 failed only after the primary SSH deploy path succeeded; independent remote verification showed live remained paused and the settlement-probability dry-run config changed to autofactor_formula:auto_settlement_conservative_settlement_edge.\n- This PR fixes the postflight false negative. It does not claim profitability; fresh closed dry-run rows and recorded replay parity are still required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal deployment guard validation for improved system reliability.
  * Updated deployment infrastructure and verification processes.

* **Tests**
  * Strengthened workflow security test coverage for deployment verification.

* **Documentation**
  * Updated internal task tracking with deployment repair notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->