### PR TITLE
fix: align PM5D settlement dry-run exposure limit

### DIFF
--- a/config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json
+++ b/config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json
@@ -2,7 +2,7 @@
   "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
   "bundle_id": "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun",
   "account_id": "acct-pm5d-dryrun",
-  "max_gross_exposure": "5.00",
+  "max_gross_exposure": "60.00",
   "runtime_mode": "paper",
   "desired_state": "running"
 }

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from decimal import Decimal
+import json
 import tomllib
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 STRATEGY_DIR = ROOT / "config" / "strategies"
+DEPLOYMENT_DIR = ROOT / "config" / "deployments"
 
 
 class StrategyConfigContractTests(unittest.TestCase):
@@ -41,6 +44,32 @@ class StrategyConfigContractTests(unittest.TestCase):
         for _, runtime in recorders:
             self.assertGreater(runtime["record_market_updates_max_records"], 0)
             self.assertGreater(runtime["record_market_updates_max_bytes"], 0)
+
+    def test_settlement_probability_dryrun_deployment_exposure_covers_strategy_sizing(self) -> None:
+        strategy = tomllib.loads(
+            (
+                STRATEGY_DIR
+                / "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+            ).read_text()
+        )
+        deployment = json.loads(
+            (
+                DEPLOYMENT_DIR
+                / "pm5d.threelayer.settlement-probability-btc-eth.dryrun.json"
+            ).read_text()
+        )
+
+        strategy_config = strategy["strategy"]
+        expected_exposure = Decimal(str(strategy_config["stake_usd"])) * Decimal(
+            str(strategy_config["max_positions"])
+        )
+        deployment_limit = Decimal(deployment["max_gross_exposure"])
+
+        self.assertEqual(
+            deployment["bundle_id"],
+            "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun",
+        )
+        self.assertGreaterEqual(deployment_limit, expected_exposure)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Raise `pm5d.threelayer.settlement-probability-btc-eth.dryrun` deployment `max_gross_exposure` from `5.00` to `60.00`.
- The strategy config uses `stake_usd=15.0` and `max_positions=4`, so the deployment-level exposure display/control contract should cover the configured sizing envelope.
- Add a config contract test so this active dry-run manifest cannot silently drift below `stake_usd * max_positions` again.

## Why

After the post-reset dry-run resumed, the first fresh trade used requested notional `15.0` while the deployment registry still displayed `max_gross_exposure=5.00`. That makes the operator surface misleading and weakens the deployment-level risk contract, even though the dry-run execution path records simulated strategy runtime orders.

## Verification

- `python3 -m unittest tests.test_strategy_config_contracts`
- `git diff --check -- config/deployments/pm5d.threelayer.settlement-probability-btc-eth.dryrun.json tests/test_strategy_config_contracts.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment exposure parameters for the settlement probability strategy.

* **Tests**
  * Added validation tests to ensure deployment configurations align with strategy requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/481)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->