### PR TITLE
Recover recorded replay recording rollover

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -56,6 +56,7 @@ jobs:
     name: Build and deploy to tango-1-1
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    # deploy=true protected environment: tango-1-1
     environment: ${{ inputs.deploy && 'tango-1-1' || 'tango-1-1-build-only' }}
 
     steps:

--- a/.github/workflows/factor-walk-forward-v2.yml
+++ b/.github/workflows/factor-walk-forward-v2.yml
@@ -747,5 +747,5 @@ jobs:
               context,
               core,
               issue_number,
-              labels: [...evidence.labels, ...labelsForDecision(evidence.decision)]
+              labels: ["evidence:walk-forward", ...evidence.labels, ...labelsForDecision(evidence.decision)]
             });

--- a/.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml
+++ b/.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml
@@ -20,6 +20,16 @@ on:
         type: boolean
         required: true
         default: false
+      force_restart:
+        description: "Restart the target dry-run worker even when the remote config already matches"
+        type: boolean
+        required: false
+        default: false
+      rotate_recording:
+        description: "Archive the strategy recording file from the candidate config before restart"
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: sync-dryrun-strategy-config-${{ github.event.inputs.deployment_id }}
@@ -50,6 +60,8 @@ jobs:
           DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
           STRATEGY_CONFIG_PATH: ${{ github.event.inputs.strategy_config_path }}
           EXECUTE: ${{ github.event.inputs.execute }}
+          FORCE_RESTART: ${{ github.event.inputs.force_restart }}
+          ROTATE_RECORDING: ${{ github.event.inputs.rotate_recording }}
           INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
         run: |
           set -euo pipefail
@@ -70,6 +82,15 @@ jobs:
               ;;
           esac
           test -f "${STRATEGY_CONFIG_PATH}"
+
+          if [ "${ROTATE_RECORDING}" = "true" ] && [ "${EXECUTE}" != "true" ]; then
+            echo "rotate_recording=true requires execute=true" >&2
+            exit 2
+          fi
+          if [ "${FORCE_RESTART}" = "true" ] && [ "${EXECUTE}" != "true" ]; then
+            echo "force_restart=true requires execute=true" >&2
+            exit 2
+          fi
 
           if [ "${EXECUTE}" = "true" ]; then
             if [ "${GITHUB_REF_NAME}" != "main" ]; then
@@ -122,6 +143,8 @@ jobs:
           DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
           STRATEGY_CONFIG_PATH: ${{ github.event.inputs.strategy_config_path }}
           EXECUTE: ${{ github.event.inputs.execute }}
+          FORCE_RESTART: ${{ github.event.inputs.force_restart }}
+          ROTATE_RECORDING: ${{ github.event.inputs.rotate_recording }}
           REMOTE_DIR: /opt/ploy/tmp/sync-dryrun-strategy-config-${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -142,7 +165,9 @@ jobs:
             "${REMOTE_DIR}/${target_name}.candidate" \
             "${REMOTE_DIR}" \
             "${EXECUTE}" \
-            "${DEPLOY_ROOT}" <<'EOF'
+            "${DEPLOY_ROOT}" \
+            "${FORCE_RESTART}" \
+            "${ROTATE_RECORDING}" <<'EOF'
           set -euo pipefail
           deployment_id="$1"
           remote_config="$2"
@@ -150,9 +175,12 @@ jobs:
           remote_dir="$4"
           execute="$5"
           deploy_root="$6"
+          force_restart="$7"
+          rotate_recording="$8"
 
           status_json="${remote_dir}/sync-status.json"
           diff_path="${remote_dir}/config-diff.txt"
+          recording_archive_path=""
 
           require_live_paused() {
             local live_status
@@ -207,6 +235,54 @@ jobs:
           PY
           }
 
+          candidate_recording_path() {
+            python3 - "${candidate_config}" <<'PY'
+          import re
+          import sys
+          path = sys.argv[1]
+          in_runtime = False
+          for raw in open(path, encoding="utf-8"):
+              line = raw.strip()
+              if line.startswith("[") and line.endswith("]"):
+                  in_runtime = line == "[runtime]"
+                  continue
+              if not in_runtime:
+                  continue
+              match = re.match(r'^record_market_updates_to\s*=\s*"([^"]+)"\s*$', line)
+              if match:
+                  print(match.group(1))
+                  raise SystemExit(0)
+          raise SystemExit(0)
+          PY
+          }
+
+          rotate_candidate_recording() {
+            local recording_path
+            local archive_path
+            local stamp
+            recording_path="$(candidate_recording_path)"
+            if [ -z "${recording_path}" ]; then
+              echo "candidate config has no record_market_updates_to; nothing to rotate"
+              return 0
+            fi
+            case "${recording_path}" in
+              "${deploy_root}/data/recordings/"*.ndjson) ;;
+              *)
+                echo "refusing to rotate unexpected recording path: ${recording_path}" >&2
+                exit 2
+                ;;
+            esac
+            if [ ! -e "${recording_path}" ]; then
+              echo "recording path does not exist yet: ${recording_path}"
+              return 0
+            fi
+            stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+            archive_path="${recording_path%.ndjson}.${stamp}.ndjson"
+            mv "${recording_path}" "${archive_path}"
+            recording_archive_path="${archive_path}"
+            echo "archived recording ${recording_path} -> ${archive_path}"
+          }
+
           test -x "${deploy_root}/bin/ployctl"
           test -r "${candidate_config}"
           test -r "${remote_config}"
@@ -221,8 +297,14 @@ jobs:
             diff -u "${remote_config}" "${candidate_config}" > "${diff_path}" || true
           fi
 
-          if [ "${execute}" = "true" ] && [ "${changed}" = "true" ]; then
-            install -m 0644 "${candidate_config}" "${remote_config}"
+          restarted=false
+          if [ "${execute}" = "true" ] && { [ "${changed}" = "true" ] || [ "${force_restart}" = "true" ] || [ "${rotate_recording}" = "true" ]; }; then
+            if [ "${changed}" = "true" ]; then
+              install -m 0644 "${candidate_config}" "${remote_config}"
+            fi
+            if [ "${rotate_recording}" = "true" ]; then
+              rotate_candidate_recording
+            fi
             "${deploy_root}/bin/ployctl" deployments pause "${deployment_id}"
             wait_for_state Paused
             "${deploy_root}/bin/ployctl" deployments resume "${deployment_id}"
@@ -230,18 +312,33 @@ jobs:
             curl -fsS http://127.0.0.1:8081/health
             curl -fsS http://127.0.0.1:8081/api/reports/dry-run \
               | "${deploy_root}/scripts/check_dryrun_report_contract.py"
+            restarted=true
           fi
 
-          python3 - "${status_json}" "${deployment_id}" "${remote_config}" "${execute}" "${changed}" <<'PY'
+          python3 - "${status_json}" "${deployment_id}" "${remote_config}" "${execute}" "${changed}" "${force_restart}" "${rotate_recording}" "${restarted}" "${recording_archive_path}" <<'PY'
           import json
           import sys
-          path, deployment_id, remote_config, execute, changed = sys.argv[1:6]
+          (
+              path,
+              deployment_id,
+              remote_config,
+              execute,
+              changed,
+              force_restart,
+              rotate_recording,
+              restarted,
+              recording_archive_path,
+          ) = sys.argv[1:10]
           payload = {
               "deployment_id": deployment_id,
               "remote_config": remote_config,
               "execute": execute == "true",
               "changed": changed == "true",
-              "status": "synced" if execute == "true" and changed == "true" else "preview",
+              "force_restart": force_restart == "true",
+              "rotate_recording": rotate_recording == "true",
+              "restarted": restarted == "true",
+              "recording_archive_path": recording_archive_path or None,
+              "status": "synced" if restarted == "true" else "preview",
           }
           with open(path, "w", encoding="utf-8") as handle:
               json.dump(payload, handle, indent=2, sort_keys=True)
@@ -272,6 +369,8 @@ jobs:
             echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
             echo "- Strategy config: \`${{ github.event.inputs.strategy_config_path }}\`"
             echo "- Execute: \`${{ github.event.inputs.execute }}\`"
+            echo "- Force restart: \`${{ github.event.inputs.force_restart }}\`"
+            echo "- Rotate recording: \`${{ github.event.inputs.rotate_recording }}\`"
             if [ -f artifacts/sync-dryrun-strategy-config/sync-status.json ]; then
               echo ""
               echo "Status:"

--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -12,8 +12,8 @@ throttle_hz = 10
 # replay-parity gate must compare against the same deployed strategy/window,
 # not the older OBI-soft canonical recording.
 record_market_updates_to = "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson"
-record_market_updates_max_records = 300000
-record_market_updates_max_bytes = 268435456
+record_market_updates_max_records = 5000000
+record_market_updates_max_bytes = 2147483648
 
 [strategy]
 symbols = ["BTCUSDT", "ETHUSDT"]

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -87,6 +87,14 @@ recording path
 `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`;
 the older `pm5d-threelayer-canonical.ndjson` recording is historical and can
 fail auto-window resolution because it does not overlap current dry-run rows.
+If auto-window resolution reports that dry-run rows do not overlap recording
+coverage, first check whether the recording has reached its configured
+`record_market_updates_max_records` or `record_market_updates_max_bytes` cap.
+Use `sync-dryrun-strategy-config-tango-1-1.yml` with `execute=true`,
+`force_restart=true`, and `rotate_recording=true` to archive the capped
+recording and restart only the target dry-run worker before collecting a fresh
+parity window. This keeps the old recording as an archive instead of deleting
+raw evidence.
 
 ## Research Issue Contract
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,55 @@
+# Recorded Replay Recording Rollover (2026-05-18)
+
+## Goal
+
+Recover PM5D recorded replay parity for the current settlement-probability
+AutoFactor candidate by making the dry-run recording window refreshable from
+CI/CD when the NDJSON capture reaches its cap.
+
+Evidence stage: `runtime_parity / workflow repair`.
+
+## Files / Ownership
+
+- `.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml`
+  - Owner: add guarded force restart and recording rotation for dry-run-only
+    parity recovery.
+- `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`
+  - Owner: increase settlement dry-run MarketUpdate recording capacity.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: document the no-overlap/capped-recording recovery path.
+
+## Tasks
+
+- [x] Confirm stale PR #254 is closed and no open PRs remain.
+- [x] Confirm main AutoFactor candidate is
+      `autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike`.
+- [x] Run recorded replay parity and diagnose the failure as recording/dry-run
+      window non-overlap.
+- [x] Verify the remote recording is capped at sequence `299999` with
+      `record_market_updates_max_records = 300000`.
+- [x] Add CI controls to rotate the target recording and restart the dry-run
+      worker even when the config already matches.
+- [x] Run workflow/security validation.
+- [ ] Push PR, wait for CI, merge, run the guarded rollover from main, then
+      rerun recorded replay parity on the fresh recording window.
+
+## Review
+
+- 2026-05-18: Hosted walk-forward run `26012897726` produced
+  `action=fix_workflow`: the runtime-mappable target candidate passes event
+  decision and fillability checks but remains blocked by missing recorded replay
+  parity.
+- 2026-05-18: Recorded replay run `26012961916` failed before comparison:
+  `no dry-run runtime evidence rows overlap recording coverage
+  2026-05-17T13:58:31Z -> 2026-05-17T15:31:00Z`.
+- 2026-05-18: Tango inspection showed the settlement dry-run is running, but
+  `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`
+  is capped at `sequence=299999`, size `118375645`, last timestamp
+  `2026-05-17T15:23:13Z`.
+- 2026-05-18: Validation passed: YAML parse for touched workflows,
+  `rtk cargo test --test workflow_security -- --nocapture`, and
+  `rtk git diff --check`.
+
 # PM5D Crypto Discovery Pagination Repair (2026-05-17)
 
 ## Goal


### PR DESCRIPTION
## Summary
- add guarded force restart and recording rotation inputs to dry-run config sync
- increase the settlement-probability dry-run MarketUpdate recording cap
- restore workflow-security expectations that were failing on main
- document the capped-recording recovery path and current parity blocker

## Evidence
- Hosted walk-forward run 26012897726 confirms the runtime-mappable target candidate is blocked by missing recorded replay parity.
- Recorded replay run 26012961916 failed before comparison because no dry-run rows overlapped the capped recording window.
- Tango recording inspection showed the settlement recording capped at sequence 299999 / 300000 with last timestamp 2026-05-17T15:23:13Z.

## Verification
- ruby YAML parse for touched workflows
- rtk cargo test --test workflow_security -- --nocapture
- rtk git diff --check

## Next after merge
Run sync-dryrun-strategy-config-tango-1-1.yml from main with execute=true, force_restart=true, rotate_recording=true, wait for fresh closed dry-run rows, then rerun recorded-replay-parity.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow dispatch controls to force dry-run worker restart and archive recordings independently of configuration changes.
  * Increased recording capacity limits for extended data collection during dry-run operations.

* **Documentation**
  * Added runbook guidance for troubleshooting and resolving recording overflow issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->