### PR TITLE
Include PM5D track record migration in tango deploy

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -49,6 +49,7 @@ env:
     039_fix_strategy_track_record_side_key.sql
     038_track_record_official_residual_settlement.sql
     040_polymarket_v2_indexer_events.sql
+    041_repair_strategy_track_record_side_residual.sql
 
 jobs:
   build-and-deploy:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14820,3 +14820,7 @@ trade lifecycle for PM5D binary-option events.
   is merged, deployed from `main`, migration 041 is applied on `tango-1-1`, the
   invalid mixed-side post-cutover rows are backed up/cleared, and a fresh dry-run
   window shows zero same-event UP/DOWN BUY pairs.
+- 2026-05-12: Follow-up deploy packaging check found
+  `.github/workflows/deploy-tango-1-1.yml` did not yet include migration 041 in
+  `DEPLOY_MIGRATIONS`; added a separate workflow-only fix before triggering any
+  tango deploy.


### PR DESCRIPTION
## Summary
- add migration 041 to deploy-tango-1-1 DEPLOY_MIGRATIONS so the side-aware residual track-record view is applied on tango-1-1
- record the deploy packaging follow-up in tasks/todo.md

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'
- python3 inline assertion that migration 041 appears after migration 040
- git diff --check

## Operational note
Do not dispatch tango deploy until this workflow fix reaches main; otherwise migration 041 will not be installed/applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include a database maintenance migration.
  * Updated internal documentation to reflect deployment changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/454)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->