### PR TITLE
Clarify PM5D dry-run handoff caveat

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,8 +4,11 @@
 
 Use the fresh strict recorded replay parity evidence to continue PM5D
 settlement-probability alpha discovery on the GitHub-hosted artifact path.
-Current evidence stage is `factor_attribution` / `walk_forward`; this is not a
-dry-run or live promotion claim.
+Current evidence stage is `walk_forward` with a dry-run handoff target; this is
+not a live promotion claim. Dry-run promotion means selecting the next paper
+runtime score for controlled observation, while live promotion remains blocked
+until separate risk, reset/windowed performance, and operator approval evidence
+exists.
 
 ## Plan
 
@@ -66,6 +69,9 @@ dry-run or live promotion claim.
   `rustfmt --edition 2021 --check
   crates/ploy-strategy-bundles/src/strategies/three_layer.rs`, and
   `python3 -m py_compile scripts/apply_autofactor_handoff_to_config.py`.
+- 2026-05-12: Old dry-run rows must be reset or filtered before using
+  post-deploy profitability metrics; live trading remains blocked pending
+  separate approval and risk evidence.
 
 # Recorded Replay Parity Settlement Lifecycle Fix (2026-05-12)
 


### PR DESCRIPTION
## Summary

- Clarify that the near-strike handoff is a dry-run promotion target, not a live promotion.
- Add the explicit post-deploy caveat requested by review: old dry-run rows must be reset or filtered before profitability is read, and live trading remains blocked pending approval/risk evidence.

## Verification

- `rtk git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task documentation to clarify testing procedures and data handling requirements before using profitability metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/461)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->