### PR TITLE
Fix runtime candidate replay score override

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -138,6 +138,7 @@ jobs:
           DEPLOYMENT_ID: ${{ github.event.inputs.deployment_id }}
           CONFIG_PATH: ${{ github.event.inputs.config_path }}
           RECORDING_PATH: ${{ github.event.inputs.recording_path }}
+          RUNTIME_SCORE: ${{ github.event.inputs.runtime_score }}
           SKIP_SETTLEMENT_EXITS: ${{ github.event.inputs.skip_settlement_exits }}
           REMOTE_DIR: /opt/ploy/tmp/runtime-candidate-replay-${{ github.run_id }}
         run: |
@@ -163,13 +164,15 @@ jobs:
             "${CONFIG_PATH}" \
             "${RECORDING_PATH}" \
             "${REMOTE_DIR}" \
+            "${RUNTIME_SCORE}" \
             "${SKIP_SETTLEMENT_EXITS}" <<'EOF'
           set -euo pipefail
           deployment_id="$1"
           config_path="$2"
           recording_path="$3"
           remote_dir="$4"
-          skip_settlement_exits="$5"
+          runtime_score="$5"
+          skip_settlement_exits="$6"
           case "${skip_settlement_exits}" in
             true|false) ;;
             *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;
@@ -251,30 +254,53 @@ jobs:
           test -s "${enriched_recording}"
 
           replay_config="${remote_dir}/replay.toml"
-          python3 - "${config_path}" "${enriched_recording}" "${replay_config}" "${skip_settlement_exits}" <<'PY'
+          python3 - "${config_path}" "${enriched_recording}" "${replay_config}" "${runtime_score}" "${skip_settlement_exits}" <<'PY'
+          import json
           import sys
 
-          src, recording, dst, skip_settlement_exits = sys.argv[1:]
+          src, recording, dst, runtime_score, skip_settlement_exits = sys.argv[1:]
+          if not runtime_score:
+              raise SystemExit("runtime_score is required")
+          if "\n" in runtime_score or "\r" in runtime_score:
+              raise SystemExit("runtime_score must be single-line")
           lines = []
           inserted_replay_path = False
-          with open(src, encoding="utf-8") as handle:
-              for raw in handle.read().splitlines():
-                  stripped = raw.strip()
-                  if stripped.startswith("mode = "):
-                      lines.append('mode = "replay"')
-                      lines.append(f"skip_settlement_exits = {skip_settlement_exits}")
-                      lines.append(f'replay_market_updates_from = "{recording}"')
-                      inserted_replay_path = True
-                      continue
-                  if stripped.startswith("skip_settlement_exits"):
-                      continue
-                  if stripped.startswith("record_market_updates_to"):
-                      continue
-                  if stripped.startswith("record_market_updates_max_"):
-                      continue
-                  lines.append(raw)
+          wrote_runtime_score = False
+          source_lines = open(src, encoding="utf-8").read().splitlines()
+          has_runtime_score = any(
+              line.strip().startswith("three_layer_autofactor_runtime_score")
+              for line in source_lines
+          )
+          runtime_score_line = (
+              "three_layer_autofactor_runtime_score = "
+              f"{json.dumps(runtime_score, ensure_ascii=True)}"
+          )
+          for raw in source_lines:
+              stripped = raw.strip()
+              if stripped.startswith("mode = "):
+                  lines.append('mode = "replay"')
+                  lines.append(f"skip_settlement_exits = {skip_settlement_exits}")
+                  lines.append(f'replay_market_updates_from = "{recording}"')
+                  inserted_replay_path = True
+                  continue
+              if stripped.startswith("skip_settlement_exits"):
+                  continue
+              if stripped.startswith("record_market_updates_to"):
+                  continue
+              if stripped.startswith("record_market_updates_max_"):
+                  continue
+              if stripped.startswith("three_layer_autofactor_runtime_score"):
+                  lines.append(runtime_score_line)
+                  wrote_runtime_score = True
+                  continue
+              lines.append(raw)
+              if stripped.startswith("strategy_profile") and not has_runtime_score:
+                  lines.append(runtime_score_line)
+                  wrote_runtime_score = True
           if not inserted_replay_path:
               raise SystemExit("runtime mode line not found in source config")
+          if not wrote_runtime_score:
+              raise SystemExit("strategy_profile/runtime score location not found in source config")
           with open(dst, "w", encoding="utf-8") as handle:
               handle.write("\n".join(lines) + "\n")
           PY

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -224,6 +224,12 @@ A true pre-dry-run runtime replay artifact must be built from the JSON emitted
 by `ploy-runner run --output-json` after replaying the exact candidate config on
 an ordered MarketUpdate stream:
 
+For AutoFactor candidates that are not yet deployed, use
+`runtime-candidate-replay.yml` from `main`. The workflow treats the deployed
+Tango config as a template, writes a temporary replay config, and overrides
+`three_layer_autofactor_runtime_score` with the supplied `runtime_score` before
+replaying. It does not edit the deployed config or restart a service.
+
 ```bash
 python3 scripts/build_runtime_candidate_strategy_replay.py \
   --runtime-evaluation-json /tmp/runtime-eval.json \

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -57,7 +57,7 @@ when the mismatch is understood and tracked as a follow-up issue.
 | Walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Rolling factor validation across train/test windows |
 | Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
 | Replay/backtest accounting | `.github/workflows/backtest.yml` | Build and run replay/backtest accounting in one job on `ploy-ci-1` |
-| Candidate strategy replay | `autofactor-strategy-promotion.yml` consumer contract, then a replay-producing workflow/artifact | Required pre-dry-run proof that the selected runtime score is profitable under historical executable replay |
+| Candidate strategy replay | `.github/workflows/runtime-candidate-replay.yml` | Required pre-dry-run proof that the selected runtime score emits executable runtime decisions on a Tango MarketUpdate recording |
 | Replay/dry-run parity | `.github/workflows/replay-dryrun-parity.yml` | Compare replay/backtest evidence against a dry-run JSON report |
 | Recorded replay/dry-run parity | `.github/workflows/recorded-replay-parity.yml` | Replay a canonical MarketUpdate recording on `tango-1-1` with the deployed binary, then compare against the matching dry-run report slice |
 | Runtime evidence reset | `.github/workflows/reset-strategy-runtime-evidence.yml` | Backup-first cleanup for contaminated dry-run/paper `strategy_runtime_orders` and `strategy_runtime_fills`; follow `docs/runbooks/strategy-runtime-evidence-reset.md` |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,44 @@
+# Runtime Candidate Replay Score Override (2026-05-18)
+
+## Goal
+
+Make the runtime replay workflow validate newly discovered AutoFactor
+candidates before they are deployed, not only the score already present in the
+remote dry-run config.
+
+Evidence stage: `runtime_parity / executable_replay gate`.
+
+## Files / Ownership
+
+- `.github/workflows/runtime-candidate-replay.yml`
+  - Owner: build a temporary replay config from the Tango dry-run template and
+    override `three_layer_autofactor_runtime_score` with the requested
+    candidate score.
+- `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/runbooks/strategy-research-cicd.md`
+  - Owner: document candidate replay as the pre-dry-run runtime proof.
+
+## Tasks
+
+- [x] Confirm merged runtime replay workflow successfully produced a
+      `basis=runtime_market_update_replay` artifact on `main`.
+- [x] Verify the current candidate remains blocked with zero runtime
+      orders/fills on `406,706` replayed MarketUpdate records.
+- [x] Fix the workflow so `runtime_score` is applied to the temporary replay
+      config before the runner executes.
+
+## Review
+
+- 2026-05-18: `runtime-candidate-replay.yml` run `26026585456` succeeded and
+  uploaded `candidate-strategy-replay.json`, but the current candidate produced
+  `intents_submitted=0`, `fills=0`, `trade_count=0`,
+  `entry_fill_rate=0.0`, and blockers `trade_count_too_small`,
+  `entry_fill_rate_too_low`, and `zero_runtime_orders_and_fills`.
+- 2026-05-18: The first workflow version used the remote config score as-is,
+  which made it suitable for validating the current dry-run candidate but not a
+  newly mined search-tree candidate. The repair keeps the remote config as a
+  template and overrides only the temporary replay TOML.
+
 # Runtime Candidate Replay Artifact Gate (2026-05-18)
 
 ## Goal


### PR DESCRIPTION
## Summary
- override three_layer_autofactor_runtime_score in the temporary runtime replay config with the requested candidate runtime_score
- keep Tango config read-only while allowing newly mined AutoFactor candidates to be replayed before dry-run PRs
- document runtime-candidate-replay.yml as the pre-dry-run candidate replay gate

## Validation
- ~/go/bin/actionlint -color .github/workflows/runtime-candidate-replay.yml
- ~/go/bin/actionlint -color
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runtime-candidate-replay.yml"); puts "yaml-ok"'
- rtk git diff --check