### PR TITLE
fix: ignore zero-fill exit attempts in parity

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -6,15 +6,15 @@ on:
       deployment_id:
         description: "Dry-run deployment id to replay and compare"
         required: true
-        default: "pm5d.threelayer.obi-soft.dryrun"
+        default: "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
       config_path:
         description: "Remote deployed dry-run config path on tango-1-1"
         required: true
-        default: "/opt/ploy/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml"
+        default: "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
       recording_path:
         description: "Remote recorded MarketUpdate NDJSON path on tango-1-1"
         required: true
-        default: "/opt/ploy/data/recordings/pm5d-threelayer-canonical.ndjson"
+        default: "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson"
       since:
         description: "Inclusive ISO-8601 lower timestamp bound for parity rows, or auto"
         required: false

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -80,6 +80,11 @@ The build-only environment must still provide `TANGO_1_1_KNOWN_HOSTS` for
 pinned host verification. The SSH key may come from the protected environment
 secret or from the repository-level `TANGO_SSH_KEY` / `ALIYUN_ECS_SSH_KEY`
 fallbacks used by read-only research workflows.
+For the active settlement-probability BTC/ETH dry-run profile, use the matching
+recording path
+`/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`;
+the older `pm5d-threelayer-canonical.ndjson` recording is historical and can
+fail auto-window resolution because it does not overlap current dry-run rows.
 
 ## Research Issue Contract
 

--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -579,6 +579,49 @@ def runtime_row_summary(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def is_zero_decimal(value: Any) -> bool:
+    if value in (None, ""):
+        return False
+    try:
+        return Decimal(str(value)) == 0
+    except (InvalidOperation, ValueError):
+        return False
+
+
+def is_non_executed_exit_attempt(row: dict[str, Any]) -> bool:
+    """Return true for zero-fill exit attempts that should not block entry parity.
+
+    Recorded replay parity currently injects `skip_settlement_exits = true` so
+    the replay focuses on entry/fill accounting. Dry-run reports can still carry
+    rejected take-profit attempts from live quote polling. These attempts did
+    not fill and do not affect cashflow/PnL, so they are tracked as ignored
+    metadata instead of blocking strict parity for executable entries.
+    """
+
+    intent_id = str(row.get("intent_id") or "").lower()
+    status = normalize_status(row.get("status") or row.get("fill_status"))
+    if not intent_id.startswith("tl_tp_") or status != "REJECTED":
+        return False
+    if row.get("filled_quantity") is not None and not is_zero_decimal(row.get("filled_quantity")):
+        return False
+    if row.get("pnl") is not None and not is_zero_decimal(row.get("pnl")):
+        return False
+    return True
+
+
+def filter_non_executed_exit_attempts(
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    kept: list[dict[str, Any]] = []
+    ignored: list[dict[str, Any]] = []
+    for row in rows:
+        if is_non_executed_exit_attempt(row):
+            ignored.append(row)
+        else:
+            kept.append(row)
+    return kept, ignored
+
+
 def compare_normalized_rows(
     replay_rows: list[dict[str, Any]],
     dryrun_rows: list[dict[str, Any]],
@@ -713,6 +756,11 @@ def compare_runtime_evidence(
         until=until,
         timestamp_keys=("decision_ts",),
     )
+    replay_events, ignored_replay_events = filter_non_executed_exit_attempts(replay_events)
+    dryrun_events, ignored_dryrun_events = filter_non_executed_exit_attempts(dryrun_events)
+    replay_orders, ignored_replay_orders = filter_non_executed_exit_attempts(replay_orders)
+    dryrun_orders, ignored_dryrun_orders = filter_non_executed_exit_attempts(dryrun_orders)
+
     event_comparison = compare_normalized_rows(
         replay_events,
         dryrun_events,
@@ -753,6 +801,12 @@ def compare_runtime_evidence(
         "missing_strict_fields": missing_strict_fields,
         "mismatches": mismatches[:100],
         "settlement_exit_mismatches": settlement_mismatches,
+        "ignored_non_executed_exit_attempts": {
+            "replay_events": [runtime_row_summary(row) for row in ignored_replay_events[:50]],
+            "dryrun_events": [runtime_row_summary(row) for row in ignored_dryrun_events[:50]],
+            "replay_orders": [runtime_row_summary(row) for row in ignored_replay_orders[:50]],
+            "dryrun_orders": [runtime_row_summary(row) for row in ignored_dryrun_orders[:50]],
+        },
         "strict_parity_ready": strict_parity_ready,
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -37,6 +37,14 @@ waiting on the protected `tango-1-1` deploy approval environment.
   ED25519 host key (`SHA256:VlrhRpcFm+j+25LkYXVMHQ3Pw4xO37ECM30wE5bCBOI`) and
   updated `recorded-replay-parity.yml` to reuse repository-level `TANGO_SSH_KEY`
   or `ALIYUN_ECS_SSH_KEY` when the protected environment key is unavailable.
+- 2026-05-13: Main run `25783222380` with the matching settlement-probability
+  recording path completed successfully. Its first parity evaluation was blocked
+  only by one dry-run-only `tl_tp_` take-profit exit attempt that was
+  `REJECTED`, had zero fill, and did not affect cashflow. Updated
+  `scripts/replay_dryrun_parity.py` to ignore such non-executed exit attempts
+  while preserving them in `ignored_non_executed_exit_attempts` metadata. A
+  recomputation against the run artifacts reported `strict_parity_ready=true`,
+  events/orders/fills `4/4`, and no blocking risk flags.
 
 # One-Day PM5D OOS Smoke Window (2026-05-13)
 

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -218,6 +218,45 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertEqual(runtime["orders"]["shared_count"], 0)
         self.assertEqual(runtime["fills"]["shared_count"], 0)
 
+    def test_runtime_evidence_ignores_zero_fill_take_profit_rejections(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        rejected_exit = evidence_payload(
+            intent_id="tl_tp_token-up_1778614178726",
+            order_id="rejected-exit-order",
+            fill_id="unused-fill",
+            order_side="SELL",
+            fill_side="SELL",
+            limit_price="0.99",
+            fill_price="0",
+            event_side="SELL",
+            created_at="2026-05-02T01:03:00Z",
+        )
+        rejected_exit["runtime_evidence"]["events"][0]["fill_status"] = "REJECTED"
+        rejected_exit["runtime_evidence"]["events"][0]["entry_price"] = "0.99"
+        rejected_exit["runtime_evidence"]["events"][0]["pnl"] = "0"
+        rejected_exit["runtime_evidence"]["orders"][0]["status"] = "REJECTED"
+        rejected_exit["runtime_evidence"]["orders"][0]["filled_quantity"] = "0"
+        rejected_exit["runtime_evidence"]["orders"][0]["rejection_reason"] = "No full-depth liquidity"
+        rejected_exit["runtime_evidence"]["fills"] = []
+        dryrun["runtime_evidence"]["events"].extend(rejected_exit["runtime_evidence"]["events"])
+        dryrun["runtime_evidence"]["orders"].extend(rejected_exit["runtime_evidence"]["orders"])
+
+        result = self.run_script(replay, dryrun)
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertTrue(runtime["strict_parity_ready"])
+        self.assertEqual(result["blocking_risk_flags"], [])
+        self.assertEqual(runtime["events"]["dryrun_count"], 1)
+        self.assertEqual(runtime["orders"]["dryrun_count"], 1)
+        ignored = runtime["ignored_non_executed_exit_attempts"]
+        self.assertEqual(len(ignored["dryrun_events"]), 1)
+        self.assertEqual(len(ignored["dryrun_orders"]), 1)
+        self.assertEqual(
+            ignored["dryrun_orders"][0]["intent_id"],
+            "tl_tp_token-up_1778614178726",
+        )
+
     def test_empty_runtime_window_collects_more_instead_of_fixing_runtime(self):
         result = self.run_script({"runtime_evidence": {}}, {"runtime_evidence": {}})
 

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -265,6 +265,8 @@ fn recorded_replay_parity_supports_auto_window() {
         "approval_environment:",
         "default: \"tango-1-1-build-only\"",
         "environment: ${{ inputs.approval_environment }}",
+        "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+        "pm5d-threelayer-settlement-probability-btc-eth.ndjson",
         "TANGO_SSH_KEY",
         "ALIYUN_ECS_SSH_KEY",
         "No SSH key secret found for tango-1-1",


### PR DESCRIPTION
## Summary
- ignore rejected zero-fill tl_tp exit attempts in recorded replay parity while preserving them as metadata
- update recorded replay parity defaults to the active settlement-probability BTC/ETH dry-run and matching recording
- document the current recording path and add regression coverage

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/replay_dryrun_parity.py tests/test_replay_dryrun_parity.py
- YAML parse for .github/workflows/recorded-replay-parity.yml
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-parity-zero-exit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture
- recomputed run 25783222380 artifacts locally: strict_parity_ready=true, events/orders/fills 4/4, no blocking risk flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD runbook with corrected guidance for recorded replay parity validation, including proper recording paths and warnings about legacy configurations.

* **Tests**
  * Added new test to verify handling of rejected take-profit exit attempts in parity validation.

* **Chores**
  * Enhanced parity validation workflow to exclude non-executed exit attempts from strict comparisons while preserving them in detailed reports.
  * Updated workflow configuration defaults for recorded replay testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/495)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->