### PR TITLE
ci: pass quote age to FactorEvolve daily search

### DIFF
--- a/.github/workflows/factor-evolve-daily-research.yml
+++ b/.github/workflows/factor-evolve-daily-research.yml
@@ -15,6 +15,10 @@ on:
         description: "Comma-separated symbols present in the snapshot"
         required: false
         default: "BTCUSDT,ETHUSDT"
+      max_quote_age_secs:
+        description: "Max quote age used when the snapshot was compiled"
+        required: false
+        default: "2"
       research_budget_json:
         description: "Research budget JSON"
         required: false
@@ -153,16 +157,21 @@ jobs:
           GIT_REF: ${{ github.event.inputs.git_ref }}
           SNAPSHOT_RUN_ID: ${{ github.event.inputs.snapshot_run_id }}
           SYMBOLS: ${{ github.event.inputs.symbols }}
+          MAX_QUOTE_AGE_SECS: ${{ github.event.inputs.max_quote_age_secs }}
         run: |
           set -euo pipefail
           python3 - <<'PY' > artifacts/factor-evolve-daily/hosted-options.json
           import json
+          import os
+
+          max_quote_age_secs = os.environ.get("MAX_QUOTE_AGE_SECS", "2").strip() or "2"
           print(json.dumps({
               "chain_next_run": False,
               "chain_remaining": 0,
               "create_handoff_issue": False,
               "fail_if_blocked": False,
               "data_quality_mode": "event_complete",
+              "max_quote_age_secs": max_quote_age_secs,
               "alpha_search_plan_target": "full_depth_settlement_executable_pnl",
               "allowed_target": "full_depth_settlement_executable_pnl",
               "required_strategy_profile": "settlement_probability",

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -500,7 +500,10 @@ typed budget and latest evidence
 
 `run_mode=plan_only` emits the Research Manager plan only. `run_mode=search`
 requires a retained research snapshot and dispatches the hosted artifact
-walk-forward path with handoff/config mutation disabled. `run_mode=promote_handoff`
+walk-forward path with handoff/config mutation disabled. Pass
+`max_quote_age_secs` to match the retained snapshot compile setting; for the
+current compact snapshots the daily workflow defaults this to `2` so the
+hosted walk-forward validator does not reject the snapshot. `run_mode=promote_handoff`
 records that a manual handoff review is required; it does not edit strategy
 configs or touch runtime services.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,47 @@
+# FactorEvolve Daily Search Snapshot Quote-Age Fix (2026-05-19)
+
+## Goal
+
+Finish the FactorEvolve daily research plan by fixing the observed hosted
+search dispatch mismatch: the daily orchestrator dispatched a retained snapshot
+compiled with `max_quote_age_secs=2` into hosted walk-forward defaults that
+requested `30`, causing the validator to reject the snapshot.
+
+Evidence stage: `diagnostic / workflow_orchestration`.
+
+## Files / Ownership
+
+- `.github/workflows/factor-evolve-daily-research.yml`
+  - Owner: pass snapshot quote-age settings into hosted search options.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document the quote-age handoff requirement.
+- `tests/workflow_security.rs`
+  - Owner: regression guard that daily search forwards quote age.
+
+## Tasks
+
+- [x] Inspect recent failed hosted walk-forward runs and identify the
+      snapshot/request `max_quote_age_secs` mismatch.
+- [x] Add `max_quote_age_secs` to the daily research workflow inputs.
+- [x] Forward `max_quote_age_secs` into downstream hosted workflow
+      `options_json`.
+- [x] Document the retained-snapshot quote-age requirement.
+- [x] Add a workflow security regression guard.
+- [x] Run focused validation.
+
+## Review
+
+- 2026-05-19: Failed hosted run `26043424032` wrote
+  `snapshot max_quote_age_secs 2 does not match requested 30`. The daily
+  workflow now defaults `max_quote_age_secs` to `2` and forwards it in
+  `hosted-options.json`, keeping `run_mode=search` aligned with compact
+  retained snapshots while still allowing callers to override the value.
+- 2026-05-19: Validation passed:
+  `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "ok"'`,
+  `CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security`,
+  `rg -n "deploy|systemctl|ployctl deployments resume|create_config_pr" .github/workflows/factor-evolve-daily-research.yml || true`
+  with no matches, and `rtk git diff --check`.
+
 # FactorEvolve Research OS Task 8 - Daily Research CI Orchestrator (2026-05-18)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -103,6 +103,29 @@ fn workflow_dispatch_inputs_stay_lintable() {
 }
 
 #[test]
+fn factor_evolve_daily_search_passes_snapshot_quote_age() {
+    let workflow = workflow_contents(".github/workflows/factor-evolve-daily-research.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "max_quote_age_secs:",
+        "MAX_QUOTE_AGE_SECS: ${{ github.event.inputs.max_quote_age_secs }}",
+        "\"max_quote_age_secs\": max_quote_age_secs",
+        "-f options_json=\"$(cat artifacts/factor-evolve-daily/hosted-options.json)\"",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!("missing daily workflow quote-age handoff: {needle}"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "FactorEvolve daily search workflow guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn event_ml_rolling_evidence_has_hosted_artifact_lane() {
     let workflow = workflow_contents(".github/workflows/event-ml-rolling-evidence.yml");
     let runbook = workflow_contents("docs/runbooks/event-ml-automl-workflow.md");


### PR DESCRIPTION
## Summary
- add max_quote_age_secs to the FactorEvolve daily research workflow input
- forward quote-age into hosted walk-forward options_json so retained compact snapshots do not fail validation
- document the handoff and add a workflow security regression guard

## Verification
- python3 -m unittest tests.test_factor_research_os_registry tests.test_dryrun_report_running_candidate tests.test_dryrun_report_contracts
- python3 -m py_compile scripts/report_dryrun_summary.py scripts/check_dryrun_report_contract.py tests/test_dryrun_report_running_candidate.py tests/test_dryrun_report_contracts.py
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_os --lib
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research orderbook --lib
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor --lib
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research portfolio --lib
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --example factor_evolve_daily_plan
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --example factor_portfolio_builder
- CARGO_TARGET_DIR=/tmp/ploy-factor-evolve-audit /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "ok"'
- rtk git diff --check