### PR TITLE
Fix deploy live-paused stderr guard

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -398,7 +398,7 @@ jobs:
             require_pm5d_live_paused() {
               local live_status
               local live_line
-              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live)"
+              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live 2>&1)"
               echo "\${live_status}"
               live_line="\$(printf '%s\n' "\${live_status}" | awk '\$1 == "pm5d.threelayer.live" { print; exit }')"
               case "\${live_line}" in

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -85,7 +85,7 @@ service_exists() {{
 require_pm5d_live_paused() {{
   local live_status
   local live_line
-  live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live)"
+  live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live 2>&1)"
   echo "${{live_status}}"
   live_line="$(printf '%s\n' "${{live_status}}" | awk '$1 == "pm5d.threelayer.live" {{ print; exit }}')"
   case "${{live_line}}" in

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,39 @@
+# Deploy Live-Paused Stderr Guard Repair (2026-05-12)
+
+## Goal
+
+Stop the protected tango deploy workflow from failing after a successful
+primary SSH deploy when `ployctl deployments inspect` writes the valid live
+paused line to stderr.
+
+## Plan
+
+- [x] Reproduce the Cloud Assistant fallback false-negative on `tango-1-1`.
+- [x] Capture `ployctl deployments inspect pm5d.threelayer.live` stderr in
+  both SSH and Cloud Assistant live-paused guards before awk matching.
+- [x] Run focused workflow/security validation.
+- [ ] Land the guard fix and rerun deploy from `main` so the workflow result
+  matches the already verified remote state.
+
+## Review
+
+- 2026-05-12: Deploy run `25700821724` deployed the bundle through the primary
+  SSH path, but failed in the Cloud Assistant fallback guard. Independent
+  remote verification confirmed `pm5d.threelayer.live desired=Paused
+  observed=Paused`, the settlement-probability dry-run still Running,
+  `ployd` active/running with guardrails, and no host-side `cargo`/`rustc`
+  build process. A direct shell reproduction showed the valid live line prints
+  while command substitution receives an empty stdout value, so the guard must
+  capture stderr before selecting the exact live deployment row.
+- 2026-05-12: Updated both deploy guards to capture `ployctl deployments
+  inspect pm5d.threelayer.live 2>&1` before exact-row awk selection.
+  Verification passed: `python3 -m py_compile
+  scripts/ci/deploy_tango_cloud_assist.py`, Ruby YAML parse for
+  `.github/workflows/deploy-tango-1-1.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-live-paused-stderr /opt/homebrew/bin/timeout
+  300 rtk cargo test --locked --test workflow_security
+  tango_deploy_keeps_pm5d_live_paused`, and `rtk git diff --check`.
+
 # Runtime Quote Throttle State Repair (2026-05-12)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -371,6 +371,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
         "pm5d.threelayer.live.json",
         "desired_state=paused",
         "deployments inspect pm5d.threelayer.live",
+        "deployments inspect pm5d.threelayer.live 2>&1",
         "awk '\\$1 == \"pm5d.threelayer.live\"",
         "desired=Paused",
         "observed=Paused",
@@ -383,6 +384,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     for needle in [
         "require_pm5d_live_paused",
         "deployments inspect pm5d.threelayer.live",
+        "deployments inspect pm5d.threelayer.live 2>&1",
         "awk '$1 == \"pm5d.threelayer.live\"",
         "desired=Paused",
         "observed=Paused",


### PR DESCRIPTION
## Summary
- capture stderr from ployctl deployments inspect before live-paused awk matching
- apply the same guard repair to the SSH deploy path and Cloud Assistant fallback script
- strengthen workflow security coverage for the stderr capture contract

## Verification
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'
- CARGO_TARGET_DIR=/tmp/ploy-live-paused-stderr /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- rtk git diff --check

Context: deploy run 25700821724 completed the primary SSH deploy and remote verification shows live paused/dry-run running, but the Cloud Assistant fallback guard saw an empty stdout capture because ployctl printed the valid line to stderr.