### PR TITLE
Fix recorded replay temp table lifetime

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -248,7 +248,7 @@ jobs:
 
           "${PSQL[@]}" \
             > "${official_db_rows_json}" <<SQL
-          CREATE TEMP TABLE replay_token_ids(token_id TEXT) ON COMMIT DROP;
+          CREATE TEMP TABLE replay_token_ids(token_id TEXT);
           \\copy replay_token_ids(token_id) FROM '${official_token_ids_tsv}'
           SELECT COALESCE(
             jsonb_agg(


### PR DESCRIPTION
## Summary
- keep the replay settlement token temp table alive for the full psql session
- fixes the multi-day recorded replay failure where `ON COMMIT DROP` removed the table before the settlement join

## Verification
- python3 YAML parse for `.github/workflows/recorded-replay-parity.yml`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/ploy-temp-table-lifetime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture`

## Context
Run `25794819583` failed with `ERROR: relation "replay_token_ids" does not exist` after PR #498 because psql autocommit dropped the temp table immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing workflow configuration to optimize temporary data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/499)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->