### PR TITLE
Block aggregate AutoFactor replay promotion

### DIFF
--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -209,16 +209,16 @@ must pass historical executable replay before any dry-run handoff issue/config
 is created. Recorded replay parity remains the later dry-run/runtime parity gate
 after dry-run evidence exists.
 
-The hosted factor walk-forward sweep now builds this pre-dry-run replay artifact
-per variant when no external `candidate-strategy-replay.json` is supplied. The
-builder converts the selected runtime-mappable top bucket from
-`factor_walk_forward_v2` into `candidate-strategy-replay.json` with explicit
-event-level, one-decision-per-event, official-settlement, full-depth-entry, PnL,
-ROI, and fill-rate fields. Its `basis` is
-`factor_walk_forward_top_bucket_aggregate`; it is the historical executable
-strategy gate before dry-run, not the later recorded replay/dry-run parity
-proof. The sweep copies the best variant's `candidate-strategy-replay.json` and
-`.md` to the artifact root before the AutoFactor handoff/config PR step.
+The hosted factor walk-forward sweep can build a per-variant
+`candidate-strategy-replay.json` from the selected runtime-mappable top bucket
+when no external artifact is supplied. That generated artifact has
+`basis=factor_walk_forward_top_bucket_aggregate`; it is a diagnostic summary of
+top-bucket event accounting, not proof that the deployed runtime scorer will
+emit the same decisions on an ordered MarketUpdate stream. The promotion
+evaluator must keep such aggregate artifacts blocked until a true runtime replay
+artifact for the exact same runtime score is supplied. The sweep still copies
+the aggregate JSON and markdown to the artifact root so the next runtime-replay
+job can use it as candidate context.
 
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Build the AutoFactor candidate-strategy executable replay artifact.
+"""Build the AutoFactor candidate top-bucket diagnostic artifact.
 
 The source report must come from factor_walk_forward_v2. For settlement targets,
-that report already scores one decision per event against historical
-full-depth executable settlement labels. This script converts the selected
-runtime-mappable candidate row into the explicit replay artifact required by
-the dry-run promotion gate.
+that report scores one decision per event against historical full-depth
+executable settlement labels. This script converts the selected
+runtime-mappable candidate row into an explicit aggregate diagnostic artifact.
+
+This is not the same as replaying the deployed runtime scorer over an ordered
+MarketUpdate stream, so it must not by itself unlock a dry-run handoff.
 """
 
 from __future__ import annotations
@@ -182,6 +184,7 @@ def build_artifact(
     runtime_score = row["runtime_mapping"]["runtime_score"]
 
     artifact_blockers = list(blockers)
+    artifact_blockers.append("requires_runtime_replay_not_top_bucket_aggregate")
     if top_bucket_n < min_trade_count:
         artifact_blockers.append(f"trade_count_too_small:{top_bucket_n}<{min_trade_count}")
     if unique_events < min(top_bucket_n, min_trade_count):
@@ -202,7 +205,7 @@ def build_artifact(
         "basis": "factor_walk_forward_top_bucket_aggregate",
         "strategy_profile": row["runtime_mapping"]["strategy_profile"],
         "runtime_score": runtime_score,
-        "promotion_ready": not artifact_blockers,
+        "promotion_ready": False,
         "evidence": evidence,
         "source_factor": {
             "name": row.get("name", ""),

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -169,6 +169,7 @@ class CandidateStrategyReplay:
     evidence: str
     runtime_score: str = ""
     strategy_profile: str = ""
+    basis: str = ""
     blockers: list[str] = field(default_factory=list)
     metrics: dict[str, Any] = field(default_factory=dict)
     decision_contract: dict[str, Any] = field(default_factory=dict)
@@ -331,6 +332,7 @@ def load_candidate_strategy_replay(path: str | None) -> CandidateStrategyReplay:
         evidence=str(evidence),
         runtime_score=str(payload.get("runtime_score", "")),
         strategy_profile=str(payload.get("strategy_profile", "")),
+        basis=str(payload.get("basis", "")),
         blockers=[str(item) for item in blockers],
         metrics=metrics,
         decision_contract=contract,
@@ -362,6 +364,8 @@ def candidate_strategy_replay_blockers(
     blockers = list(replay.blockers)
     if not replay.ready:
         blockers.append("candidate_strategy_replay_not_ready")
+    if replay.basis == "factor_walk_forward_top_bucket_aggregate":
+        blockers.append("candidate_strategy_replay_not_runtime_replay")
 
     if replay.strategy_profile != required_strategy_profile:
         blockers.append(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# AutoFactor Runtime Replay Gate Repair (2026-05-18)
+
+## Goal
+
+Prevent top-bucket aggregate AutoFactor evidence from being promoted as if it
+were a true runtime replay of the deployed scorer.
+
+Evidence stage: `runtime_parity / promotion gate repair`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: generated top-bucket aggregate artifacts must stay blocked.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: reject aggregate-basis artifacts as candidate strategy replay.
+- `docs/runbooks/event-ml-automl-workflow.md`
+  - Owner: document aggregate evidence vs runtime replay evidence.
+- `tests/test_build_autofactor_candidate_strategy_replay.py`,
+  `tests/test_autofactor_strategy_promotion.py`
+  - Owner: regression coverage for fail-closed promotion.
+
+## Tasks
+
+- [x] Verify post-#536 recorded replay still emits zero intents.
+- [x] Run threshold/formula replay variants and confirm zero-intent behavior is
+      not fixed by loosening `three_layer_min_edge` or removing
+      `_x_near_strike`.
+- [x] Make aggregate top-bucket artifacts fail closed.
+- [x] Run focused Python tests and diff check.
+- [ ] Open/merge PR and continue with a true runtime replay/search workflow.
+
+## Review
+
+- 2026-05-18: The post-side-selection replay processed `172,368` updates with
+  `candidate_events=260`, `entry_evaluations=383`, and zero intents. Loosening
+  `three_layer_min_edge` to zero and changing the runtime score to the base
+  formula did not change diagnostics, proving the promoted aggregate candidate
+  is not equivalent to deployed runtime replay behavior.
+- 2026-05-18: Validation passed with
+  `python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay
+  tests.test_autofactor_strategy_promotion` and `rtk git diff --check`.
+- 2026-05-18: After CI exposed stale sweep expectations, full Python
+  validation passed with `python3 -m unittest discover -s tests -p 'test_*.py'`.
+
 # PM5D Settlement AutoFactor Side Selection (2026-05-18)
 
 ## Goal
@@ -21,8 +65,8 @@ Evidence stage: `dry_run_candidate / runtime_parity repair`.
       before applying formula/depth gates.
 - [x] Add regression coverage for bypassing the legacy direction gate.
 - [x] Run focused Rust validation.
-- [ ] Open/merge PR and deploy from `main`.
-- [ ] Re-run recording replay diagnostics and then recorded replay parity.
+- [x] Open/merge PR and deploy from `main`.
+- [x] Re-run recording replay diagnostics and then recorded replay parity.
 
 ## Review
 
@@ -36,6 +80,10 @@ Evidence stage: `dry_run_candidate / runtime_parity repair`.
   `rtk cargo test --locked -p ploy-strategy-bundles settlement_autofactor --lib`,
   `rtk cargo check --locked -p ploy-strategy-bundles`, and
   `rtk git diff --check`.
+- 2026-05-18: PR #536 merged and deployed through
+  `deploy-tango-1-1.yml` run `26020853175`. Replay after deployment moved the
+  blocker from legacy direction gate to settlement side/edge gates, so the next
+  fix is promotion-gate correctness rather than another threshold tweak.
 
 # PM5D Runtime Diagnostics Output (2026-05-18)
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -581,6 +581,22 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("candidate_strategy_replay_not_ready", first["blockers"])
         self.assertIn("Candidate strategy replay ready: `false`", handoff_md)
 
+    def test_blocks_top_bucket_aggregate_as_candidate_strategy_replay(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "basis": "factor_walk_forward_top_bucket_aggregate",
+        }
+
+        _, payload, _, handoff, _ = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertIn("candidate_strategy_replay_not_runtime_replay", first["blockers"])
+
     def test_blocks_replay_without_executable_strategy_contract(self):
         replay = {
             **DEFAULT_REPLAY_PAYLOAD,

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -45,10 +45,10 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                 output_md.read_text(encoding="utf-8"),
             )
 
-    def test_builds_ready_replay_for_runtime_mappable_settlement_candidate(self):
+    def test_builds_blocked_aggregate_for_runtime_mappable_settlement_candidate(self):
         payload, markdown = self.run_script(AUTOFACTOR_SETTLEMENT_AUTO_REPORT)
 
-        self.assertTrue(payload["promotion_ready"])
+        self.assertFalse(payload["promotion_ready"])
         self.assertEqual(
             payload["runtime_score"],
             "autofactor_formula:auto_settlement_conservative_settlement_edge",
@@ -64,8 +64,11 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(payload["metrics"]["unique_event_count"], 9966)
         self.assertGreater(payload["metrics"]["total_pnl"], 0)
         self.assertGreater(payload["metrics"]["roi"], 0)
-        self.assertEqual(payload["blocking_risk_flags"], [])
-        self.assertIn("Promotion ready: `true`", markdown)
+        self.assertIn(
+            "requires_runtime_replay_not_top_bucket_aggregate",
+            payload["blocking_risk_flags"],
+        )
+        self.assertIn("Promotion ready: `false`", markdown)
 
     def test_blocks_when_only_candidate_is_wrong_profile(self):
         payload, markdown = self.run_script(
@@ -96,7 +99,7 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 """
         payload, _ = self.run_script(report)
 
-        self.assertTrue(payload["promotion_ready"])
+        self.assertFalse(payload["promotion_ready"])
         self.assertEqual(
             payload["runtime_score"],
             "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike",

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -258,7 +258,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(summary["variants"][0]["qualified_count"], 1)
         self.assertIn("auto_settlement_conservative_settlement_edge", summary_md)
 
-    def test_builds_and_promotes_candidate_strategy_replay_when_missing(self):
+    def test_builds_blocked_aggregate_candidate_replay_when_missing(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)
             (tmp / "snapshot").mkdir()
@@ -283,11 +283,17 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
 
         self.assertEqual(summary["best_variant"], "base")
         self.assertEqual(summary["variants"][0]["candidate_replay_exit_code"], 0)
-        self.assertTrue(root_replay["promotion_ready"])
+        self.assertEqual(summary["variants"][0]["decision"], "blocked")
+        self.assertEqual(summary["variants"][0]["qualified_count"], 0)
+        self.assertFalse(root_replay["promotion_ready"])
         self.assertEqual(root_replay["basis"], "factor_walk_forward_top_bucket_aggregate")
         self.assertEqual(
             root_replay["runtime_score"],
             "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        )
+        self.assertIn(
+            "requires_runtime_replay_not_top_bucket_aggregate",
+            root_replay["blocking_risk_flags"],
         )
         self.assertEqual(root_replay, variant_replay)
 
@@ -379,11 +385,9 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             2.507843,
         )
         self.assertEqual(variant["best_runtime_mappable_factor"]["complexity"], 1)
-        self.assertEqual(variant["qualified_count"], 1)
-        self.assertEqual(
-            variant["best_qualified_strategy"]["name"],
-            "auto_settlement_conservative_settlement_edge",
-        )
+        self.assertEqual(variant["qualified_count"], 0)
+        self.assertEqual(variant["decision"], "blocked")
+        self.assertIsNone(variant["best_qualified_strategy"])
         self.assertIn("best runtime-mappable factor", summary_md)
 
     def test_best_variant_prefers_tradeable_profit_metrics_over_rank_ic(self):


### PR DESCRIPTION
## Summary
- keep generated AutoFactor top-bucket aggregate artifacts blocked from dry-run promotion
- reject aggregate-basis artifacts in the strategy promotion evaluator
- document that a true runtime replay artifact is required before handoff

## Validation
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion
- rtk git diff --check