### PR TITLE
Align candidate replay runtime mappings

### DIFF
--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -22,6 +22,12 @@ DEFAULT_ALLOWED_TARGETS = {
     "tradeable_full_depth_settlement_pnl",
 }
 
+FORMULA_RUNTIME_MAPPED_NAMES = {
+    "amplitude_weighted_momentum_30s_sigma",
+    "mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
+    "mut_spread_adjusted_external_move_full_depth_entry_gate",
+}
+
 
 def parse_float(raw: str, default: float = float("nan")) -> float:
     try:
@@ -82,11 +88,7 @@ def runtime_mapping(name: str) -> dict[str, str]:
                 else name
             ),
         }
-    if (
-        name.startswith("auto_settlement_")
-        or name.startswith("mut_")
-        or name == "amplitude_weighted_momentum_30s_sigma"
-    ):
+    if name.startswith("auto_settlement_") or name in FORMULA_RUNTIME_MAPPED_NAMES:
         return {
             "strategy_profile": "settlement_probability",
             "runtime_score": f"autofactor_formula:{name}",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,38 @@
+# Candidate Replay Runtime Mapping Alignment (2026-05-18)
+
+## Goal
+
+Prevent candidate replay generation from selecting factor formulas that the
+promotion evaluator cannot map to an executable runtime score.
+
+Evidence stage: `executable_replay / runtime mapping repair`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: match candidate replay runtime mapping to the explicit evaluator
+    runtime mapping surface.
+- `tests/test_build_autofactor_candidate_strategy_replay.py`
+  - Owner: cover unmapped `mut_*` formulas that have higher aggregate PnL but
+    cannot be promoted to the runtime.
+
+## Tasks
+
+- [x] Diagnose run `26016682552` as candidate replay/evaluator runtime-score
+      mismatch.
+- [x] Restrict generic `mut_*` replay selection to explicit runtime-mapped
+      formula names.
+- [x] Add regression coverage.
+- [ ] Run validation, open PR, wait for CI, merge, and rerun hosted search.
+
+## Review
+
+- 2026-05-18: The sweep produced a profitable candidate replay, but for
+  `mut_auto_settlement_full_depth_settlement_edge_x_near_strike_near_strike`,
+  which the evaluator correctly reported as missing runtime mapping. The replay
+  builder must select only runtime-mappable formulas so replay evidence and
+  handoff evaluation refer to the same executable scorer.
+
 # Pre-Dry-Run Recorded Parity Gate Repair (2026-05-18)
 
 ## Goal

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -81,6 +81,31 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
         self.assertIn("runtime_profile_mismatch", ",".join(payload["blocking_risk_flags"]))
         self.assertIn("Promotion ready: `false`", markdown)
 
+    def test_ignores_unmapped_mutation_even_when_aggregate_pnl_is_higher(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=false
+gate,passed,evidence
+recorded_replay_parity,false,post-dry-run gate pending
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_auto_settlement_full_depth_settlement_edge_x_near_strike_near_strike,full_depth_settlement_executable_pnl,candidate,passed,528,0.300000,0.250000,4,6.400000,1.0000,2,1.0000,1.0000,106,6.313282,0.7075,1.0000,0.00,1.40,106,1,5
+2,auto_settlement_full_depth_settlement_edge_x_near_strike,full_depth_settlement_executable_pnl,candidate,passed,528,0.288889,0.254860,4,5.260247,1.0000,2,1.0000,1.0000,106,6.012908,0.6981,1.0000,0.00,1.42,106,1,3
+"""
+        payload, _ = self.run_script(report)
+
+        self.assertTrue(payload["promotion_ready"])
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "auto_settlement_full_depth_settlement_edge_x_near_strike",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- restrict candidate replay generation to formulas with explicit runtime mappings
- prevent high-PnL but unmapped generic mut_* formulas from producing replay artifacts that cannot match the promotion evaluator
- add regression coverage for the runtime-score mismatch observed in hosted run 26016682552

## Validation
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py tests/test_build_autofactor_candidate_strategy_replay.py
- rtk git diff --check