### PR TITLE
Fix recorded replay settlement lookup for large token sets

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -171,6 +171,7 @@ jobs:
 
           settlements_json="${remote_dir}/official-settlements.json"
           official_token_ids_json="${remote_dir}/official-settlement-token-ids.json"
+          official_token_ids_tsv="${remote_dir}/official-settlement-token-ids.tsv"
           official_db_rows_json="${remote_dir}/official-settlement-db-rows.json"
           official_settlement_report="${remote_dir}/official-settlement-report.json"
           dryrun_report="${remote_dir}/dryrun-report.json"
@@ -233,14 +234,22 @@ jobs:
           python3 "${remote_dir}/extract_official_settlement_evidence.py" \
             --recording "${recording_path}" \
             --output-token-ids "${official_token_ids_json}"
-          token_ids_json="$(cat "${official_token_ids_json}")"
+          python3 - "${official_token_ids_json}" "${official_token_ids_tsv}" <<'PY'
+          import json
+          import sys
+
+          src, dst = sys.argv[1:]
+          token_ids = json.load(open(src, encoding="utf-8"))
+          with open(dst, "w", encoding="utf-8") as handle:
+              for token_id in token_ids:
+                  handle.write(str(token_id).replace("\t", "").replace("\n", ""))
+                  handle.write("\n")
+          PY
 
           "${PSQL[@]}" \
-            -v token_ids_json="${token_ids_json}" \
-            > "${official_db_rows_json}" <<'SQL'
-          WITH token_ids AS (
-            SELECT jsonb_array_elements_text(:'token_ids_json'::jsonb) AS token_id
-          )
+            > "${official_db_rows_json}" <<SQL
+          CREATE TEMP TABLE replay_token_ids(token_id TEXT) ON COMMIT DROP;
+          \\copy replay_token_ids(token_id) FROM '${official_token_ids_tsv}'
           SELECT COALESCE(
             jsonb_agg(
               jsonb_build_object(
@@ -256,7 +265,7 @@ jobs:
             '[]'::jsonb
           )::text
           FROM pm_token_settlements s
-          JOIN token_ids t ON t.token_id = s.token_id
+          JOIN replay_token_ids t ON t.token_id = s.token_id
           WHERE s.resolved = true
             AND s.settled_price IS NOT NULL;
           SQL

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -283,9 +283,13 @@ fn recorded_replay_parity_supports_auto_window() {
         "skip_settlement_exits = true",
         "extract_official_settlement_evidence.py",
         "official-settlement-token-ids.json",
+        "official-settlement-token-ids.tsv",
         "official-settlement-db-rows.json",
         "official-settlement-report.json",
+        "CREATE TEMP TABLE replay_token_ids",
+        "\\copy replay_token_ids(token_id)",
         "FROM pm_token_settlements s",
+        "JOIN replay_token_ids t ON t.token_id = s.token_id",
         "--db-settlements-json \"${official_db_rows_json}\"",
         "RESOLVED_SINCE",
         "RESOLVED_UNTIL",
@@ -306,6 +310,12 @@ fn recorded_replay_parity_supports_auto_window() {
     if workflow.contains("FROM strategy_runtime_event_track_record") {
         offenders.push(
             "recorded-replay-parity.yml: official replay enrichment must not source settlement labels from track-record rows"
+                .to_string(),
+        );
+    }
+    if workflow.contains("-v token_ids_json=") || workflow.contains("jsonb_array_elements_text(:'token_ids_json'") {
+        offenders.push(
+            "recorded-replay-parity.yml: token ids must not be passed as one large psql argv value"
                 .to_string(),
         );
     }


### PR DESCRIPTION
## Summary
- avoid passing all replay token ids as one large psql argv value
- materialize token ids as TSV and load them into a temporary psql table with \copy
- add workflow guard coverage for the large-token-set path

## Verification
- python3 YAML parse for .github/workflows/recorded-replay-parity.yml
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-large-token-set /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture

## Context
The multi-day recorded replay run 25794516485 failed before replay with  when the official settlement lookup passed all token ids through .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced security validation in workflow tests to verify proper token ID handling and prevent data format security issues.

* **Chores**
  * Optimized internal settlement token processing workflow with improved data format handling and query performance alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/498)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->