### PR TITLE
Align settlement AutoFactor full-depth edge gate

### DIFF
--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -1604,16 +1604,34 @@ impl ThreeLayerStrategy {
             let entry_probability = settlement_formula_side_probability.unwrap_or(effective_p);
 
             // Layer 3: Edge score
-            let Some((entry_price_f, edge, rr, edge_score)) =
-                evaluate_edge_score(entry_probability, ask, regime, &self.config)
-            else {
-                self.bump("skip_edge_score");
-                continue;
-            };
-            if self.config.profile.uses_snapshot_scoring() && rr < self.config.min_reward_risk {
+            let (entry_price_f, edge, rr, edge_score) =
+                if settlement_formula_side_probability.is_some() {
+                    let top_quote_edge =
+                        entry_probability - ask - crypto_fee_cost(ask);
+                    let top_quote_edge_score = three_layer_model::threshold_score(
+                        top_quote_edge,
+                        self.config.min_edge.max(0.0),
+                        0.08,
+                        false,
+                    )
+                    .clamp(-0.50, 1.0);
+                    (ask, top_quote_edge, 0.0, top_quote_edge_score)
+                } else {
+                    let Some(edge_score) =
+                        evaluate_edge_score(entry_probability, ask, regime, &self.config)
+                    else {
+                        self.bump("skip_edge_score");
+                        continue;
+                    };
+                    edge_score
+                };
+            if settlement_formula_side_probability.is_none()
+                && self.config.profile.uses_snapshot_scoring()
+                && rr < self.config.min_reward_risk
+            {
                 self.bump("skip_reward_risk");
                 continue;
-            }
+            };
 
             let executable_formula_entry_price_f = if settlement_formula_side_probability.is_some()
             {
@@ -4441,6 +4459,82 @@ mod tests {
             "settlement AutoFactor should evaluate executable edge even when legacy direction gate would reject; decisions={decisions:?} diagnostics={diagnostics:?}"
         );
         assert_eq!(diagnostics.get("skip_direction_score"), None);
+    }
+
+    #[test]
+    fn settlement_autofactor_uses_full_depth_before_edge_gate() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+        config.min_entry_score = 0.25;
+        config.max_sweep_levels = 3;
+        config.max_sweep_price_delta = dec!(0.10);
+        config.autofactor_runtime_score =
+            Some("autofactor_formula:auto_settlement_full_depth_settlement_edge".to_string());
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-up"),
+                bid: Some(dec!(0.53)),
+                ask: Some(dec!(0.55)),
+                bid_size: Some(dec!(200)),
+                ask_size: Some(dec!(200)),
+                bid_levels: Vec::new(),
+                ask_levels: vec![level(dec!(0.48), dec!(200))],
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-down"),
+                bid: Some(dec!(0.43)),
+                ask: Some(dec!(0.47)),
+                bid_size: Some(dec!(200)),
+                ask_size: Some(dec!(200)),
+                bid_levels: Vec::new(),
+                ask_levels: vec![level(dec!(0.47), dec!(200))],
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        match decisions.as_slice() {
+            [StrategyDecision::Enter { signal, .. }] => {
+                let signal = signal.as_ref().expect("signal");
+                assert!(
+                    signal.edge > 0.02,
+                    "expected full-depth executable edge above min_edge, got {}",
+                    signal.edge
+                );
+            }
+            other => panic!(
+                "settlement AutoFactor should not reject on stale top-ask edge before full-depth executable edge; decisions={other:?} diagnostics={diagnostics:?}"
+            ),
+        }
+        assert_eq!(diagnostics.get("skip_edge_score"), None);
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,44 @@
+# Settlement AutoFactor Full-Depth Runtime Gate (2026-05-18)
+
+## Goal
+
+Align settlement AutoFactor runtime entry gating with the search-tree
+full-depth executable edge semantics so candidates are not rejected on a
+top-ask edge check before CLOB depth is evaluated.
+
+Evidence stage: `runtime_parity / executable_replay repair`.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: settlement AutoFactor runtime scoring and diagnostics.
+
+## Tasks
+
+- [x] Diagnose runtime replay zero-intent blockers after search produced a
+      runtime-mappable discovery candidate.
+- [x] Move settlement AutoFactor edge rejection behind full-depth executable
+      entry calculation.
+- [x] Add regression coverage for a top-ask edge miss with a positive
+      full-depth executable edge.
+- [x] Run focused Rust validation and package validation.
+
+## Review
+
+- 2026-05-18: Search run `26027662010` found `191` candidates and `118`
+  discovery passes. The best runtime-mappable settlement candidate was
+  `auto_settlement_full_depth_settlement_edge`, but runtime replay run
+  `26027767111` still produced `intents_submitted=0`, `fills=0`, and dominant
+  diagnostics `skip_edge_score=621` / `skip_settlement_side_score=172`.
+- 2026-05-18: The runtime path was evaluating a top-ask edge gate before
+  computing full-depth executable entry price for settlement AutoFactor
+  formulas. This could reject exactly the class of candidates searched under
+  `full_depth_settlement_executable_pnl`.
+- 2026-05-18: Local validation passed:
+  `rtk cargo test --locked -p ploy-strategy-bundles settlement_autofactor --lib`,
+  `rtk cargo check --locked -p ploy-strategy-bundles`, and
+  `rtk git diff --check`.
+
 # Runtime Candidate Replay Score Override (2026-05-18)
 
 ## Goal


### PR DESCRIPTION
## Summary
- avoid rejecting settlement AutoFactor runtime entries on the preliminary top-ask edge before full-depth executable entry is evaluated
- keep non-settlement AutoFactor and legacy profile edge/reward-risk gates unchanged
- add a regression test for positive full-depth executable edge with a weak top-ask edge

## Evidence stage
runtime_parity / executable_replay repair

## Validation
- rtk cargo test --locked -p ploy-strategy-bundles settlement_autofactor --lib
- rtk cargo check --locked -p ploy-strategy-bundles
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the three-layer strategy's entry gating logic when using settlement-auto-factor runtime scoring to evaluate full-depth executable data before applying edge gates, improving signal accuracy.

* **Tests**
  * Added regression test validating full-depth settlement auto-factor runtime scoring behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->