### PR TITLE
Release expired entry order risk in replay

### DIFF
--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -188,6 +188,19 @@ where
             updates_processed += 1;
             self.executor.observe_market_update(&update);
 
+            if let MarketUpdate::EventExpired { event_id, .. } = &update {
+                let canceled = self
+                    .trading
+                    .cancel_active_entry_orders_for_market(event_id.as_ref());
+                if canceled > 0 {
+                    debug!(
+                        event_id = %event_id,
+                        canceled,
+                        "Canceled active entry orders for expired event",
+                    );
+                }
+            }
+
             // Throttle: skip high-frequency evaluation updates if within the same time slot.
             // Lifecycle and quote updates always pass through because they mutate strategy state
             // that must stay aligned with the executor's order-book view.

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::fills::{FillLedger, FillRecord};
-use crate::intents::{TradeSide, TradingIntent};
-use crate::orders::OrderLedger;
+use crate::intents::{IntentPurpose, TradeSide, TradingIntent};
+use crate::orders::{OrderLedger, OrderState};
 use crate::pnl::PnlSnapshot;
 use crate::positions::{PositionLedger, PositionSnapshot};
 use crate::risk::{snapshot_from_state, RiskSnapshot};
@@ -157,6 +157,34 @@ impl TradingRuntime {
 
     pub fn cancel_order(&mut self, order_id: &str) -> Option<&crate::orders::OrderRecord> {
         self.orders.cancel(order_id)
+    }
+
+    pub fn cancel_active_entry_orders_for_market(&mut self, market_id: &str) -> usize {
+        let order_ids = self
+            .orders
+            .orders()
+            .filter(|order| {
+                matches!(
+                    order.state,
+                    OrderState::Pending | OrderState::Acknowledged | OrderState::PartiallyFilled
+                )
+            })
+            .filter(|order| {
+                self.intent(&order.intent_id).is_some_and(|intent| {
+                    intent.market_id == market_id
+                        && matches!(intent.purpose, IntentPurpose::Entry | IntentPurpose::Hedge)
+                })
+            })
+            .map(|order| order.order_id.clone())
+            .collect::<Vec<_>>();
+
+        for order_id in &order_ids {
+            self.orders.cancel(order_id);
+        }
+        if !order_ids.is_empty() {
+            self.prune_inactive_intents();
+        }
+        order_ids.len()
     }
 
     pub fn order(&self, order_id: &str) -> Option<&crate::orders::OrderRecord> {
@@ -357,6 +385,78 @@ mod tests {
         assert_eq!(restored.positions.len(), 1);
         assert_eq!(restored.positions[0].net_qty, dec!(1));
         assert_eq!(restored.risk.active_orders, 1);
+    }
+
+    #[test]
+    fn cancel_active_entry_orders_for_market_releases_expired_event_reserve() {
+        let mut runtime = TradingRuntime::default();
+        let opened_at = Utc::now();
+        runtime.submit_intent(
+            TradingIntent {
+                intent_id: "entry-expired".to_string(),
+                deployment_id: "example.replay".to_string(),
+                market_id: "expired-event".to_string(),
+                token_id: "token-expired".to_string(),
+                side: TradeSide::Buy,
+                quantity: dec!(10),
+                limit_price: Some(dec!(0.60)),
+                purpose: IntentPurpose::Entry,
+                created_at: opened_at,
+            },
+            "order-expired",
+        );
+        runtime.acknowledge_order("order-expired", "venue-expired");
+        assert!(runtime.record_fill(FillRecord {
+            fill_id: "fill-expired-partial".to_string(),
+            order_id: "order-expired".to_string(),
+            token_id: "token-expired".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(4),
+            price: dec!(0.60),
+            fee: Decimal::ZERO,
+            timestamp: opened_at,
+        }));
+
+        runtime.submit_intent(
+            TradingIntent {
+                intent_id: "entry-live".to_string(),
+                deployment_id: "example.replay".to_string(),
+                market_id: "live-event".to_string(),
+                token_id: "token-live".to_string(),
+                side: TradeSide::Buy,
+                quantity: dec!(2),
+                limit_price: Some(dec!(0.50)),
+                purpose: IntentPurpose::Entry,
+                created_at: opened_at,
+            },
+            "order-live",
+        );
+        runtime.acknowledge_order("order-live", "venue-live");
+
+        let before = runtime.snapshot(&BTreeMap::new()).risk;
+        assert_eq!(before.active_orders, 2);
+        assert_eq!(before.reserved_order_exposure, dec!(4.60));
+
+        assert_eq!(
+            runtime.cancel_active_entry_orders_for_market("expired-event"),
+            1
+        );
+        assert_eq!(
+            runtime
+                .order("order-expired")
+                .expect("expired order")
+                .state,
+            OrderState::Canceled
+        );
+        assert_eq!(
+            runtime.order("order-live").expect("live order").state,
+            OrderState::Acknowledged
+        );
+
+        let after = runtime.snapshot(&BTreeMap::new()).risk;
+        assert_eq!(after.active_orders, 1);
+        assert_eq!(after.reserved_order_exposure, dec!(1.00));
+        assert_eq!(after.gross_exposure, dec!(2.40));
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,31 @@
+# Expired Event Entry Order Cancellation (2026-05-13)
+
+## Goal
+
+Fix replay/backtest risk accounting so partially filled entry orders do not keep
+reserving exposure after their event expires and settlement exits are processed.
+
+## Plan
+
+- [x] Add a trading-runtime method to cancel active entry/hedge orders by
+      market/event id.
+- [x] Call it when the strategy runtime receives `EventExpired`.
+- [x] Validate with focused Rust tests.
+- [ ] Rerun multi-day replay.
+
+## Review
+
+- 2026-05-13: Multi-day executable replay run `25796371589` generated 40 fills
+  but only 4 entry intents. The remaining 36 fills were settlement exits, while
+  the original partial entry orders stayed active and kept reserving risk; this
+  blocked later entries even though the underlying events had expired.
+- 2026-05-13: Verification passed: `git diff --check`,
+  `CARGO_TARGET_DIR=/tmp/ploy-expired-order-cancel /opt/homebrew/bin/timeout
+  300 rtk cargo test --locked -p ploy-trading
+  cancel_active_entry_orders_for_market --lib -- --nocapture`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-expired-order-cancel /opt/homebrew/bin/timeout
+  300 rtk cargo check --locked -p ploy-strategy-bundles --lib`.
+
 # Recorded Replay Settlement Exit Option (2026-05-13)
 
 ## Goal


### PR DESCRIPTION
## Summary
- cancel active entry/hedge orders for a market when EventExpired is processed
- release reserved exposure from partially filled entry orders after event expiry
- add trading-runtime coverage for canceling only the expired market's entry order reserve

## Verification
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-expired-order-cancel /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-trading cancel_active_entry_orders_for_market --lib -- --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-expired-order-cancel /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-strategy-bundles --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic market event expiration handling: The system now proactively detects when market events expire and automatically cancels any associated active entry orders. Risk accounting metrics are updated to reflect the cancellations, including reduced active orders and reserved exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/502)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->