### PR TITLE
Fix recorded replay settlement JSON output

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -246,10 +246,10 @@ jobs:
                   handle.write("\n")
           PY
 
-          "${PSQL[@]}" \
-            > "${official_db_rows_json}" <<SQL
+          "${PSQL[@]}" <<SQL
           CREATE TEMP TABLE replay_token_ids(token_id TEXT);
           \\copy replay_token_ids(token_id) FROM '${official_token_ids_tsv}'
+          \\o ${official_db_rows_json}
           SELECT COALESCE(
             jsonb_agg(
               jsonb_build_object(
@@ -268,6 +268,7 @@ jobs:
           JOIN replay_token_ids t ON t.token_id = s.token_id
           WHERE s.resolved = true
             AND s.settled_price IS NOT NULL;
+          \\o
           SQL
 
           python3 "${remote_dir}/extract_official_settlement_evidence.py" \

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Multi-Day Recorded Replay JSON Output Fix (2026-05-13)
+
+## Goal
+
+Unblock the larger PM5D `executable_replay` run by ensuring official settlement
+DB rows are written as pure JSON even when the workflow stages token ids through
+`psql` temp tables.
+
+## Plan
+
+- [x] Fix the workflow so `official-settlement-db-rows.json` captures only the
+      final JSON `SELECT`, not `CREATE TABLE` / `COPY` status output.
+- [x] Run focused YAML / workflow guard validation.
+- [ ] Merge the fix to `main` and rerun the multi-day recorded replay from
+      `main`.
+
+## Review
+
+- 2026-05-13: Multi-day replay run `25795098744` reached the official
+  settlement lookup but failed while parsing `official-settlement-db-rows.json`.
+  The likely cause is `psql` status output polluting a file that downstream
+  Python expects to be JSON.
+- 2026-05-13: Verification passed: YAML parse for
+  `.github/workflows/recorded-replay-parity.yml`, `git diff --check`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-replay-json-output /opt/homebrew/bin/timeout 300
+  rtk cargo test --locked -p ploy
+  recorded_replay_parity_supports_auto_window --test workflow_security -- --exact
+  --nocapture`.
+
 # Official Settlement Replay Enrichment Fix (2026-05-13)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -288,6 +288,7 @@ fn recorded_replay_parity_supports_auto_window() {
         "official-settlement-report.json",
         "CREATE TEMP TABLE replay_token_ids",
         "\\copy replay_token_ids(token_id)",
+        "\\o ${official_db_rows_json}",
         "FROM pm_token_settlements s",
         "JOIN replay_token_ids t ON t.token_id = s.token_id",
         "--db-settlements-json \"${official_db_rows_json}\"",


### PR DESCRIPTION
## Summary
- write official settlement DB rows using psql \o only around the final JSON SELECT
- keep temp-table staging for large token sets without polluting the JSON artifact
- update workflow guard and task notes

## Verification
- python3 YAML parse for .github/workflows/recorded-replay-parity.yml
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-replay-json-output /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recorded replay workflow to generate clean JSON output by excluding temporary database operation messages that were corrupting data validation in multi-day replay runs.

* **Tests**
  * Added verification to ensure proper JSON output handling in recorded replay workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/500)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->