### PR TITLE
Deploy Rust collectors on tango

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -200,6 +200,8 @@ jobs:
           done
           cp deployment/systemd/ploy-binance-aggtrade-collector.service dist/deployment/systemd/ploy-binance-aggtrade-collector.service
           cp deployment/systemd/ploy-binance-lob-collector.service dist/deployment/systemd/ploy-binance-lob-collector.service
+          cp deployment/systemd/ploy-binance-price-collector.service dist/deployment/systemd/ploy-binance-price-collector.service
+          cp deployment/systemd/ploy-deribit-iv-collector.service dist/deployment/systemd/ploy-deribit-iv-collector.service
           cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
           cp deployment/systemd/ploy-market-discovery.service dist/deployment/systemd/ploy-market-discovery.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
@@ -489,6 +491,8 @@ jobs:
             install -d /etc/systemd/system/ploy-quote-collector.service.d
             install -m 0644 ./deployment/systemd/ploy-binance-aggtrade-collector.service /etc/systemd/system/ploy-binance-aggtrade-collector.service
             install -m 0644 ./deployment/systemd/ploy-binance-lob-collector.service /etc/systemd/system/ploy-binance-lob-collector.service
+            install -m 0644 ./deployment/systemd/ploy-binance-price-collector.service /etc/systemd/system/ploy-binance-price-collector.service
+            install -m 0644 ./deployment/systemd/ploy-deribit-iv-collector.service /etc/systemd/system/ploy-deribit-iv-collector.service
             install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
             install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
             install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
@@ -520,12 +524,10 @@ jobs:
             systemctl restart ploy-binance-aggtrade-collector.service
             systemctl enable --now ploy-binance-lob-collector.service
             systemctl restart ploy-binance-lob-collector.service
-            if service_exists ploy-binance-price-collector.service; then
-              systemctl restart ploy-binance-price-collector.service
-            fi
-            if service_exists ploy-deribit-iv-collector.service; then
-              systemctl restart ploy-deribit-iv-collector.service
-            fi
+            systemctl enable --now ploy-binance-price-collector.service
+            systemctl restart ploy-binance-price-collector.service
+            systemctl enable --now ploy-deribit-iv-collector.service
+            systemctl restart ploy-deribit-iv-collector.service
             systemctl enable --now ploy-deribit-greeks-collector.service
             systemctl restart ploy-deribit-greeks-collector.service
             systemctl enable --now ploy-market-discovery.service
@@ -562,12 +564,10 @@ jobs:
             fi
             systemctl is-active --quiet ploy-pm-trade-collector.service
             require_service_guardrails ploy-pm-trade-collector.service
-            if service_exists ploy-binance-price-collector.service; then
-              systemctl is-active --quiet ploy-binance-price-collector.service
-            fi
-            if service_exists ploy-deribit-iv-collector.service; then
-              systemctl is-active --quiet ploy-deribit-iv-collector.service
-            fi
+            systemctl is-active --quiet ploy-binance-price-collector.service
+            require_service_guardrails ploy-binance-price-collector.service
+            systemctl is-active --quiet ploy-deribit-iv-collector.service
+            require_service_guardrails ploy-deribit-iv-collector.service
             systemctl is-active --quiet ploy-deribit-greeks-collector.service
             require_service_guardrails ploy-deribit-greeks-collector.service
             systemctl is-active --quiet ploy-market-discovery.service

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ serde_json = "1"
 sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "rust_decimal", "json"] }
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 toml = "0.8"
 toml_edit = "0.22"
 async-trait = "0.1"

--- a/crates/ploy-market-data/src/binance_collectors.rs
+++ b/crates/ploy-market-data/src/binance_collectors.rs
@@ -20,7 +20,6 @@ use futures::{SinkExt, StreamExt};
 use rust_decimal::Decimal;
 use serde_json::Value;
 use sqlx::PgPool;
-use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{error, info, warn};
 
@@ -29,7 +28,6 @@ use tracing::{error, info, warn};
 // ---------------------------------------------------------------------------
 
 const BINANCE_WS_URL: &str = "wss://stream.binance.com:9443/stream";
-const DEFAULT_SYMBOLS: &str = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT";
 
 fn parse_symbols(raw: &str) -> Vec<String> {
     raw.split(',')
@@ -46,6 +44,7 @@ fn ms_to_utc(ms: i64) -> DateTime<Utc> {
 
 /// Shared signal — set to false on shutdown request.
 type SharedRunning = Arc<AtomicBool>;
+type CollectorResult<T> = Result<T, String>;
 
 fn running_flag() -> SharedRunning {
     let flag = Arc::new(AtomicBool::new(true));
@@ -63,21 +62,23 @@ async fn binance_connect(
     streams: &[String],
 ) -> Result<
     (
-        futures_util::stream::SplitSink<
+        futures::stream::SplitSink<
             tokio_tungstenite::WebSocketStream<
                 tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
             >,
             Message,
         >,
-        futures_util::stream::SplitStream<
+        futures::stream::SplitStream<
             tokio_tungstenite::WebSocketStream<
                 tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
             >,
         >,
     ),
-    anyhow::Error,
+    String,
 > {
-    let (ws, _) = connect_async(BINANCE_WS_URL).await?;
+    let (ws, _) = connect_async(BINANCE_WS_URL)
+        .await
+        .map_err(|error| error.to_string())?;
     let (mut write, read) = ws.split();
 
     let subscribe = serde_json::json!({
@@ -87,7 +88,8 @@ async fn binance_connect(
     });
     write
         .send(Message::Text(subscribe.to_string().into()))
-        .await?;
+        .await
+        .map_err(|error| error.to_string())?;
 
     Ok((write, read))
 }
@@ -102,9 +104,15 @@ async fn binance_connect(
 pub async fn collect_binance_price(pool: PgPool, symbols_raw: &str, batch_size: usize) {
     let symbols = parse_symbols(symbols_raw);
     let running = running_flag();
-    let streams: Vec<String> = symbols.iter().map(|s| format!("{}@trade", s.to_lowercase())).collect();
+    let streams: Vec<String> = symbols
+        .iter()
+        .map(|s| format!("{}@trade", s.to_lowercase()))
+        .collect();
 
-    info!("[binance-price] Starting collector for symbols: {:?}", symbols);
+    info!(
+        "[binance-price] Starting collector for symbols: {:?}",
+        symbols
+    );
 
     loop {
         if !running.load(Ordering::SeqCst) {
@@ -127,13 +135,16 @@ pub async fn collect_binance_price(pool: PgPool, symbols_raw: &str, batch_size: 
 
 async fn run_price_ws(
     pool: &PgPool,
-    symbols: &[String],
+    _symbols: &[String],
     streams: &[String],
     batch_size: usize,
     running: &SharedRunning,
-) -> Result<(), anyhow::Error> {
+) -> CollectorResult<()> {
     let (_write, mut read) = binance_connect(streams).await?;
-    info!("[binance-price] WebSocket connected, subscribed to {} streams", streams.len());
+    info!(
+        "[binance-price] WebSocket connected, subscribed to {} streams",
+        streams.len()
+    );
 
     let mut pending = 0u32;
     let mut inserted: u64 = 0;
@@ -153,7 +164,7 @@ async fn run_price_ws(
                         break;
                     }
                     Some(Ok(Message::Text(text))) => {
-                        let val: Value = serde_json::from_str(&text)?;
+                        let val: Value = serde_json::from_str(&text).map_err(|error| error.to_string())?;
                         // Skip subscription confirmation
                         if val.get("result").is_some() { continue; }
                         let data = match val.get("data") {
@@ -178,7 +189,8 @@ async fn run_price_ws(
                         .bind(qty)
                         .bind(trade_time)
                         .execute(pool)
-                        .await?;
+                        .await
+                        .map_err(|error| error.to_string())?;
 
                         pending += 1;
                         inserted += 1;
@@ -194,7 +206,7 @@ async fn run_price_ws(
                             last_report = Instant::now();
                         }
                     }
-                    Some(Ok(Message::Ping(data))) => continue,
+                    Some(Ok(Message::Ping(_))) => continue,
                     Some(Ok(Message::Pong(_))) => continue,
                     Some(Ok(Message::Close(_))) => {
                         warn!("[binance-price] WebSocket closed by server");
@@ -222,9 +234,15 @@ async fn run_price_ws(
 pub async fn collect_binance_aggtrade(pool: PgPool, symbols_raw: &str, batch_size: usize) {
     let symbols = parse_symbols(symbols_raw);
     let running = running_flag();
-    let streams: Vec<String> = symbols.iter().map(|s| format!("{}@aggTrade", s.to_lowercase())).collect();
+    let streams: Vec<String> = symbols
+        .iter()
+        .map(|s| format!("{}@aggTrade", s.to_lowercase()))
+        .collect();
 
-    info!("[binance-aggtrade] Starting collector for symbols: {:?}", symbols);
+    info!(
+        "[binance-aggtrade] Starting collector for symbols: {:?}",
+        symbols
+    );
 
     loop {
         if !running.load(Ordering::SeqCst) {
@@ -251,9 +269,12 @@ async fn run_aggtrade_ws(
     streams: &[String],
     batch_size: usize,
     running: &SharedRunning,
-) -> Result<(), anyhow::Error> {
+) -> CollectorResult<()> {
     let (_write, mut read) = binance_connect(streams).await?;
-    info!("[binance-aggtrade] WebSocket connected, subscribed to {} streams", streams.len());
+    info!(
+        "[binance-aggtrade] WebSocket connected, subscribed to {} streams",
+        streams.len()
+    );
 
     let mut pending = 0u32;
     let mut inserted: u64 = 0;
@@ -268,7 +289,7 @@ async fn run_aggtrade_ws(
                     None => { warn!("[binance-aggtrade] WebSocket stream ended"); break; }
                     Some(Err(e)) => { warn!("[binance-aggtrade] WebSocket error: {e}"); break; }
                     Some(Ok(Message::Text(text))) => {
-                        let val: Value = serde_json::from_str(&text)?;
+                        let val: Value = serde_json::from_str(&text).map_err(|error| error.to_string())?;
                         if val.get("result").is_some() { continue; }
                         let data = match val.get("data") { Some(d) => d, None => continue, };
 
@@ -297,7 +318,8 @@ async fn run_aggtrade_ws(
                         .bind(event_time)
                         .bind(is_buyer_maker)
                         .execute(pool)
-                        .await?;
+                        .await
+                        .map_err(|error| error.to_string())?;
 
                         if result.rows_affected() > 0 {
                             inserted += 1;
@@ -341,7 +363,12 @@ async fn run_aggtrade_ws(
 /// Schema: `binance_lob_ticks (symbol, update_id, best_bid, best_ask, mid_price,
 ///          spread_bps, obi_5, obi_10, bid_volume_5, ask_volume_5, bids, asks,
 ///          event_time, source)`
-pub async fn collect_binance_lob(pool: PgPool, symbols_raw: &str, depth_levels: usize, batch_size: usize) {
+pub async fn collect_binance_lob(
+    pool: PgPool,
+    symbols_raw: &str,
+    depth_levels: usize,
+    batch_size: usize,
+) {
     let symbols = parse_symbols(symbols_raw);
     let running = running_flag();
     let streams: Vec<String> = symbols
@@ -349,14 +376,26 @@ pub async fn collect_binance_lob(pool: PgPool, symbols_raw: &str, depth_levels: 
         .map(|s| format!("{}@depth{}@100ms", s.to_lowercase(), depth_levels))
         .collect();
 
-    info!("[binance-lob] Starting collector symbols={:?} depth={}", symbols, depth_levels);
+    info!(
+        "[binance-lob] Starting collector symbols={:?} depth={}",
+        symbols, depth_levels
+    );
 
     loop {
         if !running.load(Ordering::SeqCst) {
             break;
         }
 
-        match run_lob_ws(&pool, &symbols, &streams, depth_levels, batch_size, &running).await {
+        match run_lob_ws(
+            &pool,
+            &symbols,
+            &streams,
+            depth_levels,
+            batch_size,
+            &running,
+        )
+        .await
+        {
             Ok(()) => {
                 info!("[binance-lob] Collector finished (shutdown)");
                 break;
@@ -403,9 +442,7 @@ fn obi(bid_vol: Decimal, ask_vol: Decimal) -> Decimal {
 fn levels_to_json(levels: &[(Decimal, Decimal)]) -> Value {
     let arr: Vec<Value> = levels
         .iter()
-        .map(|(p, s)| {
-            serde_json::json!({"price": format!("{}", p), "size": format!("{}", s)})
-        })
+        .map(|(p, s)| serde_json::json!({"price": format!("{}", p), "size": format!("{}", s)}))
         .collect();
     Value::Array(arr)
 }
@@ -417,9 +454,12 @@ async fn run_lob_ws(
     depth_levels: usize,
     batch_size: usize,
     running: &SharedRunning,
-) -> Result<(), anyhow::Error> {
+) -> CollectorResult<()> {
     let (_write, mut read) = binance_connect(streams).await?;
-    info!("[binance-lob] WebSocket connected, subscribed to {} streams", streams.len());
+    info!(
+        "[binance-lob] WebSocket connected, subscribed to {} streams",
+        streams.len()
+    );
 
     let mut pending = 0u32;
     let mut inserted: u64 = 0;
@@ -433,7 +473,7 @@ async fn run_lob_ws(
                     None => { warn!("[binance-lob] WebSocket stream ended"); break; }
                     Some(Err(e)) => { warn!("[binance-lob] WebSocket error: {e}"); break; }
                     Some(Ok(Message::Text(text))) => {
-                        let val: Value = serde_json::from_str(&text)?;
+                        let val: Value = serde_json::from_str(&text).map_err(|error| error.to_string())?;
                         if val.get("result").is_some() { continue; }
                         let data = match val.get("data") { Some(d) => d, None => continue, };
 
@@ -453,8 +493,8 @@ async fn run_lob_ws(
                             _ => continue,
                         };
 
-                        let bids = raw_bids.map(parse_level).unwrap_or_default();
-                        let asks = raw_asks.map(parse_level).unwrap_or_default();
+                        let bids = raw_bids.map(|levels| parse_level(levels)).unwrap_or_default();
+                        let asks = raw_asks.map(|levels| parse_level(levels)).unwrap_or_default();
 
                         if bids.is_empty() || asks.is_empty() { continue; }
 
@@ -497,7 +537,8 @@ async fn run_lob_ws(
                         .bind(asks_json)
                         .bind(event_time)
                         .execute(pool)
-                        .await?;
+                        .await
+                        .map_err(|error| error.to_string())?;
 
                         pending += 1;
                         inserted += 1;

--- a/crates/ploy-market-data/src/binance_collectors.rs
+++ b/crates/ploy-market-data/src/binance_collectors.rs
@@ -1,0 +1,525 @@
+//! Binance WebSocket data collectors — price ticks, aggregated trades, and L2 orderbook.
+//!
+//! Each collector is a long-running `async fn` that connects to Binance's combined
+//! WebSocket stream, subscribes to the relevant `@trade` / `@aggTrade` / `@depth<N>@100ms`
+//! channels, parses the JSON payloads, and persists normalized rows to PostgreSQL.
+//!
+//! All three share the same reconnection and batching strategy.
+//!
+//! Run via `ploy-runner`:
+//!   ploy-runner collect-binance-lob --symbols BTCUSDT,ETHUSDT,SOLUSDT
+//!   ploy-runner collect-binance-price --symbols BTCUSDT,ETHUSDT,SOLUSDT
+//!   ploy-runner collect-binance-aggtrade --symbols BTCUSDT,ETHUSDT,SOLUSDT
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, TimeZone, Utc};
+use futures::{SinkExt, StreamExt};
+use rust_decimal::Decimal;
+use serde_json::Value;
+use sqlx::PgPool;
+use tokio::sync::Mutex;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{error, info, warn};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const BINANCE_WS_URL: &str = "wss://stream.binance.com:9443/stream";
+const DEFAULT_SYMBOLS: &str = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT";
+
+fn parse_symbols(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_uppercase())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Parse a millisecond epoch from a Binance JSON field into a `DateTime<Utc>`.
+fn ms_to_utc(ms: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32)
+        .unwrap()
+}
+
+/// Shared signal — set to false on shutdown request.
+type SharedRunning = Arc<AtomicBool>;
+
+fn running_flag() -> SharedRunning {
+    let flag = Arc::new(AtomicBool::new(true));
+    let f = flag.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Shutdown signal received, stopping collector...");
+        f.store(false, Ordering::SeqCst);
+    });
+    flag
+}
+
+/// Connect to Binance combined stream, subscribe, return the writer + reader.
+async fn binance_connect(
+    streams: &[String],
+) -> Result<
+    (
+        futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            Message,
+        >,
+        futures_util::stream::SplitStream<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+        >,
+    ),
+    anyhow::Error,
+> {
+    let (ws, _) = connect_async(BINANCE_WS_URL).await?;
+    let (mut write, read) = ws.split();
+
+    let subscribe = serde_json::json!({
+        "method": "SUBSCRIBE",
+        "params": streams,
+        "id": 1,
+    });
+    write
+        .send(Message::Text(subscribe.to_string().into()))
+        .await?;
+
+    Ok((write, read))
+}
+
+// ---------------------------------------------------------------------------
+// Price collector (binance_price_ticks)
+// ---------------------------------------------------------------------------
+
+/// Collect spot trade prices from Binance `@trade` streams.
+///
+/// Schema: `binance_price_ticks (symbol, price, quantity, trade_time, received_at)`
+pub async fn collect_binance_price(pool: PgPool, symbols_raw: &str, batch_size: usize) {
+    let symbols = parse_symbols(symbols_raw);
+    let running = running_flag();
+    let streams: Vec<String> = symbols.iter().map(|s| format!("{}@trade", s.to_lowercase())).collect();
+
+    info!("[binance-price] Starting collector for symbols: {:?}", symbols);
+
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+
+        match run_price_ws(&pool, &symbols, &streams, batch_size, &running).await {
+            Ok(()) => {
+                info!("[binance-price] Collector finished (shutdown)");
+                break;
+            }
+            Err(e) => {
+                error!("[binance-price] Connection error: {e}, reconnecting in 5s...");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+    info!("[binance-price] Collector stopped");
+}
+
+async fn run_price_ws(
+    pool: &PgPool,
+    symbols: &[String],
+    streams: &[String],
+    batch_size: usize,
+    running: &SharedRunning,
+) -> Result<(), anyhow::Error> {
+    let (_write, mut read) = binance_connect(streams).await?;
+    info!("[binance-price] WebSocket connected, subscribed to {} streams", streams.len());
+
+    let mut pending = 0u32;
+    let mut inserted: u64 = 0;
+    let mut last_report = Instant::now();
+    let mut batch_timer = Instant::now();
+
+    while running.load(Ordering::SeqCst) {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    None => {
+                        warn!("[binance-price] WebSocket stream ended");
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        warn!("[binance-price] WebSocket error: {e}");
+                        break;
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        let val: Value = serde_json::from_str(&text)?;
+                        // Skip subscription confirmation
+                        if val.get("result").is_some() { continue; }
+                        let data = match val.get("data") {
+                            Some(d) => d,
+                            None => continue,
+                        };
+
+                        let symbol = data["s"].as_str().unwrap_or("").to_string();
+                        let price_str = data["p"].as_str().unwrap_or("0");
+                        let qty_str = data["q"].as_str().unwrap_or("0");
+                        let trade_time_ms = data["T"].as_i64().unwrap_or(0);
+
+                        let price: Decimal = price_str.parse().unwrap_or(Decimal::ZERO);
+                        let qty: Decimal = qty_str.parse().unwrap_or(Decimal::ZERO);
+                        let trade_time = ms_to_utc(trade_time_ms);
+
+                        sqlx::query(
+                            "INSERT INTO binance_price_ticks (symbol, price, quantity, trade_time) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"
+                        )
+                        .bind(&symbol)
+                        .bind(price)
+                        .bind(qty)
+                        .bind(trade_time)
+                        .execute(pool)
+                        .await?;
+
+                        pending += 1;
+                        inserted += 1;
+
+                        if pending >= batch_size as u32 || batch_timer.elapsed() >= Duration::from_secs(1) {
+                            pending = 0;
+                            batch_timer = Instant::now();
+                        }
+
+                        if last_report.elapsed() >= Duration::from_secs(60) {
+                            info!("[binance-price] Inserted {} ticks in last minute", inserted);
+                            inserted = 0;
+                            last_report = Instant::now();
+                        }
+                    }
+                    Some(Ok(Message::Ping(data))) => continue,
+                    Some(Ok(Message::Pong(_))) => continue,
+                    Some(Ok(Message::Close(_))) => {
+                        warn!("[binance-price] WebSocket closed by server");
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// AggTrade collector (binance_agg_trade_ticks)
+// ---------------------------------------------------------------------------
+
+/// Collect aggregated trade data from Binance `@aggTrade` streams.
+///
+/// Schema: `binance_agg_trade_ticks (symbol, agg_trade_id, first_trade_id, last_trade_id,
+///          price, quantity, trade_time, event_time, is_buyer_maker, received_at)`
+pub async fn collect_binance_aggtrade(pool: PgPool, symbols_raw: &str, batch_size: usize) {
+    let symbols = parse_symbols(symbols_raw);
+    let running = running_flag();
+    let streams: Vec<String> = symbols.iter().map(|s| format!("{}@aggTrade", s.to_lowercase())).collect();
+
+    info!("[binance-aggtrade] Starting collector for symbols: {:?}", symbols);
+
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+
+        match run_aggtrade_ws(&pool, &symbols, &streams, batch_size, &running).await {
+            Ok(()) => {
+                info!("[binance-aggtrade] Collector finished (shutdown)");
+                break;
+            }
+            Err(e) => {
+                error!("[binance-aggtrade] Connection error: {e}, reconnecting in 5s...");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+    info!("[binance-aggtrade] Collector stopped");
+}
+
+async fn run_aggtrade_ws(
+    pool: &PgPool,
+    _symbols: &[String],
+    streams: &[String],
+    batch_size: usize,
+    running: &SharedRunning,
+) -> Result<(), anyhow::Error> {
+    let (_write, mut read) = binance_connect(streams).await?;
+    info!("[binance-aggtrade] WebSocket connected, subscribed to {} streams", streams.len());
+
+    let mut pending = 0u32;
+    let mut inserted: u64 = 0;
+    let mut duplicates: u64 = 0;
+    let mut last_report = Instant::now();
+    let mut batch_timer = Instant::now();
+
+    while running.load(Ordering::SeqCst) {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    None => { warn!("[binance-aggtrade] WebSocket stream ended"); break; }
+                    Some(Err(e)) => { warn!("[binance-aggtrade] WebSocket error: {e}"); break; }
+                    Some(Ok(Message::Text(text))) => {
+                        let val: Value = serde_json::from_str(&text)?;
+                        if val.get("result").is_some() { continue; }
+                        let data = match val.get("data") { Some(d) => d, None => continue, };
+
+                        let symbol = data["s"].as_str().unwrap_or("").to_string();
+                        let agg_trade_id = data["a"].as_i64().unwrap_or(0);
+                        let first_trade_id = data["f"].as_i64().unwrap_or(0);
+                        let last_trade_id = data["l"].as_i64().unwrap_or(0);
+                        let price: Decimal = data["p"].as_str().unwrap_or("0").parse().unwrap_or(Decimal::ZERO);
+                        let qty: Decimal = data["q"].as_str().unwrap_or("0").parse().unwrap_or(Decimal::ZERO);
+                        let trade_time = ms_to_utc(data["T"].as_i64().unwrap_or(0));
+                        let event_time = ms_to_utc(data["E"].as_i64().unwrap_or(0));
+                        let is_buyer_maker = data["m"].as_bool().unwrap_or(false);
+
+                        let result = sqlx::query(
+                            "INSERT INTO binance_agg_trade_ticks \
+                             (symbol, agg_trade_id, first_trade_id, last_trade_id, price, quantity, trade_time, event_time, is_buyer_maker) \
+                             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT DO NOTHING"
+                        )
+                        .bind(&symbol)
+                        .bind(agg_trade_id)
+                        .bind(first_trade_id)
+                        .bind(last_trade_id)
+                        .bind(price)
+                        .bind(qty)
+                        .bind(trade_time)
+                        .bind(event_time)
+                        .bind(is_buyer_maker)
+                        .execute(pool)
+                        .await?;
+
+                        if result.rows_affected() > 0 {
+                            inserted += 1;
+                        } else {
+                            duplicates += 1;
+                        }
+                        pending += 1;
+
+                        if pending >= batch_size as u32 || batch_timer.elapsed() >= Duration::from_secs(1) {
+                            pending = 0;
+                            batch_timer = Instant::now();
+                        }
+
+                        if last_report.elapsed() >= Duration::from_secs(60) {
+                            info!("[binance-aggtrade] Inserted {} agg trades in last minute (duplicates={})", inserted, duplicates);
+                            inserted = 0;
+                            duplicates = 0;
+                            last_report = Instant::now();
+                        }
+                    }
+                    Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
+                    Some(Ok(Message::Close(_))) => { warn!("[binance-aggtrade] WS closed"); break; }
+                    _ => continue,
+                }
+            }
+            _ = tokio::signal::ctrl_c() => break,
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// LOB collector (binance_lob_ticks)
+// ---------------------------------------------------------------------------
+
+/// Collect orderbook depth snapshots from Binance `@depth<N>@100ms` streams.
+///
+/// Computes mid-price, spread (bps), OBI (order-book imbalance at depths 5/10),
+/// and persists the full level-2 snapshot as JSONB in `bids` / `asks`.
+///
+/// Schema: `binance_lob_ticks (symbol, update_id, best_bid, best_ask, mid_price,
+///          spread_bps, obi_5, obi_10, bid_volume_5, ask_volume_5, bids, asks,
+///          event_time, source)`
+pub async fn collect_binance_lob(pool: PgPool, symbols_raw: &str, depth_levels: usize, batch_size: usize) {
+    let symbols = parse_symbols(symbols_raw);
+    let running = running_flag();
+    let streams: Vec<String> = symbols
+        .iter()
+        .map(|s| format!("{}@depth{}@100ms", s.to_lowercase(), depth_levels))
+        .collect();
+
+    info!("[binance-lob] Starting collector symbols={:?} depth={}", symbols, depth_levels);
+
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+
+        match run_lob_ws(&pool, &symbols, &streams, depth_levels, batch_size, &running).await {
+            Ok(()) => {
+                info!("[binance-lob] Collector finished (shutdown)");
+                break;
+            }
+            Err(e) => {
+                error!("[binance-lob] Connection error: {e}, reconnecting in 5s...");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+    info!("[binance-lob] Collector stopped");
+}
+
+fn parse_level(raw_levels: &[Value]) -> Vec<(Decimal, Decimal)> {
+    raw_levels
+        .iter()
+        .filter_map(|level| {
+            let arr = level.as_array()?;
+            if arr.len() < 2 {
+                return None;
+            }
+            let price: Decimal = arr[0].as_str()?.parse().ok()?;
+            let size: Decimal = arr[1].as_str()?.parse().ok()?;
+            if price <= Decimal::ZERO || size <= Decimal::ZERO {
+                return None;
+            }
+            Some((price, size))
+        })
+        .collect()
+}
+
+fn sum_volume(levels: &[(Decimal, Decimal)], depth: usize) -> Decimal {
+    levels.iter().take(depth).map(|(_, s)| s).sum()
+}
+
+fn obi(bid_vol: Decimal, ask_vol: Decimal) -> Decimal {
+    let denom = bid_vol + ask_vol;
+    if denom == Decimal::ZERO {
+        return Decimal::ZERO;
+    }
+    (bid_vol - ask_vol) / denom
+}
+
+fn levels_to_json(levels: &[(Decimal, Decimal)]) -> Value {
+    let arr: Vec<Value> = levels
+        .iter()
+        .map(|(p, s)| {
+            serde_json::json!({"price": format!("{}", p), "size": format!("{}", s)})
+        })
+        .collect();
+    Value::Array(arr)
+}
+
+async fn run_lob_ws(
+    pool: &PgPool,
+    _symbols: &[String],
+    streams: &[String],
+    depth_levels: usize,
+    batch_size: usize,
+    running: &SharedRunning,
+) -> Result<(), anyhow::Error> {
+    let (_write, mut read) = binance_connect(streams).await?;
+    info!("[binance-lob] WebSocket connected, subscribed to {} streams", streams.len());
+
+    let mut pending = 0u32;
+    let mut inserted: u64 = 0;
+    let mut last_report = Instant::now();
+    let mut batch_timer = Instant::now();
+
+    while running.load(Ordering::SeqCst) {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    None => { warn!("[binance-lob] WebSocket stream ended"); break; }
+                    Some(Err(e)) => { warn!("[binance-lob] WebSocket error: {e}"); break; }
+                    Some(Ok(Message::Text(text))) => {
+                        let val: Value = serde_json::from_str(&text)?;
+                        if val.get("result").is_some() { continue; }
+                        let data = match val.get("data") { Some(d) => d, None => continue, };
+
+                        let stream_name = val.get("stream").and_then(|s| s.as_str());
+                        let symbol = data["s"].as_str()
+                            .or_else(|| stream_name.and_then(|s| s.split('@').next()))
+                            .unwrap_or("")
+                            .to_uppercase();
+
+                        let event_time_ms = data["E"].as_i64();
+                        let update_id = data["u"].as_i64().or_else(|| data["lastUpdateId"].as_i64());
+                        let raw_bids = data["b"].as_array().or_else(|| data["bids"].as_array());
+                        let raw_asks = data["a"].as_array().or_else(|| data["asks"].as_array());
+
+                        let (event_time_ms, update_id) = match (event_time_ms, update_id) {
+                            (Some(e), Some(u)) => (e, u),
+                            _ => continue,
+                        };
+
+                        let bids = raw_bids.map(parse_level).unwrap_or_default();
+                        let asks = raw_asks.map(parse_level).unwrap_or_default();
+
+                        if bids.is_empty() || asks.is_empty() { continue; }
+
+                        let best_bid = bids[0].0;
+                        let best_ask = asks[0].0;
+                        if best_bid <= Decimal::ZERO || best_ask <= Decimal::ZERO || best_ask < best_bid {
+                            continue;
+                        }
+
+                        let mid_price = (best_bid + best_ask) / Decimal::from(2);
+                        if mid_price <= Decimal::ZERO { continue; }
+
+                        let spread = (best_ask - best_bid) / mid_price * Decimal::from(10_000);
+                        let bid_vol_5 = sum_volume(&bids, 5);
+                        let ask_vol_5 = sum_volume(&asks, 5);
+                        let bid_vol_10 = sum_volume(&bids, 10);
+                        let ask_vol_10 = sum_volume(&asks, 10);
+                        let event_time = ms_to_utc(event_time_ms);
+
+                        let bids_json = levels_to_json(&bids[..bids.len().min(depth_levels)]);
+                        let asks_json = levels_to_json(&asks[..asks.len().min(depth_levels)]);
+
+                        sqlx::query(
+                            "INSERT INTO binance_lob_ticks \
+                             (symbol, update_id, best_bid, best_ask, mid_price, spread_bps, \
+                              obi_5, obi_10, bid_volume_5, ask_volume_5, bids, asks, event_time, source) \
+                             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'binance_depth_ws')"
+                        )
+                        .bind(&symbol)
+                        .bind(update_id)
+                        .bind(best_bid)
+                        .bind(best_ask)
+                        .bind(mid_price)
+                        .bind(spread)
+                        .bind(obi(bid_vol_5, ask_vol_5))
+                        .bind(obi(bid_vol_10, ask_vol_10))
+                        .bind(bid_vol_5)
+                        .bind(ask_vol_5)
+                        .bind(bids_json)
+                        .bind(asks_json)
+                        .bind(event_time)
+                        .execute(pool)
+                        .await?;
+
+                        pending += 1;
+                        inserted += 1;
+
+                        if pending >= batch_size as u32 || batch_timer.elapsed() >= Duration::from_secs(1) {
+                            pending = 0;
+                            batch_timer = Instant::now();
+                        }
+
+                        if last_report.elapsed() >= Duration::from_secs(60) {
+                            info!("[binance-lob] Inserted {} snapshots in last minute", inserted);
+                            inserted = 0;
+                            last_report = Instant::now();
+                        }
+                    }
+                    Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
+                    Some(Ok(Message::Close(_))) => { warn!("[binance-lob] WS closed"); break; }
+                    _ => continue,
+                }
+            }
+            _ = tokio::signal::ctrl_c() => break,
+        }
+    }
+    Ok(())
+}

--- a/crates/ploy-market-data/src/deribit_collectors.rs
+++ b/crates/ploy-market-data/src/deribit_collectors.rs
@@ -43,20 +43,6 @@ fn parse_currencies(raw: &str) -> Vec<String> {
         .collect()
 }
 
-fn to_opt_decimal(val: Option<&Value>) -> Option<Decimal> {
-    let s = val?.as_str().or_else(|| {
-        val.as_f64().map(|f| {
-            // Float path: just format it
-            Box::leak(format!("{}", f).into_boxed_str())
-        })
-    })?;
-    Decimal::from_str_exact(s).ok().or_else(|| {
-        // Fallback: try parsing as float
-        val.and_then(|v| v.as_f64())
-            .map(|f| Decimal::try_from(f).unwrap_or(Decimal::ZERO))
-    })
-}
-
 // ---------------------------------------------------------------------------
 // IV collector (deribit_iv_ticks)
 // ---------------------------------------------------------------------------
@@ -68,7 +54,10 @@ fn to_opt_decimal(val: Option<&Value>) -> Option<Decimal> {
 pub async fn collect_deribit_iv(pool: PgPool, currencies_raw: &str, poll_secs: u64) {
     let currencies = parse_currencies(currencies_raw);
     let running = running_flag();
-    info!("[deribit-iv] Starting collector currencies={:?} poll_secs={}", currencies, poll_secs);
+    info!(
+        "[deribit-iv] Starting collector currencies={:?} poll_secs={}",
+        currencies, poll_secs
+    );
 
     while running.load(Ordering::SeqCst) {
         let start = Instant::now();
@@ -95,9 +84,14 @@ pub async fn collect_deribit_iv(pool: PgPool, currencies_raw: &str, poll_secs: u
     info!("[deribit-iv] Collector stopped");
 }
 
-async fn fetch_and_store_iv(pool: &PgPool, currency: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn fetch_and_store_iv(
+    pool: &PgPool,
+    currency: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let url = format!("{DERIBIT_API_BASE}/get_book_summary_by_currency");
-    let resp = reqwest::get(&url)
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
         .query(&[("currency", currency), ("kind", "option")])
         .timeout(Duration::from_secs(20))
         .send()
@@ -115,17 +109,21 @@ async fn fetch_and_store_iv(pool: &PgPool, currency: &str) -> Result<(), Box<dyn
 
         // Parse expiry / strike / option_type from instrument name like "BTC-29MAR24-50000-C"
         let parts: Vec<&str> = instrument_name.split('-').collect();
-        let (expiry_ts, strike, option_type) = if parts.len() >= 4 {
-            (parse_deribit_expiry(parts.get(1).unwrap_or(&"")),
-             parts.get(2).and_then(|s| s.parse::<Decimal>().ok()),
-             parts.get(3).map(|s| s.to_string()))
+        let (expiry_ts, _strike, _option_type) = if parts.len() >= 4 {
+            (
+                parse_deribit_expiry(parts.get(1).unwrap_or(&"")),
+                parts.get(2).and_then(|s| s.parse::<Decimal>().ok()),
+                parts.get(3).map(|s| s.to_string()),
+            )
         } else {
             (None, None, None)
         };
 
         let creation_ms = item["creation_timestamp"].as_i64();
-        let creation_ts = creation_ms
-            .map(|ms| Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32).unwrap());
+        let creation_ts = creation_ms.map(|ms| {
+            Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32)
+                .unwrap()
+        });
 
         let mark_iv_raw = item["mark_iv"].as_f64();
         let bid_iv_raw = item["bid_iv"].as_f64();
@@ -133,24 +131,33 @@ async fn fetch_and_store_iv(pool: &PgPool, currency: &str) -> Result<(), Box<dyn
 
         let normalize = |raw: Option<f64>| -> Option<Decimal> {
             let v = raw?;
-            if v <= 0.0 { return None; }
+            if v <= 0.0 {
+                return None;
+            }
             let normalized = if v > 2.0 { v / 100.0 } else { v };
             Decimal::try_from(normalized).ok()
         };
 
-        let underlying_price = item["underlying_price"].as_f64()
+        let underlying_price = item["underlying_price"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let index_price = item["index_price"].as_f64()
+        let index_price = item["index_price"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let mark_price = item["mark_price"].as_f64()
+        let mark_price = item["mark_price"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let best_bid = item["bid_price"].as_f64()
+        let best_bid = item["bid_price"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let best_ask = item["ask_price"].as_f64()
+        let best_ask = item["ask_price"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let open_interest = item["open_interest"].as_f64()
+        let open_interest = item["open_interest"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
-        let volume = item["volume"].as_f64()
+        let volume = item["volume"]
+            .as_f64()
             .and_then(|v| Decimal::try_from(v).ok());
 
         sqlx::query(
@@ -197,22 +204,37 @@ async fn fetch_and_store_iv(pool: &PgPool, currency: &str) -> Result<(), Box<dyn
         .await?;
     }
 
-    info!("[deribit-iv] Fetched {} instruments for currency={}", rows.len(), currency);
+    info!(
+        "[deribit-iv] Fetched {} instruments for currency={}",
+        rows.len(),
+        currency
+    );
     Ok(())
 }
 
 /// Parse Deribit expiry codes like "29MAR24" into UTC 08:00 timestamp.
 fn parse_deribit_expiry(code: &str) -> Option<DateTime<Utc>> {
-    if code.len() < 7 { return None; }
+    if code.len() < 7 {
+        return None;
+    }
     let day: u32 = code[0..2].parse().ok()?;
-    let mon_str = &code[2..5].to_uppercase();
+    let mon_str = code[2..5].to_uppercase();
     let year: i32 = code[5..].parse().ok()?;
     let year = if year < 100 { year + 2000 } else { year };
 
-    let month = match mon_str {
-        "JAN" => 1, "FEB" => 2, "MAR" => 3, "APR" => 4,
-        "MAY" => 5, "JUN" => 6, "JUL" => 7, "AUG" => 8,
-        "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12,
+    let month = match mon_str.as_str() {
+        "JAN" => 1,
+        "FEB" => 2,
+        "MAR" => 3,
+        "APR" => 4,
+        "MAY" => 5,
+        "JUN" => 6,
+        "JUL" => 7,
+        "AUG" => 8,
+        "SEP" => 9,
+        "OCT" => 10,
+        "NOV" => 11,
+        "DEC" => 12,
         _ => return None,
     };
 
@@ -232,7 +254,10 @@ fn parse_deribit_expiry(code: &str) -> Option<DateTime<Utc>> {
 pub async fn collect_deribit_greeks(pool: PgPool, currencies_raw: &str, poll_secs: u64) {
     let currencies = parse_currencies(currencies_raw);
     let running = running_flag();
-    info!("[deribit-greeks] Starting collector currencies={:?} poll_secs={}", currencies, poll_secs);
+    info!(
+        "[deribit-greeks] Starting collector currencies={:?} poll_secs={}",
+        currencies, poll_secs
+    );
 
     while running.load(Ordering::SeqCst) {
         let start = Instant::now();
@@ -260,7 +285,10 @@ pub async fn collect_deribit_greeks(pool: PgPool, currencies_raw: &str, poll_sec
 }
 
 /// Find the ATM instrument for a currency, then fetch its order book for Greeks.
-async fn pick_and_fetch_greeks(pool: &PgPool, currency: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn pick_and_fetch_greeks(
+    pool: &PgPool,
+    currency: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Pick ATM instrument from recent deribit_iv_ticks
     let instrument: Option<(String,)> = sqlx::query_as(
         r#"
@@ -297,23 +325,31 @@ async fn pick_and_fetch_greeks(pool: &PgPool, currency: &str) -> Result<(), Box<
 
     // Fetch order book via Deribit REST API
     let url = format!("{DERIBIT_API_BASE}/get_order_book");
-    let resp = reqwest::get(&url)
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
         .query(&[("instrument_name", &instrument_name)])
         .timeout(Duration::from_secs(20))
         .send()
         .await?;
     let payload: Value = resp.json().await?;
-    let result = payload["result"].as_object().ok_or("missing result object")?;
+    let result = payload["result"]
+        .as_object()
+        .ok_or("missing result object")?;
 
-    let ts_ms = result.get("timestamp")
+    let ts_ms = result
+        .get("timestamp")
         .and_then(|v| v.as_i64())
         .unwrap_or_else(|| Utc::now().timestamp_millis());
-    let source_ts = Utc.timestamp_opt(ts_ms / 1000, ((ts_ms % 1000) * 1_000_000) as u32).unwrap();
+    let source_ts = Utc
+        .timestamp_opt(ts_ms / 1000, ((ts_ms % 1000) * 1_000_000) as u32)
+        .unwrap();
 
     let greeks = result.get("greeks").and_then(|g| g.as_object());
 
     let to_dec = |key: &str| -> Option<Decimal> {
-        result.get(key)
+        result
+            .get(key)
             .and_then(|v| v.as_f64())
             .and_then(|f| Decimal::try_from(f).ok())
     };

--- a/crates/ploy-market-data/src/deribit_collectors.rs
+++ b/crates/ploy-market-data/src/deribit_collectors.rs
@@ -1,0 +1,379 @@
+//! Deribit HTTP data collectors — implied volatility ticks and ATM greeks.
+//!
+//! Both collectors poll the Deribit public REST API periodically and persist
+//! normalized rows to PostgreSQL using batched INSERT ... ON CONFLICT upserts.
+//!
+//! Run via `ploy-runner`:
+//!   ploy-runner collect-deribit-iv --currencies BTC,ETH,SOL --poll-secs 30
+//!   ploy-runner collect-deribit-greeks --currencies BTC,ETH,SOL --poll-secs 30
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, TimeZone, Utc};
+use rust_decimal::Decimal;
+use serde_json::Value;
+use sqlx::PgPool;
+use tracing::{error, info, warn};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const DERIBIT_API_BASE: &str = "https://www.deribit.com/api/v2/public";
+
+type SharedRunning = Arc<AtomicBool>;
+
+fn running_flag() -> SharedRunning {
+    let flag = Arc::new(AtomicBool::new(true));
+    let f = flag.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Shutdown signal received, stopping Deribit collector...");
+        f.store(false, Ordering::SeqCst);
+    });
+    flag
+}
+
+fn parse_currencies(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_uppercase())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn to_opt_decimal(val: Option<&Value>) -> Option<Decimal> {
+    let s = val?.as_str().or_else(|| {
+        val.as_f64().map(|f| {
+            // Float path: just format it
+            Box::leak(format!("{}", f).into_boxed_str())
+        })
+    })?;
+    Decimal::from_str_exact(s).ok().or_else(|| {
+        // Fallback: try parsing as float
+        val.and_then(|v| v.as_f64())
+            .map(|f| Decimal::try_from(f).unwrap_or(Decimal::ZERO))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// IV collector (deribit_iv_ticks)
+// ---------------------------------------------------------------------------
+
+/// Collect option book summaries from Deribit `get_book_summary_by_currency`.
+///
+/// Polls every `poll_secs` seconds for each configured currency and upserts
+/// normalized IV ticks into `deribit_iv_ticks`.
+pub async fn collect_deribit_iv(pool: PgPool, currencies_raw: &str, poll_secs: u64) {
+    let currencies = parse_currencies(currencies_raw);
+    let running = running_flag();
+    info!("[deribit-iv] Starting collector currencies={:?} poll_secs={}", currencies, poll_secs);
+
+    while running.load(Ordering::SeqCst) {
+        let start = Instant::now();
+
+        for currency in &currencies {
+            if !running.load(Ordering::SeqCst) {
+                break;
+            }
+            if let Err(e) = fetch_and_store_iv(&pool, currency).await {
+                error!("[deribit-iv] currency={currency} error: {e}");
+            }
+        }
+
+        let elapsed = start.elapsed();
+        let sleep = if elapsed.as_secs() < poll_secs {
+            poll_secs - elapsed.as_secs()
+        } else {
+            0
+        };
+        if sleep > 0 {
+            tokio::time::sleep(Duration::from_secs(sleep)).await;
+        }
+    }
+    info!("[deribit-iv] Collector stopped");
+}
+
+async fn fetch_and_store_iv(pool: &PgPool, currency: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let url = format!("{DERIBIT_API_BASE}/get_book_summary_by_currency");
+    let resp = reqwest::get(&url)
+        .query(&[("currency", currency), ("kind", "option")])
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await?;
+    let payload: Value = resp.json().await?;
+    let rows = payload["result"].as_array().ok_or("missing result array")?;
+
+    let fetched_at = Utc::now();
+
+    for item in rows {
+        let instrument_name = match item["instrument_name"].as_str() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        // Parse expiry / strike / option_type from instrument name like "BTC-29MAR24-50000-C"
+        let parts: Vec<&str> = instrument_name.split('-').collect();
+        let (expiry_ts, strike, option_type) = if parts.len() >= 4 {
+            (parse_deribit_expiry(parts.get(1).unwrap_or(&"")),
+             parts.get(2).and_then(|s| s.parse::<Decimal>().ok()),
+             parts.get(3).map(|s| s.to_string()))
+        } else {
+            (None, None, None)
+        };
+
+        let creation_ms = item["creation_timestamp"].as_i64();
+        let creation_ts = creation_ms
+            .map(|ms| Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32).unwrap());
+
+        let mark_iv_raw = item["mark_iv"].as_f64();
+        let bid_iv_raw = item["bid_iv"].as_f64();
+        let ask_iv_raw = item["ask_iv"].as_f64();
+
+        let normalize = |raw: Option<f64>| -> Option<Decimal> {
+            let v = raw?;
+            if v <= 0.0 { return None; }
+            let normalized = if v > 2.0 { v / 100.0 } else { v };
+            Decimal::try_from(normalized).ok()
+        };
+
+        let underlying_price = item["underlying_price"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let index_price = item["index_price"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let mark_price = item["mark_price"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let best_bid = item["bid_price"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let best_ask = item["ask_price"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let open_interest = item["open_interest"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+        let volume = item["volume"].as_f64()
+            .and_then(|v| Decimal::try_from(v).ok());
+
+        sqlx::query(
+            r#"
+            INSERT INTO deribit_iv_ticks (
+                currency, instrument_name, creation_ts, expiry_ts,
+                mark_iv, bid_iv, ask_iv,
+                underlying_price, index_price, mark_price,
+                best_bid_price, best_ask_price,
+                open_interest, volume,
+                payload, fetched_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb, $16)
+            ON CONFLICT (currency, instrument_name, creation_ts, fetched_at) DO UPDATE SET
+                mark_iv = EXCLUDED.mark_iv,
+                bid_iv = EXCLUDED.bid_iv,
+                ask_iv = EXCLUDED.ask_iv,
+                underlying_price = EXCLUDED.underlying_price,
+                index_price = EXCLUDED.index_price,
+                mark_price = EXCLUDED.mark_price,
+                best_bid_price = EXCLUDED.best_bid_price,
+                best_ask_price = EXCLUDED.best_ask_price,
+                open_interest = EXCLUDED.open_interest,
+                volume = EXCLUDED.volume,
+                payload = EXCLUDED.payload
+            "#,
+        )
+        .bind(currency)
+        .bind(&instrument_name)
+        .bind(creation_ts)
+        .bind(expiry_ts)
+        .bind(normalize(mark_iv_raw))
+        .bind(normalize(bid_iv_raw))
+        .bind(normalize(ask_iv_raw))
+        .bind(underlying_price)
+        .bind(index_price)
+        .bind(mark_price)
+        .bind(best_bid)
+        .bind(best_ask)
+        .bind(open_interest)
+        .bind(volume)
+        .bind(item.to_string())
+        .bind(fetched_at)
+        .execute(pool)
+        .await?;
+    }
+
+    info!("[deribit-iv] Fetched {} instruments for currency={}", rows.len(), currency);
+    Ok(())
+}
+
+/// Parse Deribit expiry codes like "29MAR24" into UTC 08:00 timestamp.
+fn parse_deribit_expiry(code: &str) -> Option<DateTime<Utc>> {
+    if code.len() < 7 { return None; }
+    let day: u32 = code[0..2].parse().ok()?;
+    let mon_str = &code[2..5].to_uppercase();
+    let year: i32 = code[5..].parse().ok()?;
+    let year = if year < 100 { year + 2000 } else { year };
+
+    let month = match mon_str {
+        "JAN" => 1, "FEB" => 2, "MAR" => 3, "APR" => 4,
+        "MAY" => 5, "JUN" => 6, "JUL" => 7, "AUG" => 8,
+        "SEP" => 9, "OCT" => 10, "NOV" => 11, "DEC" => 12,
+        _ => return None,
+    };
+
+    chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .map(|d| d.and_hms_opt(8, 0, 0).unwrap())
+        .map(|dt| DateTime::from_naive_utc_and_offset(dt, Utc))
+}
+
+// ---------------------------------------------------------------------------
+// ATM Greeks collector (deribit_atm_greeks_ticks)
+// ---------------------------------------------------------------------------
+
+/// Collect ATM option greeks by:
+///   1. Picking the nearest ATM instrument per currency from `deribit_iv_ticks`
+///   2. Calling Deribit `get_order_book` for Greeks
+///   3. Upserting into `deribit_atm_greeks_ticks`
+pub async fn collect_deribit_greeks(pool: PgPool, currencies_raw: &str, poll_secs: u64) {
+    let currencies = parse_currencies(currencies_raw);
+    let running = running_flag();
+    info!("[deribit-greeks] Starting collector currencies={:?} poll_secs={}", currencies, poll_secs);
+
+    while running.load(Ordering::SeqCst) {
+        let start = Instant::now();
+
+        for currency in &currencies {
+            if !running.load(Ordering::SeqCst) {
+                break;
+            }
+            if let Err(e) = pick_and_fetch_greeks(&pool, currency).await {
+                error!("[deribit-greeks] currency={currency} error: {e}");
+            }
+        }
+
+        let elapsed = start.elapsed();
+        let sleep = if elapsed.as_secs() < poll_secs {
+            poll_secs - elapsed.as_secs()
+        } else {
+            0
+        };
+        if sleep > 0 {
+            tokio::time::sleep(Duration::from_secs(sleep)).await;
+        }
+    }
+    info!("[deribit-greeks] Collector stopped");
+}
+
+/// Find the ATM instrument for a currency, then fetch its order book for Greeks.
+async fn pick_and_fetch_greeks(pool: &PgPool, currency: &str) -> Result<(), Box<dyn std::error::Error>> {
+    // Pick ATM instrument from recent deribit_iv_ticks
+    let instrument: Option<(String,)> = sqlx::query_as(
+        r#"
+        WITH candidates AS (
+            SELECT instrument_name,
+                   underlying_price,
+                   abs(NULLIF(split_part(instrument_name, '-', 3), '')::numeric - underlying_price) AS atm_distance
+            FROM deribit_iv_ticks
+            WHERE upper(currency) = $1
+              AND fetched_at >= NOW() - INTERVAL '10 minutes'
+              AND creation_ts IS NOT NULL
+              AND underlying_price IS NOT NULL
+              AND instrument_name ~ '^[^-]+-[0-9]{1,2}[A-Z]{3}[0-9]{2}-[0-9]+(\.[0-9]+)?-[CP]$'
+            ORDER BY fetched_at DESC, creation_ts DESC
+            LIMIT 500
+        )
+        SELECT instrument_name
+        FROM candidates
+        ORDER BY atm_distance ASC
+        LIMIT 1
+        "#,
+    )
+    .bind(currency)
+    .fetch_optional(pool)
+    .await?;
+
+    let instrument_name = match instrument {
+        Some((n,)) => n,
+        None => {
+            warn!("[deribit-greeks] No recent instruments for {currency}, skipping");
+            return Ok(());
+        }
+    };
+
+    // Fetch order book via Deribit REST API
+    let url = format!("{DERIBIT_API_BASE}/get_order_book");
+    let resp = reqwest::get(&url)
+        .query(&[("instrument_name", &instrument_name)])
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await?;
+    let payload: Value = resp.json().await?;
+    let result = payload["result"].as_object().ok_or("missing result object")?;
+
+    let ts_ms = result.get("timestamp")
+        .and_then(|v| v.as_i64())
+        .unwrap_or_else(|| Utc::now().timestamp_millis());
+    let source_ts = Utc.timestamp_opt(ts_ms / 1000, ((ts_ms % 1000) * 1_000_000) as u32).unwrap();
+
+    let greeks = result.get("greeks").and_then(|g| g.as_object());
+
+    let to_dec = |key: &str| -> Option<Decimal> {
+        result.get(key)
+            .and_then(|v| v.as_f64())
+            .and_then(|f| Decimal::try_from(f).ok())
+    };
+    let greek_dec = |key: &str| -> Option<Decimal> {
+        greeks
+            .and_then(|g| g.get(key))
+            .and_then(|v| v.as_f64())
+            .and_then(|f| Decimal::try_from(f).ok())
+    };
+
+    sqlx::query(
+        r#"
+        INSERT INTO deribit_atm_greeks_ticks (
+            currency, instrument_name, source_ts, fetched_at,
+            mark_iv, bid_iv, ask_iv,
+            delta, gamma, vega, theta, rho,
+            mark_price, underlying_price, index_price,
+            best_bid_price, best_ask_price, open_interest,
+            raw
+        ) VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::jsonb)
+        ON CONFLICT (currency, instrument_name, source_ts) DO UPDATE SET
+            fetched_at = NOW(),
+            mark_iv = EXCLUDED.mark_iv,
+            bid_iv = EXCLUDED.bid_iv,
+            ask_iv = EXCLUDED.ask_iv,
+            delta = EXCLUDED.delta,
+            gamma = EXCLUDED.gamma,
+            vega = EXCLUDED.vega,
+            theta = EXCLUDED.theta,
+            rho = EXCLUDED.rho,
+            mark_price = EXCLUDED.mark_price,
+            underlying_price = EXCLUDED.underlying_price,
+            index_price = EXCLUDED.index_price,
+            best_bid_price = EXCLUDED.best_bid_price,
+            best_ask_price = EXCLUDED.best_ask_price,
+            open_interest = EXCLUDED.open_interest,
+            raw = EXCLUDED.raw
+        "#,
+    )
+    .bind(currency)
+    .bind(&instrument_name)
+    .bind(source_ts)
+    .bind(to_dec("mark_iv"))
+    .bind(to_dec("bid_iv"))
+    .bind(to_dec("ask_iv"))
+    .bind(greek_dec("delta"))
+    .bind(greek_dec("gamma"))
+    .bind(greek_dec("vega"))
+    .bind(greek_dec("theta"))
+    .bind(greek_dec("rho"))
+    .bind(to_dec("mark_price"))
+    .bind(to_dec("underlying_price"))
+    .bind(to_dec("index_price"))
+    .bind(to_dec("best_bid_price"))
+    .bind(to_dec("best_ask_price"))
+    .bind(to_dec("open_interest"))
+    .bind(serde_json::to_string(result).unwrap_or_default())
+    .execute(pool)
+    .await?;
+
+    info!("[deribit-greeks] Stored Greeks for {instrument_name}");
+    Ok(())
+}

--- a/crates/ploy-market-data/src/lib.rs
+++ b/crates/ploy-market-data/src/lib.rs
@@ -1,5 +1,9 @@
 #[cfg(feature = "live")]
+pub mod binance_collectors;
+#[cfg(feature = "live")]
 pub mod collector;
+#[cfg(feature = "live")]
+pub mod deribit_collectors;
 #[cfg(feature = "live")]
 pub mod diagnostics;
 #[cfg(feature = "live")]
@@ -8,6 +12,7 @@ pub mod discovery;
 pub mod feeds;
 #[cfg(feature = "live")]
 pub mod pm_trades;
+#[cfg(feature = "live")]
 pub mod reference_prices;
 #[cfg(feature = "live")]
 pub mod scanner;

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -10,15 +10,25 @@ fn print_usage_for(program: &str) {
     eprintln!("Usage: {program} [COMMAND] [OPTIONS]");
     eprintln!();
     eprintln!("Commands:");
-    eprintln!("  run               Run the strategy (default)");
+    eprintln!("  run                       Run the strategy (default)");
     #[cfg(feature = "ops")]
-    eprintln!("  check-db          Check database data completeness");
+    eprintln!("  check-db                  Check database data completeness");
     #[cfg(feature = "ops")]
-    eprintln!("  collect-markets  Discover Polymarket markets into the local DB catalog");
+    eprintln!("  collect-markets           Discover Polymarket markets into the local DB catalog");
     #[cfg(feature = "ops")]
-    eprintln!("  collect-quotes    Collect orderbook quotes from Polymarket CLOB WebSocket");
+    eprintln!("  collect-quotes            Collect orderbook quotes from Polymarket CLOB WebSocket");
     #[cfg(feature = "ops")]
-    eprintln!("  collect-pm-trades Collect public Polymarket trade prints from Data API");
+    eprintln!("  collect-pm-trades         Collect public Polymarket trade prints from Data API");
+    #[cfg(feature = "ops")]
+    eprintln!("  collect-binance-lob       Collect Binance L2 orderbook depth snapshots");
+    #[cfg(feature = "ops")]
+    eprintln!("  collect-binance-price     Collect Binance spot trade prices");
+    #[cfg(feature = "ops")]
+    eprintln!("  collect-binance-aggtrade  Collect Binance aggregated trades");
+    #[cfg(feature = "ops")]
+    eprintln!("  collect-deribit-iv        Collect Deribit option IV ticks (HTTP poll)");
+    #[cfg(feature = "ops")]
+    eprintln!("  collect-deribit-greeks    Collect Deribit ATM option greeks (HTTP poll)");
     eprintln!();
     eprintln!("Options for 'run':");
     eprintln!("  --config <path>          Unified TOML config file (required)");
@@ -55,17 +65,61 @@ pub async fn run_with_args(args: Vec<String>) {
     let command = args.get(1).map(|s| s.as_str());
     match command {
         Some("check-db") => {
-            run_check_db(&args).await;
+            #[cfg(feature = "ops")]
+            ops::run_check_db(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The check-db command requires the full/ops runner build");
         }
         Some("collect-quotes") => {
-            run_collect_quotes(&args).await;
+            #[cfg(feature = "ops")]
+            ops::run_collect_quotes(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-quotes command requires the full/ops runner build");
         }
         Some("collect-markets") => {
-            run_collect_markets(&args).await;
+            #[cfg(feature = "ops")]
+            ops::run_collect_markets(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-markets command requires the full/ops runner build");
         }
         Some("collect-pm-trades") => {
-            run_collect_pm_trades(&args).await;
+            #[cfg(feature = "ops")]
+            ops::run_collect_pm_trades(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-pm-trades command requires the full/ops runner build");
         }
+        // --- New Binance/Deribit collectors ---
+        Some("collect-binance-lob") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_binance_lob(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-binance-lob command requires the full/ops runner build");
+        }
+        Some("collect-binance-price") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_binance_price(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-binance-price command requires the full/ops runner build");
+        }
+        Some("collect-binance-aggtrade") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_binance_aggtrade(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-binance-aggtrade command requires the full/ops runner build");
+        }
+        Some("collect-deribit-iv") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_deribit_iv(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-deribit-iv command requires the full/ops runner build");
+        }
+        Some("collect-deribit-greeks") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_deribit_greeks(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-deribit-greeks command requires the full/ops runner build");
+        }
+        // --- End new collectors ---
         Some("run") | None => {
             run::run_command(&args, command).await;
         }
@@ -119,48 +173,4 @@ fn init_tracing() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(env_filter)
         .try_init();
-}
-
-#[cfg(feature = "ops")]
-async fn run_check_db(args: &[String]) {
-    ops::run_check_db(args).await;
-}
-
-#[cfg(not(feature = "ops"))]
-async fn run_check_db(_args: &[String]) {
-    eprintln!("The check-db command requires the full/ops runner build");
-    std::process::exit(1);
-}
-
-#[cfg(feature = "ops")]
-async fn run_collect_quotes(args: &[String]) {
-    ops::run_collect_quotes(args).await;
-}
-
-#[cfg(not(feature = "ops"))]
-async fn run_collect_quotes(_args: &[String]) {
-    eprintln!("The collect-quotes command requires the full/ops runner build");
-    std::process::exit(1);
-}
-
-#[cfg(feature = "ops")]
-async fn run_collect_markets(args: &[String]) {
-    ops::run_collect_markets(args).await;
-}
-
-#[cfg(not(feature = "ops"))]
-async fn run_collect_markets(_args: &[String]) {
-    eprintln!("The collect-markets command requires the full/ops runner build");
-    std::process::exit(1);
-}
-
-#[cfg(feature = "ops")]
-async fn run_collect_pm_trades(args: &[String]) {
-    ops::run_collect_pm_trades(args).await;
-}
-
-#[cfg(not(feature = "ops"))]
-async fn run_collect_pm_trades(_args: &[String]) {
-    eprintln!("The collect-pm-trades command requires the full/ops runner build");
-    std::process::exit(1);
 }

--- a/crates/ploy-runner-host/src/ops.rs
+++ b/crates/ploy-runner-host/src/ops.rs
@@ -1,4 +1,8 @@
+use ploy_market_data::binance_collectors::{
+    collect_binance_aggtrade, collect_binance_lob, collect_binance_price,
+};
 use ploy_market_data::collector::{CollectorConfig, QuoteCollector};
+use ploy_market_data::deribit_collectors::{collect_deribit_greeks, collect_deribit_iv};
 use ploy_market_data::diagnostics::check_database;
 use ploy_market_data::pm_trades::{TradeCollector, TradeCollectorConfig};
 use ploy_market_data::scanner::{MarketDiscoveryCollectorConfig, run_market_discovery_collector};
@@ -61,6 +65,32 @@ pub fn print_usage() {
     eprintln!(
         "  env PLOY_PM_TRADE_COLLECTOR_TAKER_ONLY      true/false Data API takerOnly (default: true)"
     );
+    eprintln!();
+    eprintln!("Options for 'collect-binance-lob':");
+    eprintln!("  --symbols <list>  Comma-separated symbols (default: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT)");
+    eprintln!("  --depth <n>       Depth levels (default: 20)");
+    eprintln!("  --batch-size <n>  DB commit batch size (default: 25)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!();
+    eprintln!("Options for 'collect-binance-price':");
+    eprintln!("  --symbols <list>  Comma-separated symbols (default: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT)");
+    eprintln!("  --batch-size <n>  DB commit batch size (default: 25)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!();
+    eprintln!("Options for 'collect-binance-aggtrade':");
+    eprintln!("  --symbols <list>  Comma-separated symbols (default: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT)");
+    eprintln!("  --batch-size <n>  DB commit batch size (default: 50)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!();
+    eprintln!("Options for 'collect-deribit-iv':");
+    eprintln!("  --currencies <l>  Comma-separated currencies (default: BTC,ETH,SOL)");
+    eprintln!("  --poll-secs <n>   Poll interval in seconds (default: 30)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!();
+    eprintln!("Options for 'collect-deribit-greeks':");
+    eprintln!("  --currencies <l>  Comma-separated currencies (default: BTC,ETH,SOL)");
+    eprintln!("  --poll-secs <n>   Poll interval in seconds (default: 30)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
 }
 
 pub async fn run_collect_markets(args: &[String]) {
@@ -280,4 +310,145 @@ fn parse_symbols(symbols: &str) -> Vec<String> {
         .filter(|symbol| !symbol.is_empty())
         .map(ToOwned::to_owned)
         .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Binance collectors
+// ---------------------------------------------------------------------------
+
+pub async fn run_collect_binance_lob(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let symbols = arg_value(args, "--symbols")
+        .map(String::as_str)
+        .unwrap_or("BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT");
+    let depth = arg_value(args, "--depth")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(20);
+    let batch = arg_value(args, "--batch-size")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(25);
+
+    let pool = match PgPoolOptions::new().max_connections(3).connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB connection failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    collect_binance_lob(pool, symbols, depth, batch).await;
+}
+
+pub async fn run_collect_binance_price(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let symbols = arg_value(args, "--symbols")
+        .map(String::as_str)
+        .unwrap_or("BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT");
+    let batch = arg_value(args, "--batch-size")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(25);
+
+    let pool = match PgPoolOptions::new().max_connections(3).connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB connection failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    collect_binance_price(pool, symbols, batch).await;
+}
+
+pub async fn run_collect_binance_aggtrade(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let symbols = arg_value(args, "--symbols")
+        .map(String::as_str)
+        .unwrap_or("BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT");
+    let batch = arg_value(args, "--batch-size")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(50);
+
+    let pool = match PgPoolOptions::new().max_connections(3).connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB connection failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    collect_binance_aggtrade(pool, symbols, batch).await;
+}
+
+// ---------------------------------------------------------------------------
+// Deribit collectors
+// ---------------------------------------------------------------------------
+
+pub async fn run_collect_deribit_iv(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let currencies = arg_value(args, "--currencies")
+        .map(String::as_str)
+        .unwrap_or("BTC,ETH,SOL");
+    let poll_secs = arg_value(args, "--poll-secs")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30);
+
+    let pool = match PgPoolOptions::new().max_connections(2).connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB connection failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    collect_deribit_iv(pool, currencies, poll_secs).await;
+}
+
+pub async fn run_collect_deribit_greeks(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let currencies = arg_value(args, "--currencies")
+        .map(String::as_str)
+        .unwrap_or("BTC,ETH,SOL");
+    let poll_secs = arg_value(args, "--poll-secs")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30);
+
+    let pool = match PgPoolOptions::new().max_connections(2).connect(&db_url).await {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("DB connection failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    collect_deribit_greeks(pool, currencies, poll_secs).await;
 }

--- a/deployment/systemd/ploy-binance-aggtrade-collector.service
+++ b/deployment/systemd/ploy-binance-aggtrade-collector.service
@@ -8,17 +8,19 @@ Type=simple
 WorkingDirectory=/opt/ploy
 Environment=BINANCE_AGGTRADE_SYMBOLS=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT
 Environment=BINANCE_AGGTRADE_COMMIT_BATCH_SIZE=50
-Environment=BINANCE_AGGTRADE_COMMIT_INTERVAL_SECS=1.0
-Environment=BINANCE_AGGTRADE_REPORT_INTERVAL_SECS=60
 Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
-ExecStart=/usr/bin/python3 /opt/ploy/scripts/binance_aggtrade_collector.py
+ExecStartPre=/bin/sleep 11
+ExecStart=/opt/ploy/bin/ploy-runner collect-binance-aggtrade \
+    --symbols ${BINANCE_AGGTRADE_SYMBOLS} \
+    --batch-size ${BINANCE_AGGTRADE_COMMIT_BATCH_SIZE}
 Restart=always
-RestartSec=5
+RestartSec=11
 StandardOutput=journal
 StandardError=journal
 
 MemoryHigh=256M
 MemoryMax=512M
+CPUQuota=35%
 OOMPolicy=kill
 
 [Install]

--- a/deployment/systemd/ploy-binance-lob-collector.service
+++ b/deployment/systemd/ploy-binance-lob-collector.service
@@ -9,17 +9,20 @@ WorkingDirectory=/opt/ploy
 Environment=BINANCE_LOB_SYMBOLS=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT
 Environment=BINANCE_LOB_LEVELS=20
 Environment=BINANCE_LOB_COMMIT_BATCH_SIZE=25
-Environment=BINANCE_LOB_COMMIT_INTERVAL_SECS=1.0
-Environment=BINANCE_LOB_REPORT_INTERVAL_SECS=60
 Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
-ExecStart=/usr/bin/python3 /opt/ploy/scripts/binance_lob_collector.py
+ExecStartPre=/bin/sleep 17
+ExecStart=/opt/ploy/bin/ploy-runner collect-binance-lob \
+    --symbols ${BINANCE_LOB_SYMBOLS} \
+    --depth ${BINANCE_LOB_LEVELS} \
+    --batch-size ${BINANCE_LOB_COMMIT_BATCH_SIZE}
 Restart=always
-RestartSec=5
+RestartSec=17
 StandardOutput=journal
 StandardError=journal
 
 MemoryHigh=384M
 MemoryMax=768M
+CPUQuota=70%
 OOMPolicy=kill
 
 [Install]

--- a/deployment/systemd/ploy-binance-price-collector.service
+++ b/deployment/systemd/ploy-binance-price-collector.service
@@ -5,18 +5,22 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/root/ploy
+WorkingDirectory=/opt/ploy
 Environment=BINANCE_PRICE_SYMBOLS=BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT
+Environment=BINANCE_PRICE_COMMIT_BATCH_SIZE=25
 Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
-ExecStart=/usr/bin/python3 /root/ploy/scripts/binance_price_collector.py
+ExecStartPre=/bin/sleep 7
+ExecStart=/opt/ploy/bin/ploy-runner collect-binance-price \
+    --symbols ${BINANCE_PRICE_SYMBOLS} \
+    --batch-size ${BINANCE_PRICE_COMMIT_BATCH_SIZE}
 Restart=always
-RestartSec=5
+RestartSec=7
 StandardOutput=journal
 StandardError=journal
 
-# Memory limits
 MemoryHigh=256M
 MemoryMax=512M
+CPUQuota=35%
 OOMPolicy=kill
 
 [Install]

--- a/deployment/systemd/ploy-deribit-greeks-collector.service
+++ b/deployment/systemd/ploy-deribit-greeks-collector.service
@@ -8,15 +8,19 @@ Type=simple
 WorkingDirectory=/opt/ploy
 Environment=DERIBIT_GREEKS_CURRENCIES=BTC,ETH,SOL
 Environment=DERIBIT_GREEKS_POLL_SECS=30
-Environment=DERIBIT_GREEKS_HTTP_TIMEOUT_SECS=20
-ExecStart=/usr/bin/env bash -lc 'if [ -f /opt/ploy/.env ]; then set -a; . /opt/ploy/.env >/dev/null 2>&1; set +a; fi; exec /usr/bin/python3 /opt/ploy/scripts/deribit_atm_greeks_collector.py'
+Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
+ExecStartPre=/bin/sleep 29
+ExecStart=/opt/ploy/bin/ploy-runner collect-deribit-greeks \
+    --currencies ${DERIBIT_GREEKS_CURRENCIES} \
+    --poll-secs ${DERIBIT_GREEKS_POLL_SECS}
 Restart=always
-RestartSec=5
+RestartSec=29
 StandardOutput=journal
 StandardError=journal
 
-MemoryHigh=1280M
-MemoryMax=1536M
+MemoryHigh=256M
+MemoryMax=512M
+CPUQuota=25%
 OOMPolicy=kill
 
 [Install]

--- a/deployment/systemd/ploy-deribit-iv-collector.service
+++ b/deployment/systemd/ploy-deribit-iv-collector.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Ploy Deribit IV Collector
+After=postgresql.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ploy
+Environment=DERIBIT_IV_CURRENCIES=BTC,ETH,SOL
+Environment=DERIBIT_IV_POLL_SECS=30
+Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
+ExecStartPre=/bin/sleep 23
+ExecStart=/opt/ploy/bin/ploy-runner collect-deribit-iv \
+    --currencies ${DERIBIT_IV_CURRENCIES} \
+    --poll-secs ${DERIBIT_IV_POLL_SECS}
+Restart=always
+RestartSec=23
+StandardOutput=journal
+StandardError=journal
+
+MemoryHigh=256M
+MemoryMax=512M
+CPUQuota=25%
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -198,6 +198,8 @@ done
 install -d /etc/systemd/system/ploy-quote-collector.service.d
 install -m 0644 ./deployment/systemd/ploy-binance-aggtrade-collector.service /etc/systemd/system/ploy-binance-aggtrade-collector.service
 install -m 0644 ./deployment/systemd/ploy-binance-lob-collector.service /etc/systemd/system/ploy-binance-lob-collector.service
+install -m 0644 ./deployment/systemd/ploy-binance-price-collector.service /etc/systemd/system/ploy-binance-price-collector.service
+install -m 0644 ./deployment/systemd/ploy-deribit-iv-collector.service /etc/systemd/system/ploy-deribit-iv-collector.service
 install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
 install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
 install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
@@ -226,12 +228,10 @@ systemctl enable --now ploy-binance-aggtrade-collector.service
 systemctl restart ploy-binance-aggtrade-collector.service
 systemctl enable --now ploy-binance-lob-collector.service
 systemctl restart ploy-binance-lob-collector.service
-if service_exists ploy-binance-price-collector.service; then
-  systemctl restart ploy-binance-price-collector.service
-fi
-if service_exists ploy-deribit-iv-collector.service; then
-  systemctl restart ploy-deribit-iv-collector.service
-fi
+systemctl enable --now ploy-binance-price-collector.service
+systemctl restart ploy-binance-price-collector.service
+systemctl enable --now ploy-deribit-iv-collector.service
+systemctl restart ploy-deribit-iv-collector.service
 systemctl enable --now ploy-deribit-greeks-collector.service
 systemctl restart ploy-deribit-greeks-collector.service
 systemctl enable --now ploy-market-discovery.service
@@ -258,12 +258,10 @@ if service_exists ploy-quote-collector.service; then
 fi
 systemctl is-active --quiet ploy-pm-trade-collector.service
 require_service_guardrails ploy-pm-trade-collector.service
-if service_exists ploy-binance-price-collector.service; then
-  systemctl is-active --quiet ploy-binance-price-collector.service
-fi
-if service_exists ploy-deribit-iv-collector.service; then
-  systemctl is-active --quiet ploy-deribit-iv-collector.service
-fi
+systemctl is-active --quiet ploy-binance-price-collector.service
+require_service_guardrails ploy-binance-price-collector.service
+systemctl is-active --quiet ploy-deribit-iv-collector.service
+require_service_guardrails ploy-deribit-iv-collector.service
 systemctl is-active --quiet ploy-deribit-greeks-collector.service
 require_service_guardrails ploy-deribit-greeks-collector.service
 systemctl is-active --quiet ploy-market-discovery.service

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -53,6 +53,49 @@ without allowing free-form generated code into the research loop.
   lean replay/backtest, and Rust runner live/default. CodeRabbit review was
   still pending when this evidence was recorded.
 
+# Rust Collector CI Repair (2026-05-12)
+
+## Goal
+
+Make `feat/rust-collectors` compile in the release/deploy workflows, then use
+CI-built artifacts for the tango collector migration.
+
+## Files / Ownership
+
+- `crates/ploy-market-data/src/binance_collectors.rs`
+  - Owner: remove accidental undeclared dependency references and keep collector
+    error handling within existing crate dependencies.
+- `crates/ploy-market-data/Cargo.toml`
+  - Owner: enable only the Tokio feature needed by long-running collector
+    shutdown handling.
+
+## Tasks
+
+- [x] Recreate the failing branch in a clean worktree and inspect failed CI logs.
+- [x] Fix the full runner compile errors without broad dependency churn.
+- [x] Run focused local compile checks matching release/deploy feature usage.
+- [ ] Commit and push the fix to `feat/rust-collectors`.
+- [ ] Re-run/monitor CI and only deploy CI-built artifacts after green checks.
+
+## Review
+
+- 2026-05-12: Release run `25705528136` failed on
+  `origin/feat/rust-collectors@d111518a` while building
+  `new-ploy-runner --features full`. The blocking errors are in
+  `ploy-market-data`: `tokio::signal` is gated off, `futures_util` is referenced
+  without a direct dependency, and `anyhow::Error` is referenced without a
+  direct dependency.
+- 2026-05-12: Fixed the collector compile blockers by enabling the workspace
+  Tokio `signal` feature, using `futures::stream` types, and keeping Binance
+  collector fallible helpers on `String` errors. The first compile pass also
+  exposed collector-local issues in LOB level parsing and Deribit `reqwest`
+  client construction; those were fixed without broad dependency changes.
+  Verification passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked --features ops -p ploy-runner-host`,
+  `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner --features full`,
+  `rustfmt --edition 2021 --check crates/ploy-market-data/src/binance_collectors.rs crates/ploy-market-data/src/deribit_collectors.rs`,
+  and `rtk git diff --check`.
+
 # Deploy Live-Paused Stderr Guard Repair (2026-05-12)
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -74,8 +74,12 @@ CI-built artifacts for the tango collector migration.
 - [x] Recreate the failing branch in a clean worktree and inspect failed CI logs.
 - [x] Fix the full runner compile errors without broad dependency churn.
 - [x] Run focused local compile checks matching release/deploy feature usage.
-- [ ] Commit and push the fix to `feat/rust-collectors`.
-- [ ] Re-run/monitor CI and only deploy CI-built artifacts after green checks.
+- [x] Commit and push the fix to `feat/rust-collectors`.
+- [x] Re-run/monitor CI and only deploy CI-built artifacts after green checks.
+- [x] Wire tango collector units and deploy workflow to start the Rust collector
+  commands instead of the Python scripts.
+- [ ] Land on `main`, run the protected `deploy-tango-1-1` workflow, and verify
+  remote service state/CPU.
 
 ## Review
 
@@ -94,6 +98,19 @@ CI-built artifacts for the tango collector migration.
   `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked --features ops -p ploy-runner-host`,
   `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner --features full`,
   `rustfmt --edition 2021 --check crates/ploy-market-data/src/binance_collectors.rs crates/ploy-market-data/src/deribit_collectors.rs`,
+  and `rtk git diff --check`.
+- 2026-05-12: Commit `22218348` was pushed to `feat/rust-collectors`, and
+  release-platform build-only run `25705959622` completed successfully for that
+  SHA.
+- 2026-05-12: The initial branch only added runner commands; it did not switch
+  the tango collector units. Updated the five collector units to call
+  `/opt/ploy/bin/ploy-runner collect-*`, added staggered startup/restart delays
+  and CPU quotas, and made both SSH and Cloud Assistant deploy paths install
+  and verify all five collector units. Verification passed:
+  Ruby YAML parse for `.github/workflows/deploy-tango-1-1.yml`,
+  `python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py`,
+  `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-deploy /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused`,
+  `CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-deploy /opt/homebrew/bin/timeout 300 rtk cargo check --locked --features ops -p ploy-runner-host`,
   and `rtk git diff --check`.
 
 # Deploy Live-Paused Stderr Guard Repair (2026-05-12)


### PR DESCRIPTION
## Summary
- add Rust Binance and Deribit collector commands to the full runner
- switch tango collector systemd units from Python scripts to ploy-runner collect-* commands
- install and verify all five collector units in SSH and Cloud Assistant deploy paths

## Verification
- CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked --features ops -p ploy-runner-host
- CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-ops /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p new-ploy-runner --features full
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml")'
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- CARGO_TARGET_DIR=/tmp/ploy-rust-collectors-deploy /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- rtk git diff --check
- release-platform build-only run 25705959622 passed
- deploy-tango-1-1 build-only run 25706641946 passed