### PR TITLE
Add runtime candidate replay gate

### DIFF
--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -205,10 +205,15 @@ Required artifact:
 In the hosted factor walk-forward sweep, this artifact is generated per variant
 when an external replay artifact is not supplied. The generated artifact is
 based on the selected runtime-mappable `factor_walk_forward_v2` top bucket and
-declares `basis=factor_walk_forward_top_bucket_aggregate`. It is sufficient for
-the pre-dry-run executable strategy gate only when the report target already
-uses event-level, official-settlement, full-depth executable labels. It does not
-replace recorded replay/dry-run parity after a dry-run runtime has produced
+declares `basis=factor_walk_forward_top_bucket_aggregate`. It is only candidate
+context. It is not sufficient for the pre-dry-run executable strategy gate,
+because it does not prove the deployed runtime scorer emits the same decisions
+on an ordered MarketUpdate stream.
+
+The dry-run handoff gate requires a true runtime replay artifact with
+`basis=runtime_market_update_replay`, produced from `ploy-runner run
+--output-json` by `scripts/build_runtime_candidate_strategy_replay.py`. It does
+not replace recorded replay/dry-run parity after a dry-run runtime has produced
 orders and fills.
 
 Recorded replay/dry-run parity is intentionally after dry-run in the promotion
@@ -379,8 +384,9 @@ Every complete CI/CD alpha-search run should upload:
   decision, including whether the next run was dispatched and why the chain
   stopped when it did not continue
 - `factor-walk-forward-v2/report.txt`: existing walk-forward report
-- `candidate-strategy-replay.json`: selected runtime-score historical
-  executable replay proof required before dry-run handoff
+- `candidate-strategy-replay.json`: selected runtime-score historical runtime
+  replay proof with `basis=runtime_market_update_replay`, required before
+  dry-run handoff
 - `autofactor-factor-registry.json`: evaluated factor rows and blockers
 - `autofactor-strategy-handoff.json`: ready/blocked handoff manifest
 

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -220,6 +220,24 @@ artifact for the exact same runtime score is supplied. The sweep still copies
 the aggregate JSON and markdown to the artifact root so the next runtime-replay
 job can use it as candidate context.
 
+A true pre-dry-run runtime replay artifact must be built from the JSON emitted
+by `ploy-runner run --output-json` after replaying the exact candidate config on
+an ordered MarketUpdate stream:
+
+```bash
+python3 scripts/build_runtime_candidate_strategy_replay.py \
+  --runtime-evaluation-json /tmp/runtime-eval.json \
+  --runtime-score autofactor_formula:<candidate> \
+  --full-depth-entry \
+  --output-json /tmp/candidate-strategy-replay.json \
+  --output-md /tmp/candidate-strategy-replay.md
+```
+
+This artifact declares `basis=runtime_market_update_replay`. It stays blocked
+when the runtime produced zero orders/fills, lacks official settlement rows,
+lacks one-event-one-decision evidence, lacks confirmed full-depth entry
+accounting, or fails trade-count/fill-rate/PnL thresholds.
+
 For an existing Factor Walk-Forward V2 artifact, use the hosted GitHub workflow
 instead of waiting for the self-hosted research runner:
 

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Build a true runtime-replay candidate strategy artifact.
+
+This consumes the JSON written by `ploy-runner run --output-json` after running
+the candidate strategy config over an ordered MarketUpdate replay. Unlike the
+AutoFactor top-bucket aggregate helper, this artifact represents the deployed
+runtime scorer's actual intent/order/fill behavior on the replay stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+RUNTIME_REPLAY_BASIS = "runtime_market_update_replay"
+
+
+def decimal_value(raw: Any, default: Decimal = Decimal("0")) -> Decimal:
+    try:
+        if raw is None:
+            return default
+        return Decimal(str(raw))
+    except (InvalidOperation, ValueError):
+        return default
+
+
+def is_closed_settlement(raw: Any) -> bool:
+    if raw is None:
+        return False
+    text = str(raw).strip().lower()
+    return text not in {"", "open", "none", "null", "nan"}
+
+
+def runtime_evidence(payload: dict[str, Any]) -> dict[str, Any]:
+    evidence = payload.get("runtime_evidence")
+    return evidence if isinstance(evidence, dict) else {}
+
+
+def result_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    result = payload.get("result")
+    return result if isinstance(result, dict) else {}
+
+
+def purpose_is_entry(row: dict[str, Any]) -> bool:
+    purpose = str(row.get("purpose") or row.get("signal_inputs", {}).get("purpose") or "ENTRY")
+    return purpose.upper() == "ENTRY"
+
+
+def build_artifact(
+    runtime_eval: dict[str, Any],
+    *,
+    runtime_score: str,
+    strategy_profile: str,
+    stake_usd: Decimal,
+    full_depth_entry: bool,
+    min_trade_count: int,
+    min_fill_rate: Decimal,
+    min_roi: Decimal,
+    evidence: str,
+) -> dict[str, Any]:
+    evidence_rows = runtime_evidence(runtime_eval)
+    result = result_payload(runtime_eval)
+    events = [row for row in evidence_rows.get("events") or [] if isinstance(row, dict)]
+    orders = [row for row in evidence_rows.get("orders") or [] if isinstance(row, dict)]
+    fills = [row for row in evidence_rows.get("fills") or [] if isinstance(row, dict)]
+    intents = [row for row in evidence_rows.get("intents") or [] if isinstance(row, dict)]
+
+    entry_orders = [row for row in orders if purpose_is_entry(row)]
+    entry_fills = [row for row in fills if purpose_is_entry(row)]
+    entry_events = [row for row in events if purpose_is_entry(row)]
+
+    event_ids = [
+        str(row.get("event_id") or row.get("market_id"))
+        for row in entry_orders
+        if row.get("event_id") or row.get("market_id")
+    ]
+    unique_event_count = len(set(event_ids))
+    event_decision_counts = Counter(event_ids)
+    max_event_decisions = max(event_decision_counts.values(), default=0)
+
+    filled_order_ids = {
+        str(row.get("order_id"))
+        for row in entry_fills
+        if row.get("order_id") and decimal_value(row.get("quantity")) > 0
+    }
+    trade_count = len(filled_order_ids)
+    order_count = len(entry_orders)
+    intent_count = len(intents) or int(result.get("intents_submitted") or 0)
+    denominator = max(order_count, intent_count, 1)
+    entry_fill_rate = Decimal(trade_count) / Decimal(denominator)
+
+    settled_event_count = sum(1 for row in entry_events if is_closed_settlement(row.get("settlement")))
+    total_pnl = sum((decimal_value(row.get("pnl")) for row in entry_events), Decimal("0"))
+    if not entry_events:
+        total_pnl = decimal_value(result.get("net_pnl"), decimal_value(result.get("realized_pnl")))
+    notional = stake_usd * Decimal(trade_count)
+    roi = total_pnl / notional if notional > 0 else Decimal("0")
+
+    blocking_flags: list[str] = []
+    if trade_count < min_trade_count:
+        blocking_flags.append(f"trade_count_too_small:{trade_count}<{min_trade_count}")
+    if unique_event_count < min(trade_count, min_trade_count):
+        blocking_flags.append(
+            f"unique_event_count_too_small:{unique_event_count}<{min(trade_count, min_trade_count)}"
+        )
+    if max_event_decisions != 1 and trade_count > 0:
+        blocking_flags.append(f"one_event_decision_violation:{max_event_decisions}")
+    if entry_fill_rate < min_fill_rate:
+        blocking_flags.append(
+            f"entry_fill_rate_too_low:{entry_fill_rate:.4f}<{min_fill_rate:.4f}"
+        )
+    if settled_event_count < trade_count:
+        blocking_flags.append(f"official_settlement_missing:{settled_event_count}<{trade_count}")
+    if not full_depth_entry:
+        blocking_flags.append("full_depth_entry_not_confirmed")
+    if roi < min_roi:
+        blocking_flags.append(f"roi_too_low:{roi:.6f}<{min_roi:.6f}")
+    if not entry_orders and not entry_fills:
+        blocking_flags.append("zero_runtime_orders_and_fills")
+
+    diagnostics = runtime_eval.get("strategy_diagnostics") or result.get("strategy_diagnostics") or {}
+
+    return {
+        "schema_version": 1,
+        "kind": "autofactor_candidate_strategy_replay",
+        "evidence_stage": "executable_replay",
+        "basis": RUNTIME_REPLAY_BASIS,
+        "strategy_profile": strategy_profile,
+        "runtime_score": runtime_score,
+        "promotion_ready": not blocking_flags,
+        "evidence": evidence,
+        "decision_contract": {
+            "event_level": trade_count > 0 and unique_event_count == trade_count,
+            "one_decision_per_event": trade_count > 0 and max_event_decisions == 1,
+            "official_settlement": trade_count > 0 and settled_event_count >= trade_count,
+            "full_depth_entry": full_depth_entry,
+            "stake_usd": float(stake_usd),
+        },
+        "metrics": {
+            "updates_processed": int(result.get("updates_processed") or 0),
+            "intents_submitted": int(result.get("intents_submitted") or intent_count),
+            "orders": order_count,
+            "fills": len(entry_fills),
+            "trade_count": trade_count,
+            "unique_event_count": unique_event_count,
+            "settlement_event_count": settled_event_count,
+            "max_event_decisions": max_event_decisions,
+            "entry_fill_rate": float(entry_fill_rate),
+            "total_pnl": float(total_pnl),
+            "roi": float(roi),
+        },
+        "strategy_diagnostics": diagnostics,
+        "blocking_risk_flags": blocking_flags,
+    }
+
+
+def render_markdown(artifact: dict[str, Any]) -> str:
+    metrics = artifact.get("metrics") or {}
+    flags = artifact.get("blocking_risk_flags") or []
+    lines = [
+        "# Runtime Candidate Strategy Replay",
+        "",
+        f"- Promotion ready: `{str(artifact.get('promotion_ready')).lower()}`",
+        f"- Basis: `{artifact.get('basis')}`",
+        f"- Runtime score: `{artifact.get('runtime_score')}`",
+        f"- Strategy profile: `{artifact.get('strategy_profile')}`",
+        f"- Updates processed: `{metrics.get('updates_processed')}`",
+        f"- Intents submitted: `{metrics.get('intents_submitted')}`",
+        f"- Trades: `{metrics.get('trade_count')}`",
+        f"- Unique events: `{metrics.get('unique_event_count')}`",
+        f"- Entry fill rate: `{metrics.get('entry_fill_rate')}`",
+        f"- Total PnL: `{metrics.get('total_pnl')}`",
+        f"- ROI: `{metrics.get('roi')}`",
+        "",
+        "## Blocking Risk Flags",
+        "",
+    ]
+    lines.extend(f"- `{flag}`" for flag in flags) if flags else lines.append("- `<none>`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime-evaluation-json", required=True)
+    parser.add_argument("--runtime-score", required=True)
+    parser.add_argument("--strategy-profile", default="settlement_probability")
+    parser.add_argument("--stake-usd", default="15")
+    parser.add_argument("--full-depth-entry", action="store_true")
+    parser.add_argument("--min-trade-count", type=int, default=50)
+    parser.add_argument("--min-fill-rate", default="0.30")
+    parser.add_argument("--min-roi", default="0")
+    parser.add_argument("--evidence", default="")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    runtime_path = Path(args.runtime_evaluation_json)
+    runtime_eval = json.loads(runtime_path.read_text(encoding="utf-8"))
+    artifact = build_artifact(
+        runtime_eval,
+        runtime_score=args.runtime_score,
+        strategy_profile=args.strategy_profile,
+        stake_usd=decimal_value(args.stake_usd),
+        full_depth_entry=args.full_depth_entry,
+        min_trade_count=args.min_trade_count,
+        min_fill_rate=decimal_value(args.min_fill_rate),
+        min_roi=decimal_value(args.min_roi),
+        evidence=args.evidence or str(runtime_path),
+    )
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.output_md:
+        output_md = Path(args.output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(render_markdown(artifact), encoding="utf-8")
+    print(json.dumps(artifact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -364,8 +364,11 @@ def candidate_strategy_replay_blockers(
     blockers = list(replay.blockers)
     if not replay.ready:
         blockers.append("candidate_strategy_replay_not_ready")
-    if replay.basis == "factor_walk_forward_top_bucket_aggregate":
-        blockers.append("candidate_strategy_replay_not_runtime_replay")
+    if replay.basis != "runtime_market_update_replay":
+        blockers.append(
+            "candidate_strategy_replay_not_runtime_replay:"
+            f"{replay.basis or '<missing>'}!=runtime_market_update_replay"
+        )
 
     if replay.strategy_profile != required_strategy_profile:
         blockers.append(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,52 @@
+# Runtime Candidate Replay Artifact Gate (2026-05-18)
+
+## Goal
+
+Create the true runtime replay artifact required before AutoFactor search
+candidates can become dry-run handoffs.
+
+Evidence stage: `runtime_parity / executable_replay gate`.
+
+## Files / Ownership
+
+- `scripts/build_runtime_candidate_strategy_replay.py`
+  - Owner: convert `ploy-runner run --output-json` runtime evaluations into
+    fail-closed `candidate-strategy-replay.json` artifacts.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: accept only `basis=runtime_market_update_replay` for dry-run
+    handoff.
+- `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document aggregate candidate context vs true runtime replay proof.
+- `tests/test_build_runtime_candidate_strategy_replay.py`,
+  `tests/test_autofactor_strategy_promotion.py`
+  - Owner: regression coverage for the runtime replay basis.
+
+## Tasks
+
+- [x] Inspect runner `strategy_runtime_evaluation` JSON and runtime evidence
+      fields.
+- [x] Add runtime replay artifact builder with zero-intent, settlement,
+      one-event-one-decision, fill-rate, full-depth, and ROI blockers.
+- [x] Make promotion evaluator require `basis=runtime_market_update_replay`.
+- [x] Run full Python validation and diff check.
+- [ ] Open/merge PR and then wire the hosted search workflow to produce this
+      artifact before config PR creation.
+
+## Review
+
+- 2026-05-18: Runtime evaluation JSON already exposes `result`,
+  `runtime_evidence`, `snapshot_counts`, and `strategy_diagnostics`, so the
+  first implementation can be a Python artifact builder without changing the
+  runner binary.
+- 2026-05-18: Validation passed with
+  `python3 -m unittest discover -s tests -p 'test_*.py'` and
+  `rtk git diff --check`. Running the new builder on the post-#536
+  zero-intent replay produced `basis=runtime_market_update_replay`,
+  `promotion_ready=false`, `trade_count=0`, and blockers
+  `trade_count_too_small`, `entry_fill_rate_too_low`, and
+  `zero_runtime_orders_and_fills`.
+
 # AutoFactor Runtime Replay Gate Repair (2026-05-18)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -142,6 +142,7 @@ DEFAULT_REPLAY_PAYLOAD = {
     "schema_version": 1,
     "kind": "autofactor_candidate_strategy_replay",
     "evidence_stage": "executable_replay",
+    "basis": "runtime_market_update_replay",
     "strategy_profile": "settlement_probability",
     "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
     "promotion_ready": True,
@@ -595,7 +596,11 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(payload["decision"], "blocked")
         self.assertEqual(handoff["status"], "blocked")
         first = payload["evaluated_factors"][0]
-        self.assertIn("candidate_strategy_replay_not_runtime_replay", first["blockers"])
+        self.assertIn(
+            "candidate_strategy_replay_not_runtime_replay:"
+            "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+            first["blockers"],
+        )
 
     def test_blocks_replay_without_executable_strategy_contract(self):
         replay = {

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -1,0 +1,196 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_runtime_candidate_strategy_replay.py"
+
+
+def runtime_eval_payload(*, settled=True, pnl="12.5"):
+    settlement = "1" if settled else "open"
+    return {
+        "artifact_type": "strategy_runtime_evaluation",
+        "result": {
+            "updates_processed": 1000,
+            "intents_submitted": 2,
+            "fills_recorded": 2,
+            "strategy_diagnostics": {"candidate_events": 2},
+        },
+        "runtime_evidence": {
+            "basis": "trading_runtime_snapshot",
+            "intents": [
+                {
+                    "intent_id": "intent-1",
+                    "event_id": "event-1",
+                    "quantity": "10",
+                    "limit_price": "0.42",
+                },
+                {
+                    "intent_id": "intent-2",
+                    "event_id": "event-2",
+                    "quantity": "10",
+                    "limit_price": "0.43",
+                },
+            ],
+            "orders": [
+                {
+                    "intent_id": "intent-1",
+                    "order_id": "order-1",
+                    "event_id": "event-1",
+                    "purpose": "ENTRY",
+                    "quantity": "10",
+                    "filled_quantity": "10",
+                    "status": "FILLED",
+                },
+                {
+                    "intent_id": "intent-2",
+                    "order_id": "order-2",
+                    "event_id": "event-2",
+                    "purpose": "ENTRY",
+                    "quantity": "10",
+                    "filled_quantity": "10",
+                    "status": "FILLED",
+                },
+            ],
+            "fills": [
+                {
+                    "intent_id": "intent-1",
+                    "order_id": "order-1",
+                    "event_id": "event-1",
+                    "purpose": "ENTRY",
+                    "quantity": "10",
+                    "price": "0.42",
+                    "fee": "0",
+                },
+                {
+                    "intent_id": "intent-2",
+                    "order_id": "order-2",
+                    "event_id": "event-2",
+                    "purpose": "ENTRY",
+                    "quantity": "10",
+                    "price": "0.43",
+                    "fee": "0",
+                },
+            ],
+            "events": [
+                {
+                    "intent_id": "intent-1",
+                    "order_id": "order-1",
+                    "event_id": "event-1",
+                    "signal_inputs": {"purpose": "ENTRY"},
+                    "settlement": settlement,
+                    "pnl": pnl,
+                },
+                {
+                    "intent_id": "intent-2",
+                    "order_id": "order-2",
+                    "event_id": "event-2",
+                    "signal_inputs": {"purpose": "ENTRY"},
+                    "settlement": settlement,
+                    "pnl": "0",
+                },
+            ],
+        },
+    }
+
+
+class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
+    def run_script(self, payload, *extra_args):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runtime_json = tmp_path / "runtime-eval.json"
+            output_json = tmp_path / "candidate-strategy-replay.json"
+            output_md = tmp_path / "candidate-strategy-replay.md"
+            runtime_json.write_text(json.dumps(payload), encoding="utf-8")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--runtime-evaluation-json",
+                    str(runtime_json),
+                    "--runtime-score",
+                    "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "--output-json",
+                    str(output_json),
+                    "--output-md",
+                    str(output_md),
+                    *extra_args,
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return (
+                json.loads(output_json.read_text(encoding="utf-8")),
+                output_md.read_text(encoding="utf-8"),
+            )
+
+    def test_builds_ready_runtime_market_update_replay_artifact(self):
+        payload, markdown = self.run_script(
+            runtime_eval_payload(),
+            "--full-depth-entry",
+            "--min-trade-count",
+            "2",
+        )
+
+        self.assertTrue(payload["promotion_ready"])
+        self.assertEqual(payload["basis"], "runtime_market_update_replay")
+        self.assertEqual(payload["metrics"]["trade_count"], 2)
+        self.assertEqual(payload["metrics"]["unique_event_count"], 2)
+        self.assertEqual(payload["metrics"]["settlement_event_count"], 2)
+        self.assertEqual(payload["metrics"]["entry_fill_rate"], 1.0)
+        self.assertGreater(payload["metrics"]["roi"], 0)
+        self.assertEqual(payload["blocking_risk_flags"], [])
+        self.assertIn("Promotion ready: `true`", markdown)
+
+    def test_blocks_zero_intent_runtime_replay_with_diagnostics(self):
+        payload, _ = self.run_script(
+            {
+                "result": {
+                    "updates_processed": 172368,
+                    "intents_submitted": 0,
+                    "fills_recorded": 0,
+                    "strategy_diagnostics": {
+                        "candidate_events": 260,
+                        "skip_edge_score": 183,
+                    },
+                },
+                "runtime_evidence": {
+                    "basis": "trading_runtime_snapshot",
+                    "events": [],
+                    "orders": [],
+                    "fills": [],
+                    "intents": [],
+                },
+            },
+            "--full-depth-entry",
+            "--min-trade-count",
+            "2",
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["metrics"]["updates_processed"], 172368)
+        self.assertEqual(payload["metrics"]["trade_count"], 0)
+        self.assertIn("trade_count_too_small:0<2", payload["blocking_risk_flags"])
+        self.assertIn("zero_runtime_orders_and_fills", payload["blocking_risk_flags"])
+        self.assertEqual(payload["strategy_diagnostics"]["skip_edge_score"], 183)
+
+    def test_blocks_open_settlement_and_unconfirmed_depth(self):
+        payload, _ = self.run_script(
+            runtime_eval_payload(settled=False),
+            "--min-trade-count",
+            "2",
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertIn("official_settlement_missing:0<2", payload["blocking_risk_flags"])
+        self.assertIn("full_depth_entry_not_confirmed", payload["blocking_risk_flags"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -90,6 +90,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                     "schema_version": 1,
                     "kind": "autofactor_candidate_strategy_replay",
                     "evidence_stage": "executable_replay",
+                    "basis": "runtime_market_update_replay",
                     "strategy_profile": "settlement_probability",
                     "runtime_score": runtime_score,
                     "promotion_ready": True,


### PR DESCRIPTION
## Summary
- add a runtime-market-update replay artifact builder for candidate strategy replay evidence
- require AutoFactor promotion inputs to use basis=runtime_market_update_replay
- document aggregate top-bucket evidence as candidate context only

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'
- rtk git diff --check
- generated a blocked artifact from the post-#536 zero-intent runtime replay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CI/CD pipeline documentation with clarified artifact basis requirements and specific runtime replay specifications for candidate strategy handoff.
  * Added detailed qualification criteria for runtime replay artifacts, including required metrics and blocking conditions, in Event ML AutoML workflow runbook.

* **Tests**
  * Added comprehensive validation tests for runtime replay artifact generation and strategy promotion evaluation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->