### PR TITLE
Promote PM5D near-strike dry-run handoff

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -3515,6 +3515,44 @@ mod tests {
     }
 
     #[test]
+    fn autofactor_near_strike_formula_adjusts_settlement_edge() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+
+        let near_inputs = AutoSettlementFactorInputs {
+            settlement_edge: 0.06,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            entry_capacity_ratio: 3.0,
+            side_spread: 0.03,
+            external_pressure: 0.0,
+            iv_change_1m: 0.0,
+        };
+        let far_inputs = AutoSettlementFactorInputs {
+            distance_over_sigma: 0.90,
+            ..near_inputs
+        };
+
+        let (near_raw, near_score) = autofactor_formula_entry_score(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            near_inputs,
+            config.min_edge,
+        )
+        .expect("near-strike settlement formula score");
+        let (far_raw, far_score) = autofactor_formula_entry_score(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            far_inputs,
+            config.min_edge,
+        )
+        .expect("far settlement formula score");
+
+        assert!((near_raw - 0.048).abs() < 1e-9);
+        assert!((far_raw - 0.006).abs() < 1e-9);
+        assert!(near_score > far_score);
+    }
+
+    #[test]
     fn edge_score_returns_continuous_value() {
         let config = test_config();
         // ask=0.35 → fee≈0.00455, edge=0.55-0.35-0.00455≈0.195 → edge_score≈1.95 clamped to 1.0

--- a/tasks/research_evidence/pm5d_alpha_search_ready_handoff_20260512.md
+++ b/tasks/research_evidence/pm5d_alpha_search_ready_handoff_20260512.md
@@ -1,0 +1,120 @@
+# Research Evidence: PM5D Alpha Search Ready Handoff - 2026-05-12
+
+## Decision
+
+Status: `promote-to-dry-run`
+
+One-line decision: Run `25737965398` produced a ready dry-run handoff for the
+PM5D settlement-probability lane, but this is not live-promotion evidence.
+
+## Semantic Context
+
+- Strategy lane: `settlement_probability`
+- Evidence stage: `walk_forward`
+- Lifecycle segment tested: `signal -> pnl`
+- Promotion target, if any: `dry-run`
+
+## Hypothesis
+
+- Claim: Conservative settlement edge, optionally gated by near-strike event
+  geometry, can rank PM5D BTC/ETH binary-option entries with positive
+  executable settlement PnL after full-depth entry pricing.
+- Expected edge mechanism: Buy the side whose estimated settlement probability
+  exceeds executable entry cost, while requiring the full-depth settlement
+  target and runtime replay parity gate.
+- Failure criteria: No qualified strategy, blocked promotion gate, missing
+  replay parity, unstable symbol/window behavior, or missing runtime scorer
+  mapping.
+- Next decision this evidence should unlock: create or keep a dry-run handoff
+  and collect a fresh post-reset dry-run window before any live discussion.
+
+## Inputs
+
+- Git ref: `main@025e90b657ee641bcbb35e1411ccde3bf5c74c42`
+- Workflow run: `25737965398`
+- Snapshot or artifact: `research-snapshot-25642459432`,
+  `factor-walk-forward-v2-25737965398`
+- Dataset/window: `2026-04-24 00:00:00 UTC` ->
+  `2026-05-01 00:00:00 UTC`
+- Symbols/events: `BTCUSDT,ETHUSDT`; event-complete gate reported
+  `event_complete_events=292`, `event_complete_rows=468`
+- Config: `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`
+- Local/remote artifact paths:
+  `/tmp/pm5d-alpha-25737965398/factor-walk-forward-v2-25737965398`
+
+## Data Surface Audit
+
+- Binance spot/trade ticks: `present`
+- Binance L2/LOB: `present`
+- Polymarket quote ticks: `present`
+- Polymarket full CLOB depth: `present`
+- Official settlement: `present`
+- Runtime/dry-run fills: `present for parity gate`
+- Data audit status: `critical` on the broad snapshot audit; PM5D scoped
+  event-complete gate passed for this run.
+- Missing surfaces and impact: Broad snapshot audit caveats remain a reason to
+  keep this at dry-run handoff, not live promotion.
+
+## Accounting Semantics
+
+- Event accounting: `one-event-one-trade`
+- Entry price model: full-depth executable entry sweep for fixed `15` USD stake
+- Exit or settlement label: official settlement / full-depth settlement
+  executable PnL
+- Fillability assumption: promotion gate used `min_entry_fill_rate=0.0500`
+  with event-complete rows
+- Fees/slippage/latency assumption: workflow report used executable full-depth
+  pricing and quote-age constraints
+- Capacity or stake assumption: `stake_usd=15`
+
+## Results
+
+- Headline metrics: `237` generated candidates, `71` passed search feedback,
+  best search reward `4.894975850946932`.
+- Stability metrics: handoff strategies both had `positive_window_ratio=1.0`,
+  `symbol_positive_ratio=1.0`, and `window_count=4`.
+- Calibration or bucket behavior: promotion gate evidence required
+  `max_ece=0.0500`.
+- Fill rate/capacity: promotion gate evidence required
+  `min_entry_fill_rate=0.0500`.
+- PnL/ROI:
+  - `auto_settlement_conservative_settlement_edge`: `n=377`, `icir=2.0567`,
+    `spearman_ic=0.160886`, `top_bucket_avg_label=2.154376`,
+    `top_bucket_positive_label_rate=0.6053`.
+  - `auto_settlement_conservative_settlement_edge_x_near_strike`: `n=377`,
+    `icir=1.999983`, `spearman_ic=0.163584`,
+    `top_bucket_avg_label=2.825599`,
+    `top_bucket_positive_label_rate=0.6316`.
+- Drawdown/risk: Not established by this evidence; must be observed in a fresh
+  dry-run window with kill switch and fixed stake.
+
+## Promotion Gate Check
+
+- Hypothesis explicit: `pass`
+- Data provenance recorded: `pass`
+- Executable pricing conservative: `pass`
+- Settlement/exit label matches lane: `pass`
+- Walk-forward or leakage guard: `pass`
+- Replay/runtime parity: `pass` via recorded replay parity run `25737603431`
+  with `strict_parity_ready=true`
+- Runtime scorer/config mapping: `pass` for the two handoff strategies
+- Risk/stake/kill switch stated: `pass for stake`; kill-switch verification is
+  required before deployment monitoring
+
+## Caveats
+
+- This is a dry-run handoff only. It is not evidence to trade live.
+- The current dry-run report still contains older rows, so fresh strategy
+  performance must be measured from a reset or explicitly bounded post-cutover
+  window.
+- The prior dry-run config already used
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`; this
+  branch applies the near-strike variant for the next dry-run comparison.
+
+## Follow-Up
+
+- Open and merge a dry-run handoff/config PR for the near-strike variant.
+- Reset or window the dry-run evidence so old rows cannot contaminate the next
+  profitability read.
+- Deploy dry-run from `main`, then collect fresh quote quality, fills,
+  settlement PnL, drawdown, and replay parity before any live-candidate step.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,72 @@
+# PM5D Tradable Strategy Search Continuation (2026-05-12)
+
+## Goal
+
+Use the fresh strict recorded replay parity evidence to continue PM5D
+settlement-probability alpha discovery on the GitHub-hosted artifact path.
+Current evidence stage is `factor_attribution` / `walk_forward`; this is not a
+dry-run or live promotion claim.
+
+## Plan
+
+- [x] Re-read `docs/PROJECT_SEMANTICS.md`; current prerequisite evidence stage
+  from run `25737603431` is `runtime_parity`.
+- [x] Verify run `25737603431` completed from `main` and produced strict replay
+  / dry-run parity.
+- [x] Trigger a hosted artifact walk-forward alpha search from `main` using the
+  retained research snapshot, typed LLM prior, prior MCTS plan, and fresh parity
+  artifact.
+- [x] Download and inspect the search artifacts.
+- [x] Record candidate count, passed count, best factor, handoff status,
+  caveats, and next decision.
+- [x] Apply the ready near-strike dry-run handoff to the settlement-probability
+  dry-run config for review.
+- [x] Validate the config change with focused tests.
+
+## Review
+
+- 2026-05-12: Recorded replay parity run `25737603431` completed from
+  `main@025e90b657ee641bcbb35e1411ccde3bf5c74c42`. Artifact
+  `recorded-replay-parity-25737603431` reported `decision=continue`,
+  `runtime_evidence_comparison.strict_parity_ready=true`, no blocking risk
+  flags, no order/fill/event mismatches, and no replay `tl_settle_*` rows.
+  Resolved window mode was `auto_recording_intersection` over
+  `2026-05-12T13:07:35.573000Z..2026-05-12T13:13:55.625000Z`.
+- 2026-05-12: Hosted artifact alpha-search run `25737965398` completed from
+  `main@025e90b657ee641bcbb35e1411ccde3bf5c74c42` using snapshot
+  `25642459432`, parity run `25737603431`, prior
+  `tasks/alpha_search_priors/pm5d_settlement_liquidity_prior_20260512.json`,
+  and prior MCTS plan `25707061616`. Search feedback produced `237`
+  candidates, `71` passed, best reward `4.894975850946932`, and best selected
+  factor
+  `mcts_mcts_auto_settlement_conservative_settlement_edge_x_near_strike_near_strike_near_strike`.
+  Promotion handoff was `status=ready` with two dry-run handoff strategies:
+  `auto_settlement_conservative_settlement_edge` and
+  `auto_settlement_conservative_settlement_edge_x_near_strike`.
+- 2026-05-12: Evidence recorded in
+  `tasks/research_evidence/pm5d_alpha_search_ready_handoff_20260512.md`.
+  Current config already uses the base conservative settlement edge; the
+  near-strike variant requires a config change if selected for the next dry-run
+  comparison.
+- 2026-05-12: Applied the ready near-strike handoff to
+  `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`.
+  The only config change is `three_layer_autofactor_runtime_score` from
+  `autofactor_formula:auto_settlement_conservative_settlement_edge` to
+  `autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike`.
+- 2026-05-12: Added a focused runtime scorer test for the near-strike
+  AutoFactor formula. Verification passed:
+  `python3 -m unittest tests.test_apply_autofactor_handoff_to_config
+  tests.test_autofactor_strategy_promotion`,
+  `CARGO_TARGET_DIR=/tmp/ploy-nearstrike-handoff /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked -p ploy-strategy-bundles
+  autofactor_near_strike_formula_adjusts_settlement_edge --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-nearstrike-config /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked -p ploy-strategy-bundles
+  settlement_probability_config_carries_autofactor_handoff_score --lib`,
+  `rustfmt --edition 2021 --check
+  crates/ploy-strategy-bundles/src/strategies/three_layer.rs`, and
+  `python3 -m py_compile scripts/apply_autofactor_handoff_to_config.py`.
+
 # Recorded Replay Parity Settlement Lifecycle Fix (2026-05-12)
 
 ## Goal


### PR DESCRIPTION
## Summary

- Switch the PM5D settlement-probability dry-run runtime score to the ready near-strike AutoFactor handoff from run `25737965398`.
- Add a focused runtime scorer test proving the near-strike formula is supported and changes the settlement edge score.
- Record the fresh parity/search evidence and caveats for dry-run-only promotion.

## Evidence

- Recorded replay parity run `25737603431`: `strict_parity_ready=true`, no blocking flags, no order/fill/event mismatches.
- Hosted alpha search run `25737965398`: handoff `status=ready`, `237` candidates, `71` passed, promotion gate ready with `replay_parity_ready=true`.
- Selected dry-run comparison score: `autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike`.

## Verification

- `python3 -m unittest tests.test_apply_autofactor_handoff_to_config tests.test_autofactor_strategy_promotion`
- `CARGO_TARGET_DIR=/tmp/ploy-nearstrike-handoff /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_near_strike_formula_adjusts_settlement_edge --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-nearstrike-config /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`
- `rustfmt --edition 2021 --check crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
- `python3 -m py_compile scripts/apply_autofactor_handoff_to_config.py`
- `rtk git diff --check`

## Caveat

This is dry-run handoff only. Old dry-run rows must be reset or filtered to a fresh post-deploy window before reading profitability, and live trading remains blocked pending separate approval and risk evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation for near-strike settlement-edge autofactor formula behavior in strategy calculations.

* **Chores**
  * Updated three-layer strategy configuration to use an optimized near-strike settlement-probability formula variant.
  * Added research and task documentation tracking strategy development progress and verification metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->