### PR TITLE
fix: coalesce quote persist batches

### DIFF
--- a/crates/ploy-market-data/src/collector.rs
+++ b/crates/ploy-market-data/src/collector.rs
@@ -146,6 +146,7 @@ const HEALTH_CHECK_INTERVAL_SECS: u64 = 15;
 const DEFAULT_PERSIST_QUEUE_CAPACITY: usize = 4_096;
 const DEFAULT_PERSIST_WORKERS: usize = 4;
 const DEFAULT_PERSIST_BATCH_SIZE: usize = 50;
+const DEFAULT_PERSIST_BATCH_WINDOW_MS: u64 = 10;
 const DEFAULT_STALE_AFTER_SECS: u64 = 120;
 
 fn is_tradeable_price(price: Decimal) -> bool {
@@ -595,6 +596,7 @@ impl QuoteCollector {
                     };
 
                     let mut jobs = vec![job];
+                    sleep(StdDuration::from_millis(DEFAULT_PERSIST_BATCH_WINDOW_MS)).await;
                     {
                         let mut rx = rx.lock().await;
                         while jobs.len() < DEFAULT_PERSIST_BATCH_SIZE {


### PR DESCRIPTION
## Summary
- add a 10ms quote persistence coalescing window before draining queued book updates
- keep the batch size cap unchanged at 50 so write latency remains bounded while reducing per-update transactions

## Verification
- rustfmt --edition 2021 --check crates/ploy-market-data/src/collector.rs
- rtk cargo check --locked --features ops -p ploy-runner-host
- rtk cargo test --locked -p ploy-market-data --features live
- rtk cargo test --locked --test workflow_security tango_deploy_keeps_pm5d_live_paused
- rtk git diff --check