### PR TITLE
Fix PM5D same-event side guards

### DIFF
--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -901,6 +901,30 @@ impl ThreeLayerStrategy {
         })
     }
 
+    fn event_position_exists(
+        event: &EventWindow,
+        positions: &PositionLedger,
+        selected_token_id: &str,
+    ) -> bool {
+        [event.up_token.as_ref(), event.down_token.as_ref()]
+            .into_iter()
+            .any(|token_id| {
+                token_id != selected_token_id && positions.net_qty(token_id) > Decimal::ZERO
+            })
+    }
+
+    fn event_active_order_exists(
+        event: &EventWindow,
+        orders: &OrderLedger,
+        selected_token_id: &str,
+    ) -> bool {
+        [event.up_token.as_ref(), event.down_token.as_ref()]
+            .into_iter()
+            .any(|token_id| {
+                token_id != selected_token_id && Self::active_order_exists(orders, token_id)
+            })
+    }
+
     fn event_ml_quote(&self, token_id: &str, now: DateTime<Utc>) -> Option<(f64, f64, f64)> {
         let quote = self.quotes.get(token_id)?;
         let bid = quote
@@ -1096,6 +1120,14 @@ impl ThreeLayerStrategy {
         }
         if Self::active_order_exists(orders, token_id) {
             self.bump("skip_active_order");
+            return None;
+        }
+        if Self::event_position_exists(event, positions, token_id) {
+            self.bump("skip_existing_event_position");
+            return None;
+        }
+        if Self::event_active_order_exists(event, orders, token_id) {
+            self.bump("skip_active_event_order");
             return None;
         }
         if self.token_reject_active(token_id, now) {
@@ -1297,6 +1329,14 @@ impl ThreeLayerStrategy {
             }
             if Self::active_order_exists(orders, token_id) {
                 self.bump("skip_active_order");
+                continue;
+            }
+            if Self::event_position_exists(event, positions, token_id) {
+                self.bump("skip_existing_event_position");
+                continue;
+            }
+            if Self::event_active_order_exists(event, orders, token_id) {
+                self.bump("skip_active_event_order");
                 continue;
             }
             if self.token_reject_active(token_id, now) {
@@ -2746,6 +2786,84 @@ mod tests {
     }
 
     #[test]
+    fn opposite_side_position_blocks_same_event_entry() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = position_with_token("token-down", now);
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            decisions.is_empty(),
+            "an existing DOWN position must block a new UP entry in the same event"
+        );
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("skip_existing_event_position"), Some(&1));
+    }
+
+    #[test]
+    fn opposite_side_active_order_blocks_same_event_entry() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = active_order_for_token("token-down", now);
+
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            decisions.is_empty(),
+            "an active DOWN order must block a new UP entry in the same event"
+        );
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("skip_active_event_order"), Some(&1));
+    }
+
+    #[test]
     fn event_ml_runtime_model_selects_best_settlement_edge_side() {
         use chrono::TimeZone;
 
@@ -2795,6 +2913,52 @@ mod tests {
             }
             other => panic!("expected one Event ML executable DOWN entry, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn event_ml_opposite_side_position_blocks_same_event_entry() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_edge = 0.01;
+        config.min_entry_score = -0.50;
+        config.autofactor_runtime_score = Some("event_ml_model:baseline_v1".to_string());
+        config.event_ml_model = Some(event_ml_model_with_intercept(-2.0));
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = position_with_token("token-up", now);
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &entry_quote("token-down", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(
+            decisions.is_empty(),
+            "Event ML must not enter DOWN when the same event already has an UP position"
+        );
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("skip_existing_event_position"), Some(&1));
     }
 
     #[test]

--- a/migrations/041_repair_strategy_track_record_side_residual.sql
+++ b/migrations/041_repair_strategy_track_record_side_residual.sql
@@ -1,0 +1,242 @@
+-- Migration: 041_repair_strategy_track_record_side_residual
+-- Description: Rebuild strategy runtime track-record views so Polymarket
+--              event rows stay token/side-aware while preserving official
+--              settlement residual accounting.
+
+DROP VIEW IF EXISTS strategy_runtime_daily_track_record;
+DROP VIEW IF EXISTS strategy_runtime_event_track_record;
+
+CREATE VIEW strategy_runtime_event_track_record AS
+WITH settlement_prices AS (
+    SELECT
+        token_id,
+        CASE
+            WHEN settled_price >= 0.99 THEN 1.0::NUMERIC
+            WHEN settled_price <= 0.01 THEN 0.0::NUMERIC
+            ELSE settled_price
+        END AS official_price,
+        resolved_at,
+        fetched_at
+    FROM pm_token_settlements
+    WHERE resolved = true
+      AND settled_price IS NOT NULL
+),
+normalized_fills AS (
+    SELECT
+        f.runtime_mode,
+        f.strategy_id,
+        f.deployment_id,
+        COALESCE(NULLIF(f.event_id, ''), f.intent_id) AS trade_key,
+        f.event_id,
+        f.intent_id,
+        f.symbol,
+        f.token_id,
+        f.market_side,
+        f.fill_side,
+        f.quantity,
+        f.price AS recorded_price,
+        sp.official_price AS official_settlement_price,
+        COALESCE(sp.resolved_at, sp.fetched_at) AS official_settlement_at,
+        f.fill_side = 'SELL' AND f.intent_id LIKE '%settle_%' AS is_settlement_exit,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE '%settle_%'
+                AND sp.official_price IS NOT NULL
+            THEN sp.official_price
+            ELSE f.price
+        END AS effective_price,
+        CASE
+            WHEN f.fill_side = 'SELL'
+                AND f.intent_id LIKE '%settle_%'
+                AND sp.official_price IS NOT NULL
+                AND ABS(f.price - sp.official_price) > 0.00000001::NUMERIC
+            THEN true
+            ELSE false
+        END AS settlement_exit_corrected,
+        f.fee,
+        f.fill_timestamp
+    FROM strategy_runtime_fills f
+    LEFT JOIN settlement_prices sp ON sp.token_id = f.token_id
+),
+aggregated AS (
+    SELECT
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        token_id,
+        market_side,
+        MAX(event_id) AS event_id,
+        MIN(intent_id) AS intent_id,
+        MAX(symbol) AS symbol,
+        BOOL_OR(settlement_exit_corrected) AS settlement_exit_corrected,
+        MAX(official_settlement_price) AS official_settlement_price,
+        MAX(official_settlement_at) AS official_settlement_at,
+        MIN(fill_timestamp) AS first_fill_at,
+        MAX(fill_timestamp) AS last_fill_at,
+        MIN(fill_timestamp) FILTER (WHERE fill_side = 'BUY') AS opened_at,
+        MAX(fill_timestamp) FILTER (WHERE fill_side = 'SELL') AS recorded_closed_at,
+        COUNT(*) AS fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'BUY') AS buy_fill_count,
+        COUNT(*) FILTER (WHERE fill_side = 'SELL') AS sell_fill_count,
+        COALESCE(SUM(quantity) FILTER (WHERE fill_side = 'BUY'), 0::NUMERIC) AS buy_quantity,
+        COALESCE(
+            SUM(quantity) FILTER (WHERE fill_side = 'SELL' AND NOT is_settlement_exit),
+            0::NUMERIC
+        ) AS market_sell_quantity,
+        COALESCE(
+            SUM(quantity) FILTER (WHERE fill_side = 'SELL' AND is_settlement_exit),
+            0::NUMERIC
+        ) AS settlement_exit_quantity,
+        COALESCE(
+            SUM(quantity * recorded_price) FILTER (WHERE fill_side = 'SELL'),
+            0::NUMERIC
+        ) AS recorded_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price) FILTER (WHERE fill_side = 'BUY'),
+            0::NUMERIC
+        ) AS buy_notional,
+        COALESCE(
+            SUM(quantity * effective_price)
+                FILTER (WHERE fill_side = 'SELL' AND NOT is_settlement_exit),
+            0::NUMERIC
+        ) AS market_sell_notional,
+        COALESCE(
+            SUM(quantity * effective_price)
+                FILTER (WHERE fill_side = 'SELL' AND is_settlement_exit),
+            0::NUMERIC
+        ) AS settlement_exit_notional,
+        COALESCE(SUM(fee), 0::NUMERIC) AS total_fee
+    FROM normalized_fills
+    GROUP BY
+        runtime_mode,
+        strategy_id,
+        deployment_id,
+        trade_key,
+        token_id,
+        market_side
+),
+computed AS (
+    SELECT
+        a.*,
+        CASE
+            WHEN a.official_settlement_price IS NOT NULL
+             AND a.buy_quantity > a.market_sell_quantity + a.settlement_exit_quantity
+            THEN a.buy_quantity - a.market_sell_quantity - a.settlement_exit_quantity
+            ELSE 0::NUMERIC
+        END AS official_residual_quantity
+    FROM aggregated a
+)
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    trade_key,
+    event_id,
+    intent_id,
+    symbol,
+    token_id,
+    market_side,
+    first_fill_at,
+    last_fill_at,
+    opened_at,
+    CASE
+        WHEN official_residual_quantity > 0 THEN COALESCE(official_settlement_at, recorded_closed_at)
+        ELSE recorded_closed_at
+    END AS closed_at,
+    fill_count,
+    buy_fill_count,
+    sell_fill_count,
+    buy_quantity,
+    market_sell_quantity + settlement_exit_quantity + official_residual_quantity AS sell_quantity,
+    market_sell_quantity + settlement_exit_quantity AS recorded_sell_quantity,
+    settlement_exit_quantity,
+    official_residual_quantity,
+    buy_notional,
+    market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+        AS sell_notional,
+    recorded_sell_notional,
+    total_fee,
+    CASE
+        WHEN buy_quantity > 0 THEN buy_notional / buy_quantity
+        ELSE NULL
+    END AS avg_entry_price,
+    CASE
+        WHEN market_sell_quantity + settlement_exit_quantity > 0
+        THEN recorded_sell_notional / (market_sell_quantity + settlement_exit_quantity)
+        ELSE NULL
+    END AS recorded_exit_price,
+    CASE
+        WHEN settlement_exit_quantity > 0 OR official_residual_quantity > 0
+        THEN official_settlement_price
+        ELSE NULL
+    END AS official_exit_price,
+    CASE
+        WHEN market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        THEN (
+            market_sell_notional
+            + settlement_exit_notional
+            + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+        ) / (market_sell_quantity + settlement_exit_quantity + official_residual_quantity)
+        ELSE NULL
+    END AS avg_exit_price,
+    settlement_exit_corrected OR official_residual_quantity > 0 AS settlement_corrected,
+    buy_quantity > 0
+        AND market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        AND ABS(buy_quantity - (
+            market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        )) <= 0.00000001::NUMERIC AS is_confirmed,
+    (
+        market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+    ) - buy_notional AS gross_pnl,
+    (
+        market_sell_notional
+        + settlement_exit_notional
+        + official_residual_quantity * COALESCE(official_settlement_price, 0::NUMERIC)
+    ) - buy_notional - total_fee AS net_pnl,
+    buy_quantity > 0
+        AND market_sell_quantity + settlement_exit_quantity + official_residual_quantity > 0
+        AND ABS(buy_quantity - (
+            market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        )) <= 0.00000001::NUMERIC AS is_closed,
+    CASE
+        WHEN buy_quantity > market_sell_quantity + settlement_exit_quantity + official_residual_quantity
+        THEN buy_quantity - market_sell_quantity - settlement_exit_quantity - official_residual_quantity
+        ELSE 0::NUMERIC
+    END AS open_quantity
+FROM computed;
+
+CREATE VIEW strategy_runtime_daily_track_record AS
+SELECT
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date AS trading_day_cst,
+    COUNT(*) AS trade_count,
+    COUNT(*) FILTER (WHERE is_closed) AS closed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed) AS confirmed_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND settlement_corrected) AS corrected_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl > 0) AS winning_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND is_confirmed AND net_pnl < 0) AS losing_trade_count,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl > 0) AS winning_trade_count_all,
+    COUNT(*) FILTER (WHERE is_closed AND net_pnl < 0) AS losing_trade_count_all,
+    COALESCE(SUM(buy_notional), 0::NUMERIC) AS total_buy_notional,
+    COALESCE(SUM(sell_notional), 0::NUMERIC) AS total_sell_notional,
+    COALESCE(SUM(recorded_sell_notional), 0::NUMERIC) AS total_recorded_sell_notional,
+    COALESCE(SUM(total_fee), 0::NUMERIC) AS total_fee,
+    COALESCE(SUM(gross_pnl), 0::NUMERIC) AS gross_pnl,
+    COALESCE(SUM(net_pnl), 0::NUMERIC) AS net_pnl,
+    COALESCE(AVG(net_pnl), 0::NUMERIC) AS avg_net_pnl,
+    COALESCE(SUM(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_net_pnl,
+    COALESCE(AVG(net_pnl) FILTER (WHERE is_confirmed), 0::NUMERIC) AS confirmed_avg_net_pnl,
+    COALESCE(SUM(open_quantity), 0::NUMERIC) AS residual_open_quantity
+FROM strategy_runtime_event_track_record
+GROUP BY
+    runtime_mode,
+    strategy_id,
+    deployment_id,
+    (COALESCE(closed_at, last_fill_at) AT TIME ZONE 'Asia/Shanghai')::date;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14768,3 +14768,55 @@ lookback window.
 - [ ] Reduce quote collector CPU by sampling raw orderbook snapshots while
   preserving full-resolution top-of-book quote ticks.
 - [ ] Run focused checks, merge, deploy, and re-sample `tango-1-1` CPU.
+
+# PM5D Same-Event Side Guard Repair (2026-05-12)
+
+## Goal
+
+Keep the paused settlement-probability dry-run in `dry_run_candidate`
+diagnostic mode until runtime and reporting enforce one event, one decision, one
+trade lifecycle for PM5D binary-option events.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: add event-level entry guards for both Event ML and AutoFactor/normal
+    entry paths.
+- `migrations/039_fix_strategy_track_record_side_key.sql`
+  - Owner: keep side-aware grouping without dropping official residual
+    settlement accounting.
+- `migrations/041_repair_strategy_track_record_side_residual.sql`
+  - Owner: re-apply the repaired view on databases that may already have
+    marked migration 039 as applied.
+
+## Tasks
+
+- [x] Add event-level position/order guards before BUY entry decisions.
+- [x] Add focused unit tests for opposite-side position and active-order locks.
+- [x] Repair the side-aware track-record view while preserving official
+      settlement residual fields.
+- [x] Run focused validation and record deployment follow-up blockers.
+
+## Review
+
+- 2026-05-12: Added same-event entry locks to `ThreeLayerStrategy` for both
+  Event ML and normal/AutoFactor BUY paths. Same-token guards still fire first;
+  the new event guards block only the opposite token side and emit
+  `skip_existing_event_position` or `skip_active_event_order`.
+- 2026-05-12: Added migration 041 to rebuild
+  `strategy_runtime_event_track_record` / `strategy_runtime_daily_track_record`
+  with grouping by `runtime_mode, strategy_id, deployment_id, trade_key,
+  token_id, market_side`, while retaining official residual settlement columns
+  such as `recorded_sell_quantity`, `settlement_exit_quantity`,
+  `official_residual_quantity`, `official_exit_price`, `is_confirmed`, and
+  `settlement_corrected`.
+- 2026-05-12: Local validation passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-same-event-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles same_event --lib`
+  (`4 passed, 159 filtered out`) and `git diff --check`. `cargo fmt --check`
+  still reports pre-existing formatting drift in unrelated files, so this slice
+  did not apply broad formatting.
+- Deployment follow-up: keep
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun` paused until this fix
+  is merged, deployed from `main`, migration 041 is applied on `tango-1-1`, the
+  invalid mixed-side post-cutover rows are backed up/cleared, and a fresh dry-run
+  window shows zero same-event UP/DOWN BUY pairs.

--- a/tests/test_dryrun_report_contracts.py
+++ b/tests/test_dryrun_report_contracts.py
@@ -12,6 +12,7 @@ SUMMARY_SCRIPT = ROOT / "scripts" / "report_dryrun_summary.py"
 HTML_SCRIPT = ROOT / "scripts" / "report_strategy.py"
 CHECK_SCRIPT = ROOT / "scripts" / "check_dryrun_report_contract.py"
 SIDE_KEY_MIGRATION = ROOT / "migrations" / "039_fix_strategy_track_record_side_key.sql"
+SIDE_RESIDUAL_REPAIR_MIGRATION = ROOT / "migrations" / "041_repair_strategy_track_record_side_residual.sql"
 
 
 def load_summary_module():
@@ -217,6 +218,29 @@ class DryRunReportContractTests(unittest.TestCase):
 
         self.assertIn("trade_key,\n        token_id,\n        market_side", migration)
         self.assertIn("GROUP BY\n        runtime_mode,\n        strategy_id,\n        deployment_id,\n        trade_key,\n        token_id,\n        market_side", migration)
+
+    def test_migration_versions_are_unique(self) -> None:
+        migration_versions = [
+            path.name.split("_", 1)[0]
+            for path in (ROOT / "migrations").glob("[0-9][0-9][0-9]_*.sql")
+        ]
+
+        duplicates = {
+            version
+            for version in migration_versions
+            if migration_versions.count(version) > 1
+        }
+        self.assertEqual(duplicates, set())
+
+    def test_side_residual_repair_preserves_official_settlement_accounting(self) -> None:
+        migration = SIDE_RESIDUAL_REPAIR_MIGRATION.read_text()
+
+        self.assertIn("041_repair_strategy_track_record_side_residual", migration)
+        self.assertIn("GROUP BY\n        runtime_mode,\n        strategy_id,\n        deployment_id,\n        trade_key,\n        token_id,\n        market_side", migration)
+        self.assertIn("official_residual_quantity", migration)
+        self.assertIn("recorded_sell_quantity", migration)
+        self.assertIn("settlement_exit_quantity", migration)
+        self.assertIn("settlement_corrected", migration)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add event-level opposite-side position/order guards for PM5D three-layer entries
- add migration 041 to rebuild runtime track-record views with token/side grouping while preserving official residual settlement accounting
- add dry-run report contract tests for unique migration versions and side-aware residual accounting

## Verification
- python3 -m unittest tests.test_dryrun_report_contracts
- CARGO_TARGET_DIR=/tmp/ploy-same-event-guard /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles same_event --lib
- git diff --check

## Operational note
Keep pm5d.threelayer.settlement-probability-btc-eth.dryrun paused until this reaches main, migration 041 is applied on tango-1-1, invalid mixed-side rows are cleared, and a fresh window verifies zero same-event UP/DOWN BUY pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event-level side guards to prevent conflicting entry decisions when opposite positions or orders already exist within the same event window.

* **Bug Fixes**
  * Repaired strategy track record reporting views to correctly account for settlement pricing adjustments and residual quantities.

* **Tests**
  * Extended test coverage with new cases verifying side guard logic and settlement accounting accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/453)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->