### PR TITLE
ci: verify clean baseline after runtime reset

### DIFF
--- a/.github/workflows/reset-strategy-runtime-evidence.yml
+++ b/.github/workflows/reset-strategy-runtime-evidence.yml
@@ -214,6 +214,21 @@ jobs:
           ssh tango-1-1 "${remote_cmd}"
           scp -r "tango-1-1:${remote_backup}/." artifacts/reset-strategy-runtime-evidence/
 
+      - name: Verify post-reset clean baseline
+        if: ${{ github.event.inputs.execute == 'true' }}
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/reset-strategy-runtime-evidence
+          curl -fsS --max-time 10 "http://${DEPLOY_HOST}/api/reports/dry-run" \
+            > artifacts/reset-strategy-runtime-evidence/post-reset-dryrun-report.json
+          python3 scripts/check_dryrun_candidate_gate.py \
+            --dryrun-json artifacts/reset-strategy-runtime-evidence/post-reset-dryrun-report.json \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            --mode clean-baseline \
+            > artifacts/reset-strategy-runtime-evidence/post-reset-clean-baseline-gate.json
+
       - name: Publish summary
         if: always()
         run: |
@@ -237,6 +252,12 @@ jobs:
           print(f"- Deleted orders: `{payload['deleted_orders']}`")
           print(f"- After: orders=`{payload['after']['orders']}`, fills=`{payload['after']['fills']}`")
           print("- Raw market data tables were not touched.")
+          gate_path = Path("artifacts/reset-strategy-runtime-evidence/post-reset-clean-baseline-gate.json")
+          if gate_path.exists():
+              gate = json.loads(gate_path.read_text())
+              print(f"- Post-reset clean-baseline gate: `{gate.get('status')}`")
+              if gate.get("reason"):
+                  print(f"- Post-reset gate reason: `{gate.get('reason')}`")
           PY
 
       - name: Upload reset artifact

--- a/docs/runbooks/strategy-runtime-evidence-reset.md
+++ b/docs/runbooks/strategy-runtime-evidence-reset.md
@@ -121,6 +121,7 @@ download the reset artifact and verify:
 - `deleted_orders` equals the expected target order count.
 - `after.orders=0` and `after.fills=0` for the reset scope.
 - Backup JSON files are present in the artifact.
+- `post-reset-clean-baseline-gate.json` has `status=passed`.
 
 ## Resume Clean Observation
 
@@ -159,6 +160,10 @@ gh workflow run dryrun-candidate-gate.yml \
   -f deployment_id=pm5d.threelayer.settlement-probability-btc-eth.dryrun \
   -f mode=clean-baseline
 ```
+
+The destructive reset workflow also runs this clean-baseline gate automatically
+after `execute=true`. The standalone workflow is for manual rechecks or later
+promotion reviews.
 
 The post-reset dry-run report should start from a clean baseline. A new
 profitability claim needs a fresh observation window, not the reset itself.


### PR DESCRIPTION
## Summary
- Run `check_dryrun_candidate_gate.py --mode clean-baseline` automatically after `reset-strategy-runtime-evidence.yml` executes a destructive reset.
- Upload `post-reset-dryrun-report.json` and `post-reset-clean-baseline-gate.json` in the reset artifact.
- Update the reset runbook to require the post-reset gate artifact to pass.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reset-strategy-runtime-evidence.yml"); puts "yaml ok"'`\n- `python3 -m unittest tests.test_check_dryrun_candidate_gate tests.test_reset_strategy_runtime_evidence`\n- `python3 -m py_compile scripts/check_dryrun_candidate_gate.py scripts/reset_strategy_runtime_evidence.py`\n- `git diff --check -- .github/workflows/reset-strategy-runtime-evidence.yml docs/runbooks/strategy-runtime-evidence-reset.md`\n\nNo runtime state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added automatic validation step to the reset workflow that executes upon completion
  * Validation results now display in the workflow summary for easy review

* **Documentation**
  * Updated reset workflow runbook with validation requirements and clarified process flow for both automated and manual verification scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/474)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->