### PR TITLE
Classify empty replay parity windows as collect-more

### DIFF
--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -757,6 +757,19 @@ def compare_runtime_evidence(
     }
 
 
+def has_no_comparable_runtime_sample(runtime_evidence_comparison: dict[str, Any]) -> bool:
+    """Return true when the selected window has no replay or dry-run rows to compare."""
+    for row_type in ("events", "orders", "fills"):
+        comparison = runtime_evidence_comparison.get(row_type) or {}
+        if comparison.get("replay_count", 0) != 0:
+            return False
+        if comparison.get("dryrun_count", 0) != 0:
+            return False
+        if comparison.get("shared_count", 0) != 0:
+            return False
+    return True
+
+
 def compare_events(
     replay_events: list[dict[str, Any]], dryrun_events: list[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -890,10 +903,15 @@ def build_result(
         legacy_event_flags.append("legacy_event_missing_strict_parity_fields")
 
     decision = "continue"
-    if not runtime_evidence_comparison["strict_parity_ready"]:
+    no_comparable_runtime_sample = has_no_comparable_runtime_sample(runtime_evidence_comparison)
+    if no_comparable_runtime_sample:
+        decision = "collect-more"
+    elif not runtime_evidence_comparison["strict_parity_ready"]:
         decision = "fix-data-or-runtime-mismatch"
     advisory_flags: list[str] = []
-    blocking_risk_flags = list(risk_flags)
+    if no_comparable_runtime_sample:
+        advisory_flags.append("no_comparable_runtime_sample")
+    blocking_risk_flags = [] if no_comparable_runtime_sample else list(risk_flags)
 
     return {
         "schema_version": 1,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Recorded Replay No-Sample Classification Fix (2026-05-12)
+
+## Goal
+
+Prevent PM5D recorded replay/dry-run parity windows with no comparable runtime
+rows from being mislabeled as data or runtime failures. Evidence stage is
+`runtime_parity`; an empty sampled window should block promotion as
+`collect-more`, not imply a broken runner, collector, or scorer.
+
+## Plan
+
+- [x] Re-read the project semantic contract and strategy research runbook.
+- [x] Inspect current dry-run evidence and the latest #419 parity comments.
+- [x] Change the parity evaluator to classify all-empty replay/dry-run runtime
+  windows as `decision=collect-more`.
+- [x] Preserve real mismatches and one-sided missing rows as
+  `fix-data-or-runtime-mismatch`.
+- [x] Add a regression test for empty runtime windows.
+- [x] Run focused parity tests.
+
+## Review
+
+- 2026-05-12: Current target dry-run report for
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun` still shows 16 closed
+  trades, realized PnL `-58.21`, profit factor `0.4501`, and max drawdown
+  `-86.0965`; this remains a revise/collect-more candidate, not a profitable
+  strategy claim.
+- 2026-05-12: Latest recorded parity evidence on #419 had shared
+  orders/fills `0 / 0`. That is an under-sampled window, not enough evidence to
+  diagnose runtime drift.
+- 2026-05-12: `scripts/replay_dryrun_parity.py` now emits
+  `decision=collect-more` plus advisory flag `no_comparable_runtime_sample`
+  when events, orders, and fills are empty on both replay and dry-run sides.
+  One-sided missing rows and field mismatches still produce
+  `fix-data-or-runtime-mismatch`.
+- 2026-05-12: Verification passed:
+  `python3 -m unittest tests.test_replay_dryrun_parity`.
+
 # PM5D Tradable Strategy Search Continuation (2026-05-12)
 
 ## Goal

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -218,6 +218,18 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertEqual(runtime["orders"]["shared_count"], 0)
         self.assertEqual(runtime["fills"]["shared_count"], 0)
 
+    def test_empty_runtime_window_collects_more_instead_of_fixing_runtime(self):
+        result = self.run_script({"runtime_evidence": {}}, {"runtime_evidence": {}})
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertFalse(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "collect-more")
+        self.assertIn("no_comparable_runtime_sample", result["advisory_flags"])
+        self.assertEqual(result["blocking_risk_flags"], [])
+        self.assertEqual(runtime["events"]["shared_count"], 0)
+        self.assertEqual(runtime["orders"]["shared_count"], 0)
+        self.assertEqual(runtime["fills"]["shared_count"], 0)
+
     def test_filters_limit_comparison_to_matching_deployment_window(self):
         replay = evidence_payload()
         dryrun = evidence_payload()


### PR DESCRIPTION
## Summary
- classify recorded replay/dry-run parity windows with no comparable runtime rows as `decision=collect-more` instead of `fix-data-or-runtime-mismatch`
- add `no_comparable_runtime_sample` as an advisory flag while preserving real one-sided missing rows and field mismatches as runtime/data blockers
- document the PM5D no-sample parity fix in `tasks/todo.md`

## Verification
- `python3 -m unittest tests.test_replay_dryrun_parity`
- `python3 -m py_compile scripts/replay_dryrun_parity.py`

## Context
This prevents PM5D windows with shared orders/fills `0 / 0` from being mislabeled as data or runtime failures. They still block promotion through `parity:blocked`, but the next decision becomes collect-more rather than fix-runtime/fix-data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of scenarios with insufficient comparison data—now correctly classified as requiring more data collection rather than flagged as runtime failures.

* **Tests**
  * Added regression test for edge cases with empty comparison windows.

* **Documentation**
  * Updated task tracking with parity evaluator enhancements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/462)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->