### PR TITLE
ci: add dry-run strategy config sync workflow

### DIFF
--- a/.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml
+++ b/.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml
@@ -1,0 +1,282 @@
+name: Sync dry-run strategy config to tango-1-1
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref; execute=true requires main"
+        required: true
+        default: "main"
+      deployment_id:
+        description: "Dry-run deployment id to restart after config sync"
+        required: true
+        default: "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+      strategy_config_path:
+        description: "Repo strategy TOML path to sync"
+        required: true
+        default: "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+      execute:
+        description: "Install the config and restart only the target dry-run worker"
+        type: boolean
+        required: true
+        default: false
+
+concurrency:
+  group: sync-dryrun-strategy-config-${{ github.event.inputs.deployment_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+
+jobs:
+  sync-config:
+    name: Sync dry-run strategy config
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Validate inputs
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          STRATEGY_CONFIG_PATH: ${{ github.event.inputs.strategy_config_path }}
+          EXECUTE: ${{ github.event.inputs.execute }}
+          INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
+        run: |
+          set -euo pipefail
+
+          case "${DEPLOYMENT_ID}" in
+            *.dryrun) ;;
+            *)
+              echo "deployment_id must be a dry-run deployment ending in .dryrun: ${DEPLOYMENT_ID}" >&2
+              exit 2
+              ;;
+          esac
+
+          case "${STRATEGY_CONFIG_PATH}" in
+            config/strategies/*.toml) ;;
+            *)
+              echo "strategy_config_path must be under config/strategies and end with .toml: ${STRATEGY_CONFIG_PATH}" >&2
+              exit 2
+              ;;
+          esac
+          test -f "${STRATEGY_CONFIG_PATH}"
+
+          if [ "${EXECUTE}" = "true" ]; then
+            if [ "${GITHUB_REF_NAME}" != "main" ]; then
+              echo "execute=true must dispatch the workflow from main; got ${GITHUB_REF_NAME}" >&2
+              exit 2
+            fi
+            if [ "${INPUT_GIT_REF}" != "main" ]; then
+              echo "execute=true must use git_ref=main; got ${INPUT_GIT_REF}" >&2
+              exit 2
+            fi
+            git fetch --no-tags --depth=1 origin main
+            checked_out_sha="$(git rev-parse HEAD)"
+            main_sha="$(git rev-parse origin/main)"
+            if [ "${checked_out_sha}" != "${main_sha}" ]; then
+              echo "checked-out SHA ${checked_out_sha} does not match origin/main ${main_sha}" >&2
+              exit 2
+            fi
+          fi
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+          TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          printf '%s\n' "${TANGO_1_1_SSH_KEY}" > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Sync config or preview diff
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          STRATEGY_CONFIG_PATH: ${{ github.event.inputs.strategy_config_path }}
+          EXECUTE: ${{ github.event.inputs.execute }}
+          REMOTE_DIR: /opt/ploy/tmp/sync-dryrun-strategy-config-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/sync-dryrun-strategy-config
+
+          target_name="$(basename "${STRATEGY_CONFIG_PATH}")"
+          remote_config="${DEPLOY_ROOT}/config/strategies/${target_name}"
+
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}" <<'EOF'
+          set -euo pipefail
+          mkdir -p "$1"
+          EOF
+          scp "${STRATEGY_CONFIG_PATH}" "tango-1-1:${REMOTE_DIR}/${target_name}.candidate"
+
+          ssh tango-1-1 /bin/bash -s -- \
+            "${DEPLOYMENT_ID}" \
+            "${remote_config}" \
+            "${REMOTE_DIR}/${target_name}.candidate" \
+            "${REMOTE_DIR}" \
+            "${EXECUTE}" \
+            "${DEPLOY_ROOT}" <<'EOF'
+          set -euo pipefail
+          deployment_id="$1"
+          remote_config="$2"
+          candidate_config="$3"
+          remote_dir="$4"
+          execute="$5"
+          deploy_root="$6"
+
+          status_json="${remote_dir}/sync-status.json"
+          diff_path="${remote_dir}/config-diff.txt"
+
+          require_live_paused() {
+            local live_status
+            local live_line
+            live_status="$("${deploy_root}/bin/ployctl" deployments inspect pm5d.threelayer.live 2>&1)"
+            printf '%s\n' "${live_status}"
+            live_line="$(printf '%s\n' "${live_status}" | awk '$1 == "pm5d.threelayer.live" { print; exit }')"
+            case "${live_line}" in
+              *"desired=Paused"*"observed=Paused"*) ;;
+              *)
+                echo "pm5d.threelayer.live must remain desired=Paused observed=Paused" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          wait_for_state() {
+            local expected="$1"
+            local line
+            for _ in $(seq 1 20); do
+              line="$("${deploy_root}/bin/ployctl" deployments inspect "${deployment_id}" 2>&1 | awk -v id="${deployment_id}" '$1 == id { print; exit }')"
+              printf '%s\n' "${line}"
+              case "${line}" in
+                *"observed=${expected}"*) return 0 ;;
+              esac
+              sleep 1
+            done
+            echo "deployment ${deployment_id} did not reach observed=${expected}" >&2
+            exit 1
+          }
+
+          require_flat_risk() {
+            curl -fsS http://127.0.0.1:8081/api/trading/state > "${remote_dir}/trading-state.json"
+            python3 - "${deployment_id}" "${remote_dir}/trading-state.json" <<'PY'
+          import json
+          import sys
+          deployment_id = sys.argv[1]
+          path = sys.argv[2]
+          rows = json.load(open(path, encoding="utf-8"))
+          row = next((item for item in rows if item.get("deployment_id") == deployment_id), None)
+          if row is None:
+              raise SystemExit(f"deployment not present in trading state: {deployment_id}")
+          risk = row.get("risk") or {}
+          fields = {
+              "pending_intents": int(risk.get("pending_intents") or 0),
+              "active_orders": int(risk.get("active_orders") or 0),
+              "open_positions": int(risk.get("open_positions") or 0),
+          }
+          if any(fields.values()):
+              raise SystemExit(f"refusing config sync while deployment is not flat: {fields}")
+          print(f"target deployment is flat: {fields}")
+          PY
+          }
+
+          test -x "${deploy_root}/bin/ployctl"
+          test -r "${candidate_config}"
+          test -r "${remote_config}"
+          require_live_paused
+          require_flat_risk
+
+          if cmp -s "${candidate_config}" "${remote_config}"; then
+            changed=false
+            printf 'candidate config matches remote config\n' > "${diff_path}"
+          else
+            changed=true
+            diff -u "${remote_config}" "${candidate_config}" > "${diff_path}" || true
+          fi
+
+          if [ "${execute}" = "true" ] && [ "${changed}" = "true" ]; then
+            install -m 0644 "${candidate_config}" "${remote_config}"
+            "${deploy_root}/bin/ployctl" deployments pause "${deployment_id}"
+            wait_for_state Paused
+            "${deploy_root}/bin/ployctl" deployments resume "${deployment_id}"
+            wait_for_state Running
+            curl -fsS http://127.0.0.1:8081/health
+            curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
+              | "${deploy_root}/scripts/check_dryrun_report_contract.py"
+          fi
+
+          python3 - "${status_json}" "${deployment_id}" "${remote_config}" "${execute}" "${changed}" <<'PY'
+          import json
+          import sys
+          path, deployment_id, remote_config, execute, changed = sys.argv[1:6]
+          payload = {
+              "deployment_id": deployment_id,
+              "remote_config": remote_config,
+              "execute": execute == "true",
+              "changed": changed == "true",
+              "status": "synced" if execute == "true" and changed == "true" else "preview",
+          }
+          with open(path, "w", encoding="utf-8") as handle:
+              json.dump(payload, handle, indent=2, sort_keys=True)
+              handle.write("\n")
+          PY
+          EOF
+
+          scp "tango-1-1:${REMOTE_DIR}/sync-status.json" artifacts/sync-dryrun-strategy-config/sync-status.json
+          scp "tango-1-1:${REMOTE_DIR}/config-diff.txt" artifacts/sync-dryrun-strategy-config/config-diff.txt
+          cat artifacts/sync-dryrun-strategy-config/sync-status.json
+
+      - name: Upload sync artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sync-dryrun-strategy-config-${{ github.run_id }}
+          path: artifacts/sync-dryrun-strategy-config/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dry-run Strategy Config Sync"
+            echo ""
+            echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
+            echo "- Strategy config: \`${{ github.event.inputs.strategy_config_path }}\`"
+            echo "- Execute: \`${{ github.event.inputs.execute }}\`"
+            if [ -f artifacts/sync-dryrun-strategy-config/sync-status.json ]; then
+              echo ""
+              echo "Status:"
+              echo '```json'
+              cat artifacts/sync-dryrun-strategy-config/sync-status.json
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -53,6 +53,7 @@ mismatch is understood and tracked as a follow-up issue.
 | Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
 | Recorded replay/dry-run parity | `.github/workflows/recorded-replay-parity.yml` | Replay a canonical MarketUpdate recording on `tango-1-1` with the deployed binary, then compare against the matching dry-run report slice |
 | Runtime evidence reset | `.github/workflows/reset-strategy-runtime-evidence.yml` | Backup-first cleanup for contaminated dry-run/paper `strategy_runtime_orders` and `strategy_runtime_fills`; follow `docs/runbooks/strategy-runtime-evidence-reset.md` |
+| Dry-run config sync | `.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml` | Protected config-only sync for a reviewed dry-run strategy TOML; restarts only the target dry-run worker and avoids collector restarts during clean-window waits |
 | Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports; use `source_dataset_run_id` for the GitHub-hosted artifact path |
 | Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
 | Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# Dry-Run Strategy Config-Only Sync (2026-05-13)
+
+## Goal
+
+Add a protected config-only sync path for reviewed PM5D dry-run strategy TOML
+changes, so the dry-run scorer can be aligned with `main` without using the
+full tango deploy workflow that restarts market-data collectors during
+clean-window waits.
+
+## Plan
+
+- [x] Add a `workflow_dispatch` sync workflow with preview-by-default behavior.
+- [x] Restrict the target to `.dryrun` deployments and `config/strategies/*.toml`.
+- [x] Gate execution on `git_ref=main`, live deployment still paused, and the
+      target dry-run deployment being flat.
+- [x] Install only the selected TOML and restart only the target dry-run worker
+      via `ployctl deployments pause/resume`.
+- [x] Upload diff/status artifacts and document the workflow in the strategy
+      research CI/CD runbook.
+- [x] Run local YAML/diff validation.
+
+## Review
+
+- 2026-05-13: Added
+  `.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml` as the narrow
+  config sync path. It does not restart Binance/PM collectors and defaults to
+  preview mode.
+- 2026-05-13: Updated `docs/runbooks/strategy-research-cicd.md` workflow map.
+- 2026-05-13: Local validation passed: Ruby YAML parse for the new workflow and
+  `git diff --check` on touched files. Local `actionlint` was not installed, so
+  PR CI remains the workflow-lint authority.
+
 # Market Data Coverage Audit Automation (2026-05-13)
 
 ## Goal


### PR DESCRIPTION
## Summary
- add a protected config-only workflow for syncing reviewed dry-run strategy TOML files to tango-1-1
- default to preview mode and upload diff/status artifacts
- for execute=true, require main, live paused, target dry-run deployment flat, then restart only the target dry-run worker via ployctl pause/resume
- document the workflow in the strategy research CI/CD runbook and task tracker

## Verification
- Ruby YAML parse for `.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml`
- `git diff --check -- .github/workflows/sync-dryrun-strategy-config-tango-1-1.yml docs/runbooks/strategy-research-cicd.md tasks/todo.md`

No workflow dispatch was executed from this branch; no remote service or trading state mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual, preview-first dry-run config sync for strategy TOML files (restricts to dry-run deployments and strategy paths)
  * Safe apply mode with validation, flat-state checks, pause/resume of only the target dry-run worker, health verification, and artifacted diff/status outputs

* **Documentation**
  * Added workflow documentation to the strategy CI/CD runbook and task notes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/489)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->