### PR TITLE
Add runtime candidate replay workflow

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -1,0 +1,394 @@
+name: Runtime Candidate Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_id:
+        description: "Deployment id used for replay evidence rows"
+        required: true
+        default: "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+      config_path:
+        description: "Remote strategy config path on tango-1-1"
+        required: true
+        default: "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+      recording_path:
+        description: "Remote MarketUpdate NDJSON recording path on tango-1-1"
+        required: true
+        default: "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson"
+      runtime_score:
+        description: "Exact runtime score expected by promotion evaluator"
+        required: true
+        default: "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike"
+      strategy_profile:
+        description: "Expected strategy profile"
+        required: true
+        default: "settlement_probability"
+      min_trade_count:
+        description: "Minimum filled entry trades required"
+        required: false
+        default: "50"
+      min_fill_rate:
+        description: "Minimum entry fill rate required"
+        required: false
+        default: "0.30"
+      min_roi:
+        description: "Minimum replay ROI required"
+        required: false
+        default: "0"
+      full_depth_entry:
+        description: "Confirm this replay config uses full-depth executable entry accounting"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      skip_settlement_exits:
+        description: "Skip settlement exits while replaying; false is required for settlement PnL evidence"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+concurrency:
+  group: runtime-candidate-replay-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.runtime_score }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  PLATFORM_TARGET: x86_64-unknown-linux-gnu
+  DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
+  REPLAY_EVIDENCE_ISSUE: "538"
+
+jobs:
+  runtime-candidate-replay:
+    name: Build runtime candidate replay artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: tango-1-1-build-only
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build replay runner from workflow ref
+        run: |
+          set -euo pipefail
+          cargo build --release --locked \
+            --target "${PLATFORM_TARGET}" \
+            --features new-ploy-runner/full \
+            -p new-ploy-runner
+          strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
+          TANGO_SSH_KEY: ${{ secrets.TANGO_SSH_KEY }}
+          ALIYUN_ECS_SSH_KEY: ${{ secrets.ALIYUN_ECS_SSH_KEY }}
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "${DEPLOY_HOST}"
+          install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          key_source=""
+          selected_key=""
+          if [ -n "${TANGO_1_1_SSH_KEY}" ]; then
+            selected_key="${TANGO_1_1_SSH_KEY}"
+            key_source="TANGO_1_1_SSH_KEY"
+          elif [ -n "${TANGO_SSH_KEY}" ]; then
+            selected_key="${TANGO_SSH_KEY}"
+            key_source="TANGO_SSH_KEY"
+          elif [ -n "${ALIYUN_ECS_SSH_KEY}" ]; then
+            selected_key="${ALIYUN_ECS_SSH_KEY}"
+            key_source="ALIYUN_ECS_SSH_KEY"
+          else
+            echo "No SSH key secret found for tango-1-1 in this workflow context." >&2
+            exit 1
+          fi
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          printf '%s\n' "${selected_key}" > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          echo "tango-1-1-key-source=${key_source}"
+          ssh-keygen -y -f ~/.ssh/tango_1_1_key >/dev/null
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Run runtime replay on tango-1-1
+        env:
+          DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
+          CONFIG_PATH: ${{ github.event.inputs.config_path }}
+          RECORDING_PATH: ${{ github.event.inputs.recording_path }}
+          SKIP_SETTLEMENT_EXITS: ${{ github.event.inputs.skip_settlement_exits }}
+          REMOTE_DIR: /opt/ploy/tmp/runtime-candidate-replay-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/runtime-replay
+
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}" <<'EOF'
+          set -euo pipefail
+          mkdir -p "$1"
+          EOF
+          scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" \
+            tango-1-1:"${REMOTE_DIR}/ploy-runner"
+          scp scripts/enrich_recording_official_settlement.py \
+            tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
+          scp scripts/enrich_replay_runtime_evidence.py \
+            tango-1-1:"${REMOTE_DIR}/enrich_replay_runtime_evidence.py"
+          scp scripts/extract_official_settlement_evidence.py \
+            tango-1-1:"${REMOTE_DIR}/extract_official_settlement_evidence.py"
+
+          # shellcheck disable=SC2029
+          ssh tango-1-1 /bin/bash -s -- \
+            "${DEPLOYMENT_ID}" \
+            "${CONFIG_PATH}" \
+            "${RECORDING_PATH}" \
+            "${REMOTE_DIR}" \
+            "${SKIP_SETTLEMENT_EXITS}" <<'EOF'
+          set -euo pipefail
+          deployment_id="$1"
+          config_path="$2"
+          recording_path="$3"
+          remote_dir="$4"
+          skip_settlement_exits="$5"
+          case "${skip_settlement_exits}" in
+            true|false) ;;
+            *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;
+          esac
+
+          mkdir -p "${remote_dir}"
+          chmod +x "${remote_dir}/ploy-runner"
+          test -x "${remote_dir}/ploy-runner"
+          test -r "${config_path}"
+          test -r "${recording_path}"
+
+          set -a
+          . /opt/ploy/.env
+          set +a
+          if [ -n "${PLOY_DATABASE__URL:-}" ]; then
+            PSQL=(psql "${PLOY_DATABASE__URL}" -v ON_ERROR_STOP=1 -t -A)
+          else
+            PSQL=(env PGPASSWORD=postgres psql -U postgres -d ploy -v ON_ERROR_STOP=1 -t -A)
+          fi
+
+          official_token_ids_json="${remote_dir}/official-settlement-token-ids.json"
+          official_token_ids_tsv="${remote_dir}/official-settlement-token-ids.tsv"
+          official_db_rows_json="${remote_dir}/official-settlement-db-rows.json"
+          settlements_json="${remote_dir}/official-settlements.json"
+          official_settlement_report="${remote_dir}/official-settlement-report.json"
+          enriched_recording="${remote_dir}/recording-official-settlement.ndjson"
+
+          python3 "${remote_dir}/extract_official_settlement_evidence.py" \
+            --recording "${recording_path}" \
+            --output-token-ids "${official_token_ids_json}"
+          python3 - "${official_token_ids_json}" "${official_token_ids_tsv}" <<'PY'
+          import json
+          import sys
+
+          src, dst = sys.argv[1:]
+          token_ids = json.load(open(src, encoding="utf-8"))
+          with open(dst, "w", encoding="utf-8") as handle:
+              for token_id in token_ids:
+                  handle.write(str(token_id).replace("\t", "").replace("\n", ""))
+                  handle.write("\n")
+          PY
+
+          "${PSQL[@]}" <<SQL
+          CREATE TEMP TABLE replay_token_ids(token_id TEXT);
+          \\copy replay_token_ids(token_id) FROM '${official_token_ids_tsv}'
+          \\o ${official_db_rows_json}
+          SELECT COALESCE(
+            jsonb_agg(
+              jsonb_build_object(
+                'token_id', s.token_id,
+                'market_slug', s.market_slug,
+                'outcome', s.outcome,
+                'settlement', s.settled_price::text,
+                'resolved', s.resolved,
+                'resolved_at', s.resolved_at
+              )
+              ORDER BY s.token_id
+            ),
+            '[]'::jsonb
+          )::text
+          FROM pm_token_settlements s
+          JOIN replay_token_ids t ON t.token_id = s.token_id
+          WHERE s.resolved = true
+            AND s.settled_price IS NOT NULL;
+          \\o
+          SQL
+
+          python3 "${remote_dir}/extract_official_settlement_evidence.py" \
+            --recording "${recording_path}" \
+            --db-settlements-json "${official_db_rows_json}" \
+            --output-json "${settlements_json}" \
+            --report-json "${official_settlement_report}"
+
+          python3 "${remote_dir}/enrich_recording_official_settlement.py" \
+            --input "${recording_path}" \
+            --output "${enriched_recording}" \
+            --settlements-json "${settlements_json}" \
+            --report-json "${remote_dir}/recording-enrichment.json"
+          test -s "${enriched_recording}"
+
+          replay_config="${remote_dir}/replay.toml"
+          python3 - "${config_path}" "${enriched_recording}" "${replay_config}" "${skip_settlement_exits}" <<'PY'
+          import sys
+
+          src, recording, dst, skip_settlement_exits = sys.argv[1:]
+          lines = []
+          inserted_replay_path = False
+          with open(src, encoding="utf-8") as handle:
+              for raw in handle.read().splitlines():
+                  stripped = raw.strip()
+                  if stripped.startswith("mode = "):
+                      lines.append('mode = "replay"')
+                      lines.append(f"skip_settlement_exits = {skip_settlement_exits}")
+                      lines.append(f'replay_market_updates_from = "{recording}"')
+                      inserted_replay_path = True
+                      continue
+                  if stripped.startswith("skip_settlement_exits"):
+                      continue
+                  if stripped.startswith("record_market_updates_to"):
+                      continue
+                  if stripped.startswith("record_market_updates_max_"):
+                      continue
+                  lines.append(raw)
+          if not inserted_replay_path:
+              raise SystemExit("runtime mode line not found in source config")
+          with open(dst, "w", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          PY
+
+          timeout 600 "${remote_dir}/ploy-runner" run \
+            --config "${replay_config}" \
+            --deployment-id "${deployment_id}" \
+            --output-json "${remote_dir}/runtime-evaluation.json"
+
+          python3 "${remote_dir}/enrich_replay_runtime_evidence.py" \
+            --input-json "${remote_dir}/runtime-evaluation.json" \
+            --output-json "${remote_dir}/runtime-evaluation.json" \
+            --settlements-json "${settlements_json}" \
+            --report-json "${remote_dir}/runtime-evidence-enrichment.json"
+
+          ls -lh "${remote_dir}/runtime-evaluation.json" "${official_settlement_report}" "${remote_dir}/recording-enrichment.json" "${remote_dir}/runtime-evidence-enrichment.json"
+          EOF
+
+          scp tango-1-1:"${REMOTE_DIR}/runtime-evaluation.json" artifacts/runtime-replay/runtime-evaluation.json
+          scp tango-1-1:"${REMOTE_DIR}/official-settlement-report.json" artifacts/runtime-replay/official-settlement-report.json
+          scp tango-1-1:"${REMOTE_DIR}/recording-enrichment.json" artifacts/runtime-replay/recording-enrichment.json
+          scp tango-1-1:"${REMOTE_DIR}/runtime-evidence-enrichment.json" artifacts/runtime-replay/runtime-evidence-enrichment.json
+
+      - name: Build candidate strategy replay artifact
+        env:
+          RUNTIME_SCORE: ${{ github.event.inputs.runtime_score }}
+          STRATEGY_PROFILE: ${{ github.event.inputs.strategy_profile }}
+          MIN_TRADE_COUNT: ${{ github.event.inputs.min_trade_count }}
+          MIN_FILL_RATE: ${{ github.event.inputs.min_fill_rate }}
+          MIN_ROI: ${{ github.event.inputs.min_roi }}
+          FULL_DEPTH_ENTRY: ${{ github.event.inputs.full_depth_entry }}
+        run: |
+          set -euo pipefail
+          args=(
+            --runtime-evaluation-json artifacts/runtime-replay/runtime-evaluation.json
+            --runtime-score "${RUNTIME_SCORE}"
+            --strategy-profile "${STRATEGY_PROFILE}"
+            --min-trade-count "${MIN_TRADE_COUNT}"
+            --min-fill-rate "${MIN_FILL_RATE}"
+            --min-roi "${MIN_ROI}"
+            --evidence "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            --output-json artifacts/runtime-replay/candidate-strategy-replay.json
+            --output-md artifacts/runtime-replay/candidate-strategy-replay.md
+          )
+          if [ "${FULL_DEPTH_ENTRY}" = "true" ]; then
+            args+=(--full-depth-entry)
+          fi
+          python3 scripts/build_runtime_candidate_strategy_replay.py "${args[@]}"
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Runtime Candidate Replay"
+            echo ""
+            echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
+            echo "- Config: \`${{ github.event.inputs.config_path }}\`"
+            echo "- Recording: \`${{ github.event.inputs.recording_path }}\`"
+            echo "- Runtime score: \`${{ github.event.inputs.runtime_score }}\`"
+            echo "- Artifact: \`runtime-candidate-replay-${{ github.run_id }}\`"
+            if [ -f artifacts/runtime-replay/candidate-strategy-replay.json ]; then
+              echo ""
+              echo '```json'
+              python3 -c 'import json; data=json.load(open("artifacts/runtime-replay/candidate-strategy-replay.json")); print(json.dumps({"promotion_ready": data.get("promotion_ready"), "basis": data.get("basis"), "metrics": data.get("metrics"), "blocking_risk_flags": data.get("blocking_risk_flags")}, indent=2, sort_keys=True))'
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload runtime replay artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: runtime-candidate-replay-${{ github.run_id }}
+          path: artifacts/runtime-replay/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Comment replay evidence on issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const issue_number = Number(process.env.REPLAY_EVIDENCE_ISSUE);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let ready = false;
+            let metrics = {};
+            let blockers = ["missing_candidate_strategy_replay_artifact"];
+            if (fs.existsSync("artifacts/runtime-replay/candidate-strategy-replay.json")) {
+              const data = JSON.parse(fs.readFileSync("artifacts/runtime-replay/candidate-strategy-replay.json", "utf8"));
+              ready = Boolean(data.promotion_ready);
+              metrics = data.metrics || {};
+              blockers = data.blocking_risk_flags || [];
+            }
+            const body = [
+              "Runtime candidate replay evidence:",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run URL: ${runUrl}`,
+              `- Deployment: \`${{ github.event.inputs.deployment_id }}\``,
+              `- Config: \`${{ github.event.inputs.config_path }}\``,
+              `- Recording: \`${{ github.event.inputs.recording_path }}\``,
+              `- Runtime score: \`${{ github.event.inputs.runtime_score }}\``,
+              `- Artifact: \`runtime-candidate-replay-${process.env.GITHUB_RUN_ID}\``,
+              `- Promotion ready: \`${ready}\``,
+              `- Trade count: \`${metrics.trade_count ?? "n/a"}\``,
+              `- Unique events: \`${metrics.unique_event_count ?? "n/a"}\``,
+              `- Entry fill rate: \`${metrics.entry_fill_rate ?? "n/a"}\``,
+              `- ROI: \`${metrics.roi ?? "n/a"}\``,
+              `- Blocking flags: \`${blockers.join(", ") || "none"}\``
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,8 +30,9 @@ Evidence stage: `runtime_parity / executable_replay gate`.
       one-event-one-decision, fill-rate, full-depth, and ROI blockers.
 - [x] Make promotion evaluator require `basis=runtime_market_update_replay`.
 - [x] Run full Python validation and diff check.
-- [ ] Open/merge PR and then wire the hosted search workflow to produce this
+- [x] Open/merge PR and then wire the hosted search workflow to produce this
       artifact before config PR creation.
+- [x] Add and validate the read-only GitHub Actions runtime replay workflow.
 
 ## Review
 
@@ -46,6 +47,12 @@ Evidence stage: `runtime_parity / executable_replay gate`.
   `promotion_ready=false`, `trade_count=0`, and blockers
   `trade_count_too_small`, `entry_fill_rate_too_low`, and
   `zero_runtime_orders_and_fills`.
+- 2026-05-18: PR #539 merged with all checks passing. The next slice adds
+  `.github/workflows/runtime-candidate-replay.yml`, a read-only workflow that
+  builds a CI runner, replays the candidate config on Tango recording data, and
+  uploads `candidate-strategy-replay.json`.
+- 2026-05-18: Added the read-only workflow and validated local YAML parsing,
+  full Python tests, and diff whitespace checks.
 
 # AutoFactor Runtime Replay Gate Repair (2026-05-18)
 


### PR DESCRIPTION
## Summary
- add a read-only Runtime Candidate Replay workflow for Tango recordings
- build a CI runner, replay a candidate config, enrich official settlement evidence, and upload candidate-strategy-replay.json
- record the workflow slice in tasks/todo.md

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runtime-candidate-replay.yml")'
- python3 -m unittest discover -s tests -p 'test_*.py'
- rtk git diff --check