### PR TITLE
Fix recorded replay official settlement enrichment

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -126,8 +126,8 @@ jobs:
             tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
           scp scripts/enrich_replay_runtime_evidence.py \
             tango-1-1:"${REMOTE_DIR}/enrich_replay_runtime_evidence.py"
-          scp scripts/extract_dryrun_settlement_evidence.py \
-            tango-1-1:"${REMOTE_DIR}/extract_dryrun_settlement_evidence.py"
+          scp scripts/extract_official_settlement_evidence.py \
+            tango-1-1:"${REMOTE_DIR}/extract_official_settlement_evidence.py"
           scp scripts/replay_dryrun_parity.py \
             tango-1-1:"${REMOTE_DIR}/replay_dryrun_parity.py"
           scp scripts/resolve_recorded_replay_window.py \
@@ -155,7 +155,7 @@ jobs:
           test -r "${recording_path}"
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
           test -r "${remote_dir}/enrich_replay_runtime_evidence.py"
-          test -r "${remote_dir}/extract_dryrun_settlement_evidence.py"
+          test -r "${remote_dir}/extract_official_settlement_evidence.py"
           test -r "${remote_dir}/replay_dryrun_parity.py"
           test -r "${remote_dir}/resolve_recorded_replay_window.py"
 
@@ -170,6 +170,9 @@ jobs:
           case "${until_ts}" in ""|auto|AUTO) auto_window=true ;; esac
 
           settlements_json="${remote_dir}/official-settlements.json"
+          official_token_ids_json="${remote_dir}/official-settlement-token-ids.json"
+          official_db_rows_json="${remote_dir}/official-settlement-db-rows.json"
+          official_settlement_report="${remote_dir}/official-settlement-report.json"
           dryrun_report="${remote_dir}/dryrun-report.json"
           enriched_recording="${remote_dir}/recording-official-settlement.ndjson"
           enrichment_report="${remote_dir}/recording-enrichment.json"
@@ -227,65 +230,42 @@ jobs:
           fi
           echo "Recorded replay parity window: ${since_ts} -> ${until_ts} (requested ${requested_since_ts} -> ${requested_until_ts})"
 
+          python3 "${remote_dir}/extract_official_settlement_evidence.py" \
+            --recording "${recording_path}" \
+            --output-token-ids "${official_token_ids_json}"
+          token_ids_json="$(cat "${official_token_ids_json}")"
+
           "${PSQL[@]}" \
-            -v deployment_id="${deployment_id}" \
-            -v since_ts="${since_ts}" \
-            -v until_ts="${until_ts}" \
-            > "${settlements_json}" <<'SQL'
-          WITH row_outcomes AS (
-            SELECT
-              event_id,
-              token_id,
-              avg_exit_price::text AS settlement,
-              CASE
-                WHEN market_side = 'UP' AND avg_exit_price >= 0.99 THEN 1
-                WHEN market_side = 'UP' AND avg_exit_price <= 0.01 THEN 0
-                WHEN market_side = 'DOWN' AND avg_exit_price >= 0.99 THEN 0
-                WHEN market_side = 'DOWN' AND avg_exit_price <= 0.01 THEN 1
-                ELSE NULL
-              END AS outcome_int
-            FROM strategy_runtime_event_track_record
-            WHERE runtime_mode IN ('dry_run', 'dryrun')
-              AND deployment_id = :'deployment_id'
-              AND is_closed
-              AND opened_at >= :'since_ts'::timestamptz - INTERVAL '10 minutes'
-              AND opened_at <= :'until_ts'::timestamptz + INTERVAL '10 minutes'
-          ),
-          unambiguous AS (
-            SELECT
-              event_id,
-              token_id,
-              MIN(outcome_int) AS outcome_int,
-              MIN(settlement) AS settlement
-            FROM row_outcomes
-            WHERE event_id IS NOT NULL
-              AND token_id IS NOT NULL
-              AND outcome_int IS NOT NULL
-              AND settlement IS NOT NULL
-            GROUP BY event_id, token_id
-            HAVING MIN(outcome_int) = MAX(outcome_int)
+            -v token_ids_json="${token_ids_json}" \
+            > "${official_db_rows_json}" <<'SQL'
+          WITH token_ids AS (
+            SELECT jsonb_array_elements_text(:'token_ids_json'::jsonb) AS token_id
           )
           SELECT COALESCE(
             jsonb_agg(
               jsonb_build_object(
-                'event_id', event_id,
-                'token_id', token_id,
-                'settlement', settlement,
-                'resolved_up_won', outcome_int = 1
+                'token_id', s.token_id,
+                'market_slug', s.market_slug,
+                'outcome', s.outcome,
+                'settlement', s.settled_price::text,
+                'resolved', s.resolved,
+                'resolved_at', s.resolved_at
               )
-              ORDER BY event_id, token_id
+              ORDER BY s.token_id
             ),
             '[]'::jsonb
           )::text
-          FROM unambiguous;
+          FROM pm_token_settlements s
+          JOIN token_ids t ON t.token_id = s.token_id
+          WHERE s.resolved = true
+            AND s.settled_price IS NOT NULL;
           SQL
 
-          python3 "${remote_dir}/extract_dryrun_settlement_evidence.py" \
-            --dryrun-json "${dryrun_report}" \
+          python3 "${remote_dir}/extract_official_settlement_evidence.py" \
+            --recording "${recording_path}" \
+            --db-settlements-json "${official_db_rows_json}" \
             --output-json "${settlements_json}" \
-            --deployment-id "${deployment_id}" \
-            --since "${since_ts}" \
-            --until "${until_ts}"
+            --report-json "${official_settlement_report}"
 
           python3 "${remote_dir}/enrich_recording_official_settlement.py" \
             --input "${recording_path}" \
@@ -341,6 +321,7 @@ jobs:
           scp tango-1-1:"${REMOTE_DIR}/replay-evaluation.json" artifacts/replay/evaluation.json
           scp tango-1-1:"${REMOTE_DIR}/recording-enrichment.json" artifacts/replay/recording-enrichment.json
           scp tango-1-1:"${REMOTE_DIR}/replay-evidence-enrichment.json" artifacts/replay/replay-evidence-enrichment.json
+          scp tango-1-1:"${REMOTE_DIR}/official-settlement-report.json" artifacts/replay/official-settlement-report.json
           scp tango-1-1:"${REMOTE_DIR}/dryrun-report.json" artifacts/dryrun/dryrun.json
           scp tango-1-1:"${REMOTE_DIR}/resolved-window.json" artifacts/parity/resolved-window.json
           scp tango-1-1:"${REMOTE_DIR}/resolved-window.env" artifacts/parity/resolved-window.env

--- a/scripts/extract_official_settlement_evidence.py
+++ b/scripts/extract_official_settlement_evidence.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build replay settlement evidence from official token settlements.
+
+Recorded replay needs two different settlement views:
+
+- event-level `resolved_up_won` for EventExpired replay updates
+- token-level settlement prices for runtime evidence PnL enrichment
+
+The recording owns the event semantics (`event_id`, `up_token`, `down_token`).
+`pm_token_settlements` owns official token settlement prices. This helper joins
+those two surfaces without using dry-run report rows as settlement labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+def is_winning_price(value: Any) -> bool | None:
+    try:
+        price = Decimal(str(value))
+    except InvalidOperation:
+        return None
+    if price >= Decimal("0.99"):
+        return True
+    if price <= Decimal("0.01"):
+        return False
+    return None
+
+
+def iter_recording(path: Path):
+    with path.open(encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{line_number}: invalid NDJSON: {exc}") from exc
+            if not isinstance(record, dict):
+                raise SystemExit(f"{path}:{line_number}: expected JSON object record")
+            yield record
+
+
+def extract_recording_token_map(path: Path) -> tuple[dict[str, dict[str, str]], dict[str, tuple[str, str]]]:
+    events: dict[str, dict[str, str]] = {}
+    token_to_event_side: dict[str, tuple[str, str]] = {}
+
+    for record in iter_recording(path):
+        update = record.get("update")
+        if not isinstance(update, dict) or update.get("kind") != "event_discovered":
+            continue
+
+        event_id = update.get("event_id")
+        up_token = update.get("up_token")
+        down_token = update.get("down_token")
+        if event_id is None or up_token is None or down_token is None:
+            continue
+
+        event_key = str(event_id)
+        up_key = str(up_token)
+        down_key = str(down_token)
+        events[event_key] = {"up_token": up_key, "down_token": down_key}
+        token_to_event_side[up_key] = (event_key, "UP")
+        token_to_event_side[down_key] = (event_key, "DOWN")
+
+    return events, token_to_event_side
+
+
+def load_db_rows(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict):
+        payload = payload.get("settlements", [])
+    if not isinstance(payload, list):
+        return []
+    return [row for row in payload if isinstance(row, dict)]
+
+
+def build_settlements(
+    db_rows: list[dict[str, Any]],
+    token_to_event_side: dict[str, tuple[str, str]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    settlements: dict[tuple[str, str], dict[str, Any]] = {}
+    event_outcomes: dict[str, set[bool]] = {}
+    skipped = {
+        "unmapped_token": 0,
+        "unresolved": 0,
+        "missing_settlement": 0,
+        "ambiguous_price": 0,
+    }
+
+    for row in db_rows:
+        token_id = row.get("token_id")
+        if token_id is None:
+            skipped["unmapped_token"] += 1
+            continue
+        token_key = str(token_id)
+        event_side = token_to_event_side.get(token_key)
+        if event_side is None:
+            skipped["unmapped_token"] += 1
+            continue
+        if row.get("resolved") is False:
+            skipped["unresolved"] += 1
+            continue
+        settlement = row.get("settlement", row.get("settled_price"))
+        if settlement is None:
+            skipped["missing_settlement"] += 1
+            continue
+
+        token_won = is_winning_price(settlement)
+        if token_won is None:
+            skipped["ambiguous_price"] += 1
+            continue
+
+        event_id, side = event_side
+        resolved_up_won = token_won if side == "UP" else not token_won
+        event_outcomes.setdefault(event_id, set()).add(resolved_up_won)
+        settlements[(event_id, token_key)] = {
+            "event_id": event_id,
+            "token_id": token_key,
+            "settlement": str(settlement),
+            "resolved_up_won": resolved_up_won,
+            "source": "pm_token_settlements",
+        }
+
+    conflicts = sorted(event_id for event_id, outcomes in event_outcomes.items() if len(outcomes) > 1)
+    if conflicts:
+        settlements = {
+            key: value for key, value in settlements.items() if value["event_id"] not in set(conflicts)
+        }
+
+    output = sorted(settlements.values(), key=lambda item: (item["event_id"], item["token_id"]))
+    report = {
+        "db_settlement_rows": len(db_rows),
+        "official_settlement_count": len(output),
+        "official_settlement_event_count": len({item["event_id"] for item in output}),
+        "conflicting_event_count": len(conflicts),
+        "conflicting_events": conflicts,
+        "skipped": skipped,
+    }
+    return output, report
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--recording", required=True)
+    parser.add_argument("--db-settlements-json")
+    parser.add_argument("--output-json")
+    parser.add_argument("--report-json")
+    parser.add_argument("--output-token-ids")
+    args = parser.parse_args()
+
+    events, token_to_event_side = extract_recording_token_map(Path(args.recording))
+
+    if args.output_token_ids:
+        write_json(Path(args.output_token_ids), sorted(token_to_event_side))
+
+    if args.db_settlements_json:
+        if not args.output_json:
+            raise SystemExit("--output-json is required with --db-settlements-json")
+        settlements, report = build_settlements(
+            load_db_rows(Path(args.db_settlements_json)),
+            token_to_event_side,
+        )
+        report["recording_event_count"] = len(events)
+        report["recording_token_count"] = len(token_to_event_side)
+        write_json(Path(args.output_json), settlements)
+        if args.report_json:
+            write_json(Path(args.report_json), report)
+        print(json.dumps(report, sort_keys=True))
+    elif args.output_json:
+        raise SystemExit("--db-settlements-json is required with --output-json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,112 @@
+# Official Settlement Replay Enrichment Fix (2026-05-13)
+
+## Goal
+
+Fix `recorded-replay-parity.yml` so `settlement_event_count=0` means the
+official settlement table truly has no matching settled tokens, not that the
+workflow accidentally overwrote official settlement evidence with dry-run report
+rows.
+
+## Plan
+
+- [x] Add a recording-aware official settlement extractor keyed by
+      `event_discovered` up/down token ids and `pm_token_settlements`.
+- [x] Wire recorded replay parity to use official DB settlement rows first and
+      keep dry-run settlement extraction out of the official enrichment path.
+- [x] Add tests for extractor semantics and workflow regression coverage.
+- [x] Run focused tests and record the outcome.
+
+## Review
+
+- 2026-05-13: Root cause confirmed: the workflow queried a settlement JSON and
+  then overwrote the same file with dry-run report-derived settlement evidence.
+  After the clean dry-run reset, that fallback could be empty, producing
+  `settlement_event_count=0` even though official DB rows existed.
+- 2026-05-13: Added `scripts/extract_official_settlement_evidence.py`. It reads
+  `event_discovered` rows from the recording to map `event_id` to `up_token` /
+  `down_token`, then joins official `pm_token_settlements` token prices into
+  replay settlement evidence. Dry-run rows are no longer a settlement label
+  source for recorded replay enrichment.
+- 2026-05-13: Direct tango DB check found official settlement rows for all 4
+  replay tokens from run `25789692556`.
+- 2026-05-13: Smoke against
+  `/opt/ploy/tmp/pm5d-settlement-24h-20260512T090000Z-20260513T090000Z.ndjson`
+  produced `official_settlement_event_count=218`,
+  `official_settlement_count=436`, and `conflicting_event_count=0`.
+  Re-running recording enrichment with those official rows produced
+  `settlement_event_count=218` and `event_expired_enriched=182` out of 190
+  expired rows. The 8 unmatched expired rows were boundary events ending at
+  `2026-05-12T09:00:00Z`, `09:05:00Z`, or `09:10:00Z` whose
+  `event_discovered` rows were outside the merged 24h slice, so the recording
+  did not contain up/down token semantics for them.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_extract_official_settlement_evidence
+  tests.test_enrich_recording_official_settlement
+  tests.test_extract_dryrun_settlement_evidence`, YAML parse for
+  `.github/workflows/recorded-replay-parity.yml`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-official-settlement-fix /opt/homebrew/bin/timeout
+  300 rtk cargo test --locked -p ploy
+  recorded_replay_parity_supports_auto_window --test workflow_security -- --exact
+  --nocapture`.
+- 2026-05-13: PR replay run `25793423775` on branch
+  `fix/recorded-replay-official-settlement` completed successfully against the
+  same 24h merged recording. Artifacts showed
+  `official_settlement_event_count=218`, replay settlement enrichment `4/4`,
+  and replay event PnL sum `31.566722281344`. Parity remained blocked because
+  dry-run runtime rows for the historical window were empty after the clean
+  evidence reset, not because settlement enrichment was missing.
+
+# Settlement Probability 24h Replay And Clean Dry-Run Reset (2026-05-13)
+
+## Goal
+
+Produce a real 24h historical replay/backtest view for the current
+settlement-probability PM5D BTC/ETH strategy, and reset contaminated dry-run
+runtime evidence so future statistics start from a clean baseline.
+
+## Plan
+
+- [x] Confirm current deployed config, data coverage, and clean evidence stage.
+- [x] Run a 24h historical replay/backtest path using the current strategy
+      config from `main`.
+- [x] Preview backup/reset for
+      `pm5d.threelayer.settlement-probability-btc-eth.dryrun`.
+- [x] Pause the dry-run deployment, execute the reset, and verify the backup
+      artifact plus clean baseline gate.
+- [x] Resume/redeploy the dry-run config from `main` and verify it is running
+      with zero stale runtime evidence.
+
+## Review
+
+- 2026-05-13: Explicit 24h recorded replay request
+  `25789111238` showed the default current recording path was not enough for a
+  real one-day replay: replay produced only 4 events while the dry-run window
+  had 11 events, because older recording segments had been rotated away from
+  the active path.
+- 2026-05-13: Built a temporary merged recording on `tango-1-1` at
+  `/opt/ploy/tmp/pm5d-settlement-24h-20260512T090000Z-20260513T090000Z.ndjson`
+  from 6 rotated/current NDJSON files. The merged file contains 1,371,571
+  records / 507,010,320 bytes for `2026-05-12T09:00:00Z ->
+  2026-05-13T09:00:00Z`.
+- 2026-05-13: 24h replay run `25789692556` processed the merged feed and
+  generated 4 intents/fills with event-level cashflow PnL `-50.2783`, but all
+  replay events had `settlement=open` and `recording-enrichment.json` reported
+  `settlement_event_count=0`; treat this as executable-entry replay evidence,
+  not final settlement PnL.
+- 2026-05-13: Reset preview `25789111228` matched 26 orders / 11 fills for the
+  target dry-run deployment and touched only `strategy_runtime_orders` and
+  `strategy_runtime_fills`.
+- 2026-05-13: After pausing the deployment, destructive reset run
+  `25789303336` passed the running-deployment guard, backed up the matched
+  rows, deleted 26 orders, and left `after.orders=0`, `after.fills=0`; the
+  post-reset clean-baseline gate passed before the deployment was resumed.
+- 2026-05-13: Resumed and config-synced/restarted the dry-run via
+  `25789406430`. Remote config is on `main` score
+  `autofactor_formula:auto_settlement_conservative_settlement_edge`; deployment
+  is `desired=Running observed=Running`. New post-reset dry-run evidence began
+  immediately, so clean-baseline API checks now show fresh open positions rather
+  than stale pre-reset rows.
+
 # Recorded Replay Parity Read-Only Environment (2026-05-13)
 
 ## Goal

--- a/tests/test_extract_official_settlement_evidence.py
+++ b/tests/test_extract_official_settlement_evidence.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "extract_official_settlement_evidence.py"
+
+
+def discovered(event_id, up_token, down_token):
+    return {
+        "sequence": 1,
+        "recorded_at": "2026-05-12T09:00:00Z",
+        "update": {
+            "kind": "event_discovered",
+            "event_id": event_id,
+            "symbol": "BTCUSDT",
+            "up_token": up_token,
+            "down_token": down_token,
+            "end_time": "2026-05-12T09:05:00Z",
+            "resolved_up_won": None,
+        },
+    }
+
+
+class ExtractOfficialSettlementEvidenceTests(unittest.TestCase):
+    def run_script(self, recording_rows, db_rows):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            recording = tmp_path / "recording.ndjson"
+            db_json = tmp_path / "db-settlements.json"
+            output = tmp_path / "official-settlements.json"
+            report = tmp_path / "report.json"
+            token_ids = tmp_path / "token-ids.json"
+            recording.write_text(
+                "".join(json.dumps(row) + "\n" for row in recording_rows),
+                encoding="utf-8",
+            )
+            db_json.write_text(json.dumps(db_rows), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--recording",
+                    str(recording),
+                    "--output-token-ids",
+                    str(token_ids),
+                    "--db-settlements-json",
+                    str(db_json),
+                    "--output-json",
+                    str(output),
+                    "--report-json",
+                    str(report),
+                ],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return (
+                json.loads(output.read_text(encoding="utf-8")),
+                json.loads(report.read_text(encoding="utf-8")),
+                json.loads(token_ids.read_text(encoding="utf-8")),
+            )
+
+    def test_builds_event_and_token_settlement_from_official_rows(self):
+        settlements, report, token_ids = self.run_script(
+            [discovered("evt-1", "token-up", "token-down")],
+            [
+                {
+                    "token_id": "token-up",
+                    "settlement": "1.000000",
+                    "resolved": True,
+                },
+                {
+                    "token_id": "token-down",
+                    "settlement": "0.000000",
+                    "resolved": True,
+                },
+            ],
+        )
+
+        self.assertEqual(token_ids, ["token-down", "token-up"])
+        self.assertEqual(report["official_settlement_event_count"], 1)
+        self.assertEqual(report["official_settlement_count"], 2)
+        self.assertEqual(
+            settlements,
+            [
+                {
+                    "event_id": "evt-1",
+                    "resolved_up_won": True,
+                    "settlement": "0.000000",
+                    "source": "pm_token_settlements",
+                    "token_id": "token-down",
+                },
+                {
+                    "event_id": "evt-1",
+                    "resolved_up_won": True,
+                    "settlement": "1.000000",
+                    "source": "pm_token_settlements",
+                    "token_id": "token-up",
+                },
+            ],
+        )
+
+    def test_filters_unmapped_unresolved_and_conflicting_rows(self):
+        settlements, report, _ = self.run_script(
+            [discovered("evt-1", "token-up", "token-down")],
+            [
+                {"token_id": "token-up", "settlement": "1", "resolved": True},
+                {"token_id": "token-down", "settlement": "1", "resolved": True},
+                {"token_id": "other", "settlement": "1", "resolved": True},
+                {"token_id": "token-up", "settlement": "1", "resolved": False},
+            ],
+        )
+
+        self.assertEqual(settlements, [])
+        self.assertEqual(report["conflicting_event_count"], 1)
+        self.assertEqual(report["skipped"]["unmapped_token"], 1)
+        self.assertEqual(report["skipped"]["unresolved"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -281,6 +281,12 @@ fn recorded_replay_parity_supports_auto_window() {
         "resolved-window.json",
         "resolved-window.env",
         "skip_settlement_exits = true",
+        "extract_official_settlement_evidence.py",
+        "official-settlement-token-ids.json",
+        "official-settlement-db-rows.json",
+        "official-settlement-report.json",
+        "FROM pm_token_settlements s",
+        "--db-settlements-json \"${official_db_rows_json}\"",
         "RESOLVED_SINCE",
         "RESOLVED_UNTIL",
         "Requested window",
@@ -290,6 +296,18 @@ fn recorded_replay_parity_supports_auto_window() {
         if !workflow.contains(needle) {
             offenders.push(format!("recorded-replay-parity.yml: missing `{needle}`"));
         }
+    }
+    if workflow.contains("extract_dryrun_settlement_evidence.py") {
+        offenders.push(
+            "recorded-replay-parity.yml: dry-run settlement extraction must not feed official replay enrichment"
+                .to_string(),
+        );
+    }
+    if workflow.contains("FROM strategy_runtime_event_track_record") {
+        offenders.push(
+            "recorded-replay-parity.yml: official replay enrichment must not source settlement labels from track-record rows"
+                .to_string(),
+        );
     }
 
     for needle in [


### PR DESCRIPTION
## Summary
- source recorded replay settlement evidence from pm_token_settlements instead of dry-run reports
- add recording-aware event/token settlement extractor
- add unit and workflow guard coverage to prevent dry-run rows from feeding official settlement enrichment

## Verification
- python3 -m unittest tests.test_extract_official_settlement_evidence tests.test_enrich_recording_official_settlement tests.test_extract_dryrun_settlement_evidence
- python3 YAML parse for .github/workflows/recorded-replay-parity.yml
- CARGO_TARGET_DIR=/tmp/ploy-official-settlement-fix /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture
- workflow_dispatch recorded-replay-parity run 25793423775 on fix/recorded-replay-official-settlement

## Replay Evidence
- 24h window: 2026-05-12T09:00:00Z -> 2026-05-13T09:00:00Z
- official_settlement_event_count=218
- replay settlement-enriched event rows=4
- replay event PnL sum=31.566722281344
- parity blocked because historical dry-run rows for this reset window are empty, not because settlement enrichment is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Recorded-replay parity workflow now uses official settlement evidence and uploads an official settlement report to replay artifacts.

* **New Features**
  * Added a tool to derive and filter official settlement evidence from recordings and DB exports.

* **Tests**
  * New suite validating settlement extraction, filtering, conflict detection, and workflow guard checks enforcing correct evidence use.

* **Documentation**
  * Added run notes and playbook for official-settlement replay enrichment and clean dry-run reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/497)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->