### PR TITLE
Upload artifact when reset guard blocks

### DIFF
--- a/.github/workflows/reset-strategy-runtime-evidence.yml
+++ b/.github/workflows/reset-strategy-runtime-evidence.yml
@@ -98,7 +98,11 @@ jobs:
           ALLOW_RUNNING: ${{ github.event.inputs.allow_running }}
         run: |
           set -euo pipefail
+          mkdir -p artifacts/reset-strategy-runtime-evidence
           if [ "${EXECUTE}" != "true" ] || [ "${ALLOW_RUNNING}" = "true" ]; then
+            printf '{"allow_running":%s,"execute":%s,"guard":"running_deployment","schema_version":1,"status":"skipped"}\n' \
+              "${ALLOW_RUNNING}" "${EXECUTE}" \
+              > artifacts/reset-strategy-runtime-evidence/guard-status.json
             exit 0
           fi
           curl -fsS --max-time 10 "http://${DEPLOY_HOST}/api/deployments" > /tmp/deployments.json
@@ -115,11 +119,34 @@ jobs:
           desired = str(target.get("desired_state") or "").lower()
           observed = str(target.get("observed_state") or "").lower()
           if "running" in {desired, observed}:
+              Path("artifacts/reset-strategy-runtime-evidence/guard-status.json").write_text(
+                  json.dumps({
+                      "schema_version": 1,
+                      "guard": "running_deployment",
+                      "status": "blocked",
+                      "deployment_id": deployment_id,
+                      "desired_state": desired,
+                      "observed_state": observed,
+                      "reason": "deployment_running",
+                  }, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8",
+              )
               raise SystemExit(
                   f"deployment {deployment_id!r} is still running "
                   f"(desired_state={desired!r}, observed_state={observed!r}); "
                   "pause/stop it or set allow_running=true explicitly"
               )
+          Path("artifacts/reset-strategy-runtime-evidence/guard-status.json").write_text(
+              json.dumps({
+                  "schema_version": 1,
+                  "guard": "running_deployment",
+                  "status": "allowed",
+                  "deployment_id": deployment_id,
+                  "desired_state": desired,
+                  "observed_state": observed,
+              }, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
           print(
               f"deployment {deployment_id} is not running "
               f"(desired_state={desired!r}, observed_state={observed!r})"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -97,6 +97,10 @@ raw market data and default to preview/backup only.
   while the target deployment is desired/observed `running`, unless
   `allow_running=true` is explicitly supplied. This makes the pause-before-reset
   rule machine-enforced instead of chat-only.
+- 2026-05-13: Guard verification run `25748565967` correctly failed before SSH
+  or reset execution with deployment still `desired_state=running` /
+  `observed_state=running`. A follow-up patch now writes `guard-status.json` so
+  fail-closed reset attempts still upload auditable artifact evidence.
 
 # Recorded Replay No-Sample Classification Fix (2026-05-12)
 


### PR DESCRIPTION
## Summary
- write guard-status.json before reset workflow exits early or blocks a running deployment
- document guard verification run 25748565967

## Evidence
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color .github/workflows/reset-strategy-runtime-evidence.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reset-strategy-runtime-evidence.yml"); puts "ok"'
- git diff --check -- .github/workflows/reset-strategy-runtime-evidence.yml tasks/todo.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audit logging for deployment reset operations with status artifacts capturing reset decisions and deployment state information.

* **Improvements**
  * Guard verification now produces evidence artifacts for both blocked and allowed reset attempts, improving operational transparency and compliance tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/466)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->