### PR TITLE
Add closed-loop alpha search CI gate

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -385,6 +385,8 @@ jobs:
           fi
           if [ -n "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}" ]; then
             args+=(--alpha-search-llm-prior-json "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}")
+          elif [ -f artifacts/alpha-search-plan/next-llm-prior.json ]; then
+            args+=(--alpha-search-llm-prior-json artifacts/alpha-search-plan/next-llm-prior.json)
           fi
           if [ "${WALK_FAIL_IF_BLOCKED}" = "true" ]; then
             args+=(--fail-if-blocked)
@@ -680,6 +682,26 @@ jobs:
               raise SystemExit(2)
           PY
 
+      - name: Classify alpha search closed-loop action
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -d artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2 ]; then
+            echo "No factor-walk-forward-v2 artifact directory found; skipping closed-loop classifier."
+            exit 0
+          fi
+          target="${WALK_ALPHA_SEARCH_PLAN_TARGET}"
+          prior_path="artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2/alpha-search/${target}/next-llm-prior.json"
+          python3 scripts/alpha_search_closed_loop_agent.py \
+            artifacts/factor-walk-forward-v2-upload \
+            --target "${target}" \
+            --output-json artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json \
+            --output-md artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.md \
+            --output-prior-json "${prior_path}"
+          if [ -f "${prior_path}" ]; then
+            echo "Generated closed-loop typed prior at ${prior_path}."
+          fi
+
       - name: Summarize alpha search chain evidence
         if: always()
         run: |
@@ -714,12 +736,17 @@ jobs:
             echo "Missing alpha search chain decision artifact; skipping chained dispatch."
             exit 0
           fi
+          closed_loop_path="artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json"
+          if [ ! -f "${closed_loop_path}" ]; then
+            echo "Missing closed-loop classifier decision artifact; skipping chained dispatch."
+            exit 0
+          fi
           should_dispatch="$(python3 - <<'PY'
           import json
           from pathlib import Path
 
-          payload = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json").read_text(encoding="utf-8"))
-          print("true" if payload.get("should_dispatch") else "false")
+          closed_loop = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json").read_text(encoding="utf-8"))
+          print("true" if closed_loop.get("allow_dispatch") is True else "false")
           PY
           )"
           if [ "${should_dispatch}" != "true" ]; then
@@ -727,8 +754,8 @@ jobs:
           import json
           from pathlib import Path
 
-          payload = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/chain-decision.json").read_text(encoding="utf-8"))
-          print(payload.get("reason", "unknown"))
+          closed_loop = json.loads(Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json").read_text(encoding="utf-8"))
+          print(closed_loop.get("reason", "unknown"))
           PY
           )"
             echo "Alpha search chain decision is ${reason}; skipping chained dispatch."
@@ -745,6 +772,7 @@ jobs:
           data["alpha_search_plan_run_id"] = os.environ["GITHUB_RUN_ID"]
           data["alpha_search_plan_artifact_name"] = f"factor-walk-forward-v2-{os.environ['GITHUB_RUN_ID']}"
           data["alpha_search_plan_target"] = os.environ["WALK_ALPHA_SEARCH_PLAN_TARGET"]
+          data["alpha_search_llm_prior_json"] = ""
           remaining = max(0, int(os.environ["WALK_CHAIN_REMAINING"]) - 1)
           data["chain_remaining"] = remaining
           data["chain_next_run"] = remaining > 0

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -159,6 +159,7 @@ struct NodeMetric {
     stability: f64,
     diversity: f64,
     execution_cost: f64,
+    event_uniqueness: f64,
     overfit_risk: f64,
     runtime_readiness: f64,
     reward: f64,
@@ -167,6 +168,10 @@ struct NodeMetric {
     positive_window_ratio: f64,
     top_bucket_avg_label: f64,
     top_bucket_full_depth_entry_fill_rate: f64,
+    top_bucket_avg_entry_sweep_slippage_bps: f64,
+    top_bucket_avg_entry_sweep_levels: f64,
+    top_bucket_unique_event_count: usize,
+    top_bucket_max_event_decisions: usize,
     monotonicity_score: f64,
     complexity: usize,
 }
@@ -470,6 +475,7 @@ fn node_metric(idx: usize, report: &AutoFactorReport) -> NodeMetric {
         stability: report.positive_window_ratio.clamp(0.0, 1.0),
         diversity: 1.0 / report.complexity.max(1) as f64,
         execution_cost: execution_score(report),
+        event_uniqueness: event_uniqueness_score(report),
         overfit_risk: 1.0 / report.complexity.max(1) as f64,
         runtime_readiness: if report.name.starts_with("auto_settlement_")
             || report.name == "amplitude_weighted_momentum_30s_sigma"
@@ -486,6 +492,12 @@ fn node_metric(idx: usize, report: &AutoFactorReport) -> NodeMetric {
         top_bucket_full_depth_entry_fill_rate: finite_or_zero(
             report.top_bucket_full_depth_entry_fill_rate,
         ),
+        top_bucket_avg_entry_sweep_slippage_bps: finite_or_zero(
+            report.top_bucket_avg_entry_sweep_slippage_bps,
+        ),
+        top_bucket_avg_entry_sweep_levels: finite_or_zero(report.top_bucket_avg_entry_sweep_levels),
+        top_bucket_unique_event_count: report.top_bucket_unique_event_count,
+        top_bucket_max_event_decisions: report.top_bucket_max_event_decisions,
         monotonicity_score: finite_or_zero(report.monotonicity_score),
         complexity: report.complexity,
     }
@@ -593,6 +605,7 @@ fn proposed_mutation(selected_dimension: &str) -> &'static str {
         "effectiveness" => "replace_denominator",
         "monotonicity" => "clip_or_squash",
         "execution_quality" => "add_capacity_gate",
+        "event_uniqueness" => "add_capacity_gate",
         "overfit_risk" => "remove_component",
         "exploit" => "add_capacity_gate",
         _ => "clip_or_squash",
@@ -611,7 +624,10 @@ fn reward(report: &AutoFactorReport) -> f64 {
         + finite_or_zero(report.positive_window_ratio)
         + normalized_positive(report.top_bucket_avg_label)
         + execution_score(report)
+        + event_uniqueness_score(report)
         + finite_or_zero(report.monotonicity_score)
+        - event_decision_penalty(report)
+        - execution_penalty(report)
         - (report.complexity as f64 / 32.0)
 }
 
@@ -637,7 +653,66 @@ fn execution_score(report: &AutoFactorReport) -> f64 {
     (top_bucket_fillability * slippage_score * levels_score + structure_bonus).clamp(0.0, 1.0)
 }
 
+fn execution_penalty(report: &AutoFactorReport) -> f64 {
+    let fillability = finite_or_zero(report.top_bucket_full_depth_entry_fill_rate);
+    let slippage_bps = finite_or_zero(report.top_bucket_avg_entry_sweep_slippage_bps);
+    let levels = finite_or_zero(report.top_bucket_avg_entry_sweep_levels);
+    let fillability_penalty = if report.top_bucket_n > 0 && fillability < 0.30 {
+        (0.30 - fillability) * 2.0
+    } else {
+        0.0
+    };
+    let slippage_penalty = if slippage_bps > 200.0 {
+        ((slippage_bps - 200.0) / 200.0).min(4.0)
+    } else {
+        0.0
+    };
+    let levels_penalty = if levels > 3.0 {
+        ((levels - 3.0) * 0.5).min(2.0)
+    } else {
+        0.0
+    };
+    fillability_penalty + slippage_penalty + levels_penalty
+}
+
+fn event_uniqueness_score(report: &AutoFactorReport) -> f64 {
+    if report.top_bucket_n == 0 {
+        return 0.0;
+    }
+    let unique_ratio =
+        (report.top_bucket_unique_event_count as f64 / report.top_bucket_n as f64).clamp(0.0, 1.0);
+    let decision_ratio = if report.top_bucket_max_event_decisions <= 1 {
+        1.0
+    } else {
+        1.0 / report.top_bucket_max_event_decisions as f64
+    };
+    unique_ratio * decision_ratio
+}
+
+fn event_decision_penalty(report: &AutoFactorReport) -> f64 {
+    if report.top_bucket_n > 0 && report.top_bucket_unique_event_count == 0 {
+        return 1.0;
+    }
+    if report.top_bucket_max_event_decisions <= 1 {
+        0.0
+    } else {
+        ((report.top_bucket_max_event_decisions - 1) as f64 * 1.5).min(6.0)
+    }
+}
+
 fn selected_dimension(report: &AutoFactorReport) -> String {
+    if report.top_bucket_n > 0
+        && (report.top_bucket_unique_event_count == 0 || report.top_bucket_max_event_decisions > 1)
+    {
+        return "event_uniqueness".to_string();
+    }
+    if report.top_bucket_n > 0
+        && (report.top_bucket_full_depth_entry_fill_rate < 0.30
+            || report.top_bucket_avg_entry_sweep_slippage_bps > 200.0
+            || report.top_bucket_avg_entry_sweep_levels > 3.0)
+    {
+        return "execution_quality".to_string();
+    }
     match report.reason.as_str() {
         "too_few_observations" | "no_powered_windows" => "sample_power",
         "low_icir" | "unstable_positive_windows" => "stability",
@@ -712,6 +787,40 @@ mod tests {
     use super::*;
     use crate::autofactor::{AutoFactorDecision, FactorExpr};
 
+    fn sample_report(name: &str) -> AutoFactorReport {
+        AutoFactorReport {
+            name: name.to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Input("conservative_settlement_edge".to_string()),
+            n: 100,
+            pearson_ic: 0.2,
+            spearman_ic: 0.25,
+            window_count: 3,
+            window_ic_mean: 0.2,
+            icir: 1.2,
+            positive_window_ratio: 1.0,
+            symbol_count: 2,
+            symbol_ic_mean: 0.18,
+            symbol_icir: 1.0,
+            symbol_positive_ratio: 1.0,
+            bucket_avg_labels: vec![-0.1, 0.0, 0.2],
+            bottom_bucket_n: 20,
+            bottom_bucket_avg_label: -0.1,
+            top_bucket_n: 20,
+            top_bucket_avg_label: 0.2,
+            top_bucket_positive_label_rate: 0.7,
+            top_bucket_full_depth_entry_fill_rate: 0.8,
+            top_bucket_avg_entry_sweep_slippage_bps: 20.0,
+            top_bucket_avg_entry_sweep_levels: 1.5,
+            top_bucket_unique_event_count: 20,
+            top_bucket_max_event_decisions: 1,
+            monotonicity_score: 1.0,
+            complexity: 1,
+            decision: AutoFactorDecision::Candidate,
+            reason: "passed".to_string(),
+        }
+    }
+
     #[test]
     fn writes_search_artifact_bundle() {
         let tmp =
@@ -741,6 +850,8 @@ mod tests {
             top_bucket_full_depth_entry_fill_rate: 0.8,
             top_bucket_avg_entry_sweep_slippage_bps: 20.0,
             top_bucket_avg_entry_sweep_levels: 1.5,
+            top_bucket_unique_event_count: 20,
+            top_bucket_max_event_decisions: 1,
             monotonicity_score: 1.0,
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
@@ -801,6 +912,8 @@ mod tests {
             top_bucket_full_depth_entry_fill_rate: 0.8,
             top_bucket_avg_entry_sweep_slippage_bps: 20.0,
             top_bucket_avg_entry_sweep_levels: 1.5,
+            top_bucket_unique_event_count: 20,
+            top_bucket_max_event_decisions: 1,
             monotonicity_score: 1.0,
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
@@ -844,5 +957,67 @@ mod tests {
         assert_eq!(node.visits, 4);
         assert!(node.total_reward > 6.0);
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn repeated_event_candidate_ranks_below_one_event_candidate() {
+        let mut repeated = sample_report("auto_settlement_high_raw_score_repeated_event");
+        repeated.spearman_ic = 0.95;
+        repeated.icir = 3.0;
+        repeated.top_bucket_avg_label = 0.7;
+        repeated.top_bucket_unique_event_count = 4;
+        repeated.top_bucket_max_event_decisions = 5;
+
+        let mut one_event = sample_report("auto_settlement_lower_raw_score_one_event");
+        one_event.spearman_ic = 0.35;
+        one_event.icir = 0.9;
+        one_event.top_bucket_avg_label = 0.25;
+        one_event.top_bucket_unique_event_count = one_event.top_bucket_n;
+        one_event.top_bucket_max_event_decisions = 1;
+
+        let reports = vec![repeated, one_event];
+        let metrics = reports
+            .iter()
+            .enumerate()
+            .map(|(idx, report)| node_metric(idx, report))
+            .collect::<Vec<_>>();
+        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
+
+        assert_eq!(
+            plan.selected_nodes
+                .first()
+                .map(|node| node.factor_name.as_str()),
+            Some("auto_settlement_lower_raw_score_one_event")
+        );
+        assert!(
+            reward(&reports[0]) < reward(&reports[1]),
+            "repeated-event penalty should dominate raw IC/top-bucket strength"
+        );
+    }
+
+    #[test]
+    fn repeated_event_candidate_selects_event_uniqueness_mutation() {
+        let mut report = sample_report("auto_settlement_repeated_event_branch");
+        report.top_bucket_unique_event_count = 6;
+        report.top_bucket_max_event_decisions = 3;
+        report.reason = "passed".to_string();
+
+        assert_eq!(selected_dimension(&report), "event_uniqueness");
+        assert_eq!(
+            proposed_mutation(&selected_dimension(&report)),
+            "add_capacity_gate"
+        );
+    }
+
+    #[test]
+    fn high_sweep_slippage_selects_execution_quality() {
+        let mut report = sample_report("auto_settlement_high_sweep_slippage");
+        report.top_bucket_avg_entry_sweep_slippage_bps = 450.0;
+        report.top_bucket_avg_entry_sweep_levels = 3.4;
+        report.reason = "passed".to_string();
+
+        assert_eq!(selected_dimension(&report), "execution_quality");
+        assert!(execution_penalty(&report) > 0.0);
     }
 }

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -278,6 +278,8 @@ pub struct AutoFactorReport {
     pub top_bucket_full_depth_entry_fill_rate: f64,
     pub top_bucket_avg_entry_sweep_slippage_bps: f64,
     pub top_bucket_avg_entry_sweep_levels: f64,
+    pub top_bucket_unique_event_count: usize,
+    pub top_bucket_max_event_decisions: usize,
     pub monotonicity_score: f64,
     pub complexity: usize,
     pub decision: AutoFactorDecision,
@@ -344,6 +346,7 @@ struct BucketSummary {
     full_depth_entry_fill_rate: f64,
     avg_entry_sweep_slippage_bps: f64,
     avg_entry_sweep_levels: f64,
+    indexes: Vec<usize>,
 }
 
 pub fn evaluate_named_factor(
@@ -352,6 +355,7 @@ pub fn evaluate_named_factor(
     labels: &[f64],
     windows: &[String],
     symbols: &[String],
+    event_ids: &[String],
     options: &AutoFactorOptions,
 ) -> Result<AutoFactorReport, AutoFactorError> {
     if labels.len() != matrix.len() {
@@ -370,6 +374,12 @@ pub fn evaluate_named_factor(
         return Err(AutoFactorError::WindowLengthMismatch {
             expected: matrix.len(),
             actual: symbols.len(),
+        });
+    }
+    if !event_ids.is_empty() && event_ids.len() != matrix.len() {
+        return Err(AutoFactorError::WindowLengthMismatch {
+            expected: matrix.len(),
+            actual: event_ids.len(),
         });
     }
 
@@ -460,6 +470,8 @@ pub fn evaluate_named_factor(
     let monotonicity_score = monotonicity_score(&bucket_avg_labels);
     let bottom = buckets.first();
     let top = buckets.last();
+    let (top_bucket_unique_event_count, top_bucket_max_event_decisions) =
+        top_bucket_event_decision_stats(top, event_ids);
     let complexity = factor.expr.complexity();
     let (decision, reason) = autofactor_decision(
         scored.len(),
@@ -507,6 +519,8 @@ pub fn evaluate_named_factor(
         top_bucket_avg_entry_sweep_levels: top
             .map(|bucket| bucket.avg_entry_sweep_levels)
             .unwrap_or(f64::NAN),
+        top_bucket_unique_event_count,
+        top_bucket_max_event_decisions,
         monotonicity_score,
         complexity,
         decision,
@@ -522,10 +536,22 @@ pub fn mine_autofactors(
     symbols: &[String],
     options: &AutoFactorOptions,
 ) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
+    mine_autofactors_with_event_ids(factors, matrix, labels, windows, symbols, &[], options)
+}
+
+pub fn mine_autofactors_with_event_ids(
+    factors: &[NamedFactorExpr],
+    matrix: &AutoFactorMatrix,
+    labels: &[f64],
+    windows: &[String],
+    symbols: &[String],
+    event_ids: &[String],
+    options: &AutoFactorOptions,
+) -> Result<Vec<AutoFactorReport>, AutoFactorError> {
     let mut reports = Vec::with_capacity(factors.len());
     for factor in factors {
         reports.push(evaluate_named_factor(
-            factor, matrix, labels, windows, symbols, options,
+            factor, matrix, labels, windows, symbols, event_ids, options,
         )?);
     }
     reports.sort_by(|lhs, rhs| {
@@ -548,11 +574,11 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
         "target labels are side-aligned executable PnL for the requested target; reports are candidate discovery gates, not deploy decisions.\n",
     );
     out.push_str(
-        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity\n",
+        "rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity\n",
     );
     for (idx, report) in reports.iter().take(top_n).enumerate() {
         out.push_str(&format!(
-            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{},{:.4},{:.4},{},{:.6},{:.4},{:.4},{:.2},{:.2},{}\n",
+            "{},{},{},{},{},{},{:.6},{:.6},{},{:.6},{:.4},{},{:.4},{:.4},{},{:.6},{:.4},{:.4},{:.2},{:.2},{},{},{}\n",
             idx + 1,
             report.name,
             report.target.as_deref().unwrap_or("<unspecified>"),
@@ -573,6 +599,8 @@ pub fn format_autofactor_reports(reports: &[AutoFactorReport], top_n: usize) -> 
             report.top_bucket_full_depth_entry_fill_rate,
             report.top_bucket_avg_entry_sweep_slippage_bps,
             report.top_bucket_avg_entry_sweep_levels,
+            report.top_bucket_unique_event_count,
+            report.top_bucket_max_event_decisions,
             report.complexity,
         ));
     }
@@ -613,6 +641,7 @@ pub fn mine_domain_autofactors_from_v2_with_guidance(
     let labels = autofactor_labels_from_v2(rows, target);
     let windows = autofactor_windows_from_v2(rows);
     let symbols = autofactor_symbols_from_v2(rows);
+    let event_ids = autofactor_event_ids_from_v2(rows);
     let target_name = target.as_str().to_string();
     let candidates = domain_candidates_for_target_with_guidance(
         &matrix.input_names(),
@@ -626,7 +655,15 @@ pub fn mine_domain_autofactors_from_v2_with_guidance(
         factor
     })
     .collect::<Vec<_>>();
-    mine_autofactors(&candidates, &matrix, &labels, &windows, &symbols, options)
+    mine_autofactors_with_event_ids(
+        &candidates,
+        &matrix,
+        &labels,
+        &windows,
+        &symbols,
+        &event_ids,
+        options,
+    )
 }
 
 pub fn autofactor_matrix_from_v2(
@@ -765,6 +802,10 @@ pub fn autofactor_windows_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
 
 pub fn autofactor_symbols_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
     rows.iter().map(|row| row.symbol.clone()).collect()
+}
+
+pub fn autofactor_event_ids_from_v2(rows: &[FactorObservationV2]) -> Vec<String> {
+    rows.iter().map(|row| row.event_id.clone()).collect()
 }
 
 fn valid_pm_price(value: f64) -> bool {
@@ -1626,10 +1667,30 @@ fn build_buckets(
                             }))
                         })
                         .unwrap_or(f64::NAN),
+                    indexes: slice.iter().map(|(idx, _, _)| *idx).collect(),
                 }
             })
         })
         .collect()
+}
+
+fn top_bucket_event_decision_stats(
+    bucket: Option<&BucketSummary>,
+    event_ids: &[String],
+) -> (usize, usize) {
+    let Some(bucket) = bucket else {
+        return (0, 0);
+    };
+    if event_ids.is_empty() {
+        return (0, 0);
+    }
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for idx in &bucket.indexes {
+        if let Some(event_id) = event_ids.get(*idx) {
+            *counts.entry(event_id.as_str()).or_default() += 1;
+        }
+    }
+    (counts.len(), counts.values().copied().max().unwrap_or(0))
 }
 
 fn autofactor_decision(
@@ -2175,8 +2236,9 @@ mod tests {
             ..Default::default()
         };
         let symbols = Vec::new();
-        let report = evaluate_named_factor(&factor, &matrix, &labels, &windows, &symbols, &options)
-            .expect("report");
+        let report =
+            evaluate_named_factor(&factor, &matrix, &labels, &windows, &symbols, &[], &options)
+                .expect("report");
         assert_eq!(report.decision, AutoFactorDecision::Reject);
         assert_eq!(report.reason, "too_complex");
     }

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -176,6 +176,8 @@ The reward should not be a single PnL number. It should combine:
 - stability: positive-window ratio, window decay, symbol holdout behavior
 - diversity: novelty versus accepted/watchlisted factor expressions
 - execution cost: spread, capacity, fillability, quote age, turnover-like churn
+- event uniqueness: top-bucket one-event-one-decision behavior, unique event
+  coverage, and repeated-event penalties before promotion
 - overfit risk: complexity, parameter count, train/test decay, permutation and
   time-shift sensitivity
 - runtime readiness: explicit profile mapping and scorer support
@@ -359,6 +361,78 @@ factor, handoff status, recommended action, and chain stop reason per run. It
 is a review aid only; it does not replace the promotion evaluator or replay
 parity gate.
 
+## Closed-Loop Agent Review
+
+After a hosted alpha-search run or chain stops, run the closed-loop classifier
+before deciding what to do next:
+
+```bash
+python3 scripts/alpha_search_closed_loop_agent.py \
+  /tmp/ploy-alpha-run-25683730944 \
+  --output-json /tmp/alpha-closed-loop-decision.json \
+  --output-md /tmp/alpha-closed-loop-decision.md \
+  --output-prior-json /tmp/alpha-next-llm-prior.json
+```
+
+The classifier reads existing CI artifacts only. It does not call an LLM, does
+not edit runtime config, and does not promote a strategy. Its output action is
+one of:
+
+- `ready_handoff`: use the existing ready-only AutoFactor handoff/config PR
+  path.
+- `continue_search`: dispatch the next bounded hosted MCTS iteration only when
+  the classifier also emits `allow_dispatch=true`.
+- `revise_prior`: review and pass the generated typed prior JSON into the next
+  run through `options_json.alpha_search_llm_prior_json`.
+- `fix_data`: repair missing/weak data surfaces before more search.
+- `fix_runtime`: repair runtime scorer, mapping, or parity before promotion.
+- `fix_workflow`: repair missing CI evidence artifacts, such as recorded
+  replay parity, before interpreting promotion readiness.
+
+Stagnation, empty selected-node plans, and high rejection ratios map to
+`revise_prior` with `allow_dispatch=false`. That makes the workflow stop
+automatic chaining, publish a bounded typed prior draft, and require a human or
+LLM judgment step before another explicit research-CI dispatch.
+
+Execution blockers also take priority over runtime mapping blockers. For
+example, `one_event_decision_violation`, top-bucket slippage, or fillability
+problems mean the candidate is still a search/prior problem; the classifier
+returns `revise_prior` even if the same factor also lacks a runtime mapping.
+
+This is the current closed-loop boundary: a failed or stagnant search now
+produces a machine-readable next action and, when appropriate, a bounded typed
+prior draft using only the existing allowed mutation types. It still cannot
+guarantee profitability, does not call an external LLM, and cannot bypass
+walk-forward, promotion, replay parity, dry-run, or live approval gates.
+
+## Event-Level Promotion Gate
+
+PM5D settlement strategies are event-rooted binary options. A deployable
+candidate must prove the top deployable bucket behaves like one event, one
+decision, one trade lifecycle. The AutoFactor report therefore exposes:
+
+- `top_bucket_unique_event_count`
+- `top_bucket_max_event_decisions`
+- `top_bucket_avg_entry_sweep_slip_bps`
+- `top_bucket_avg_entry_sweep_levels`
+
+`scripts/evaluate_autofactor_strategy_promotion.py` treats missing event
+decision fields as `missing_one_event_decision_gate` and blocks promotion when
+`top_bucket_max_event_decisions > 1`. This keeps repeated observation rows or
+same-event UP/DOWN rows from being counted as independent deployable trades.
+Diagnostic rows can still be useful for research, but a dry-run handoff must
+pass this event-level gate.
+
+The search layer also consumes these fields before promotion. `node-metrics.json`
+records event uniqueness and top-bucket sweep metrics, `reward` penalizes
+repeated event decisions, missing top-bucket event coverage, high average sweep
+slippage, excessive sweep levels, and low top-bucket fillability, and
+`mcts-expansion-plan.json` routes repeated-event branches to
+`event_uniqueness` / `add_capacity_gate` instead of generic exploitation. This
+keeps MCTS from repeatedly expanding branches that look strong only because
+the same event contributed multiple diagnostic rows or because the entry was
+not realistically executable.
+
 ## Completion Criteria
 
 The method is fully defined only when CI exposes all of the following:
@@ -370,6 +444,7 @@ The method is fully defined only when CI exposes all of the following:
 - multi-dimensional node scoring from CI backtest feedback
 - frequent-subtree/root-gene avoidance
 - full search artifact bundle
+- event-level one-decision promotion gate
 - existing walk-forward and promotion gates
 - ready-only issue/config PR creation
 
@@ -418,6 +493,19 @@ Current implementation status:
   `search-feedback.json.best_reward` with the prior plan artifact's
   `search-feedback.json.best_reward` and stops with `reward_stagnation` when
   the configured `alpha_search_min_reward_improvement` threshold is not met.
+- Implemented: `scripts/alpha_search_closed_loop_agent.py` classifies stopped
+  or blocked chains into a next action and emits a bounded typed prior draft
+  when the correct action is `revise_prior`.
+- Implemented: chained dispatch is fail-closed on the classifier artifact. The
+  hosted workflow requires `closed-loop-decision.json` and dispatches only when
+  it contains `allow_dispatch=true`; older chain decisions alone cannot trigger
+  the next run.
+- Implemented: AutoFactor promotion now fail-closes on missing or repeated
+  top-bucket event decisions, so dry-run handoff cannot count repeated rows
+  from the same event as independent deployable trades.
+- Implemented: alpha-search node metrics and MCTS reward now include
+  event-level uniqueness and execution-capacity penalties, so repeated-event or
+  high-slippage candidates are de-prioritized before the promotion gate.
 - Implemented as artifact and input contract: `llm-priors.json` records the
   typed prior schema, and an operator- or LLM-produced prior file can now enter
   CI through `--alpha-search-llm-prior-json` / `options_json.alpha_search_llm_prior_json`.

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Classify alpha-search artifacts into the next closed-loop research action.
+
+This script does not call an LLM and does not promote strategies. It turns the
+existing CI artifact bundle into an auditable next action: continue the MCTS
+chain, revise the typed prior, fix data/workflow/runtime gates, or hand off a
+ready strategy through the existing promotion path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TARGET = "full_depth_settlement_executable_pnl"
+RUN_ID_RE = re.compile(r"(\d{8,})")
+
+ALLOWED_MUTATIONS = {
+    "add_feature_gate",
+    "replace_denominator",
+    "add_spread_penalty",
+    "add_capacity_gate",
+    "add_near_strike_interaction",
+    "change_time_window",
+    "clip_or_squash",
+    "invert_or_contrarian",
+    "remove_component",
+}
+
+DIMENSION_TO_MUTATION = {
+    "sample_power": "add_feature_gate",
+    "stability": "add_feature_gate",
+    "effectiveness": "replace_denominator",
+    "monotonicity": "clip_or_squash",
+    "execution_quality": "add_capacity_gate",
+    "overfit_risk": "remove_component",
+    "exploit": "add_capacity_gate",
+}
+
+PREFERRED_FEATURES = {
+    "add_feature_gate": ["near_strike_score", "quote_freshness_score", "pm_lag_score"],
+    "add_capacity_gate": ["full_depth_entry_fillable_gate", "entry_capacity_score"],
+    "add_near_strike_interaction": ["near_strike_score"],
+    "add_spread_penalty": ["side_spread"],
+    "replace_denominator": ["side_spread", "entry_capacity_score"],
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def optional_json(path: Path) -> Any:
+    if not path.exists():
+        return None
+    return load_json(path)
+
+
+def artifact_root(path: Path) -> Path:
+    if (path / "factor-walk-forward-v2").is_dir():
+        return path / "factor-walk-forward-v2"
+    return path
+
+
+def infer_run_id(path: Path, chain: dict[str, Any]) -> str:
+    value = chain.get("current_run_id")
+    if value:
+        return str(value)
+    for part in reversed(path.parts):
+        if match := RUN_ID_RE.search(part):
+            return match.group(1)
+    return ""
+
+
+def load_artifact(path: Path, target: str) -> dict[str, Any]:
+    root = artifact_root(path)
+    alpha_root = root / "alpha-search" / target
+    chain = optional_json(path / "alpha-search-chain" / "chain-decision.json")
+    if chain is None:
+        chain = optional_json(root.parent / "alpha-search-chain" / "chain-decision.json")
+    chain = chain or {}
+    return {
+        "artifact_dir": str(path),
+        "root": root,
+        "run_id": infer_run_id(path, chain),
+        "target": target,
+        "feedback": optional_json(alpha_root / "search-feedback.json") or {},
+        "plan": optional_json(alpha_root / "mcts-expansion-plan.json") or {},
+        "state": optional_json(alpha_root / "mcts-state.json") or {},
+        "handoff": optional_json(root / "autofactor-strategy-handoff.json") or {},
+        "promotion": optional_json(root / "autofactor-strategy-promotion.json") or {},
+        "chain": chain,
+        "search_space": optional_json(alpha_root / "search-space.json") or {},
+    }
+
+
+def as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def selected_nodes(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    value = plan.get("selected_nodes")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def blocker_strings(payload: Any) -> list[str]:
+    out: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "blockers" and isinstance(value, list):
+                out.extend(str(item) for item in value)
+            elif key in {"blocking_risk_flags", "blocked_gates"} and isinstance(value, list):
+                out.extend(str(item) for item in value)
+            else:
+                out.extend(blocker_strings(value))
+    elif isinstance(payload, list):
+        for item in payload:
+            out.extend(blocker_strings(item))
+    return out
+
+
+def classify_blockers(blockers: list[str]) -> str | None:
+    text = " ".join(blockers).lower()
+    if not text:
+        return None
+    if any(
+        token in text
+        for token in [
+            "one_event_decision_violation",
+            "top_bucket_entry_sweep",
+            "entry_sweep_slippage",
+            "fill_rate",
+            "fillability",
+            "capacity",
+            "depth",
+        ]
+    ):
+        return "revise_prior"
+    if any(
+        token in text
+        for token in [
+            "recorded_replay_parity: blocked: no recorded replay parity artifact",
+            "no recorded replay parity artifact",
+            "missing-artifact",
+            "missing_artifact",
+        ]
+    ):
+        return "fix_workflow"
+    if any(token in text for token in ["parity", "runtime", "mapping", "profile"]):
+        return "fix_runtime"
+    if any(
+        token in text
+        for token in ["settlement", "official", "data", "coverage", "missing", "freshness"]
+    ):
+        return "fix_data"
+    return None
+
+
+def latest_run(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    return runs[-1]
+
+
+def best_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    scored = [
+        run
+        for run in runs
+        if as_float(run["feedback"].get("best_reward")) is not None
+    ]
+    if not scored:
+        return None
+    return max(scored, key=lambda run: as_float(run["feedback"].get("best_reward")) or float("-inf"))
+
+
+def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    current = latest_run(runs)
+    handoff = current["handoff"]
+    chain = current["chain"]
+    feedback = current["feedback"]
+    plan = current["plan"]
+    blockers = blocker_strings(current["promotion"]) + blocker_strings(handoff)
+    blocker_action = classify_blockers(blockers)
+
+    candidate_count = int(feedback.get("candidate_count") or 0)
+    rejected_count = int(feedback.get("rejected_count") or 0)
+    reject_ratio = rejected_count / candidate_count if candidate_count > 0 else 0.0
+    current_reward = as_float(feedback.get("best_reward"))
+    prior_rewards = [
+        as_float(run["feedback"].get("best_reward"))
+        for run in runs[:-1]
+        if as_float(run["feedback"].get("best_reward")) is not None
+    ]
+    prior_best_reward = max(prior_rewards) if prior_rewards else None
+
+    if handoff.get("status") == "ready":
+        action = "ready_handoff"
+        reason = "autofactor_strategy_handoff_ready"
+    elif blocker_action in {"fix_runtime", "fix_data", "fix_workflow", "revise_prior"}:
+        action = blocker_action
+        reason = f"promotion_blockers_require_{blocker_action}"
+    elif not feedback:
+        action = "fix_data"
+        reason = "missing_search_feedback"
+    elif candidate_count == 0:
+        action = "fix_data"
+        reason = "zero_search_candidates"
+    elif chain.get("reason") == "reward_stagnation":
+        action = "revise_prior"
+        reason = "reward_stagnation"
+    elif (
+        current_reward is not None
+        and prior_best_reward is not None
+        and current_reward <= prior_best_reward
+    ):
+        action = "revise_prior"
+        reason = "latest_best_reward_did_not_improve"
+    elif chain.get("reason") == "no_selected_nodes":
+        action = "revise_prior"
+        reason = "no_selected_nodes"
+    elif not selected_nodes(plan):
+        action = "revise_prior"
+        reason = "mcts_plan_has_no_selected_nodes"
+    elif reject_ratio >= 0.75:
+        action = "revise_prior"
+        reason = "high_rejected_candidate_ratio"
+    elif chain.get("reason") == "continue" and chain.get("should_dispatch") is True:
+        action = "continue_search"
+        reason = "mcts_chain_requested_next_run"
+    elif chain.get("reason") in {
+        "missing_mcts_expansion_plan",
+        "missing_current_search_feedback",
+        "missing_best_reward",
+        "invalid_best_reward",
+    }:
+        action = "fix_data"
+        reason = str(chain.get("reason"))
+    elif handoff.get("status") == "blocked":
+        action = blocker_action or "revise_prior"
+        reason = "handoff_blocked_without_ready_strategy"
+    else:
+        action = "continue_search"
+        reason = "search_has_expandable_mcts_nodes"
+
+    allow_dispatch = (
+        action == "continue_search"
+        and chain.get("reason") == "continue"
+        and chain.get("should_dispatch") is True
+    )
+    best = best_run(runs)
+    return {
+        "schema_version": 1,
+        "kind": "alpha_search_closed_loop_decision",
+        "target": current["target"],
+        "decision": action,
+        "action": action,
+        "allow_dispatch": allow_dispatch,
+        "reason": reason,
+        "guarantee": "No profitability guarantee. This artifact only selects the next evidence-producing action.",
+        "profit_claim": False,
+        "external_llm_called": False,
+        "evidence_stage": "walk_forward",
+        "current_run": summarize_run(current),
+        "best_run": summarize_run(best) if best else None,
+        "artifact_count": len(runs),
+        "runs": [summarize_run(run) for run in runs],
+        "promotion_blockers": blockers,
+        "next_steps": next_steps(action),
+        "prior_revision_required": action == "revise_prior",
+    }
+
+
+def summarize_run(run: dict[str, Any]) -> dict[str, Any]:
+    feedback = run["feedback"]
+    handoff = run["handoff"]
+    chain = run["chain"]
+    plan_nodes = selected_nodes(run["plan"])
+    return {
+        "artifact_dir": run["artifact_dir"],
+        "run_id": run["run_id"],
+        "candidate_count": feedback.get("candidate_count"),
+        "passed_count": feedback.get("passed_count"),
+        "rejected_count": feedback.get("rejected_count"),
+        "best_candidate": feedback.get("best_candidate"),
+        "best_reward": feedback.get("best_reward"),
+        "selected_node_count": len(plan_nodes),
+        "top_selected_factor": plan_nodes[0].get("factor_name") if plan_nodes else None,
+        "handoff_status": handoff.get("status"),
+        "recommended_action": handoff.get("recommended_action"),
+        "chain_reason": chain.get("reason"),
+        "chain_should_dispatch": chain.get("should_dispatch"),
+    }
+
+
+def next_steps(action: str) -> list[str]:
+    if action == "ready_handoff":
+        return [
+            "Run the ready-only AutoFactor promotion/config PR path.",
+            "Do not deploy live; dry-run promotion still requires normal PR and runtime gates.",
+        ]
+    if action == "continue_search":
+        return [
+            "Dispatch the next bounded hosted alpha-search iteration with the current MCTS plan.",
+            "Keep evidence stage as walk_forward until promotion gates pass.",
+        ]
+    if action == "revise_prior":
+        return [
+            "Review weak dimensions and generated typed prior mutations.",
+            "Pass the generated prior JSON through options_json.alpha_search_llm_prior_json on the next search run.",
+        ]
+    if action == "fix_data":
+        return [
+            "Fix missing or weak data surfaces before additional model/search tuning.",
+            "Rebuild or choose a snapshot with official settlement, full-depth CLOB, and adequate event coverage.",
+        ]
+    if action == "fix_runtime":
+        return [
+            "Fix runtime scorer/config/parity mapping before promoting any factor.",
+            "Rerun recorded replay/dry-run parity after the runtime fix.",
+        ]
+    return [
+        "Repair the workflow artifact bundle before interpreting search quality.",
+        "Rerun the hosted artifact workflow and require the full alpha-search artifact bundle.",
+    ]
+
+
+def feature_available(search_space: dict[str, Any], feature: str) -> bool:
+    pool = search_space.get("feature_pool")
+    return isinstance(pool, list) and feature in pool
+
+
+def choose_feature(search_space: dict[str, Any], mutation_type: str) -> str | None:
+    for feature in PREFERRED_FEATURES.get(mutation_type, []):
+        if feature_available(search_space, feature):
+            return feature
+    return None
+
+
+def mutation_from_node(node: dict[str, Any]) -> str:
+    proposed = str(node.get("proposed_mutation") or "")
+    if proposed in ALLOWED_MUTATIONS:
+        return proposed
+    dimension = str(node.get("selected_dimension") or "")
+    return DIMENSION_TO_MUTATION.get(dimension, "clip_or_squash")
+
+
+def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int) -> dict[str, Any]:
+    current = latest_run(runs)
+    mutations = []
+    for node in selected_nodes(current["plan"])[:limit]:
+        base_factor = str(node.get("factor_name") or "")
+        if not base_factor:
+            continue
+        mutation_type = mutation_from_node(node)
+        if mutation_type == "do_not_expand_collect_more_data":
+            mutation_type = "add_feature_gate"
+        item: dict[str, Any] = {
+            "base_factor": base_factor,
+            "mutation_type": mutation_type,
+            "name": f"llm_{base_factor}_{mutation_type}",
+        }
+        feature = choose_feature(current["search_space"], mutation_type)
+        if feature:
+            if mutation_type == "replace_denominator":
+                item["denominator_feature"] = feature
+            else:
+                item["feature"] = feature
+        if mutation_type in {"replace_denominator", "add_spread_penalty"}:
+            item["constant"] = 0.01
+        if mutation_type == "clip_or_squash":
+            item["lo"] = -3.0
+            item["hi"] = 3.0
+        if mutation_type == "change_time_window":
+            item["window"] = 30
+        mutations.append(item)
+
+    if not mutations and decision["action"] == "revise_prior":
+        mutations.append(
+            {
+                "base_factor": "auto_settlement_full_depth_settlement_edge",
+                "mutation_type": "add_capacity_gate",
+                "name": "llm_full_depth_edge_capacity_gate",
+                "feature": "entry_capacity_score",
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "kind": "typed_llm_prior_draft",
+        "source": "alpha_search_closed_loop_agent",
+        "target": current["target"],
+        "decision_reason": decision["reason"],
+        "mutations": mutations,
+    }
+
+
+def write_markdown(decision: dict[str, Any], path: Path, prior_path: Path | None) -> None:
+    current = decision["current_run"]
+    lines = [
+        "# Alpha Search Closed-Loop Decision",
+        "",
+        f"- Action: `{decision['action']}`",
+        f"- Reason: `{decision['reason']}`",
+        f"- Allow chained dispatch: `{decision['allow_dispatch']}`",
+        f"- Evidence stage: `{decision['evidence_stage']}`",
+        f"- Target: `{decision['target']}`",
+        f"- Current run: `{current.get('run_id') or 'n/a'}`",
+        f"- Best candidate: `{current.get('best_candidate') or 'n/a'}`",
+        f"- Best reward: `{current.get('best_reward') if current.get('best_reward') is not None else 'n/a'}`",
+        f"- Handoff status: `{current.get('handoff_status') or 'n/a'}`",
+        f"- Chain reason: `{current.get('chain_reason') or 'n/a'}`",
+        "",
+        decision["guarantee"],
+        "",
+        "## Next Steps",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in decision["next_steps"])
+    if prior_path is not None:
+        lines.extend(["", f"Typed prior draft: `{prior_path}`"])
+    if decision["promotion_blockers"]:
+        lines.extend(["", "## Promotion Blockers", ""])
+        lines.extend(f"- `{item}`" for item in decision["promotion_blockers"][:20])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact_dir", nargs="+", help="Downloaded alpha-search artifact directories")
+    parser.add_argument("--target", default=DEFAULT_TARGET)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md", required=True)
+    parser.add_argument("--output-prior-json")
+    parser.add_argument("--prior-mutation-limit", type=int, default=6)
+    args = parser.parse_args()
+
+    runs = [load_artifact(Path(value), args.target) for value in args.artifact_dir]
+    decision = closed_loop_decision(runs)
+
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    prior_path = Path(args.output_prior_json) if args.output_prior_json else None
+    if prior_path is not None and decision["prior_revision_required"]:
+        prior = build_prior(runs, decision, max(1, args.prior_mutation_limit))
+        prior_path.parent.mkdir(parents=True, exist_ok=True)
+        prior_path.write_text(json.dumps(prior, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    elif prior_path is not None and prior_path.exists():
+        prior_path.unlink()
+
+    write_markdown(decision, Path(args.output_md), prior_path if decision["prior_revision_required"] else None)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -183,6 +183,8 @@ class AutoFactorRow:
     top_bucket_full_depth_entry_fill_rate: float
     top_bucket_avg_entry_sweep_slip_bps: float | None
     top_bucket_avg_entry_sweep_levels: float | None
+    top_bucket_unique_event_count: int
+    top_bucket_max_event_decisions: int
     complexity: int
 
 
@@ -212,6 +214,8 @@ def factor_metrics(row: AutoFactorRow) -> dict[str, Any]:
         "top_bucket_full_depth_entry_fill_rate": row.top_bucket_full_depth_entry_fill_rate,
         "top_bucket_avg_entry_sweep_slip_bps": row.top_bucket_avg_entry_sweep_slip_bps,
         "top_bucket_avg_entry_sweep_levels": row.top_bucket_avg_entry_sweep_levels,
+        "top_bucket_unique_event_count": row.top_bucket_unique_event_count,
+        "top_bucket_max_event_decisions": row.top_bucket_max_event_decisions,
         "complexity": row.complexity,
     }
 
@@ -336,6 +340,12 @@ def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
                 ),
                 top_bucket_avg_entry_sweep_levels=finite_or_none(
                     parse_float(item.get("top_bucket_avg_entry_sweep_levels", "nan"))
+                ),
+                top_bucket_unique_event_count=parse_int(
+                    item.get("top_bucket_unique_event_count", "0")
+                ),
+                top_bucket_max_event_decisions=parse_int(
+                    item.get("top_bucket_max_event_decisions", "0")
                 ),
                 complexity=parse_int(item["complexity"]),
             )
@@ -489,6 +499,13 @@ def evaluate(
             )
         if row.window_count < min_window_count:
             blockers.append(f"window_count_too_small:{row.window_count}<{min_window_count}")
+        if row.top_bucket_unique_event_count <= 0 or row.top_bucket_max_event_decisions <= 0:
+            blockers.append("missing_one_event_decision_gate")
+        elif row.top_bucket_max_event_decisions > 1:
+            blockers.append(
+                "one_event_decision_violation:"
+                f"max_event_decisions={row.top_bucket_max_event_decisions}"
+            )
         if not mapping:
             blockers.append("missing_runtime_strategy_mapping")
         else:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -213,6 +213,51 @@ Evidence stage: `dry_run_candidate`.
   `CARGO_TARGET_DIR=/tmp/ploy-three-layer-slippage rtk cargo test -p ploy-strategy-bundles config --lib`,
   and `rtk git diff --check`.
 
+# Closed-Loop Alpha Search Reward Hardening (2026-05-18)
+
+## Goal
+
+Move event-level uniqueness and execution capacity from promotion-only
+blockers into the MCTS/search reward itself, so the next CI search expands
+tradeable one-event-one-decision candidates instead of repeatedly selecting
+high raw-score but non-deployable branches.
+
+Evidence stage: `factor_attribution / alpha-search CI repair`.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/alpha_search.rs`
+  - Owner: expose event-decision and top-bucket sweep metrics in node metrics,
+    penalize repeated-event and poor-execution branches in reward/UCB, and
+    steer selected dimensions toward bounded capacity/event filters.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document that search reward includes event-level uniqueness and
+    execution-capacity penalties before promotion.
+
+## Tasks
+
+- [x] Add event uniqueness / repeated-decision metrics to MCTS node metrics.
+- [x] Penalize `top_bucket_max_event_decisions > 1`, low event diversity, high
+      sweep slippage, and excessive sweep levels in `reward`.
+- [x] Route repeated-event candidates to `event_uniqueness` /
+      `add_capacity_gate` style mutations before generic exploit.
+- [x] Add focused Rust regression tests for ranking and selected mutation.
+- [x] Run focused validation and push the PR update after green checks.
+
+## Review
+
+- 2026-05-18: Added event-level uniqueness and top-bucket sweep fields to
+  alpha-search node metrics. Repeated top-bucket event decisions now select
+  `event_uniqueness`, propose `add_capacity_gate`, and receive a direct reward
+  penalty before the promotion gate. High sweep slippage, excessive sweep
+  levels, and low top-bucket fillability select `execution_quality` and also
+  reduce reward.
+- 2026-05-18: Focused local validation passed:
+  `rtk cargo test --locked -p ploy-research alpha_search --lib`,
+  `rtk cargo test --locked -p ploy-research autofactor --lib`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
+  workflow YAML load, `rustfmt --check`, and `rtk git diff --check`.
+
 # Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -1,0 +1,304 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import alpha_search_closed_loop_agent as agent
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "alpha_search_closed_loop_agent.py"
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def artifact(
+    root: Path,
+    *,
+    handoff_status: str = "blocked",
+    chain_reason: str = "chain_next_run_false",
+    should_dispatch: bool = False,
+    selected_nodes: list[dict] | None = None,
+    feedback: dict | None = None,
+    promotion: dict | None = None,
+    write_feedback: bool = True,
+) -> Path:
+    target = "full_depth_settlement_executable_pnl"
+    factor_root = root / "factor-walk-forward-v2"
+    alpha_root = factor_root / "alpha-search" / target
+    if write_feedback:
+        write_json(
+            alpha_root / "search-feedback.json",
+            feedback
+            or {
+                "target": target,
+                "candidate_count": 4,
+                "rejected_count": 1,
+                "passed_count": 0,
+                "best_candidate": "auto_settlement_full_depth_settlement_edge",
+                "best_reward": 1.25,
+            },
+        )
+    write_json(
+        alpha_root / "mcts-expansion-plan.json",
+        {
+            "target": target,
+            "selected_nodes": selected_nodes
+            if selected_nodes is not None
+            else [
+                {
+                    "factor_name": "auto_settlement_full_depth_settlement_edge",
+                    "selected_dimension": "execution_quality",
+                    "proposed_mutation": "add_capacity_gate",
+                }
+            ],
+        },
+    )
+    write_json(
+        alpha_root / "search-space.json",
+        {
+            "target": target,
+            "feature_pool": [
+                "entry_capacity_score",
+                "full_depth_entry_fillable_gate",
+                "near_strike_score",
+                "side_spread",
+            ],
+        },
+    )
+    write_json(
+        factor_root / "autofactor-strategy-handoff.json",
+        {
+            "status": handoff_status,
+            "recommended_action": "create_dry_run_handoff"
+            if handoff_status == "ready"
+            else "do_not_promote",
+        },
+    )
+    write_json(
+        factor_root / "autofactor-strategy-promotion.json",
+        promotion or {"decision": "blocked", "evaluated_factors": []},
+    )
+    write_json(
+        root / "alpha-search-chain" / "chain-decision.json",
+        {
+            "current_run_id": "123456789",
+            "reason": chain_reason,
+            "should_dispatch": should_dispatch,
+        },
+    )
+    return root
+
+
+def run_artifact(parent: Path, run_id: str, *, best_reward: float) -> Path:
+    return artifact(
+        parent / f"factor-walk-forward-v2-{run_id}",
+        feedback={
+            "target": agent.DEFAULT_TARGET,
+            "candidate_count": 4,
+            "rejected_count": 1,
+            "passed_count": 0,
+            "best_candidate": "auto_settlement_full_depth_settlement_edge",
+            "best_reward": best_reward,
+        },
+    )
+
+
+class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
+    def test_ready_handoff_wins(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), handoff_status="ready")
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "ready_handoff")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertFalse(decision["profit_claim"])
+            self.assertFalse(decision["external_llm_called"])
+            self.assertFalse(decision["prior_revision_required"])
+
+    def test_continue_search_when_chain_dispatches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), chain_reason="continue", should_dispatch=True)
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "continue_search")
+            self.assertTrue(decision["allow_dispatch"])
+
+    def test_reward_stagnation_generates_prior_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), chain_reason="reward_stagnation")
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertTrue(decision["prior_revision_required"])
+
+    def test_high_rejection_generates_prior_from_selected_nodes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 10,
+                    "rejected_count": 8,
+                    "passed_count": 0,
+                    "best_candidate": "auto_settlement_full_depth_settlement_edge",
+                    "best_reward": 1.25,
+                },
+            )
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertEqual(prior["mutations"][0]["mutation_type"], "add_capacity_gate")
+            self.assertEqual(prior["mutations"][0]["feature"], "full_depth_entry_fillable_gate")
+
+    def test_multiple_artifacts_detect_reward_stagnation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = run_artifact(root, "11111111", best_reward=2.0)
+            second = run_artifact(root, "22222222", best_reward=2.0)
+            decision = agent.closed_loop_decision(
+                [
+                    agent.load_artifact(first, agent.DEFAULT_TARGET),
+                    agent.load_artifact(second, agent.DEFAULT_TARGET),
+                ]
+            )
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertEqual(decision["artifact_count"], 2)
+
+    def test_no_selected_nodes_generates_safe_fallback_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), chain_reason="no_selected_nodes", selected_nodes=[])
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertTrue(decision["prior_revision_required"])
+            self.assertEqual(
+                prior["mutations"][0]["base_factor"],
+                "auto_settlement_full_depth_settlement_edge",
+            )
+
+    def test_runtime_blocker_routes_to_fix_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {"blockers": ["missing_runtime_strategy_mapping"]}
+                    ],
+                },
+            )
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_runtime")
+
+    def test_execution_blockers_take_priority_over_runtime_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "one_event_decision_violation:max_event_decisions=3",
+                                "missing_runtime_strategy_mapping",
+                            ]
+                        }
+                    ],
+                },
+            )
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertFalse(decision["allow_dispatch"])
+            self.assertTrue(decision["prior_revision_required"])
+
+    def test_missing_recorded_replay_artifact_routes_to_fix_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "recorded_replay_parity: blocked: no recorded replay parity artifact was supplied to this report"
+                            ]
+                        }
+                    ],
+                },
+            )
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_workflow")
+            self.assertFalse(decision["allow_dispatch"])
+
+    def test_missing_feedback_routes_to_fix_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), write_feedback=False)
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_data")
+
+    def test_cli_writes_json_markdown_and_prior_for_revise_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = artifact(
+                root,
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 10,
+                    "rejected_count": 8,
+                    "passed_count": 0,
+                    "best_candidate": "auto_settlement_full_depth_settlement_edge",
+                    "best_reward": 1.25,
+                },
+            )
+            output_json = root / "decision.json"
+            output_md = root / "decision.md"
+            output_prior = root / "llm-priors-draft.json"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(path),
+                    "--output-json",
+                    str(output_json),
+                    "--output-md",
+                    str(output_md),
+                    "--output-prior-json",
+                    str(output_prior),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            decision = json.loads(output_json.read_text(encoding="utf-8"))
+            prior = json.loads(output_prior.read_text(encoding="utf-8"))
+            markdown = output_md.read_text(encoding="utf-8")
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(prior["kind"], "typed_llm_prior_draft")
+            self.assertEqual(prior["mutations"][0]["mutation_type"], "add_capacity_gate")
+            self.assertIn("No profitability guarantee", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -67,59 +67,59 @@ AUTOFACTOR_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable repricing PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,63255,0.112526,0.058830,54,0.948193,0.8889,0.5000,12651,1.902254,0.6656,0.9000,5
-2,settlement_fair_edge,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.208894,-0.007501,45,-2.321308,0.0222,0.5000,11555,-2.981937,0.5035,0.9000,1
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,63255,0.112526,0.058830,54,0.948193,0.8889,0.5000,12651,1.902254,0.6656,0.9000,12651,1,5
+2,settlement_fair_edge,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.208894,-0.007501,45,-2.321308,0.0222,0.5000,11555,-2.981937,0.5035,0.9000,11555,1,1
 
 # AutoFactor target=full_depth_reprice_pnl_10s
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable repricing PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,spread_adjusted_external_move,full_depth_reprice_pnl_10s,candidate,passed,49789,0.327294,0.123771,40,3.301626,1.0000,0.5000,9958,1.625037,0.5354,0.9000,5
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,spread_adjusted_external_move,full_depth_reprice_pnl_10s,candidate,passed,49789,0.327294,0.123771,40,3.301626,1.0000,0.5000,9958,1.625037,0.5354,0.9000,9958,1,5
 """
 
 AUTOFACTOR_SETTLEMENT_AUTO_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,1
-2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,6,0.8333,1.0000,9966,2.631575,0.6790,0.9000,3
-3,auto_settlement_conservative_settlement_edge_x_entry_price_quality,full_depth_settlement_executable_pnl,candidate,passed,49831,0.106112,0.155901,43,1.031294,0.9070,6,0.8333,1.0000,9966,2.512771,0.6712,0.9000,3
-4,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,11555,-0.301991,0.4785,0.9000,3
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,9966,1,1
+2,auto_settlement_conservative_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,49831,0.107526,0.157904,43,1.044245,0.9302,6,0.8333,1.0000,9966,2.631575,0.6790,0.9000,9966,1,3
+3,auto_settlement_conservative_settlement_edge_x_entry_price_quality,full_depth_settlement_executable_pnl,candidate,passed,49831,0.106112,0.155901,43,1.031294,0.9070,6,0.8333,1.0000,9966,2.512771,0.6712,0.9000,9966,1,3
+4,auto_settlement_full_depth_settlement_edge_x_external_pressure,full_depth_settlement_executable_pnl,reject,nonpositive_rank_ic,57777,-0.021993,0.069182,45,0.217558,0.4667,6,0.5000,0.5000,11555,-0.301991,0.4785,0.9000,11555,1,3
 """
 
 AUTOFACTOR_PREDICTIVE_EXTERNAL_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,amplitude_weighted_momentum_30s_sigma,full_depth_settlement_executable_pnl,candidate,passed,3167,0.083421,0.044219,8,1.102341,0.8750,2,1.0000,1.0000,634,1.471203,0.6120,0.9000,3
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,amplitude_weighted_momentum_30s_sigma,full_depth_settlement_executable_pnl,candidate,passed,3167,0.083421,0.044219,8,1.102341,0.8750,2,1.0000,1.0000,634,1.471203,0.6120,0.9000,634,1,3
 """
 
 AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,6
-2,mut_spread_adjusted_external_move_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.065967,0.092183,14,1.268732,0.9286,2,1.0000,0.5000,667,1.388814,0.6042,1.0000,7
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,667,1,6
+2,mut_spread_adjusted_external_move_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.065967,0.092183,14,1.268732,0.9286,2,1.0000,0.5000,667,1.388814,0.6042,1.0000,667,1,7
 """
 
 AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity
-1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,80.00,2.20,1
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,80.00,2.20,667,1,1
 """
 
 AUTOFACTOR_TOP_BUCKET_BAD_EXECUTION_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,complexity
-1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,450.00,3.40,1
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_conservative_settlement_edge,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,450.00,3.40,667,1,1
 """
 
 CORE_SUITE_REPORT = f"""
@@ -464,8 +464,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
     def test_blocks_runtime_mapped_candidate_with_low_top_bucket_fillability(self):
         thin_report = AUTOFACTOR_SETTLEMENT_AUTO_REPORT.replace(
-            ",0.6836,0.9000,1",
-            ",0.6836,0.1458,1",
+            ",0.6836,0.9000,9966,1,1",
+            ",0.6836,0.1458,9966,1,1",
             1,
         )
 
@@ -482,6 +482,42 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn(
             "top_bucket_full_depth_entry_fill_rate_too_low:0.1458<0.3000",
             thin["blockers"],
+        )
+
+    def test_blocks_candidate_when_one_event_decision_gate_is_missing(self):
+        legacy_report = AUTOFACTOR_SETTLEMENT_AUTO_REPORT.replace(
+            ",top_bucket_unique_event_count,top_bucket_max_event_decisions",
+            "",
+        )
+        legacy_report = legacy_report.replace(",9966,1,1", ",1", 1)
+
+        _, payload, _, handoff, _ = self.run_script(READY_GATE + legacy_report)
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertIn("missing_one_event_decision_gate", first["blockers"])
+
+    def test_blocks_candidate_when_top_bucket_repeats_event(self):
+        duplicate_event_report = AUTOFACTOR_SETTLEMENT_AUTO_REPORT.replace(
+            ",9966,1,1",
+            ",4000,3,1",
+            1,
+        )
+
+        _, payload, _, handoff, _ = self.run_script(READY_GATE + duplicate_event_report)
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        first = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "auto_settlement_conservative_settlement_edge"
+        )
+        self.assertFalse(first["qualified"])
+        self.assertIn(
+            "one_event_decision_violation:max_event_decisions=3",
+            first["blockers"],
         )
 
 

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -22,8 +22,8 @@ recorded_replay_parity,true,blocking_flags=<none>
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,1
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,9966,1,1
 """)
 '''
 
@@ -38,9 +38,9 @@ recorded_replay_parity,false,shared_event_count=0
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,3335,0.067525,0.081201,14,1.288053,0.9286,2,1.0000,1.0000,667,1.660059,0.6132,0.9000,6
-2,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,2798,0.067534,0.091002,12,1.018091,0.7500,2,1.0000,1.0000,560,2.507843,0.6250,0.9000,1
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,3335,0.067525,0.081201,14,1.288053,0.9286,2,1.0000,1.0000,667,1.660059,0.6132,0.9000,667,1,6
+2,auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl,candidate,passed,2798,0.067534,0.091002,12,1.018091,0.7500,2,1.0000,1.0000,560,2.507843,0.6250,0.9000,560,1,1
 """)
 '''
 
@@ -59,8 +59,8 @@ recorded_replay_parity,true,blocking_flags=<none>
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,mut_spread_adjusted_external_move_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.065967,0.092183,14,1.268732,0.9286,2,1.0000,0.5000,667,1.388814,0.6042,1.0000,7
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_spread_adjusted_external_move_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.065967,0.092183,14,1.268732,0.9286,2,1.0000,0.5000,667,1.388814,0.6042,1.0000,667,1,7
 """)
 else:
     print("""=== Settlement Probability PRD Promotion Gate ===
@@ -71,8 +71,8 @@ recorded_replay_parity,true,blocking_flags=<none>
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
 target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
-rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,complexity
-1,mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,6
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate,tradeable_full_depth_settlement_pnl,candidate,passed,3335,0.080512,0.076800,14,0.951390,0.9286,2,1.0000,0.7500,667,0.872484,0.5757,1.0000,667,1,6
 """)
 '''
 


### PR DESCRIPTION
## Summary
- add a deterministic alpha-search closed-loop classifier for hosted artifact runs
- require closed-loop classifier authorization before chained dispatch
- add one-event-one-decision AutoFactor promotion fields and fail-closed gate

## Validation
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/alpha_search_closed_loop_agent.py tests/test_autofactor_strategy_promotion.py tests/test_alpha_search_closed_loop_agent.py
- CARGO_TARGET_DIR=/tmp/ploy-closed-loop-alpha-ci /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor --lib
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "yaml ok"'\n- rtk git diff --check\n\n## Safety\nNo live trading or deployment changes. Research CI remains walk-forward/factor-attribution evidence; promotion still requires the existing gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated closed-loop review for alpha-search that emits a machine-readable decision and optional typed prior draft.
  * Chained dispatch now respects the closed-loop decision outcome and clears prior data when forwarding runs.
  * Event-level analytics and promotion gates to block factors with repeated/missing event decisions.

* **Documentation**
  * CI/CD docs updated to describe the closed-loop review actions and event-level promotion requirements.

* **Tests**
  * Expanded tests covering closed-loop routing, prior-draft generation, and event-level promotion gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->