### PR TITLE
feat: add PM5D entry-price quality alpha prior

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -609,6 +609,9 @@ pub fn autofactor_matrix_from_v2(
             f64::NAN
         }
     });
+    insert_column(&mut columns, "entry_price_quality_score", rows, |row| {
+        entry_price_quality_score(row.entry_ask)
+    });
     insert_column(&mut columns, "repricing_gap_side_10s", rows, |row| {
         row.side_model_edge
     });
@@ -1131,6 +1134,17 @@ fn deterministic_mutation_layer(
             );
         }
 
+        if settlement_target && input_names.contains("entry_price_quality_score") {
+            push_mutation(
+                &mut out,
+                seed,
+                depth,
+                "entry_price_quality",
+                mul(seed.expr.clone(), input("entry_price_quality_score")),
+                "add_feature_gate: penalize brittle binary-ticket prices before runtime handoff.",
+            );
+        }
+
         if !settlement_target && input_names.contains("poly_quote_age") {
             push_mutation(
                 &mut out,
@@ -1210,6 +1224,14 @@ fn settlement_native_generated_candidates(input_names: &BTreeSet<String>) -> Vec
                 "Settlement edge gated by full-depth entry capacity.",
             );
         }
+        if input_names.contains("entry_price_quality_score") {
+            push_generated(
+                &mut out,
+                format!("auto_settlement_{edge_name}_x_entry_price_quality"),
+                mul(input(edge_name), input("entry_price_quality_score")),
+                "Settlement edge gated by binary entry-price quality.",
+            );
+        }
         if has_all(input_names, &["near_strike_score", "entry_capacity_score"]) {
             push_generated(
                 &mut out,
@@ -1219,6 +1241,27 @@ fn settlement_native_generated_candidates(input_names: &BTreeSet<String>) -> Vec
                     input("entry_capacity_score"),
                 ),
                 "Settlement edge gated by both near-strike state and executable capacity.",
+            );
+        }
+        if has_all(
+            input_names,
+            &[
+                "near_strike_score",
+                "entry_capacity_score",
+                "entry_price_quality_score",
+            ],
+        ) {
+            push_generated(
+                &mut out,
+                format!("auto_settlement_{edge_name}_x_near_strike_x_capacity_x_entry_price_quality"),
+                mul(
+                    mul(
+                        mul(input(edge_name), input("near_strike_score")),
+                        input("entry_capacity_score"),
+                    ),
+                    input("entry_price_quality_score"),
+                ),
+                "Settlement edge gated by near-strike state, executable capacity, and entry-price quality.",
             );
         }
         if input_names.contains("side_spread") {
@@ -1577,6 +1620,15 @@ fn near_strike_score(row: &FactorObservationV2) -> f64 {
     } else {
         f64::NAN
     }
+}
+
+fn entry_price_quality_score(entry_price: f64) -> f64 {
+    if !valid_pm_price(entry_price) {
+        return f64::NAN;
+    }
+    let low_ticket_gate = ((entry_price - 0.08) / 0.12).clamp(0.0, 1.0);
+    let expensive_ticket_gate = ((0.85 - entry_price) / 0.20).clamp(0.0, 1.0);
+    low_ticket_gate.min(expensive_ticket_gate)
 }
 
 fn time_remaining_bucket(secs: i64) -> &'static str {
@@ -2003,6 +2055,13 @@ mod tests {
         assert!(full_depth_edge.spearman_ic > 0.95);
         assert!(reports.iter().any(|report| {
             report.name == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity"
+        }));
+        assert!(reports.iter().any(|report| {
+            report.name == "auto_settlement_full_depth_settlement_edge_x_entry_price_quality"
+        }));
+        assert!(reports.iter().any(|report| {
+            report.name
+                == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality"
         }));
         assert!(
             reports

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -829,6 +829,7 @@ venue = "sportsbook"
             runtime_score,
             AutoSettlementFactorInputs {
                 settlement_edge: 0.06,
+                entry_price: 0.30,
                 distance_over_sigma: 0.20,
                 direction_sign: 1.0,
                 entry_capacity_ratio: 3.0,

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -1430,6 +1430,7 @@ impl ThreeLayerStrategy {
                 if let Some(runtime_score) = self.config.autofactor_runtime_score.as_deref() {
                     let inputs = AutoSettlementFactorInputs {
                         settlement_edge: edge,
+                        entry_price: entry_price_f,
                         distance_over_sigma,
                         direction_sign,
                         entry_capacity_ratio,
@@ -3496,6 +3497,7 @@ mod tests {
 
         let inputs = AutoSettlementFactorInputs {
             settlement_edge: 0.06,
+            entry_price: 0.30,
             distance_over_sigma: 0.20,
             direction_sign: 1.0,
             entry_capacity_ratio: 3.0,
@@ -3522,6 +3524,7 @@ mod tests {
 
         let near_inputs = AutoSettlementFactorInputs {
             settlement_edge: 0.06,
+            entry_price: 0.30,
             distance_over_sigma: 0.20,
             direction_sign: 1.0,
             entry_capacity_ratio: 3.0,
@@ -3550,6 +3553,45 @@ mod tests {
         assert!((near_raw - 0.048).abs() < 1e-9);
         assert!((far_raw - 0.006).abs() < 1e-9);
         assert!(near_score > far_score);
+    }
+
+    #[test]
+    fn autofactor_entry_price_quality_formula_penalizes_brittle_ticket_prices() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+
+        let good_inputs = AutoSettlementFactorInputs {
+            settlement_edge: 0.06,
+            entry_price: 0.30,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            entry_capacity_ratio: 3.0,
+            side_spread: 0.03,
+            external_pressure: 0.0,
+            iv_change_1m: 0.0,
+        };
+        let low_ticket_inputs = AutoSettlementFactorInputs {
+            entry_price: 0.10,
+            ..good_inputs
+        };
+
+        let (good_raw, good_score) = autofactor_formula_entry_score(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+            good_inputs,
+            config.min_edge,
+        )
+        .expect("entry-price-quality settlement formula score");
+        let (low_raw, low_score) = autofactor_formula_entry_score(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+            low_ticket_inputs,
+            config.min_edge,
+        )
+        .expect("low-ticket settlement formula score");
+
+        assert!((good_raw - 0.06).abs() < 1e-9);
+        assert!((low_raw - 0.01).abs() < 1e-9);
+        assert!(good_score > low_score);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -52,6 +52,7 @@ pub struct EntryScoreInputs {
 #[derive(Debug, Clone, Copy)]
 pub struct AutoSettlementFactorInputs {
     pub settlement_edge: f64,
+    pub entry_price: f64,
     pub distance_over_sigma: f64,
     pub direction_sign: f64,
     pub entry_capacity_ratio: f64,
@@ -110,6 +111,15 @@ pub fn auto_settlement_entry_capacity_score(entry_capacity_ratio: f64) -> f64 {
     }
 }
 
+pub fn auto_settlement_entry_price_quality_score(entry_price: f64) -> f64 {
+    if !entry_price.is_finite() || entry_price <= 0.0 || entry_price >= 1.0 {
+        return f64::NAN;
+    }
+    let low_ticket_gate = ((entry_price - 0.08) / 0.12).clamp(0.0, 1.0);
+    let expensive_ticket_gate = ((0.85 - entry_price) / 0.20).clamp(0.0, 1.0);
+    low_ticket_gate.min(expensive_ticket_gate)
+}
+
 pub fn auto_settlement_formula_score(
     runtime_score: &str,
     inputs: AutoSettlementFactorInputs,
@@ -140,12 +150,23 @@ pub fn auto_settlement_formula_score(
                 auto_settlement_near_strike_score(inputs.distance_over_sigma, inputs.direction_sign)
         }
         "_x_capacity" => score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio),
+        "_x_entry_price_quality" => {
+            score *= auto_settlement_entry_price_quality_score(inputs.entry_price)
+        }
         "_x_near_strike_x_capacity" => {
             score *= auto_settlement_near_strike_score(
                 inputs.distance_over_sigma,
                 inputs.direction_sign,
             );
             score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio);
+        }
+        "_x_near_strike_x_capacity_x_entry_price_quality" => {
+            score *= auto_settlement_near_strike_score(
+                inputs.distance_over_sigma,
+                inputs.direction_sign,
+            );
+            score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio);
+            score *= auto_settlement_entry_price_quality_score(inputs.entry_price);
         }
         "_spread_adjusted" => {
             if !inputs.side_spread.is_finite() || inputs.side_spread < 0.0 {
@@ -176,7 +197,11 @@ pub fn norm_cdf(x: f64) -> f64 {
     let d = 0.3989422804014327 * (-x * x / 2.0).exp();
     let p =
         d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
-    if x >= 0.0 { 1.0 - p } else { p }
+    if x >= 0.0 {
+        1.0 - p
+    } else {
+        p
+    }
 }
 
 pub fn calibrate_direction_probability(
@@ -243,7 +268,11 @@ pub fn reward_risk_ratio(entry_price: f64) -> f64 {
     let fee = crypto_fee_cost(entry_price);
     let reward = 1.0 - entry_price - fee;
     let risk = entry_price + fee;
-    if risk <= 0.0 { f64::NAN } else { reward / risk }
+    if risk <= 0.0 {
+        f64::NAN
+    } else {
+        reward / risk
+    }
 }
 
 pub fn evaluate_direction_score(

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -63,9 +63,17 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
         **SETTLEMENT_RUNTIME_MAPPING,
         "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_capacity",
     },
+    "auto_settlement_full_depth_settlement_edge_x_entry_price_quality": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_entry_price_quality",
+    },
     "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity": {
         **SETTLEMENT_RUNTIME_MAPPING,
         "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity",
+    },
+    "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
     },
     "auto_settlement_full_depth_settlement_edge_spread_adjusted": {
         **SETTLEMENT_RUNTIME_MAPPING,
@@ -91,9 +99,17 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
         **SETTLEMENT_RUNTIME_MAPPING,
         "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_capacity",
     },
+    "auto_settlement_conservative_settlement_edge_x_entry_price_quality": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+    },
     "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity": {
         **SETTLEMENT_RUNTIME_MAPPING,
         "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity",
+    },
+    "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality": {
+        **SETTLEMENT_RUNTIME_MAPPING,
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
     },
     "auto_settlement_conservative_settlement_edge_spread_adjusted": {
         **SETTLEMENT_RUNTIME_MAPPING,

--- a/tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json
+++ b/tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json
@@ -1,0 +1,75 @@
+{
+  "mutations": [
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_conservative_settlement_edge_entry_price_quality",
+      "feature": "entry_price_quality_score"
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_full_depth_settlement_edge_entry_price_quality",
+      "feature": "entry_price_quality_score"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_conservative_entry_price_quality_near_strike"
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_full_depth_entry_price_quality_near_strike"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_capacity_gate",
+      "name": "llm_conservative_entry_price_quality_capacity",
+      "feature": "entry_capacity_score"
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_capacity_gate",
+      "name": "llm_full_depth_entry_price_quality_capacity",
+      "feature": "entry_capacity_score"
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_spread_penalty",
+      "name": "llm_conservative_entry_price_quality_spread_penalty",
+      "constant": 0.01
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge_x_entry_price_quality",
+      "mutation_type": "add_spread_penalty",
+      "name": "llm_full_depth_entry_price_quality_spread_penalty",
+      "constant": 0.01
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
+      "mutation_type": "clip_or_squash",
+      "name": "llm_conservative_strict_entry_quality_squashed",
+      "lo": -0.25,
+      "hi": 0.25
+    },
+    {
+      "base_factor": "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
+      "mutation_type": "clip_or_squash",
+      "name": "llm_full_depth_strict_entry_quality_squashed",
+      "lo": -0.25,
+      "hi": 0.25
+    },
+    {
+      "base_factor": "spread_adjusted_external_move",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_repricing_external_move_entry_price_quality",
+      "feature": "entry_price_quality_score"
+    },
+    {
+      "base_factor": "spread_adjusted_external_move",
+      "mutation_type": "add_near_strike_interaction",
+      "name": "llm_repricing_external_move_near_strike_for_lag_diagnostic"
+    }
+  ]
+}

--- a/tasks/research_evidence/pm5d_entry_price_quality_prior_20260513.md
+++ b/tasks/research_evidence/pm5d_entry_price_quality_prior_20260513.md
@@ -1,0 +1,102 @@
+# Research Evidence: PM5D Entry-Price Quality Alpha Prior - 2026-05-13
+
+## Decision
+
+Status: `continue`
+
+One-line decision: add entry-price quality as a bounded research/runtime feature
+so alpha search can penalize brittle binary-ticket prices before any dry-run
+handoff.
+
+## Semantic Context
+
+- Strategy lane: `settlement_probability`
+- Evidence stage: `factor_attribution`
+- Lifecycle segment tested: `signal`
+- Promotion target, if any: `none`
+
+## Hypothesis
+
+- Claim: settlement edge should be gated by executable entry-price quality,
+  because very low-priced or very expensive binary tickets are more likely to
+  turn apparent probability edge into fragile execution or calibration edge.
+- Expected edge mechanism: retain settlement-probability candidates only when
+  the entry price is in a range where the 15U stake has usable payout structure
+  and less brittle quote behavior.
+- Failure criteria: walk-forward/MCTS rejects the entry-price-quality variants,
+  symbol holdout weakens, or dry-run/replay parity cannot map the selected
+  formula into the runtime scorer.
+- Next decision this evidence should unlock: run hosted artifact alpha search
+  after a clean retained BTC/ETH data window is available.
+
+## Inputs
+
+- Git ref: pending branch `research/pm5d-low-price-alpha-prior`
+- Workflow run: not run yet
+- Snapshot or artifact: none
+- Dataset/window: none
+- Symbols/events: intended BTCUSDT, ETHUSDT PM5D
+- Config:
+  `tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json`
+- Local/remote artifact paths: local repo files only
+
+## Data Surface Audit
+
+- Binance spot/trade ticks: `not applicable`
+- Binance L2/LOB: `not applicable`
+- Polymarket quote ticks: `not applicable`
+- Polymarket full CLOB depth: `not applicable`
+- Official settlement: `not applicable`
+- Runtime/dry-run fills: `not applicable`
+- Data audit status: not run; known 24h BTC/ETH LOB gap must age out before
+  promotion-grade walk-forward.
+- Missing surfaces and impact: this is prior/schema work only, not performance
+  evidence.
+
+## Accounting Semantics
+
+- Event accounting: `one-event-one-trade`
+- Entry price model: bounded `entry_price_quality_score` from executable
+  `entry_ask`
+- Exit or settlement label: future run must use
+  `full_depth_settlement_executable_pnl`
+- Fillability assumption: future run must use full-depth / conservative
+  executable pricing and capacity gates
+- Fees/slippage/latency assumption: future run must retain spread and quote-age
+  gates
+- Capacity or stake assumption: future run should keep 15U stake semantics
+
+## Results
+
+- Headline metrics: none; no backtest was run.
+- Stability metrics: none.
+- Calibration or bucket behavior: to be evaluated by hosted walk-forward.
+- Fill rate/capacity: not tested.
+- PnL/ROI: not tested.
+- Drawdown/risk: not tested.
+
+## Promotion Gate Check
+
+- Hypothesis explicit: `pass`
+- Data provenance recorded: `n/a`
+- Executable pricing conservative: `n/a`
+- Settlement/exit label matches lane: `n/a`
+- Walk-forward or leakage guard: `n/a`
+- Replay/runtime parity: `n/a`
+- Runtime scorer/config mapping: `pass`
+- Risk/stake/kill switch stated: `n/a`
+
+## Caveats
+
+- This is not evidence that a strategy is profitable.
+- The new feature is intentionally bounded and conservative; it can reduce
+  search reward by rejecting low-priced or expensive tickets that previously
+  looked attractive on raw edge.
+- Promotion remains blocked until clean data audit, hosted walk-forward,
+  ready handoff, fresh dry-run sample, and recorded replay/dry-run parity pass.
+
+## Follow-Up
+
+- After `2026-05-13 10:48 +08`, rerun the BTC/ETH 24h market-data audit.
+- If clean, run hosted artifact alpha search with
+  `alpha_search_llm_prior_json=tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,45 @@
+# PM5D Entry-Price Quality Alpha Prior (2026-05-13)
+
+## Goal
+
+Make the alpha-search system able to explore and promote bounded
+entry-price-quality variants for PM5D settlement-probability formulas, instead
+of leaving entry-price caveats as chat-only guidance.
+
+## Plan
+
+- [x] Add a bounded `entry_price_quality_score` feature to research
+  AutoFactor inputs.
+- [x] Generate settlement-native candidates that combine settlement edge with
+  entry-price quality, capacity, and near-strike gates.
+- [x] Add runtime scorer support for the same formula suffixes.
+- [x] Add promotion mappings so ready candidates can become dry-run handoff
+  artifacts.
+- [x] Add a machine-readable alpha-search prior for the next hosted run.
+- [x] Run focused Python and Rust verification.
+- [ ] After the known BTC/ETH LOB gap ages out, run a fresh 24h data audit
+  before hosted walk-forward/MCTS search.
+
+## Review
+
+- 2026-05-13: Added
+  `tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json`.
+  This prior is factor-attribution/search guidance only; it is not a
+  profitability claim.
+- 2026-05-13: Added
+  `tasks/research_evidence/pm5d_entry_price_quality_prior_20260513.md` to make
+  the current evidence stage explicit and block promotion until clean data,
+  walk-forward, dry-run, and parity gates pass.
+- 2026-05-13: Focused verification passed:
+  `python3 -m json.tool tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json`,
+  promotion mapping smoke for four new AutoFactor formula names,
+  `python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py`,
+  `python3 -m unittest tests.test_autofactor_strategy_promotion`,
+  `rtk cargo test --locked -p ploy-research mines_generated_settlement_native_candidates_from_v2_rows --lib`,
+  `rtk cargo test --locked -p ploy-research typed_llm_prior_mutations_compile_into_factor_expr_candidates --lib`,
+  `rtk cargo test --locked -p ploy-strategy-bundles autofactor_entry_price_quality_formula_penalizes_brittle_ticket_prices --lib`,
+  and `rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`.
+
 # Research Snapshot Timestamp Window Fix (2026-05-12)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -56,7 +56,8 @@ target labels are side-aligned executable settlement PnL; reports are candidate 
 rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
 1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,2.666226,0.6836,1
 2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,6,0.8333,1.0000,2.631575,0.6790,3
-3,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,-0.301991,0.4785,3
+3,auto_settlement_conservative_settlement_edge_x_entry_price_quality,full_depth_settlement_executable_pnl,candidate,passed,49831,0.106112,0.155901,43,1.031294,0.9070,6,0.8333,1.0000,2.512771,0.6712,3
+4,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,-0.301991,0.4785,3
 """
 
 CORE_SUITE_REPORT = f"""
@@ -150,7 +151,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(registry["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
         self.assertEqual(handoff["blocked_factor_count"], 1)
-        self.assertEqual(len(handoff["strategies"]), 2)
+        self.assertEqual(len(handoff["strategies"]), 3)
         self.assertEqual(
             handoff["strategies"][0]["runtime_score"],
             "autofactor_formula:auto_settlement_conservative_settlement_edge",
@@ -161,6 +162,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
         self.assertIn(
             "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            handoff_md,
+        )
+        self.assertIn(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
             handoff_md,
         )
         self.assertIn("top bucket avg label", handoff_md)
@@ -236,7 +241,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         self.assertEqual(payload["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
-        self.assertEqual(len(handoff["strategies"]), 2)
+        self.assertEqual(len(handoff["strategies"]), 3)
         first = payload["qualified_strategies"][0]["factor"]
         self.assertEqual(first["symbol_count"], 6)
         self.assertEqual(first["symbol_positive_ratio"], 0.8333)


### PR DESCRIPTION
## Summary
- add bounded entry_price_quality_score to PM5D AutoFactor research inputs and generated settlement candidates
- add matching runtime formula suffixes and promotion mappings for entry-price-quality handoffs
- add a machine-readable alpha-search prior and research evidence note for the next hosted walk-forward run

## Verification
- python3 -m json.tool tasks/alpha_search_priors/pm5d_entry_price_quality_prior_20260513.json
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_autofactor_strategy_promotion
- CARGO_TARGET_DIR=/tmp/ploy-entry-price-quality-research /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research mines_generated_settlement_native_candidates_from_v2_rows --lib
- CARGO_TARGET_DIR=/tmp/ploy-entry-price-quality-research /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research typed_llm_prior_mutations_compile_into_factor_expr_candidates --lib
- CARGO_TARGET_DIR=/tmp/ploy-entry-price-quality-strategy /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_entry_price_quality_formula_penalizes_brittle_ticket_prices --lib
- CARGO_TARGET_DIR=/tmp/ploy-entry-price-quality-strategy /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib

## Notes
This is factor-attribution/search plumbing only. It does not claim a profitable strategy and should not be promoted before clean market-data audit, hosted walk-forward, fresh dry-run evidence, and recorded replay/dry-run parity pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced entry price quality scoring to penalize brittle binary-ticket prices in settlement strategies.
  * Added new settlement-native candidate variants gated on entry price quality, enabling more refined strategy generation.
  * Extended autofactor formula scoring to incorporate entry price quality factors for improved settlement probability evaluation.

* **Documentation**
  * Added research evidence documentation for entry price quality alpha prior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/484)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->