### PR TITLE
Fix recorded replay settlement parity

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -316,8 +316,11 @@ jobs:
                   stripped = raw.strip()
                   if stripped.startswith("mode = "):
                       lines.append('mode = "replay"')
+                      lines.append("skip_settlement_exits = true")
                       lines.append(f'replay_market_updates_from = "{recording}"')
                       inserted_replay_path = True
+                      continue
+                  if stripped.startswith("skip_settlement_exits"):
                       continue
                   if stripped.startswith("record_market_updates_to"):
                       continue

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -5,8 +5,8 @@
 
 use chrono::{DateTime, Utc};
 use ploy_market_contracts::{InstrumentKind, PredictionFamily, VenueKind};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
@@ -87,6 +87,12 @@ pub struct RuntimeSection {
     pub market_data_source: MarketDataSource,
     /// Required when `mode = "replay"`; points at a previously recorded NDJSON log.
     pub replay_market_updates_from: Option<PathBuf>,
+    /// Override settlement-exit submission for parity replays.
+    ///
+    /// Live mode defaults to skipping settlement exits because Polymarket
+    /// settles on-chain. Replay/backtest/dry-run default to preserving strategy
+    /// exits unless this field is explicitly set.
+    pub skip_settlement_exits: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -322,7 +328,10 @@ impl FullConfig {
             mode,
             throttle_hz: self.runtime.throttle_hz,
             max_updates: self.runtime.max_updates,
-            skip_settlement_exits: mode == RuntimeMode::Live,
+            skip_settlement_exits: self
+                .runtime
+                .skip_settlement_exits
+                .unwrap_or(mode == RuntimeMode::Live),
         }
     }
 
@@ -495,6 +504,41 @@ replay_market_updates_from = "captures/dryrun.ndjson"
             config.replay_market_updates_path(),
             Some(Path::new("captures/dryrun.ndjson"))
         );
+    }
+
+    #[test]
+    fn replay_runtime_can_skip_settlement_exits_for_dryrun_parity() {
+        let replay_toml = r#"
+[runtime]
+mode = "replay"
+replay_market_updates_from = "captures/dryrun.ndjson"
+skip_settlement_exits = true
+
+[strategy]
+"#;
+
+        let config = FullConfig::from_toml(replay_toml).unwrap();
+        let runtime = config.runtime_config();
+
+        assert_eq!(runtime.mode, RuntimeMode::Replay);
+        assert!(runtime.skip_settlement_exits);
+    }
+
+    #[test]
+    fn replay_runtime_preserves_settlement_exits_by_default() {
+        let replay_toml = r#"
+[runtime]
+mode = "replay"
+replay_market_updates_from = "captures/dryrun.ndjson"
+
+[strategy]
+"#;
+
+        let config = FullConfig::from_toml(replay_toml).unwrap();
+        let runtime = config.runtime_config();
+
+        assert_eq!(runtime.mode, RuntimeMode::Replay);
+        assert!(!runtime.skip_settlement_exits);
     }
 
     #[test]
@@ -765,7 +809,7 @@ venue = "sportsbook"
     #[test]
     fn settlement_probability_config_carries_autofactor_handoff_score() {
         use crate::strategies::three_layer_model::{
-            AutoSettlementFactorInputs, auto_settlement_formula_score,
+            auto_settlement_formula_score, AutoSettlementFactorInputs,
         };
 
         let path = strategy_config_dir()

--- a/scripts/enrich_replay_runtime_evidence.py
+++ b/scripts/enrich_replay_runtime_evidence.py
@@ -83,8 +83,13 @@ def runtime_rows_by_intent(payload: dict[str, Any], row_name: str) -> dict[str, 
     return indexed
 
 
-def event_cashflow_by_event_token(payload: dict[str, Any]) -> dict[tuple[str, str], str]:
+def event_cashflow_by_event_token(
+    payload: dict[str, Any],
+    prices: dict[tuple[str, str], str],
+) -> dict[tuple[str, str], str]:
     totals: dict[tuple[str, str], Decimal] = {}
+    buy_quantities: dict[tuple[str, str], Decimal] = {}
+    has_sell_fill: set[tuple[str, str]] = set()
     runtime = payload.get("runtime_evidence") or {}
     fills = runtime.get("fills") or []
     if not isinstance(fills, list):
@@ -106,24 +111,41 @@ def event_cashflow_by_event_token(payload: dict[str, Any]) -> dict[tuple[str, st
         except InvalidOperation:
             continue
         side = str(fill.get("fill_side") or fill.get("side") or "").upper()
+        key = (str(event_id), str(token_id))
         signed = quantity * price
         if side == "BUY":
             signed = -signed
+            buy_quantities[key] = buy_quantities.get(key, Decimal("0")) + quantity
         elif side != "SELL":
             continue
-        key = (str(event_id), str(token_id))
+        else:
+            has_sell_fill.add(key)
         totals[key] = totals.get(key, Decimal("0")) + signed - fee
+    for key, settlement in prices.items():
+        if key in has_sell_fill:
+            continue
+        buy_quantity = buy_quantities.get(key)
+        if buy_quantity is None:
+            continue
+        try:
+            settlement_price = Decimal(str(settlement))
+        except InvalidOperation:
+            continue
+        totals[key] = totals.get(key, Decimal("0")) + buy_quantity * settlement_price
     return {key: format(value.normalize(), "f") for key, value in totals.items()}
 
 
-def backfill_replay_event_identity(payload: dict[str, Any]) -> int:
+def backfill_replay_event_identity(
+    payload: dict[str, Any],
+    prices: dict[tuple[str, str], str],
+) -> int:
     runtime = payload.get("runtime_evidence") or {}
     events = runtime.get("events") or []
     if not isinstance(events, list):
         return 0
     fills_by_intent = runtime_rows_by_intent(payload, "fills")
     orders_by_intent = runtime_rows_by_intent(payload, "orders")
-    cashflow_by_event_token = event_cashflow_by_event_token(payload)
+    cashflow_by_event_token = event_cashflow_by_event_token(payload, prices)
     changed = 0
 
     for event in events:
@@ -170,7 +192,7 @@ def backfill_replay_event_identity(payload: dict[str, Any]) -> int:
 
 
 def enrich_payload(payload: dict[str, Any], prices: dict[tuple[str, str], str]) -> dict[str, int]:
-    backfilled = backfill_replay_event_identity(payload)
+    backfilled = backfill_replay_event_identity(payload, prices)
     events = ((payload.get("runtime_evidence") or {}).get("events") or [])
     stats = {
         "runtime_events": 0,

--- a/tasks/research_evidence/pm5d_hosted_alpha_search_continuation_20260512.md
+++ b/tasks/research_evidence/pm5d_hosted_alpha_search_continuation_20260512.md
@@ -1,0 +1,137 @@
+# Research Evidence: PM5D Hosted Alpha Search Continuation - 2026-05-12
+
+## Decision
+
+Status: `revise`
+
+One-line decision: Hosted alpha search found and extended candidate settlement
+factors, but no candidate is promotable because the latest recorded replay
+parity artifact blocks dry-run handoff.
+
+## Semantic Context
+
+- Strategy lane: `settlement_probability`
+- Evidence stage: `factor_attribution | walk_forward`
+- Lifecycle segment tested: `signal | pnl`
+- Promotion target, if any: `none`
+
+## Hypothesis
+
+- Claim: Prior PM5D settlement/liquidity factors can be reused as typed
+  alpha-search priors, then expanded by MCTS-guided mutations to find stronger
+  settlement-probability factors for BTC/ETH five-minute Polymarket events.
+- Expected edge mechanism: Estimate settlement probability and only prefer a
+  side when the settlement edge survives executable entry price, full-depth
+  fillability, spread/capacity penalties, and event geometry gates.
+- Failure criteria: No positive walk-forward candidates, reward stagnation,
+  missing search artifacts, blocked promotion gate, replay/runtime mismatch, or
+  candidate complexity increasing faster than robustness.
+- Next decision this evidence should unlock: Fix replay/runtime parity before
+  any dry-run promotion; keep `auto_settlement_conservative_settlement_edge`
+  and the near-strike MCTS variants as research candidates only.
+
+## Inputs
+
+- Git ref: `main@d4f9ff48`
+- Workflow runs:
+  - `25722101811`: failed pre-research because `end_date=2026-05-01` resolved
+    outside the snapshot window.
+  - `25722193283`: successful hosted alpha-search continuation.
+  - `25722317462`: successful chained alpha-search follow-up.
+- Snapshot or artifact:
+  - `research-snapshot-25642459432`
+  - `recorded-replay-parity-25714741551`
+  - prior MCTS artifact `factor-walk-forward-v2-25707061616`
+- Dataset/window: `2026-04-24T00:00:00Z -> 2026-05-01T00:00:00Z`
+- Symbols/events: `BTCUSDT,ETHUSDT` PM5D events
+- Config: `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`
+- Local/remote artifact paths:
+  - `/tmp/ploy-alpha-25722193283`
+  - `/tmp/ploy-alpha-25722317462`
+  - GitHub Actions artifact `factor-walk-forward-v2-25722193283`
+  - GitHub Actions artifact `factor-walk-forward-v2-25722317462`
+
+## Data Surface Audit
+
+- Binance spot/trade ticks: `present`
+- Binance L2/LOB: `present`
+- Polymarket quote ticks: `present`
+- Polymarket full CLOB depth: `present`
+- Official settlement: `present`
+- Runtime/dry-run fills: `present for parity artifact, but mismatched`
+- Data audit status: `caveated`
+- Missing surfaces and impact: No missing research snapshot surface blocked the
+  walk-forward runs. Promotion is blocked because the latest replay parity
+  artifact reports runtime/dry-run lifecycle mismatch.
+
+## Accounting Semantics
+
+- Event accounting: `one-event-one-trade`
+- Entry price model: fixed `stake_usd=15` with executable full-depth settlement
+  target `full_depth_settlement_executable_pnl`
+- Exit or settlement label: official settlement target in the retained research
+  snapshot
+- Fillability assumption: full-depth executable settlement PnL target with
+  event-complete data quality
+- Fees/slippage/latency assumption: encoded in the factor walk-forward target
+  and promotion evaluator; no live queue-position proof
+- Capacity or stake assumption: `stake_usd=15`
+
+## Results
+
+- Headline metrics:
+  - Run `25722193283`: `237` candidates, `71` passed, best factor
+    `mcts_mcts_auto_settlement_conservative_settlement_edge_x_near_strike_near_strike_near_strike`,
+    best reward `4.894975850946932`, handoff `blocked`.
+  - Run `25722317462`: `193` candidates, `38` passed, best factor
+    `auto_settlement_conservative_settlement_edge`, best reward
+    `4.81954070569323`, handoff `blocked`.
+- Stability metrics: The best factors report positive-window ratio `1.0` on
+  this retained walk-forward window, but this is still one artifact window and
+  must not be treated as production stability.
+- Calibration or bucket behavior: Best first-run candidate had top-bucket
+  average label `2.6722902978466125`; the simpler conservative settlement edge
+  had top-bucket average label `2.1543761988825487`.
+- Fill rate/capacity: Evaluated through the full-depth settlement executable
+  PnL target; runtime/dry-run fill parity remains blocked.
+- PnL/ROI: Reward and top-bucket labels are discovery metrics, not executable
+  strategy PnL.
+- Drawdown/risk: Not sufficient for promotion in this evidence stage.
+
+## Promotion Gate Check
+
+- Hypothesis explicit: `pass`
+- Data provenance recorded: `pass`
+- Executable pricing conservative: `pass`
+- Settlement/exit label matches lane: `pass`
+- Walk-forward or leakage guard: `pass`
+- Replay/runtime parity: `fail`
+- Runtime scorer/config mapping: `caveated`
+- Risk/stake/kill switch stated: `caveated`
+
+## Caveats
+
+- Both successful runs were blocked by:
+  `recorded_replay_parity: runtime_ready=false event_ready=true
+  blocking_flags=events_present_in_replay_missing_from_dryrun|orders_present_in_replay_missing_from_dryrun|fills_present_in_replay_missing_from_dryrun
+  decision=fix-data-or-runtime-mismatch`.
+- The first successful run improved best reward from the prior `4.81954070569323`
+  to `4.894975850946932`, but the best factor is a high-complexity repeated
+  near-strike MCTS mutation with lower runtime readiness than the simple
+  conservative settlement edge.
+- The chained follow-up stopped with `reward_stagnation`: current best reward
+  `4.81954070569323` was below previous best `4.894975850946932`.
+- Search feedback explicitly states that alpha-search evidence is discovery
+  evidence only; promotion still requires AutoFactor promotion gate and
+  replay/runtime parity.
+
+## Follow-Up
+
+- Fix recorded replay parity for the settlement-probability dry-run lane before
+  promoting any candidate.
+- After parity is ready, rerun hosted alpha search with the same retained
+  snapshot plus a fresh parity artifact, then require `autofactor-strategy-handoff.json`
+  status `ready`.
+- Prefer the simpler `auto_settlement_conservative_settlement_edge` for runtime
+  handoff unless repeated near-strike variants prove incremental value across
+  additional windows without excessive complexity.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,111 @@
+# Recorded Replay Parity Settlement Lifecycle Fix (2026-05-12)
+
+## Goal
+
+Fix the current recorded replay/dry-run parity blocker for the PM5D
+settlement-probability lane: replay creates settlement SELL exits and later
+extra entries, while the dry-run report represents settlement through
+event-level track records and does not persist matching settlement SELL
+orders/fills for the sampled window.
+
+## Plan
+
+- [x] Read `docs/PROJECT_SEMANTICS.md`; current evidence stage is
+  `runtime_parity`.
+- [x] Reproduce the blocker from run `25714741551` artifacts and identify the
+  exact missing rows.
+- [x] Identify root cause: replay starts from an empty state and currently
+  records synthetic settlement exits, which frees positions and creates extra
+  replay-only entries not present in dry-run evidence.
+- [x] Add a runtime config switch so the recorded parity workflow can make
+  replay skip settlement exit orders.
+- [x] Backfill replay event-level settlement PnL from official settlement when
+  synthetic settlement exits are skipped.
+- [x] Add focused tests for the no-settlement-exit parity path.
+- [x] Validate focused tests.
+- [ ] Land the fix on `main`, then dispatch a fresh recorded replay parity run
+  from `main` after the fix lands.
+
+## Review
+
+- 2026-05-12: Run `25714741551` had 4 shared entry rows that matched exactly,
+  plus 6 replay-only rows: 4 settlement SELL exits and 2 later entries. The
+  later entries are a consequence of replay freeing positions through synthetic
+  settlement exits while the dry-run report did not persist those exit
+  orders/fills.
+- 2026-05-12: Added `[runtime].skip_settlement_exits` override support and made
+  `recorded-replay-parity.yml` inject `skip_settlement_exits = true` into the
+  generated replay config. Replay remains settlement-aware through event-level
+  enrichment instead of synthetic settlement SELL order/fill rows.
+- 2026-05-12: Updated replay evidence enrichment so official settlement can
+  compute event-level PnL for BUY entries when no synthetic settlement SELL fill
+  exists.
+- 2026-05-12: Verification passed:
+  `python3 -m unittest tests.test_enrich_replay_runtime_evidence
+  tests.test_replay_dryrun_parity tests.test_extract_dryrun_settlement_evidence`,
+  `python3 -m py_compile scripts/enrich_replay_runtime_evidence.py
+  scripts/replay_dryrun_parity.py scripts/extract_dryrun_settlement_evidence.py`,
+  YAML parse for `.github/workflows/recorded-replay-parity.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-parity-settlement-lifecycle
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p
+  ploy-strategy-bundles config::tests::replay_runtime --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-parity-workflow-security
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test
+  workflow_security recorded_replay_parity_supports_auto_window`, `rustfmt
+  --edition 2021 --check crates/ploy-strategy-bundles/src/config.rs`, and
+  `rtk git diff --check`.
+
+# PM5D Hosted Alpha Search Continuation (2026-05-12)
+
+## Goal
+
+Continue systematic PM5D alpha discovery on GitHub-hosted artifact workflows
+after the quote freshness fix landed on `main`, while keeping promotion blocked
+until fresh recorded replay/runtime parity is ready.
+
+## Plan
+
+- [x] Re-read `docs/PROJECT_SEMANTICS.md` and
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`; current evidence stage is
+  `factor_attribution` / `walk_forward`, not live promotion.
+- [x] Confirm existing candidate status: `auto_settlement_conservative_settlement_edge`
+  is a candidate factor/handoff from prior hosted search, but not a verified
+  profitable strategy because latest parity is blocked.
+- [x] Verify quote freshness fix is present on `origin/main`.
+- [x] Dispatch a GitHub-hosted artifact alpha-search continuation from `main`
+  using the typed PM5D settlement/liquidity prior and retained snapshot.
+- [x] Monitor the workflow, download the resulting artifacts, and summarize
+  candidate count, passed count, best factor, handoff status, and caveats.
+- [x] Record whether the next action is `continue`, `revise`, `reject`, or
+  `promote to dry-run` under the repo semantic gates.
+
+## Review
+
+- 2026-05-12: Existing dry-run profitability evidence remains underpowered and
+  blocked by recorded replay parity mismatch. New search runs may find better
+  factors, but they cannot become dry-run/live promotion evidence until parity
+  is fixed.
+- 2026-05-12: Dispatched hosted workflow run `25722101811` from `main` with
+  snapshot `25642459432`, latest parity artifact
+  `recorded-replay-parity-25714741551`, typed prior
+  `tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json`,
+  prior MCTS artifact `factor-walk-forward-v2-25707061616`, BTC/ETH, and
+  `full_depth_settlement_executable_pnl`.
+- 2026-05-12: Run `25722101811` failed before research because the workflow
+  treats `end_date` as inclusive; `2026-05-01` resolved to
+  `2026-05-02T00:00Z`, outside snapshot `25642459432`. Re-dispatch with
+  `end_date=2026-04-30` for the same exclusive `2026-05-01T00:00Z` window.
+- 2026-05-12: Re-dispatched corrected hosted workflow as run `25722193283`.
+- 2026-05-12: Run `25722193283` succeeded and improved best reward to
+  `4.894975850946932` with `237` candidates and `71` passed; best factor was
+  `mcts_mcts_auto_settlement_conservative_settlement_edge_x_near_strike_near_strike_near_strike`.
+  Handoff remained `blocked` by latest replay/runtime parity.
+- 2026-05-12: Chained run `25722317462` succeeded, then stopped with
+  `reward_stagnation`; best factor reverted to
+  `auto_settlement_conservative_settlement_edge`, `193` candidates, `38`
+  passed, handoff `blocked`. Evidence recorded in
+  `tasks/research_evidence/pm5d_hosted_alpha_search_continuation_20260512.md`.
+
 # PM5D Quote Freshness And Hosted Evidence Correction (2026-05-12)
 
 ## Goal

--- a/tests/test_enrich_replay_runtime_evidence.py
+++ b/tests/test_enrich_replay_runtime_evidence.py
@@ -168,6 +168,51 @@ class EnrichReplayRuntimeEvidenceTests(unittest.TestCase):
         self.assertEqual(report["runtime_events_settlement_enriched"], 1)
         self.assertGreaterEqual(report["runtime_events_identity_backfilled"], 8)
 
+    def test_backfills_settlement_pnl_without_synthetic_sell_fill(self):
+        payload = {
+            "runtime_evidence": {
+                "events": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "token_id": "token-up",
+                        "decision_ts": None,
+                        "event_id": None,
+                        "market_id": None,
+                        "side": "UNKNOWN",
+                        "settlement": "open",
+                        "pnl": "-15.1080000000",
+                    }
+                ],
+                "orders": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "created_at": None,
+                    }
+                ],
+                "fills": [
+                    {
+                        "intent_id": "tl_btcusdt_up_2221812_1778500092316",
+                        "token_id": "token-up",
+                        "fill_side": "BUY",
+                        "quantity": "23.4375",
+                        "price": "0.64",
+                        "fee": "0.1080000000",
+                        "fill_timestamp": "2026-05-11T11:48:12.316Z",
+                    }
+                ],
+            }
+        }
+        output, report = self.run_script(
+            payload,
+            [{"event_id": "2221812", "token_id": "token-up", "settlement": "1.00000000000000000000"}],
+        )
+
+        event = output["runtime_evidence"]["events"][0]
+        self.assertEqual(event["event_id"], "2221812")
+        self.assertEqual(event["settlement"], "1.00000000000000000000")
+        self.assertEqual(event["pnl"], "8.3295")
+        self.assertEqual(report["runtime_events_settlement_enriched"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -268,6 +268,7 @@ fn recorded_replay_parity_supports_auto_window() {
         "LIMIT 20",
         "resolved-window.json",
         "resolved-window.env",
+        "skip_settlement_exits = true",
         "RESOLVED_SINCE",
         "RESOLVED_UNTIL",
         "Requested window",


### PR DESCRIPTION
## Summary
- add an explicit runtime skip_settlement_exits override for recorded replay parity
- make recorded-replay-parity replay configs skip synthetic settlement exits
- backfill replay event-level settlement PnL from official settlement when no synthetic SELL fill exists
- record hosted alpha-search evidence and parity root-cause notes

## Verification
- python3 -m unittest tests.test_enrich_replay_runtime_evidence tests.test_replay_dryrun_parity tests.test_extract_dryrun_settlement_evidence
- python3 -m py_compile scripts/enrich_replay_runtime_evidence.py scripts/replay_dryrun_parity.py scripts/extract_dryrun_settlement_evidence.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/recorded-replay-parity.yml"); puts "yaml ok"'
- CARGO_TARGET_DIR=/tmp/ploy-parity-settlement-lifecycle /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles config::tests::replay_runtime --lib
- CARGO_TARGET_DIR=/tmp/ploy-parity-workflow-security /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security recorded_replay_parity_supports_auto_window
- rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/config.rs
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skip_settlement_exits` configuration option for controlling synthetic settlement exit handling during replay mode.

* **Bug Fixes**
  * Fixed replay parity lifecycle mismatch where synthetic settlement exits were causing discrepancies between replay and dry-run execution.
  * Improved PnL enrichment computation during replay by incorporating settlement price data.

* **Documentation**
  * Added research evidence documenting a promotion blocker related to replay/runtime parity issues requiring resolution.

* **Tests**
  * Extended test coverage for settlement exit behavior and PnL backfilling in replay scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->