### PR TITLE
Expose runtime strategy diagnostics

### DIFF
--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -22,6 +22,7 @@ use crate::traits::{Executor, Feed, MarketUpdate, Recorder, StrategyDecision, St
 
 const MIN_LIVE_RETRY_SHARES: Decimal = dec!(1.00);
 const MIN_LIVE_RETRY_NOTIONAL: Decimal = dec!(1.00);
+const DIAGNOSTIC_LOG_INTERVAL_UPDATES: u64 = 50_000;
 
 /// Operating mode for the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -409,6 +410,18 @@ where
                 .await;
             }
 
+            if updates_processed % DIAGNOSTIC_LOG_INTERVAL_UPDATES == 0 {
+                info!(
+                    mode = ?self.config.mode,
+                    strategy = self.strategy.name(),
+                    updates = updates_processed,
+                    intents = intents_submitted,
+                    fills = fills_recorded,
+                    diagnostics = ?self.strategy.diagnostics(),
+                    "StrategyRuntime diagnostic checkpoint",
+                );
+            }
+
             // 3. Check update limit (backtest bound).
             if let Some(max) = self.config.max_updates {
                 if updates_processed >= max {
@@ -442,6 +455,7 @@ where
             fills = result.fills_recorded,
             elapsed = format!("{:.1}s", result.elapsed_secs),
             net_pnl = %result.pnl.net_pnl(),
+            diagnostics = ?result.strategy_diagnostics,
             "StrategyRuntime finished",
         );
 

--- a/crates/ploy-strategy-runtime/src/lib.rs
+++ b/crates/ploy-strategy-runtime/src/lib.rs
@@ -147,6 +147,11 @@ fn write_strategy_evaluation(
     snapshot: &ploy_trading::TradingRuntimeSnapshot,
 ) {
     let cashflow = snapshot.fill_cashflow_summary();
+    let strategy_diagnostics: BTreeMap<&str, u64> = result
+        .strategy_diagnostics
+        .iter()
+        .map(|(key, value)| (key.as_str(), *value))
+        .collect();
     let artifact = json!({
         "schema_version": 1,
         "artifact_type": "strategy_runtime_evaluation",
@@ -165,7 +170,9 @@ fn write_strategy_evaluation(
             "net_pnl": result.pnl.net_pnl(),
             "risk": &result.risk,
             "elapsed_secs": result.elapsed_secs,
+            "strategy_diagnostics": strategy_diagnostics,
         },
+        "strategy_diagnostics": strategy_diagnostics,
         "cashflow": {
             "buy_shares": cashflow.buy_shares,
             "sell_shares": cashflow.sell_shares,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,43 @@
+# PM5D Runtime Diagnostics Output (2026-05-18)
+
+## Goal
+
+Make dry-run/replay zero-trade failures actionable by surfacing strategy gate
+diagnostics in runner logs and `--output-json` artifacts.
+
+Evidence stage: `dry_run_candidate / runtime_parity diagnostic`.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/src/engine.rs`
+  - Owner: runtime checkpoint/final logs include strategy diagnostic counters.
+- `crates/ploy-strategy-runtime/src/lib.rs`
+  - Owner: `strategy_runtime_evaluation` JSON includes strategy diagnostics.
+
+## Tasks
+
+- [x] Verify current Tango dry-run has market updates but no signal/order rows.
+- [x] Reproduce zero-intent behavior by replaying the active recording.
+- [x] Add diagnostics to logs and output JSON.
+- [x] Run focused Rust validation.
+- [ ] Open/merge PR and deploy from `main`.
+- [ ] Re-run recorded replay diagnostic and decide whether config gates or
+      feed ordering need the next fix.
+
+## Review
+
+- 2026-05-18: Remote DB showed zero `signal_history`,
+  `strategy_runtime_orders`, and `strategy_runtime_fills` rows for the active
+  settlement-probability dry-run window despite a healthy runner and growing
+  recording. A read-only replay of the copied recording processed 172,368
+  updates with zero intents/fills, so the current blocker is before order
+  execution.
+- 2026-05-18: Focused validation passed:
+  `rtk cargo check --locked -p ploy-strategy-bundles -p ploy-strategy-runtime`
+  and `rtk cargo test --locked -p ploy-strategy-bundles
+  diagnostics_count_entry_gate_reasons --lib`. `cargo fmt --check` remains
+  blocked by pre-existing formatting drift outside this slice.
+
 # Candidate Replay Runtime Mapping Alignment (2026-05-18)
 
 ## Goal


### PR DESCRIPTION
## Summary
- include strategy gate diagnostics in runtime checkpoint/final logs
- include strategy diagnostics in strategy_runtime_evaluation JSON output
- record current PM5D zero-intent diagnostic evidence in tasks/todo.md

## Verification
- rtk cargo check --locked -p ploy-strategy-bundles -p ploy-strategy-runtime
- rtk cargo test --locked -p ploy-strategy-bundles diagnostics_count_entry_gate_reasons --lib
- rtk git diff --check

Note: cargo fmt --check is still blocked by pre-existing formatting drift outside this slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strategy execution now includes periodic diagnostic logging reporting processed updates, submitted intents, and recorded fills.
  * Strategy diagnostics are now included in JSON output artifacts for enhanced runtime visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->