### PR TITLE
Prioritize target blockers in closed loop

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -216,7 +216,9 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     chain = current["chain"]
     feedback = current["feedback"]
     plan = current["plan"]
-    blockers = target_blocker_strings(current["promotion"], current["target"]) + blocker_strings(handoff)
+    target_blockers = target_blocker_strings(current["promotion"], current["target"])
+    handoff_blockers = blocker_strings(handoff)
+    blockers = target_blockers or handoff_blockers
     blocker_action = classify_blockers(blockers)
 
     candidate_count = int(feedback.get("candidate_count") or 0)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -334,6 +334,32 @@ Evidence stage: `walk_forward / alpha-search CI repair`.
   `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
   and `rtk git diff --check`.
 
+# Closed-Loop Target Blocker Priority (2026-05-18)
+
+## Goal
+
+When a target-specific candidate exists, classify the next closed-loop action
+from that candidate's blockers before falling back to global handoff blockers.
+This prevents global market fillability text from masking the real next action,
+such as missing recorded replay parity for a fillable target bucket.
+
+Evidence stage: `walk_forward / alpha-search CI repair`.
+
+## Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: prioritize target-level promotion blockers over handoff/global
+    blockers for action classification.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: cover target replay blockers taking priority over global fillability
+    handoff text.
+
+## Tasks
+
+- [x] Classify from target-level blockers when present.
+- [x] Keep handoff/global blockers as fallback when no target blocker exists.
+- [x] Add focused regression coverage.
+
 # Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -277,6 +277,36 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(decision["decision"], "fix_workflow")
             self.assertFalse(decision["allow_dispatch"])
 
+    def test_target_factor_blockers_take_priority_over_handoff_global_blockers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "global_promotion_gate_not_ready:recorded_replay_parity: blocked: no recorded replay parity artifact was supplied to this report"
+                            ],
+                            "factor": {"target": agent.DEFAULT_TARGET},
+                        }
+                    ],
+                },
+            )
+            handoff = path / "factor-walk-forward-v2" / "autofactor-strategy-handoff.json"
+            payload = json.loads(handoff.read_text(encoding="utf-8"))
+            payload["promotion_gate"] = {
+                "blocked_gates": [
+                    "global_full_depth_entry_fillability: global_full_depth_entry_fill_rate=0.1311 min_required=0.3000"
+                ]
+            }
+            write_json(handoff, payload)
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_workflow")
+
     def test_missing_feedback_routes_to_fix_data(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(Path(tmp), write_feedback=False)


### PR DESCRIPTION
## Summary
- classify closed-loop next actions from target-level factor blockers when present
- use handoff/global blockers only as fallback
- add regression coverage for recorded replay blockers taking priority over global fillability text

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- rtk git diff --check

## Evidence Stage
walk_forward / alpha-search CI repair
