### PR TITLE
Produce AutoFactor candidate replay artifact in sweep

### DIFF
--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -202,6 +202,15 @@ Required artifact:
 - `candidate-strategy-replay.json` or
   `autofactor-candidate-strategy-replay.json`
 
+In the hosted factor walk-forward sweep, this artifact is generated per variant
+when an external replay artifact is not supplied. The generated artifact is
+based on the selected runtime-mappable `factor_walk_forward_v2` top bucket and
+declares `basis=factor_walk_forward_top_bucket_aggregate`. It is sufficient for
+the pre-dry-run executable strategy gate only when the report target already
+uses event-level, official-settlement, full-depth executable labels. It does not
+replace recorded replay/dry-run parity after a dry-run runtime has produced
+orders and fills.
+
 Minimum contract:
 
 - `evidence_stage=executable_replay`

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -205,6 +205,17 @@ must pass historical executable replay before any dry-run handoff issue/config
 is created. Recorded replay parity remains the later dry-run/runtime parity gate
 after dry-run evidence exists.
 
+The hosted factor walk-forward sweep now builds this pre-dry-run replay artifact
+per variant when no external `candidate-strategy-replay.json` is supplied. The
+builder converts the selected runtime-mappable top bucket from
+`factor_walk_forward_v2` into `candidate-strategy-replay.json` with explicit
+event-level, one-decision-per-event, official-settlement, full-depth-entry, PnL,
+ROI, and fill-rate fields. Its `basis` is
+`factor_walk_forward_top_bucket_aggregate`; it is the historical executable
+strategy gate before dry-run, not the later recorded replay/dry-run parity
+proof. The sweep copies the best variant's `candidate-strategy-replay.json` and
+`.md` to the artifact root before the AutoFactor handoff/config PR step.
+
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:
 

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Build the AutoFactor candidate-strategy executable replay artifact.
+
+The source report must come from factor_walk_forward_v2. For settlement targets,
+that report already scores one decision per event against historical
+full-depth executable settlement labels. This script converts the selected
+runtime-mappable candidate row into the explicit replay artifact required by
+the dry-run promotion gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ALLOWED_TARGETS = {
+    "full_depth_settlement_executable_pnl",
+    "tradeable_full_depth_settlement_pnl",
+}
+
+
+def parse_float(raw: str, default: float = float("nan")) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_int(raw: str, default: int = 0) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    in_section = False
+    header: list[str] | None = None
+    current_target = ""
+    for line in report_text.splitlines():
+        if line.startswith("# AutoFactor target="):
+            current_target = line.split("=", 1)[1].strip()
+            in_section = True
+            header = None
+            continue
+        if not in_section:
+            continue
+        if line.startswith("rank,name,target,"):
+            header = next(csv.reader([line]))
+            continue
+        if not line.strip():
+            in_section = False
+            header = None
+            current_target = ""
+            continue
+        if header is None or line.startswith("===") or line.startswith("target labels"):
+            continue
+        values = next(csv.reader([line]))
+        if len(values) != len(header):
+            continue
+        item = dict(zip(header, values))
+        item["target"] = item.get("target") or current_target
+        rows.append(item)
+    return rows
+
+
+def runtime_mapping(name: str) -> dict[str, str]:
+    if name in {
+        "spread_adjusted_external_move",
+        "repricing_gap_side_10s",
+    }:
+        return {
+            "strategy_profile": "repricing_momentum",
+            "runtime_score": (
+                "spread_adjusted_external_move_score"
+                if name == "spread_adjusted_external_move"
+                else name
+            ),
+        }
+    if (
+        name.startswith("auto_settlement_")
+        or name.startswith("mut_")
+        or name == "amplitude_weighted_momentum_30s_sigma"
+    ):
+        return {
+            "strategy_profile": "settlement_probability",
+            "runtime_score": f"autofactor_formula:{name}",
+        }
+    return {"strategy_profile": "", "runtime_score": ""}
+
+
+def row_score(row: dict[str, Any]) -> tuple[float, ...]:
+    return (
+        parse_float(row.get("top_bucket_avg_label", "")),
+        parse_float(row.get("icir", "")),
+        parse_float(row.get("positive_window_ratio", "")),
+        parse_float(row.get("spearman_ic", "")),
+    )
+
+
+def select_candidate(
+    rows: list[dict[str, Any]],
+    *,
+    allowed_targets: set[str],
+    required_strategy_profile: str,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    candidates: list[dict[str, Any]] = []
+    blockers: list[str] = []
+    for row in rows:
+        mapping = runtime_mapping(str(row.get("name", "")))
+        row_target = str(row.get("target", ""))
+        if row_target not in allowed_targets:
+            continue
+        if row.get("decision") != "candidate" or row.get("reason") != "passed":
+            blockers.append(f"not_candidate:{row.get('name')}:{row.get('decision')}:{row.get('reason')}")
+            continue
+        if mapping.get("strategy_profile") != required_strategy_profile:
+            blockers.append(
+                "runtime_profile_mismatch:"
+                f"{row.get('name')}:{mapping.get('strategy_profile') or '<missing>'}!="
+                f"{required_strategy_profile}"
+            )
+            continue
+        if not mapping.get("runtime_score"):
+            blockers.append(f"missing_runtime_score:{row.get('name')}")
+            continue
+        row = dict(row)
+        row["runtime_mapping"] = mapping
+        candidates.append(row)
+    if not candidates:
+        return None, blockers or ["no_runtime_mappable_candidate"]
+    return max(candidates, key=row_score), []
+
+
+def build_artifact(
+    row: dict[str, Any] | None,
+    *,
+    blockers: list[str],
+    stake_usd: float,
+    required_strategy_profile: str,
+    evidence: str,
+    min_trade_count: int,
+    min_fill_rate: float,
+    min_roi: float,
+) -> dict[str, Any]:
+    if row is None:
+        return {
+            "schema_version": 1,
+            "kind": "autofactor_candidate_strategy_replay",
+            "evidence_stage": "executable_replay",
+            "basis": "factor_walk_forward_top_bucket_aggregate",
+            "strategy_profile": required_strategy_profile,
+            "runtime_score": "",
+            "promotion_ready": False,
+            "evidence": evidence,
+            "decision_contract": {
+                "event_level": True,
+                "one_decision_per_event": True,
+                "official_settlement": True,
+                "full_depth_entry": True,
+                "stake_usd": stake_usd,
+            },
+            "metrics": {},
+            "blocking_risk_flags": blockers,
+        }
+
+    top_bucket_n = parse_int(row.get("top_bucket_n", "0"))
+    unique_events = parse_int(row.get("top_bucket_unique_event_count", "0"))
+    max_event_decisions = parse_int(row.get("top_bucket_max_event_decisions", "0"))
+    avg_label = parse_float(row.get("top_bucket_avg_label", "nan"))
+    fill_rate = parse_float(row.get("top_bucket_full_depth_entry_fill_rate", "nan"))
+    total_pnl = avg_label * top_bucket_n if avg_label == avg_label else float("nan")
+    notional = stake_usd * top_bucket_n
+    roi = total_pnl / notional if notional > 0 and total_pnl == total_pnl else float("nan")
+    runtime_score = row["runtime_mapping"]["runtime_score"]
+
+    artifact_blockers = list(blockers)
+    if top_bucket_n < min_trade_count:
+        artifact_blockers.append(f"trade_count_too_small:{top_bucket_n}<{min_trade_count}")
+    if unique_events < min(top_bucket_n, min_trade_count):
+        artifact_blockers.append(
+            f"unique_event_count_too_small:{unique_events}<{min(top_bucket_n, min_trade_count)}"
+        )
+    if max_event_decisions != 1:
+        artifact_blockers.append(f"one_event_decision_violation:{max_event_decisions}")
+    if not (fill_rate == fill_rate) or fill_rate < min_fill_rate:
+        artifact_blockers.append(f"entry_fill_rate_too_low:{fill_rate:.4f}<{min_fill_rate:.4f}")
+    if not (roi == roi) or roi < min_roi:
+        artifact_blockers.append(f"roi_too_low:{roi:.6f}<{min_roi:.6f}")
+
+    return {
+        "schema_version": 1,
+        "kind": "autofactor_candidate_strategy_replay",
+        "evidence_stage": "executable_replay",
+        "basis": "factor_walk_forward_top_bucket_aggregate",
+        "strategy_profile": row["runtime_mapping"]["strategy_profile"],
+        "runtime_score": runtime_score,
+        "promotion_ready": not artifact_blockers,
+        "evidence": evidence,
+        "source_factor": {
+            "name": row.get("name", ""),
+            "target": row.get("target", ""),
+            "decision": row.get("decision", ""),
+            "reason": row.get("reason", ""),
+        },
+        "decision_contract": {
+            "event_level": True,
+            "one_decision_per_event": True,
+            "official_settlement": True,
+            "full_depth_entry": True,
+            "stake_usd": stake_usd,
+            "entry_policy": "top_scoring_bucket",
+        },
+        "metrics": {
+            "trade_count": top_bucket_n,
+            "unique_event_count": unique_events,
+            "total_pnl": total_pnl,
+            "roi": roi,
+            "entry_fill_rate": fill_rate,
+            "top_bucket_positive_label_rate": parse_float(
+                row.get("top_bucket_positive_label_rate", "nan")
+            ),
+            "avg_entry_sweep_slip_bps": parse_float(
+                row.get("top_bucket_avg_entry_sweep_slip_bps")
+                or row.get("top_bucket_avg_entry_sweep_slippage_bps")
+                or "nan"
+            ),
+            "avg_entry_sweep_levels": parse_float(
+                row.get("top_bucket_avg_entry_sweep_levels", "nan")
+            ),
+            "max_event_decisions": max_event_decisions,
+        },
+        "blocking_risk_flags": artifact_blockers,
+    }
+
+
+def render_markdown(artifact: dict[str, Any]) -> str:
+    metrics = artifact.get("metrics") or {}
+    lines = [
+        "# AutoFactor Candidate Strategy Replay",
+        "",
+        f"- Promotion ready: `{str(artifact.get('promotion_ready')).lower()}`",
+        f"- Runtime score: `{artifact.get('runtime_score') or '<none>'}`",
+        f"- Strategy profile: `{artifact.get('strategy_profile') or '<none>'}`",
+        f"- Evidence stage: `{artifact.get('evidence_stage')}`",
+        f"- Trades: `{metrics.get('trade_count', 'n/a')}`",
+        f"- Unique events: `{metrics.get('unique_event_count', 'n/a')}`",
+        f"- Total PnL: `{metrics.get('total_pnl', 'n/a')}`",
+        f"- ROI: `{metrics.get('roi', 'n/a')}`",
+        f"- Entry fill rate: `{metrics.get('entry_fill_rate', 'n/a')}`",
+        "",
+        "## Blocking Risk Flags",
+        "",
+    ]
+    flags = artifact.get("blocking_risk_flags") or []
+    if flags:
+        lines.extend(f"- `{flag}`" for flag in flags)
+    else:
+        lines.append("- `<none>`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md", default="")
+    parser.add_argument("--allowed-target", action="append", default=[])
+    parser.add_argument("--required-strategy-profile", default="settlement_probability")
+    parser.add_argument("--stake-usd", type=float, default=15.0)
+    parser.add_argument("--min-trade-count", type=int, default=50)
+    parser.add_argument("--min-fill-rate", type=float, default=0.30)
+    parser.add_argument("--min-roi", type=float, default=0.0)
+    parser.add_argument("--evidence", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report_path = Path(args.report)
+    rows = parse_autofactor_rows(report_path.read_text(encoding="utf-8"))
+    allowed_targets = set(args.allowed_target or DEFAULT_ALLOWED_TARGETS)
+    row, blockers = select_candidate(
+        rows,
+        allowed_targets=allowed_targets,
+        required_strategy_profile=args.required_strategy_profile,
+    )
+    artifact = build_artifact(
+        row,
+        blockers=blockers,
+        stake_usd=args.stake_usd,
+        required_strategy_profile=args.required_strategy_profile,
+        evidence=args.evidence or str(report_path),
+        min_trade_count=args.min_trade_count,
+        min_fill_rate=args.min_fill_rate,
+        min_roi=args.min_roi,
+    )
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.output_md:
+        output_md = Path(args.output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(render_markdown(artifact), encoding="utf-8")
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -175,8 +175,36 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
         "--required-strategy-profile",
         args.required_strategy_profile,
     ]
-    if args.candidate_strategy_replay_json:
-        command.extend(["--candidate-strategy-replay-json", args.candidate_strategy_replay_json])
+    replay_json = args.candidate_strategy_replay_json or str(
+        variant_dir / "candidate-strategy-replay.json"
+    )
+    command.extend(["--candidate-strategy-replay-json", replay_json])
+    for target in args.allowed_target:
+        command.extend(["--allowed-target", target])
+    return command
+
+
+def candidate_replay_args(
+    args: argparse.Namespace,
+    report: Path,
+    variant_dir: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        args.candidate_replay_builder,
+        "--report",
+        str(report),
+        "--output-json",
+        str(variant_dir / "candidate-strategy-replay.json"),
+        "--output-md",
+        str(variant_dir / "candidate-strategy-replay.md"),
+        "--required-strategy-profile",
+        args.required_strategy_profile,
+        "--stake-usd",
+        args.stake_usd,
+        "--evidence",
+        str(report),
+    ]
     for target in args.allowed_target:
         command.extend(["--allowed-target", target])
     return command
@@ -307,6 +335,8 @@ def promote_best_variant(best: dict[str, Any] | None, output_dir: Path) -> None:
         "autofactor-factor-registry.json",
         "autofactor-strategy-handoff.json",
         "autofactor-strategy-handoff.md",
+        "candidate-strategy-replay.json",
+        "candidate-strategy-replay.md",
         "evaluator-output.json",
     ]:
         src = source / name
@@ -369,6 +399,28 @@ def run_variant(
     if result.returncode:
         return item
 
+    if not args.candidate_strategy_replay_json:
+        replay_result = subprocess.run(
+            candidate_replay_args(args, report_path, variant_dir),
+            cwd=args.cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        (variant_dir / "candidate-strategy-replay-output.json").write_text(
+            replay_result.stdout,
+            encoding="utf-8",
+        )
+        if replay_result.stderr:
+            (variant_dir / "candidate-strategy-replay-stderr.txt").write_text(
+                replay_result.stderr,
+                encoding="utf-8",
+            )
+        item["candidate_replay_exit_code"] = replay_result.returncode
+        if replay_result.returncode != 0:
+            item["status"] = "candidate_replay_failed"
+            return item
+
     eval_result = subprocess.run(
         promotion_args(args, report_path, variant_dir),
         cwd=args.cwd,
@@ -429,6 +481,10 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binary", required=True)
     parser.add_argument("--evaluator", default="scripts/evaluate_autofactor_strategy_promotion.py")
+    parser.add_argument(
+        "--candidate-replay-builder",
+        default="scripts/build_autofactor_candidate_strategy_replay.py",
+    )
     parser.add_argument("--snapshot-dir", required=True)
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--symbols", required=True)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,48 @@
+# AutoFactor Candidate Strategy Replay Artifact (2026-05-18)
+
+## Goal
+
+Make hosted PM5D factor walk-forward produce the historical executable
+candidate replay artifact required before any dry-run handoff/config PR.
+
+Evidence stage: `executable_replay / CI workflow repair`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: convert a runtime-mappable AutoFactor top bucket into the explicit
+    candidate strategy replay artifact consumed by the promotion evaluator.
+- `scripts/run_factor_walk_forward_sweep.py`
+  - Owner: build per-variant candidate replay artifacts when no external replay
+    artifact is supplied, then promote the best variant's replay artifact to
+    the hosted artifact root.
+- `tests/test_build_autofactor_candidate_strategy_replay.py`,
+  `tests/test_factor_walk_forward_sweep.py`
+  - Owner: cover builder readiness/blockers and sweep-level artifact promotion.
+- `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document that the generated artifact is a pre-dry-run executable
+    strategy gate, distinct from later recorded replay/dry-run parity.
+
+## Tasks
+
+- [x] Add an AutoFactor candidate replay artifact builder for runtime-mappable
+      settlement candidates.
+- [x] Wire the hosted sweep runner to generate `candidate-strategy-replay.json`
+      before invoking the fail-closed promotion evaluator.
+- [x] Copy the best variant's replay JSON/Markdown to the root artifact.
+- [x] Add focused unit coverage for builder output and sweep promotion.
+- [x] Update research runbooks with the replay-first artifact contract.
+- [ ] Run focused validation, open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-18: This closes the immediate CI gap after the replay-first gate:
+  hosted walk-forward no longer needs a manually pre-existing replay JSON to
+  reach the promotion evaluator. The generated artifact is explicitly marked
+  `basis=factor_walk_forward_top_bucket_aggregate`; recorded replay/dry-run
+  parity remains a separate later gate after dry-run evidence exists.
+
 # Replay-First AutoFactor Promotion Gate (2026-05-18)
 
 ## Goal

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -1,0 +1,86 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.test_autofactor_strategy_promotion import (
+    AUTOFACTOR_REPORT,
+    AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_autofactor_candidate_strategy_replay.py"
+
+
+class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
+    def run_script(self, report: str, *extra_args: str) -> tuple[dict, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            report_path = tmp_path / "report.txt"
+            output_json = tmp_path / "candidate-strategy-replay.json"
+            output_md = tmp_path / "candidate-strategy-replay.md"
+            report_path.write_text(report, encoding="utf-8")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--report",
+                    str(report_path),
+                    "--output-json",
+                    str(output_json),
+                    "--output-md",
+                    str(output_md),
+                    *extra_args,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return (
+                json.loads(output_json.read_text(encoding="utf-8")),
+                output_md.read_text(encoding="utf-8"),
+            )
+
+    def test_builds_ready_replay_for_runtime_mappable_settlement_candidate(self):
+        payload, markdown = self.run_script(AUTOFACTOR_SETTLEMENT_AUTO_REPORT)
+
+        self.assertTrue(payload["promotion_ready"])
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+        self.assertEqual(payload["evidence_stage"], "executable_replay")
+        self.assertEqual(payload["basis"], "factor_walk_forward_top_bucket_aggregate")
+        self.assertEqual(payload["strategy_profile"], "settlement_probability")
+        self.assertTrue(payload["decision_contract"]["event_level"])
+        self.assertTrue(payload["decision_contract"]["one_decision_per_event"])
+        self.assertTrue(payload["decision_contract"]["official_settlement"])
+        self.assertTrue(payload["decision_contract"]["full_depth_entry"])
+        self.assertEqual(payload["metrics"]["trade_count"], 9966)
+        self.assertEqual(payload["metrics"]["unique_event_count"], 9966)
+        self.assertGreater(payload["metrics"]["total_pnl"], 0)
+        self.assertGreater(payload["metrics"]["roi"], 0)
+        self.assertEqual(payload["blocking_risk_flags"], [])
+        self.assertIn("Promotion ready: `true`", markdown)
+
+    def test_blocks_when_only_candidate_is_wrong_profile(self):
+        payload, markdown = self.run_script(
+            AUTOFACTOR_REPORT,
+            "--allowed-target",
+            "full_depth_reprice_pnl_10s",
+            "--required-strategy-profile",
+            "settlement_probability",
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["runtime_score"], "")
+        self.assertIn("runtime_profile_mismatch", ",".join(payload["blocking_risk_flags"]))
+        self.assertIn("Promotion ready: `false`", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -258,6 +258,39 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(summary["variants"][0]["qualified_count"], 1)
         self.assertIn("auto_settlement_conservative_settlement_edge", summary_md)
 
+    def test_builds_and_promotes_candidate_strategy_replay_when_missing(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = self.fake_binary(tmp)
+            subprocess.run(
+                self.base_args(tmp, binary),
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+            root_replay = json.loads(
+                (tmp / "out" / "candidate-strategy-replay.json").read_text(encoding="utf-8")
+            )
+            variant_replay = json.loads(
+                (tmp / "out" / "001-base" / "candidate-strategy-replay.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(summary["best_variant"], "base")
+        self.assertEqual(summary["variants"][0]["candidate_replay_exit_code"], 0)
+        self.assertTrue(root_replay["promotion_ready"])
+        self.assertEqual(root_replay["basis"], "factor_walk_forward_top_bucket_aggregate")
+        self.assertEqual(
+            root_replay["runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+        self.assertEqual(root_replay, variant_replay)
+
     def test_promotes_alpha_search_artifacts_from_best_variant(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)


### PR DESCRIPTION
## Summary
- add a builder that converts a runtime-mappable AutoFactor top bucket into candidate-strategy-replay.json
- make the factor walk-forward sweep generate per-variant candidate replay artifacts when no external replay JSON is supplied
- promote the best variant's replay artifact to the hosted artifact root and document the pre-dry-run replay-first contract

## Validation
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/run_factor_walk_forward_sweep.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_factor_walk_forward_sweep.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated generation of candidate strategy replay artifacts during factor walk-forward sweeps when external replay artifacts are not supplied.

* **Documentation**
  * Clarified how candidate strategy replay artifacts are produced in hosted factor walk-forward sweeps, including specifications for basis marking, sufficiency conditions, and relationship to dry-run parity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->