### PR TITLE
Fix PM quote-quality active-window audit

### DIFF
--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -438,7 +438,7 @@ WITH active AS (
   ) AS token(token_id)
   WHERE m.symbol IN ({symbol_list})
     AND now() >= m.start_time - interval '1 minute'
-    AND now() < m.end_time + interval '1 minute'
+    AND now() < m.end_time
 ),
 latest AS (
   SELECT
@@ -479,7 +479,31 @@ SELECT json_build_object(
   )::int,
   'max_age_seconds', max(age_seconds),
   'oldest_latest_quote', min(received_at),
-  'newest_latest_quote', max(received_at)
+  'newest_latest_quote', max(received_at),
+  'missing_ask_or_size_examples', coalesce(
+    (
+      SELECT json_agg(
+        json_build_object(
+          'symbol', symbol,
+          'market_slug', market_slug,
+          'token_id', token_id,
+          'end_time', end_time,
+          'received_at', received_at,
+          'best_ask', best_ask,
+          'ask_size', ask_size
+        )
+        ORDER BY end_time, symbol, token_id
+      )
+      FROM (
+        SELECT *
+        FROM latest
+        WHERE best_ask IS NULL OR ask_size IS NULL OR ask_size <= 0
+        ORDER BY end_time, symbol, token_id
+        LIMIT 8
+      ) missing_examples
+    ),
+    '[]'::json
+  )
 )::text
 FROM latest
 """

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -364,6 +364,12 @@ the 15s strategy lag gate and executable ask/ask_size fields.
 - 2026-05-13: Live read-only validation on `tango-1-1` with the modified script
   reported `status=ok`, `active_tokens=8`, `missing_quotes=0`,
   `older_than_15s=0`, `missing_ask_or_size=0`, and `max_age_seconds=1`.
+- 2026-05-13: Follow-up audit run `25797954072` showed fresh quote rows but
+  `8/36` active tokens missing ask/ask_size. The quote-quality SQL now treats
+  only unexpired markets (`now() < end_time`) as requiring executable asks and
+  emits up to eight missing ask/size examples so future failures are
+  attributable to concrete symbols/markets/tokens instead of only an aggregate
+  count.
 
 # Dry-Run Strategy Config-Only Sync (2026-05-13)
 

--- a/tests/test_audit_market_data_gaps.py
+++ b/tests/test_audit_market_data_gaps.py
@@ -98,6 +98,18 @@ class AuditMarketDataGapsTests(unittest.TestCase):
         self.assertEqual(status, "critical")
         self.assertIn("1/20 active token quotes missing ask/ask_size", reasons)
 
+    def test_pm_quote_quality_query_excludes_expired_grace_tokens(self):
+        query = audit.pm_quote_quality_query(["BTCUSDT"], 20)
+
+        self.assertIn("AND now() < m.end_time", query)
+        self.assertNotIn("m.end_time + interval '1 minute'", query)
+
+    def test_pm_quote_quality_query_includes_missing_examples(self):
+        query = audit.pm_quote_quality_query(["BTCUSDT"], 20)
+
+        self.assertIn("'missing_ask_or_size_examples'", query)
+        self.assertIn("LIMIT 8", query)
+
     def test_pm_quote_quality_passes_fresh_complete_active_tokens(self):
         row = {
             "active_tokens": 20,


### PR DESCRIPTION
## Summary
- limit PM quote-quality executable-ask checks to unexpired markets
- add missing ask/size examples to the audit JSON for attribution
- record the follow-up in tasks/todo.md

## Evidence
- python3 -m unittest tests.test_audit_market_data_gaps
- python3 -m py_compile scripts/audit_market_data_gaps.py tests/test_audit_market_data_gaps.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected market activity validation to exclude expired markets from active consideration.

* **New Features**
  * Added detailed audit examples (up to 8) showing specific markets with missing quote data for improved troubleshooting.

* **Tests**
  * Added unit tests validating market activity detection and audit reporting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/504)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->