### PR TITLE
Add alpha search prior and MCTS state

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -33,7 +33,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -96,6 +96,8 @@ jobs:
               "alpha_search_plan_run_id": "",
               "alpha_search_plan_artifact_name": "",
               "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
+              "alpha_search_llm_prior_json": "",
+              "alpha_search_state_json": "",
               "alpha_search_min_reward_improvement": "0.0",
               "chain_next_run": "false",
               "chain_remaining": "0",
@@ -361,6 +363,16 @@ jobs:
           fi
           if [ -n "${alpha_search_plan_json}" ]; then
             args+=(--alpha-search-plan-json "${alpha_search_plan_json}")
+          fi
+          alpha_search_state_json="${WALK_ALPHA_SEARCH_STATE_JSON}"
+          if [ -z "${alpha_search_state_json}" ] && [ -f artifacts/alpha-search-plan/mcts-state.json ]; then
+            alpha_search_state_json="artifacts/alpha-search-plan/mcts-state.json"
+          fi
+          if [ -n "${alpha_search_state_json}" ]; then
+            args+=(--alpha-search-state-json "${alpha_search_state_json}")
+          fi
+          if [ -n "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}" ]; then
+            args+=(--alpha-search-llm-prior-json "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}")
           fi
           if [ "${WALK_FAIL_IF_BLOCKED}" = "true" ]; then
             args+=(--fail-if-blocked)

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -30,7 +30,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings, local snapshot registry, optional replay parity artifact"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl"}'
+        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":""}'
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
@@ -88,6 +88,12 @@ jobs:
               "replay_parity_json",
               "replay_parity_run_id",
               "replay_parity_artifact_name",
+              "alpha_search_plan_json",
+              "alpha_search_plan_run_id",
+              "alpha_search_plan_artifact_name",
+              "alpha_search_plan_target",
+              "alpha_search_llm_prior_json",
+              "alpha_search_state_json",
               "required_strategy_profile",
               "allowed_target",
               "issue_number",
@@ -197,6 +203,8 @@ jobs:
               "alpha_search_plan_run_id": "",
               "alpha_search_plan_artifact_name": "",
               "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
+              "alpha_search_llm_prior_json": "",
+              "alpha_search_state_json": "",
           }
           bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
           choices = {
@@ -581,6 +589,16 @@ jobs:
           fi
           if [ -n "${alpha_search_plan_json}" ]; then
             args+=(--alpha-search-plan-json "${alpha_search_plan_json}")
+          fi
+          alpha_search_state_json="${WALK_ALPHA_SEARCH_STATE_JSON}"
+          if [ -z "${alpha_search_state_json}" ] && [ -f artifacts/alpha-search-plan/mcts-state.json ]; then
+            alpha_search_state_json="artifacts/alpha-search-plan/mcts-state.json"
+          fi
+          if [ -n "${alpha_search_state_json}" ]; then
+            args+=(--alpha-search-state-json "${alpha_search_state_json}")
+          fi
+          if [ -n "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}" ]; then
+            args+=(--alpha-search-llm-prior-json "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}")
           fi
           ./target/release/examples/factor_walk_forward_v2 "${args[@]}" \
             | tee artifacts/factor-walk-forward-v2/report.txt

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -5,16 +5,9 @@
 //! scores executable PnL after PM CLOB fillability.
 
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_market_contracts::MarketUpdate;
 use ploy_research::{
-    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
-    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
-    FillabilityReviewOptions, FullDepthExecutionMatrixOptions, LiquidityGateV1Options,
-    LiquidityGatedAlphaV1Options, MetaLabelWalkForwardOptions, RepricingIcOptions,
-    ResearchSnapshotRequest, SettlementProbabilityDataQualityMode,
-    SettlementProbabilityPromotionGateOptions, SettlementProbabilityReportOptions,
-    SettlementProbabilityWalkForwardOptions, TradeFormationReviewOptions,
     autofactor_matrix_from_v2, build_factor_observations_v2_with_deribit_and_pm_books,
     build_factor_observations_with_lob_sampled, build_factor_stability_report,
     build_full_depth_execution_matrix, build_settlement_probability_promotion_gate_report,
@@ -27,12 +20,19 @@ use ploy_research::{
     format_trade_formation_v1_report, liquidity_gate_v1_with_deribit_and_pm_books,
     liquidity_gated_alpha_v1_with_deribit_and_pm_books, load_deribit_feature_snapshots,
     load_research_lob_snapshots_sampled, load_research_pm_book_snapshots_sampled,
-    load_research_snapshot, mine_domain_autofactors_from_v2_with_mcts_plan,
+    load_research_snapshot, mine_domain_autofactors_from_v2_with_guidance, read_mcts_search_state,
     review_fillability_v1_with_deribit_and_pm_books, review_repricing_ic_with_deribit_and_pm_books,
     review_trade_formation_v1_with_deribit_and_pm_books, validate_snapshot_request_coverage,
     walk_forward_factor_combo_v1_with_deribit_and_pm_books,
     walk_forward_factors_v2_with_deribit_and_pm_books,
-    walk_forward_meta_label_v1_with_deribit_and_pm_books, write_alpha_search_artifacts,
+    walk_forward_meta_label_v1_with_deribit_and_pm_books, write_alpha_search_artifacts_with_state,
+    AutoFactorOptions, AutoFactorV2Target, FactorComboV1Options, FactorObservation,
+    FactorReviewOptions, FactorStabilityOptions, FactorWalkForwardOptions,
+    FillabilityReviewOptions, FullDepthExecutionMatrixOptions, LiquidityGateV1Options,
+    LiquidityGatedAlphaV1Options, LlmPriorSpec, MetaLabelWalkForwardOptions, RepricingIcOptions,
+    ResearchSnapshotRequest, SettlementProbabilityDataQualityMode,
+    SettlementProbabilityPromotionGateOptions, SettlementProbabilityReportOptions,
+    SettlementProbabilityWalkForwardOptions, TradeFormationReviewOptions,
 };
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashSet;
@@ -234,6 +234,13 @@ fn alpha_search_plan_factor_names(path: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn read_llm_prior(path: &str) -> LlmPriorSpec {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("read alpha search LLM prior JSON {path} failed: {err}"));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|err| panic!("parse alpha search LLM prior JSON {path} failed: {err}"))
+}
+
 fn slice_by_time<T, F>(items: &[T], start: DateTime<Utc>, end: DateTime<Utc>, ts_fn: F) -> &[T]
 where
     F: Fn(&T) -> DateTime<Utc>,
@@ -319,6 +326,8 @@ async fn main() {
     let replay_parity_json = flag_value(&args, "--replay-parity-json");
     let alpha_search_output_dir = flag_value(&args, "--alpha-search-output-dir");
     let alpha_search_plan_json = flag_value(&args, "--alpha-search-plan-json");
+    let alpha_search_llm_prior_json = flag_value(&args, "--alpha-search-llm-prior-json");
+    let alpha_search_state_json = flag_value(&args, "--alpha-search-state-json");
     let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
     let data_quality_mode = parse_data_quality_mode(flag_value(&args, "--data-quality-mode"));
     let min_event_complete_events = flag_value(&args, "--min-event-complete-events")
@@ -718,6 +727,17 @@ async fn main() {
         .as_deref()
         .map(alpha_search_plan_factor_names)
         .unwrap_or_default();
+    let llm_prior = alpha_search_llm_prior_json.as_deref().map(read_llm_prior);
+    if let Some(path) = alpha_search_llm_prior_json.as_deref() {
+        eprintln!("alpha search typed LLM prior loaded from {path}");
+    }
+    let mcts_state = alpha_search_state_json.as_deref().map(|path| {
+        read_mcts_search_state(path)
+            .unwrap_or_else(|err| panic!("read alpha search MCTS state JSON {path} failed: {err}"))
+    });
+    if let Some(path) = alpha_search_state_json.as_deref() {
+        eprintln!("alpha search cumulative MCTS state loaded from {path}");
+    }
     if let Some(path) = alpha_search_plan_json.as_deref() {
         eprintln!(
             "alpha search MCTS plan loaded: {} selected nodes from {}",
@@ -730,11 +750,12 @@ async fn main() {
         AutoFactorV2Target::FullDepthRepricePnl30s,
         AutoFactorV2Target::FullDepthSettlementExecutablePnl,
     ] {
-        match mine_domain_autofactors_from_v2_with_mcts_plan(
+        match mine_domain_autofactors_from_v2_with_guidance(
             &autofactor_rows,
             target,
             &autofactor_options,
             &alpha_search_plan_names,
+            llm_prior.as_ref(),
         ) {
             Ok(reports) => {
                 println!("# AutoFactor target={}", target.as_str());
@@ -743,12 +764,13 @@ async fn main() {
                     alpha_search_output_dir.as_deref(),
                     alpha_search_input_names.as_ref(),
                 ) {
-                    match write_alpha_search_artifacts(
+                    match write_alpha_search_artifacts_with_state(
                         output_dir,
                         target.as_str(),
                         input_names,
                         &reports,
                         &autofactor_options,
+                        mcts_state.as_ref(),
                     ) {
                         Ok(summary) => eprintln!(
                             "alpha search artifacts written target={} candidates={} rejected={} best={} dir={}",

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::path::Path;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::autofactor::{AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr};
 
@@ -15,6 +15,26 @@ pub struct AlphaSearchArtifactSummary {
     pub candidate_count: usize,
     pub rejected_count: usize,
     pub best_candidate: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MctsSearchStateArtifact {
+    pub version: String,
+    pub mode: String,
+    pub target: String,
+    pub total_visits: usize,
+    pub nodes: Vec<MctsSearchStateNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MctsSearchStateNode {
+    pub factor_name: String,
+    pub visits: usize,
+    pub total_reward: f64,
+    pub best_reward: f64,
+    pub last_reward: f64,
+    pub selected_dimension: String,
+    pub last_decision: String,
 }
 
 #[derive(Debug)]
@@ -199,6 +219,31 @@ pub fn write_alpha_search_artifacts(
     reports: &[AutoFactorReport],
     options: &AutoFactorOptions,
 ) -> Result<AlphaSearchArtifactSummary, AlphaSearchArtifactError> {
+    write_alpha_search_artifacts_with_state(
+        output_root,
+        target,
+        input_names,
+        reports,
+        options,
+        None,
+    )
+}
+
+pub fn read_mcts_search_state(
+    path: impl AsRef<Path>,
+) -> Result<MctsSearchStateArtifact, AlphaSearchArtifactError> {
+    let raw = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+pub fn write_alpha_search_artifacts_with_state(
+    output_root: impl AsRef<Path>,
+    target: &str,
+    input_names: &[String],
+    reports: &[AutoFactorReport],
+    options: &AutoFactorOptions,
+    prior_state: Option<&MctsSearchStateArtifact>,
+) -> Result<AlphaSearchArtifactSummary, AlphaSearchArtifactError> {
     let output_dir = output_root.as_ref().join(target);
     std::fs::create_dir_all(&output_dir)?;
 
@@ -303,9 +348,11 @@ pub fn write_alpha_search_artifacts(
         .map(|(idx, report)| node_metric(idx, report))
         .collect::<Vec<_>>();
     write_json(&output_dir.join("node-metrics.json"), &node_metrics)?;
+    let mcts_state = mcts_search_state(target, &node_metrics, prior_state);
+    write_json(&output_dir.join("mcts-state.json"), &mcts_state)?;
     write_json(
         &output_dir.join("mcts-expansion-plan.json"),
-        &mcts_expansion_plan(target, &node_metrics),
+        &mcts_expansion_plan(target, &node_metrics, &mcts_state),
     )?;
 
     write_json(
@@ -442,16 +489,78 @@ fn node_metric(idx: usize, report: &AutoFactorReport) -> NodeMetric {
     }
 }
 
-fn mcts_expansion_plan(target: &str, metrics: &[NodeMetric]) -> MctsExpansionPlan {
+fn mcts_search_state(
+    target: &str,
+    metrics: &[NodeMetric],
+    prior_state: Option<&MctsSearchStateArtifact>,
+) -> MctsSearchStateArtifact {
+    let mut nodes = prior_state
+        .filter(|state| state.target == target)
+        .map(|state| {
+            state
+                .nodes
+                .iter()
+                .map(|node| (node.factor_name.clone(), node.clone()))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    for metric in metrics {
+        let mut node = nodes
+            .remove(&metric.factor_name)
+            .unwrap_or_else(|| MctsSearchStateNode {
+                factor_name: metric.factor_name.clone(),
+                visits: 0,
+                total_reward: 0.0,
+                best_reward: f64::NEG_INFINITY,
+                last_reward: 0.0,
+                selected_dimension: metric.selected_dimension.clone(),
+                last_decision: metric.decision.clone(),
+            });
+        node.visits = node.visits.saturating_add(1);
+        node.total_reward += metric.reward;
+        node.best_reward = node.best_reward.max(metric.reward);
+        node.last_reward = metric.reward;
+        node.selected_dimension = metric.selected_dimension.clone();
+        node.last_decision = metric.decision.clone();
+        nodes.insert(node.factor_name.clone(), node);
+    }
+
+    let mut nodes = nodes.into_values().collect::<Vec<_>>();
+    nodes.sort_by(|lhs, rhs| lhs.factor_name.cmp(&rhs.factor_name));
+    let total_visits = nodes.iter().map(|node| node.visits).sum();
+    MctsSearchStateArtifact {
+        version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),
+        mode: "cumulative_ucb_state".to_string(),
+        target: target.to_string(),
+        total_visits,
+        nodes,
+    }
+}
+
+fn mcts_expansion_plan(
+    target: &str,
+    metrics: &[NodeMetric],
+    state: &MctsSearchStateArtifact,
+) -> MctsExpansionPlan {
     let exploration_weight = 0.75;
-    let total_visits = metrics.len().max(1) as f64;
+    let total_visits = state.total_visits.max(1) as f64;
+    let state_by_factor = state
+        .nodes
+        .iter()
+        .map(|node| (node.factor_name.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
     let mut selected = metrics
         .iter()
         .filter(|metric| metric.decision != "reject")
         .map(|metric| {
-            let visits = 1.0_f64;
+            let state_node = state_by_factor.get(metric.factor_name.as_str());
+            let visits = state_node.map(|node| node.visits).unwrap_or(1).max(1) as f64;
+            let average_reward = state_node
+                .map(|node| node.total_reward / visits)
+                .unwrap_or(metric.reward);
             let ucb_priority =
-                metric.reward + exploration_weight * (total_visits.ln() / visits).sqrt();
+                average_reward + exploration_weight * (total_visits.ln() / visits).sqrt();
             MctsSelectedNode {
                 node_id: metric.id.clone(),
                 factor_name: metric.factor_name.clone(),
@@ -624,6 +733,82 @@ mod tests {
         assert!(tmp
             .join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
             .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/mcts-state.json")
+            .exists());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn merges_prior_mcts_state_into_search_artifacts() {
+        let tmp = std::env::temp_dir().join(format!(
+            "ploy-alpha-search-state-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let report = AutoFactorReport {
+            name: "auto_settlement_conservative_settlement_edge".to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Input("conservative_settlement_edge".to_string()),
+            n: 100,
+            pearson_ic: 0.2,
+            spearman_ic: 0.25,
+            window_count: 3,
+            window_ic_mean: 0.2,
+            icir: 1.2,
+            positive_window_ratio: 1.0,
+            symbol_count: 2,
+            symbol_ic_mean: 0.18,
+            symbol_icir: 1.0,
+            symbol_positive_ratio: 1.0,
+            bucket_avg_labels: vec![-0.1, 0.0, 0.2],
+            bottom_bucket_n: 20,
+            bottom_bucket_avg_label: -0.1,
+            top_bucket_n: 20,
+            top_bucket_avg_label: 0.2,
+            top_bucket_positive_label_rate: 0.7,
+            monotonicity_score: 1.0,
+            complexity: 1,
+            decision: AutoFactorDecision::Candidate,
+            reason: "passed".to_string(),
+        };
+        let prior = MctsSearchStateArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),
+            mode: "cumulative_ucb_state".to_string(),
+            target: "full_depth_settlement_executable_pnl".to_string(),
+            total_visits: 3,
+            nodes: vec![MctsSearchStateNode {
+                factor_name: "auto_settlement_conservative_settlement_edge".to_string(),
+                visits: 3,
+                total_reward: 6.0,
+                best_reward: 2.0,
+                last_reward: 2.0,
+                selected_dimension: "exploit".to_string(),
+                last_decision: "candidate".to_string(),
+            }],
+        };
+
+        write_alpha_search_artifacts_with_state(
+            &tmp,
+            "full_depth_settlement_executable_pnl",
+            &["conservative_settlement_edge".to_string()],
+            &[report],
+            &AutoFactorOptions::default(),
+            Some(&prior),
+        )
+        .expect("write artifacts");
+
+        let state = read_mcts_search_state(
+            tmp.join("full_depth_settlement_executable_pnl/mcts-state.json"),
+        )
+        .expect("state");
+        let node = state
+            .nodes
+            .iter()
+            .find(|node| node.factor_name == "auto_settlement_conservative_settlement_edge")
+            .expect("merged node");
+        assert_eq!(node.visits, 4);
+        assert!(node.total_reward > 6.0);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -112,6 +112,32 @@ pub struct NamedFactorExpr {
     pub notes: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmPriorSpec {
+    #[serde(default)]
+    pub mutations: Vec<LlmMutationSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmMutationSpec {
+    pub base_factor: String,
+    pub mutation_type: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub feature: Option<String>,
+    #[serde(default)]
+    pub denominator_feature: Option<String>,
+    #[serde(default)]
+    pub constant: Option<f64>,
+    #[serde(default)]
+    pub lo: Option<f64>,
+    #[serde(default)]
+    pub hi: Option<f64>,
+    #[serde(default)]
+    pub window: Option<usize>,
+}
+
 impl NamedFactorExpr {
     pub fn new(name: impl Into<String>, expr: FactorExpr) -> Self {
         Self {
@@ -514,15 +540,32 @@ pub fn mine_domain_autofactors_from_v2_with_mcts_plan(
     options: &AutoFactorOptions,
     mcts_selected_factor_names: &[String],
 ) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
+    mine_domain_autofactors_from_v2_with_guidance(
+        rows,
+        target,
+        options,
+        mcts_selected_factor_names,
+        None,
+    )
+}
+
+pub fn mine_domain_autofactors_from_v2_with_guidance(
+    rows: &[FactorObservationV2],
+    target: AutoFactorV2Target,
+    options: &AutoFactorOptions,
+    mcts_selected_factor_names: &[String],
+    llm_prior: Option<&LlmPriorSpec>,
+) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
     let matrix = autofactor_matrix_from_v2(rows)?;
     let labels = autofactor_labels_from_v2(rows, target);
     let windows = autofactor_windows_from_v2(rows);
     let symbols = autofactor_symbols_from_v2(rows);
     let target_name = target.as_str().to_string();
-    let candidates = domain_candidates_for_target_with_mcts(
+    let candidates = domain_candidates_for_target_with_guidance(
         &matrix.input_names(),
         target,
         mcts_selected_factor_names,
+        llm_prior,
     )
     .into_iter()
     .map(|mut factor| {
@@ -811,10 +854,11 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
     out
 }
 
-fn domain_candidates_for_target_with_mcts(
+fn domain_candidates_for_target_with_guidance(
     input_names: &BTreeSet<String>,
     target: AutoFactorV2Target,
     mcts_selected_factor_names: &[String],
+    llm_prior: Option<&LlmPriorSpec>,
 ) -> Vec<NamedFactorExpr> {
     let mut out = domain_seed_candidates(input_names);
     if target == AutoFactorV2Target::FullDepthSettlementExecutablePnl {
@@ -841,7 +885,162 @@ fn domain_candidates_for_target_with_mcts(
                 }),
         );
     }
+    if let Some(prior) = llm_prior {
+        let base = out.clone();
+        out.extend(llm_prior_mutation_candidates(input_names, &base, prior));
+    }
     out
+}
+
+fn llm_prior_mutation_candidates(
+    input_names: &BTreeSet<String>,
+    candidates: &[NamedFactorExpr],
+    prior: &LlmPriorSpec,
+) -> Vec<NamedFactorExpr> {
+    let by_name = candidates
+        .iter()
+        .map(|candidate| (candidate.name.as_str(), candidate))
+        .collect::<BTreeMap<_, _>>();
+    let mut out = Vec::new();
+    for mutation in &prior.mutations {
+        let Some(base) = by_name.get(mutation.base_factor.as_str()) else {
+            continue;
+        };
+        let Some((suffix, expr)) = compile_llm_mutation(input_names, base, mutation) else {
+            continue;
+        };
+        let name = mutation
+            .name
+            .as_ref()
+            .map(|name| sanitize_factor_name(name))
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| format!("llm_{}_{}", base.name, suffix));
+        out.push(NamedFactorExpr {
+            name,
+            expr,
+            target: base.target.clone(),
+            notes: vec![format!(
+                "Typed LLM-prior mutation `{}` compiled from base factor `{}`.",
+                mutation.mutation_type, base.name
+            )],
+        });
+    }
+    out
+}
+
+fn compile_llm_mutation(
+    input_names: &BTreeSet<String>,
+    base: &NamedFactorExpr,
+    mutation: &LlmMutationSpec,
+) -> Option<(&'static str, FactorExpr)> {
+    let constant = mutation.constant.unwrap_or(0.01);
+    if !constant.is_finite() || constant.abs() > 300.0 {
+        return None;
+    }
+    match mutation.mutation_type.as_str() {
+        "add_feature_gate" => {
+            let feature = existing_feature(input_names, mutation.feature.as_deref())?;
+            Some(("feature_gate", mul(base.expr.clone(), input(feature))))
+        }
+        "add_capacity_gate" => {
+            let feature = mutation
+                .feature
+                .as_deref()
+                .unwrap_or("entry_capacity_score");
+            let feature = existing_feature(input_names, Some(feature))?;
+            Some(("capacity_gate", mul(base.expr.clone(), input(feature))))
+        }
+        "add_near_strike_interaction" => {
+            let feature = existing_feature(input_names, Some("near_strike_score"))?;
+            Some(("near_strike", mul(base.expr.clone(), input(feature))))
+        }
+        "add_spread_penalty" => {
+            let feature = existing_feature(input_names, Some("side_spread"))?;
+            Some((
+                "spread_penalty",
+                safe_div_expr(
+                    base.expr.clone(),
+                    FactorExpr::Add(
+                        Box::new(input(feature)),
+                        Box::new(FactorExpr::Const(constant)),
+                    ),
+                ),
+            ))
+        }
+        "replace_denominator" => {
+            let feature = existing_feature(
+                input_names,
+                mutation
+                    .denominator_feature
+                    .as_deref()
+                    .or(mutation.feature.as_deref()),
+            )?;
+            Some((
+                "replace_denominator",
+                safe_div_expr(
+                    base.expr.clone(),
+                    FactorExpr::Add(
+                        Box::new(input(feature)),
+                        Box::new(FactorExpr::Const(constant)),
+                    ),
+                ),
+            ))
+        }
+        "clip_or_squash" => {
+            if let (Some(lo), Some(hi)) = (mutation.lo, mutation.hi) {
+                if lo.is_finite() && hi.is_finite() && lo < hi {
+                    return Some((
+                        "clip",
+                        FactorExpr::Clip {
+                            expr: Box::new(base.expr.clone()),
+                            lo,
+                            hi,
+                        },
+                    ));
+                }
+            }
+            Some(("squash", FactorExpr::Tanh(Box::new(base.expr.clone()))))
+        }
+        "change_time_window" => {
+            let window = mutation.window.unwrap_or(30);
+            if !(1..=300).contains(&window) {
+                return None;
+            }
+            Some((
+                "rolling_mean",
+                FactorExpr::RollingMean {
+                    expr: Box::new(base.expr.clone()),
+                    window,
+                },
+            ))
+        }
+        "invert_or_contrarian" => Some((
+            "contrarian",
+            mul(FactorExpr::Const(-1.0), base.expr.clone()),
+        )),
+        "remove_component" => None,
+        _ => None,
+    }
+}
+
+fn existing_feature<'a>(
+    input_names: &BTreeSet<String>,
+    feature: Option<&'a str>,
+) -> Option<&'a str> {
+    let feature = feature?;
+    input_names.contains(feature).then_some(feature)
+}
+
+fn sanitize_factor_name(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 fn deterministic_mutation_candidates(
@@ -1814,6 +2013,49 @@ mod tests {
         assert!(reports
             .iter()
             .any(|report| report.name.starts_with("mut2_")));
+    }
+
+    #[test]
+    fn typed_llm_prior_mutations_compile_into_factor_expr_candidates() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+        let prior = LlmPriorSpec {
+            mutations: vec![LlmMutationSpec {
+                base_factor: "auto_settlement_full_depth_settlement_edge".to_string(),
+                mutation_type: "add_feature_gate".to_string(),
+                name: Some("llm_full_depth_edge_near_strike".to_string()),
+                feature: Some("near_strike_score".to_string()),
+                denominator_feature: None,
+                constant: None,
+                lo: None,
+                hi: None,
+                window: None,
+            }],
+        };
+
+        let reports = mine_domain_autofactors_from_v2_with_guidance(
+            &rows,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            &options,
+            &[],
+            Some(&prior),
+        )
+        .expect("reports");
+
+        let report = reports
+            .iter()
+            .find(|report| report.name == "llm_full_depth_edge_near_strike")
+            .expect("LLM-prior compiled candidate");
+        assert_eq!(
+            report.target.as_deref(),
+            Some("full_depth_settlement_executable_pnl")
+        );
+        assert!(matches!(report.expr, FactorExpr::Mul(_, _)));
     }
 
     #[test]

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -83,15 +83,18 @@ pub fn crate_marker() -> &'static str {
 // factor registry uses the same type internally, but does not re-export its own
 // `factors_new::Regime` alias.
 pub use alpha_search::{
-    write_alpha_search_artifacts, AlphaSearchArtifactError, AlphaSearchArtifactSummary,
+    read_mcts_search_state, write_alpha_search_artifacts, write_alpha_search_artifacts_with_state,
+    AlphaSearchArtifactError, AlphaSearchArtifactSummary, MctsSearchStateArtifact,
+    MctsSearchStateNode,
 };
 pub use attribution::{factor_pnl, regime_pnl, AttributionReport, RegimePnl};
 pub use autofactor::{
     autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_windows_from_v2,
     domain_seed_candidates, evaluate_named_factor, format_autofactor_reports, mine_autofactors,
-    mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_mcts_plan,
-    AutoFactorDecision, AutoFactorError, AutoFactorMatrix, AutoFactorOptions, AutoFactorReport,
-    AutoFactorV2Target, FactorExpr, NamedFactorExpr,
+    mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_guidance,
+    mine_domain_autofactors_from_v2_with_mcts_plan, AutoFactorDecision, AutoFactorError,
+    AutoFactorMatrix, AutoFactorOptions, AutoFactorReport, AutoFactorV2Target, FactorExpr,
+    LlmMutationSpec, LlmPriorSpec, NamedFactorExpr,
 };
 pub use backtest::{run_binary_backtest, BacktestMetrics, SimulatedFill};
 pub use factors_new::{

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -360,14 +360,23 @@ Current implementation status:
   a candidate cap to keep CI runs bounded.
 - Implemented: workflow upload path for the artifact bundle through both
   Factor Walk-Forward V2 workflows.
-- Implemented: first MCTS control artifact,
-  `mcts-expansion-plan.json`, which ranks non-rejected nodes with a UCB-style
-  priority and proposes the next mutation family from each node's weakest
-  dimension.
+- Implemented: first MCTS control artifacts, `mcts-state.json` and
+  `mcts-expansion-plan.json`. The state artifact accumulates visits and
+  rewards per factor across runs, and the expansion plan ranks non-rejected
+  current-run nodes with a UCB-style priority using that cumulative state.
 - Implemented: `factor_walk_forward_v2 --alpha-search-plan-json <path>` can
   consume a prior `mcts-expansion-plan.json` and generate extra `mcts_*`
   guided mutations for selected branches. The Factor Walk-Forward workflows
   expose this as `options_json.alpha_search_plan_json`.
+- Implemented: `factor_walk_forward_v2 --alpha-search-state-json <path>` can
+  consume a prior `mcts-state.json`; when a prior alpha-search artifact is
+  downloaded via `options_json.alpha_search_plan_run_id`, the workflows pass
+  its `mcts-state.json` automatically when present.
+- Implemented: `factor_walk_forward_v2 --alpha-search-llm-prior-json <path>`
+  accepts a typed LLM-prior JSON file with bounded mutation requests. The Rust
+  layer compiles those requests into existing `FactorExpr` candidates only when
+  the requested base factor, feature, mutation type, and constants are valid.
+  Unsupported free-form code is ignored rather than evaluated.
 - Implemented: the Factor Walk-Forward workflows can download a prior plan from
   a previous run with `options_json.alpha_search_plan_run_id`,
   `alpha_search_plan_artifact_name`, and `alpha_search_plan_target`.
@@ -386,11 +395,12 @@ Current implementation status:
   `search-feedback.json.best_reward` with the prior plan artifact's
   `search-feedback.json.best_reward` and stops with `reward_stagnation` when
   the configured `alpha_search_min_reward_improvement` threshold is not met.
-- Implemented as placeholder artifact: `llm-priors.json` records the typed prior
-  schema without calling an external LLM.
-- Not yet implemented: live LLM expansion policy, typed mutation parser from
-  LLM proposals, full multi-run MCTS visit/reward backpropagation beyond the
-  current artifact-to-artifact feedback loop.
+- Implemented as artifact and input contract: `llm-priors.json` records the
+  typed prior schema, and an operator- or LLM-produced prior file can now enter
+  CI through `--alpha-search-llm-prior-json` / `options_json.alpha_search_llm_prior_json`.
+- Not yet implemented: direct live LLM API invocation inside CI. The intended
+  boundary is still external LLM proposal -> reviewed typed JSON -> Rust DSL
+  compiler -> CI evaluation.
 
 The current system is enough to start systematizing alpha discovery in CI: every
 walk-forward run can now expand interpretable bounded multi-depth mutations,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,7 +16,7 @@ without allowing free-form generated code into the research loop.
 - [x] Wire the new prior/state inputs through `factor_walk_forward_v2` and the
   hosted/self-hosted factor workflows.
 - [x] Add focused Rust/workflow tests and update alpha-search docs.
-- [ ] Open a focused PR after local verification.
+- [x] Open a focused PR after local verification.
 
 ## Review
 
@@ -46,6 +46,12 @@ without allowing free-form generated code into the research loop.
   rtk cargo check --locked -p ploy-research --features db --example
   factor_walk_forward_v2`, Ruby YAML parse for both factor walk-forward
   workflows, and `rtk git diff --check`.
+- 2026-05-12: Opened PR #444 from `feat/alpha-search-prior-state`. GitHub
+  Actions passed for workflow lint, commit hygiene, dependency audit, Python
+  script tests, frontend/sidecar, Rust control-plane/core, Rust integration
+  regressions, Rust market-data ops, Rust research heavy features, Rust runner
+  lean replay/backtest, and Rust runner live/default. CodeRabbit review was
+  still pending when this evidence was recorded.
 
 # Deploy Live-Paused Stderr Guard Repair (2026-05-12)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,52 @@
+# Alpha Search LLM Prior And MCTS State (2026-05-12)
+
+## Goal
+
+Turn the current placeholder alpha-search prior and single-run MCTS plan into a
+machine-checkable LLM-prior input path plus cumulative MCTS state artifact,
+without allowing free-form generated code into the research loop.
+
+## Plan
+
+- [x] Add a typed LLM prior/mutation schema that compiles into existing
+  `FactorExpr` candidates using only declared features, constants, and safe
+  mutation types.
+- [x] Add cumulative `mcts-state.json` merge/write support so UCB priority can
+  use prior visits and rewards instead of treating each CI run as isolated.
+- [x] Wire the new prior/state inputs through `factor_walk_forward_v2` and the
+  hosted/self-hosted factor workflows.
+- [x] Add focused Rust/workflow tests and update alpha-search docs.
+- [ ] Open a focused PR after local verification.
+
+## Review
+
+- 2026-05-12: Existing implementation already has `FactorExpr`, deterministic
+  mutations, alpha-search artifacts, `mcts-expansion-plan.json`, and hosted
+  chained dispatch. Missing pieces are true typed LLM prior input and
+  cumulative MCTS state across runs.
+- 2026-05-12: Added typed `LlmPriorSpec` / `LlmMutationSpec` input that compiles
+  into safe `FactorExpr` mutations only when referenced features exist and
+  constants/windows are bounded. Added cumulative `mcts-state.json` read/merge
+  support, made UCB priority use cumulative visits/rewards, and wired
+  `--alpha-search-llm-prior-json` plus `--alpha-search-state-json` through
+  self-hosted and hosted walk-forward workflows, including the hosted route
+  allowlist.
+- 2026-05-12: Verification passed:
+  `rustfmt --edition 2021 --check crates/ploy-research/src/alpha_search.rs
+  crates/ploy-research/src/autofactor.rs
+  crates/ploy-research/examples/factor_walk_forward_v2.rs`,
+  `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked -p ploy-research alpha_search --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked -p ploy-research autofactor --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked --test workflow_security
+  factor_walk_forward_wires_alpha_prior_and_state_inputs`,
+  `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300
+  rtk cargo check --locked -p ploy-research --features db --example
+  factor_walk_forward_v2`, Ruby YAML parse for both factor walk-forward
+  workflows, and `rtk git diff --check`.
+
 # Deploy Live-Paused Stderr Guard Repair (2026-05-12)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -335,6 +335,54 @@ fn hosted_factor_walk_forward_uploads_alpha_chain_summary() {
 }
 
 #[test]
+fn factor_walk_forward_wires_alpha_prior_and_state_inputs() {
+    let hosted = workflow_contents(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml");
+    let self_hosted = workflow_contents(".github/workflows/factor-walk-forward-v2.yml");
+    let mut offenders = Vec::new();
+
+    for (name, workflow) in [
+        ("factor-walk-forward-v2-hosted-artifact.yml", hosted.as_str()),
+        ("factor-walk-forward-v2.yml", self_hosted.as_str()),
+    ] {
+        for needle in [
+            "alpha_search_llm_prior_json",
+            "alpha_search_state_json",
+            "mcts-state.json",
+            "--alpha-search-state-json",
+            "--alpha-search-llm-prior-json",
+        ] {
+            if !workflow.contains(needle) {
+                offenders.push(format!("{name}: missing `{needle}`"));
+            }
+        }
+    }
+
+    let route_allowlist = self_hosted
+        .split("allowed = {")
+        .nth(1)
+        .and_then(|tail| tail.split("raw = os.environ").next())
+        .unwrap_or("");
+    for needle in [
+        "alpha_search_plan_run_id",
+        "alpha_search_plan_artifact_name",
+        "alpha_search_llm_prior_json",
+        "alpha_search_state_json",
+    ] {
+        if !route_allowlist.contains(needle) {
+            offenders.push(format!(
+                "factor-walk-forward-v2.yml: hosted route allowlist missing `{needle}`"
+            ));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "alpha-search prior/state workflow wiring guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn hosted_factor_walk_forward_splits_replay_parity_artifact_suffix() {
     let workflow = workflow_contents(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml");
     let mut offenders = Vec::new();


### PR DESCRIPTION
## Summary

- Add typed alpha-search LLM prior JSON support that compiles bounded mutation specs into existing `FactorExpr` candidates.
- Add cumulative `mcts-state.json` read/merge/write support and make MCTS expansion priority use prior visits/rewards.
- Wire `--alpha-search-llm-prior-json` and `--alpha-search-state-json` through self-hosted and hosted factor walk-forward workflows, including hosted route allowlisting.
- Update alpha-search docs, workflow guard coverage, and task evidence.

## Verification

- `rustfmt --edition 2021 --check crates/ploy-research/src/alpha_search.rs crates/ploy-research/src/autofactor.rs crates/ploy-research/examples/factor_walk_forward_v2.rs`
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security factor_walk_forward_wires_alpha_prior_and_state_inputs`
- `CARGO_TARGET_DIR=/tmp/ploy-alpha-prior-state /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2`
- Ruby YAML parse for both factor walk-forward workflows
- `rtk git diff --check`

## Safety

This does not add live LLM API calls or free-form generated code execution. LLM output must enter as typed JSON and is fail-closed against declared features, bounded constants/windows, and supported mutation types only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLM-guided factor generation with typed mutation specifications for directing alpha-search mining.
  * Added MCTS search state persistence across runs via artifact output and input support.
  * Updated CI/CD workflows to accept and propagate alpha-search LLM prior and state parameters.

* **Documentation**
  * Enhanced alpha-search CI/CD documentation with newly supported capabilities.

* **Tests**
  * Added workflow validation tests for alpha-search prior and state input handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/444)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->