### PR TITLE
Fix replay parity for residual-canceled partial fills

### DIFF
--- a/scripts/replay_dryrun_parity.py
+++ b/scripts/replay_dryrun_parity.py
@@ -589,6 +589,15 @@ def is_zero_decimal(value: Any) -> bool:
         return False
 
 
+def is_positive_decimal(value: Any) -> bool:
+    if value in (None, ""):
+        return False
+    try:
+        return Decimal(str(value)) > 0
+    except (InvalidOperation, ValueError):
+        return False
+
+
 def is_non_executed_exit_attempt(row: dict[str, Any]) -> bool:
     """Return true for zero-fill exit attempts that should not block entry parity.
 
@@ -621,6 +630,16 @@ def filter_non_executed_exit_attempts(
         else:
             kept.append(row)
     return kept, ignored
+
+
+def recompute_strict_parity_ready(comparison: dict[str, Any]) -> bool:
+    return (
+        bool(comparison["shared_count"])
+        and not comparison["missing_strict_fields"]
+        and not comparison["mismatches"]
+        and not comparison["missing_replay_rows"]
+        and not comparison["missing_dryrun_rows"]
+    )
 
 
 def compare_normalized_rows(
@@ -675,6 +694,73 @@ def compare_normalized_rows(
         and not (set(dryrun_index) - set(replay_index))
         and not (set(replay_index) - set(dryrun_index)),
     }
+
+
+def strict_ready_fill_intents(
+    replay_fills: list[dict[str, Any]],
+    dryrun_fills: list[dict[str, Any]],
+) -> set[tuple[str | None, str | None]]:
+    replay_index = index_normalized_rows(replay_fills, FILL_KEY_CANDIDATES)
+    dryrun_index = index_normalized_rows(dryrun_fills, FILL_KEY_CANDIDATES)
+    ready: set[tuple[str | None, str | None]] = set()
+    for key in sorted(set(replay_index) & set(dryrun_index)):
+        replay = replay_index[key]
+        dryrun = dryrun_index[key]
+        intent_id = replay.get("intent_id")
+        if not intent_id or intent_id != dryrun.get("intent_id"):
+            continue
+        if not (
+            is_positive_decimal(replay.get("quantity"))
+            and is_positive_decimal(dryrun.get("quantity"))
+        ):
+            continue
+        if all(
+            replay.get(field) is not None
+            and dryrun.get(field) is not None
+            and values_match(field, replay.get(field), dryrun.get(field))
+            for field in FILL_STRICT_FIELDS
+        ):
+            ready.add((replay.get("deployment_id"), intent_id))
+    return ready
+
+
+def is_partial_fill_residual_cancel_mismatch(
+    mismatch: dict[str, Any],
+    ready_fill_intents: set[tuple[str | None, str | None]],
+) -> bool:
+    if mismatch.get("field") not in {"status", "fill_status"}:
+        return False
+    replay_status = normalize_status(mismatch.get("replay"))
+    dryrun_status = normalize_status(mismatch.get("dryrun"))
+    if {replay_status, dryrun_status} != {"PARTIALLY_FILLED", "CANCELED"}:
+        return False
+    replay_row = mismatch.get("replay_row") or {}
+    dryrun_row = mismatch.get("dryrun_row") or {}
+    if replay_row.get("intent_id") != dryrun_row.get("intent_id"):
+        return False
+    intent_key = (replay_row.get("deployment_id"), replay_row.get("intent_id"))
+    return intent_key in ready_fill_intents
+
+
+def suppress_partial_fill_residual_cancel_mismatches(
+    comparison: dict[str, Any],
+    *,
+    ready_fill_intents: set[tuple[str | None, str | None]],
+) -> dict[str, Any]:
+    kept: list[dict[str, Any]] = []
+    ignored: list[dict[str, Any]] = []
+    for mismatch in comparison["mismatches"]:
+        if is_partial_fill_residual_cancel_mismatch(mismatch, ready_fill_intents):
+            ignored.append(mismatch)
+        else:
+            kept.append(mismatch)
+    if not ignored:
+        return comparison
+    updated = dict(comparison)
+    updated["mismatches"] = kept[:100]
+    updated["ignored_partial_fill_cancel_status_mismatches"] = ignored[:100]
+    updated["strict_parity_ready"] = recompute_strict_parity_ready(updated)
+    return updated
 
 
 def is_settlement_exit_row(row: dict[str, Any] | None) -> bool:
@@ -783,12 +869,25 @@ def compare_runtime_evidence(
         key_candidates=FILL_KEY_CANDIDATES,
         strict_fields=FILL_STRICT_FIELDS,
     )
+    ready_fill_intents = strict_ready_fill_intents(replay_fills, dryrun_fills)
+    event_comparison = suppress_partial_fill_residual_cancel_mismatches(
+        event_comparison,
+        ready_fill_intents=ready_fill_intents,
+    )
+    order_comparison = suppress_partial_fill_residual_cancel_mismatches(
+        order_comparison,
+        ready_fill_intents=ready_fill_intents,
+    )
     missing_strict_fields = sorted(
         set(event_comparison["missing_strict_fields"])
         | set(order_comparison["missing_strict_fields"])
         | set(fill_comparison["missing_strict_fields"])
     )
     mismatches = event_comparison["mismatches"] + order_comparison["mismatches"] + fill_comparison["mismatches"]
+    ignored_partial_fill_cancel_status_mismatches = (
+        event_comparison.get("ignored_partial_fill_cancel_status_mismatches", [])
+        + order_comparison.get("ignored_partial_fill_cancel_status_mismatches", [])
+    )
     settlement_mismatches = settlement_exit_price_mismatches(mismatches)
     strict_parity_ready = (
         event_comparison["strict_parity_ready"]
@@ -802,6 +901,7 @@ def compare_runtime_evidence(
         "missing_strict_fields": missing_strict_fields,
         "mismatches": mismatches[:100],
         "settlement_exit_mismatches": settlement_mismatches,
+        "ignored_partial_fill_cancel_status_mismatches": ignored_partial_fill_cancel_status_mismatches[:100],
         "ignored_non_executed_exit_attempts": {
             "replay_events": [runtime_row_summary(row) for row in ignored_replay_events[:50]],
             "dryrun_events": [runtime_row_summary(row) for row in ignored_dryrun_events[:50]],

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,45 @@
+# Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
+
+## Goal
+
+Fix recorded replay parity so entry orders that partially filled and then
+canceled their residual quantity do not block runtime parity when matching fill
+rows prove the executed cashflow is identical.
+
+## Files / Ownership
+
+- `scripts/replay_dryrun_parity.py`
+  - Owner: suppress only `PARTIALLY_FILLED` vs `CANCELED` status mismatches
+    when the same intent has strict-ready positive fill evidence.
+- `tests/test_replay_dryrun_parity.py`
+  - Owner: regression coverage for safe suppression and unsafe status drift.
+
+## Tasks
+
+- [x] Add narrow partial-fill residual-cancel parity suppression.
+- [x] Add regression coverage for matching fills and missing-fill blockers.
+- [x] Recompute run `25805852207` locally against downloaded artifacts.
+- [x] Run focused parity tests and syntax checks.
+- [ ] Merge and rerun recorded replay parity from `main`.
+
+## Review
+
+- 2026-05-13: Parity run `25805852207` succeeded as a workflow and had official
+  settlement enrichment (`official_settlement_event_count=11`,
+  `settlement_event_count=11`). Fills were strict-ready for 4/4 rows, but two
+  entry order/event rows differed only by dry-run `PARTIALLY_FILLED` vs replay
+  `CANCELED`, which likely represents replay canceling the residual quantity
+  after the same positive fill rather than a scorer/cashflow mismatch.
+- 2026-05-13: Local recompute against the downloaded run `25805852207`
+  artifacts now returns `decision=continue`, `blocking_risk_flags=[]`, and
+  `runtime_evidence_comparison.strict_parity_ready=true`. The evaluator ignores
+  only four audited status mismatches: event/order status for the two matched
+  entry intents whose fill rows are strict-ready.
+- 2026-05-13: Verification passed:
+  `python3 -m unittest tests.test_replay_dryrun_parity`,
+  `python3 -m py_compile scripts/replay_dryrun_parity.py tests/test_replay_dryrun_parity.py`,
+  and `rtk git diff --check`.
+
 # Recorded Replay Settlement Normalization (2026-05-13)
 
 ## Goal
@@ -19,7 +61,7 @@ different decimal scales do not block runtime parity.
 - [x] Normalize event settlement values through the decimal path.
 - [x] Add regression coverage for decimal-scale-only settlement differences.
 - [x] Run focused parity tests.
-- [ ] Merge and rerun recorded replay parity.
+- [x] Merge and rerun recorded replay parity.
 
 ## Review
 
@@ -54,7 +96,7 @@ settlement-probability dry-run config.
 - [x] Confirm latest handoff is ready after replay parity run `25802468869`.
 - [x] Apply the ready runtime score to the dry-run config.
 - [x] Run focused config handoff tests.
-- [ ] Merge and deploy dry-run config from `main`.
+- [x] Merge and deploy dry-run config from `main`.
 
 ## Review
 
@@ -72,6 +114,26 @@ settlement-probability dry-run config.
   `python3 -m py_compile scripts/apply_autofactor_handoff_to_config.py tests/test_apply_autofactor_handoff_to_config.py`,
   `CARGO_TARGET_DIR=/tmp/ploy-autofactor-config /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib -- --nocapture`,
   and `rtk git diff --check`.
+- 2026-05-13: PR #508 was merged to `main` as
+  `7269e605f0b1ac4ab75beb523611b4bf98e37143`, then deployed to
+  `tango-1-1` by deploy run `25803601118`. Remote config now carries
+  `three_layer_autofactor_runtime_score =
+  "autofactor_formula:auto_settlement_full_depth_settlement_edge"`;
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun` is
+  `desired=Running observed=Running`, while `pm5d.threelayer.live` remains
+  `desired=Paused observed=Paused`.
+- 2026-05-13: A candidate-quality dry-run gate immediately after deploy
+  (`25804515569`) was correctly blocked because the target had only 8 closed
+  trades and still included pre-full-depth runtime evidence:
+  `realized_pnl=-5.91`, `profit_factor=0.8696`, `buy_fill_rate_pct=97.31`.
+  The target deployment was paused, backup-reset by run `25804613362`, and
+  resumed so full-depth scorer evidence starts from a clean baseline. The reset
+  backed up and deleted 16 orders / 9 fills, left 0 orders / 0 fills, and did
+  not touch raw market data.
+- 2026-05-13: Post-resume market-data freshness audit `25804779652` passed
+  with `overall_status=ok`. For BTC/ETH Polymarket quote quality, the audit
+  reported 8 active tokens, 0 quotes older than 15 seconds, 0 missing quotes,
+  0 missing ask/ask_size, and `max_age_seconds=0`.
 
 # AutoFactor Runtime-Mappable Search Reporting (2026-05-13)
 

--- a/tests/test_replay_dryrun_parity.py
+++ b/tests/test_replay_dryrun_parity.py
@@ -149,6 +149,49 @@ class ReplayDryrunParityTests(unittest.TestCase):
         self.assertEqual(runtime["events"]["mismatches"], [])
         self.assertEqual(result["decision"], "continue")
 
+    def test_runtime_evidence_allows_partial_fill_then_residual_cancel_status_drift(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        replay["runtime_evidence"]["events"][0]["fill_status"] = "CANCELED"
+        replay["runtime_evidence"]["orders"][0]["status"] = "CANCELED"
+        replay["runtime_evidence"]["orders"][0]["filled_quantity"] = "4"
+        replay["runtime_evidence"]["fills"][0]["quantity"] = "4"
+        dryrun["runtime_evidence"]["events"][0]["fill_status"] = "PARTIALLY_FILLED"
+        dryrun["runtime_evidence"]["orders"][0]["status"] = "PARTIALLY_FILLED"
+        dryrun["runtime_evidence"]["orders"][0]["filled_quantity"] = "4.0000000"
+        dryrun["runtime_evidence"]["fills"][0]["quantity"] = "4.0000000"
+
+        result = self.run_script(replay, dryrun)
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertTrue(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "continue")
+        self.assertEqual(runtime["mismatches"], [])
+        self.assertEqual(result["blocking_risk_flags"], [])
+        ignored = runtime["ignored_partial_fill_cancel_status_mismatches"]
+        self.assertEqual(len(ignored), 2)
+        self.assertEqual({mismatch["field"] for mismatch in ignored}, {"fill_status", "status"})
+
+    def test_runtime_evidence_blocks_partial_fill_cancel_status_drift_without_fill(self):
+        replay = evidence_payload()
+        dryrun = evidence_payload()
+        replay["runtime_evidence"]["events"][0]["fill_status"] = "CANCELED"
+        replay["runtime_evidence"]["orders"][0]["status"] = "CANCELED"
+        replay["runtime_evidence"]["orders"][0]["filled_quantity"] = "4"
+        replay["runtime_evidence"]["fills"] = []
+        dryrun["runtime_evidence"]["events"][0]["fill_status"] = "PARTIALLY_FILLED"
+        dryrun["runtime_evidence"]["orders"][0]["status"] = "PARTIALLY_FILLED"
+        dryrun["runtime_evidence"]["orders"][0]["filled_quantity"] = "4"
+        dryrun["runtime_evidence"]["fills"] = []
+
+        result = self.run_script(replay, dryrun)
+
+        runtime = result["runtime_evidence_comparison"]
+        self.assertFalse(runtime["strict_parity_ready"])
+        self.assertEqual(result["decision"], "fix-data-or-runtime-mismatch")
+        self.assertIn("runtime_evidence_field_mismatches", result["blocking_risk_flags"])
+        self.assertEqual(runtime["ignored_partial_fill_cancel_status_mismatches"], [])
+
     def test_runtime_evidence_matches_semantic_rows_with_different_generated_ids(self):
         result = self.run_script(
             evidence_payload(order_id="replay-order", fill_id="replay-fill", order_side="UNKNOWN"),


### PR DESCRIPTION
## Summary
- allow recorded replay parity to treat PARTIALLY_FILLED vs CANCELED as equivalent only when the same intent has strict-ready positive fill evidence
- keep unmatched status drift blocking, and expose ignored partial-fill cancel status mismatches in parity artifacts
- document the runtime_parity evidence from run 25805852207 in tasks/todo.md

## Verification
- python3 -m unittest tests.test_replay_dryrun_parity
- python3 -m py_compile scripts/replay_dryrun_parity.py tests/test_replay_dryrun_parity.py
- rtk git diff --check
- recomputed run 25805852207 locally: decision=continue, blocking_risk_flags=[], runtime strict parity ready=true, shared events/orders/fills=4/4/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for partial-fill and cancel status mismatch handling to improve system reliability.

* **Chores**
  * Enhanced internal parity verification logic to better handle edge cases in order status comparisons.
  * Updated task tracking for ongoing parity work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/509)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->