### PR TITLE
Fix tango Cloud Assistant live-paused guard

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -400,15 +400,14 @@ jobs:
               local live_line
               live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
               echo "\${live_status}"
-              live_line="\$(printf '%s\n' "\${live_status}" | grep -F "pm5d.threelayer.live " | head -n 1 || true)"
-              if ! printf '%s\n' "\${live_line}" | grep -F "desired=Paused" >/dev/null; then
-                echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-                exit 1
-              fi
-              if ! printf '%s\n' "\${live_line}" | grep -F "observed=Paused" >/dev/null; then
-                echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-                exit 1
-              fi
+              live_line="\$(printf '%s\n' "\${live_status}" | awk '\$1 == "pm5d.threelayer.live" { print; exit }')"
+              case "\${live_line}" in
+                *"desired=Paused"*"observed=Paused"*) ;;
+                *)
+                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+                  exit 1
+                  ;;
+              esac
             }
 
             service_exists() {

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -87,15 +87,14 @@ require_pm5d_live_paused() {{
   local live_line
   live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live)"
   echo "${{live_status}}"
-  live_line="$(printf '%s\n' "${{live_status}}" | grep -F "pm5d.threelayer.live " | head -n 1 || true)"
-  if ! printf '%s\n' "${{live_line}}" | grep -F "desired=Paused" >/dev/null; then
-    echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-    exit 1
-  fi
-  if ! printf '%s\n' "${{live_line}}" | grep -F "observed=Paused" >/dev/null; then
-    echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-    exit 1
-  fi
+  live_line="$(printf '%s\n' "${{live_status}}" | awk '$1 == "pm5d.threelayer.live" {{ print; exit }}')"
+  case "${{live_line}}" in
+    *"desired=Paused"*"observed=Paused"*) ;;
+    *)
+      echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
+      exit 1
+      ;;
+  esac
 }}
 
 require_service_guardrails() {{

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -116,6 +116,53 @@ when the runtime has not received an official Polymarket resolution.
   `CARGO_TARGET_DIR=/tmp/ploy-settlement-fallback /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_exit_requires_official_resolution_even_when_spot_implies_winner --lib`,
   `CARGO_TARGET_DIR=/tmp/ploy-settlement-fallback /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles official_settlement_resolution_prices_winner_and_loser_tokens --lib`,
   and `CARGO_TARGET_DIR=/tmp/ploy-settlement-fallback /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles --lib`.
+- 2026-05-12: PR `#439` merged the official-settlement gate to `main` as
+  `eae68bb1a5bae69d6bf428fea7452bac00e088f3`. Protected deploy run
+  `25697379244` was approved and the primary SSH deploy step passed, so the
+  settlement fix is on `tango-1-1`. Independent verification confirmed
+  `pm5d.threelayer.live desired=Paused observed=Paused`,
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun desired=Running
+  observed=Running`, the dry-run config still uses
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`, and
+  `require_official_settlement=true`. The workflow still failed in the Cloud
+  Assistant fallback guard even though its own log printed the valid live line;
+  treat this as a CI/CD guard false-negative to repair before the next deploy
+  run, not as evidence that live was unpaused.
+
+# Tango Cloud Assistant Live-Paused Guard AWK Repair (2026-05-12)
+
+## Goal
+
+Remove the remaining false-negative in the Cloud Assistant live-paused guard
+after deploy run `25697379244` printed a valid
+`pm5d.threelayer.live desired=Paused observed=Paused` line but exited `1`.
+
+## Plan
+
+- [x] Diagnose deploy run `25697379244` and verify the primary SSH deploy
+  actually updated `tango-1-1`.
+- [x] Replace the fragile `grep | head` live-line selection with exact-field
+  `awk` selection in both SSH and Cloud Assistant deploy paths.
+- [x] Keep workflow-security coverage for the live-paused guard contract.
+- [x] Run focused syntax, workflow-security, and diff-hygiene verification.
+- [ ] Land the guard repair, then rerun recorded replay parity against the
+  already deployed post-fix dry-run sample.
+
+## Review
+
+- 2026-05-12: The remaining deploy failure was a guard false-negative in the
+  Cloud Assistant fallback. The SSH deploy step passed and remote verification
+  confirmed live remained paused while the target dry-run was running; no
+  `cargo` or `rustc` build process was found by exact process-name check.
+- 2026-05-12: Updated both `.github/workflows/deploy-tango-1-1.yml` and
+  `scripts/ci/deploy_tango_cloud_assist.py` to select the live deployment line
+  with `awk '$1 == "pm5d.threelayer.live" { print; exit }'` and validate both
+  `desired=Paused` and `observed=Paused` in one shell `case`, avoiding
+  `set -euo pipefail` sensitivity around `grep | head`. Verification passed:
+  `python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py`,
+  Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-live-paused-awk /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  and `rtk git diff --check`.
 
 # Alpha Search Post-Handoff Audit Refresh (2026-05-12)
 

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -371,7 +371,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
         "pm5d.threelayer.live.json",
         "desired_state=paused",
         "deployments inspect pm5d.threelayer.live",
-        "grep -F \"pm5d.threelayer.live \"",
+        "awk '\\$1 == \"pm5d.threelayer.live\"",
         "desired=Paused",
         "observed=Paused",
     ] {
@@ -383,7 +383,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     for needle in [
         "require_pm5d_live_paused",
         "deployments inspect pm5d.threelayer.live",
-        "grep -F \"pm5d.threelayer.live \"",
+        "awk '$1 == \"pm5d.threelayer.live\"",
         "desired=Paused",
         "observed=Paused",
     ] {


### PR DESCRIPTION
## Summary
- replace fragile grep/head live deployment parsing with exact-field awk selection in both SSH and Cloud Assistant deploy guards
- validate desired=Paused and observed=Paused in one shell case
- record deploy run 25697379244 false-negative and remote verification evidence in tasks/todo.md

## Verification
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'
- CARGO_TARGET_DIR=/tmp/ploy-live-paused-awk /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- rtk git diff --check

## Notes
- Deploy run 25697379244 did update tango-1-1 through the primary SSH path; independent verification showed live stayed Paused and dry-run stayed Running.
- This PR only fixes the false-negative guard for future deploy runs. It does not change runtime strategy behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment status verification robustness to prevent missed deployment state validations.

* **Tests**
  * Updated deployment monitoring test assertions to match improved verification logic.

* **Chores**
  * Updated deployment workflow and task documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/440)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->