### PR TITLE
Gate AutoFactor promotion on selected execution quality

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -617,12 +617,24 @@ fn reward(report: &AutoFactorReport) -> f64 {
 
 fn execution_score(report: &AutoFactorReport) -> f64 {
     let top_bucket_fillability = finite_or_zero(report.top_bucket_full_depth_entry_fill_rate);
+    let slippage_bps = finite_or_zero(report.top_bucket_avg_entry_sweep_slippage_bps);
+    let levels = finite_or_zero(report.top_bucket_avg_entry_sweep_levels);
+    let slippage_score = if slippage_bps <= 0.0 {
+        1.0
+    } else {
+        (1.0 - (slippage_bps / 200.0)).clamp(0.0, 1.0)
+    };
+    let levels_score = if levels <= 0.0 {
+        1.0
+    } else {
+        (1.0 - ((levels - 1.0) / 2.0)).clamp(0.0, 1.0)
+    };
     let structure_bonus = if report.name.contains("capacity") || report.name.contains("spread") {
         0.25
     } else {
         0.0
     };
-    (top_bucket_fillability + structure_bonus).clamp(0.0, 1.0)
+    (top_bucket_fillability * slippage_score * levels_score + structure_bonus).clamp(0.0, 1.0)
 }
 
 fn selected_dimension(report: &AutoFactorReport) -> String {
@@ -727,6 +739,8 @@ mod tests {
             top_bucket_avg_label: 0.2,
             top_bucket_positive_label_rate: 0.7,
             top_bucket_full_depth_entry_fill_rate: 0.8,
+            top_bucket_avg_entry_sweep_slippage_bps: 20.0,
+            top_bucket_avg_entry_sweep_levels: 1.5,
             monotonicity_score: 1.0,
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
@@ -785,6 +799,8 @@ mod tests {
             top_bucket_avg_label: 0.2,
             top_bucket_positive_label_rate: 0.7,
             top_bucket_full_depth_entry_fill_rate: 0.8,
+            top_bucket_avg_entry_sweep_slippage_bps: 20.0,
+            top_bucket_avg_entry_sweep_levels: 1.5,
             monotonicity_score: 1.0,
             complexity: 1,
             decision: AutoFactorDecision::Candidate,

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -276,6 +276,8 @@ pub struct AutoFactorReport {
     pub top_bucket_avg_label: f64,
     pub top_bucket_positive_label_rate: f64,
     pub top_bucket_full_depth_entry_fill_rate: f64,
+    pub top_bucket_avg_entry_sweep_slippage_bps: f64,
+    pub top_bucket_avg_entry_sweep_levels: f64,
     pub monotonicity_score: f64,
     pub complexity: usize,
     pub decision: AutoFactorDecision,
@@ -340,6 +342,8 @@ struct BucketSummary {
     avg_label: f64,
     positive_label_rate: f64,
     full_depth_entry_fill_rate: f64,
+    avg_entry_sweep_slippage_bps: f64,
+    avg_entry_sweep_levels: f64,
 }
 
 pub fn evaluate_named_factor(
@@ -446,6 +450,8 @@ pub fn evaluate_named_factor(
         &scored,
         options.bucket_count,
         matrix.column("full_depth_entry_fillable_gate"),
+        matrix.column("entry_sweep_slippage_bps"),
+        matrix.column("entry_sweep_levels_15u"),
     );
     let bucket_avg_labels = buckets
         .iter()
@@ -495,6 +501,12 @@ pub fn evaluate_named_factor(
         top_bucket_full_depth_entry_fill_rate: top
             .map(|bucket| bucket.full_depth_entry_fill_rate)
             .unwrap_or(f64::NAN),
+        top_bucket_avg_entry_sweep_slippage_bps: top
+            .map(|bucket| bucket.avg_entry_sweep_slippage_bps)
+            .unwrap_or(f64::NAN),
+        top_bucket_avg_entry_sweep_levels: top
+            .map(|bucket| bucket.avg_entry_sweep_levels)
+            .unwrap_or(f64::NAN),
         monotonicity_score,
         complexity,
         decision,
@@ -536,11 +548,11 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
         "target labels are side-aligned executable PnL for the requested target; reports are candidate discovery gates, not deploy decisions.\n",
     );
     out.push_str(
-        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity\n",
+        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity\n",
     );
     for (idx, report) in reports.iter().take(top_n).enumerate() {
         out.push_str(&format!(
-            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{},{:.4},{:.4},{},{:.6},{:.4},{:.4},{}\n",
+            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{},{:.4},{:.4},{},{:.6},{:.4},{:.4},{:.2},{:.2},{}\n",
             idx + 1,
             report.name,
             report.target.as_deref().unwrap_or("<unspecified>"),
@@ -559,6 +571,8 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
             report.top_bucket_avg_label,
             report.top_bucket_positive_label_rate,
             report.top_bucket_full_depth_entry_fill_rate,
+            report.top_bucket_avg_entry_sweep_slippage_bps,
+            report.top_bucket_avg_entry_sweep_levels,
             report.complexity,
         ));
     }
@@ -660,6 +674,12 @@ pub fn autofactor_matrix_from_v2(
             }
         },
     );
+    insert_column(&mut columns, "entry_sweep_slippage_bps", rows, |row| {
+        row.entry_sweep_slippage_bps
+    });
+    insert_column(&mut columns, "entry_sweep_levels_15u", rows, |row| {
+        row.entry_sweep_levels_15u
+    });
     insert_column(&mut columns, "entry_price_quality_score", rows, |row| {
         entry_price_quality_score(row.entry_ask)
     });
@@ -1560,6 +1580,8 @@ fn build_buckets(
     scored: &[(usize, f64, f64)],
     bucket_count: usize,
     full_depth_entry_fillable: Option<&[f64]>,
+    entry_sweep_slippage_bps: Option<&[f64]>,
+    entry_sweep_levels: Option<&[f64]>,
 ) -> Vec<BucketSummary> {
     let mut sorted = scored.to_vec();
     sorted.sort_by(|lhs, rhs| lhs.1.total_cmp(&rhs.1));
@@ -1588,6 +1610,20 @@ fn build_buckets(
                                     .count(),
                                 slice.len(),
                             )
+                        })
+                        .unwrap_or(f64::NAN),
+                    avg_entry_sweep_slippage_bps: entry_sweep_slippage_bps
+                        .map(|values| {
+                            finite_mean(slice.iter().filter_map(|(idx, _, _)| {
+                                values.get(*idx).copied().filter(|value| value.is_finite())
+                            }))
+                        })
+                        .unwrap_or(f64::NAN),
+                    avg_entry_sweep_levels: entry_sweep_levels
+                        .map(|values| {
+                            finite_mean(slice.iter().filter_map(|(idx, _, _)| {
+                                values.get(*idx).copied().filter(|value| value.is_finite())
+                            }))
                         })
                         .unwrap_or(f64::NAN),
                 }

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -181,6 +181,8 @@ class AutoFactorRow:
     top_bucket_avg_label: float
     top_bucket_positive_label_rate: float
     top_bucket_full_depth_entry_fill_rate: float
+    top_bucket_avg_entry_sweep_slip_bps: float | None
+    top_bucket_avg_entry_sweep_levels: float | None
     complexity: int
 
 
@@ -208,6 +210,8 @@ def factor_metrics(row: AutoFactorRow) -> dict[str, Any]:
         "top_bucket_avg_label": row.top_bucket_avg_label,
         "top_bucket_positive_label_rate": row.top_bucket_positive_label_rate,
         "top_bucket_full_depth_entry_fill_rate": row.top_bucket_full_depth_entry_fill_rate,
+        "top_bucket_avg_entry_sweep_slip_bps": row.top_bucket_avg_entry_sweep_slip_bps,
+        "top_bucket_avg_entry_sweep_levels": row.top_bucket_avg_entry_sweep_levels,
         "complexity": row.complexity,
     }
 
@@ -224,6 +228,10 @@ def parse_int(raw: str) -> int:
         return int(raw)
     except ValueError:
         return 0
+
+
+def finite_or_none(value: float) -> float | None:
+    return value if value == value else None
 
 
 def parse_promotion_gate(report_text: str) -> PromotionGate:
@@ -323,6 +331,12 @@ def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
                 top_bucket_full_depth_entry_fill_rate=parse_float(
                     item.get("top_bucket_full_depth_entry_fill_rate", "nan")
                 ),
+                top_bucket_avg_entry_sweep_slip_bps=finite_or_none(
+                    parse_float(item.get("top_bucket_avg_entry_sweep_slip_bps", "nan"))
+                ),
+                top_bucket_avg_entry_sweep_levels=finite_or_none(
+                    parse_float(item.get("top_bucket_avg_entry_sweep_levels", "nan"))
+                ),
                 complexity=parse_int(item["complexity"]),
             )
         )
@@ -371,17 +385,35 @@ def global_gate_blockers(
 
 
 def execution_quality_blockers(
-    quality: ExecutionQuality, *, max_avg_entry_sweep_slip_bps: float
+    row: AutoFactorRow,
+    quality: ExecutionQuality,
+    *,
+    max_avg_entry_sweep_slip_bps: float,
+    max_top_bucket_entry_sweep_levels: float,
 ) -> list[str]:
-    value = quality.avg_entry_sweep_slip_bps
-    if value is None:
-        return []
-    if value > max_avg_entry_sweep_slip_bps:
-        return [
-            "global_entry_sweep_slippage_too_high:"
-            f"{value:.2f}>{max_avg_entry_sweep_slip_bps:.2f}"
-        ]
-    return []
+    blockers: list[str] = []
+    slip = row.top_bucket_avg_entry_sweep_slip_bps
+    if slip is not None:
+        if slip > max_avg_entry_sweep_slip_bps:
+            blockers.append(
+                "top_bucket_entry_sweep_slippage_too_high:"
+                f"{slip:.2f}>{max_avg_entry_sweep_slip_bps:.2f}"
+            )
+    else:
+        global_slip = quality.avg_entry_sweep_slip_bps
+        if global_slip is not None and global_slip > max_avg_entry_sweep_slip_bps:
+            blockers.append(
+                "global_entry_sweep_slippage_too_high:"
+                f"{global_slip:.2f}>{max_avg_entry_sweep_slip_bps:.2f}"
+            )
+
+    levels = row.top_bucket_avg_entry_sweep_levels
+    if levels is not None and levels > max_top_bucket_entry_sweep_levels:
+        blockers.append(
+            "top_bucket_entry_sweep_levels_too_high:"
+            f"{levels:.2f}>{max_top_bucket_entry_sweep_levels:.2f}"
+        )
+    return blockers
 
 
 def evaluate(
@@ -394,14 +426,11 @@ def evaluate(
     min_top_bucket_n: int,
     min_top_bucket_entry_fill_rate: float,
     max_avg_entry_sweep_slip_bps: float,
+    max_top_bucket_entry_sweep_levels: float,
     min_window_count: int,
 ) -> dict[str, Any]:
     gate = parse_promotion_gate(report_text)
     quality = parse_execution_quality(report_text)
-    quality_blockers = execution_quality_blockers(
-        quality,
-        max_avg_entry_sweep_slip_bps=max_avg_entry_sweep_slip_bps,
-    )
     rows = parse_autofactor_rows(report_text)
     evaluated: list[EvaluatedFactor] = []
 
@@ -417,7 +446,14 @@ def evaluate(
                 hard_entry_gated=hard_entry_gated,
             )
         )
-        blockers.extend(quality_blockers)
+        blockers.extend(
+            execution_quality_blockers(
+                row,
+                quality,
+                max_avg_entry_sweep_slip_bps=max_avg_entry_sweep_slip_bps,
+                max_top_bucket_entry_sweep_levels=max_top_bucket_entry_sweep_levels,
+            )
+        )
         if row.target not in allowed_targets:
             blockers.append("target_not_allowed")
         if row.decision != "candidate" or row.reason != "passed":
@@ -476,6 +512,7 @@ def evaluate(
             "top_bucket_n": min_top_bucket_n,
             "top_bucket_full_depth_entry_fill_rate": min_top_bucket_entry_fill_rate,
             "max_avg_entry_sweep_slip_bps": max_avg_entry_sweep_slip_bps,
+            "max_top_bucket_entry_sweep_levels": max_top_bucket_entry_sweep_levels,
             "window_count": min_window_count,
         },
         "promotion_gate": asdict(gate),
@@ -714,6 +751,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-top-bucket-n", type=int, default=50)
     parser.add_argument("--min-top-bucket-entry-fill-rate", type=float, default=0.30)
     parser.add_argument("--max-avg-entry-sweep-slip-bps", type=float, default=200.0)
+    parser.add_argument("--max-top-bucket-entry-sweep-levels", type=float, default=3.0)
     parser.add_argument("--min-window-count", type=int, default=4)
     return parser.parse_args()
 
@@ -731,6 +769,7 @@ def main() -> int:
         min_top_bucket_n=args.min_top_bucket_n,
         min_top_bucket_entry_fill_rate=args.min_top_bucket_entry_fill_rate,
         max_avg_entry_sweep_slip_bps=args.max_avg_entry_sweep_slip_bps,
+        max_top_bucket_entry_sweep_levels=args.max_top_bucket_entry_sweep_levels,
         min_window_count=args.min_window_count,
     )
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -98,6 +98,22 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 2,mut_spread_adjusted_external_move_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.065967,0.092183,14,1.268732,0.9286,2,1.0000,0.5000,667,1.388814,0.6042,1.0000,7
 """
 
+AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT = """
+# AutoFactor target=tradeable_full_depth_settlement_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity
+1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,80.00,2.20,1
+"""
+
+AUTOFACTOR_TOP_BUCKET_BAD_EXECUTION_REPORT = """
+# AutoFactor target=tradeable_full_depth_settlement_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity
+1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,450.00,3.40,1
+"""
+
 CORE_SUITE_REPORT = f"""
 # Snapshot
 snapshot_schema=1
@@ -242,6 +258,28 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(registry["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
         self.assertEqual(payload["execution_quality"]["avg_entry_sweep_slip_bps"], 80.0)
+
+    def test_uses_top_bucket_execution_quality_before_global_slippage(self):
+        _, payload, _, handoff, _ = self.run_script(
+            HIGH_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        first = payload["qualified_strategies"][0]["factor"]
+        self.assertEqual(first["top_bucket_avg_entry_sweep_slip_bps"], 80.0)
+        self.assertEqual(first["top_bucket_avg_entry_sweep_levels"], 2.2)
+
+    def test_blocks_top_bucket_slippage_and_level_count(self):
+        _, payload, _, handoff, _ = self.run_script(
+            LOW_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_BAD_EXECUTION_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        blockers = payload["evaluated_factors"][0]["blockers"]
+        self.assertIn("top_bucket_entry_sweep_slippage_too_high:450.00>200.00", blockers)
+        self.assertIn("top_bucket_entry_sweep_levels_too_high:3.40>3.00", blockers)
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
         _, payload, registry, handoff, handoff_md = self.run_script(


### PR DESCRIPTION
## Summary\n- add top-bucket entry sweep slippage and level metrics to AutoFactor reports\n- make promotion gating prefer factor-specific top-bucket execution quality, with global slippage as backward-compatible fallback\n- penalize high selected-bucket slippage/level usage in alpha-search reward\n\n## Evidence\n- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep\n- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py\n- rtk cargo test -p ploy-research --lib autofactor -- alpha_search\n- rtk cargo test -p ploy-research --lib alpha_search\n- rustfmt --check crates/ploy-research/src/autofactor.rs crates/ploy-research/src/alpha_search.rs\n- rtk git diff --check\n\n## Research context\nFresh age<=2s PM5D sweep run 25982534509 remains blocked: global full-depth entry fillability 13.11% and avg entry sweep slippage 1403.50 bps. This PR makes future reports expose and gate the execution quality of the selected factor top bucket instead of relying only on global averages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added top bucket execution quality metrics tracking for entry sweep slippage and levels
  * Execution score calculation now incorporates these new metrics alongside existing fill-rate factors
  * Strategy promotion evaluation now includes configurable threshold for entry sweep metrics

* **Tests**
  * Added test cases validating top bucket execution quality metrics in strategy qualification
  * Added test fixtures for acceptable and unacceptable execution scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->