### PR TITLE
Fix hosted factor search snapshot options

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -33,7 +33,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -81,9 +81,9 @@ jobs:
               "test_window_hours": "",
               "step_days": "1",
               "step_hours": "",
-              "lob_sample_secs": "30",
-              "observation_sample_secs": "30",
-              "max_quote_age_secs": "30",
+              "lob_sample_secs": "",
+              "observation_sample_secs": "",
+              "max_quote_age_secs": "",
               "top_n": "20",
               "min_observations": "20",
               "top_quantile": "0.2",
@@ -217,6 +217,42 @@ jobs:
                   + ", ".join(missing)
               )
           print("full research snapshot payload present: " + ", ".join(required))
+          PY
+
+      - name: Resolve snapshot-bound options
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path("artifacts/research-snapshot/manifest.json").read_text(encoding="utf-8"))
+          env_to_manifest = {
+              "WALK_LOB_SAMPLE_SECS": "lob_sample_secs",
+              "WALK_OBSERVATION_SAMPLE_SECS": "observation_sample_secs",
+              "WALK_MAX_QUOTE_AGE_SECS": "max_quote_age_secs",
+          }
+          resolved = {}
+          for env_name, manifest_key in env_to_manifest.items():
+              current = os.environ.get(env_name, "").strip()
+              manifest_value = manifest.get(manifest_key)
+              if manifest_value is None:
+                  raise SystemExit(f"snapshot manifest missing {manifest_key}")
+              if current:
+                  resolved_value = current
+              else:
+                  resolved_value = str(manifest_value)
+              resolved[env_name] = resolved_value
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for env_name, value in resolved.items():
+                  handle.write(f"{env_name}={value}\n")
+
+          print(
+              "resolved snapshot-bound walk options: "
+              + ", ".join(f"{name}={value}" for name, value in sorted(resolved.items()))
+          )
           PY
 
       - name: Resolve walk-forward window


### PR DESCRIPTION
## Summary

- Make hosted factor walk-forward snapshot-bound options inherit from the downloaded research snapshot manifest when the caller does not explicitly set them.
- Change hosted workflow defaults for `lob_sample_secs`, `observation_sample_secs`, and `max_quote_age_secs` to empty values so daily search can safely use immutable snapshot provenance.
- Preserve explicit overrides for manual runs.

## Why

Run `26043424032` failed before alpha search because the snapshot manifest had `max_quote_age_secs=2`, while the hosted workflow defaulted to `30`.

## Validation

- `python3` smoke check that empty env values resolve to manifest values, including `WALK_MAX_QUOTE_AGE_SECS=2`
- `rtk git diff --check -- .github/workflows/factor-walk-forward-v2-hosted-artifact.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration defaults for sampling and quote age parameters.
  * Added automatic resolution mechanism that uses manifest values as fallback when environment-specific configurations are not set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->