### PR TITLE
Fix PM5D crypto market discovery pagination

### DIFF
--- a/crates/ploy-market-data/src/scanner.rs
+++ b/crates/ploy-market-data/src/scanner.rs
@@ -32,6 +32,9 @@ const SCAN_INTERVAL_SECS: u64 = 30;
 const SPORTS_DISCOVERY_REFRESH_SECS: i64 = 300;
 const SPORTS_DISCOVERY_LIMIT: i32 = 500;
 const DEFAULT_DISCOVERY_LOOKAHEAD_MINUTES: i64 = 20;
+const CRYPTO_MARKET_CATEGORY: &str = "Crypto";
+const CRYPTO_DISCOVERY_PAGE_LIMIT: i32 = 100;
+const CRYPTO_DISCOVERY_MAX_PAGES: i32 = 12;
 const QUOTE_FEED_GRACE_SECS: i64 = 90;
 /// How far back to look for open positions that need recovery on startup.
 const RECOVERY_LOOKBACK_HOURS: i64 = 48;
@@ -167,6 +170,7 @@ pub fn spawn_market_scanner(
             let mut request = MarketsRequest::default();
             request.end_date_min = Some(now);
             request.end_date_max = Some(now + Duration::minutes(6));
+            request.category = Some(CRYPTO_MARKET_CATEGORY.to_string());
             request.closed = Some(false);
             request.limit = Some(100);
 
@@ -613,26 +617,51 @@ async fn refresh_crypto_catalog(
     now: DateTime<Utc>,
     lookahead_minutes: i64,
 ) -> usize {
+    let mut discovered_count = 0;
+
+    for page in 0..CRYPTO_DISCOVERY_MAX_PAGES {
+        let request = crypto_markets_request(now, lookahead_minutes, page);
+
+        match client.markets(&request).await {
+            Ok(markets) => {
+                if markets.is_empty() {
+                    break;
+                }
+
+                let discovered =
+                    discover_crypto_markets(&markets, symbols, reference_prices, now).await;
+                for market in &discovered {
+                    persist_discovered_crypto_market(Some(pool), market).await;
+                }
+                discovered_count += discovered.len();
+
+                if markets.len() < CRYPTO_DISCOVERY_PAGE_LIMIT as usize {
+                    break;
+                }
+            }
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    page,
+                    "Gamma markets query failed during catalog refresh"
+                );
+                break;
+            }
+        }
+    }
+
+    discovered_count
+}
+
+fn crypto_markets_request(now: DateTime<Utc>, lookahead_minutes: i64, page: i32) -> MarketsRequest {
     let mut request = MarketsRequest::default();
     request.end_date_min = Some(now - Duration::minutes(1));
     request.end_date_max = Some(now + Duration::minutes(lookahead_minutes));
+    request.offset = Some(page * CRYPTO_DISCOVERY_PAGE_LIMIT);
+    request.category = Some(CRYPTO_MARKET_CATEGORY.to_string());
     request.closed = Some(false);
-    request.limit = Some(500);
-
-    match client.markets(&request).await {
-        Ok(markets) => {
-            let discovered =
-                discover_crypto_markets(&markets, symbols, reference_prices, now).await;
-            for market in &discovered {
-                persist_discovered_crypto_market(Some(pool), market).await;
-            }
-            discovered.len()
-        }
-        Err(error) => {
-            warn!(error = %error, "Gamma markets query failed during catalog refresh");
-            0
-        }
-    }
+    request.limit = Some(CRYPTO_DISCOVERY_PAGE_LIMIT);
+    request
 }
 
 async fn refresh_sports_catalog(client: &GammaClient, pool: Option<&PgPool>) {
@@ -751,10 +780,12 @@ async fn upsert_market_metadata(
 #[cfg(test)]
 mod tests {
     use chrono::{Duration, TimeZone, Utc};
+    use polymarket_client_sdk::ToQueryParams;
 
     use super::{
-        MarketDiscoveryCollectorConfig, extend_quote_feed_stop_at, parse_token_id,
-        quote_feed_deadline, should_refresh_sports_catalog,
+        CRYPTO_DISCOVERY_PAGE_LIMIT, CRYPTO_MARKET_CATEGORY, MarketDiscoveryCollectorConfig,
+        crypto_markets_request, extend_quote_feed_stop_at, parse_token_id, quote_feed_deadline,
+        should_refresh_sports_catalog,
     };
 
     #[test]
@@ -811,6 +842,20 @@ mod tests {
             true,
             true
         ));
+    }
+
+    #[test]
+    fn crypto_catalog_request_filters_gamma_to_crypto_category() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 17, 13, 30, 0).unwrap();
+        let request = crypto_markets_request(now, 20, 5);
+        let query = request.query_params(None);
+
+        assert_eq!(request.category.as_deref(), Some(CRYPTO_MARKET_CATEGORY));
+        assert!(query.contains("category=Crypto"));
+        assert_eq!(request.offset, Some(5 * CRYPTO_DISCOVERY_PAGE_LIMIT));
+        assert!(query.contains("offset=500"));
+        assert!(query.contains("closed=false"));
+        assert!(query.contains("limit=100"));
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# PM5D Crypto Discovery Pagination Repair (2026-05-17)
+
+## Goal
+
+Restore `dry_run_candidate` sample accumulation by making the central
+Polymarket market-discovery collector continuously find BTC/ETH crypto
+Up/Down markets even when sports markets crowd the first Gamma markets page.
+
+Evidence stage: `dry_run_candidate / runtime data-supply repair`.
+
+## Files / Ownership
+
+- `crates/ploy-market-data/src/scanner.rs`
+  - Owner: add bounded paginated Gamma market discovery for crypto catalog
+    refresh.
+- `vendor/polymarket-client-sdk/src/gamma/types/request.rs`
+  - Owner: expose Gamma `category` query serialization for compatibility with
+    the public API, while not relying on it as the only crypto filter.
+- `vendor/polymarket-client-sdk/tests/gamma.rs`
+  - Owner: cover `category` query serialization.
+
+## Tasks
+
+- [x] Verify zero dry-run samples are caused by missing future BTC/ETH catalog
+      rows, not by strategy threshold or search-tree conservatism.
+- [x] Confirm Gamma still has future crypto markets, but they can appear on
+      later pages such as `offset=500`.
+- [x] Implement bounded paginated crypto discovery.
+- [x] Add focused request serialization tests.
+- [x] Run focused local validation.
+- [ ] Push PR, wait for CI, merge, deploy from `main`, then verify future
+      BTC/ETH rows resume before resetting dry-run evidence.
+
 # AutoFactor Runtime Settlement Edge Semantics (2026-05-17)
 
 ## Goal

--- a/vendor/polymarket-client-sdk/src/gamma/types/request.rs
+++ b/vendor/polymarket-client-sdk/src/gamma/types/request.rs
@@ -189,6 +189,8 @@ pub struct MarketsRequest {
     pub end_date_min: Option<DateTime<Utc>>,
     pub end_date_max: Option<DateTime<Utc>>,
     #[builder(into)]
+    pub category: Option<String>,
+    #[builder(into)]
     pub tag_id: Option<String>,
     pub related_tags: Option<bool>,
     pub cyom: Option<bool>,

--- a/vendor/polymarket-client-sdk/tests/gamma.rs
+++ b/vendor/polymarket-client-sdk/tests/gamma.rs
@@ -1267,6 +1267,7 @@ mod query_string {
             .start_date_max(end_date)
             .end_date_min(start_date)
             .end_date_max(end_date)
+            .category("Crypto")
             .tag_id("42")
             .related_tags(true)
             .cyom(false)
@@ -1307,6 +1308,7 @@ mod query_string {
         assert!(qs.contains("start_date_max="));
         assert!(qs.contains("end_date_min="));
         assert!(qs.contains("end_date_max="));
+        assert!(qs.contains("category=Crypto"));
         assert!(qs.contains("tag_id=42"));
         assert!(qs.contains("related_tags=true"));
         assert!(qs.contains("cyom=false"));


### PR DESCRIPTION
## Summary
- page through Gamma markets during crypto catalog refresh so BTC/ETH Up/Down markets are not missed when sports markets crowd the first page
- expose the Gamma markets category query field in the vendored SDK
- record the dry-run data-supply repair in tasks/todo.md

## Verification
- cargo test -p ploy-market-data --features live crypto_catalog_request_filters_gamma_to_crypto_category -- --nocapture
- cargo test -p polymarket-client-sdk --features 'gamma clob' markets_request_all_params -- --nocapture
- git diff --check

## Notes
This fixes the current zero-sample blocker before rerunning or relaxing alpha search. Remote evidence showed future crypto markets available from Gamma on later offsets, while pm_market_catalog had no future BTC/ETH rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented paginated crypto market discovery to retrieve markets across multiple result pages with intelligent stopping conditions for empty or partial results.
  * Added category-based filtering support to market queries for improved search accuracy.

* **Tests**
  * Enhanced test coverage for category filtering, market query parameter validation, and pagination behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->