### PR TITLE
Fix settlement Deribit promotion gate

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -89,6 +89,7 @@ jobs:
               "data_quality_mode": "event_complete",
               "min_event_complete_events": "20",
               "min_event_complete_rows": "40",
+              "require_deribit": "false",
               "replay_parity_json": "",
               "replay_parity_run_id": "",
               "replay_parity_artifact_name": "",
@@ -109,7 +110,7 @@ jobs:
               "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
               "fail_if_blocked": "false",
           }
-          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "fail_if_blocked"}
+          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "fail_if_blocked", "require_deribit"}
           choices = {
               "report_suite": {"core", "full"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
@@ -356,6 +357,9 @@ jobs:
           )
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
+          fi
+          if [ "${WALK_REQUIRE_DERIBIT}" = "true" ]; then
+            args+=(--require-deribit)
           fi
           alpha_search_plan_json="${WALK_ALPHA_SEARCH_PLAN_JSON}"
           if [ -z "${alpha_search_plan_json}" ] && [ -f artifacts/alpha-search-plan/mcts-expansion-plan.json ]; then

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -194,6 +194,7 @@ jobs:
               "data_quality_mode": "strict_continuous",
               "min_event_complete_events": "20",
               "min_event_complete_rows": "40",
+              "require_deribit": "false",
               "issue_number": "",
               "snapshot_registry_dir": "",
               "replay_parity_json": "",
@@ -206,7 +207,7 @@ jobs:
               "alpha_search_llm_prior_json": "",
               "alpha_search_state_json": "",
           }
-          bool_keys = {"compile_snapshot", "allow_direct_db_debug"}
+          bool_keys = {"compile_snapshot", "allow_direct_db_debug", "require_deribit"}
           choices = {
               "report_suite": {"core", "full"},
               "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
@@ -573,6 +574,9 @@ jobs:
             --min-event-complete-rows "${WALK_MIN_EVENT_COMPLETE_ROWS}"
             --alpha-search-output-dir artifacts/factor-walk-forward-v2/alpha-search
           )
+          if [ "${WALK_REQUIRE_DERIBIT}" = "true" ]; then
+            args+=(--require-deribit)
+          fi
           if [ -n "${WALK_FACTOR_NAME_FILTER}" ]; then
             args+=(--factor-name-filter "${WALK_FACTOR_NAME_FILTER}")
           fi

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -330,6 +330,7 @@ async fn main() {
     let alpha_search_state_json = flag_value(&args, "--alpha-search-state-json");
     let allow_direct_db_debug = flag_present(&args, "--allow-direct-db-debug");
     let data_quality_mode = parse_data_quality_mode(flag_value(&args, "--data-quality-mode"));
+    let require_deribit = flag_present(&args, "--require-deribit");
     let min_event_complete_events = flag_value(&args, "--min-event-complete-events")
         .and_then(|raw| raw.parse().ok())
         .unwrap_or(20);
@@ -690,6 +691,7 @@ async fn main() {
         &conservative_execution_matrix,
         SettlementProbabilityPromotionGateOptions {
             stake_usd: options.review.stake_usd,
+            require_deribit,
             include_deribit,
             data_audit_status: snapshot_data_audit_status,
             data_quality_mode,

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -589,7 +589,7 @@ impl Default for SettlementProbabilityPromotionGateOptions {
             min_entry_fill_rate: 0.05,
             max_expected_calibration_error: 0.05,
             min_positive_window_ratio: 0.60,
-            require_deribit: true,
+            require_deribit: false,
             include_deribit: false,
             data_audit_status: None,
             data_quality_mode: SettlementProbabilityDataQualityMode::StrictContinuous,
@@ -10230,13 +10230,41 @@ mod tests {
             &execution,
             &execution,
             SettlementProbabilityPromotionGateOptions {
-                include_deribit: true,
+                include_deribit: false,
                 data_audit_status: Some("ok".to_string()),
                 replay_parity_ready: true,
                 ..Default::default()
             },
         );
         assert!(ready.ready_for_dry_run_handoff);
+        let deribit_gate = ready
+            .gates
+            .iter()
+            .find(|gate| gate.gate == "deribit_vol_surface")
+            .expect("deribit_vol_surface gate");
+        assert!(deribit_gate.passed);
+        assert!(deribit_gate.evidence.contains("require_deribit=false"));
+
+        let deribit_required = build_settlement_probability_promotion_gate_report(
+            &probability,
+            &walk_forward,
+            &execution,
+            &execution,
+            SettlementProbabilityPromotionGateOptions {
+                require_deribit: true,
+                include_deribit: false,
+                data_audit_status: Some("ok".to_string()),
+                replay_parity_ready: true,
+                ..Default::default()
+            },
+        );
+        assert!(!deribit_required.ready_for_dry_run_handoff);
+        assert!(deribit_required.gates.iter().any(|gate| {
+            gate.gate == "deribit_vol_surface"
+                && !gate.passed
+                && gate.evidence.contains("require_deribit=true include_deribit=false")
+        }));
+
         let text = format_settlement_probability_promotion_gate_report(&blocked);
         assert!(text.contains("Settlement Probability PRD Promotion Gate"));
         assert!(text.contains("ready_for_dry_run_handoff=false"));

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -292,6 +292,9 @@ dimension such as capacity, stability, or overfit risk.
   search surface once a full snapshot artifact exists.
 - `factor-walk-forward-v2.yml` should be used when a fresh DB-adjacent snapshot
   or data audit is required.
+- `pm5d-execution` settlement-probability searches should not require Deribit by
+  default. Use `options_json.require_deribit=true` only when the hypothesis
+  explicitly depends on the `pm5d-vol`/Deribit surface.
 - `autofactor-strategy-promotion.yml` should be used to re-evaluate an existing
   walk-forward artifact without rerunning search.
 - `event-ml-rolling-evidence.yml` is the supervised event-ML lane, not the

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -201,6 +201,10 @@ different.
   `factor-walk-forward-v2-hosted-artifact.yml`, or
   `settlement-probability-prd-gate.yml` with `snapshot_run_id`, when a retained
   full research snapshot artifact already exists.
+- For settlement-probability searches using the `pm5d-execution` data profile,
+  Deribit IV/Greeks are not a required promotion surface. Set
+  `options_json.require_deribit=true` only for PRD or volatility hypotheses that
+  intentionally require `pm5d-vol` / Deribit evidence.
 - Event ML rolling evidence should also default to GitHub-hosted runners after
   the source event-root dataset is artifactized. Pass `source_dataset_run_id`
   to `event-ml-rolling-evidence.yml`; only the fresh DB export branch should

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -120,6 +120,8 @@ def factor_args(args: argparse.Namespace, variant: Variant, replay_parity_json: 
         command.extend(["--factor-name-filter", values["factor_name_filter"]])
     if replay_parity_json:
         command.extend(["--replay-parity-json", replay_parity_json])
+    if args.require_deribit:
+        command.append("--require-deribit")
     if args.alpha_search_output_dir:
         command.extend(["--alpha-search-output-dir", args.alpha_search_output_dir])
     if args.alpha_search_plan_json:
@@ -317,6 +319,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--alpha-search-state-json", default="")
     parser.add_argument("--alpha-search-llm-prior-json", default="")
     parser.add_argument("--required-strategy-profile", default="settlement_probability")
+    parser.add_argument("--require-deribit", action="store_true")
     parser.add_argument("--allowed-target", action="append", default=[])
     parser.add_argument("--sweep-json", default="")
     parser.add_argument("--cwd", default=".")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,37 @@
+# Settlement Probability Deribit Gate Alignment (2026-05-13)
+
+## Goal
+
+Fix the hosted AutoFactor promotion blocker where `pm5d-execution` settlement
+probability searches were incorrectly blocked by `require_deribit=true` even
+though that scoped data profile intentionally excludes Deribit.
+
+## Plan
+
+- [x] Make the settlement-probability promotion gate not require Deribit by
+      default.
+- [x] Add an explicit `--require-deribit` override for PRD/volatility runs.
+- [x] Wire `options_json.require_deribit` through hosted and self-hosted
+      factor walk-forward workflows.
+- [x] Update tests and docs so `pm5d-execution` and `pm5d-vol` semantics stay
+      distinct.
+
+## Review
+
+- 2026-05-13: Changed the settlement-probability promotion gate default to
+  `require_deribit=false`, added the explicit `--require-deribit` CLI override,
+  and wired `options_json.require_deribit` through both factor walk-forward
+  workflows. This fixes the `pm5d-execution` handoff blocker without relaxing
+  replay parity, walk-forward OOS, calibration, execution-depth, or dry-run
+  sample gates.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
+  `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py`,
+  `CARGO_TARGET_DIR=/tmp/ploy-deribit-gate /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research settlement_probability_promotion_gate_blocks_without_replay_parity --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-deribit-gate /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy factor_walk_forward_wires_alpha_prior_and_state_inputs --test workflow_security`,
+  `CARGO_TARGET_DIR=/tmp/ploy-deribit-gate /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2`,
+  YAML parse for the two factor walk-forward workflows, and `git diff --check`.
+
 # PM5D Active Quote Quality Gate (2026-05-13)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -11,16 +11,18 @@ SCRIPT = ROOT / "scripts" / "evaluate_autofactor_strategy_promotion.py"
 
 
 READY_GATE = """=== Settlement Probability PRD Promotion Gate ===
-ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
 gate,passed,evidence
 data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+deribit_vol_surface,true,require_deribit=false include_deribit=false
 recorded_replay_parity,true,blocking_flags=<none>
 """
 
 BLOCKED_GATE = """=== Settlement Probability PRD Promotion Gate ===
-ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=0 event_complete_rows=0 replay_parity_ready=false
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=0 event_complete_rows=0 replay_parity_ready=false
 gate,passed,evidence
 data_quality,false,mode=event_complete event_complete_events=0 event_complete_rows=0
+deribit_vol_surface,true,require_deribit=false include_deribit=false
 recorded_replay_parity,false,missing replay parity
 """
 

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -13,9 +13,10 @@ WORKFLOW = ROOT / ".github" / "workflows" / "factor-walk-forward-v2-hosted-artif
 
 FAKE_REPORT = r'''
 print("""=== Settlement Probability PRD Promotion Gate ===
-ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=true include_deribit=true data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
 gate,passed,evidence
 data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+deribit_vol_surface,true,require_deribit=false include_deribit=false
 recorded_replay_parity,true,blocking_flags=<none>
 
 # AutoFactor target=full_depth_settlement_executable_pnl
@@ -186,6 +187,32 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--alpha-search-plan-json", captured)
         self.assertIn("--alpha-search-state-json", captured)
         self.assertIn("--alpha-search-llm-prior-json", captured)
+
+    def test_require_deribit_arg_passes_through_to_factor_binary(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = tmp / "capture_factor_args.py"
+            capture = tmp / "captured_args.json"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, sys\n"
+                f"open({str(capture)!r}, 'w', encoding='utf-8').write(json.dumps(sys.argv[1:]))\n"
+                f"{FAKE_REPORT}\n",
+                encoding="utf-8",
+            )
+            binary.chmod(0o755)
+
+            subprocess.run(
+                [*self.base_args(tmp, binary), "--require-deribit"],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            captured = json.loads(capture.read_text(encoding="utf-8"))
+
+        self.assertIn("--require-deribit", captured)
 
 
 if __name__ == "__main__":

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -348,9 +348,11 @@ fn factor_walk_forward_wires_alpha_prior_and_state_inputs() {
         for needle in [
             "alpha_search_llm_prior_json",
             "alpha_search_state_json",
+            "require_deribit",
             "mcts-state.json",
             "--alpha-search-state-json",
             "--alpha-search-llm-prior-json",
+            "--require-deribit",
         ] {
             if !workflow.contains(needle) {
                 offenders.push(format!("{name}: missing `{needle}`"));


### PR DESCRIPTION
## Summary
- Make Deribit optional by default for settlement-probability promotion gates so pm5d-execution snapshots are not blocked by a surface they intentionally exclude.
- Add explicit require_deribit wiring for hosted/self-hosted factor walk-forward workflows and the sweep runner.
- Document the pm5d-execution vs pm5d-vol distinction and add focused regression coverage.

## Verification
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py
- CARGO_TARGET_DIR=/tmp/ploy-deribit-gate-main /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research settlement_probability_promotion_gate_blocks_without_replay_parity --lib
- CARGO_TARGET_DIR=/tmp/ploy-deribit-gate-main /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy factor_walk_forward_wires_alpha_prior_and_state_inputs --test workflow_security
- CARGO_TARGET_DIR=/tmp/ploy-deribit-gate-main /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2
- ruby -e 'require "yaml"; %w[.github/workflows/factor-walk-forward-v2-hosted-artifact.yml .github/workflows/factor-walk-forward-v2.yml].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settlement probability searches using `pm5d-execution` no longer incorrectly require Deribit by default, preventing unnecessary search blocking.

* **New Features**
  * Added `--require-deribit` option to explicitly require Deribit validation when running factor analyses that depend on volatility surfaces.

* **Documentation**
  * Updated guidance to clarify that Deribit should only be required for PRD or volatility-dependent hypotheses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/491)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->