### PR TITLE
fix: gate dry-run candidate evidence

### DIFF
--- a/docs/runbooks/strategy-runtime-evidence-reset.md
+++ b/docs/runbooks/strategy-runtime-evidence-reset.md
@@ -140,6 +140,15 @@ curl -fsS --max-time 10 http://8.221.143.151/api/reports/dry-run \
   | jq '.strategies[]? | select(.deployment_id=="pm5d.threelayer.settlement-probability-btc-eth.dryrun") | {summary,metrics,execution_diagnostics}'
 ```
 
+Machine-check the clean baseline from the dry-run API payload:
+
+```bash
+curl -fsS --max-time 10 http://8.221.143.151/api/reports/dry-run \
+  | python3 scripts/check_dryrun_candidate_gate.py \
+      --mode clean-baseline \
+      --deployment-id pm5d.threelayer.settlement-probability-btc-eth.dryrun
+```
+
 The post-reset dry-run report should start from a clean baseline. A new
 profitability claim needs a fresh observation window, not the reset itself.
 

--- a/scripts/check_dryrun_candidate_gate.py
+++ b/scripts/check_dryrun_candidate_gate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Gate dry-run report evidence before reset completion or strategy promotion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DEPLOYMENT_ID = "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+
+
+def number(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(parsed):
+        return default
+    return parsed
+
+
+def integer(value: Any) -> int:
+    return int(number(value, default=0.0))
+
+
+def load_payload(path: str) -> dict[str, Any]:
+    if path == "-":
+        return json.load(sys.stdin)
+    with Path(path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def find_strategy(payload: dict[str, Any], deployment_id: str) -> dict[str, Any] | None:
+    for strategy in payload.get("strategies") or []:
+        if strategy.get("deployment_id") == deployment_id:
+            return strategy
+    return None
+
+
+def diagnostics_summary(strategy: dict[str, Any]) -> dict[str, Any]:
+    diagnostics = strategy.get("execution_diagnostics") or {}
+    return diagnostics.get("summary") or {}
+
+
+def clean_baseline_result(strategy: dict[str, Any] | None, deployment_id: str) -> dict[str, Any]:
+    if strategy is None:
+        return {
+            "status": "passed",
+            "mode": "clean-baseline",
+            "deployment_id": deployment_id,
+            "reason": "target_strategy_absent",
+        }
+
+    summary = strategy.get("summary") or {}
+    diagnostics = diagnostics_summary(strategy)
+    counts = {
+        "total_trades": integer(summary.get("total_trades")),
+        "closed_trades": integer(summary.get("closed_trades")),
+        "open_positions": integer(summary.get("open_positions")),
+        "total_orders": integer(diagnostics.get("total_orders")),
+        "buy_orders": integer(diagnostics.get("buy_orders")),
+        "sell_orders": integer(diagnostics.get("sell_orders")),
+    }
+    residual = {key: value for key, value in counts.items() if value != 0}
+    if residual:
+        return {
+            "status": "blocked",
+            "mode": "clean-baseline",
+            "deployment_id": deployment_id,
+            "reason": "residual_runtime_evidence",
+            "residual_counts": residual,
+            "counts": counts,
+        }
+    return {
+        "status": "passed",
+        "mode": "clean-baseline",
+        "deployment_id": deployment_id,
+        "reason": "zero_runtime_evidence",
+        "counts": counts,
+    }
+
+
+def candidate_quality_result(args: argparse.Namespace, strategy: dict[str, Any] | None) -> dict[str, Any]:
+    if strategy is None:
+        return {
+            "status": "blocked",
+            "mode": "candidate-quality",
+            "deployment_id": args.deployment_id,
+            "reason": "target_strategy_absent",
+        }
+
+    summary = strategy.get("summary") or {}
+    metrics = strategy.get("metrics") or {}
+    diagnostics = diagnostics_summary(strategy)
+    values = {
+        "closed_trades": integer(summary.get("closed_trades")),
+        "realized_pnl": number(summary.get("realized_pnl")),
+        "profit_factor": number(metrics.get("profit_factor")),
+        "max_drawdown": number(metrics.get("max_drawdown")),
+        "buy_fill_rate_pct": number(diagnostics.get("buy_fill_rate_pct")),
+    }
+    failures: dict[str, dict[str, float]] = {}
+    if values["closed_trades"] < args.min_closed_trades:
+        failures["closed_trades"] = {
+            "actual": values["closed_trades"],
+            "minimum": args.min_closed_trades,
+        }
+    if values["realized_pnl"] < args.min_realized_pnl:
+        failures["realized_pnl"] = {
+            "actual": values["realized_pnl"],
+            "minimum": args.min_realized_pnl,
+        }
+    if values["profit_factor"] < args.min_profit_factor:
+        failures["profit_factor"] = {
+            "actual": values["profit_factor"],
+            "minimum": args.min_profit_factor,
+        }
+    if values["max_drawdown"] < args.max_drawdown_floor:
+        failures["max_drawdown"] = {
+            "actual": values["max_drawdown"],
+            "minimum": args.max_drawdown_floor,
+        }
+    if values["buy_fill_rate_pct"] < args.min_buy_fill_rate_pct:
+        failures["buy_fill_rate_pct"] = {
+            "actual": values["buy_fill_rate_pct"],
+            "minimum": args.min_buy_fill_rate_pct,
+        }
+
+    return {
+        "status": "blocked" if failures else "passed",
+        "mode": "candidate-quality",
+        "deployment_id": args.deployment_id,
+        "values": values,
+        "failures": failures,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dryrun-json", default="-", help="Dry-run report JSON path or '-' for stdin")
+    parser.add_argument("--deployment-id", default=DEFAULT_DEPLOYMENT_ID)
+    parser.add_argument(
+        "--mode",
+        choices=("clean-baseline", "candidate-quality"),
+        default="clean-baseline",
+    )
+    parser.add_argument("--min-closed-trades", type=int, default=50)
+    parser.add_argument("--min-realized-pnl", type=float, default=0.0)
+    parser.add_argument("--min-profit-factor", type=float, default=1.1)
+    parser.add_argument("--max-drawdown-floor", type=float, default=-50.0)
+    parser.add_argument("--min-buy-fill-rate-pct", type=float, default=95.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = load_payload(args.dryrun_json)
+    strategy = find_strategy(payload, args.deployment_id)
+    if args.mode == "clean-baseline":
+        result = clean_baseline_result(strategy, args.deployment_id)
+    else:
+        result = candidate_quality_result(args, strategy)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_dryrun_candidate_gate.py
+++ b/tests/test_check_dryrun_candidate_gate.py
@@ -1,0 +1,114 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_dryrun_candidate_gate.py"
+DEPLOYMENT_ID = "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+
+
+def run_gate(payload, *args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class CheckDryrunCandidateGateTests(unittest.TestCase):
+    def test_clean_baseline_passes_when_target_strategy_is_absent(self):
+        result = run_gate({"strategies": []})
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"reason": "target_strategy_absent"', result.stdout)
+
+    def test_clean_baseline_blocks_residual_target_rows(self):
+        payload = {
+            "strategies": [
+                {
+                    "deployment_id": DEPLOYMENT_ID,
+                    "summary": {
+                        "total_trades": 20,
+                        "closed_trades": 20,
+                        "open_positions": 0,
+                    },
+                    "execution_diagnostics": {
+                        "summary": {
+                            "total_orders": 185,
+                            "buy_orders": 20,
+                            "sell_orders": 165,
+                        }
+                    },
+                }
+            ]
+        }
+
+        result = run_gate(payload)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('"reason": "residual_runtime_evidence"', result.stdout)
+        self.assertIn('"total_orders": 185', result.stdout)
+
+    def test_clean_baseline_accepts_zero_target_counts(self):
+        payload = {
+            "strategies": [
+                {
+                    "deployment_id": DEPLOYMENT_ID,
+                    "summary": {
+                        "total_trades": 0,
+                        "closed_trades": 0,
+                        "open_positions": 0,
+                    },
+                    "execution_diagnostics": {
+                        "summary": {
+                            "total_orders": 0,
+                            "buy_orders": 0,
+                            "sell_orders": 0,
+                        }
+                    },
+                }
+            ]
+        }
+
+        result = run_gate(payload)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"reason": "zero_runtime_evidence"', result.stdout)
+
+    def test_candidate_quality_blocks_negative_sample(self):
+        payload = {
+            "strategies": [
+                {
+                    "deployment_id": DEPLOYMENT_ID,
+                    "summary": {
+                        "closed_trades": 20,
+                        "realized_pnl": -115.17,
+                    },
+                    "metrics": {
+                        "profit_factor": 0.2927,
+                        "max_drawdown": -136.3244,
+                    },
+                    "execution_diagnostics": {
+                        "summary": {
+                            "buy_fill_rate_pct": 97.93,
+                        }
+                    },
+                }
+            ]
+        }
+
+        result = run_gate(payload, "--mode", "candidate-quality")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('"realized_pnl"', result.stdout)
+        self.assertIn('"profit_factor"', result.stdout)
+        self.assertIn('"max_drawdown"', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `scripts/check_dryrun_candidate_gate.py` for machine-checking clean post-reset baselines and candidate-quality thresholds from the dry-run API payload.
- Add focused tests covering clean absent/zero baselines, residual runtime evidence, and the current negative PM5D sample shape.
- Update the reset runbook to require the clean-baseline gate after reset.

## Verification
- `python3 -m unittest tests.test_check_dryrun_candidate_gate tests.test_dryrun_report_contracts`
- `python3 -m py_compile scripts/check_dryrun_candidate_gate.py tests/test_check_dryrun_candidate_gate.py`
- `git diff --check -- scripts/check_dryrun_candidate_gate.py tests/test_check_dryrun_candidate_gate.py docs/runbooks/strategy-runtime-evidence-reset.md`
- Live read-only check currently blocks as expected: target dry-run still has 20 trades and 185 orders.

No runtime state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new command-line tool for validating deployment candidates against quality gates, supporting clean-baseline and candidate-quality evaluation modes.

* **Documentation**
  * Updated operational runbooks to include a new step for verifying dry-run reports against clean-baseline standards.

* **Tests**
  * Added comprehensive test suite for the new validation tool.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->