### PR TITLE
docs: record dry-run gate audit evidence

### DIFF
--- a/tasks/alpha_search_completion_audit_20260512.md
+++ b/tasks/alpha_search_completion_audit_20260512.md
@@ -83,6 +83,18 @@ Latest reset / data-quality evidence:
   - desired/observed state: `running` / `running`
   - interpretation: the destructive reset is correctly blocked until the dry-run
     deployment is paused or stopped.
+- dry-run candidate gate run: `25751440786`
+  - workflow: `dryrun-candidate-gate.yml`
+  - input: `mode=clean-baseline`
+  - result: expected failure / blocked
+  - artifact: `dryrun-candidate-gate-25751440786`
+  - status: `blocked`
+  - reason: `residual_runtime_evidence`
+  - residual counts: `20` total trades, `20` closed trades, `185` total orders,
+    `20` buy orders, `165` sell orders
+  - interpretation: the CI gate now proves the current dry-run report is not a
+    clean baseline and will block post-reset promotion until runtime evidence is
+    actually cleared.
 
 Current dry-run profitability read:
 
@@ -155,6 +167,8 @@ Earlier blocker runs:
 | Latest deploy bundle can be built without mutating remote services | `deploy-tango-1-1.yml` run `25688999691` with `deploy=false` | `ready` | Build-only run built the release runner, research tools, optimize-backtest, deploy bundle, and live-paused bundle guard. |
 | Remote dry-run config matches the ready handoff on `main` | read-only `tango-1-1` config comparison | `blocked` | Remote is still `auto_settlement_full_depth_settlement_edge`; `origin/main` is `auto_settlement_conservative_settlement_edge`, so protected dry-run deploy is required. |
 | Old dry-run runtime evidence can be cleared without touching raw data | PRs `#464`, `#465`, `#466`; reset preview `25748008417`; guard run `25748940434` | `ready but not executed` | Tooling is merged and guarded. Actual deletion remains blocked until explicit approval to pause the running deployment. |
+| Reset procedure is documented and operator-gated | `docs/runbooks/strategy-runtime-evidence-reset.md`; PR `#470` | `ready` | Runbook records preflight, approval text, preview, pause, guarded execute, artifact inspection, resume, and post-reset gates. |
+| Clean post-reset baseline can be machine-checked | `scripts/check_dryrun_candidate_gate.py`; PR `#471`; workflow `dryrun-candidate-gate.yml`; PR `#472`; run `25751440786` | `ready and currently blocked` | The gate blocks the current report with `residual_runtime_evidence`: 20 trades and 185 orders remain. |
 | Current retained data window supports promotion-grade search | market-data audit `25747004738` | `blocked` | 24h coverage still includes the known Binance LOB gap. Wait for a clean 48-72h window or use shorter diagnostic-only snapshots. |
 | A profitable strategy has been produced | ready handoff plus post-merge dry-run/executable evidence | `not ready` | Current dry-run is negative: 20 closed trades, PnL `-115.17`, profit factor `0.2927`, max drawdown `-136.3244`. |
 
@@ -201,6 +215,16 @@ All runs used:
   is explicitly supplied.
 - PR #466: made running-guard failures upload `guard-status.json` so blocked
   destructive reset attempts have artifact evidence.
+- PR #470: added `docs/runbooks/strategy-runtime-evidence-reset.md`, the
+  operator runbook for preview, approval, pause, guarded reset, artifact
+  inspection, and resume.
+- PR #471: added `scripts/check_dryrun_candidate_gate.py` and focused tests so
+  clean-baseline and candidate-quality decisions are machine-checked from the
+  dry-run API payload.
+- PR #472: added `dryrun-candidate-gate.yml`, a GitHub Actions surface that
+  uploads dry-run report and gate-result artifacts for reset/promotion review.
+- Run `25751440786`: proved the dry-run candidate gate blocks the current
+  settlement-probability dry-run with `residual_runtime_evidence`.
 
 ## Remaining Actions
 
@@ -210,7 +234,9 @@ All runs used:
 3. Execute `reset-strategy-runtime-evidence.yml` with `execute=true`,
    `allow_running=false`, and `confirm=delete-strategy-runtime-evidence`.
 4. Download and inspect the reset artifacts, then verify `/api/reports/dry-run`
-   starts from a clean baseline for this deployment.
+   starts from a clean baseline for this deployment with
+   `scripts/check_dryrun_candidate_gate.py --mode clean-baseline` or
+   `dryrun-candidate-gate.yml`.
 5. Resume the dry-run only after reset verification.
 6. Wait for a clean 48-72h retained data window after the 2026-05-12 LOB gap
    ages out, then run hosted walk-forward / MCTS alpha search again.
@@ -228,6 +254,8 @@ Do not mark the user objective complete until all of the following are true:
   event evidence;
 - old runtime rows are reset or the report is explicitly filtered to a clean
   post-reset observation window;
+- `check_dryrun_candidate_gate.py --mode clean-baseline` or
+  `dryrun-candidate-gate.yml` passes for the selected dry-run deployment;
 - the retained data window used for promotion is clean enough for the declared
   evidence stage;
 - the dry-run config PR is generated from the ready handoff and passes CI;


### PR DESCRIPTION
## Summary
- Refresh the alpha-search completion audit with PR #470-#472 and dry-run candidate gate run 25751440786.
- Add the reset runbook and clean-baseline gate to the prompt-to-artifact checklist and completion rule.
- Record that the current target remains blocked by residual runtime evidence: 20 trades and 185 orders.

## Verification
- `git diff --check -- tasks/alpha_search_completion_audit_20260512.md`
- Downloaded and inspected `dryrun-candidate-gate-25751440786/gate-result.json`

No runtime state was mutated.