### PR TITLE
Normalize settlement values in replay parity

### DIFF
--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -71,6 +71,7 @@ NUMERIC_FIELDS = {
     "fee",
     "quote",
     "entry_price",
+    "settlement",
     "pnl",
 }
 
@@ -462,7 +463,7 @@ def normalize_event(row: dict[str, Any]) -> dict[str, Any]:
         "side": normalize_text(canonical_field(row, "side"), upper=True),
         "entry_price": normalize_decimal(canonical_field(row, "entry_price")),
         "fill_status": normalize_status(canonical_field(row, "fill_status")),
-        "settlement": normalize_text(canonical_field(row, "settlement"), upper=True),
+        "settlement": normalize_decimal(canonical_field(row, "settlement")),
         "pnl": normalize_decimal(canonical_field(row, "pnl")),
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,38 @@
+# Recorded Replay Settlement Normalization (2026-05-13)
+
+## Goal
+
+Fix recorded replay parity so equivalent official settlement prices with
+different decimal scales do not block runtime parity.
+
+## Files / Ownership
+
+- `scripts/replay_dryrun_parity.py`
+  - Owner: normalize `settlement` as a numeric strict field when possible.
+- `tests/test_replay_dryrun_parity.py`
+  - Owner: regression coverage for replay `1.000000` vs dry-run
+    `1.00000000000000000000`.
+
+## Tasks
+
+- [x] Reproduce the current blocker from parity run `25801826502`.
+- [x] Normalize event settlement values through the decimal path.
+- [x] Add regression coverage for decimal-scale-only settlement differences.
+- [x] Run focused parity tests.
+- [ ] Merge and rerun recorded replay parity.
+
+## Review
+
+- 2026-05-13: Run `25801826502` had 4 shared runtime events, 4 shared orders,
+  and 4 shared fills. Orders and fills were strict-ready; only event settlement
+  strings differed by scale (`1.00000000000000000000` vs `1.000000`,
+  `0.00000000000000000000` vs `0.000000`), producing
+  `runtime_evidence_field_mismatches`.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_replay_dryrun_parity tests.test_resolve_recorded_replay_window`,
+  `python3 -m py_compile scripts/replay_dryrun_parity.py tests/test_replay_dryrun_parity.py`,
+  and `rtk git diff --check`.
+
 # AutoFactor Runtime-Mappable Search Reporting (2026-05-13)
 
 ## Goal

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -136,6 +136,19 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertEqual(result["blocking_risk_flags"], [])
         self.assertEqual(result["advisory_flags"], [])
 
+    def test_runtime_evidence_normalizes_settlement_decimal_scale(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        replay["runtime_evidence"]["events"][0]["settlement"] = "1.000000"
+        dryrun["runtime_evidence"]["events"][0]["settlement"] = "1.00000000000000000000"
+
+        result = self.run_script(replay, dryrun)
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertTrue(runtime["strict_parity_ready"])
+        self.assertEqual(runtime["events"]["mismatches"], [])
+        self.assertEqual(result["decision"], "continue")
+
     def test_runtime_evidence_matches_semantic_rows_with_different_generated_ids(self):
         result = self.run_script(
             evidence_payload(order_id="replay-order", fill_id="replay-fill", order_side="UNKNOWN"),


### PR DESCRIPTION
## Summary
- normalize event settlement values as decimals for replay/dry-run parity
- add regression coverage for equivalent settlement values with different scales
- record parity run 25801826502 as the concrete blocker

## Tests
- python3 -m unittest tests.test_replay_dryrun_parity tests.test_resolve_recorded_replay_window
- python3 -m py_compile scripts/replay_dryrun_parity.py tests/test_replay_dryrun_parity.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settlement field accuracy in parity comparisons by properly handling decimal precision.
* **Tests**
  * Added regression test to verify settlement field decimal scale handling.
* **Documentation**
  * Updated task records documenting settlement normalization work completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->