### PR TITLE
Include AutoFactor summary metrics

### DIFF
--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -193,6 +193,10 @@ def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> 
                 "icir": factor.get("icir"),
                 "positive_window_ratio": factor.get("positive_window_ratio"),
                 "symbol_positive_ratio": factor.get("symbol_positive_ratio"),
+                "monotonicity": factor.get("monotonicity"),
+                "top_bucket_avg_label": factor.get("top_bucket_avg_label"),
+                "top_bucket_positive_label_rate": factor.get("top_bucket_positive_label_rate"),
+                "complexity": factor.get("complexity"),
                 "qualified": bool(item.get("qualified")),
                 "runtime_mapping": mapping,
                 "runtime_mappable": bool(mapping)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -36,6 +36,12 @@ the requested strategy profile mapping.
   `python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion`,
   `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py`,
   and `rtk git diff --check`.
+- 2026-05-13: Follow-up sweep run `25801348001` found the best
+  runtime-mappable blocked candidate in variant `auto-min50`:
+  `auto_settlement_full_depth_settlement_edge` with `icir=1.526091`,
+  `positive_window_ratio=0.875`, and `top_bucket_avg_label=1.979439`.
+  Promotion remains blocked by recorded replay parity mismatch, so this is still
+  `factor_attribution` / `walk_forward` evidence, not a dry-run strategy.
 
 # Recorded Replay CI-Built Runner (2026-05-13)
 

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -199,6 +199,11 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             variant["best_runtime_mappable_factor"]["name"],
             "auto_settlement_conservative_settlement_edge",
         )
+        self.assertEqual(
+            variant["best_runtime_mappable_factor"]["top_bucket_avg_label"],
+            2.507843,
+        )
+        self.assertEqual(variant["best_runtime_mappable_factor"]["complexity"], 1)
         self.assertIsNone(variant["best_qualified_strategy"])
         self.assertIn("best runtime-mappable factor", summary_md)
 


### PR DESCRIPTION
## Summary
- include top-bucket and complexity metrics in sweep best-factor summaries
- add regression assertions for runtime-mappable summary metrics
- record follow-up sweep result and remaining replay-parity blocker

## Tests
- python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_autofactor_strategy_promotion
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced factor sweep metadata collection to include monotonicity, top bucket metrics, and complexity values for improved factor analysis tracking.

* **Tests**
  * Updated factor sweep test assertions to validate newly captured metadata fields.

* **Documentation**
  * Added sweep results documentation with performance metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/506)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->