### PR TITLE
Support one-day PM5D OOS smoke windows

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -33,7 +33,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -76,8 +76,11 @@ jobs:
 
           defaults = {
               "train_window_days": "2",
+              "train_window_hours": "",
               "test_window_days": "1",
+              "test_window_hours": "",
               "step_days": "1",
+              "step_hours": "",
               "lob_sample_secs": "30",
               "observation_sample_secs": "30",
               "max_quote_age_secs": "30",
@@ -336,8 +339,11 @@ jobs:
             --end-ts "${WALK_END_TS}"
             --stake-usd "${{ github.event.inputs.stake_usd }}"
             --train-window-days "${WALK_TRAIN_WINDOW_DAYS}"
+            --train-window-hours "${WALK_TRAIN_WINDOW_HOURS}"
             --test-window-days "${WALK_TEST_WINDOW_DAYS}"
+            --test-window-hours "${WALK_TEST_WINDOW_HOURS}"
             --step-days "${WALK_STEP_DAYS}"
+            --step-hours "${WALK_STEP_HOURS}"
             --lob-sample-secs "${WALK_LOB_SAMPLE_SECS}"
             --observation-sample-secs "${WALK_OBSERVATION_SAMPLE_SECS}"
             --max-quote-age-secs "${WALK_MAX_QUOTE_AGE_SECS}"

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -30,7 +30,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, snapshot/data/audit settings, local snapshot registry, optional replay parity artifact"
         required: false
-        default: '{"train_window_days":2,"test_window_days":1,"step_days":1,"lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":""}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","compile_snapshot":true,"allow_direct_db_debug":false,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","data_quality_mode":"strict_continuous","min_event_complete_events":20,"min_event_complete_rows":40,"issue_number":"","snapshot_registry_dir":"","replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":""}'
 
 concurrency:
   group: factor-walk-forward-v2-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
@@ -72,8 +72,11 @@ jobs:
 
           allowed = {
               "train_window_days",
+              "train_window_hours",
               "test_window_days",
+              "test_window_hours",
               "step_days",
+              "step_hours",
               "lob_sample_secs",
               "observation_sample_secs",
               "max_quote_age_secs",
@@ -88,6 +91,7 @@ jobs:
               "replay_parity_json",
               "replay_parity_run_id",
               "replay_parity_artifact_name",
+              "require_deribit",
               "alpha_search_plan_json",
               "alpha_search_plan_run_id",
               "alpha_search_plan_artifact_name",
@@ -174,8 +178,11 @@ jobs:
 
           defaults = {
               "train_window_days": "2",
+              "train_window_hours": "",
               "test_window_days": "1",
+              "test_window_hours": "",
               "step_days": "1",
+              "step_hours": "",
               "lob_sample_secs": "30",
               "observation_sample_secs": "30",
               "max_quote_age_secs": "30",
@@ -576,6 +583,15 @@ jobs:
           )
           if [ "${WALK_REQUIRE_DERIBIT}" = "true" ]; then
             args+=(--require-deribit)
+          fi
+          if [ -n "${WALK_TRAIN_WINDOW_HOURS}" ]; then
+            args+=(--train-window-hours "${WALK_TRAIN_WINDOW_HOURS}")
+          fi
+          if [ -n "${WALK_TEST_WINDOW_HOURS}" ]; then
+            args+=(--test-window-hours "${WALK_TEST_WINDOW_HOURS}")
+          fi
+          if [ -n "${WALK_STEP_HOURS}" ]; then
+            args+=(--step-hours "${WALK_STEP_HOURS}")
           fi
           if [ -n "${WALK_FACTOR_NAME_FILTER}" ]; then
             args+=(--factor-name-filter "${WALK_FACTOR_NAME_FILTER}")

--- a/crates/ploy-research/examples/factor_walk_forward_v2.rs
+++ b/crates/ploy-research/examples/factor_walk_forward_v2.rs
@@ -302,6 +302,15 @@ async fn main() {
         step_days: flag_value(&args, "--step-days")
             .and_then(|raw| raw.parse().ok())
             .unwrap_or(1),
+        train_window_hours: flag_value(&args, "--train-window-hours")
+            .filter(|raw| !raw.trim().is_empty())
+            .and_then(|raw| raw.parse().ok()),
+        test_window_hours: flag_value(&args, "--test-window-hours")
+            .filter(|raw| !raw.trim().is_empty())
+            .and_then(|raw| raw.parse().ok()),
+        step_hours: flag_value(&args, "--step-hours")
+            .filter(|raw| !raw.trim().is_empty())
+            .and_then(|raw| raw.parse().ok()),
         top_n: flag_value(&args, "--top-n")
             .and_then(|raw| raw.parse().ok())
             .unwrap_or(20),
@@ -310,13 +319,14 @@ async fn main() {
     let report_suite = ReportSuite::parse(flag_value(&args, "--report-suite"));
 
     eprintln!(
-        "factor_walk_forward_v2: {} -> {} for {:?}, stake_usd={:.2}, train_days={}, test_days={}, observation_sample_secs={}, factor_name_filter={}, report_suite={}",
+        "factor_walk_forward_v2: {} -> {} for {:?}, stake_usd={:.2}, train_window={}, test_window={}, step={}, observation_sample_secs={}, factor_name_filter={}, report_suite={}",
         start,
         end,
         symbols,
         options.review.stake_usd,
-        options.train_window_days,
-        options.test_window_days,
+        options.train_window_label(),
+        options.test_window_label(),
+        options.step_label(),
         observation_sample_secs,
         options.factor_name_filter.as_deref().unwrap_or("<none>"),
         report_suite.as_str()

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -755,6 +755,9 @@ pub struct FactorWalkForwardOptions {
     pub train_window_days: i64,
     pub test_window_days: i64,
     pub step_days: i64,
+    pub train_window_hours: Option<i64>,
+    pub test_window_hours: Option<i64>,
+    pub step_hours: Option<i64>,
     pub top_n: usize,
     pub factor_name_filter: Option<String>,
 }
@@ -766,9 +769,52 @@ impl Default for FactorWalkForwardOptions {
             train_window_days: 2,
             test_window_days: 1,
             step_days: 1,
+            train_window_hours: None,
+            test_window_hours: None,
+            step_hours: None,
             top_n: 20,
             factor_name_filter: None,
         }
+    }
+}
+
+impl FactorWalkForwardOptions {
+    pub fn train_duration(&self) -> Duration {
+        walk_forward_duration(self.train_window_days, self.train_window_hours)
+    }
+
+    pub fn test_duration(&self) -> Duration {
+        walk_forward_duration(self.test_window_days, self.test_window_hours)
+    }
+
+    pub fn step_duration(&self) -> Duration {
+        walk_forward_duration(self.step_days, self.step_hours)
+    }
+
+    pub fn train_window_label(&self) -> String {
+        walk_forward_duration_label(self.train_window_days, self.train_window_hours)
+    }
+
+    pub fn test_window_label(&self) -> String {
+        walk_forward_duration_label(self.test_window_days, self.test_window_hours)
+    }
+
+    pub fn step_label(&self) -> String {
+        walk_forward_duration_label(self.step_days, self.step_hours)
+    }
+}
+
+fn walk_forward_duration(days: i64, hours: Option<i64>) -> Duration {
+    match hours {
+        Some(hours) => Duration::hours(hours.max(1)),
+        None => Duration::days(days.max(1)),
+    }
+}
+
+fn walk_forward_duration_label(days: i64, hours: Option<i64>) -> String {
+    match hours {
+        Some(hours) => format!("{}h", hours.max(1)),
+        None => format!("{}d", days.max(1)),
     }
 }
 
@@ -2140,9 +2186,9 @@ fn walk_forward_factor_rows(
 ) -> FactorWalkForwardReport {
     v2_rows.sort_by_key(|row| row.tick_ts);
     let health = build_data_health_report(source_rows, v2_rows);
-    let train_duration = Duration::days(options.train_window_days.max(1));
-    let test_duration = Duration::days(options.test_window_days.max(1));
-    let step_duration = Duration::days(options.step_days.max(1));
+    let train_duration = options.train_duration();
+    let test_duration = options.test_duration();
+    let step_duration = options.step_duration();
     let descriptors: Vec<FactorV2Descriptor> = factor_v2_descriptors()
         .into_iter()
         .filter(is_walk_forward_candidate_descriptor)
@@ -2764,9 +2810,9 @@ pub fn walk_forward_settlement_probability_report(
 ) -> SettlementProbabilityWalkForwardReport {
     let mut rows = rows.to_vec();
     rows.sort_by_key(|row| row.tick_ts);
-    let train_duration = Duration::days(options.walk_forward.train_window_days.max(1));
-    let test_duration = Duration::days(options.walk_forward.test_window_days.max(1));
-    let step_duration = Duration::days(options.walk_forward.step_days.max(1));
+    let train_duration = options.walk_forward.train_duration();
+    let test_duration = options.walk_forward.test_duration();
+    let step_duration = options.walk_forward.step_duration();
     let probability_options =
         normalize_settlement_probability_report_options(options.probability.clone());
 
@@ -3348,10 +3394,10 @@ pub fn format_settlement_probability_walk_forward_report(
     let mut out = String::new();
     out.push_str("=== Settlement Probability Walk-Forward Report ===\n");
     out.push_str(&format!(
-        "train_days={} test_days={} step_days={} min_obs={} probability_min_bucket_obs={} top_edge_quantile={:.2}\n",
-        report.options.walk_forward.train_window_days,
-        report.options.walk_forward.test_window_days,
-        report.options.walk_forward.step_days,
+        "train_window={} test_window={} step={} min_obs={} probability_min_bucket_obs={} top_edge_quantile={:.2}\n",
+        report.options.walk_forward.train_window_label(),
+        report.options.walk_forward.test_window_label(),
+        report.options.walk_forward.step_label(),
         report.options.walk_forward.review.min_observations,
         report.options.probability.min_bucket_observations,
         report.options.probability.top_edge_quantile,
@@ -3494,9 +3540,9 @@ fn walk_forward_factor_combo_from_v2_rows(
 ) -> FactorComboV1Report {
     let health = build_data_health_report(source_rows, v2_rows);
     let mut windows = Vec::new();
-    let train_duration = Duration::days(options.walk_forward.train_window_days.max(1));
-    let test_duration = Duration::days(options.walk_forward.test_window_days.max(1));
-    let step_duration = Duration::days(options.walk_forward.step_days.max(1));
+    let train_duration = options.walk_forward.train_duration();
+    let test_duration = options.walk_forward.test_duration();
+    let step_duration = options.walk_forward.step_duration();
     let mut train_start = start;
     let mut window_index = 0usize;
     while train_start + train_duration + test_duration <= end + Duration::seconds(1) {
@@ -3980,11 +4026,11 @@ pub fn format_factor_walk_forward_v2_report(report: &FactorWalkForwardReport) ->
     ));
     push_full_depth_health_line(&mut out, &report.health);
     out.push_str(&format!(
-        "stake_usd={:.2} train_days={} test_days={} step_days={} top_quantile={:.2} factor_name_filter={}\n\n",
+        "stake_usd={:.2} train_window={} test_window={} step={} top_quantile={:.2} factor_name_filter={}\n\n",
         report.options.review.stake_usd,
-        report.options.train_window_days,
-        report.options.test_window_days,
-        report.options.step_days,
+        report.options.train_window_label(),
+        report.options.test_window_label(),
+        report.options.step_label(),
         report.options.review.top_quantile,
         report
             .options
@@ -4102,10 +4148,10 @@ pub fn format_factor_combo_v1_report(report: &FactorComboV1Report) -> String {
     ));
     push_full_depth_health_line(&mut out, &report.health);
     out.push_str(&format!(
-        "train_days={} test_days={} step_days={} top_quantile={:.2} max_family={} max_total={} min_abs_train_pnl_ic={:.4} factor_name_filter={}\n\n",
-        report.options.walk_forward.train_window_days,
-        report.options.walk_forward.test_window_days,
-        report.options.walk_forward.step_days,
+        "train_window={} test_window={} step={} top_quantile={:.2} max_family={} max_total={} min_abs_train_pnl_ic={:.4} factor_name_filter={}\n\n",
+        report.options.walk_forward.train_window_label(),
+        report.options.walk_forward.test_window_label(),
+        report.options.walk_forward.step_label(),
         report.options.walk_forward.review.top_quantile,
         report.options.max_factors_per_family,
         report.options.max_total_factors,
@@ -4286,11 +4332,11 @@ pub fn format_liquidity_gated_alpha_v1_report(
     ));
     push_full_depth_health_line(&mut out, &report.baseline_health);
     out.push_str(&format!(
-        "stake_usd={:.2} train_days={} test_days={} step_days={} top_quantile={:.2} factor_name_filter={}\n\n",
+        "stake_usd={:.2} train_window={} test_window={} step={} top_quantile={:.2} factor_name_filter={}\n\n",
         report.options.walk_forward.review.stake_usd,
-        report.options.walk_forward.train_window_days,
-        report.options.walk_forward.test_window_days,
-        report.options.walk_forward.step_days,
+        report.options.walk_forward.train_window_label(),
+        report.options.walk_forward.test_window_label(),
+        report.options.walk_forward.step_label(),
         report.options.walk_forward.review.top_quantile,
         report
             .options
@@ -10103,6 +10149,69 @@ mod tests {
     }
 
     #[test]
+    fn settlement_probability_walk_forward_supports_intraday_oos_windows() {
+        let start = Utc::now();
+        let source_rows = (0..24)
+            .map(|idx| {
+                let mut obs = base_obs();
+                obs.event_id = format!("intraday-oos-evt-{idx}");
+                obs.tick_ts = start + Duration::hours(idx);
+                obs.settlement_up = if idx % 2 == 0 { 1.0 } else { 0.0 };
+                obs.pm_up_bid = 0.42;
+                obs.pm_up_ask = 0.46;
+                obs.pm_down_bid = 0.52;
+                obs.pm_down_ask = 0.56;
+                obs.distance_over_sigma = if idx % 2 == 0 { 0.6 } else { -0.4 };
+                obs
+            })
+            .collect::<Vec<_>>();
+        let mut rows = build_factor_observations_v2(&source_rows, &FactorReviewOptions::default());
+        rows.retain(|row| row.side == ReviewSide::Up);
+        for row in &mut rows {
+            row.label_full_depth_entry_fillable = true;
+            row.entry_sweep_avg_price_15u = row.entry_ask;
+            row.entry_sweep_shares_15u = 15.0 / row.entry_sweep_avg_price_15u;
+            row.label_full_depth_executable_pnl_15u = row
+                .label_settlement_win
+                .map(|win| win * row.entry_sweep_shares_15u - 15.0);
+        }
+
+        let report = walk_forward_settlement_probability_report(
+            &rows,
+            start,
+            start + Duration::hours(24),
+            SettlementProbabilityWalkForwardOptions {
+                walk_forward: FactorWalkForwardOptions {
+                    review: FactorReviewOptions {
+                        min_observations: 1,
+                        ..Default::default()
+                    },
+                    train_window_hours: Some(12),
+                    test_window_hours: Some(12),
+                    step_hours: Some(12),
+                    ..Default::default()
+                },
+                probability: SettlementProbabilityReportOptions {
+                    min_bucket_observations: 1,
+                    event_surface_min_bucket_observations: 1,
+                    event_surface_shrinkage_observations: 1,
+                    ..Default::default()
+                },
+            },
+        );
+
+        assert!(report
+            .windows
+            .iter()
+            .any(|row| row.model == "q_final_logit_blend"));
+        assert!(report.aggregates.iter().any(|row| {
+            row.model == "q_final_logit_blend" && row.windows >= 1
+        }));
+        let text = format_settlement_probability_walk_forward_report(&report);
+        assert!(text.contains("train_window=12h test_window=12h step=12h"));
+    }
+
+    #[test]
     fn settlement_probability_promotion_gate_blocks_without_replay_parity() {
         let probability = SettlementProbabilityReport {
             options: SettlementProbabilityReportOptions::default(),
@@ -10606,6 +10715,9 @@ mod tests {
                     train_window_days: 2,
                     test_window_days: 1,
                     step_days: 1,
+                    train_window_hours: None,
+                    test_window_hours: None,
+                    step_hours: None,
                     top_n: 10,
                     factor_name_filter: Some("side_model_prob".to_string()),
                 },
@@ -11221,6 +11333,9 @@ mod tests {
                 train_window_days: 2,
                 test_window_days: 1,
                 step_days: 1,
+                train_window_hours: None,
+                test_window_hours: None,
+                step_hours: None,
                 top_n: 10,
                 factor_name_filter: None,
             },
@@ -11421,6 +11536,9 @@ mod tests {
                     train_window_days: 2,
                     test_window_days: 1,
                     step_days: 1,
+                    train_window_hours: None,
+                    test_window_hours: None,
+                    step_hours: None,
                     top_n: 10,
                     factor_name_filter: Some("side_model_prob".to_string()),
                 },

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -295,6 +295,10 @@ dimension such as capacity, stability, or overfit risk.
 - `pm5d-execution` settlement-probability searches should not require Deribit by
   default. Use `options_json.require_deribit=true` only when the hypothesis
   explicitly depends on the `pm5d-vol`/Deribit surface.
+- One-day OOS smoke searches can use hourly windows, for example
+  `train_window_hours=12`, `test_window_hours=12`, and `step_hours=12`, when
+  only a clean 24h snapshot is available. Keep these marked as early
+  walk-forward evidence, not final promotion-grade history.
 - `autofactor-strategy-promotion.yml` should be used to re-evaluate an existing
   walk-forward artifact without rerunning search.
 - `event-ml-rolling-evidence.yml` is the supervised event-ML lane, not the

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -205,6 +205,11 @@ different.
   Deribit IV/Greeks are not a required promotion surface. Set
   `options_json.require_deribit=true` only for PRD or volatility hypotheses that
   intentionally require `pm5d-vol` / Deribit evidence.
+- For one-day PM5D OOS smoke runs, keep the evidence stage as `walk_forward`
+  but use hourly windows such as
+  `options_json.train_window_hours=12`, `test_window_hours=12`, and
+  `step_hours=12` on a clean 24h snapshot. This is an early OOS filter, not a
+  replacement for longer promotion-grade rolling evidence.
 - Event ML rolling evidence should also default to GitHub-hosted runners after
   the source event-root dataset is artifactized. Pass `source_dataset_run_id`
   to `event-ml-rolling-evidence.yml`; only the fresh DB export branch should

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -18,8 +18,11 @@ from typing import Any
 SWEEP_KEYS = {
     "label",
     "train_window_days",
+    "train_window_hours",
     "test_window_days",
+    "test_window_hours",
     "step_days",
+    "step_hours",
     "lob_sample_secs",
     "observation_sample_secs",
     "max_quote_age_secs",
@@ -31,6 +34,12 @@ SWEEP_KEYS = {
     "data_quality_mode",
     "min_event_complete_events",
     "min_event_complete_rows",
+}
+
+OPTIONAL_SWEEP_KEYS = {
+    "train_window_hours",
+    "test_window_hours",
+    "step_hours",
 }
 
 
@@ -116,6 +125,12 @@ def factor_args(args: argparse.Namespace, variant: Variant, replay_parity_json: 
         "--min-event-complete-rows",
         values["min_event_complete_rows"],
     ]
+    if values.get("train_window_hours"):
+        command.extend(["--train-window-hours", values["train_window_hours"]])
+    if values.get("test_window_hours"):
+        command.extend(["--test-window-hours", values["test_window_hours"]])
+    if values.get("step_hours"):
+        command.extend(["--step-hours", values["step_hours"]])
     if values.get("factor_name_filter"):
         command.extend(["--factor-name-filter", values["factor_name_filter"]])
     if replay_parity_json:
@@ -327,7 +342,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--fail-if-blocked", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     for key in sorted(SWEEP_KEYS - {"label"}):
-        parser.add_argument(f"--{key.replace('_', '-')}", required=True)
+        parser.add_argument(
+            f"--{key.replace('_', '-')}",
+            required=key not in OPTIONAL_SWEEP_KEYS,
+            default="",
+        )
     return parser.parse_args()
 
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# One-Day PM5D OOS Smoke Window (2026-05-13)
+
+## Goal
+
+Allow the hosted PM5D factor walk-forward path to produce a real OOS smoke
+signal from a clean 24h snapshot, instead of requiring the default 2d train + 1d
+test window before any OOS rows can exist.
+
+## Plan
+
+- [x] Add optional hourly train/test/step windows to the factor walk-forward
+      runner while preserving day-based defaults.
+- [x] Wire hourly windows through hosted and self-hosted factor walk-forward
+      workflow `options_json`.
+- [x] Add tests proving 12h train / 12h test produces settlement-probability
+      OOS windows on a 24h sample.
+- [ ] Run a hosted 24h OOS smoke from the retained clean snapshot.
+
+## Review
+
+- 2026-05-13: Added optional `train_window_hours`, `test_window_hours`, and
+  `step_hours` knobs to `factor_walk_forward_v2`. Day-based defaults remain
+  unchanged, while hosted runs can now use `12h/12h/12h` on a clean 24h
+  snapshot to produce an early OOS smoke instead of waiting for the default
+  2d train + 1d test window.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion`,
+  `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py`,
+  `CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research settlement_probability_walk_forward_supports_intraday_oos_windows --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy factor_walk_forward_wires_alpha_prior_and_state_inputs --test workflow_security`,
+  `CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2`,
+  YAML parse for the two factor walk-forward workflows, and `git diff --check`.
+
 # Settlement Probability Deribit Gate Alignment (2026-05-13)
 
 ## Goal

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -148,6 +148,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
 
         self.assertIn("--sweep-json \"${SWEEP_JSON}\"", workflow)
         self.assertIn("--factor-name-filter \"${WALK_FACTOR_NAME_FILTER}\"", workflow)
+        self.assertIn("--train-window-hours \"${WALK_TRAIN_WINDOW_HOURS}\"", workflow)
 
     def test_alpha_search_prior_and_state_args_pass_through_to_factor_binary(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
@@ -213,6 +214,42 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             captured = json.loads(capture.read_text(encoding="utf-8"))
 
         self.assertIn("--require-deribit", captured)
+
+    def test_hour_window_args_pass_through_to_factor_binary(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = tmp / "capture_factor_args.py"
+            capture = tmp / "captured_args.json"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, sys\n"
+                f"open({str(capture)!r}, 'w', encoding='utf-8').write(json.dumps(sys.argv[1:]))\n"
+                f"{FAKE_REPORT}\n",
+                encoding="utf-8",
+            )
+            binary.chmod(0o755)
+
+            subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--train-window-hours",
+                    "12",
+                    "--test-window-hours",
+                    "12",
+                    "--step-hours",
+                    "12",
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            captured = json.loads(capture.read_text(encoding="utf-8"))
+
+        self.assertIn("--train-window-hours", captured)
+        self.assertIn("--test-window-hours", captured)
+        self.assertIn("--step-hours", captured)
 
 
 if __name__ == "__main__":

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -349,6 +349,9 @@ fn factor_walk_forward_wires_alpha_prior_and_state_inputs() {
             "alpha_search_llm_prior_json",
             "alpha_search_state_json",
             "require_deribit",
+            "train_window_hours",
+            "test_window_hours",
+            "step_hours",
             "mcts-state.json",
             "--alpha-search-state-json",
             "--alpha-search-llm-prior-json",
@@ -370,6 +373,10 @@ fn factor_walk_forward_wires_alpha_prior_and_state_inputs() {
         "alpha_search_plan_artifact_name",
         "alpha_search_llm_prior_json",
         "alpha_search_state_json",
+        "require_deribit",
+        "train_window_hours",
+        "test_window_hours",
+        "step_hours",
     ] {
         if !route_allowlist.contains(needle) {
             offenders.push(format!(


### PR DESCRIPTION
## Summary
- Add optional hourly train/test/step windows for factor_walk_forward_v2 while preserving day-based defaults.
- Wire train_window_hours/test_window_hours/step_hours through hosted and self-hosted factor walk-forward workflow options.
- Document 12h train / 12h test PM5D OOS smoke usage for clean 24h snapshots.

## Verification
- python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py
- CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research settlement_probability_walk_forward_supports_intraday_oos_windows --lib
- CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy factor_walk_forward_wires_alpha_prior_and_state_inputs --test workflow_security
- CARGO_TARGET_DIR=/tmp/ploy-one-day-oos /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2
- YAML parse for factor walk-forward workflows
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hour-based window configuration for factor walk-forward operations. Users can now specify training, testing, and step windows using hourly granularity, enabling intraday out-of-sample analysis alongside traditional day-based configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->