### PR TITLE
docs: record PM5D quote freshness verification

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -353,7 +353,7 @@ text incorrectly framed `ploy-ci-1` as the current default research runner.
 - [x] Preserve near-terminal binary-option quote prices such as `0.99` and
   `0.01` instead of filtering them as non-tradeable placeholders.
 - [x] Run focused collector/runner checks.
-- [ ] Land through PR, deploy from `main`, and verify active BTC/ETH quote ages
+- [x] Land through PR, deploy from `main`, and verify active BTC/ETH quote ages
   plus collector reset logs on tango.
 
 ## Review
@@ -372,6 +372,13 @@ text incorrectly framed `ploy-ci-1` as the current default research runner.
   `cargo test -p ploy-market-data --features live --lib collector_config`, and
   `cargo check -p ploy-runner-host --features ops`. Existing warning-only
   output remains in strategy/market-data dead-code lints.
+- 2026-05-13: After deploy run `25756032457` from `main@6a6240cf`, tango
+  quote freshness was rechecked for active BTC/ETH markets: `20` active tokens,
+  `0` missing quotes, `0` quotes older than 15s, `0` missing ask/ask_size, and
+  max quote age `5.5s`. Recent `ploy-quote-collector.service` logs still showed
+  a WebSocket reset / heartbeat timeout around restart, but reconnect and
+  subscription refresh succeeded, `quotes_inserted` continued increasing, and
+  `persist_errors=0`.
 
 # PM5D Prior Factor Reuse For Alpha Search (2026-05-12)
 


### PR DESCRIPTION
## Summary

- Mark the PM5D quote freshness follow-up complete in `tasks/todo.md`.
- Record post-deploy tango verification for active BTC/ETH quote freshness.
- Capture the remaining nuance: collector logs still had a WS reset/heartbeat timeout around restart, but reconnect/subscription refresh succeeded and quote persistence kept advancing with `persist_errors=0`.

## Evidence

- Deploy run: `25756032457` from `main@6a6240cf`
- Active BTC/ETH quote check: `20` active tokens, `0` missing quotes, `0` age > 15s, `0` missing ask/ask_size, max quote age `5.5s`
- `ploy-quote-collector.service` logs: quotes continued increasing after reconnect, `persist_errors=0`

## Verification

- `git diff --check -- tasks/todo.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal documentation updates only and does not include any user-facing changes, new features, or bug fixes. No release notes are applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/482)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->