### PR TITLE
Run recorded replay with CI-built runner

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -53,18 +53,29 @@ permissions:
   issues: write
 
 env:
+  CARGO_TERM_COLOR: always
+  PLATFORM_TARGET: x86_64-unknown-linux-gnu
   DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
 
 jobs:
   parity:
     name: Replay recorded feed and compare dry-run evidence
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: ${{ inputs.approval_environment }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Build replay runner from workflow ref
+        run: |
+          set -euo pipefail
+          cargo build --release --locked \
+            --target "${PLATFORM_TARGET}" \
+            --features new-ploy-runner/full \
+            -p new-ploy-runner
+          strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
 
       - name: Configure SSH
         env:
@@ -131,6 +142,8 @@ jobs:
           set -euo pipefail
           mkdir -p "$1"
           EOF
+          scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" \
+            tango-1-1:"${REMOTE_DIR}/ploy-runner"
           scp scripts/enrich_recording_official_settlement.py \
             tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
           scp scripts/enrich_replay_runtime_evidence.py \
@@ -165,7 +178,8 @@ jobs:
           esac
 
           mkdir -p "${remote_dir}"
-          test -x /opt/ploy/bin/ploy-runner
+          chmod +x "${remote_dir}/ploy-runner"
+          test -x "${remote_dir}/ploy-runner"
           test -r "${config_path}"
           test -r "${recording_path}"
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
@@ -327,7 +341,7 @@ jobs:
               handle.write("\n".join(lines) + "\n")
           PY
 
-          timeout 600 /opt/ploy/bin/ploy-runner run \
+          timeout 600 "${remote_dir}/ploy-runner" run \
             --config "${replay_config}" \
             --deployment-id "${deployment_id}" \
             --output-json "${remote_dir}/replay-evaluation.json"

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -69,10 +69,12 @@ closed dry-run rows when available, and falls back to current open rows when a
 fresh recording has not yet accumulated closed events. The workflow records the resolved window in the workflow summary, issue comment, and
 `resolved-window.json` artifact. Manual timestamps remain supported for
 reproducing a known incident window or an older research issue.
-The workflow is read-only evidence generation: it uses the deployed
-`/opt/ploy/bin/ploy-runner`, a temporary replay config, and report/database
-reads, but it does not deploy artifacts, restart services, or enable live
-orders. Its `approval_environment` input therefore defaults to
+The workflow is read-only evidence generation: it builds `new-ploy-runner` on
+the GitHub runner from the requested workflow ref, copies that temporary binary
+to the replay scratch directory on `tango-1-1`, and uses a temporary replay
+config plus report/database reads. It does not deploy artifacts, restart
+services, replace `/opt/ploy/bin/ploy-runner`, or enable live orders. Its
+`approval_environment` input therefore defaults to
 `tango-1-1-build-only` so parity checks can run without the protected live
 deploy approval gate. Use `approval_environment=tango-1-1` only when an operator
 explicitly wants the protected environment approval for an incident replay.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# Recorded Replay CI-Built Runner (2026-05-13)
+
+## Goal
+
+Ensure recorded replay evidence actually runs the current `main` code by
+building the runner on GitHub Actions and copying a temporary binary to tango
+for replay, without replacing the deployed runner or building Rust on tango.
+
+## Plan
+
+- [x] Build `new-ploy-runner` from the workflow ref on the GitHub runner.
+- [x] Copy the temporary binary into the replay scratch directory on
+      `tango-1-1`.
+- [x] Run recorded replay with that temporary binary instead of
+      `/opt/ploy/bin/ploy-runner`.
+- [x] Validate workflow guard tests.
+- [ ] Rerun multi-day replay.
+
+## Review
+
+- 2026-05-13: Replay run `25797199561` still matched the prior run after the
+  expired-order fix because `recorded-replay-parity.yml` was executing the
+  already deployed `/opt/ploy/bin/ploy-runner`. That made replay evidence stale
+  relative to the just-merged `main` code.
+- 2026-05-13: Verification passed: YAML parse for
+  `.github/workflows/recorded-replay-parity.yml`, `git diff --check`,
+  `recorded_replay_parity_supports_auto_window`, and
+  `workflow_dispatch_inputs_stay_lintable`.
+
 # Expired Event Entry Order Cancellation (2026-05-13)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -264,6 +264,12 @@ fn recorded_replay_parity_supports_auto_window() {
     for needle in [
         "approval_environment:",
         "default: \"tango-1-1-build-only\"",
+        "Build replay runner from workflow ref",
+        "--features new-ploy-runner/full",
+        "-p new-ploy-runner",
+        "target/${PLATFORM_TARGET}/release/new-ploy-runner",
+        "tango-1-1:\"${REMOTE_DIR}/ploy-runner\"",
+        "timeout 600 \"${remote_dir}/ploy-runner\" run",
         "skip_settlement_exits:",
         "Skip settlement exits for entry-only dry-run parity",
         "SKIP_SETTLEMENT_EXITS",
@@ -304,6 +310,16 @@ fn recorded_replay_parity_supports_auto_window() {
     ] {
         if !workflow.contains(needle) {
             offenders.push(format!("recorded-replay-parity.yml: missing `{needle}`"));
+        }
+    }
+    for needle in [
+        "builds `new-ploy-runner` on\n",
+        "does not deploy artifacts, restart\nservices, replace `/opt/ploy/bin/ploy-runner`, or enable live orders",
+    ] {
+        if !runbook.contains(needle) {
+            offenders.push(format!(
+                "strategy-research-cicd.md: missing recorded replay note `{needle}`"
+            ));
         }
     }
     if workflow.contains("extract_dryrun_settlement_evidence.py") {


### PR DESCRIPTION
## Summary
- build new-ploy-runner from the workflow ref on GitHub Actions
- copy the temporary runner to tango replay scratch space
- run recorded replay with that temporary binary instead of the deployed /opt/ploy/bin/ploy-runner
- document that this remains read-only and does not replace the deployed runner

## Verification
- python3 YAML parse for .github/workflows/recorded-replay-parity.yml
- git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-replay-ci-built-runner /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-replay-ci-built-runner /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy workflow_dispatch_inputs_stay_lintable --test workflow_security -- --exact --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/Build**
  * CI workflow now builds the runner binary during execution instead of using a pre-installed version
  * Increased job timeout to accommodate the build step

* **Documentation**
  * Updated runbook to document the new CI-based runner build and deployment process

* **Tests**
  * Enhanced workflow validation tests to verify proper build and deployment behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/503)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->