### PR TITLE
Filter closed-loop blockers by target

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -135,6 +135,29 @@ def blocker_strings(payload: Any) -> list[str]:
     return out
 
 
+def target_blocker_strings(payload: Any, target: str) -> list[str]:
+    out: list[str] = []
+    if isinstance(payload, dict):
+        evaluated = payload.get("evaluated_factors")
+        if isinstance(evaluated, list):
+            for item in evaluated:
+                if not isinstance(item, dict):
+                    continue
+                factor = item.get("factor")
+                factor_target = factor.get("target") if isinstance(factor, dict) else None
+                if factor_target in {None, target}:
+                    blockers = item.get("blockers", [])
+                    if isinstance(blockers, list):
+                        out.extend(str(blocker) for blocker in blockers)
+                    else:
+                        out.extend(blocker_strings(blockers))
+            payload = {key: value for key, value in payload.items() if key != "evaluated_factors"}
+        out.extend(blocker_strings(payload))
+    else:
+        out.extend(blocker_strings(payload))
+    return out
+
+
 def classify_blockers(blockers: list[str]) -> str | None:
     text = " ".join(blockers).lower()
     if not text:
@@ -193,7 +216,7 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     chain = current["chain"]
     feedback = current["feedback"]
     plan = current["plan"]
-    blockers = blocker_strings(current["promotion"]) + blocker_strings(handoff)
+    blockers = target_blocker_strings(current["promotion"], current["target"]) + blocker_strings(handoff)
     blocker_action = classify_blockers(blockers)
 
     candidate_count = int(feedback.get("candidate_count") or 0)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -299,6 +299,41 @@ Evidence stage: `factor_attribution / executable_replay semantics repair`.
   `rustfmt --check crates/ploy-research/src/autofactor.rs`, and
   `rtk git diff --check`.
 
+# Closed-Loop Target Blocker Filtering (2026-05-18)
+
+## Goal
+
+Prevent the closed-loop classifier for
+`full_depth_settlement_executable_pnl` from treating blockers on non-target
+repricing diagnostic rows as the next action for the settlement search loop.
+
+Evidence stage: `walk_forward / alpha-search CI repair`.
+
+## Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: filter `evaluated_factors` blockers by requested target before
+    classifying the next closed-loop action.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: cover non-target blocker filtering.
+
+## Tasks
+
+- [x] Filter promotion blockers by factor target for closed-loop action
+      classification.
+- [x] Preserve handoff/global blockers as target-relevant blockers.
+- [x] Add regression coverage and run focused Python validation.
+
+## Review
+
+- 2026-05-18: Closed-loop blocker classification now ignores blockers from
+  `evaluated_factors` whose `factor.target` differs from the requested
+  alpha-search target, while still keeping handoff/global blockers.
+- 2026-05-18: Validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep`,
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  and `rtk git diff --check`.
+
 # Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -193,6 +193,8 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(
                 Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
                 promotion={
                     "decision": "blocked",
                     "evaluated_factors": [
@@ -209,6 +211,8 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(
                 Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
                 promotion={
                     "decision": "blocked",
                     "evaluated_factors": [
@@ -227,6 +231,30 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(decision["decision"], "revise_prior")
             self.assertFalse(decision["allow_dispatch"])
             self.assertTrue(decision["prior_revision_required"])
+
+    def test_non_target_factor_blockers_do_not_drive_target_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "target_not_allowed",
+                                "one_event_decision_violation:max_event_decisions=4",
+                            ],
+                            "factor": {"target": "full_depth_reprice_pnl_10s"},
+                        }
+                    ],
+                },
+            )
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "continue_search")
 
     def test_missing_recorded_replay_artifact_routes_to_fix_workflow(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- ignore non-target evaluated-factor blockers when classifying the closed-loop action for a specific alpha-search target
- keep handoff/global blockers target-relevant
- add regression coverage for repricing blockers not driving settlement-search action

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- rtk git diff --check

## Evidence Stage
walk_forward / alpha-search CI repair
