### PR TITLE
Guard runtime evidence reset while deployment is running

### DIFF
--- a/.github/workflows/reset-strategy-runtime-evidence.yml
+++ b/.github/workflows/reset-strategy-runtime-evidence.yml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: true
         default: false
+      allow_running:
+        description: "Allow execute=true while deployment desired/observed state is running"
+        type: boolean
+        required: true
+        default: false
       confirm:
         description: "Required when execute=true: delete-strategy-runtime-evidence"
         required: false
@@ -84,6 +89,41 @@ jobs:
               raise SystemExit("execute=true requires confirm=delete-strategy-runtime-evidence")
           if any(mode not in {"dry_run", "dryrun", "paper"} for mode in modes):
               raise SystemExit("this workflow only resets dry-run/paper runtime modes")
+          PY
+
+      - name: Block destructive reset while deployment is running
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          EXECUTE: ${{ github.event.inputs.execute }}
+          ALLOW_RUNNING: ${{ github.event.inputs.allow_running }}
+        run: |
+          set -euo pipefail
+          if [ "${EXECUTE}" != "true" ] || [ "${ALLOW_RUNNING}" = "true" ]; then
+            exit 0
+          fi
+          curl -fsS --max-time 10 "http://${DEPLOY_HOST}/api/deployments" > /tmp/deployments.json
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          deployment_id = os.environ["DEPLOYMENT_ID"]
+          deployments = json.loads(Path("/tmp/deployments.json").read_text(encoding="utf-8"))
+          target = next((item for item in deployments if item.get("deployment_id") == deployment_id), None)
+          if target is None:
+              raise SystemExit(f"deployment {deployment_id!r} not found; refusing destructive reset")
+          desired = str(target.get("desired_state") or "").lower()
+          observed = str(target.get("observed_state") or "").lower()
+          if "running" in {desired, observed}:
+              raise SystemExit(
+                  f"deployment {deployment_id!r} is still running "
+                  f"(desired_state={desired!r}, observed_state={observed!r}); "
+                  "pause/stop it or set allow_running=true explicitly"
+              )
+          print(
+              f"deployment {deployment_id} is not running "
+              f"(desired_state={desired!r}, observed_state={observed!r})"
+          )
           PY
 
       - name: Configure SSH

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -88,6 +88,15 @@ raw market data and default to preview/backup only.
   tests/test_reset_strategy_runtime_evidence.py`, YAML parse for
   `.github/workflows/reset-strategy-runtime-evidence.yml`, and `git diff
   --check` on the touched files.
+- 2026-05-13: Reset preview run `25748008417` on `main` succeeded with
+  `execute=false`: it matched and backed up `185` orders and `20` fills for
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun`. The deployment was
+  still `desired_state=running` / `observed_state=running`, so no destructive
+  reset was executed.
+- 2026-05-13: Added a follow-up workflow guard so `execute=true` refuses to run
+  while the target deployment is desired/observed `running`, unless
+  `allow_running=true` is explicitly supplied. This makes the pause-before-reset
+  rule machine-enforced instead of chat-only.
 
 # Recorded Replay No-Sample Classification Fix (2026-05-12)
 


### PR DESCRIPTION
## Summary
- block destructive runtime-evidence reset when target deployment is desired/observed running
- add an explicit allow_running override for exceptional operator cases
- document the reset preview result and pause-before-reset guard

## Evidence
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color .github/workflows/reset-strategy-runtime-evidence.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reset-strategy-runtime-evidence.yml"); puts "ok"'
- git diff --check -- .github/workflows/reset-strategy-runtime-evidence.yml tasks/todo.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a safety check to block destructive reset actions when deployments are in a running state, with an optional override flag for controlled execution.

* **Chores**
  * Updated documentation to reflect the new deployment state validation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->