### PR TITLE
Prefer eligible target blockers in closed loop

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -137,6 +137,7 @@ def blocker_strings(payload: Any) -> list[str]:
 
 def target_blocker_strings(payload: Any, target: str) -> list[str]:
     out: list[str] = []
+    eligible: list[str] = []
     if isinstance(payload, dict):
         evaluated = payload.get("evaluated_factors")
         if isinstance(evaluated, list):
@@ -146,12 +147,25 @@ def target_blocker_strings(payload: Any, target: str) -> list[str]:
                 factor = item.get("factor")
                 factor_target = factor.get("target") if isinstance(factor, dict) else None
                 if factor_target in {None, target}:
+                    row_blockers: list[str] = []
                     blockers = item.get("blockers", [])
                     if isinstance(blockers, list):
-                        out.extend(str(blocker) for blocker in blockers)
+                        row_blockers.extend(str(blocker) for blocker in blockers)
                     else:
-                        out.extend(blocker_strings(blockers))
+                        row_blockers.extend(blocker_strings(blockers))
+                    out.extend(row_blockers)
+                    runtime_mapping = item.get("runtime_mapping")
+                    if (
+                        isinstance(factor, dict)
+                        and factor.get("decision") == "candidate"
+                        and factor.get("reason") == "passed"
+                        and isinstance(runtime_mapping, dict)
+                        and runtime_mapping.get("runtime_score")
+                    ):
+                        eligible.extend(row_blockers)
             payload = {key: value for key, value in payload.items() if key != "evaluated_factors"}
+        if eligible:
+            return eligible
         out.extend(blocker_strings(payload))
     else:
         out.extend(blocker_strings(payload))

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -360,6 +360,31 @@ Evidence stage: `walk_forward / alpha-search CI repair`.
 - [x] Keep handoff/global blockers as fallback when no target blocker exists.
 - [x] Add focused regression coverage.
 
+# Closed-Loop Eligible Target Candidate Priority (2026-05-18)
+
+## Goal
+
+When multiple target rows exist, classify the next action from runtime-mappable
+`candidate/passed` target rows before using weaker target diagnostics. This
+keeps a replay-parity blocker on the best deployable candidate from being
+masked by execution blockers on non-mappable exploratory rows.
+
+Evidence stage: `walk_forward / alpha-search CI repair`.
+
+## Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: prefer eligible target candidate blockers when classifying actions.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: cover runtime-mappable target candidates taking priority over weaker
+    target rows.
+
+## Tasks
+
+- [x] Prefer runtime-mappable `candidate/passed` target blockers.
+- [x] Fall back to all target blockers when no eligible target candidate exists.
+- [x] Add focused regression coverage.
+
 # Recorded Replay Partial-Fill Cancel Parity (2026-05-13)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -307,6 +307,48 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(decision["decision"], "fix_workflow")
 
+    def test_runtime_mappable_target_candidate_blockers_take_priority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "top_bucket_entry_sweep_slippage_too_high:450.00>200.00",
+                                "missing_runtime_strategy_mapping",
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": None,
+                        },
+                        {
+                            "blockers": [
+                                "global_promotion_gate_not_ready:recorded_replay_parity: blocked: no recorded replay parity artifact was supplied to this report"
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": "autofactor_formula:edge",
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_workflow")
+
     def test_missing_feedback_routes_to_fix_data(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(Path(tmp), write_feedback=False)


### PR DESCRIPTION
## Summary
- prefer runtime-mappable candidate/passed target blockers for closed-loop action classification
- fall back to all target blockers only when no eligible target candidate exists
- add regression coverage and verify the latest downloaded artifact classifies as fix_workflow

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- rtk git diff --check
- local reclassification of run 26012527827 artifact: fix_workflow / promotion_blockers_require_fix_workflow

## Evidence Stage
walk_forward / alpha-search CI repair
