### PR TITLE
Promote selected execution AutoFactor dry-run score

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate"
+three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30


### PR DESCRIPTION
## Summary\n- update the PM5D settlement-probability dry-run config to the top selected-execution AutoFactor candidate from run 25982956070\n- replace the old predictive spread-move runtime score with autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike\n\n## Evidence\n- factor-walk-forward-v2-hosted-artifact run 25982956070: settlement-auto-age2-selected-exec qualified=5\n- selected strategy metrics: ICIR=2.609642, top_bucket_avg_label=2.670029, positive_label_rate=0.6180, top_bucket_full_depth_entry_fill_rate=1.0, top_bucket_avg_entry_sweep_slip_bps=0.0, top_bucket_avg_entry_sweep_levels=1.34\n- python3 scripts/apply_autofactor_handoff_to_config.py --dry-run against the ready handoff\n- rtk cargo test -p ploy-strategy-bundles config::tests::settlement_probability_config_carries_autofactor_handoff_score\n- rtk git diff --check\n\n## Scope\nDry-run config only. This does not deploy and does not enable live trading.