### PR TITLE
Fix AutoFactor promotion fillability gate

### DIFF
--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -13,6 +13,8 @@ For `autofactor_formula:*` runtime scores, the PRD model-specific
 `symbol_holdout` and `walk_forward_oos` gates are replaced by formula-level
 symbol/window stability from the AutoFactor row. Data quality, Deribit,
 execution-depth, calibration, and replay-parity gates remain global blockers.
+Hard entry gates are still execution filters, not permission to waive failed
+configured-stake capacity at the global promotion gate.
 
 The current PM5D/PM15D settlement PRD should not silently promote a good
 repricing factor into the settlement strategy lane.
@@ -341,12 +343,6 @@ def global_gate_blockers(
         for item in gate.blocked_gates
         if not item.startswith(MODEL_SPECIFIC_PRD_GATE_PREFIXES)
     ]
-    if hard_entry_gated:
-        blockers = [
-            item
-            for item in blockers
-            if not item.startswith("global_full_depth_entry_fillability:")
-        ]
     if blockers:
         return [f"global_promotion_gate_not_ready:{item}" for item in blockers]
     return []

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,49 @@
+# AutoFactor Promotion Gate Fillability Repair (2026-05-17)
+
+## Goal
+
+Prevent hard-entry-gated AutoFactor rows from bypassing failed global
+full-depth fillability. A candidate that cannot show configured-stake capacity
+at the promotion gate remains research evidence, not a dry-run handoff.
+
+Evidence stage: `factor_attribution / promotion-gate repair`.
+
+## Files / Ownership
+
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: keep global execution-depth blockers fail-closed for strategy
+    handoff.
+- `tests/test_autofactor_strategy_promotion.py`
+  - Owner: regression coverage for hard-entry-gated formulas when global
+    full-depth fillability fails.
+
+## Tasks
+
+- [x] Remove the hard-entry-gate waiver for global full-depth fillability.
+- [x] Update regression tests to require the global fillability blocker.
+- [x] Run focused promotion-gate tests and syntax/diff checks.
+- [x] Re-evaluate the previously downloaded run artifact and confirm handoff
+      is blocked.
+- [x] Commit, push, and open a PR.
+
+## Review
+
+- 2026-05-17: Removed the hard-entry-gated special case that stripped
+  `global_full_depth_entry_fillability` from AutoFactor promotion blockers.
+  Hard entry gates remain useful search/runtime filters, but they no longer
+  turn a globally unfillable 15U promotion gate into a dry-run handoff.
+- 2026-05-17: Replayed downloaded walk-forward artifact `25853644079`. The old
+  artifact had `promotion_gate.ready=false` and
+  `global_full_depth_entry_fill_rate=0.1458 min_required=0.9500`, yet its saved
+  handoff was `status=ready` for
+  `mut_spread_adjusted_external_move_full_depth_entry_gate`. With this patch,
+  the same report evaluates to `decision=blocked`,
+  handoff `status=blocked`, and `recommended_action=do_not_promote`.
+- 2026-05-17: Verification passed:
+  `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
+  `python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py`,
+  and `rtk git diff --check`.
+
 # PM5D Sweep Slippage Execution Gate (2026-05-17)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -241,7 +241,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
         self.assertIn("full_depth_entry_gate", handoff_md)
 
-    def test_hard_gate_predictive_formula_waives_global_fillability_not_replay_parity(self):
+    def test_hard_gate_predictive_formula_keeps_global_fillability_blocker(self):
         _, payload, _, handoff, _ = self.run_script(
             HARD_GATE_REPLAY_BLOCKED_GATE + AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT
         )
@@ -250,7 +250,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(handoff["status"], "blocked")
         first = payload["evaluated_factors"][0]
         self.assertFalse(first["qualified"])
-        self.assertNotIn(
+        self.assertIn(
             "global_promotion_gate_not_ready:global_full_depth_entry_fillability: "
             "global_full_depth_entry_fill_rate=0.1458 min_required=0.3000",
             first["blockers"],


### PR DESCRIPTION
## Summary
- keep global full-depth fillability as a hard promotion blocker for hard-entry-gated AutoFactor formulas
- update regression coverage so 15U capacity failures cannot produce ready handoffs
- document the repaired evidence stage and replay of prior artifact 25853644079

## Verification
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py
- rtk git diff --check
- re-evaluated downloaded run 25853644079: old handoff status=ready despite gate ready=false; patched evaluator returns decision=blocked and handoff status=blocked
