### PR TITLE
ci: add dry-run candidate gate workflow

### DIFF
--- a/.github/workflows/dryrun-candidate-gate.yml
+++ b/.github/workflows/dryrun-candidate-gate.yml
@@ -1,0 +1,131 @@
+name: Dry-Run Candidate Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref"
+        required: true
+        default: "main"
+      report_url:
+        description: "Dry-run report API URL"
+        required: true
+        default: "http://8.221.143.151/api/reports/dry-run"
+      deployment_id:
+        description: "Deployment id to evaluate"
+        required: true
+        default: "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+      mode:
+        description: "Gate mode: clean-baseline or candidate-quality"
+        required: true
+        default: "clean-baseline"
+      min_closed_trades:
+        description: "Candidate-quality minimum closed trades"
+        required: true
+        default: "50"
+      min_realized_pnl:
+        description: "Candidate-quality minimum realized PnL"
+        required: true
+        default: "0"
+      min_profit_factor:
+        description: "Candidate-quality minimum profit factor"
+        required: true
+        default: "1.1"
+      max_drawdown_floor:
+        description: "Candidate-quality max drawdown floor"
+        required: true
+        default: "-50"
+      min_buy_fill_rate_pct:
+        description: "Candidate-quality minimum buy fill rate pct"
+        required: true
+        default: "95"
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Evaluate dry-run evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Validate inputs
+        env:
+          MODE: ${{ github.event.inputs.mode }}
+        run: |
+          set -euo pipefail
+          case "${MODE}" in
+            clean-baseline|candidate-quality) ;;
+            *) echo "unsupported mode: ${MODE}" >&2; exit 2 ;;
+          esac
+
+      - name: Run dry-run candidate gate
+        env:
+          REPORT_URL: ${{ github.event.inputs.report_url }}
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          MODE: ${{ github.event.inputs.mode }}
+          MIN_CLOSED_TRADES: ${{ github.event.inputs.min_closed_trades }}
+          MIN_REALIZED_PNL: ${{ github.event.inputs.min_realized_pnl }}
+          MIN_PROFIT_FACTOR: ${{ github.event.inputs.min_profit_factor }}
+          MAX_DRAWDOWN_FLOOR: ${{ github.event.inputs.max_drawdown_floor }}
+          MIN_BUY_FILL_RATE_PCT: ${{ github.event.inputs.min_buy_fill_rate_pct }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/dryrun-candidate-gate
+          curl -fsS --max-time 10 "${REPORT_URL}" > artifacts/dryrun-candidate-gate/dryrun-report.json
+          set +e
+          python3 scripts/check_dryrun_candidate_gate.py \
+            --dryrun-json artifacts/dryrun-candidate-gate/dryrun-report.json \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            --mode "${MODE}" \
+            --min-closed-trades "${MIN_CLOSED_TRADES}" \
+            --min-realized-pnl "${MIN_REALIZED_PNL}" \
+            --min-profit-factor "${MIN_PROFIT_FACTOR}" \
+            --max-drawdown-floor "${MAX_DRAWDOWN_FLOOR}" \
+            --min-buy-fill-rate-pct "${MIN_BUY_FILL_RATE_PCT}" \
+            > artifacts/dryrun-candidate-gate/gate-result.json
+          status="$?"
+          set -e
+          cat artifacts/dryrun-candidate-gate/gate-result.json
+          exit "${status}"
+
+      - name: Publish summary
+        if: always()
+        run: |
+          set -euo pipefail
+          result="artifacts/dryrun-candidate-gate/gate-result.json"
+          if [ ! -f "${result}" ]; then
+            echo "No gate result artifact found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("artifacts/dryrun-candidate-gate/gate-result.json").read_text())
+          print("## Dry-Run Candidate Gate")
+          print("")
+          print(f"- Status: `{payload.get('status')}`")
+          print(f"- Mode: `{payload.get('mode')}`")
+          print(f"- Deployment: `{payload.get('deployment_id')}`")
+          if payload.get("reason"):
+              print(f"- Reason: `{payload.get('reason')}`")
+          if payload.get("residual_counts"):
+              print(f"- Residual counts: `{json.dumps(payload['residual_counts'], sort_keys=True)}`")
+          if payload.get("failures"):
+              print(f"- Failures: `{json.dumps(payload['failures'], sort_keys=True)}`")
+          PY
+
+      - name: Upload gate artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dryrun-candidate-gate-${{ github.run_id }}
+          path: artifacts/dryrun-candidate-gate/
+          retention-days: 30

--- a/docs/runbooks/strategy-runtime-evidence-reset.md
+++ b/docs/runbooks/strategy-runtime-evidence-reset.md
@@ -149,6 +149,17 @@ curl -fsS --max-time 10 http://8.221.143.151/api/reports/dry-run \
       --deployment-id pm5d.threelayer.settlement-probability-btc-eth.dryrun
 ```
 
+Or run the same check as an auditable GitHub Actions artifact:
+
+```bash
+gh workflow run dryrun-candidate-gate.yml \
+  --repo proerror77/ploy \
+  --ref main \
+  -f git_ref=main \
+  -f deployment_id=pm5d.threelayer.settlement-probability-btc-eth.dryrun \
+  -f mode=clean-baseline
+```
+
 The post-reset dry-run report should start from a clean baseline. A new
 profitability claim needs a fresh observation window, not the reset itself.
 


### PR DESCRIPTION
## Summary
- Add a manual `dryrun-candidate-gate.yml` workflow that fetches the dry-run report API, runs `check_dryrun_candidate_gate.py`, and uploads report/result artifacts.
- Document the workflow in the runtime evidence reset runbook as the auditable post-reset clean-baseline check.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dryrun-candidate-gate.yml"); puts "yaml ok"'`\n- `python3 -m unittest tests.test_check_dryrun_candidate_gate tests.test_dryrun_report_contracts`\n- `git diff --check -- .github/workflows/dryrun-candidate-gate.yml docs/runbooks/strategy-runtime-evidence-reset.md`\n- Live read-only clean-baseline gate currently blocks as expected because the target still has 20 trades and 185 orders.\n\nNo runtime state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a GitHub Actions workflow for validating deployment candidates. Users can manually trigger the workflow with customizable performance thresholds and deployment identifiers to validate dry-run results. The workflow automatically generates detailed validation reports and publishes results as artifacts for review and audit purposes.

* **Documentation**
  * Updated operational runbooks with instructions for running the new candidate validation workflow as part of baseline verification processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->