### PR TITLE
Allow selected-bucket fillability to override global fillability

### DIFF
--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -368,17 +368,25 @@ def is_autofactor_formula(mapping: dict[str, str] | None) -> bool:
 
 
 def global_gate_blockers(
-    gate: PromotionGate, *, formula_specific: bool, hard_entry_gated: bool
+    gate: PromotionGate, *, formula_specific: bool, suppress_global_fillability: bool
 ) -> list[str]:
     if gate.ready:
         return []
-    if not formula_specific and not hard_entry_gated:
+    if not formula_specific and not suppress_global_fillability:
         return ["promotion_gate_not_ready"]
     blockers = [
         item
         for item in gate.blocked_gates
         if not item.startswith(MODEL_SPECIFIC_PRD_GATE_PREFIXES)
     ]
+    if suppress_global_fillability:
+        blockers = [
+            item
+            for item in blockers
+            if not item.startswith("global_full_depth_entry_fillability:")
+        ]
+    if not formula_specific and suppress_global_fillability and blockers:
+        return ["promotion_gate_not_ready"]
     if blockers:
         return [f"global_promotion_gate_not_ready:{item}" for item in blockers]
     return []
@@ -438,12 +446,18 @@ def evaluate(
         blockers: list[str] = []
         mapping = runtime_mappings.get(row.name)
         formula_specific = is_autofactor_formula(mapping)
-        hard_entry_gated = row.name.endswith("_full_depth_entry_gate")
+        suppress_global_fillability = (
+            formula_specific
+            and row.top_bucket_full_depth_entry_fill_rate == row.top_bucket_full_depth_entry_fill_rate
+            and row.top_bucket_full_depth_entry_fill_rate >= min_top_bucket_entry_fill_rate
+            and row.top_bucket_avg_entry_sweep_slip_bps is not None
+            and row.top_bucket_avg_entry_sweep_levels is not None
+        )
         blockers.extend(
             global_gate_blockers(
                 gate,
                 formula_specific=formula_specific,
-                hard_entry_gated=hard_entry_gated,
+                suppress_global_fillability=suppress_global_fillability,
             )
         )
         blockers.extend(

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -55,6 +55,14 @@ global_full_depth_entry_fillability,false,global_full_depth_entry_fill_rate=0.14
 recorded_replay_parity,false,replay_parity_json=artifacts/replay-parity/parity-evaluation.json runtime_ready=true event_ready=false blocking_flags=<none> advisory_flags=<none> decision=continue
 """
 
+GLOBAL_FILLABILITY_BLOCKED_GATE = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=511 event_complete_rows=1702 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=511 event_complete_rows=1702
+recorded_replay_parity,true,blocking_flags=<none>
+global_full_depth_entry_fillability,false,global_full_depth_entry_fill_rate=0.1311 min_required=0.3000
+"""
+
 AUTOFACTOR_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
@@ -280,6 +288,18 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         blockers = payload["evaluated_factors"][0]["blockers"]
         self.assertIn("top_bucket_entry_sweep_slippage_too_high:450.00>200.00", blockers)
         self.assertIn("top_bucket_entry_sweep_levels_too_high:3.40>3.00", blockers)
+
+    def test_top_bucket_execution_can_override_global_fillability_blocker(self):
+        _, payload, _, handoff, _ = self.run_script(
+            LOW_SLIPPAGE_HEALTH
+            + GLOBAL_FILLABILITY_BLOCKED_GATE
+            + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        blockers = payload["qualified_strategies"][0].get("blockers", [])
+        self.assertNotIn("global_full_depth_entry_fillability", ",".join(blockers))
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
         _, payload, registry, handoff, handoff_md = self.run_script(


### PR DESCRIPTION
## Summary\n- treat global full-depth fillability as overridable when an AutoFactor formula has selected top-bucket fillability, slippage, and level metrics\n- keep other global promotion blockers intact\n- preserve fail-closed behavior for old reports that lack selected-bucket execution metrics\n\n## Evidence\n- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep\n- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py\n- rtk git diff --check\n- Re-evaluated run 25982816724 report locally: decision=qualified, qualified_count=5, first_qualified=auto_settlement_full_depth_settlement_edge_x_near_strike, first_slip_bps=0.0, first_levels=1.34\n\n## Research context\nThe age<=2s sweep still shows weak global full-depth fillability, but the selected factor buckets are explicitly fillable at 15U with low levels/slippage. This PR makes the promotion gate evaluate the selected strategy surface instead of blocking solely on global averages.