### PR TITLE
Require candidate replay before AutoFactor dry-run handoff

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -78,8 +78,12 @@ jobs:
             find artifacts/source -maxdepth 4 -type f -print >&2
             exit 2
           fi
-          echo "REPORT_PATH=${report_path}" >> "$GITHUB_ENV"
-          echo "ARTIFACT_NAME=${artifact_name}" >> "$GITHUB_ENV"
+          replay_path="$(find artifacts/source \( -name 'candidate-strategy-replay.json' -o -name 'autofactor-candidate-strategy-replay.json' \) -print -quit)"
+          {
+            echo "REPORT_PATH=${report_path}"
+            echo "CANDIDATE_STRATEGY_REPLAY_PATH=${replay_path}"
+            echo "ARTIFACT_NAME=${artifact_name}"
+          } >> "$GITHUB_ENV"
 
       - name: Evaluate AutoFactor strategy promotion
         run: |
@@ -95,6 +99,9 @@ jobs:
             --required-strategy-profile "${{ github.event.inputs.required_strategy_profile }}"
             --allowed-target "${{ github.event.inputs.allowed_target }}"
           )
+          if [ -n "${CANDIDATE_STRATEGY_REPLAY_PATH:-}" ]; then
+            args+=(--candidate-strategy-replay-json "${CANDIDATE_STRATEGY_REPLAY_PATH}")
+          fi
           if [ "${{ github.event.inputs.fail_if_blocked }}" = "true" ]; then
             args+=(--fail-if-blocked)
           fi
@@ -109,6 +116,7 @@ jobs:
             echo ""
             echo "- Source run: \`${{ github.event.inputs.factor_walk_forward_run_id }}\`"
             echo "- Source artifact: \`${ARTIFACT_NAME:-unknown}\`"
+            echo "- Candidate strategy replay artifact: \`${CANDIDATE_STRATEGY_REPLAY_PATH:-missing}\`"
             echo "- Required strategy profile: \`${{ github.event.inputs.required_strategy_profile }}\`"
             echo "- Allowed target: \`${{ github.event.inputs.allowed_target }}\`"
             echo ""

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -330,6 +330,7 @@ jobs:
           if [ -z "${replay_parity_json}" ] && [ -f artifacts/replay-parity/parity-evaluation.json ]; then
             replay_parity_json="artifacts/replay-parity/parity-evaluation.json"
           fi
+          candidate_strategy_replay_json="$(find artifacts/source artifacts/research-snapshot artifacts/alpha-search-plan artifacts/factor-walk-forward-v2 -name 'candidate-strategy-replay.json' -o -name 'autofactor-candidate-strategy-replay.json' 2>/dev/null | head -1 || true)"
           args=(
             --binary ./target/fast/examples/factor_walk_forward_v2
             --evaluator scripts/evaluate_autofactor_strategy_promotion.py
@@ -365,6 +366,9 @@ jobs:
           )
           if [ -n "${replay_parity_json}" ]; then
             args+=(--replay-parity-json "${replay_parity_json}")
+          fi
+          if [ -n "${candidate_strategy_replay_json}" ]; then
+            args+=(--candidate-strategy-replay-json "${candidate_strategy_replay_json}")
           fi
           if [ "${WALK_REQUIRE_DERIBIT}" = "true" ]; then
             args+=(--require-deribit)

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -7,6 +7,7 @@ two-layer search architecture:
 LLM semantic prior layer
   -> MCTS/systematic search layer
   -> CI backtest feedback layer
+  -> candidate strategy executable replay layer
   -> promotion/handoff gate
 ```
 
@@ -63,6 +64,7 @@ research snapshot
   -> alpha-search artifact bundle
   -> MCTS expansion plan
   -> optional chained hosted search iteration
+  -> candidate strategy executable replay artifact
   -> AutoFactor promotion evaluation
   -> blocked/ready handoff artifact
   -> optional dry-run config PR
@@ -83,10 +85,12 @@ semantic hypothesis + formula prior
 
 The main unresolved blocker is no longer "can the system generate/explore alpha
 candidates?" It can. The current blocker is promotion quality evidence:
-recorded replay/dry-run parity must be ready for the target dry-run lane, the
-handoff artifact must be `status=ready`, and any resulting config PR must still
-pass normal CI before deployment. Search reward, MCTS rank, or a ready-looking
-candidate row is not enough to claim a profitable strategy.
+the selected runtime score must first pass a strategy-level historical
+`executable_replay` using event-level decisions, full-depth executable prices
+and depth, conservative fills, and official settlement. After dry-run starts,
+recorded replay/dry-run parity must also be ready for the target dry-run lane.
+Search reward, MCTS rank, or a ready-looking candidate row is not enough to
+claim a profitable strategy.
 
 ## Architecture
 
@@ -187,7 +191,28 @@ Required artifact:
 - `search-feedback.json`
 - `search-feedback.md`
 
-### 4. Promotion/Handoff Layer
+### 4. Candidate Strategy Executable Replay Layer
+
+This layer turns the selected factor/runtime score into a historical strategy
+replay before any dry-run handoff. It is separate from factor IC/ICIR scoring
+and separate from recorded replay parity.
+
+Required artifact:
+
+- `candidate-strategy-replay.json` or
+  `autofactor-candidate-strategy-replay.json`
+
+Minimum contract:
+
+- `evidence_stage=executable_replay`
+- exact `strategy_profile` and `runtime_score`
+- event-level, one-decision-per-event accounting
+- official settlement labels
+- full-depth executable entry/depth/fill assumptions
+- trade count, unique event count, entry fill rate, PnL or ROI, and drawdown
+- `promotion_ready=true` and no blocking risk flags
+
+### 5. Promotion/Handoff Layer
 
 Only this layer can produce a dry-run handoff or config PR. The LLM and MCTS
 layers can generate candidates, but they cannot promote them.
@@ -196,6 +221,7 @@ The existing fail-closed path remains:
 
 ```text
 factor-walk-forward-v2/report.txt
+  + candidate-strategy-replay.json
   -> scripts/evaluate_autofactor_strategy_promotion.py
   -> autofactor-factor-registry.json
   -> autofactor-strategy-handoff.json
@@ -340,6 +366,8 @@ Every complete CI/CD alpha-search run should upload:
   decision, including whether the next run was dispatched and why the chain
   stopped when it did not continue
 - `factor-walk-forward-v2/report.txt`: existing walk-forward report
+- `candidate-strategy-replay.json`: selected runtime-score historical
+  executable replay proof required before dry-run handoff
 - `autofactor-factor-registry.json`: evaluated factor rows and blockers
 - `autofactor-strategy-handoff.json`: ready/blocked handoff manifest
 

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -149,6 +149,7 @@ evaluator before creating any dry-run handoff:
 ```bash
 python3 scripts/evaluate_autofactor_strategy_promotion.py \
   --report /tmp/factor-walk-forward-v2/report.txt \
+  --candidate-strategy-replay-json /tmp/candidate-strategy-replay.json \
   --output-json /tmp/autofactor-strategy-promotion.json \
   --output-md /tmp/autofactor-strategy-promotion.md \
   --output-registry-json /tmp/autofactor-factor-registry.json \
@@ -164,7 +165,11 @@ The evaluator requires all of the following:
   `full_depth_settlement_executable_pnl`;
 - the factor has an explicit runtime strategy-profile mapping; and
 - the runtime profile matches the requested promotion lane, defaulting to
-  `settlement_probability`.
+  `settlement_probability`; and
+- a candidate strategy executable replay artifact is ready for the exact same
+  runtime score, with event-level decisions, full-depth executable accounting,
+  official settlement, enough trades, positive ROI/PnL, and no blocking risk
+  flags.
 
 This deliberately blocks cases where a factor is statistically good in the
 wrong lane. For example, `spread_adjusted_external_move` can be a valid
@@ -195,8 +200,10 @@ The built-in promotion evaluator maps the generated `auto_settlement_*`
 formula family to the `settlement_probability` strategy profile with
 `autofactor_formula:<factor_name>` runtime score identifiers. That mapping only
 removes the profile/mapping blocker; it does not override the PRD promotion
-gate. Recorded replay parity and the other settlement gates must still be
-ready before a handoff issue/config is created.
+gate. It also does not replace the strategy replay gate: the same runtime score
+must pass historical executable replay before any dry-run handoff issue/config
+is created. Recorded replay parity remains the later dry-run/runtime parity gate
+after dry-run evidence exists.
 
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:
@@ -210,8 +217,11 @@ gh workflow run autofactor-strategy-promotion.yml \
 ```
 
 This downloads `factor-walk-forward-v2-<run-id>`, runs the same evaluator on
-`report.txt`, uploads `autofactor-strategy-promotion-<run-id>` artifacts, and
-can optionally comment on a research issue.
+`report.txt`, automatically uses `candidate-strategy-replay.json` or
+`autofactor-candidate-strategy-replay.json` when the source artifact contains
+one, uploads `autofactor-strategy-promotion-<run-id>` artifacts, and can
+optionally comment on a research issue. If no candidate strategy replay artifact
+is present, the handoff stays blocked by design.
 
 The hosted workflow also has a fail-closed `create_handoff_issue` input. Leave
 it `false` for diagnostics. When set to `true`, the workflow creates a dry-run
@@ -297,7 +307,9 @@ gh workflow run factor-walk-forward-v2-hosted-artifact.yml \
 
 This keeps the full chain on GitHub-hosted runners after snapshot creation:
 snapshot artifact -> hosted walk-forward -> promotion evaluator -> ready
-handoff -> CI-gated config PR. The generated PR updates only
+handoff -> CI-gated config PR. The promotion evaluator still requires a
+candidate strategy replay artifact inside the source artifact before the
+handoff can be ready. The generated PR updates only
 `three_layer_autofactor_runtime_score`; deployment remains a separate explicit
 dry-run step from `main`.
 

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -26,18 +26,25 @@ Idea / hypothesis
   -> declare strategy_family, profile, data window, assumptions, and success criteria
   -> run the smallest research workflow that can falsify the hypothesis
   -> attach artifact-backed evidence and labels to the issue
-  -> if evidence supports runtime work, create an implementation issue / PR
+  -> if factor/search evidence is positive, run candidate strategy executable replay
+  -> if replay proves the same scorer, event-level decisions, full-depth executable prices, fills, and official settlement, create an implementation issue / PR
   -> PR validation through Platform CI
   -> merge to protected main
   -> deploy dry-run from main through protected Runtime CD
   -> verify remote service, config, persistence, and data freshness
-  -> compare replay/backtest evidence with dry-run evidence
+  -> compare recorded dry-run behavior with replayed recorded MarketUpdate evidence
   -> decide: promote, collect-more, revise, fix-data, fix-runtime, fix-workflow, or reject
 ```
 
-The loop is not complete after a profitable backtest. It is complete only when
-the dry-run behavior is reconciled against replay expectations, or when the
-mismatch is understood and tracked as a follow-up issue.
+The loop is not allowed to enter dry-run after a factor/search result alone.
+The replay gate before dry-run is a strategy-level `executable_replay` artifact,
+not an IC/ICIR row and not recorded replay parity. It must use the same scorer
+that would be configured at runtime, one event-level decision per market event,
+full-depth executable entry/depth/fill assumptions, and official settlement.
+
+The loop is not complete after a profitable replay. It is complete only when
+the dry-run behavior is reconciled against recorded replay expectations, or
+when the mismatch is understood and tracked as a follow-up issue.
 
 ## Workflow Map
 
@@ -50,6 +57,7 @@ mismatch is understood and tracked as a follow-up issue.
 | Walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Rolling factor validation across train/test windows |
 | Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
 | Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
+| Candidate strategy replay | `autofactor-strategy-promotion.yml` consumer contract, then a replay-producing workflow/artifact | Required pre-dry-run proof that the selected runtime score is profitable under historical executable replay |
 | Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
 | Recorded replay/dry-run parity | `.github/workflows/recorded-replay-parity.yml` | Replay a canonical MarketUpdate recording on `tango-1-1` with the deployed binary, then compare against the matching dry-run report slice |
 | Runtime evidence reset | `.github/workflows/reset-strategy-runtime-evidence.yml` | Backup-first cleanup for contaminated dry-run/paper `strategy_runtime_orders` and `strategy_runtime_fills`; follow `docs/runbooks/strategy-runtime-evidence-reset.md` |
@@ -180,16 +188,20 @@ Parity labels:
 
 Do not promote a strategy from research directly to live. Promotion is staged:
 
-1. `decision:promote` on the research issue means it can become an
-   implementation issue or PR.
-2. Runtime code/config changes must pass Platform CI and merge to `main`.
-3. Dry-run deployment must be triggered from `main` through a protected
+1. `decision:continue` or a positive factor/search artifact means run
+   candidate strategy executable replay next; it does not mean dry-run.
+2. `decision:promote` on the research issue requires a ready candidate
+   strategy replay artifact for the exact runtime score, profile, event-level
+   decision contract, full-depth executable accounting, and official settlement.
+   Only then can it become an implementation issue or PR.
+3. Runtime code/config changes must pass Platform CI and merge to `main`.
+4. Dry-run deployment must be triggered from `main` through a protected
    environment.
-4. Remote verification must prove service health, expected config, persistence,
+5. Remote verification must prove service health, expected config, persistence,
    data freshness, and no on-host Rust build.
-5. Replay/dry-run parity must either report `strict_parity_ready=true` or create
-   a follow-up issue explaining the mismatch.
-6. Live promotion requires a separate approval with explicit stake, loss, and
+6. Recorded replay/dry-run parity must either report `strict_parity_ready=true`
+   or create a follow-up issue explaining the mismatch.
+7. Live promotion requires a separate approval with explicit stake, loss, and
    rollback limits.
 
 ## Current Strategy Profiles

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -7,7 +7,9 @@ An AutoFactor row is only a qualified strategy when:
 1. all global settlement PRD promotion gates are ready;
 2. the row is a `candidate` with reason `passed`;
 3. the target is one of the allowed executable targets; and
-4. the factor has an explicit runtime strategy-profile mapping.
+4. the factor has an explicit runtime strategy-profile mapping; and
+5. a strategy-level historical executable replay artifact proves the same
+   runtime score under event-level, full-depth, official-settlement accounting.
 
 For `autofactor_formula:*` runtime scores, the PRD model-specific
 `symbol_holdout` and `walk_forward_oos` gates are replaced by formula-level
@@ -162,6 +164,17 @@ class ExecutionQuality:
 
 
 @dataclass
+class CandidateStrategyReplay:
+    ready: bool
+    evidence: str
+    runtime_score: str = ""
+    strategy_profile: str = ""
+    blockers: list[str] = field(default_factory=list)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    decision_contract: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class AutoFactorRow:
     rank: int
     name: str
@@ -283,6 +296,133 @@ def parse_execution_quality(report_text: str) -> ExecutionQuality:
         if value == value:
             return ExecutionQuality(avg_entry_sweep_slip_bps=value)
     return ExecutionQuality()
+
+
+def load_candidate_strategy_replay(path: str | None) -> CandidateStrategyReplay:
+    if not path:
+        return CandidateStrategyReplay(
+            ready=False,
+            evidence="missing candidate strategy executable replay artifact",
+            blockers=["missing_candidate_strategy_replay"],
+        )
+    replay_path = Path(path)
+    if not replay_path.is_file():
+        return CandidateStrategyReplay(
+            ready=False,
+            evidence=f"candidate strategy executable replay artifact not found: {path}",
+            blockers=["missing_candidate_strategy_replay"],
+        )
+    payload = json.loads(replay_path.read_text(encoding="utf-8"))
+    metrics = payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {}
+    contract = (
+        payload.get("decision_contract")
+        if isinstance(payload.get("decision_contract"), dict)
+        else {}
+    )
+    blockers = payload.get("blocking_risk_flags") or payload.get("blockers") or []
+    if not isinstance(blockers, list):
+        blockers = [str(blockers)]
+    ready = bool(payload.get("promotion_ready") is True or payload.get("status") == "ready")
+    evidence = payload.get("evidence") or payload.get("run_url") or str(replay_path)
+    return CandidateStrategyReplay(
+        ready=ready,
+        evidence=str(evidence),
+        runtime_score=str(payload.get("runtime_score", "")),
+        strategy_profile=str(payload.get("strategy_profile", "")),
+        blockers=[str(item) for item in blockers],
+        metrics=metrics,
+        decision_contract=contract,
+    )
+
+
+def numeric_metric(metrics: dict[str, Any], *names: str) -> float | None:
+    for name in names:
+        if name not in metrics:
+            continue
+        try:
+            value = float(metrics[name])
+        except (TypeError, ValueError):
+            continue
+        if value == value:
+            return value
+    return None
+
+
+def candidate_strategy_replay_blockers(
+    replay: CandidateStrategyReplay,
+    *,
+    mapping: dict[str, str] | None,
+    required_strategy_profile: str,
+    min_replay_trade_count: int,
+    min_replay_fill_rate: float,
+    min_replay_roi: float,
+) -> list[str]:
+    blockers = list(replay.blockers)
+    if not replay.ready:
+        blockers.append("candidate_strategy_replay_not_ready")
+
+    if replay.strategy_profile != required_strategy_profile:
+        blockers.append(
+            "candidate_strategy_replay_profile_mismatch:"
+            f"{replay.strategy_profile or '<missing>'}!={required_strategy_profile}"
+        )
+
+    runtime_score = (mapping or {}).get("runtime_score", "")
+    if not runtime_score:
+        blockers.append("candidate_strategy_replay_missing_expected_runtime_score")
+    elif replay.runtime_score != runtime_score:
+        blockers.append(
+            "candidate_strategy_replay_runtime_score_mismatch:"
+            f"{replay.runtime_score or '<missing>'}!={runtime_score}"
+        )
+
+    required_contract_flags = (
+        "event_level",
+        "one_decision_per_event",
+        "official_settlement",
+        "full_depth_entry",
+    )
+    for flag in required_contract_flags:
+        if replay.decision_contract.get(flag) is not True:
+            blockers.append(f"candidate_strategy_replay_missing_contract:{flag}")
+
+    trades = numeric_metric(replay.metrics, "trade_count", "closed_trades")
+    if trades is None:
+        blockers.append("candidate_strategy_replay_missing_metric:trade_count")
+    elif trades < min_replay_trade_count:
+        blockers.append(
+            "candidate_strategy_replay_trade_count_too_small:"
+            f"{trades:.0f}<{min_replay_trade_count}"
+        )
+
+    unique_events = numeric_metric(replay.metrics, "unique_event_count")
+    if unique_events is None:
+        blockers.append("candidate_strategy_replay_missing_metric:unique_event_count")
+    elif trades is not None and unique_events < min(trades, min_replay_trade_count):
+        blockers.append(
+            "candidate_strategy_replay_unique_event_count_too_small:"
+            f"{unique_events:.0f}<{min(trades, min_replay_trade_count):.0f}"
+        )
+
+    fill_rate = numeric_metric(replay.metrics, "entry_fill_rate", "buy_fill_rate")
+    if fill_rate is None:
+        blockers.append("candidate_strategy_replay_missing_metric:entry_fill_rate")
+    elif fill_rate < min_replay_fill_rate:
+        blockers.append(
+            "candidate_strategy_replay_entry_fill_rate_too_low:"
+            f"{fill_rate:.4f}<{min_replay_fill_rate:.4f}"
+        )
+
+    roi = numeric_metric(replay.metrics, "roi", "return_on_notional")
+    total_pnl = numeric_metric(replay.metrics, "total_pnl", "realized_pnl")
+    if roi is None and total_pnl is None:
+        blockers.append("candidate_strategy_replay_missing_profit_metric")
+    elif roi is not None and roi < min_replay_roi:
+        blockers.append(f"candidate_strategy_replay_roi_too_low:{roi:.6f}<{min_replay_roi:.6f}")
+    elif roi is None and total_pnl is not None and total_pnl <= 0.0:
+        blockers.append(f"candidate_strategy_replay_total_pnl_nonpositive:{total_pnl:.6f}")
+
+    return blockers
 
 
 def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
@@ -437,6 +577,7 @@ def execution_quality_blockers(
 def evaluate(
     report_text: str,
     *,
+    candidate_strategy_replay: CandidateStrategyReplay,
     allowed_targets: tuple[str, ...],
     required_strategy_profile: str,
     runtime_mappings: dict[str, dict[str, str]],
@@ -446,6 +587,9 @@ def evaluate(
     max_avg_entry_sweep_slip_bps: float,
     max_top_bucket_entry_sweep_levels: float,
     min_window_count: int,
+    min_replay_trade_count: int,
+    min_replay_fill_rate: float,
+    min_replay_roi: float,
 ) -> dict[str, Any]:
     gate = parse_promotion_gate(report_text)
     quality = parse_execution_quality(report_text)
@@ -516,6 +660,16 @@ def evaluate(
                 blockers.append(
                     f"runtime_profile_mismatch:{mapped_profile}!={required_strategy_profile}"
                 )
+        blockers.extend(
+            candidate_strategy_replay_blockers(
+                candidate_strategy_replay,
+                mapping=mapping,
+                required_strategy_profile=required_strategy_profile,
+                min_replay_trade_count=min_replay_trade_count,
+                min_replay_fill_rate=min_replay_fill_rate,
+                min_replay_roi=min_replay_roi,
+            )
+        )
         if formula_specific:
             if row.symbol_count < 2:
                 blockers.append("formula_symbol_holdout_too_few_symbols")
@@ -545,9 +699,13 @@ def evaluate(
             "max_avg_entry_sweep_slip_bps": max_avg_entry_sweep_slip_bps,
             "max_top_bucket_entry_sweep_levels": max_top_bucket_entry_sweep_levels,
             "window_count": min_window_count,
+            "candidate_strategy_replay_trade_count": min_replay_trade_count,
+            "candidate_strategy_replay_entry_fill_rate": min_replay_fill_rate,
+            "candidate_strategy_replay_roi": min_replay_roi,
         },
         "promotion_gate": asdict(gate),
         "execution_quality": asdict(quality),
+        "candidate_strategy_replay": asdict(candidate_strategy_replay),
         "qualified_strategies": [
             {
                 "factor": asdict(item.factor),
@@ -592,6 +750,7 @@ def build_factor_registry(result: dict[str, Any]) -> dict[str, Any]:
         "allowed_targets": result["allowed_targets"],
         "promotion_gate": result["promotion_gate"],
         "execution_quality": result["execution_quality"],
+        "candidate_strategy_replay": result["candidate_strategy_replay"],
         "entries": entries,
     }
 
@@ -622,6 +781,7 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
         "allowed_targets": result["allowed_targets"],
         "promotion_gate": result["promotion_gate"],
         "execution_quality": result["execution_quality"],
+        "candidate_strategy_replay": result["candidate_strategy_replay"],
         "strategies": strategies,
         "blocked_factor_count": sum(
             1 for item in result["evaluated_factors"] if not item["qualified"]
@@ -638,6 +798,8 @@ def render_handoff_markdown(handoff: dict[str, Any]) -> str:
         f"Required strategy profile: `{handoff['required_strategy_profile']}`",
         f"Allowed targets: `{', '.join(handoff['allowed_targets'])}`",
         f"Avg entry sweep slip bps: `{handoff['execution_quality'].get('avg_entry_sweep_slip_bps')}`",
+        f"Candidate strategy replay ready: `{str(handoff['candidate_strategy_replay'].get('ready')).lower()}`",
+        f"Candidate strategy replay runtime score: `{handoff['candidate_strategy_replay'].get('runtime_score')}`",
         "",
     ]
     if handoff["status"] != "ready":
@@ -706,6 +868,7 @@ def render_handoff_markdown(handoff: dict[str, Any]) -> str:
             "- Confirm the runtime score is implemented in the shared scorer.",
             "- Confirm the dry-run config uses the same full-depth execution gates as research.",
             "- Confirm replay parity remains ready for the source report.",
+            "- Confirm the candidate strategy executable replay artifact remains attached and ready.",
             "- Start with small fixed stake and the existing kill switch.",
             "",
         ]
@@ -726,6 +889,12 @@ def render_markdown(result: dict[str, Any]) -> str:
         f"- Ready: `{str(result['promotion_gate']['ready']).lower()}`",
         f"- Evidence: `{result['promotion_gate']['evidence']}`",
         f"- Avg entry sweep slip bps: `{result['execution_quality'].get('avg_entry_sweep_slip_bps')}`",
+        "",
+        "## Candidate Strategy Replay",
+        "",
+        f"- Ready: `{str(result['candidate_strategy_replay']['ready']).lower()}`",
+        f"- Evidence: `{result['candidate_strategy_replay']['evidence']}`",
+        f"- Runtime score: `{result['candidate_strategy_replay']['runtime_score']}`",
         "",
         "## Qualified Strategies",
         "",
@@ -771,6 +940,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-handoff-md", default="")
     parser.add_argument("--runtime-mapping-json", default="")
     parser.add_argument(
+        "--candidate-strategy-replay-json",
+        default="",
+        help="Strategy-level historical executable replay artifact for the selected runtime score.",
+    )
+    parser.add_argument(
         "--allowed-target",
         action="append",
         default=[],
@@ -784,6 +958,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-avg-entry-sweep-slip-bps", type=float, default=200.0)
     parser.add_argument("--max-top-bucket-entry-sweep-levels", type=float, default=3.0)
     parser.add_argument("--min-window-count", type=int, default=4)
+    parser.add_argument("--min-replay-trade-count", type=int, default=50)
+    parser.add_argument("--min-replay-fill-rate", type=float, default=0.30)
+    parser.add_argument("--min-replay-roi", type=float, default=0.0)
     return parser.parse_args()
 
 
@@ -793,6 +970,9 @@ def main() -> int:
     allowed_targets = tuple(args.allowed_target or DEFAULT_ALLOWED_TARGETS)
     result = evaluate(
         report_text,
+        candidate_strategy_replay=load_candidate_strategy_replay(
+            args.candidate_strategy_replay_json or None
+        ),
         allowed_targets=allowed_targets,
         required_strategy_profile=args.required_strategy_profile,
         runtime_mappings=load_runtime_mappings(args.runtime_mapping_json or None),
@@ -802,6 +982,9 @@ def main() -> int:
         max_avg_entry_sweep_slip_bps=args.max_avg_entry_sweep_slip_bps,
         max_top_bucket_entry_sweep_levels=args.max_top_bucket_entry_sweep_levels,
         min_window_count=args.min_window_count,
+        min_replay_trade_count=args.min_replay_trade_count,
+        min_replay_fill_rate=args.min_replay_fill_rate,
+        min_replay_roi=args.min_replay_roi,
     )
 
     if args.output_json:

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -175,6 +175,8 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
         "--required-strategy-profile",
         args.required_strategy_profile,
     ]
+    if args.candidate_strategy_replay_json:
+        command.extend(["--candidate-strategy-replay-json", args.candidate_strategy_replay_json])
     for target in args.allowed_target:
         command.extend(["--allowed-target", target])
     return command
@@ -434,6 +436,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end-ts", required=True)
     parser.add_argument("--stake-usd", required=True)
     parser.add_argument("--replay-parity-json", default="")
+    parser.add_argument("--candidate-strategy-replay-json", default="")
     parser.add_argument("--alpha-search-output-dir", default="")
     parser.add_argument("--alpha-search-plan-json", default="")
     parser.add_argument("--alpha-search-state-json", default="")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,50 @@
+# Replay-First AutoFactor Promotion Gate (2026-05-18)
+
+## Goal
+
+Fix the PM5D alpha-research CI/CD order so factor/search evidence cannot create
+a dry-run handoff until the selected runtime score has passed historical
+strategy-level executable replay.
+
+Evidence stage: `workflow repair / executable_replay gate`.
+
+## Files / Ownership
+
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: require candidate strategy replay JSON before handoff readiness.
+- `.github/workflows/autofactor-strategy-promotion.yml`
+  - Owner: auto-discover replay artifact in the source walk-forward artifact.
+- `docs/runbooks/strategy-research-cicd.md`,
+  `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document replay-first ordering before dry-run.
+- `tests/test_autofactor_strategy_promotion.py`
+  - Owner: cover missing replay, bad replay contract, and runtime-score match.
+
+## Tasks
+
+- [x] Confirm the existing docs/gates could be read as factor/search -> dry-run
+      without a separate strategy-level replay artifact.
+- [x] Add fail-closed candidate strategy replay validation to the promotion
+      evaluator.
+- [x] Wire the hosted promotion workflow to find replay artifacts without
+      adding a new workflow input.
+- [x] Update docs/runbooks to make the correct order explicit:
+      factor/search -> executable replay -> dry-run -> recorded replay parity
+      -> live.
+- [x] Run focused validation.
+- [ ] Open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-18: Root cause is process/gate ordering, not just stale dry-run data:
+  AutoFactor rows measured factor quality and execution labels, but the
+  promotion evaluator did not require a selected strategy replay artifact with
+  the same runtime scorer before a dry-run handoff/config PR.
+- 2026-05-18: Validation passed: promotion/sweep Python unittests, Python
+  compile checks, workflow YAML parsing, workflow security test, and diff
+  hygiene.
+
 # Recorded Replay Recording Rollover (2026-05-18)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -138,16 +138,49 @@ candidate,bucket,count
 {AUTOFACTOR_SETTLEMENT_AUTO_REPORT}
 """
 
+DEFAULT_REPLAY_PAYLOAD = {
+    "schema_version": 1,
+    "kind": "autofactor_candidate_strategy_replay",
+    "evidence_stage": "executable_replay",
+    "strategy_profile": "settlement_probability",
+    "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+    "promotion_ready": True,
+    "decision_contract": {
+        "event_level": True,
+        "one_decision_per_event": True,
+        "official_settlement": True,
+        "full_depth_entry": True,
+        "max_sweep_levels": 3,
+        "stake_usd": 15,
+    },
+    "metrics": {
+        "trade_count": 100,
+        "unique_event_count": 100,
+        "total_pnl": 12.5,
+        "roi": 0.03,
+        "entry_fill_rate": 0.95,
+    },
+    "blocking_risk_flags": [],
+}
+
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
-    def run_script(self, report, *extra_args, check=True):
+    def run_script(self, report, *extra_args, check=True, replay_payload=DEFAULT_REPLAY_PAYLOAD):
         with tempfile.TemporaryDirectory() as tmp:
             report_path = Path(tmp) / "report.txt"
+            replay_path = Path(tmp) / "candidate-strategy-replay.json"
             output_json = Path(tmp) / "promotion.json"
             output_registry = Path(tmp) / "registry.json"
             output_handoff = Path(tmp) / "handoff.json"
             output_handoff_md = Path(tmp) / "handoff.md"
             report_path.write_text(report, encoding="utf-8")
+            replay_args = []
+            if replay_payload is not None:
+                replay_path.write_text(
+                    json.dumps(replay_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                replay_args = ["--candidate-strategy-replay-json", str(replay_path)]
             result = subprocess.run(
                 [
                     sys.executable,
@@ -162,6 +195,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     str(output_handoff),
                     "--output-handoff-md",
                     str(output_handoff_md),
+                    *replay_args,
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -212,8 +246,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(payload["decision"], "qualified")
         self.assertEqual(registry["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
-        self.assertEqual(handoff["blocked_factor_count"], 1)
-        self.assertEqual(len(handoff["strategies"]), 3)
+        self.assertEqual(handoff["blocked_factor_count"], 3)
+        self.assertEqual(len(handoff["strategies"]), 1)
         self.assertEqual(
             handoff["strategies"][0]["runtime_score"],
             "autofactor_formula:auto_settlement_conservative_settlement_edge",
@@ -222,16 +256,20 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             handoff["strategies"][0]["strategy_profile"],
             "settlement_probability",
         )
-        self.assertIn(
-            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
-            handoff_md,
-        )
-        self.assertIn(
-            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
-            handoff_md,
-        )
+        self.assertIn("Candidate strategy replay ready: `true`", handoff_md)
         self.assertIn("top bucket avg label", handoff_md)
         self.assertNotIn("top bucket pnl", handoff_md.lower())
+        near_strike = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "auto_settlement_conservative_settlement_edge_x_near_strike"
+        )
+        self.assertIn(
+            "candidate_strategy_replay_runtime_score_mismatch:"
+            "autofactor_formula:auto_settlement_conservative_settlement_edge!="
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
+            near_strike["blockers"],
+        )
         rejected = next(
             item
             for item in payload["evaluated_factors"]
@@ -302,8 +340,13 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertNotIn("global_full_depth_entry_fillability", ",".join(blockers))
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": "autofactor_formula:amplitude_weighted_momentum_30s_sigma",
+        }
         _, payload, registry, handoff, handoff_md = self.run_script(
-            READY_GATE + AUTOFACTOR_PREDICTIVE_EXTERNAL_REPORT
+            READY_GATE + AUTOFACTOR_PREDICTIVE_EXTERNAL_REPORT,
+            replay_payload=replay,
         )
 
         self.assertEqual(payload["decision"], "qualified")
@@ -320,14 +363,19 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("amplitude_weighted_momentum_30s_sigma", handoff_md)
 
     def test_qualifies_tradeable_hard_gate_predictive_formula_when_gate_is_ready(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
+        }
         _, payload, registry, handoff, handoff_md = self.run_script(
-            READY_GATE + AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT
+            READY_GATE + AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT,
+            replay_payload=replay,
         )
 
         self.assertEqual(payload["decision"], "qualified")
         self.assertEqual(registry["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
-        self.assertEqual(len(handoff["strategies"]), 2)
+        self.assertEqual(len(handoff["strategies"]), 1)
         self.assertEqual(
             handoff["strategies"][0]["runtime_score"],
             "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
@@ -377,12 +425,18 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("Promote AutoFactor strategy handoff to dry-run", handoff_md)
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "strategy_profile": "repricing_momentum",
+            "runtime_score": "spread_adjusted_external_move_score",
+        }
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
             "full_depth_reprice_pnl_10s",
             "--required-strategy-profile",
             "repricing_momentum",
+            replay_payload=replay,
         )
 
         self.assertEqual(payload["decision"], "qualified")
@@ -423,7 +477,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         self.assertEqual(payload["decision"], "qualified")
         self.assertEqual(handoff["status"], "ready")
-        self.assertEqual(len(handoff["strategies"]), 3)
+        self.assertEqual(len(handoff["strategies"]), 1)
         first = payload["qualified_strategies"][0]["factor"]
         self.assertEqual(first["symbol_count"], 6)
         self.assertEqual(first["symbol_positive_ratio"], 0.8333)
@@ -452,8 +506,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         _, payload, _, handoff, _ = self.run_script(READY_GATE + sparse_report)
 
-        self.assertEqual(payload["decision"], "qualified")
-        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
         sparse = next(
             item
             for item in payload["evaluated_factors"]
@@ -471,8 +525,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         _, payload, _, handoff, _ = self.run_script(READY_GATE + thin_report)
 
-        self.assertEqual(payload["decision"], "qualified")
-        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
         thin = next(
             item
             for item in payload["evaluated_factors"]
@@ -507,8 +561,8 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
         _, payload, _, handoff, _ = self.run_script(READY_GATE + duplicate_event_report)
 
-        self.assertEqual(payload["decision"], "qualified")
-        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
         first = next(
             item
             for item in payload["evaluated_factors"]
@@ -519,6 +573,51 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "one_event_decision_violation:max_event_decisions=3",
             first["blockers"],
         )
+
+    def test_blocks_ready_factor_when_candidate_strategy_replay_is_missing(self):
+        _, payload, _, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=None,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertIn("missing_candidate_strategy_replay", first["blockers"])
+        self.assertIn("candidate_strategy_replay_not_ready", first["blockers"])
+        self.assertIn("Candidate strategy replay ready: `false`", handoff_md)
+
+    def test_blocks_replay_without_executable_strategy_contract(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "promotion_ready": True,
+            "decision_contract": {
+                "event_level": True,
+                "one_decision_per_event": True,
+                "official_settlement": False,
+                "full_depth_entry": False,
+            },
+            "metrics": {
+                "trade_count": 8,
+                "unique_event_count": 8,
+                "roi": -0.01,
+                "entry_fill_rate": 0.20,
+            },
+        }
+
+        _, payload, _, handoff, _ = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        blockers = payload["evaluated_factors"][0]["blockers"]
+        self.assertIn("candidate_strategy_replay_missing_contract:official_settlement", blockers)
+        self.assertIn("candidate_strategy_replay_missing_contract:full_depth_entry", blockers)
+        self.assertIn("candidate_strategy_replay_trade_count_too_small:8<50", blockers)
+        self.assertIn("candidate_strategy_replay_entry_fill_rate_too_low:0.2000<0.3000", blockers)
+        self.assertIn("candidate_strategy_replay_roi_too_low:-0.010000<0.000000", blockers)
 
 
 if __name__ == "__main__":

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -78,6 +78,43 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 
 
 class FactorWalkForwardSweepTests(unittest.TestCase):
+    def replay_file(
+        self,
+        tmp: Path,
+        runtime_score: str = "autofactor_formula:auto_settlement_conservative_settlement_edge",
+    ) -> Path:
+        replay = tmp / f"candidate-strategy-replay-{runtime_score.replace(':', '_')}.json"
+        replay.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "autofactor_candidate_strategy_replay",
+                    "evidence_stage": "executable_replay",
+                    "strategy_profile": "settlement_probability",
+                    "runtime_score": runtime_score,
+                    "promotion_ready": True,
+                    "decision_contract": {
+                        "event_level": True,
+                        "one_decision_per_event": True,
+                        "official_settlement": True,
+                        "full_depth_entry": True,
+                    },
+                    "metrics": {
+                        "trade_count": 100,
+                        "unique_event_count": 100,
+                        "total_pnl": 12.5,
+                        "roi": 0.03,
+                        "entry_fill_rate": 0.95,
+                    },
+                    "blocking_risk_flags": [],
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        return replay
+
     def base_args(self, tmp: Path, binary: Path) -> list[str]:
         return [
             sys.executable,
@@ -199,7 +236,13 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                 ]
             )
             result = subprocess.run(
-                [*self.base_args(tmp, binary), "--sweep-json", sweep_json],
+                [
+                    *self.base_args(tmp, binary),
+                    "--candidate-strategy-replay-json",
+                    str(self.replay_file(tmp)),
+                    "--sweep-json",
+                    sweep_json,
+                ],
                 cwd=ROOT,
                 text=True,
                 capture_output=True,
@@ -243,6 +286,8 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             subprocess.run(
                 [
                     *self.base_args(tmp, binary),
+                    "--candidate-strategy-replay-json",
+                    str(self.replay_file(tmp)),
                     "--sweep-json",
                     sweep_json,
                     "--alpha-search-output-dir",
@@ -318,6 +363,13 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             subprocess.run(
                 [
                     *self.base_args(tmp, binary),
+                    "--candidate-strategy-replay-json",
+                    str(
+                        self.replay_file(
+                            tmp,
+                            "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate",
+                        )
+                    ),
                     "--allowed-target",
                     "tradeable_full_depth_settlement_pnl",
                     "--sweep-json",
@@ -346,6 +398,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--sweep-json \"${SWEEP_JSON}\"", workflow)
         self.assertIn("--factor-name-filter \"${WALK_FACTOR_NAME_FILTER}\"", workflow)
         self.assertIn("--train-window-hours \"${WALK_TRAIN_WINDOW_HOURS}\"", workflow)
+        self.assertIn("--candidate-strategy-replay-json", workflow)
 
     def test_alpha_search_prior_and_state_args_pass_through_to_factor_binary(self):
         with tempfile.TemporaryDirectory() as raw_tmp:


### PR DESCRIPTION
## Summary
- require a candidate strategy executable replay artifact before AutoFactor promotion can produce a dry-run handoff
- auto-discover candidate replay artifacts in hosted promotion/search workflows without adding workflow_dispatch inputs
- update PM5D alpha-search/runbook docs to make the order explicit: factor/search -> executable replay -> dry-run -> recorded replay parity -> live

## Tests
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py
- ruby -e 'require "yaml"; %w[.github/workflows/autofactor-strategy-promotion.yml .github/workflows/factor-walk-forward-v2-hosted-artifact.yml].each { |f| YAML.load_file(f); puts f }'
- rtk cargo test --test workflow_security -- --nocapture
- rtk git diff --check