### PR TITLE
Score settlement AutoFactors at event level

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -384,7 +384,7 @@ pub fn evaluate_named_factor(
     }
 
     let signal = factor.expr.evaluate(matrix)?;
-    let scored: Vec<(usize, f64, f64)> = signal
+    let scored_rows: Vec<(usize, f64, f64)> = signal
         .iter()
         .zip(labels.iter())
         .enumerate()
@@ -392,6 +392,11 @@ pub fn evaluate_named_factor(
             (score.is_finite() && label.is_finite()).then_some((idx, *score, *label))
         })
         .collect();
+    let scored = if uses_event_level_decisions(factor.target.as_deref()) {
+        one_decision_per_event(&scored_rows, event_ids)
+    } else {
+        scored_rows
+    };
 
     let pairs: Vec<(f64, f64)> = scored
         .iter()
@@ -1674,6 +1679,45 @@ fn build_buckets(
         .collect()
 }
 
+fn uses_event_level_decisions(target: Option<&str>) -> bool {
+    matches!(
+        target,
+        Some(
+            "settlement_executable_pnl"
+                | "full_depth_settlement_executable_pnl"
+                | "tradeable_full_depth_settlement_pnl"
+        )
+    )
+}
+
+fn one_decision_per_event(
+    scored: &[(usize, f64, f64)],
+    event_ids: &[String],
+) -> Vec<(usize, f64, f64)> {
+    if event_ids.is_empty() {
+        return scored.to_vec();
+    }
+
+    let mut best_by_event: BTreeMap<&str, (usize, f64, f64)> = BTreeMap::new();
+    for (idx, score, label) in scored {
+        let Some(event_id) = event_ids.get(*idx) else {
+            continue;
+        };
+        best_by_event
+            .entry(event_id.as_str())
+            .and_modify(|current| {
+                if *score > current.1 || (*score == current.1 && *idx < current.0) {
+                    *current = (*idx, *score, *label);
+                }
+            })
+            .or_insert((*idx, *score, *label));
+    }
+
+    let mut selected = best_by_event.into_values().collect::<Vec<_>>();
+    selected.sort_by_key(|(idx, _, _)| *idx);
+    selected
+}
+
 fn top_bucket_event_decision_stats(
     bucket: Option<&BucketSummary>,
     event_ids: &[String],
@@ -2305,6 +2349,33 @@ mod tests {
             Some("settlement_executable_pnl")
         );
         assert!(fair_edge.spearman_ic > 0.95);
+        assert_eq!(fair_edge.n, 40);
+        assert_eq!(
+            fair_edge.top_bucket_unique_event_count,
+            fair_edge.top_bucket_n
+        );
+        assert_eq!(fair_edge.top_bucket_max_event_decisions, 1);
+    }
+
+    #[test]
+    fn repricing_targets_keep_row_level_diagnostics() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+        let reports =
+            mine_domain_autofactors_from_v2(&rows, AutoFactorV2Target::RepricePnl10s, &options)
+                .expect("reports");
+        let repricing_gap = reports
+            .iter()
+            .find(|report| report.name == "repricing_gap_side_10s")
+            .expect("repricing gap report");
+
+        assert_eq!(repricing_gap.n, 80);
+        assert!(repricing_gap.top_bucket_max_event_decisions > 1);
     }
 
     #[test]
@@ -2334,6 +2405,12 @@ mod tests {
             Some("full_depth_settlement_executable_pnl")
         );
         assert!(full_depth_edge.spearman_ic > 0.95);
+        assert_eq!(full_depth_edge.n, 40);
+        assert_eq!(
+            full_depth_edge.top_bucket_unique_event_count,
+            full_depth_edge.top_bucket_n
+        );
+        assert_eq!(full_depth_edge.top_bucket_max_event_decisions, 1);
         assert!(reports.iter().any(|report| {
             report.name == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity"
         }));

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -433,6 +433,13 @@ keeps MCTS from repeatedly expanding branches that look strong only because
 the same event contributed multiple diagnostic rows or because the entry was
 not realistically executable.
 
+For settlement targets, AutoFactor scoring itself must be event-level:
+`settlement_executable_pnl`, `full_depth_settlement_executable_pnl`, and
+`tradeable_full_depth_settlement_pnl` collapse observations to one scored
+candidate decision per event before IC, bucket, and promotion metrics are
+computed. Repricing targets can remain row-level diagnostics because their
+question is short-horizon quote movement, not final event settlement.
+
 ## Completion Criteria
 
 The method is fully defined only when CI exposes all of the following:
@@ -506,6 +513,9 @@ Current implementation status:
 - Implemented: alpha-search node metrics and MCTS reward now include
   event-level uniqueness and execution-capacity penalties, so repeated-event or
   high-slippage candidates are de-prioritized before the promotion gate.
+- Implemented: settlement AutoFactor targets score one candidate decision per
+  event before bucket and promotion metrics, while repricing targets preserve
+  row-level diagnostics.
 - Implemented as artifact and input contract: `llm-priors.json` records the
   typed prior schema, and an operator- or LLM-produced prior file can now enter
   CI through `--alpha-search-llm-prior-json` / `options_json.alpha_search_llm_prior_json`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -258,6 +258,47 @@ Evidence stage: `factor_attribution / alpha-search CI repair`.
   `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
   workflow YAML load, `rustfmt --check`, and `rtk git diff --check`.
 
+# AutoFactor Event-Level Settlement Decisions (2026-05-18)
+
+## Goal
+
+Stop settlement-probability AutoFactor searches from treating multiple rows in
+the same 5-minute event as independent deployable decisions. Settlement targets
+should evaluate one candidate decision per event before bucket, IC, and
+promotion metrics are computed.
+
+Evidence stage: `factor_attribution / executable_replay semantics repair`.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/autofactor.rs`
+  - Owner: collapse settlement targets to one scored decision per event while
+    preserving row-level diagnostics for repricing targets.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: clarify that settlement target scoring is event-level, while
+    repricing diagnostics may remain row-level.
+
+## Tasks
+
+- [x] Apply one-decision-per-event scoring to settlement AutoFactor targets.
+- [x] Preserve row-level scoring for repricing targets.
+- [x] Add regression coverage for settlement dedup and repricing row-level
+      diagnostics.
+- [x] Run focused validation, open PR, merge after green CI, then rerun hosted
+      alpha search from `main`.
+
+## Review
+
+- 2026-05-18: Settlement AutoFactor targets now collapse scored rows to one
+  highest-score candidate decision per event before IC, bucket, and promotion
+  metrics. Repricing targets keep row-level diagnostics.
+- 2026-05-18: Focused validation passed:
+  `rtk cargo test --locked -p ploy-research autofactor --lib`,
+  `rtk cargo test --locked -p ploy-research alpha_search --lib`,
+  `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_alpha_search_closed_loop_agent`,
+  `rustfmt --check crates/ploy-research/src/autofactor.rs`, and
+  `rtk git diff --check`.
+
 # Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
 
 ## Goal


### PR DESCRIPTION
## Summary
- collapse settlement AutoFactor scoring to one candidate decision per event before IC, bucket, and promotion metrics
- preserve row-level diagnostics for repricing targets
- document the event-level settlement scoring contract

## Validation
- CARGO_TARGET_DIR=/tmp/ploy-event-level-autofactor /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor --lib
- CARGO_TARGET_DIR=/tmp/ploy-event-level-autofactor /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_alpha_search_closed_loop_agent
- rustfmt --check crates/ploy-research/src/autofactor.rs
- rtk git diff --check

## Evidence Stage
factor_attribution / executable_replay semantics repair
