### PR TITLE
Add PM5D alpha prior reuse plan

### DIFF
--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -124,6 +124,10 @@ def factor_args(args: argparse.Namespace, variant: Variant, replay_parity_json: 
         command.extend(["--alpha-search-output-dir", args.alpha_search_output_dir])
     if args.alpha_search_plan_json:
         command.extend(["--alpha-search-plan-json", args.alpha_search_plan_json])
+    if args.alpha_search_state_json:
+        command.extend(["--alpha-search-state-json", args.alpha_search_state_json])
+    if args.alpha_search_llm_prior_json:
+        command.extend(["--alpha-search-llm-prior-json", args.alpha_search_llm_prior_json])
     return command
 
 
@@ -310,6 +314,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--replay-parity-json", default="")
     parser.add_argument("--alpha-search-output-dir", default="")
     parser.add_argument("--alpha-search-plan-json", default="")
+    parser.add_argument("--alpha-search-state-json", default="")
+    parser.add_argument("--alpha-search-llm-prior-json", default="")
     parser.add_argument("--required-strategy-profile", default="settlement_probability")
     parser.add_argument("--allowed-target", action="append", default=[])
     parser.add_argument("--sweep-json", default="")

--- a/tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json
+++ b/tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json
@@ -1,0 +1,73 @@
+{
+  "mutations": [
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_conservative_settlement_edge_near_strike"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_capacity_gate",
+      "name": "llm_conservative_settlement_edge_capacity",
+      "feature": "entry_capacity_score"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_conservative_settlement_edge_liquidity_gated_model_prob",
+      "feature": "side_model_prob"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_conservative_settlement_edge_fair_prob_gate",
+      "feature": "side_fair_prob"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "replace_denominator",
+      "name": "llm_conservative_settlement_edge_distance_scaled",
+      "denominator_feature": "side_distance_over_sigma",
+      "constant": 0.25
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_spread_penalty",
+      "name": "llm_conservative_settlement_edge_spread_penalty",
+      "constant": 0.01
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_full_depth_settlement_edge_near_strike"
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge",
+      "mutation_type": "add_capacity_gate",
+      "name": "llm_full_depth_settlement_edge_capacity",
+      "feature": "entry_capacity_score"
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge",
+      "mutation_type": "clip_or_squash",
+      "name": "llm_full_depth_settlement_edge_squashed"
+    },
+    {
+      "base_factor": "spread_adjusted_external_move",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_repricing_external_move_near_strike"
+    },
+    {
+      "base_factor": "spread_adjusted_external_move",
+      "mutation_type": "add_capacity_gate",
+      "name": "llm_repricing_external_move_capacity",
+      "feature": "entry_capacity_score"
+    },
+    {
+      "base_factor": "spread_adjusted_external_move",
+      "mutation_type": "change_time_window",
+      "name": "llm_repricing_external_move_rolling_30s",
+      "window": 30
+    }
+  ]
+}

--- a/tasks/research_evidence/pm5d_alpha_factor_reuse_plan_20260512.md
+++ b/tasks/research_evidence/pm5d_alpha_factor_reuse_plan_20260512.md
@@ -1,0 +1,111 @@
+# PM5D Alpha Factor Reuse Plan - 2026-05-12
+
+## Evidence Stage
+
+`factor_attribution` -> `walk_forward`.
+
+This plan is not dry-run or live approval. It turns prior PM5D factor evidence
+into a typed alpha-search prior that can be evaluated by CI.
+
+## Product Semantics
+
+PM5D / PM15D Polymarket crypto events are binary-option-like markets. Each
+event has an `UP` side and a `DOWN` side. At settlement, one side pays `1` and
+the other pays `0`. The main deployable lane is therefore:
+
+```text
+estimated settlement probability - executable entry price - friction > 0
+```
+
+Promotion evidence must use official settlement, executable prices, fillability,
+walk-forward/OOS windows, and replay/dry-run parity.
+
+## Prior Factor Evidence To Reuse
+
+| Lane | Factor family | Historical read | Decision |
+| --- | --- | --- | --- |
+| Settlement probability | `side_fair_prob` | Strong IC/ICIR for settlement outcome and executable settlement PnL, but naive `side_fair_edge = side_fair_prob - entry_ask - fee` was rejected. | Reuse as a probability signal, not as a direct edge-subtraction formula. |
+| Liquidity-gated alpha | `side_model_prob`, `side_distance_over_sigma` | Raw lane was unstable, but liquidity-gated rows became positive across prior OOS windows with full fillability. | Reuse only behind conservative/full-depth settlement edge and capacity gates. |
+| Execution quality | `entry_capacity_score`, `side_spread`, full-depth/conservative sweep prices | Required to prevent positive probability signals from becoming non-executable trades. | Hard gate or denominator/penalty, not optional decoration. |
+| Near-strike geometry | `near_strike_score`, `side_distance_over_sigma` | Short-dated near-strike events are where small external moves matter most, but they can overfit. | Use as bounded interaction and require walk-forward stability. |
+| Repricing backup | `spread_adjusted_external_move` | Strong repricing IC/ICIR, especially BTC/ETH/SOL; not the primary settlement lane. | Keep as backup branch, not settlement-promotion evidence. |
+
+## Negative Constraints
+
+- Do not promote naked `side_fair_edge`; previous settlement executable-PnL
+  evidence rejected it.
+- Do not promote raw `side_model_prob` or raw `side_distance_over_sigma`
+  without liquidity/full-depth gates.
+- Do not treat `exit_bid_change_30s`, `entry_ask_change_30s`,
+  `pm_reprice_speed_30s`, or `obi_persistence_30s_side` as standalone
+  settlement strategies. Prior liquidity-gated reads rejected or weakened them.
+- Do not count many entry timestamps from the same event as independent
+  deployable trades unless runtime implements the same multi-entry lifecycle.
+
+## Typed Prior Artifact
+
+Use:
+
+```text
+tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json
+```
+
+The file intentionally contains only supported mutation types:
+
+- `add_near_strike_interaction`
+- `add_capacity_gate`
+- `add_feature_gate`
+- `replace_denominator`
+- `add_spread_penalty`
+- `clip_or_squash`
+- `change_time_window`
+
+The Rust alpha-search compiler should ignore any mutation whose base factor or
+feature is absent from the current snapshot.
+
+## Recommended First CI Run
+
+Run on a retained full research snapshot, preferably the latest BTC/ETH
+settlement-probability snapshot with recorded parity available. Use
+`full_depth_settlement_executable_pnl` as the allowed target.
+
+Suggested hosted artifact inputs:
+
+```json
+{
+  "train_window_days": 2,
+  "test_window_days": 1,
+  "step_days": 1,
+  "lob_sample_secs": 30,
+  "observation_sample_secs": 30,
+  "max_quote_age_secs": 30,
+  "top_n": 20,
+  "min_observations": 20,
+  "top_quantile": 0.2,
+  "factor_name_filter": "",
+  "data_quality_mode": "event_complete",
+  "min_event_complete_events": 20,
+  "min_event_complete_rows": 40,
+  "alpha_search_llm_prior_json": "tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json",
+  "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
+  "alpha_search_min_reward_improvement": 0.01,
+  "chain_next_run": true,
+  "chain_remaining": 2,
+  "required_strategy_profile": "settlement_probability",
+  "allowed_target": "full_depth_settlement_executable_pnl",
+  "fail_if_blocked": false
+}
+```
+
+## Success Criteria
+
+Continue only if the run produces:
+
+- non-empty alpha-search artifacts;
+- `mcts-state.json` and `mcts-expansion-plan.json`;
+- candidate factors with positive reward and no promotion blockers;
+- walk-forward/OOS support, not just in-sample ranking;
+- `autofactor-strategy-handoff.json status=ready` before any config PR.
+
+Promotion remains blocked unless recorded replay/dry-run parity and fresh
+dry-run executable evidence are clean.

--- a/tasks/research_evidence/pm5d_alpha_factor_reuse_plan_20260512.md
+++ b/tasks/research_evidence/pm5d_alpha_factor_reuse_plan_20260512.md
@@ -109,3 +109,49 @@ Continue only if the run produces:
 
 Promotion remains blocked unless recorded replay/dry-run parity and fresh
 dry-run executable evidence are clean.
+
+## First Hosted Run Result
+
+Run:
+
+- Workflow: `factor-walk-forward-v2-hosted-artifact.yml`
+- Run: `25707061616`
+- Branch/ref: `research/pm5d-alpha-prior-reuse`
+- Snapshot: `25642459432`
+- Replay parity artifact: `recorded-replay-parity-25687392088`
+- Symbols: `BTCUSDT,ETHUSDT`
+- Window: `2026-04-24T00:00:00Z -> 2026-05-01T00:00:00Z`
+- Target: `full_depth_settlement_executable_pnl`
+
+Result:
+
+- Status: workflow success.
+- Alpha-search candidates: `193`.
+- Passed candidates: `38`.
+- Best reward: `4.81954070569323`.
+- Best selected factor: `auto_settlement_conservative_settlement_edge`.
+- Handoff: `ready`.
+- Recommended action: `create_dry_run_handoff`.
+- Chain decision: `ready_handoff`, so no follow-up chained run was dispatched.
+
+Prior-specific read:
+
+- The typed prior compiled into `llm_*` candidates, including near-strike,
+  capacity, fair-probability, spread-penalty, full-depth, and repricing backup
+  variants.
+- The best typed-prior candidate was
+  `llm_conservative_settlement_edge_near_strike` with reward
+  `4.775414902351155`, matching the deterministic near-strike branch.
+- The best overall factor stayed the simpler
+  `auto_settlement_conservative_settlement_edge`.
+
+Interpretation:
+
+- Reusing the user's previous factors is valid: the prior entered CI and
+  produced evaluated candidates.
+- The prior did not beat the simpler conservative settlement edge on this
+  BTC/ETH snapshot/window.
+- The next strategy step should not be to add more formula complexity. It
+  should be to deploy/collect/compare the ready conservative settlement dry-run
+  candidate, then use fresh dry-run evidence to decide whether near-strike or
+  capacity variants deserve a second promotion attempt.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -44,6 +44,13 @@ liquidity-gated factors instead of starting from generic exploration.
   passed: `python3 -m unittest tests.test_factor_walk_forward_sweep`,
   `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py
   tests/test_factor_walk_forward_sweep.py`, and `rtk git diff --check`.
+- 2026-05-12: Re-ran hosted alpha-search as `25707061616`; it completed
+  successfully and produced alpha-search artifacts. Summary: candidates `193`,
+  passed `38`, best reward `4.81954070569323`, best factor
+  `auto_settlement_conservative_settlement_edge`, handoff `ready`, recommended
+  action `create_dry_run_handoff`, chain decision `ready_handoff`. The typed
+  prior compiled into `llm_*` candidates, but did not beat the simpler
+  conservative settlement edge on this BTC/ETH window.
 
 # Alpha Search LLM Prior And MCTS State (2026-05-12)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# PM5D Prior Factor Reuse For Alpha Search (2026-05-12)
+
+## Goal
+
+Turn the user's earlier PM5D factor findings into a typed alpha-search prior so
+the next CI runs search around known promising settlement-probability and
+liquidity-gated factors instead of starting from generic exploration.
+
+## Plan
+
+- [x] Re-read the project semantic contract for PM5D binary-option settlement
+  accounting and evidence stages.
+- [x] Review prior factor evidence for `side_fair_prob`,
+  liquidity-gated `side_model_prob` / `side_distance_over_sigma`,
+  full-depth/conservative settlement edge, near-strike, capacity, spread, and
+  repricing backup factors.
+- [x] Write a reusable research evidence plan separating reusable factors from
+  negative constraints.
+- [x] Add a typed LLM prior JSON file that can be passed to
+  `factor_walk_forward_v2 --alpha-search-llm-prior-json`.
+- [ ] Run or dispatch the first hosted alpha-search chain from the prior once a
+  retained snapshot/run target is selected.
+
+## Review
+
+- 2026-05-12: Added
+  `tasks/research_evidence/pm5d_alpha_factor_reuse_plan_20260512.md` and
+  `tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json`.
+  The prior reuses the historically strongest settlement and liquidity-gated
+  factors while marking rejected or unstable standalone factors as constraints.
+
 # Alpha Search LLM Prior And MCTS State (2026-05-12)
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,8 +18,10 @@ liquidity-gated factors instead of starting from generic exploration.
   negative constraints.
 - [x] Add a typed LLM prior JSON file that can be passed to
   `factor_walk_forward_v2 --alpha-search-llm-prior-json`.
-- [ ] Run or dispatch the first hosted alpha-search chain from the prior once a
+- [x] Run or dispatch the first hosted alpha-search chain from the prior once a
   retained snapshot/run target is selected.
+- [x] Repair the hosted sweep wrapper so typed alpha-search prior/state
+  arguments pass through to the Rust factor binary.
 
 ## Review
 
@@ -28,6 +30,20 @@ liquidity-gated factors instead of starting from generic exploration.
   `tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json`.
   The prior reuses the historically strongest settlement and liquidity-gated
   factors while marking rejected or unstable standalone factors as constraints.
+- 2026-05-12: Dispatched hosted alpha-search run `25706878456` from branch
+  `research/pm5d-alpha-prior-reuse` against snapshot `25642459432`,
+  BTC/ETH, `2026-04-24 -> 2026-05-01`, recorded parity artifact
+  `recorded-replay-parity-25687392088`, and target
+  `full_depth_settlement_executable_pnl`. The run proved checkout, option
+  parsing, snapshot/parity download, and Rust build, but failed in
+  `Run factor walk-forward sweep` because `scripts/run_factor_walk_forward_sweep.py`
+  did not yet accept `--alpha-search-llm-prior-json`.
+- 2026-05-12: Added sweep-wrapper pass-through for
+  `--alpha-search-state-json` and `--alpha-search-llm-prior-json`, plus a
+  focused unittest proving those args reach the factor binary. Verification
+  passed: `python3 -m unittest tests.test_factor_walk_forward_sweep`,
+  `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py
+  tests/test_factor_walk_forward_sweep.py`, and `rtk git diff --check`.
 
 # Alpha Search LLM Prior And MCTS State (2026-05-12)
 

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -148,6 +148,45 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--sweep-json \"${SWEEP_JSON}\"", workflow)
         self.assertIn("--factor-name-filter \"${WALK_FACTOR_NAME_FILTER}\"", workflow)
 
+    def test_alpha_search_prior_and_state_args_pass_through_to_factor_binary(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = tmp / "capture_factor_args.py"
+            capture = tmp / "captured_args.json"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                f"open({str(capture)!r}, 'w', encoding='utf-8').write(json.dumps(sys.argv[1:]))\n"
+                f"{FAKE_REPORT}\n",
+                encoding="utf-8",
+            )
+            binary.chmod(0o755)
+
+            subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--alpha-search-output-dir",
+                    "artifacts/alpha",
+                    "--alpha-search-plan-json",
+                    "artifacts/plan/mcts-expansion-plan.json",
+                    "--alpha-search-state-json",
+                    "artifacts/plan/mcts-state.json",
+                    "--alpha-search-llm-prior-json",
+                    "tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json",
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            captured = json.loads(capture.read_text(encoding="utf-8"))
+
+        self.assertIn("--alpha-search-output-dir", captured)
+        self.assertIn("--alpha-search-plan-json", captured)
+        self.assertIn("--alpha-search-state-json", captured)
+        self.assertIn("--alpha-search-llm-prior-json", captured)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a PM5D settlement/liquidity typed alpha-search prior built from prior factor evidence.
- Record which earlier factors are reusable and which should remain negative constraints.
- Fix the hosted sweep wrapper so `--alpha-search-state-json` and `--alpha-search-llm-prior-json` pass through to `factor_walk_forward_v2`.
- Record hosted run `25707061616`, which proved the prior compiles/evaluates and confirmed the conservative settlement edge remains the best current BTC/ETH candidate.

## Evidence

- `python3 -m unittest tests.test_factor_walk_forward_sweep`
- `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py`
- `jq . tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json`
- `rtk git diff --check`
- Hosted alpha-search run: https://github.com/proerror77/ploy/actions/runs/25707061616

## Result

Run `25707061616` produced `193` candidates, `38` passed candidates, best reward `4.81954070569323`, ready handoff, and best selected factor `auto_settlement_conservative_settlement_edge`. The typed prior produced evaluated `llm_*` candidates but did not beat the simpler conservative settlement edge on this BTC/ETH window.
