### PR TITLE
Downgrade one-sided PM quote liquidity audit

### DIFF
--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -517,6 +517,7 @@ def classify_pm_quote_quality(row: dict[str, Any]) -> tuple[str, list[str]]:
     missing_quotes = int(row.get("missing_quotes") or 0)
     older_than_15s = int(row.get("older_than_15s") or 0)
     missing_ask_or_size = int(row.get("missing_ask_or_size") or 0)
+    missing_bid_or_size = int(row.get("missing_bid_or_size") or 0)
 
     if active_tokens == 0:
         status = "critical"
@@ -528,9 +529,20 @@ def classify_pm_quote_quality(row: dict[str, Any]) -> tuple[str, list[str]]:
         status = "critical"
         reasons.append(f"{older_than_15s}/{active_tokens} active token quotes older than 15s")
     if missing_ask_or_size > 0:
-        status = "critical"
+        if missing_ask_or_size == active_tokens:
+            status = "critical"
+        elif STATUS_ORDER[status] < STATUS_ORDER["warn"]:
+            status = "warn"
         reasons.append(
             f"{missing_ask_or_size}/{active_tokens} active token quotes missing ask/ask_size"
+        )
+    if missing_bid_or_size > 0:
+        if missing_bid_or_size == active_tokens:
+            status = "critical"
+        elif STATUS_ORDER[status] < STATUS_ORDER["warn"]:
+            status = "warn"
+        reasons.append(
+            f"{missing_bid_or_size}/{active_tokens} active token quotes missing bid/bid_size"
         )
 
     if not reasons:

--- a/tests/test_audit_market_data_gaps.py
+++ b/tests/test_audit_market_data_gaps.py
@@ -84,19 +84,36 @@ class AuditMarketDataGapsTests(unittest.TestCase):
         self.assertEqual(coverage_status, "ok")
         self.assertIn("latest lag 1200s > 600s", reasons)
 
-    def test_pm_quote_quality_blocks_missing_ask_size(self):
+    def test_pm_quote_quality_warns_on_one_sided_quote_liquidity(self):
         row = {
             "active_tokens": 20,
             "missing_quotes": 0,
             "older_than_15s": 0,
             "missing_ask_or_size": 1,
+            "missing_bid_or_size": 1,
+            "max_age_seconds": 4,
+        }
+
+        status, reasons = audit.classify_pm_quote_quality(row)
+
+        self.assertEqual(status, "warn")
+        self.assertIn("1/20 active token quotes missing ask/ask_size", reasons)
+        self.assertIn("1/20 active token quotes missing bid/bid_size", reasons)
+
+    def test_pm_quote_quality_blocks_missing_asks_for_all_active_tokens(self):
+        row = {
+            "active_tokens": 20,
+            "missing_quotes": 0,
+            "older_than_15s": 0,
+            "missing_ask_or_size": 20,
+            "missing_bid_or_size": 0,
             "max_age_seconds": 4,
         }
 
         status, reasons = audit.classify_pm_quote_quality(row)
 
         self.assertEqual(status, "critical")
-        self.assertIn("1/20 active token quotes missing ask/ask_size", reasons)
+        self.assertIn("20/20 active token quotes missing ask/ask_size", reasons)
 
     def test_pm_quote_quality_query_excludes_expired_grace_tokens(self):
         query = audit.pm_quote_quality_query(["BTCUSDT"], 20)
@@ -116,6 +133,7 @@ class AuditMarketDataGapsTests(unittest.TestCase):
             "missing_quotes": 0,
             "older_than_15s": 0,
             "missing_ask_or_size": 0,
+            "missing_bid_or_size": 0,
             "max_age_seconds": 5,
         }
 


### PR DESCRIPTION
## Summary
- keep missing PM quotes and stale active-token quotes as critical
- classify small one-sided ask/bid liquidity gaps as warn instead of critical
- add tests for one-sided liquidity warning and systemic missing ask critical

## Verification
- python3 -m unittest tests.test_audit_market_data_gaps tests.test_market_data_gap_audit_scope
- python3 scripts/audit_market_data_gaps.py --help

## Context
The latest post-sync freshness audit had fresh PM quotes/orderbooks and Binance data, but failed critical because 1/8 active tokens had no ask/ask_size. That should block that token through execution/fillability gates, not mark the whole collector as critical.