### PR TITLE
ci: run scheduled full market-data audit in coverage mode

### DIFF
--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -126,6 +126,9 @@ jobs:
           symbols="${INPUT_SYMBOLS:-${DEFAULT_SYMBOLS}}"
           fail_on="${INPUT_FAIL_ON:-critical}"
           gate_mode="${INPUT_GATE_MODE:-freshness}"
+          if [ "${EVENT_NAME}" = "schedule" ] && [ "${EVENT_SCHEDULE}" = "17 */6 * * *" ]; then
+            gate_mode="coverage"
+          fi
 
           case "${run_full}" in
             true|false) ;;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# Market Data Coverage Audit Automation (2026-05-13)
+
+## Goal
+
+Make the scheduled full market-data audit enforce retained-window coverage, so
+PM5D promotion-grade search does not depend only on manual `gate_mode=coverage`
+dispatches after known data gaps age out.
+
+## Plan
+
+- [x] Keep 30-minute scheduled collector-health checks on freshness mode.
+- [x] Switch the 6-hour full scheduled audit to coverage mode.
+- [x] Add workflow-scope regression coverage.
+- [x] Validate workflow YAML and focused audit tests.
+
+## Review
+
+- 2026-05-13: `.github/workflows/market-data-gap-audit.yml` now forces
+  `gate_mode=coverage` for the `17 */6 * * *` full scheduled audit while
+  preserving manual `workflow_dispatch` input behavior.
+- 2026-05-13: Verification passed:
+  `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/market-data-gap-audit.yml"); puts "yaml ok"'`
+  and
+  `python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_audit_market_data_gaps`.
+
 # PM5D Entry-Price Quality Alpha Prior (2026-05-13)
 
 ## Goal

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -55,6 +55,11 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         )
         self.assertIn("Run remote gap audits via Cloud Assistant fallback", workflow)
         self.assertIn(str(CLOUD_ASSIST_SCRIPT.relative_to(ROOT)), workflow)
+        self.assertIn(
+            'if [ "${EVENT_NAME}" = "schedule" ] && [ "${EVENT_SCHEDULE}" = "17 */6 * * *" ]; then',
+            workflow,
+        )
+        self.assertIn('gate_mode="coverage"', workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- force the 6-hour full scheduled market-data audit to use retained-window coverage mode
- keep manual workflow_dispatch gate_mode behavior unchanged
- add workflow-scope regression coverage and task notes

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/market-data-gap-audit.yml"); puts "yaml ok"'
- python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_audit_market_data_gaps

## Notes
This supports PM5D alpha-search promotion gating by making retained-window coverage blockers visible in scheduled CI, instead of relying only on manual gate_mode=coverage dispatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled market data audit workflow now automatically enforces full coverage mode during routine runs every 6 hours, eliminating dependency on manual dispatches.

* **Tests**
  * Expanded test coverage to verify scheduled workflow behavior and coverage mode enforcement.

* **Documentation**
  * Updated project documentation with execution plan and verification commands for market data audit automation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/485)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->