### PR TITLE
Fix recorded replay auto window selection

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -99,6 +99,10 @@ jobs:
             tango-1-1:"${REMOTE_DIR}/enrich_replay_runtime_evidence.py"
           scp scripts/extract_dryrun_settlement_evidence.py \
             tango-1-1:"${REMOTE_DIR}/extract_dryrun_settlement_evidence.py"
+          scp scripts/replay_dryrun_parity.py \
+            tango-1-1:"${REMOTE_DIR}/replay_dryrun_parity.py"
+          scp scripts/resolve_recorded_replay_window.py \
+            tango-1-1:"${REMOTE_DIR}/resolve_recorded_replay_window.py"
 
           # shellcheck disable=SC2029
           ssh tango-1-1 /bin/bash -s -- \
@@ -123,6 +127,8 @@ jobs:
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
           test -r "${remote_dir}/enrich_replay_runtime_evidence.py"
           test -r "${remote_dir}/extract_dryrun_settlement_evidence.py"
+          test -r "${remote_dir}/replay_dryrun_parity.py"
+          test -r "${remote_dir}/resolve_recorded_replay_window.py"
 
           set -a
           . /opt/ploy/.env
@@ -149,58 +155,12 @@ jobs:
           fi
 
           if [ "${auto_window}" = true ]; then
-            "${PSQL[@]}" \
-              -v deployment_id="${deployment_id}" \
-              > "${resolved_window_json}" <<'SQL'
-          WITH recent_closed AS (
-            SELECT
-              opened_at,
-              COALESCE(closed_at, last_fill_at, opened_at) AS evidence_at
-            FROM strategy_runtime_event_track_record
-            WHERE runtime_mode IN ('dry_run', 'dryrun')
-              AND deployment_id = :'deployment_id'
-              AND is_closed
-              AND opened_at IS NOT NULL
-            ORDER BY COALESCE(closed_at, last_fill_at, opened_at) DESC
-            LIMIT 20
-          ),
-          bounds AS (
-            SELECT
-              MIN(opened_at) - INTERVAL '60 seconds' AS since_ts,
-              MAX(evidence_at) + INTERVAL '60 seconds' AS until_ts,
-              COUNT(*) AS closed_row_count
-            FROM recent_closed
-          )
-          SELECT jsonb_build_object(
-            'mode', 'auto',
-            'closed_row_count', closed_row_count,
-            'since', to_char(since_ts AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-            'until', to_char(until_ts AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
-          )::text
-          FROM bounds
-          WHERE closed_row_count > 0;
-          SQL
-            test -s "${resolved_window_json}"
-            python3 - "${resolved_window_json}" "${resolved_window_env}" <<'PY'
-          import json
-          import sys
-
-          source, dest = sys.argv[1:]
-          text = open(source, encoding="utf-8").read().strip()
-          if not text:
-              raise SystemExit("auto parity window found no closed dry-run rows")
-          payload = json.loads(text)
-          since = payload.get("since")
-          until = payload.get("until")
-          row_count = int(payload.get("closed_row_count") or 0)
-          if not since or not until or row_count <= 0:
-              raise SystemExit(f"invalid auto parity window: {payload}")
-          with open(dest, "w", encoding="utf-8") as handle:
-              handle.write(f"RESOLVED_SINCE={since}\n")
-              handle.write(f"RESOLVED_UNTIL={until}\n")
-              handle.write(f"RESOLVED_WINDOW_MODE=auto\n")
-              handle.write(f"RESOLVED_CLOSED_ROW_COUNT={row_count}\n")
-          PY
+            python3 "${remote_dir}/resolve_recorded_replay_window.py" \
+              --recording "${recording_path}" \
+              --dryrun-json "${dryrun_report}" \
+              --deployment-id "${deployment_id}" \
+              --output-json "${resolved_window_json}" \
+              --output-env "${resolved_window_env}"
             # shellcheck disable=SC1090
             . "${resolved_window_env}"
             since_ts="${RESOLVED_SINCE}"

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -61,11 +61,12 @@ mismatch is understood and tracked as a follow-up issue.
 | Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
 
 `recorded-replay-parity.yml` defaults `since=auto` and `until=auto`. In auto
-mode it queries the target dry-run deployment on `tango-1-1`, selects the most
-recent closed dry-run track-record rows, and records the resolved window in the
-workflow summary, issue comment, and `resolved-window.json` artifact. Manual
-timestamps remain supported for reproducing a known incident window or an older
-research issue.
+mode it scans the target recording on `tango-1-1`, intersects that recording
+coverage with the dry-run report for the target deployment, prefers the latest
+closed dry-run rows when available, and falls back to current open rows when a
+fresh recording has not yet accumulated closed events. The workflow records the resolved window in the workflow summary, issue comment, and
+`resolved-window.json` artifact. Manual timestamps remain supported for
+reproducing a known incident window or an older research issue.
 
 ## Research Issue Contract
 

--- a/scripts/resolve_recorded_replay_window.py
+++ b/scripts/resolve_recorded_replay_window.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Resolve a recorded replay parity window from recording and dry-run evidence.
+
+The recorded replay parity workflow replays a bounded MarketUpdate recording.
+After runtime restarts, that recording may only cover the new process window
+while the dry-run report still contains older closed rows. This helper selects
+the latest dry-run evidence rows that actually overlap the recording coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from replay_dryrun_parity import (
+    extract_runtime_events,
+    extract_runtime_fills,
+    extract_runtime_orders,
+    load_json,
+    normalize_text,
+    parse_timestamp,
+)
+
+
+WINDOW_PAD = timedelta(seconds=60)
+
+
+def update_timestamps(record: dict[str, Any]) -> list[datetime]:
+    timestamps: list[datetime] = []
+    for key in ("recorded_at", "timestamp", "ts"):
+        parsed = parse_timestamp(record.get(key))
+        if parsed is not None:
+            timestamps.append(parsed)
+
+    update = record.get("update")
+    if isinstance(update, dict):
+        for key in ("ts", "timestamp", "start_time", "end_time"):
+            parsed = parse_timestamp(update.get(key))
+            if parsed is not None:
+                timestamps.append(parsed)
+    return timestamps
+
+
+def recording_bounds(path: Path) -> dict[str, Any]:
+    min_ts: datetime | None = None
+    max_ts: datetime | None = None
+    records = 0
+    with path.open(encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{line_number}: invalid NDJSON: {exc}") from exc
+            if not isinstance(record, dict):
+                continue
+            records += 1
+            for ts in update_timestamps(record):
+                min_ts = ts if min_ts is None or ts < min_ts else min_ts
+                max_ts = ts if max_ts is None or ts > max_ts else max_ts
+    if min_ts is None or max_ts is None:
+        raise SystemExit(f"{path}: no parseable recording timestamps found")
+    return {"records": records, "min_ts": min_ts, "max_ts": max_ts}
+
+
+def row_ts(row: dict[str, Any]) -> datetime | None:
+    for key in ("decision_ts", "created_at", "fill_timestamp", "opened_at", "timestamp"):
+        parsed = parse_timestamp(row.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def row_closed(row: dict[str, Any]) -> bool:
+    settlement = normalize_text(row.get("settlement"), upper=True)
+    status = normalize_text(row.get("status"), upper=True)
+    fill_status = normalize_text(row.get("fill_status"), upper=True)
+    return bool(
+        settlement
+        and settlement != "OPEN"
+        or status in {"CLOSED", "SETTLED"}
+        or fill_status in {"CLOSED", "SETTLED"}
+    )
+
+
+def candidate_rows(report: Any, deployment_id: str, start: datetime, end: datetime) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for source, extracted in (
+        ("event", extract_runtime_events(report)),
+        ("order", extract_runtime_orders(report)),
+        ("fill", extract_runtime_fills(report)),
+    ):
+        for row in extracted:
+            if normalize_text(row.get("deployment_id")) != deployment_id:
+                continue
+            ts = row_ts(row)
+            if ts is None or ts < start or ts > end:
+                continue
+            key = (source, normalize_text(row.get("intent_id")) or normalize_text(row.get("event_id")) or ts.isoformat())
+            if key in seen:
+                continue
+            seen.add(key)
+            enriched = dict(row)
+            enriched["_source"] = source
+            enriched["_ts"] = ts
+            rows.append(enriched)
+    return rows
+
+
+def iso(ts: datetime) -> str:
+    return ts.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def resolve_window(
+    *,
+    recording_path: Path,
+    dryrun_report_path: Path,
+    deployment_id: str,
+    max_rows: int,
+) -> dict[str, Any]:
+    bounds = recording_bounds(recording_path)
+    recording_start = bounds["min_ts"] - WINDOW_PAD
+    recording_end = bounds["max_ts"] + WINDOW_PAD
+    report = load_json(dryrun_report_path)
+    rows = candidate_rows(report, deployment_id, recording_start, recording_end)
+    if not rows:
+        raise SystemExit(
+            "no dry-run runtime evidence rows overlap recording coverage "
+            f"{iso(recording_start)} -> {iso(recording_end)} for {deployment_id}"
+        )
+
+    closed_rows = [row for row in rows if row_closed(row)]
+    selected_pool = closed_rows if closed_rows else rows
+    selected = sorted(selected_pool, key=lambda row: row["_ts"], reverse=True)[:max_rows]
+    min_selected = min(row["_ts"] for row in selected)
+    max_selected = max(row["_ts"] for row in selected)
+    since = min_selected - WINDOW_PAD
+    until = max_selected + WINDOW_PAD
+
+    return {
+        "mode": "auto_recording_intersection",
+        "recording": {
+            "records": bounds["records"],
+            "since": iso(bounds["min_ts"]),
+            "until": iso(bounds["max_ts"]),
+        },
+        "selected_row_count": len(selected),
+        "selected_closed_row_count": len([row for row in selected if row_closed(row)]),
+        "selected_sources": sorted({str(row.get("_source")) for row in selected}),
+        "since": iso(since),
+        "until": iso(until),
+    }
+
+
+def write_env(path: Path, window: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(f"RESOLVED_SINCE={window['since']}\n")
+        handle.write(f"RESOLVED_UNTIL={window['until']}\n")
+        handle.write(f"RESOLVED_WINDOW_MODE={window['mode']}\n")
+        handle.write(f"RESOLVED_CLOSED_ROW_COUNT={window['selected_closed_row_count']}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--recording", required=True)
+    parser.add_argument("--dryrun-json", required=True)
+    parser.add_argument("--deployment-id", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-env", required=True)
+    parser.add_argument("--max-rows", type=int, default=20)
+    args = parser.parse_args()
+
+    window = resolve_window(
+        recording_path=Path(args.recording),
+        dryrun_report_path=Path(args.dryrun_json),
+        deployment_id=args.deployment_id,
+        max_rows=args.max_rows,
+    )
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with output_json.open("w", encoding="utf-8") as handle:
+        json.dump(window, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    write_env(Path(args.output_env), window)
+    print(json.dumps(window, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,7 +23,7 @@ orders/fills for the sampled window.
   synthetic settlement exits are skipped.
 - [x] Add focused tests for the no-settlement-exit parity path.
 - [x] Validate focused tests.
-- [ ] Land the fix on `main`, then dispatch a fresh recorded replay parity run
+- [x] Land the fix on `main`, then dispatch a fresh recorded replay parity run
   from `main` after the fix lands.
 
 ## Review
@@ -54,6 +54,16 @@ orders/fills for the sampled window.
   workflow_security recorded_replay_parity_supports_auto_window`, `rustfmt
   --edition 2021 --check crates/ploy-strategy-bundles/src/config.rs`, and
   `rtk git diff --check`.
+- 2026-05-12: PR #458 merged to `main` as `f8a9ef5f`; fresh recorded replay
+  parity run `25735155294` completed from `main`, but remains blocked:
+  `decision=fix-data-or-runtime-mismatch`,
+  `runtime_evidence_comparison.strict_parity_ready=false`, shared
+  orders/fills/events `4`, and blocking flags still include replay/dry-run
+  missing rows. The new evidence shows the workflow generated a replay config
+  with `skip_settlement_exits = true`, but it still ran the currently deployed
+  `/opt/ploy/bin/ploy-runner`; that deployed binary emitted `tl_settle_*` SELL
+  rows and 12 intents/fills, so the next required action is to deploy the
+  CI-built `main` runner to `tango-1-1` and rerun recorded replay parity.
 
 # PM5D Hosted Alpha Search Continuation (2026-05-12)
 

--- a/tests/test_resolve_recorded_replay_window.py
+++ b/tests/test_resolve_recorded_replay_window.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "resolve_recorded_replay_window.py"
+
+
+def write_ndjson(path, rows):
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+class ResolveRecordedReplayWindowTests(unittest.TestCase):
+    def run_script(self, recording_rows, dryrun_payload):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            recording = tmp_path / "recording.ndjson"
+            dryrun = tmp_path / "dryrun.json"
+            output = tmp_path / "window.json"
+            env = tmp_path / "window.env"
+            write_ndjson(recording, recording_rows)
+            dryrun.write_text(json.dumps(dryrun_payload), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--recording",
+                    str(recording),
+                    "--dryrun-json",
+                    str(dryrun),
+                    "--deployment-id",
+                    "pm5d.test",
+                    "--output-json",
+                    str(output),
+                    "--output-env",
+                    str(env),
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return json.loads(output.read_text(encoding="utf-8")), env.read_text(encoding="utf-8")
+
+    def test_prefers_closed_rows_inside_recording_coverage(self):
+        window, env = self.run_script(
+            [
+                {
+                    "recorded_at": "2026-05-12T13:00:00Z",
+                    "update": {"kind": "quote", "ts": "2026-05-12T13:00:00Z"},
+                },
+                {
+                    "recorded_at": "2026-05-12T13:10:00Z",
+                    "update": {"kind": "event_expired", "end_time": "2026-05-12T13:10:00Z"},
+                },
+            ],
+            {
+                "runtime_evidence": {
+                    "events": [
+                        {
+                            "deployment_id": "pm5d.test",
+                            "intent_id": "old",
+                            "decision_ts": "2026-05-12T12:00:00Z",
+                            "settlement": "0",
+                        },
+                        {
+                            "deployment_id": "pm5d.test",
+                            "intent_id": "closed",
+                            "decision_ts": "2026-05-12T13:05:00Z",
+                            "settlement": "1",
+                        },
+                        {
+                            "deployment_id": "pm5d.test",
+                            "intent_id": "open",
+                            "decision_ts": "2026-05-12T13:06:00Z",
+                            "settlement": "open",
+                        },
+                    ]
+                }
+            },
+        )
+
+        self.assertEqual(window["mode"], "auto_recording_intersection")
+        self.assertEqual(window["selected_row_count"], 1)
+        self.assertEqual(window["selected_closed_row_count"], 1)
+        self.assertEqual(window["since"], "2026-05-12T13:04:00Z")
+        self.assertEqual(window["until"], "2026-05-12T13:06:00Z")
+        self.assertIn("RESOLVED_WINDOW_MODE=auto_recording_intersection", env)
+
+    def test_falls_back_to_open_rows_when_no_closed_rows_overlap(self):
+        window, _ = self.run_script(
+            [
+                {
+                    "recorded_at": "2026-05-12T13:00:00Z",
+                    "update": {"kind": "quote", "ts": "2026-05-12T13:00:00Z"},
+                },
+                {
+                    "recorded_at": "2026-05-12T13:10:00Z",
+                    "update": {"kind": "quote", "ts": "2026-05-12T13:10:00Z"},
+                },
+            ],
+            {
+                "runtime_evidence": {
+                    "events": [
+                        {
+                            "deployment_id": "pm5d.test",
+                            "intent_id": "open-1",
+                            "decision_ts": "2026-05-12T13:06:00Z",
+                            "settlement": "open",
+                        }
+                    ]
+                }
+            },
+        )
+
+        self.assertEqual(window["selected_row_count"], 1)
+        self.assertEqual(window["selected_closed_row_count"], 0)
+        self.assertEqual(window["since"], "2026-05-12T13:05:00Z")
+        self.assertEqual(window["until"], "2026-05-12T13:07:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -263,9 +263,9 @@ fn recorded_replay_parity_supports_auto_window() {
 
     for needle in [
         "default: \"auto\"",
-        "auto parity window found no closed dry-run rows",
-        "recent_closed AS",
-        "LIMIT 20",
+        "resolve_recorded_replay_window.py",
+        "--recording \"${recording_path}\"",
+        "--dryrun-json \"${dryrun_report}\"",
         "resolved-window.json",
         "resolved-window.env",
         "skip_settlement_exits = true",


### PR DESCRIPTION
## Summary
- resolve recorded replay auto windows from recording coverage intersected with dry-run evidence
- prefer closed rows when present, but fall back to current open rows after fresh recording restarts
- keep recorded replay workflow docs and workflow security guard aligned

## Verification
- python3 -m unittest tests.test_resolve_recorded_replay_window tests.test_replay_dryrun_parity tests.test_enrich_replay_runtime_evidence
- python3 -m py_compile scripts/resolve_recorded_replay_window.py scripts/replay_dryrun_parity.py scripts/enrich_recording_official_settlement.py scripts/enrich_replay_runtime_evidence.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/recorded-replay-parity.yml"); puts "yaml ok"'\n- CARGO_TARGET_DIR=/tmp/ploy-parity-workflow-security-2 /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security recorded_replay_parity_supports_auto_window\n- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic replay parity window resolution now intelligently intersects recorded timeline data with dry-run evidence, preferring closed settlement rows when available and falling back to open rows when needed.

* **Documentation**
  * Updated runbook documentation detailing the enhanced auto window resolution behavior.

* **Tests**
  * Added integration test coverage for the window resolution logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/459)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->