### PR TITLE
Fix dry-run gate Infinity profit factor handling

### DIFF
--- a/scripts/check_dryrun_candidate_gate.py
+++ b/scripts/check_dryrun_candidate_gate.py
@@ -14,13 +14,15 @@ from typing import Any
 DEFAULT_DEPLOYMENT_ID = "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
 
 
-def number(value: Any, default: float = 0.0) -> float:
+def number(value: Any, default: float = 0.0, *, allow_infinite: bool = False) -> float:
     if value is None:
         return default
     try:
         parsed = float(value)
     except (TypeError, ValueError):
         return default
+    if allow_infinite and math.isinf(parsed):
+        return parsed
     if not math.isfinite(parsed):
         return default
     return parsed
@@ -99,10 +101,11 @@ def candidate_quality_result(args: argparse.Namespace, strategy: dict[str, Any] 
     summary = strategy.get("summary") or {}
     metrics = strategy.get("metrics") or {}
     diagnostics = diagnostics_summary(strategy)
+    profit_factor = number(metrics.get("profit_factor"), allow_infinite=True)
     values = {
         "closed_trades": integer(summary.get("closed_trades")),
         "realized_pnl": number(summary.get("realized_pnl")),
-        "profit_factor": number(metrics.get("profit_factor")),
+        "profit_factor": "Infinity" if profit_factor == math.inf else profit_factor,
         "max_drawdown": number(metrics.get("max_drawdown")),
         "buy_fill_rate_pct": number(diagnostics.get("buy_fill_rate_pct")),
     }
@@ -117,7 +120,7 @@ def candidate_quality_result(args: argparse.Namespace, strategy: dict[str, Any] 
             "actual": values["realized_pnl"],
             "minimum": args.min_realized_pnl,
         }
-    if values["profit_factor"] < args.min_profit_factor:
+    if profit_factor < args.min_profit_factor:
         failures["profit_factor"] = {
             "actual": values["profit_factor"],
             "minimum": args.min_profit_factor,

--- a/tests/test_check_dryrun_candidate_gate.py
+++ b/tests/test_check_dryrun_candidate_gate.py
@@ -109,6 +109,37 @@ class CheckDryrunCandidateGateTests(unittest.TestCase):
         self.assertIn('"profit_factor"', result.stdout)
         self.assertIn('"max_drawdown"', result.stdout)
 
+    def test_candidate_quality_treats_infinite_profit_factor_as_passing_metric(self):
+        payload = {
+            "strategies": [
+                {
+                    "deployment_id": DEPLOYMENT_ID,
+                    "summary": {
+                        "closed_trades": 4,
+                        "realized_pnl": 26.74,
+                    },
+                    "metrics": {
+                        "profit_factor": "Infinity",
+                        "max_drawdown": 0.0,
+                    },
+                    "execution_diagnostics": {
+                        "summary": {
+                            "buy_fill_rate_pct": 94.22,
+                        }
+                    },
+                }
+            ]
+        }
+
+        result = run_gate(payload, "--mode", "candidate-quality")
+        output = json.loads(result.stdout)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(output["values"]["profit_factor"], "Infinity")
+        self.assertNotIn("profit_factor", output["failures"])
+        self.assertIn("closed_trades", output["failures"])
+        self.assertIn("buy_fill_rate_pct", output["failures"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- parse string Infinity as a passing infinite profit factor for candidate-quality gates
- keep gate output JSON-friendly by reporting the displayed value as "Infinity"
- add regression coverage using the current post-reset dry-run shape

## Verification
- python3 -m unittest tests.test_check_dryrun_candidate_gate
- python3 -m py_compile scripts/check_dryrun_candidate_gate.py tests/test_check_dryrun_candidate_gate.py
- rtk git diff --check
- local recompute of dry-run gate run 25807240887 artifact: still blocked only by closed_trades and buy_fill_rate_pct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Infinite profit factor values in strategy metrics are now properly recognized and treated as valid passing metrics during candidate quality assessment, preventing incorrect failure reports.

* **Tests**
  * Added test coverage to verify that infinite profit factor values are correctly handled in strategy validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/510)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->