### PR TITLE
Move recorded parity after dry-run handoff

### DIFF
--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -3154,13 +3154,16 @@ pub fn build_settlement_probability_promotion_gate_report(
             if options.replay_parity_ready {
                 "recorded replay parity marked ready by caller".to_string()
             } else {
-                "blocked: no recorded replay parity artifact was supplied to this report"
+                "post-dry-run gate pending: no recorded replay parity artifact was supplied to this report"
                     .to_string()
             }
         }),
     });
 
-    let ready_for_dry_run_handoff = gates.iter().all(|gate| gate.passed);
+    let ready_for_dry_run_handoff = gates
+        .iter()
+        .filter(|gate| gate.gate != "recorded_replay_parity")
+        .all(|gate| gate.passed);
     SettlementProbabilityPromotionGateReport {
         options,
         ready_for_dry_run_handoff,
@@ -10238,7 +10241,7 @@ mod tests {
     }
 
     #[test]
-    fn settlement_probability_promotion_gate_blocks_without_replay_parity() {
+    fn settlement_probability_promotion_gate_tracks_pending_post_dryrun_replay_parity() {
         let probability = SettlementProbabilityReport {
             options: SettlementProbabilityReportOptions::default(),
             baselines: vec![SettlementProbabilityBaselineRow {
@@ -10341,23 +10344,25 @@ mod tests {
             }],
         };
 
-        let blocked = build_settlement_probability_promotion_gate_report(
+        let pending_parity = build_settlement_probability_promotion_gate_report(
             &probability,
             &walk_forward,
             &execution,
             &execution,
             SettlementProbabilityPromotionGateOptions {
-                include_deribit: true,
+                include_deribit: false,
                 data_audit_status: Some("ok".to_string()),
                 replay_parity_ready: false,
                 ..Default::default()
             },
         );
-        assert!(!blocked.ready_for_dry_run_handoff);
-        assert!(blocked
+        assert!(pending_parity.ready_for_dry_run_handoff);
+        assert!(pending_parity
             .gates
             .iter()
-            .any(|gate| gate.gate == "recorded_replay_parity" && !gate.passed));
+            .any(|gate| gate.gate == "recorded_replay_parity"
+                && !gate.passed
+                && gate.evidence.contains("post-dry-run gate pending")));
 
         let ready = build_settlement_probability_promotion_gate_report(
             &probability,
@@ -10422,7 +10427,7 @@ mod tests {
                 && gate.evidence.contains("require_deribit=true include_deribit=false")
         }));
 
-        let text = format_settlement_probability_promotion_gate_report(&blocked);
+        let text = format_settlement_probability_promotion_gate_report(&deribit_required);
         assert!(text.contains("Settlement Probability PRD Promotion Gate"));
         assert!(text.contains("ready_for_dry_run_handoff=false"));
     }

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -211,6 +211,10 @@ uses event-level, official-settlement, full-depth executable labels. It does not
 replace recorded replay/dry-run parity after a dry-run runtime has produced
 orders and fills.
 
+Recorded replay/dry-run parity is intentionally after dry-run in the promotion
+sequence. It should be reported as pending during pre-dry-run research, not as a
+blocker that prevents a historically replayed candidate from entering dry-run.
+
 Minimum contract:
 
 - `evidence_stage=executable_replay`

--- a/docs/PROJECT_SEMANTICS.md
+++ b/docs/PROJECT_SEMANTICS.md
@@ -106,7 +106,9 @@ and passes the relevant gates:
 - executable price and fillability assumptions are conservative
 - settlement or exit label matches the intended strategy lane
 - train/test or walk-forward split prevents leakage
-- replay/dry-run parity is present for runtime handoff
+- historical executable replay is present before dry-run handoff
+- replay/dry-run parity is present after dry-run evidence exists and before
+  live promotion
 - runtime scorer/config mapping is explicit
 - risk, stake, kill switch, and daily loss limits are stated
 - caveats and next decision are recorded

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -157,7 +157,7 @@ python3 scripts/evaluate_autofactor_strategy_promotion.py \
   --output-handoff-md /tmp/autofactor-strategy-handoff.md
 ```
 
-The evaluator requires all of the following:
+The evaluator requires all of the following before a dry-run handoff:
 
 - the surrounding PRD promotion gate reports `ready_for_dry_run_handoff=true`;
 - the AutoFactor row has `decision=candidate` and `reason=passed`;
@@ -170,6 +170,10 @@ The evaluator requires all of the following:
   runtime score, with event-level decisions, full-depth executable accounting,
   official settlement, enough trades, positive ROI/PnL, and no blocking risk
   flags.
+
+Recorded replay/dry-run parity is not a pre-dry-run blocker because it needs
+dry-run runtime orders/fills to compare against. It remains a required later
+gate before live promotion or risk scaling.
 
 This deliberately blocks cases where a factor is statistically good in the
 wrong lane. For example, `spread_adjusted_external_move` can be a valid

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -272,6 +272,8 @@ def parse_promotion_gate(report_text: str) -> PromotionGate:
             if len(parts) != 3:
                 continue
             gate, passed, gate_evidence = parts
+            if gate == "recorded_replay_parity":
+                continue
             if passed.lower() != "true":
                 blocked.append(f"{gate}: {gate_evidence}")
 

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -228,6 +228,8 @@ def parse_promotion_gate(report_text: str) -> PromotionGateEvaluation:
             if len(parts) != 3:
                 continue
             gate, passed, evidence = parts
+            if gate == "recorded_replay_parity":
+                continue
             if passed.lower() != "true":
                 blocked_gates.append(f"{gate}: {evidence}")
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# Pre-Dry-Run Recorded Parity Gate Repair (2026-05-18)
+
+## Goal
+
+Keep recorded replay/dry-run parity in the correct stage: after dry-run
+runtime evidence exists, not before a historically replayed candidate may enter
+dry-run.
+
+Evidence stage: `promotion gate ordering / executable_replay to dry-run`.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/factors_v2.rs`
+  - Owner: make `ready_for_dry_run_handoff` ignore the post-dry-run recorded
+    parity advisory row.
+- `scripts/evaluate_autofactor_strategy_promotion.py`,
+  `scripts/run_settlement_probability_prd_gate.py`
+  - Owner: do not turn the recorded parity advisory row into a pre-dry-run
+    global blocker.
+- `docs/PROJECT_SEMANTICS.md`,
+  `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document historical executable replay before dry-run and recorded
+    replay/dry-run parity after dry-run.
+- `tests/test_autofactor_strategy_promotion.py`
+  - Owner: cover that recorded parity no longer blocks the pre-dry-run
+    promotion parser.
+
+## Tasks
+
+- [x] Diagnose old hosted run blocker as premature `recorded_replay_parity`.
+- [x] Keep the report row for traceability but remove it from dry-run handoff
+      readiness.
+- [x] Update Python promotion parsers to treat recorded parity as post-dry-run.
+- [x] Update docs and focused tests.
+- [ ] Run validation, open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-18: The previous gate ordering still effectively required dry-run
+  runtime parity before dry-run existed. That made the loop circular. The fixed
+  order is historical executable replay -> dry-run -> recorded replay/dry-run
+  parity -> live/risk scaling.
+
 # AutoFactor Candidate Strategy Replay Artifact (2026-05-18)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -400,13 +400,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "global_full_depth_entry_fill_rate=0.1458 min_required=0.3000",
             first["blockers"],
         )
-        self.assertIn(
-            "global_promotion_gate_not_ready:recorded_replay_parity: "
-            "replay_parity_json=artifacts/replay-parity/parity-evaluation.json "
-            "runtime_ready=true event_ready=false blocking_flags=<none> "
-            "advisory_flags=<none> decision=continue",
-            first["blockers"],
-        )
+        self.assertNotIn("recorded_replay_parity", ",".join(first["blockers"]))
 
     def test_core_suite_report_is_sufficient_for_handoff_evaluation(self):
         self.assertNotIn("=== Fillability Review V1 Data Health ===", CORE_SUITE_REPORT)

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -379,7 +379,11 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             2.507843,
         )
         self.assertEqual(variant["best_runtime_mappable_factor"]["complexity"], 1)
-        self.assertIsNone(variant["best_qualified_strategy"])
+        self.assertEqual(variant["qualified_count"], 1)
+        self.assertEqual(
+            variant["best_qualified_strategy"]["name"],
+            "auto_settlement_conservative_settlement_edge",
+        )
         self.assertIn("best runtime-mappable factor", summary_md)
 
     def test_best_variant_prefers_tradeable_profit_metrics_over_rank_ic(self):


### PR DESCRIPTION
## Summary
- keep recorded replay/dry-run parity as a post-dry-run gate instead of blocking pre-dry-run handoff readiness
- update AutoFactor and PRD promotion parsers to ignore the recorded parity advisory row as a pre-dry-run global blocker
- document the corrected order: historical executable replay -> dry-run -> recorded replay/dry-run parity -> live/risk scaling

## Validation
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_build_autofactor_candidate_strategy_replay
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/run_settlement_probability_prd_gate.py
- rtk cargo test -p ploy-research settlement_probability_promotion_gate_tracks_pending_post_dryrun_replay_parity --features db --lib
- rtk git diff --check