### PR TITLE
fix: run recorded replay parity in readonly environment

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -27,6 +27,14 @@ on:
         description: "Optional GitHub issue number for posting parity evidence"
         required: false
         default: "321"
+      approval_environment:
+        description: "GitHub environment for read-only tango access"
+        required: false
+        default: "tango-1-1-build-only"
+        type: choice
+        options:
+          - "tango-1-1-build-only"
+          - "tango-1-1"
 
 concurrency:
   group: recorded-replay-parity-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.since }}-${{ github.event.inputs.until }}
@@ -44,7 +52,7 @@ jobs:
     name: Replay recorded feed and compare dry-run evidence
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: tango-1-1
+    environment: ${{ inputs.approval_environment }}
 
     steps:
       - name: Checkout code

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -69,6 +69,13 @@ closed dry-run rows when available, and falls back to current open rows when a
 fresh recording has not yet accumulated closed events. The workflow records the resolved window in the workflow summary, issue comment, and
 `resolved-window.json` artifact. Manual timestamps remain supported for
 reproducing a known incident window or an older research issue.
+The workflow is read-only evidence generation: it uses the deployed
+`/opt/ploy/bin/ploy-runner`, a temporary replay config, and report/database
+reads, but it does not deploy artifacts, restart services, or enable live
+orders. Its `approval_environment` input therefore defaults to
+`tango-1-1-build-only` so parity checks can run without the protected live
+deploy approval gate. Use `approval_environment=tango-1-1` only when an operator
+explicitly wants the protected environment approval for an incident replay.
 
 ## Research Issue Contract
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# Recorded Replay Parity Read-Only Environment (2026-05-13)
+
+## Goal
+
+Unblock PM5D settlement-probability promotion evidence by letting
+`recorded-replay-parity.yml` run as read-only runtime-parity evidence without
+waiting on the protected `tango-1-1` deploy approval environment.
+
+## Plan
+
+- [x] Add an explicit read-only approval environment input to
+      `recorded-replay-parity.yml`, defaulting to `tango-1-1-build-only`.
+- [x] Add workflow-security coverage so recorded replay parity keeps the
+      read-only default and pinned SSH verification.
+- [x] Update the strategy research runbook with the read-only parity dispatch
+      semantics.
+- [x] Validate YAML/workflow guard tests and open a PR through the normal flow.
+
+## Review
+
+- 2026-05-13: `recorded-replay-parity.yml` now accepts
+  `approval_environment`, defaulting to `tango-1-1-build-only`, while retaining
+  the option to use protected `tango-1-1` approval for operator-requested
+  incident replays. The parity job still uses pinned SSH known_hosts and the
+  already deployed tango runner; it does not deploy, restart services, or enable
+  live orders.
+- 2026-05-13: Verification passed: YAML parse for
+  `.github/workflows/recorded-replay-parity.yml`, `git diff --check`,
+  `CARGO_TARGET_DIR=/tmp/ploy-recorded-parity-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture`,
+  and
+  `CARGO_TARGET_DIR=/tmp/ploy-recorded-parity-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy workflow_dispatch_inputs_stay_lintable --test workflow_security -- --exact --nocapture`.
+
 # One-Day PM5D OOS Smoke Window (2026-05-13)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -262,10 +262,16 @@ fn recorded_replay_parity_supports_auto_window() {
     let mut offenders = Vec::new();
 
     for needle in [
+        "approval_environment:",
+        "default: \"tango-1-1-build-only\"",
+        "environment: ${{ inputs.approval_environment }}",
         "default: \"auto\"",
         "resolve_recorded_replay_window.py",
         "--recording \"${recording_path}\"",
         "--dryrun-json \"${dryrun_report}\"",
+        "StrictHostKeyChecking yes",
+        "UserKnownHostsFile ~/.ssh/known_hosts",
+        "TANGO_1_1_KNOWN_HOSTS",
         "resolved-window.json",
         "resolved-window.env",
         "skip_settlement_exits = true",
@@ -284,6 +290,8 @@ fn recorded_replay_parity_supports_auto_window() {
         "defaults `since=auto` and `until=auto`",
         "records the resolved window",
         "timestamps remain supported",
+        "`approval_environment` input therefore defaults to",
+        "`tango-1-1-build-only`",
     ] {
         if !runbook.contains(needle) {
             offenders.push(format!("strategy-research-cicd.md: missing `{needle}`"));


### PR DESCRIPTION
## Summary
- add an approval_environment input to recorded replay parity, defaulting to tango-1-1-build-only
- keep protected tango-1-1 approval available for operator-requested incident replays
- document the read-only parity semantics and guard them in workflow_security

## Verification
- YAML parse for .github/workflows/recorded-replay-parity.yml
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-recorded-parity-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-recorded-parity-env /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy workflow_dispatch_inputs_stay_lintable --test workflow_security -- --exact --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable approval environment selection for recorded replay parity workflow checks, defaulting to build-only mode.

* **Documentation**
  * Clarified that recorded replay parity workflow generates read-only evidence and documented approval environment behavior.

* **Tests**
  * Enhanced security validation for workflow SSH host-key verification and configuration contracts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/493)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->