### PR TITLE
Separate AutoFactor discovery from runtime candidates

### DIFF
--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -172,14 +172,16 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
     return command
 
 
-def best_factor(promotion: dict[str, Any], allowed_targets: set[str]) -> dict[str, Any] | None:
+def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> list[dict[str, Any]]:
     evaluated = promotion.get("evaluated_factors") or []
-    candidates: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for item in evaluated:
         factor = item.get("factor") or {}
         if factor.get("target") not in allowed_targets:
             continue
-        candidates.append(
+        mapping = item.get("runtime_mapping") or {}
+        blockers = item.get("blockers") or []
+        rows.append(
             {
                 "name": factor.get("name", ""),
                 "target": factor.get("target", ""),
@@ -192,22 +194,55 @@ def best_factor(promotion: dict[str, Any], allowed_targets: set[str]) -> dict[st
                 "positive_window_ratio": factor.get("positive_window_ratio"),
                 "symbol_positive_ratio": factor.get("symbol_positive_ratio"),
                 "qualified": bool(item.get("qualified")),
-                "blockers": item.get("blockers") or [],
+                "runtime_mapping": mapping,
+                "runtime_mappable": bool(mapping)
+                and not any(str(blocker).startswith("runtime_profile_mismatch:") for blocker in blockers)
+                and "empty_runtime_strategy_profile" not in blockers,
+                "blockers": blockers,
             }
         )
+    return rows
+
+
+def _factor_score(item: dict[str, Any]) -> tuple[float, float, float, float]:
+    return (
+        1.0 if item["decision"] == "candidate" and item["reason"] == "passed" else 0.0,
+        float(item.get("positive_window_ratio") or 0.0),
+        float(item.get("symbol_positive_ratio") or 0.0),
+        float(item.get("spearman_ic") or 0.0),
+    )
+
+
+def best_factor(promotion: dict[str, Any], allowed_targets: set[str]) -> dict[str, Any] | None:
+    candidates = ranked_factor_rows(promotion, allowed_targets)
     if not candidates:
         return None
 
     def score(item: dict[str, Any]) -> tuple[float, float, float, float, float]:
         return (
             1.0 if item["qualified"] else 0.0,
-            1.0 if item["decision"] == "candidate" else 0.0,
-            float(item.get("positive_window_ratio") or 0.0),
-            float(item.get("symbol_positive_ratio") or 0.0),
-            float(item.get("spearman_ic") or 0.0),
+            *_factor_score(item),
         )
 
     return max(candidates, key=score)
+
+
+def best_factor_by_kind(
+    promotion: dict[str, Any],
+    allowed_targets: set[str],
+    *,
+    kind: str,
+) -> dict[str, Any] | None:
+    candidates = ranked_factor_rows(promotion, allowed_targets)
+    if kind == "qualified":
+        candidates = [item for item in candidates if item["qualified"]]
+    elif kind == "runtime_mappable":
+        candidates = [item for item in candidates if item["runtime_mappable"]]
+    elif kind != "discovery":
+        raise ValueError(f"unknown factor kind: {kind}")
+    if not candidates:
+        return None
+    return max(candidates, key=_factor_score)
 
 
 def write_markdown(summary: dict[str, Any], path: Path) -> None:
@@ -218,20 +253,24 @@ def write_markdown(summary: dict[str, Any], path: Path) -> None:
         f"- Total elapsed seconds: `{summary['total_elapsed_seconds']:.2f}`",
         f"- Best variant: `{summary.get('best_variant') or '<none>'}`",
         "",
-        "| variant | status | decision | qualified | elapsed_s | best factor | best blockers |",
-        "| --- | --- | --- | ---: | ---: | --- | --- |",
+        "| variant | status | decision | qualified | elapsed_s | best qualified strategy | best runtime-mappable factor | best discovery factor | discovery blockers |",
+        "| --- | --- | --- | ---: | ---: | --- | --- | --- | --- |",
     ]
     for item in summary["variants"]:
-        best = item.get("best_factor") or {}
+        discovery = item.get("best_discovery_factor") or item.get("best_factor") or {}
+        runtime = item.get("best_runtime_mappable_factor") or {}
+        qualified = item.get("best_qualified_strategy") or {}
         lines.append(
-            "| {variant} | {status} | {decision} | {qualified} | {elapsed:.2f} | {factor} | {blockers} |".format(
+            "| {variant} | {status} | {decision} | {qualified_count} | {elapsed:.2f} | {qualified_factor} | {runtime_factor} | {discovery_factor} | {blockers} |".format(
                 variant=item["label"],
                 status=item["status"],
                 decision=item.get("decision") or "",
-                qualified=item.get("qualified_count", 0),
+                qualified_count=item.get("qualified_count", 0),
                 elapsed=item.get("elapsed_seconds", 0.0),
-                factor=best.get("name", ""),
-                blockers=", ".join(best.get("blockers") or []),
+                qualified_factor=qualified.get("name", ""),
+                runtime_factor=runtime.get("name", ""),
+                discovery_factor=discovery.get("name", ""),
+                blockers=", ".join(discovery.get("blockers") or []),
             )
         )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -315,6 +354,21 @@ def run_variant(
     item["qualified_count"] = len(promotion.get("qualified_strategies") or [])
     item["promotion_gate_ready"] = bool((promotion.get("promotion_gate") or {}).get("ready"))
     item["best_factor"] = best_factor(promotion, allowed_targets)
+    item["best_discovery_factor"] = best_factor_by_kind(
+        promotion,
+        allowed_targets,
+        kind="discovery",
+    )
+    item["best_runtime_mappable_factor"] = best_factor_by_kind(
+        promotion,
+        allowed_targets,
+        kind="runtime_mappable",
+    )
+    item["best_qualified_strategy"] = best_factor_by_kind(
+        promotion,
+        allowed_targets,
+        kind="qualified",
+    )
     return item
 
 
@@ -381,8 +435,19 @@ def main() -> int:
             completed,
             key=lambda item: (
                 item.get("qualified_count", 0),
-                float((item.get("best_factor") or {}).get("positive_window_ratio") or 0.0),
-                float((item.get("best_factor") or {}).get("spearman_ic") or 0.0),
+                1.0 if item.get("best_runtime_mappable_factor") else 0.0,
+                float(
+                    (item.get("best_runtime_mappable_factor") or item.get("best_factor") or {}).get(
+                        "positive_window_ratio"
+                    )
+                    or 0.0
+                ),
+                float(
+                    (item.get("best_runtime_mappable_factor") or item.get("best_factor") or {}).get(
+                        "spearman_ic"
+                    )
+                    or 0.0
+                ),
             ),
         )
     summary = {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,42 @@
+# AutoFactor Runtime-Mappable Search Reporting (2026-05-13)
+
+## Goal
+
+Prevent hosted alpha-search artifacts from presenting high-scoring discovery
+factors as deployable strategy candidates when they lack a runtime scorer or
+the requested strategy profile mapping.
+
+## Files / Ownership
+
+- `scripts/run_factor_walk_forward_sweep.py`
+  - Owner: split sweep summary fields into discovery, runtime-mappable, and
+    qualified strategy candidates.
+- `tests/test_factor_walk_forward_sweep.py`
+  - Owner: cover rank-1 unmapped discovery factors with lower-ranked
+    settlement-native runtime-mappable candidates.
+
+## Tasks
+
+- [x] Add machine-readable summary fields for `best_discovery_factor`,
+      `best_runtime_mappable_factor`, and `best_qualified_strategy`.
+- [x] Make best-variant selection prefer runtime-mappable candidates before
+      unmapped discovery-only factors when no strategy qualifies.
+- [x] Update Markdown summaries so operators can see why the best discovery
+      factor is blocked.
+- [x] Run focused promotion/sweep tests and syntax checks.
+
+## Review
+
+- 2026-05-13: Current evidence stage remains `factor_attribution` /
+  `walk_forward`, not dry-run promotion. The latest hosted search found useful
+  discovery factors, but the top `mut_*` factor had no runtime strategy mapping.
+  The sweep summary now keeps that discovery signal visible while separately
+  identifying the best runtime-mappable settlement candidate.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion`,
+  `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py`,
+  and `rtk git diff --check`.
+
 # Recorded Replay CI-Built Runner (2026-05-13)
 
 ## Goal

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -27,6 +27,23 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 """)
 '''
 
+FAKE_UNMAPPED_BEST_REPORT = r'''
+print("""=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=false
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+deribit_vol_surface,true,require_deribit=false include_deribit=false
+recorded_replay_parity,false,shared_event_count=0
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_avg_label,top_bucket_positive_label_rate,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,3335,0.067525,0.081201,14,1.288053,0.9286,2,1.0000,1.0000,1.660059,0.6132,6
+2,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,2798,0.067534,0.091002,12,1.018091,0.7500,2,1.0000,1.0000,2.507843,0.6250,1
+""")
+'''
+
 
 class FactorWalkForwardSweepTests(unittest.TestCase):
     def base_args(self, tmp: Path, binary: Path) -> list[str]:
@@ -90,6 +107,17 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         binary.chmod(0o755)
         return binary
 
+    def fake_binary_with_report(self, tmp: Path, report: str) -> Path:
+        binary = tmp / "fake_factor_walk_forward.py"
+        binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            f"{report}\n",
+            encoding="utf-8",
+        )
+        binary.chmod(0o755)
+        return binary
+
     def test_dry_run_expands_sweep_variants(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)
@@ -142,6 +170,37 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(summary["variants"][0]["decision"], "qualified")
         self.assertEqual(summary["variants"][0]["qualified_count"], 1)
         self.assertIn("auto_settlement_conservative_settlement_edge", summary_md)
+
+    def test_summary_separates_discovery_from_runtime_mappable_candidates(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = self.fake_binary_with_report(tmp, FAKE_UNMAPPED_BEST_REPORT)
+            subprocess.run(
+                self.base_args(tmp, binary),
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+            summary_md = (tmp / "out" / "sweep-summary.md").read_text(encoding="utf-8")
+
+        variant = summary["variants"][0]
+        self.assertEqual(
+            variant["best_discovery_factor"]["name"],
+            "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
+        self.assertIn(
+            "missing_runtime_strategy_mapping",
+            variant["best_discovery_factor"]["blockers"],
+        )
+        self.assertEqual(
+            variant["best_runtime_mappable_factor"]["name"],
+            "auto_settlement_conservative_settlement_edge",
+        )
+        self.assertIsNone(variant["best_qualified_strategy"])
+        self.assertIn("best runtime-mappable factor", summary_md)
 
     def test_hosted_workflow_passes_empty_factor_filter_to_sweep_runner(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- split factor sweep summaries into best discovery, runtime-mappable, and qualified strategy candidates
- prefer runtime-mappable candidates when selecting a blocked best variant
- add regression coverage for rank-1 unmapped discovery factors

## Tests
- python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced factor ranking and selection with granular categorization into qualified strategies, runtime-mappable factors, and discovery factors.
  * Improved sweep summary reporting with separate columns for each factor type and blocker information.
  * Refined best-variant selection to prioritize runtime-mappable candidates when available.

* **Tests**
  * Added test coverage for discovery vs. runtime-mappable factor separation and blocker detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/505)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->