### PR TITLE
Add model-based settlement AutoFactor path

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -697,6 +697,23 @@ pub fn autofactor_matrix_from_v2(
             row.conservative_entry_sweep_avg_price_15u,
         )
     });
+    insert_column(
+        &mut columns,
+        "model_full_depth_settlement_edge",
+        rows,
+        |row| settlement_edge(row.side_model_prob, row.entry_sweep_avg_price_15u),
+    );
+    insert_column(
+        &mut columns,
+        "model_conservative_settlement_edge",
+        rows,
+        |row| {
+            settlement_edge(
+                row.side_model_prob,
+                row.conservative_entry_sweep_avg_price_15u,
+            )
+        },
+    );
     insert_column(&mut columns, "entry_capacity_score", rows, |row| {
         if row.entry_capacity_ratio.is_finite() {
             (row.entry_capacity_ratio / 3.0).clamp(0.0, 1.0)
@@ -1344,12 +1361,12 @@ fn settlement_native_generated_candidates(input_names: &BTreeSet<String>) -> Vec
     let mut out = Vec::new();
     let edge_inputs = [
         (
-            "full_depth_settlement_edge",
-            "Full-depth q minus entry sweep price and fee.",
+            "model_full_depth_settlement_edge",
+            "Full-depth external model q minus entry sweep price and fee.",
         ),
         (
-            "conservative_settlement_edge",
-            "Conservative q minus entry sweep price and fee.",
+            "model_conservative_settlement_edge",
+            "Conservative external model q minus entry sweep price and fee.",
         ),
     ];
     for (edge_name, note) in edge_inputs {
@@ -2066,7 +2083,7 @@ mod tests {
             time_remaining_secs: 120,
             regime: Regime::Middle,
             side: ReviewSide::Up,
-            side_model_prob: 0.5,
+            side_model_prob: (0.50 + score * 0.01).clamp(0.01, 0.99),
             side_fair_prob: (0.50 + score * 0.01).clamp(0.01, 0.99),
             side_model_edge: score * 0.01,
             side_distance_over_sigma: 0.25,
@@ -2397,8 +2414,8 @@ mod tests {
 
         let full_depth_edge = reports
             .iter()
-            .find(|report| report.name == "auto_settlement_full_depth_settlement_edge")
-            .expect("generated full-depth settlement edge report");
+            .find(|report| report.name == "auto_settlement_model_full_depth_settlement_edge")
+            .expect("generated model full-depth settlement edge report");
         assert_eq!(full_depth_edge.decision, AutoFactorDecision::Candidate);
         assert_eq!(
             full_depth_edge.target.as_deref(),
@@ -2412,20 +2429,21 @@ mod tests {
         );
         assert_eq!(full_depth_edge.top_bucket_max_event_decisions, 1);
         assert!(reports.iter().any(|report| {
-            report.name == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity"
+            report.name
+                == "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
         }));
         assert!(reports.iter().any(|report| {
-            report.name == "auto_settlement_full_depth_settlement_edge_x_entry_price_quality"
+            report.name == "auto_settlement_model_full_depth_settlement_edge_x_entry_price_quality"
         }));
         assert!(reports.iter().any(|report| {
             report.name
-                == "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality"
+                == "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality"
         }));
         assert!(
             reports
                 .iter()
                 .any(|report| report.name
-                    == "mut_auto_settlement_full_depth_settlement_edge_capacity")
+                    == "mut_auto_settlement_model_full_depth_settlement_edge_capacity")
         );
         assert!(reports
             .iter()

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -587,6 +587,17 @@ fn is_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
     let name = name.strip_prefix("mut_").unwrap_or(name);
     name.starts_with("auto_settlement_full_depth_settlement_edge")
         || name.starts_with("auto_settlement_conservative_settlement_edge")
+        || name.starts_with("auto_settlement_model_full_depth_settlement_edge")
+        || name.starts_with("auto_settlement_model_conservative_settlement_edge")
+}
+
+fn is_model_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
+    let name = runtime_score
+        .strip_prefix("autofactor_formula:")
+        .unwrap_or(runtime_score);
+    let name = name.strip_prefix("mut_").unwrap_or(name);
+    name.starts_with("auto_settlement_model_full_depth_settlement_edge")
+        || name.starts_with("auto_settlement_model_conservative_settlement_edge")
 }
 
 fn signum(value: f64) -> f64 {
@@ -1135,10 +1146,40 @@ impl ThreeLayerStrategy {
         Some(if betting_up { fair_up } else { 1.0 - fair_up })
     }
 
+    fn runtime_side_model_probability(
+        &self,
+        spot_price: f64,
+        price_to_beat: f64,
+        sigma_horizon: f64,
+        betting_up: bool,
+    ) -> Option<f64> {
+        if spot_price <= 0.0
+            || price_to_beat <= 0.0
+            || !sigma_horizon.is_finite()
+            || sigma_horizon <= 0.0
+        {
+            return None;
+        }
+        let probability_up =
+            three_layer_model::norm_cdf((spot_price / price_to_beat).ln() / sigma_horizon);
+        if !probability_up.is_finite() {
+            return None;
+        }
+        Some(if betting_up {
+            probability_up
+        } else {
+            1.0 - probability_up
+        })
+    }
+
     fn settlement_autofactor_best_direction(
         &self,
         event: &EventWindow,
         now: DateTime<Utc>,
+        spot_price: f64,
+        price_to_beat: f64,
+        sigma_horizon: f64,
+        use_model_probability: bool,
     ) -> Option<(f64, f64, f64)> {
         [true, false]
             .into_iter()
@@ -1153,7 +1194,16 @@ impl ThreeLayerStrategy {
                 if ask < self.config.min_entry_price || ask > self.config.max_entry_price {
                     return None;
                 }
-                let side_probability = self.runtime_side_fair_probability(event, betting_up, now)?;
+                let side_probability = if use_model_probability {
+                    self.runtime_side_model_probability(
+                        spot_price,
+                        price_to_beat,
+                        sigma_horizon,
+                        betting_up,
+                    )?
+                } else {
+                    self.runtime_side_fair_probability(event, betting_up, now)?
+                };
                 let edge = three_layer_model::expected_value_per_share(side_probability, ask);
                 if !edge.is_finite() {
                     return None;
@@ -1560,13 +1610,24 @@ impl ThreeLayerStrategy {
                 .as_deref()
                 .map(is_settlement_autofactor_runtime_score)
                 .unwrap_or(false);
+            let uses_model_settlement_autofactor = runtime_score
+                .as_deref()
+                .map(is_model_settlement_autofactor_runtime_score)
+                .unwrap_or(false);
 
             // Layer 1: Direction score. Settlement AutoFactor profiles select
             // the executable UP/DOWN side by settlement edge, not by the
             // legacy CEX-only direction gate.
             let Some((direction_sign, effective_p, direction_score)) =
                 (if uses_settlement_autofactor {
-                    self.settlement_autofactor_best_direction(event, now)
+                    self.settlement_autofactor_best_direction(
+                        event,
+                        now,
+                        spot_price,
+                        price_to_beat,
+                        sigma_h,
+                        uses_model_settlement_autofactor,
+                    )
                 } else {
                     evaluate_direction_score(
                         distance_over_sigma,
@@ -1673,9 +1734,17 @@ impl ThreeLayerStrategy {
             }
 
             let settlement_formula_side_probability = if uses_settlement_autofactor {
-                let Some(side_probability) =
+                let side_probability = if uses_model_settlement_autofactor {
+                    self.runtime_side_model_probability(
+                        spot_price,
+                        price_to_beat,
+                        sigma_h,
+                        betting_up,
+                    )
+                } else {
                     self.runtime_side_fair_probability(event, betting_up, now)
-                else {
+                };
+                let Some(side_probability) = side_probability else {
                     self.bump("skip_autofactor_score_unavailable");
                     continue;
                 };
@@ -4761,9 +4830,105 @@ mod tests {
     }
 
     #[test]
+    fn model_settlement_autofactor_uses_external_model_probability() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+        config.min_entry_score = 0.25;
+        config.autofactor_runtime_score =
+            Some("autofactor_formula:auto_settlement_model_full_depth_settlement_edge".to_string());
+        let mut strategy = ThreeLayerStrategy::new(config);
+        for (offset, price) in [
+            (-5, dec!(100000)),
+            (-4, dec!(100020)),
+            (-3, dec!(99990)),
+            (-2, dec!(100040)),
+            (-1, dec!(100000)),
+        ] {
+            strategy.on_update(
+                &MarketUpdate::SpotPrice {
+                    symbol: Arc::from("BTCUSDT"),
+                    price,
+                    ts: now + chrono::Duration::seconds(offset),
+                },
+                &PositionLedger::default(),
+                &OrderLedger::default(),
+            );
+        }
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-up"),
+                bid: Some(dec!(0.19)),
+                ask: Some(dec!(0.20)),
+                bid_size: Some(dec!(200)),
+                ask_size: Some(dec!(200)),
+                bid_levels: Vec::new(),
+                ask_levels: vec![level(dec!(0.20), dec!(200))],
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-down"),
+                bid: Some(dec!(0.79)),
+                ask: Some(dec!(0.80)),
+                bid_size: Some(dec!(200)),
+                ask_size: Some(dec!(200)),
+                bid_levels: Vec::new(),
+                ask_levels: vec![level(dec!(0.80), dec!(200))],
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        let decisions = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100500),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+
+        match decisions.as_slice() {
+            [StrategyDecision::Enter { intent, signal }] => {
+                assert_eq!(intent.token_id, "token-up");
+                let signal = signal.as_ref().expect("signal");
+                assert!(
+                    signal.p_hat > 0.50,
+                    "model settlement AutoFactor must use model probability, got {}",
+                    signal.p_hat
+                );
+                assert!(
+                    signal.edge > 0.02,
+                    "expected executable model settlement edge above min_edge, got {}",
+                    signal.edge
+                );
+            }
+            other => panic!("expected model settlement AutoFactor entry, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn identifies_settlement_autofactor_runtime_scores() {
         assert!(is_settlement_autofactor_runtime_score(
             "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike"
+        ));
+        assert!(is_settlement_autofactor_runtime_score(
+            "autofactor_formula:auto_settlement_model_full_depth_settlement_edge_x_near_strike"
+        ));
+        assert!(is_model_settlement_autofactor_runtime_score(
+            "autofactor_formula:auto_settlement_model_conservative_settlement_edge_x_capacity"
         ));
         assert!(is_settlement_autofactor_runtime_score(
             "autofactor_formula:mut_auto_settlement_conservative_settlement_edge_x_capacity"

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -165,21 +165,19 @@ pub fn auto_settlement_formula_score(
         return score.is_finite().then_some(score);
     }
 
-    let is_full_depth = name.starts_with("auto_settlement_full_depth_settlement_edge");
-    let is_conservative = name.starts_with("auto_settlement_conservative_settlement_edge");
-    if !is_full_depth && !is_conservative {
-        return None;
-    }
-
+    let settlement_prefix = [
+        "auto_settlement_full_depth_settlement_edge",
+        "auto_settlement_conservative_settlement_edge",
+        "auto_settlement_model_full_depth_settlement_edge",
+        "auto_settlement_model_conservative_settlement_edge",
+    ]
+    .into_iter()
+    .find(|prefix| name.starts_with(prefix))?;
     if !inputs.settlement_edge.is_finite() {
         return None;
     }
     let mut score = inputs.settlement_edge;
-    let suffix = if is_full_depth {
-        name.strip_prefix("auto_settlement_full_depth_settlement_edge")
-    } else {
-        name.strip_prefix("auto_settlement_conservative_settlement_edge")
-    }?;
+    let suffix = name.strip_prefix(settlement_prefix)?;
 
     match suffix {
         "" => {}

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -259,7 +259,9 @@ Features should be grouped by data meaning, not only by column name:
 - Polymarket quote state: side ask/bid, spread, quote age, PM lag
 - full-depth execution: sweep price, capacity, conservative depth assumptions
 - event geometry: time remaining, distance to strike, near-strike score
-- probability state: q estimates, market prior, EventVolSurface prior
+- probability state: external/model q estimates, market prior, EventVolSurface
+  prior; PM quote-implied fair probability is diagnostic unless paired with an
+  independent predictive model
 - volatility state: realized/IV/DVOL primitives when present and audited
 - risk/friction: fees, slippage, fillability, capacity, turnover proxies
 

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -195,11 +195,13 @@ corresponding output paths are provided:
 
 Factor Walk-Forward V2 also includes a constrained settlement-native generator
 for the `full_depth_settlement_executable_pnl` target. It automatically expands
-full-depth and conservative settlement edge primitives into `auto_settlement_*`
-formula candidates with near-strike, capacity, spread, external-pressure, and
-short-IV-change interactions. These rows are still discovery evidence only:
-they must pass the same promotion evaluator and runtime mapping gates before
-becoming a dry-run handoff.
+external model-probability full-depth and conservative settlement edge
+primitives into `auto_settlement_model_*` formula candidates with near-strike,
+capacity, spread, external-pressure, and short-IV-change interactions. PM
+quote-implied fair-edge primitives remain diagnostics because they mostly
+measure market residuals, not predictive settlement probability. These rows are
+still discovery evidence only: they must pass the same promotion evaluator and
+runtime mapping gates before becoming a dry-run handoff.
 The built-in promotion evaluator maps the generated `auto_settlement_*`
 formula family to the `settlement_probability` strategy profile with
 `autofactor_formula:<factor_name>` runtime score identifiers. That mapping only

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -430,9 +430,9 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
     if not mutations and decision["action"] == "revise_prior":
         mutations.append(
             {
-                "base_factor": "auto_settlement_full_depth_settlement_edge",
+                "base_factor": "auto_settlement_model_full_depth_settlement_edge",
                 "mutation_type": "add_capacity_gate",
-                "name": "llm_full_depth_edge_capacity_gate",
+                "name": "llm_model_full_depth_edge_capacity_gate",
                 "feature": "entry_capacity_score",
             }
         )

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -150,6 +150,27 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
     },
 }
 
+for _base in (
+    "auto_settlement_model_full_depth_settlement_edge",
+    "auto_settlement_model_conservative_settlement_edge",
+):
+    for _suffix in (
+        "",
+        "_x_near_strike",
+        "_x_capacity",
+        "_x_entry_price_quality",
+        "_x_near_strike_x_capacity",
+        "_x_near_strike_x_capacity_x_entry_price_quality",
+        "_spread_adjusted",
+        "_x_external_pressure",
+        "_x_iv_change",
+    ):
+        _name = f"{_base}{_suffix}"
+        BUILTIN_RUNTIME_MAPPINGS[_name] = {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "runtime_score": f"autofactor_formula:{_name}",
+        }
+
 
 @dataclass
 class PromotionGate:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,63 @@
+# Model-Based Settlement AutoFactor Runtime Path (2026-05-18)
+
+## Goal
+
+Fix the search/runtime semantic mismatch exposed by replay run `26030858802`:
+quote-implied `side_fair_prob - executable_ask` is a market residual, not a
+predictive settlement probability edge. Add a model-probability settlement edge
+family that can be searched and replayed with the same runtime scorer.
+
+Evidence stage: `runtime_parity / executable_replay repair`.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/autofactor.rs`
+  - Owner: expose model-probability full-depth settlement edge columns and
+    generated candidates.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: make runtime model-settlement AutoFactor scores use external
+    spot/strike/sigma model probability for side selection and entry edge.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs`
+  - Owner: parse model-settlement formula names.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: map only runtime-supported model-settlement formulas to handoff.
+
+## Tasks
+
+- [x] Use runtime replay diagnostics to isolate the mismatch.
+- [x] Add model-based settlement edge search candidates.
+- [x] Add runtime scorer support for model-settlement formulas.
+- [x] Update promotion mapping/tests so model-settlement candidates can hand off.
+- [x] Run focused Rust/Python validation.
+- [ ] Push PR, merge, rerun factor search and runtime candidate replay.
+
+## Review
+
+- 2026-05-18: Replay run `26030858802` proved the previous selected
+  `auto_settlement_full_depth_settlement_edge` candidate is a market-implied
+  fair-edge residual: `settlement_autofactor_raw_score_pass_min_edge=0`,
+  `settlement_autofactor_executable_edge_fail_min_edge=629`, and `0` runtime
+  intents. This blocks promotion and explains the zero-trade replay.
+- 2026-05-18: Added model-probability settlement edge columns and generated
+  `auto_settlement_model_*` candidates so search can evaluate an independent
+  predictive settlement probability against executable full-depth prices.
+- 2026-05-18: Runtime now routes `auto_settlement_model_*` formulas through the
+  spot/strike/sigma model probability path for side selection and edge
+  evaluation, while PM quote-implied settlement formulas keep the existing fair
+  probability behavior for diagnostics.
+- 2026-05-18: Focused validation passed:
+  `rtk cargo test --locked -p ploy-strategy-bundles settlement_autofactor --lib`
+  (`7 passed, 180 filtered out`),
+  `rtk cargo test --locked -p ploy-research mines_generated_settlement_native_candidates_from_v2_rows --lib`
+  (`1 passed, 99 filtered out`),
+  `rtk cargo check --locked -p ploy-strategy-bundles`,
+  `rtk cargo check --locked -p ploy-research`,
+  `python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/alpha_search_closed_loop_agent.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion`
+  (`36 tests`),
+  a direct runtime-mapping import assertion, and `rtk git diff --check`.
+  Local `pytest` is unavailable in this worktree environment.
+
 # Settlement AutoFactor Runtime Replay Diagnostics (2026-05-18)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -186,7 +186,7 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertTrue(decision["prior_revision_required"])
             self.assertEqual(
                 prior["mutations"][0]["base_factor"],
-                "auto_settlement_full_depth_settlement_edge",
+                "auto_settlement_model_full_depth_settlement_edge",
             )
 
     def test_runtime_blocker_routes_to_fix_runtime(self) -> None:


### PR DESCRIPTION
## Summary
- add model-probability full-depth/conservative settlement edge columns and generated AutoFactor candidates
- route auto_settlement_model_* runtime scores through external spot/strike/sigma probability instead of PM quote-implied fair probability
- add promotion mappings and closed-loop prior defaults for model-settlement formulas
- document that PM quote-implied fair edge is diagnostic, not a predictive settlement edge

## Evidence
- runtime replay 26030858802 showed quote-implied fair-edge candidate had 0/629 raw scores passing min_edge and 0 runtime intents

## Validation
- rtk cargo test --locked -p ploy-strategy-bundles settlement_autofactor --lib
- rtk cargo test --locked -p ploy-research mines_generated_settlement_native_candidates_from_v2_rows --lib
- rtk cargo check --locked -p ploy-strategy-bundles
- rtk cargo check --locked -p ploy-research
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/alpha_search_closed_loop_agent.py
- direct runtime mapping import assertion for auto_settlement_model_* mappings
- rtk git diff --check

Note: local pytest is unavailable in this worktree environment.