### PR TITLE
Add audited runtime evidence reset workflow

### DIFF
--- a/.github/workflows/reset-strategy-runtime-evidence.yml
+++ b/.github/workflows/reset-strategy-runtime-evidence.yml
@@ -1,0 +1,181 @@
+name: Reset Strategy Runtime Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref"
+        required: true
+        default: "main"
+      deployment_id:
+        description: "Deployment id to reset"
+        required: true
+        default: "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+      strategy_id:
+        description: "Optional strategy_id filter"
+        required: false
+        default: ""
+      runtime_modes:
+        description: "Comma-separated runtime modes"
+        required: true
+        default: "dry_run,dryrun,paper"
+      after_ts:
+        description: "Optional inclusive lower bound, ISO-8601"
+        required: false
+        default: ""
+      before_ts:
+        description: "Optional exclusive upper bound, ISO-8601"
+        required: false
+        default: ""
+      execute:
+        description: "Actually delete rows after backup"
+        type: boolean
+        required: true
+        default: false
+      confirm:
+        description: "Required when execute=true: delete-strategy-runtime-evidence"
+        required: false
+        default: ""
+
+concurrency:
+  group: reset-strategy-runtime-evidence-${{ github.event.inputs.deployment_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+
+jobs:
+  reset:
+    name: Backup and optionally reset runtime evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Validate reset inputs
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          RUNTIME_MODES: ${{ github.event.inputs.runtime_modes }}
+          EXECUTE: ${{ github.event.inputs.execute }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import sys
+
+          deployment_id = os.environ["DEPLOYMENT_ID"].strip()
+          if not deployment_id:
+              raise SystemExit("deployment_id is required")
+          modes = [item.strip() for item in os.environ["RUNTIME_MODES"].split(",") if item.strip()]
+          if not modes:
+              raise SystemExit("runtime_modes must include at least one mode")
+          execute = os.environ["EXECUTE"].lower() == "true"
+          if execute and os.environ["CONFIRM"] != "delete-strategy-runtime-evidence":
+              raise SystemExit("execute=true requires confirm=delete-strategy-runtime-evidence")
+          if any(mode not in {"dry_run", "dryrun", "paper"} for mode in modes):
+              raise SystemExit("this workflow only resets dry-run/paper runtime modes")
+          PY
+
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.TANGO_1_1_SSH_KEY }}' > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Run reset tool on tango-1-1
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          STRATEGY_ID: ${{ github.event.inputs.strategy_id }}
+          RUNTIME_MODES: ${{ github.event.inputs.runtime_modes }}
+          AFTER_TS: ${{ github.event.inputs.after_ts }}
+          BEFORE_TS: ${{ github.event.inputs.before_ts }}
+          EXECUTE: ${{ github.event.inputs.execute }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+          run_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_dir="${DEPLOY_ROOT}/tmp/reset-strategy-runtime-evidence-${run_id}"
+          remote_backup="${DEPLOY_ROOT}/reports/reset-strategy-runtime-evidence/${run_id}"
+          mkdir -p artifacts/reset-strategy-runtime-evidence
+          # shellcheck disable=SC2029
+          ssh tango-1-1 "mkdir -p '${remote_dir}' '${remote_backup}'"
+          scp scripts/reset_strategy_runtime_evidence.py "tango-1-1:${remote_dir}/reset_strategy_runtime_evidence.py"
+
+          args=(
+            "--deployment-id" "${DEPLOYMENT_ID}"
+            "--runtime-modes" "${RUNTIME_MODES}"
+            "--backup-dir" "${remote_backup}"
+          )
+          if [ -n "${STRATEGY_ID}" ]; then
+            args+=("--strategy-id" "${STRATEGY_ID}")
+          fi
+          if [ -n "${AFTER_TS}" ]; then
+            args+=("--after-ts" "${AFTER_TS}")
+          fi
+          if [ -n "${BEFORE_TS}" ]; then
+            args+=("--before-ts" "${BEFORE_TS}")
+          fi
+          if [ "${EXECUTE}" = "true" ]; then
+            args+=("--execute" "--confirm" "${CONFIRM}")
+          fi
+
+          remote_cmd="$(printf '%q ' python3 "${remote_dir}/reset_strategy_runtime_evidence.py" "${args[@]}")"
+          printf '%s\n' "${remote_cmd}" > artifacts/reset-strategy-runtime-evidence/argv.txt
+          # shellcheck disable=SC2029
+          ssh tango-1-1 "${remote_cmd}"
+          scp -r "tango-1-1:${remote_backup}/." artifacts/reset-strategy-runtime-evidence/
+
+      - name: Publish summary
+        if: always()
+        run: |
+          set -euo pipefail
+          manifest="artifacts/reset-strategy-runtime-evidence/manifest.json"
+          if [ ! -f "${manifest}" ]; then
+            echo "No reset manifest found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/reset-strategy-runtime-evidence/manifest.json").read_text())
+          print("## Strategy Runtime Evidence Reset")
+          print("")
+          print(f"- Deployment: `{payload['deployment_id']}`")
+          print(f"- Execute: `{payload['execute']}`")
+          print(f"- Runtime modes: `{','.join(payload['runtime_modes'])}`")
+          print(f"- Before: orders=`{payload['before']['orders']}`, fills=`{payload['before']['fills']}`")
+          print(f"- Deleted orders: `{payload['deleted_orders']}`")
+          print(f"- After: orders=`{payload['after']['orders']}`, fills=`{payload['after']['fills']}`")
+          print("- Raw market data tables were not touched.")
+          PY
+
+      - name: Upload reset artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: reset-strategy-runtime-evidence-${{ github.run_id }}
+          path: artifacts/reset-strategy-runtime-evidence/
+          retention-days: 30

--- a/scripts/reset_strategy_runtime_evidence.py
+++ b/scripts/reset_strategy_runtime_evidence.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Backup and optionally clear strategy runtime evidence rows.
+
+This intentionally targets runtime evidence tables only:
+
+- strategy_runtime_orders
+- strategy_runtime_fills
+
+Track-record reports are views derived from these tables. Raw market data,
+quotes, orderbooks, settlements, and research snapshots are not touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DB_URL = (
+    os.environ.get("PLOY_DATABASE__URL")
+    or os.environ.get("DATABASE_URL")
+    or "postgresql://postgres:postgres@localhost:5432/ploy"
+)
+
+DEFAULT_RUNTIME_MODES = ("dry_run", "dryrun", "paper")
+CONFIRMATION = "delete-strategy-runtime-evidence"
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def validate_timestamp(raw: str | None, flag: str) -> str | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SystemExit(f"{flag} must be ISO-8601 timestamp, got {raw!r}") from exc
+    return raw
+
+
+def split_runtime_modes(raw: str) -> list[str]:
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    if not values:
+        raise SystemExit("--runtime-modes must include at least one mode")
+    return values
+
+
+def order_predicate(args: argparse.Namespace) -> str:
+    clauses = [f"deployment_id = {sql_literal(args.deployment_id)}"]
+    modes = ", ".join(sql_literal(mode) for mode in args.runtime_modes)
+    clauses.append(f"runtime_mode IN ({modes})")
+    if args.strategy_id:
+        clauses.append(f"strategy_id = {sql_literal(args.strategy_id)}")
+    if args.after_ts:
+        clauses.append(f"recorded_at >= {sql_literal(args.after_ts)}::timestamptz")
+    if args.before_ts:
+        clauses.append(f"recorded_at < {sql_literal(args.before_ts)}::timestamptz")
+    return " AND ".join(clauses)
+
+
+def fill_predicate(args: argparse.Namespace) -> str:
+    order_where = order_predicate(args)
+    return (
+        "EXISTS ("
+        "SELECT 1 FROM strategy_runtime_orders o "
+        "WHERE o.order_id = strategy_runtime_fills.order_id "
+        f"AND {order_where}"
+        ")"
+    )
+
+
+def run_psql(sql: str, *, timeout: int = 60) -> str:
+    result = subprocess.run(
+        [
+            "psql",
+            DB_URL,
+            "-t",
+            "-A",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or result.stdout)
+        raise SystemExit(result.returncode)
+    return result.stdout.strip()
+
+
+def count_rows(table: str, predicate: str) -> int:
+    raw = run_psql(f"SELECT COUNT(*) FROM {table} WHERE {predicate};")
+    return int(raw or "0")
+
+
+def backup_table(table: str, predicate: str, output: Path, order_by: str) -> None:
+    sql = f"""
+COPY (
+  SELECT COALESCE(jsonb_agg(to_jsonb(rows) ORDER BY {order_by}), '[]'::jsonb)
+  FROM (
+    SELECT *
+    FROM {table}
+    WHERE {predicate}
+  ) rows
+) TO STDOUT;
+"""
+    result = subprocess.run(
+        ["psql", DB_URL, "-v", "ON_ERROR_STOP=1", "-c", sql],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or result.stdout)
+        raise SystemExit(result.returncode)
+    output.write_text((result.stdout.strip() or "[]") + "\n", encoding="utf-8")
+
+
+def execute_delete(predicate: str) -> int:
+    sql = f"""
+WITH deleted AS (
+  DELETE FROM strategy_runtime_orders
+  WHERE {predicate}
+  RETURNING 1
+)
+SELECT COUNT(*) FROM deleted;
+"""
+    return int(run_psql(sql, timeout=120) or "0")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backup and optionally clear dry-run strategy_runtime_orders/fills "
+            "for one deployment. Raw market data is not touched."
+        )
+    )
+    parser.add_argument("--deployment-id", required=True)
+    parser.add_argument("--strategy-id", default="")
+    parser.add_argument(
+        "--runtime-modes",
+        default=",".join(DEFAULT_RUNTIME_MODES),
+        help="Comma-separated runtime modes to match; default: dry_run,dryrun,paper",
+    )
+    parser.add_argument("--after-ts", default="")
+    parser.add_argument("--before-ts", default="")
+    parser.add_argument("--backup-dir", required=True)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument(
+        "--confirm",
+        default="",
+        help=f"Required with --execute: {CONFIRMATION}",
+    )
+    args = parser.parse_args(argv)
+    args.runtime_modes = split_runtime_modes(args.runtime_modes)
+    args.after_ts = validate_timestamp(args.after_ts, "--after-ts")
+    args.before_ts = validate_timestamp(args.before_ts, "--before-ts")
+    if args.execute and args.confirm != CONFIRMATION:
+        raise SystemExit(f"--execute requires --confirm {CONFIRMATION!r}")
+    if args.after_ts and args.before_ts:
+        after = datetime.fromisoformat(args.after_ts.replace("Z", "+00:00"))
+        before = datetime.fromisoformat(args.before_ts.replace("Z", "+00:00"))
+        if after >= before:
+            raise SystemExit("--after-ts must be earlier than --before-ts")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    backup_dir = Path(args.backup_dir)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    orders_where = order_predicate(args)
+    fills_where = fill_predicate(args)
+    before = {
+        "orders": count_rows("strategy_runtime_orders", orders_where),
+        "fills": count_rows("strategy_runtime_fills", fills_where),
+    }
+
+    backup_table(
+        "strategy_runtime_orders",
+        orders_where,
+        backup_dir / "strategy_runtime_orders.json",
+        "rows.recorded_at, rows.order_id",
+    )
+    backup_table(
+        "strategy_runtime_fills",
+        fills_where,
+        backup_dir / "strategy_runtime_fills.json",
+        "rows.fill_timestamp, rows.fill_id",
+    )
+
+    deleted_orders = execute_delete(orders_where) if args.execute else 0
+    after = {
+        "orders": count_rows("strategy_runtime_orders", orders_where),
+        "fills": count_rows("strategy_runtime_fills", fills_where),
+    }
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "tool": "reset_strategy_runtime_evidence.py",
+        "execute": args.execute,
+        "deployment_id": args.deployment_id,
+        "strategy_id": args.strategy_id or None,
+        "runtime_modes": args.runtime_modes,
+        "after_ts": args.after_ts,
+        "before_ts": args.before_ts,
+        "tables_touched_when_execute": ["strategy_runtime_orders", "strategy_runtime_fills"],
+        "tables_not_touched": [
+            "clob_quote_ticks",
+            "clob_orderbook_snapshots",
+            "pm_token_settlements",
+            "pm_market_metadata",
+            "binance_price_ticks",
+            "binance_agg_trade_ticks",
+            "binance_lob_ticks",
+            "deribit_iv_ticks",
+            "deribit_atm_greeks_ticks",
+        ],
+        "before": before,
+        "deleted_orders": deleted_orders,
+        "after": after,
+        "backup_files": {
+            "orders": "strategy_runtime_orders.json",
+            "fills": "strategy_runtime_fills.json",
+        },
+    }
+    (backup_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -29,6 +29,65 @@ windows, which forced snapshots to include same-day LOB gaps.
   `--start-date` / `--end-date` as the default path.
 - 2026-05-12: Local validation passed:
   `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml")'`.
+- 2026-05-12: Post-gap diagnostic snapshot run `25746212164` completed from
+  `main@9863844f75fe7a3adf172fe811795def2bb88757` with exact window
+  `2026-05-12 11:00:00 +08` to `2026-05-12 23:30:00 +08`. Data audit was
+  `ok`; artifact rows were observations=`5929`, Deribit=`3002`, PM books=`2884`.
+  This is a diagnostic/factor-attribution input, not promotion-grade
+  walk-forward evidence.
+- 2026-05-12: Diagnostic hosted factor review run `25746661147` succeeded from
+  snapshot `25746212164`. It showed positive short-window buckets for
+  `side=down` and `entry_liquidity_usd=150..500u`, while current model-edge
+  probability buckets still had poor executable PnL. Next tradeable-strategy
+  step is a clean 48-72h snapshot plus hosted walk-forward/MCTS chain, not
+  promotion from this intraday diagnostic.
+- 2026-05-13: 24h BTC/ETH market-data coverage audit run `25747004738`
+  completed with `quick` 1h status `ok`, but 24h retained coverage still
+  `critical` because `binance_lob/BTCUSDT` and `binance_lob/ETHUSDT` have the
+  known 80-minute gap from `2026-05-12 09:28 +08` to `10:48 +08`. Do not run a
+  promotion-grade 24h/48h walk-forward over this window.
+- 2026-05-13: Current settlement-probability dry-run report remains negative:
+  17 closed trades, realized PnL `-72.34`, profit factor `0.3971`, max drawdown
+  `-93.5018`. This is still a rejected/currently-bad dry-run, not a candidate.
+
+# Strategy Runtime Evidence Reset Tooling (2026-05-13)
+
+## Goal
+
+Make dry-run evidence resets reproducible and auditable so old runtime rows do
+not contaminate post-cutover PM5D strategy evaluation. The reset must preserve
+raw market data and default to preview/backup only.
+
+## Plan
+
+- [x] Add a deployment-scoped reset script for `strategy_runtime_orders` and
+  `strategy_runtime_fills`.
+- [x] Require backup artifacts before optional deletion.
+- [x] Require explicit confirmation for destructive execution.
+- [x] Add a GitHub Actions workflow that runs the tool on `tango-1-1` under the
+  existing environment gate and uploads the backup/manifest artifact.
+- [x] Add focused tests for predicate scoping, fill ownership, confirmation,
+  and timestamp-window validation.
+
+## Review
+
+- 2026-05-13: Added `scripts/reset_strategy_runtime_evidence.py`. It scopes by
+  deployment id, dry-run/paper runtime modes, optional strategy id, and optional
+  timestamp bounds; it backs up orders/fills to JSON plus `manifest.json`; it
+  deletes only via `--execute --confirm delete-strategy-runtime-evidence`.
+  Raw market data, PM metadata, settlements, Binance, Deribit, and orderbook
+  tables are explicitly not touched.
+- 2026-05-13: Added `.github/workflows/reset-strategy-runtime-evidence.yml` as
+  the remote execution surface. It validates dry-run/paper modes, uses the
+  `tango-1-1` environment approval gate, copies the checked-out script to a
+  remote temp dir, retrieves backup artifacts, and uploads them with 30-day
+  retention.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_reset_strategy_runtime_evidence`,
+  `python3 -m py_compile scripts/reset_strategy_runtime_evidence.py
+  tests/test_reset_strategy_runtime_evidence.py`, YAML parse for
+  `.github/workflows/reset-strategy-runtime-evidence.yml`, and `git diff
+  --check` on the touched files.
 
 # Recorded Replay No-Sample Classification Fix (2026-05-12)
 

--- a/tests/test_reset_strategy_runtime_evidence.py
+++ b/tests/test_reset_strategy_runtime_evidence.py
@@ -1,0 +1,70 @@
+import argparse
+import unittest
+
+from scripts import reset_strategy_runtime_evidence as reset
+
+
+class ResetStrategyRuntimeEvidenceTest(unittest.TestCase):
+    def test_order_predicate_is_deployment_scoped_and_quotes_literals(self):
+        args = argparse.Namespace(
+            deployment_id="pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+            strategy_id="three_layer",
+            runtime_modes=["dry_run"],
+            after_ts="2026-05-12T11:00:00+08:00",
+            before_ts="2026-05-13T00:00:00+08:00",
+        )
+
+        predicate = reset.order_predicate(args)
+
+        self.assertIn("deployment_id = 'pm5d.threelayer.settlement-probability-btc-eth.dryrun'", predicate)
+        self.assertIn("runtime_mode IN ('dry_run')", predicate)
+        self.assertIn("strategy_id = 'three_layer'", predicate)
+        self.assertIn("recorded_at >= '2026-05-12T11:00:00+08:00'::timestamptz", predicate)
+        self.assertIn("recorded_at < '2026-05-13T00:00:00+08:00'::timestamptz", predicate)
+
+    def test_fill_predicate_deletes_only_fills_attached_to_matching_orders(self):
+        args = argparse.Namespace(
+            deployment_id="deploy-a",
+            strategy_id="",
+            runtime_modes=["dry_run", "paper"],
+            after_ts=None,
+            before_ts=None,
+        )
+
+        predicate = reset.fill_predicate(args)
+
+        self.assertIn("EXISTS (SELECT 1 FROM strategy_runtime_orders o", predicate)
+        self.assertIn("o.order_id = strategy_runtime_fills.order_id", predicate)
+        self.assertIn("deployment_id = 'deploy-a'", predicate)
+        self.assertIn("runtime_mode IN ('dry_run', 'paper')", predicate)
+
+    def test_execute_requires_confirmation(self):
+        with self.assertRaises(SystemExit):
+            reset.parse_args(
+                [
+                    "--deployment-id",
+                    "deploy-a",
+                    "--backup-dir",
+                    "/tmp/backup",
+                    "--execute",
+                ]
+            )
+
+    def test_timestamp_window_must_be_ordered(self):
+        with self.assertRaises(SystemExit):
+            reset.parse_args(
+                [
+                    "--deployment-id",
+                    "deploy-a",
+                    "--backup-dir",
+                    "/tmp/backup",
+                    "--after-ts",
+                    "2026-05-13T00:00:00+08:00",
+                    "--before-ts",
+                    "2026-05-12T00:00:00+08:00",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deployment-scoped strategy runtime evidence reset script with backup-first behavior
- add a tango-gated manual workflow to run the reset tool and upload backup artifacts
- document the current PM5D data/dry-run state and add focused reset-tool tests

## Evidence
- python3 -m unittest tests.test_reset_strategy_runtime_evidence
- python3 -m py_compile scripts/reset_strategy_runtime_evidence.py tests/test_reset_strategy_runtime_evidence.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reset-strategy-runtime-evidence.yml"); puts "ok"'
- git diff --check -- tasks/todo.md scripts/reset_strategy_runtime_evidence.py tests/test_reset_strategy_runtime_evidence.py .github/workflows/reset-strategy-runtime-evidence.yml

## Notes
- The tool defaults to backup/preview only. Destructive execution requires execute=true plus confirm=delete-strategy-runtime-evidence.
- Raw market-data tables are not touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to backup and optionally reset strategy runtime data with deployment, runtime-mode and optional time-range filtering plus explicit confirmation gating.
  * New operational CLI tool to produce guarded backups, manifests and perform targeted deletes when confirmed.

* **Tests**
  * Added tests covering predicate generation, timestamp validation, and execute-confirmation behavior.

* **Chores**
  * Updated documentation with reset procedure and verification steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/464)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->