### PR TITLE
Fix runtime replay entry accounting

### DIFF
--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -47,8 +47,46 @@ def result_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def purpose_is_entry(row: dict[str, Any]) -> bool:
-    purpose = str(row.get("purpose") or row.get("signal_inputs", {}).get("purpose") or "ENTRY")
-    return purpose.upper() == "ENTRY"
+    intent_id = str(row.get("intent_id") or "")
+    side = str(row.get("side") or row.get("fill_side") or row.get("order_side") or "").upper()
+    if intent_id.startswith("tl_settle_") or side == "SELL":
+        return False
+    purpose = row.get("purpose") or row.get("signal_inputs", {}).get("purpose")
+    if purpose is not None:
+        return str(purpose).upper() == "ENTRY"
+    return side == "BUY"
+
+
+def row_key(row: dict[str, Any], key: str) -> str | None:
+    raw = row.get(key)
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def build_event_id_lookup(rows: list[dict[str, Any]]) -> dict[tuple[str, str], str]:
+    lookup: dict[tuple[str, str], str] = {}
+    for row in rows:
+        event_id = row_key(row, "event_id") or row_key(row, "market_id")
+        if not event_id:
+            continue
+        for key in ("intent_id", "order_id", "token_id"):
+            value = row_key(row, key)
+            if value:
+                lookup[(key, value)] = event_id
+    return lookup
+
+
+def resolved_event_id(row: dict[str, Any], lookup: dict[tuple[str, str], str]) -> str | None:
+    event_id = row_key(row, "event_id") or row_key(row, "market_id")
+    if event_id:
+        return event_id
+    for key in ("intent_id", "order_id", "token_id"):
+        value = row_key(row, key)
+        if value and (key, value) in lookup:
+            return lookup[(key, value)]
+    return None
 
 
 def build_artifact(
@@ -74,10 +112,12 @@ def build_artifact(
     entry_fills = [row for row in fills if purpose_is_entry(row)]
     entry_events = [row for row in events if purpose_is_entry(row)]
 
+    event_lookup = build_event_id_lookup(events + intents + orders + fills)
+    decision_rows = entry_events or entry_orders
     event_ids = [
-        str(row.get("event_id") or row.get("market_id"))
-        for row in entry_orders
-        if row.get("event_id") or row.get("market_id")
+        event_id
+        for row in decision_rows
+        if (event_id := resolved_event_id(row, event_lookup))
     ]
     unique_event_count = len(set(event_ids))
     event_decision_counts = Counter(event_ids)
@@ -89,8 +129,26 @@ def build_artifact(
         if row.get("order_id") and decimal_value(row.get("quantity")) > 0
     }
     trade_count = len(filled_order_ids)
-    order_count = len(entry_orders)
-    intent_count = len(intents) or int(result.get("intents_submitted") or 0)
+    if entry_events:
+        filled_entry_event_ids = {
+            event_id
+            for row in entry_events
+            if (
+                str(row.get("fill_status") or "").upper() == "FILLED"
+                or (row_key(row, "order_id") in filled_order_ids)
+            )
+            and (event_id := resolved_event_id(row, event_lookup))
+        }
+        trade_count = len(filled_entry_event_ids)
+    entry_order_ids = {order_id for row in entry_orders if (order_id := row_key(row, "order_id"))}
+    entry_order_ids.update(
+        order_id for row in entry_events if (order_id := row_key(row, "order_id"))
+    )
+    order_count = len(entry_order_ids)
+    entry_intents = [row for row in intents if purpose_is_entry(row)]
+    intent_count = max(len(entry_intents), len(entry_events))
+    if intent_count == 0:
+        intent_count = int(result.get("intents_submitted") or 0)
     denominator = max(order_count, intent_count, 1)
     entry_fill_rate = Decimal(trade_count) / Decimal(denominator)
 
@@ -143,7 +201,8 @@ def build_artifact(
         },
         "metrics": {
             "updates_processed": int(result.get("updates_processed") or 0),
-            "intents_submitted": int(result.get("intents_submitted") or intent_count),
+            "intents_submitted": intent_count,
+            "runtime_intents_submitted": int(result.get("intents_submitted") or intent_count),
             "orders": order_count,
             "fills": len(entry_fills),
             "trade_count": trade_count,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,44 @@
+# Runtime Candidate Replay Entry Accounting Repair (2026-05-18)
+
+## Goal
+
+Fix the candidate replay artifact builder so executable replay metrics count
+only real entry BUY decisions and recover event identity from runtime evidence
+rows whose order/fill records do not carry `event_id`.
+
+Evidence stage: `runtime_parity / executable_replay repair`.
+
+## Files / Ownership
+
+- `scripts/build_runtime_candidate_strategy_replay.py`
+  - Owner: event identity resolution and entry-only metric aggregation.
+- `tests/test_build_runtime_candidate_strategy_replay.py`
+  - Owner: regression coverage for missing order event IDs and settlement SELL
+    rows that must not inflate entry trade counts or PnL.
+
+## Tasks
+
+- [x] Inspect run `26034972055` replay artifact and identify the metric anomaly.
+- [x] Repair entry filtering and event-id resolution.
+- [x] Add regression tests for missing order/fill event IDs plus settlement
+      SELL rows.
+- [x] Validate locally, then rerun the artifact builder on run `26034972055`.
+- [ ] Push PR/CI/merge and rerun `runtime-candidate-replay.yml` on `main`.
+
+## Review
+
+- 2026-05-18: Run `26034972055` reported `91` fills and only `1` unique event,
+  but raw runtime evidence has `46` BUY decision events with `46` unique
+  event IDs and `45` SELL settlement/exit rows. The old artifact builder
+  treated missing `purpose` as `ENTRY` and therefore mixed settlement SELL rows
+  into entry metrics, while orders/fills lacked `event_id` and needed lookup
+  through events/intents/order IDs.
+- 2026-05-18: After fixing the builder, the same runtime replay artifact
+  re-evaluates as `46` entry trades, `46` unique events, entry fill rate
+  `1.0`, total PnL `-68.063927`, and ROI `-0.098643`. The candidate remains
+  blocked by low trade count, one missing official settlement row, and negative
+  ROI; it is not a profitable strategy candidate.
+
 # Model-Based Settlement AutoFactor Runtime Path (2026-05-18)
 
 ## Goal

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -191,6 +191,131 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertIn("official_settlement_missing:0<2", payload["blocking_risk_flags"])
         self.assertIn("full_depth_entry_not_confirmed", payload["blocking_risk_flags"])
 
+    def test_resolves_missing_order_event_ids_and_ignores_settlement_exits(self):
+        payload = runtime_eval_payload()
+        evidence = payload["runtime_evidence"]
+        evidence["intents"] = []
+        evidence["orders"] = [
+            {
+                "intent_id": "tl_btcusdt_up_100_123",
+                "order_id": "entry-order-1",
+                "event_id": None,
+                "market_id": None,
+                "purpose": None,
+                "order_side": "UNKNOWN",
+                "quantity": "10",
+                "filled_quantity": "10",
+                "status": "FILLED",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_settle_100_up",
+                "order_id": "settle-order-1",
+                "event_id": None,
+                "market_id": None,
+                "purpose": None,
+                "order_side": "UNKNOWN",
+                "quantity": "10",
+                "filled_quantity": "10",
+                "status": "FILLED",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_ethusdt_down_101_456",
+                "order_id": "entry-order-2",
+                "event_id": None,
+                "market_id": None,
+                "purpose": None,
+                "order_side": "UNKNOWN",
+                "quantity": "10",
+                "filled_quantity": "10",
+                "status": "FILLED",
+                "token_id": "token-down-101",
+            },
+        ]
+        evidence["fills"] = [
+            {
+                "intent_id": "tl_btcusdt_up_100_123",
+                "order_id": "entry-order-1",
+                "event_id": None,
+                "market_id": None,
+                "fill_side": "BUY",
+                "purpose": None,
+                "quantity": "10",
+                "price": "0.42",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_settle_100_up",
+                "order_id": "settle-order-1",
+                "event_id": None,
+                "market_id": None,
+                "fill_side": "SELL",
+                "purpose": None,
+                "quantity": "10",
+                "price": "1",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_ethusdt_down_101_456",
+                "order_id": "entry-order-2",
+                "event_id": None,
+                "market_id": None,
+                "fill_side": "BUY",
+                "purpose": None,
+                "quantity": "10",
+                "price": "0.43",
+                "token_id": "token-down-101",
+            },
+        ]
+        evidence["events"] = [
+            {
+                "intent_id": "tl_btcusdt_up_100_123",
+                "order_id": "entry-order-1",
+                "event_id": "100",
+                "market_id": "100",
+                "side": "BUY",
+                "signal_inputs": {"purpose": "ENTRY"},
+                "fill_status": "FILLED",
+                "settlement": "1",
+                "pnl": "5",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_settle_100_up",
+                "order_id": "settle-order-1",
+                "event_id": "100",
+                "market_id": "100",
+                "side": "SELL",
+                "signal_inputs": {"purpose": "ENTRY"},
+                "fill_status": "FILLED",
+                "settlement": "open",
+                "pnl": "10",
+                "token_id": "token-up-100",
+            },
+            {
+                "intent_id": "tl_ethusdt_down_101_456",
+                "order_id": "entry-order-2",
+                "event_id": "101",
+                "market_id": "101",
+                "side": "BUY",
+                "signal_inputs": {"purpose": "ENTRY"},
+                "fill_status": "FILLED",
+                "settlement": "1",
+                "pnl": "7",
+                "token_id": "token-down-101",
+            },
+        ]
+
+        artifact, _ = self.run_script(payload, "--full-depth-entry", "--min-trade-count", "2")
+
+        self.assertTrue(artifact["promotion_ready"])
+        self.assertEqual(artifact["metrics"]["trade_count"], 2)
+        self.assertEqual(artifact["metrics"]["unique_event_count"], 2)
+        self.assertEqual(artifact["metrics"]["settlement_event_count"], 2)
+        self.assertEqual(artifact["metrics"]["total_pnl"], 12.0)
+        self.assertEqual(artifact["metrics"]["entry_fill_rate"], 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- count only real BUY entry decisions in runtime candidate replay artifacts
- resolve event IDs from events/intents/orders/fills when order/fill rows omit event_id
- add regression coverage for missing order event IDs and settlement SELL rows

## Evidence
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_autofactor_strategy_promotion
- python3 -m py_compile scripts/build_runtime_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py
- rtk git diff --check

## Replay Recheck
Run 26034972055 now re-evaluates as 46 entry trades, 46 unique events, entry_fill_rate 1.0, total_pnl -68.063927, roi -0.098643. Promotion remains blocked; the prior 91-fill +554 PnL artifact was polluted by settlement SELL rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved event identification and tracking accuracy in runtime replay artifacts.
  * Enhanced fill and trade counting metrics to be event-driven for better precision.
  * Added robust fallback logic for recovering missing event identifiers.
  * Refined settlement transaction exclusion in entry accounting.

* **Tests**
  * Added validation test for event identifier resolution and settlement scenarios.

* **Documentation**
  * Added task documentation for entry accounting improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->