### PR TITLE
fix: dedupe polymarket trade collector writes

### DIFF
--- a/crates/ploy-market-data/src/pm_trades.rs
+++ b/crates/ploy-market-data/src/pm_trades.rs
@@ -5,6 +5,7 @@
 //! collector: quotes tell us what was executable, while trade prints let research
 //! measure PM trade imbalance, bursts, and trade-to-quote response.
 
+use std::collections::HashSet;
 use std::io;
 use std::str::FromStr;
 use std::time::Duration as StdDuration;
@@ -16,7 +17,7 @@ use polymarket_client_sdk::data::types::MarketFilter;
 use polymarket_client_sdk::data::types::Side;
 use polymarket_client_sdk::data::Client as DataClient;
 use polymarket_client_sdk::types::B256;
-use sqlx::PgPool;
+use sqlx::{PgPool, QueryBuilder};
 use tokio::time::sleep;
 use tracing::{info, warn};
 
@@ -27,6 +28,7 @@ const DEFAULT_TRADE_LOOKBACK_SECS: i64 = 7_200;
 const DEFAULT_API_LIMIT: i32 = 500;
 const DEFAULT_PER_MARKET_DELAY_MS: u64 = 250;
 const DEFAULT_STALE_AFTER_SECS: u64 = 180;
+const TRADE_DEDUPE_OVERLAP_SECS: i64 = 5;
 
 /// Configuration for public Polymarket trade collection.
 #[derive(Debug, Clone)]
@@ -99,6 +101,13 @@ struct ActiveTradeMarketRow {
     market_slug: String,
     symbol: String,
     condition_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct PersistableTrade<'a> {
+    trade: &'a Trade,
+    side: &'static str,
+    trade_ts: DateTime<Utc>,
 }
 
 #[derive(Debug, Default)]
@@ -271,11 +280,26 @@ impl TradeCollector {
 
         let trades = self.data.trades(&request).await?;
         let fetched = trades.len() as u64;
+        let latest_seen_trade_ts =
+            latest_persisted_trade_ts(&self.pool, &market.condition_id.to_string()).await?;
+        let existing_boundary_keys = match latest_seen_trade_ts {
+            Some(latest_seen_trade_ts) => {
+                existing_trade_keys_since(
+                    &self.pool,
+                    &market.condition_id.to_string(),
+                    latest_seen_trade_ts.saturating_sub(TRADE_DEDUPE_OVERLAP_SECS),
+                )
+                .await?
+            }
+            None => HashSet::new(),
+        };
         let (inserted, skipped) = persist_trades(
             &self.pool,
             &trades,
             self.config.trade_lookback_secs,
             Utc::now(),
+            latest_seen_trade_ts,
+            &existing_boundary_keys,
         )
         .await?;
 
@@ -308,9 +332,12 @@ async fn persist_trades(
     trades: &[Trade],
     trade_lookback_secs: i64,
     now: DateTime<Utc>,
+    latest_seen_trade_ts: Option<i64>,
+    existing_boundary_keys: &HashSet<String>,
 ) -> Result<(u64, u64), sqlx::Error> {
-    let mut inserted = 0_u64;
     let mut skipped = 0_u64;
+    let mut batch_keys = HashSet::with_capacity(trades.len());
+    let mut rows = Vec::with_capacity(trades.len());
 
     for trade in trades {
         let Some(side) = trade_side(&trade.side) else {
@@ -325,67 +352,166 @@ async fn persist_trades(
             skipped += 1;
             continue;
         }
+        let key = trade_dedupe_key(trade, side);
+        if seen_trade(
+            latest_seen_trade_ts,
+            existing_boundary_keys,
+            &batch_keys,
+            trade.timestamp,
+            &key,
+        ) {
+            skipped += 1;
+            continue;
+        }
 
-        let result = sqlx::query(
-            r#"
-            INSERT INTO clob_trade_ticks (
-                domain,
-                condition_id,
-                token_id,
-                side,
-                size,
-                price,
-                trade_ts,
-                trade_ts_unix,
-                transaction_hash,
-                proxy_wallet,
-                title,
-                slug,
-                outcome,
-                outcome_index,
-                source,
-                received_at
-            ) VALUES (
-                'Crypto',
-                $1,
-                $2,
-                $3,
-                $4,
-                $5,
-                $6,
-                $7,
-                $8,
-                $9,
-                $10,
-                $11,
-                $12,
-                $13,
-                'polymarket_data_api',
-                NOW()
-            )
-            ON CONFLICT DO NOTHING
-            "#,
-        )
-        .bind(trade.condition_id.to_string())
-        .bind(trade.asset.to_string())
-        .bind(side)
-        .bind(trade.size)
-        .bind(trade.price)
-        .bind(trade_ts)
-        .bind(trade.timestamp)
-        .bind(trade.transaction_hash.to_string())
-        .bind(trade.proxy_wallet.to_string())
-        .bind(&trade.title)
-        .bind(&trade.slug)
-        .bind(&trade.outcome)
-        .bind(trade.outcome_index)
-        .execute(pool)
-        .await?;
-
-        inserted += result.rows_affected();
+        batch_keys.insert(key);
+        rows.push(PersistableTrade {
+            trade,
+            side,
+            trade_ts,
+        });
     }
 
+    if rows.is_empty() {
+        return Ok((0, skipped));
+    }
+
+    let mut insert = QueryBuilder::new(
+        r#"
+        INSERT INTO clob_trade_ticks (
+            domain,
+            condition_id,
+            token_id,
+            side,
+            size,
+            price,
+            trade_ts,
+            trade_ts_unix,
+            transaction_hash,
+            proxy_wallet,
+            title,
+            slug,
+            outcome,
+            outcome_index,
+            source,
+            received_at
+        )
+        "#,
+    );
+
+    insert.push_values(rows.iter(), |mut row, item| {
+        row.push_bind("Crypto")
+            .push_bind(item.trade.condition_id.to_string())
+            .push_bind(item.trade.asset.to_string())
+            .push_bind(item.side)
+            .push_bind(item.trade.size)
+            .push_bind(item.trade.price)
+            .push_bind(item.trade_ts)
+            .push_bind(item.trade.timestamp)
+            .push_bind(item.trade.transaction_hash.to_string())
+            .push_bind(item.trade.proxy_wallet.to_string())
+            .push_bind(&item.trade.title)
+            .push_bind(&item.trade.slug)
+            .push_bind(&item.trade.outcome)
+            .push_bind(item.trade.outcome_index)
+            .push_bind("polymarket_data_api")
+            .push_bind(now);
+    });
+    insert.push(" ON CONFLICT DO NOTHING");
+
+    let inserted = insert.build().execute(pool).await?.rows_affected();
+
     Ok((inserted, skipped))
+}
+
+async fn latest_persisted_trade_ts(
+    pool: &PgPool,
+    condition_id: &str,
+) -> Result<Option<i64>, sqlx::Error> {
+    sqlx::query_scalar(
+        r#"
+        SELECT trade_ts_unix
+        FROM clob_trade_ticks
+        WHERE condition_id = $1
+          AND source = 'polymarket_data_api'
+        ORDER BY trade_ts DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(condition_id)
+    .fetch_optional(pool)
+    .await
+}
+
+async fn existing_trade_keys_since(
+    pool: &PgPool,
+    condition_id: &str,
+    min_trade_ts_unix: i64,
+) -> Result<HashSet<String>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, String, String, i64)>(
+        r#"
+            SELECT
+                transaction_hash,
+                token_id,
+                side,
+                trade_ts_unix
+            FROM clob_trade_ticks
+            WHERE condition_id = $1
+              AND source = 'polymarket_data_api'
+              AND trade_ts >= to_timestamp($2)
+            "#,
+    )
+    .bind(condition_id)
+    .bind(min_trade_ts_unix)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(transaction_hash, token_id, side, trade_ts_unix)| {
+            trade_key_parts(&transaction_hash, &token_id, &side, trade_ts_unix)
+        })
+        .collect())
+}
+
+fn seen_trade(
+    latest_seen_trade_ts: Option<i64>,
+    existing_boundary_keys: &HashSet<String>,
+    batch_keys: &HashSet<String>,
+    trade_ts_unix: i64,
+    key: &str,
+) -> bool {
+    if batch_keys.contains(key) {
+        return true;
+    }
+
+    let Some(latest_seen_trade_ts) = latest_seen_trade_ts else {
+        return false;
+    };
+
+    if trade_ts_unix < latest_seen_trade_ts.saturating_sub(TRADE_DEDUPE_OVERLAP_SECS) {
+        return true;
+    }
+
+    trade_ts_unix <= latest_seen_trade_ts && existing_boundary_keys.contains(key)
+}
+
+fn trade_dedupe_key(trade: &Trade, side: &str) -> String {
+    trade_key_parts(
+        &trade.transaction_hash.to_string(),
+        &trade.asset.to_string(),
+        side,
+        trade.timestamp,
+    )
+}
+
+fn trade_key_parts(
+    transaction_hash: &str,
+    token_id: &str,
+    side: &str,
+    trade_ts_unix: i64,
+) -> String {
+    format!("{transaction_hash}|{token_id}|{side}|{trade_ts_unix}")
 }
 
 fn trade_side(side: &Side) -> Option<&'static str> {
@@ -413,11 +539,12 @@ fn stale_for_too_long(last_success_at: Option<DateTime<Utc>>, stale_after_secs: 
 #[cfg(test)]
 mod tests {
     use super::{
-        active_markets_query, trade_side, trade_timestamp, TradeCollectorConfig, DEFAULT_API_LIMIT,
-        DEFAULT_MARKET_LOOKAHEAD_SECS, DEFAULT_MARKET_LOOKBACK_SECS, DEFAULT_REFRESH_INTERVAL_SECS,
-        DEFAULT_STALE_AFTER_SECS, DEFAULT_TRADE_LOOKBACK_SECS,
+        active_markets_query, seen_trade, trade_side, trade_timestamp, TradeCollectorConfig,
+        DEFAULT_API_LIMIT, DEFAULT_MARKET_LOOKAHEAD_SECS, DEFAULT_MARKET_LOOKBACK_SECS,
+        DEFAULT_REFRESH_INTERVAL_SECS, DEFAULT_STALE_AFTER_SECS, DEFAULT_TRADE_LOOKBACK_SECS,
     };
     use polymarket_client_sdk::data::types::Side;
+    use std::collections::HashSet;
 
     #[test]
     fn trade_collector_config_fills_safe_defaults() {
@@ -473,5 +600,42 @@ mod tests {
         assert!(!query.contains("LOWER(market_family)"));
         assert!(!query.contains("COALESCE(end_time"));
         assert!(!query.contains("COALESCE(start_time"));
+    }
+
+    #[test]
+    fn seen_trade_skips_old_and_boundary_duplicates() {
+        let mut existing = HashSet::new();
+        existing.insert("tx|token|BUY|100".to_string());
+        let batch = HashSet::from(["batch|token|BUY|105".to_string()]);
+
+        assert!(seen_trade(
+            Some(105),
+            &existing,
+            &batch,
+            99,
+            "old|token|BUY|99"
+        ));
+        assert!(seen_trade(
+            Some(105),
+            &existing,
+            &batch,
+            100,
+            "tx|token|BUY|100"
+        ));
+        assert!(seen_trade(
+            Some(105),
+            &existing,
+            &batch,
+            105,
+            "batch|token|BUY|105"
+        ));
+        assert!(!seen_trade(
+            Some(105),
+            &existing,
+            &batch,
+            106,
+            "new|token|BUY|106"
+        ));
+        assert!(!seen_trade(None, &existing, &batch, 1, "new|token|BUY|1"));
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14740,3 +14740,25 @@ settlement-probability dry-run config without touching live trading.
   `python3 -m unittest tests.test_apply_autofactor_handoff_to_config tests.test_factor_walk_forward_sweep`,
   `CARGO_TARGET_DIR=/tmp/ploy-sweep-config /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`,
   and `git diff --check`.
+
+# Tango CPU Loading Follow-Up: PM Trade De-Dupe (2026-05-12)
+
+## Goal
+
+Reduce `tango-1-1` CPU/IO load after the Rust collector deployment by stopping
+the Polymarket trade collector from repeatedly persisting the same two-hour
+lookback window.
+
+## Files / Ownership
+
+- `crates/ploy-market-data/src/pm_trades.rs`
+  - Owner: add DB-backed trade cursor filtering and batch inserts.
+
+## Tasks
+
+- [x] Verify the deployed collector and identify the remaining hot path.
+- [x] Confirm remote `clob_trade_ticks` is missing the trade idempotency unique
+  index and is accumulating duplicate rows.
+- [x] Implement collector-side de-dupe and batch persistence.
+- [x] Run focused local Rust checks.
+- [ ] Push PR, merge, deploy from `main`, and verify remote CPU/freshness.


### PR DESCRIPTION
## Summary
- add DB-backed cursor filtering for the Polymarket trade collector so it skips already persisted lookback-window trades
- batch insert new trade rows instead of issuing one INSERT per trade
- document the tango CPU follow-up slice in tasks/todo.md

## Evidence
- remote tango sample before fix: recent 30m clob_trade_ticks had 235796 rows but only 56699 distinct trade keys
- rustfmt --edition 2021 --check crates/ploy-market-data/src/pm_trades.rs
- rtk cargo check --locked --features ops -p ploy-runner-host
- rtk cargo test --locked -p ploy-market-data pm_trades --features live
- rtk git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trade deduplication logic to more accurately identify and prevent duplicate market trades from being stored in the database.

* **Performance**
  * Optimized trade data persistence with improved batch processing for enhanced system efficiency and reduced resource consumption.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->