### PR TITLE
chore: apply PM5D AutoFactor dry-run handoff

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30


### PR DESCRIPTION
# AutoFactor Config Handoff

- Status: `ready`
- Config: `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`
- Changed: `true`
- Action: `updated`
- Previous runtime score: `autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike`
- New runtime score: `autofactor_formula:auto_settlement_conservative_settlement_edge`
- Strategy: `auto_settlement_conservative_settlement_edge`
- Target: `full_depth_settlement_executable_pnl`
- Strategy profile: `settlement_probability`
- ICIR: `1.018091`
- Top bucket avg label: `2.507843`

Source hosted walk-forward run: https://github.com/proerror77/ploy/actions/runs/25784012885
Source snapshot run: 25775400112

This PR is generated from a ready hosted handoff artifact. It does not deploy and does not enable live trading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime configuration parameters for settlement probability calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/496)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->