### PR TITLE
Block AutoFactor handoff on high sweep slippage

### DIFF
--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -15,6 +15,9 @@ symbol/window stability from the AutoFactor row. Data quality, Deribit,
 execution-depth, calibration, and replay-parity gates remain global blockers.
 Hard entry gates are still execution filters, not permission to waive failed
 configured-stake capacity at the global promotion gate.
+Full-depth fillability is also insufficient by itself: if the average entry
+sweep slippage is too high, the candidate is executable only by accepting a
+materially worse price and must stay blocked.
 
 The current PM5D/PM15D settlement PRD should not silently promote a good
 repricing factor into the settlement strategy lane.
@@ -154,6 +157,11 @@ class PromotionGate:
 
 
 @dataclass
+class ExecutionQuality:
+    avg_entry_sweep_slip_bps: float | None = None
+
+
+@dataclass
 class AutoFactorRow:
     rank: int
     name: str
@@ -249,6 +257,20 @@ def parse_promotion_gate(report_text: str) -> PromotionGate:
             blocked_gates=["missing_promotion_gate"],
         )
     return PromotionGate(ready=ready, evidence=evidence, blocked_gates=blocked)
+
+
+def parse_execution_quality(report_text: str) -> ExecutionQuality:
+    prefix = "full_depth_entry_fill_rate="
+    marker = "avg_entry_sweep_slip_bps="
+    for line in report_text.splitlines():
+        if not line.startswith(prefix) or marker not in line:
+            continue
+        tail = line.split(marker, 1)[1]
+        raw = tail.split(maxsplit=1)[0]
+        value = parse_float(raw)
+        if value == value:
+            return ExecutionQuality(avg_entry_sweep_slip_bps=value)
+    return ExecutionQuality()
 
 
 def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
@@ -348,6 +370,20 @@ def global_gate_blockers(
     return []
 
 
+def execution_quality_blockers(
+    quality: ExecutionQuality, *, max_avg_entry_sweep_slip_bps: float
+) -> list[str]:
+    value = quality.avg_entry_sweep_slip_bps
+    if value is None:
+        return []
+    if value > max_avg_entry_sweep_slip_bps:
+        return [
+            "global_entry_sweep_slippage_too_high:"
+            f"{value:.2f}>{max_avg_entry_sweep_slip_bps:.2f}"
+        ]
+    return []
+
+
 def evaluate(
     report_text: str,
     *,
@@ -357,9 +393,15 @@ def evaluate(
     min_factor_n: int,
     min_top_bucket_n: int,
     min_top_bucket_entry_fill_rate: float,
+    max_avg_entry_sweep_slip_bps: float,
     min_window_count: int,
 ) -> dict[str, Any]:
     gate = parse_promotion_gate(report_text)
+    quality = parse_execution_quality(report_text)
+    quality_blockers = execution_quality_blockers(
+        quality,
+        max_avg_entry_sweep_slip_bps=max_avg_entry_sweep_slip_bps,
+    )
     rows = parse_autofactor_rows(report_text)
     evaluated: list[EvaluatedFactor] = []
 
@@ -375,6 +417,7 @@ def evaluate(
                 hard_entry_gated=hard_entry_gated,
             )
         )
+        blockers.extend(quality_blockers)
         if row.target not in allowed_targets:
             blockers.append("target_not_allowed")
         if row.decision != "candidate" or row.reason != "passed":
@@ -432,9 +475,11 @@ def evaluate(
             "factor_n": min_factor_n,
             "top_bucket_n": min_top_bucket_n,
             "top_bucket_full_depth_entry_fill_rate": min_top_bucket_entry_fill_rate,
+            "max_avg_entry_sweep_slip_bps": max_avg_entry_sweep_slip_bps,
             "window_count": min_window_count,
         },
         "promotion_gate": asdict(gate),
+        "execution_quality": asdict(quality),
         "qualified_strategies": [
             {
                 "factor": asdict(item.factor),
@@ -478,6 +523,7 @@ def build_factor_registry(result: dict[str, Any]) -> dict[str, Any]:
         "required_strategy_profile": result["required_strategy_profile"],
         "allowed_targets": result["allowed_targets"],
         "promotion_gate": result["promotion_gate"],
+        "execution_quality": result["execution_quality"],
         "entries": entries,
     }
 
@@ -507,6 +553,7 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
         "required_strategy_profile": result["required_strategy_profile"],
         "allowed_targets": result["allowed_targets"],
         "promotion_gate": result["promotion_gate"],
+        "execution_quality": result["execution_quality"],
         "strategies": strategies,
         "blocked_factor_count": sum(
             1 for item in result["evaluated_factors"] if not item["qualified"]
@@ -522,6 +569,7 @@ def render_handoff_markdown(handoff: dict[str, Any]) -> str:
         f"Recommended action: `{handoff['recommended_action']}`",
         f"Required strategy profile: `{handoff['required_strategy_profile']}`",
         f"Allowed targets: `{', '.join(handoff['allowed_targets'])}`",
+        f"Avg entry sweep slip bps: `{handoff['execution_quality'].get('avg_entry_sweep_slip_bps')}`",
         "",
     ]
     if handoff["status"] != "ready":
@@ -609,6 +657,7 @@ def render_markdown(result: dict[str, Any]) -> str:
         "",
         f"- Ready: `{str(result['promotion_gate']['ready']).lower()}`",
         f"- Evidence: `{result['promotion_gate']['evidence']}`",
+        f"- Avg entry sweep slip bps: `{result['execution_quality'].get('avg_entry_sweep_slip_bps')}`",
         "",
         "## Qualified Strategies",
         "",
@@ -664,6 +713,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-factor-n", type=int, default=100)
     parser.add_argument("--min-top-bucket-n", type=int, default=50)
     parser.add_argument("--min-top-bucket-entry-fill-rate", type=float, default=0.30)
+    parser.add_argument("--max-avg-entry-sweep-slip-bps", type=float, default=200.0)
     parser.add_argument("--min-window-count", type=int, default=4)
     return parser.parse_args()
 
@@ -680,6 +730,7 @@ def main() -> int:
         min_factor_n=args.min_factor_n,
         min_top_bucket_n=args.min_top_bucket_n,
         min_top_bucket_entry_fill_rate=args.min_top_bucket_entry_fill_rate,
+        max_avg_entry_sweep_slip_bps=args.max_avg_entry_sweep_slip_bps,
         min_window_count=args.min_window_count,
     )
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,49 @@
+# AutoFactor Promotion Gate Slippage Repair (2026-05-17)
+
+## Goal
+
+Prevent AutoFactor strategy handoff from treating 15U fillability as sufficient
+when the same report shows excessive average entry sweep slippage. A strategy
+that can only be filled by accepting materially worse prices remains research
+evidence, not a dry-run config candidate.
+
+Evidence stage: `factor_attribution / promotion-gate repair`.
+
+## Files / Ownership
+
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: parse global entry sweep slippage from walk-forward data health and
+    fail handoff when it exceeds the conservative cap.
+- `tests/test_autofactor_strategy_promotion.py`
+  - Owner: regression coverage for high-slippage and low-slippage promotion
+    reports.
+
+## Tasks
+
+- [x] Add a global average entry sweep slippage blocker.
+- [x] Add high/low slippage regression tests.
+- [x] Run focused promotion-gate tests and syntax/diff checks.
+- [x] Re-evaluate run `25982142342` and confirm the ready handoff becomes
+      blocked.
+- [x] Commit, push, and open a PR.
+
+## Review
+
+- 2026-05-17: Added a fail-closed global entry sweep slippage blocker to the
+  AutoFactor promotion evaluator. The default cap is
+  `max_avg_entry_sweep_slip_bps=200.0`; reports without the data-health metric
+  retain existing behavior, but reports with excessive average entry sweep
+  slippage cannot produce a ready handoff.
+- 2026-05-17: Re-evaluated fresh walk-forward run `25982142342`. Before this
+  patch the artifact produced handoff `status=ready` despite
+  `avg_entry_sweep_slip_bps=1912.92`; with this patch it evaluates to
+  `decision=blocked`, handoff `status=blocked`,
+  `recommended_action=do_not_promote`, and zero qualified strategies.
+- 2026-05-17: Verification passed:
+  `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
+  `python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py`,
+  and `rtk git diff --check`.
+
 # AutoFactor Promotion Gate Fillability Repair (2026-05-17)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -18,6 +18,18 @@ deribit_vol_surface,true,require_deribit=false include_deribit=false
 recorded_replay_parity,true,blocking_flags=<none>
 """
 
+LOW_SLIPPAGE_HEALTH = """=== Factor Walk-Forward V2 Data Health ===
+source_obs=1000 v2_rows=2000 settlement_labels=2000 executable_pnl_rows=1500 deribit_rows=0
+entry_fill_rate=80.00% rejection_rate=20.00% exit_fill_rate=75.00% avg_pm_lag_secs=1.20
+full_depth_entry_fill_rate=95.00% full_depth_exit_fill_rate=90.00% full_depth_pnl_rows=1900 avg_entry_sweep_slip_bps=80.00 avg_exit_sweep_slip_bps=40.00
+"""
+
+HIGH_SLIPPAGE_HEALTH = """=== Factor Walk-Forward V2 Data Health ===
+source_obs=1000 v2_rows=2000 settlement_labels=2000 executable_pnl_rows=1500 deribit_rows=0
+entry_fill_rate=80.00% rejection_rate=20.00% exit_fill_rate=75.00% avg_pm_lag_secs=1.20
+full_depth_entry_fill_rate=95.00% full_depth_exit_fill_rate=90.00% full_depth_pnl_rows=1900 avg_entry_sweep_slip_bps=1912.92 avg_exit_sweep_slip_bps=40.00
+"""
+
 BLOCKED_GATE = """=== Settlement Probability PRD Promotion Gate ===
 ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=0 event_complete_rows=0 replay_parity_ready=false
 gate,passed,evidence
@@ -203,6 +215,33 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
         self.assertFalse(rejected["qualified"])
         self.assertIn("autofactor_not_candidate:reject:nonpositive_rank_ic", rejected["blockers"])
+
+    def test_blocks_when_global_entry_sweep_slippage_is_too_high(self):
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            HIGH_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(registry["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertFalse(first["qualified"])
+        self.assertIn(
+            "global_entry_sweep_slippage_too_high:1912.92>200.00",
+            first["blockers"],
+        )
+        self.assertEqual(handoff["execution_quality"]["avg_entry_sweep_slip_bps"], 1912.92)
+        self.assertIn("Avg entry sweep slip bps: `1912.92`", handoff_md)
+
+    def test_allows_low_global_entry_sweep_slippage(self):
+        _, payload, registry, handoff, _ = self.run_script(
+            LOW_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(payload["execution_quality"]["avg_entry_sweep_slip_bps"], 80.0)
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
         _, payload, registry, handoff, handoff_md = self.run_script(


### PR DESCRIPTION
## Summary
- parse global avg entry sweep slippage from factor walk-forward data health
- block AutoFactor strategy handoff when avg entry sweep slippage exceeds the conservative cap
- include execution quality in registry/handoff artifacts and add high/low slippage regression coverage

## Evidence
- Fresh walk-forward run 25982142342 produced a ready handoff before this patch despite avg_entry_sweep_slip_bps=1912.92
- Re-evaluating that report with this patch returns decision=blocked, handoff status=blocked, recommended_action=do_not_promote, and zero qualified strategies

## Verification
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py
- rtk git diff --check
