### PR TITLE
ci: isolate legacy Python checks

### DIFF
--- a/.github/workflows/legacy-python-tools.yml
+++ b/.github/workflows/legacy-python-tools.yml
@@ -1,0 +1,30 @@
+name: Legacy Python Tools
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/legacy-python-tools.yml"
+      - "scripts/**/*.py"
+      - "tests/test_*.py"
+      - "Dockerfile.collector"
+  workflow_dispatch:
+
+concurrency:
+  group: legacy-python-tools-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    name: Legacy Python unittest compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run legacy Python unittest suite
+        run: python3 -m unittest discover -s tests -p 'test_*.py'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,17 +91,6 @@ jobs:
           # RUSTSEC-2025-0021: gix-features 0.39.1 SHA-1 collision; pulled by burn-dataset, no git ops in prod.
           cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104 --ignore RUSTSEC-2025-0021
 
-  python-script-tests:
-    name: Python script tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run Python unittest suite
-        run: python3 -m unittest discover -s tests -p 'test_*.py'
-
   rust-control-plane:
     name: Rust control-plane/core
     runs-on: ubuntu-latest

--- a/docs/runbooks/ci-language-policy.md
+++ b/docs/runbooks/ci-language-policy.md
@@ -1,0 +1,55 @@
+# CI Language Policy
+
+Ploy is a Rust-first trading platform workspace. Required pull-request
+validation should prove the Rust control plane, runner, strategy, research,
+contract, frontend, and deployment surfaces still build and test.
+
+## Required CI
+
+The required PR workflow is `.github/workflows/test.yml`.
+
+It should stay focused on:
+
+- Rust workspace build, check, test, audit, and integration lanes.
+- Workflow lint.
+- Frontend and sidecar contract generation/build checks.
+
+Do not add Python tests or Python package setup back to this workflow. If a
+new operational helper is important enough to gate required PR CI, implement it
+as Rust code or migrate it into an existing Rust crate first.
+
+## Legacy Python Surface
+
+As of 2026-05-14, the repo still contains a legacy Python compatibility
+surface:
+
+- 46 Python helper scripts under `scripts/`.
+- 23 Python unit test files under `tests/`.
+- `Dockerfile.collector`, which still packages Python collector scripts.
+- Several research/operator workflows that call `python3` for JSON glue,
+  artifact analysis, or compatibility scripts.
+
+These files are not the product runtime contract. They are compatibility and
+operator helpers that should either be migrated into Rust or retired when their
+Rust replacement exists.
+
+## Legacy Python Checks
+
+The isolated workflow is `.github/workflows/legacy-python-tools.yml`.
+
+It runs only when Python helper surfaces change, or when manually dispatched.
+This keeps compatibility coverage for existing helper scripts without making
+Python a required language for the main project CI.
+
+## Migration Rule
+
+When touching a Python helper, choose one of these outcomes:
+
+- Keep it as legacy compatibility and update the isolated legacy workflow if
+  coverage is still useful.
+- Replace it with Rust under `apps/` or `crates/` and remove the Python entry.
+- Retire it if no workflow, runbook, deployment, or operator path still calls
+  it.
+
+Do not introduce new Python production or required-CI surfaces without an
+explicit architectural decision.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -50,7 +50,8 @@ when the mismatch is understood and tracked as a follow-up issue.
 
 | Purpose | Workflow | Default role |
 | --- | --- | --- |
-| PR validation | `.github/workflows/test.yml` | Required Platform CI gate for code, contracts, frontend, integration, dependency audit, and workflow lint |
+| PR validation | `.github/workflows/test.yml` | Required Rust-first Platform CI gate for code, contracts, frontend, integration, dependency audit, and workflow lint |
+| Legacy Python compatibility | `.github/workflows/legacy-python-tools.yml` | Isolated, path-scoped checks for remaining Python helper scripts; not part of the Rust-first required CI contract |
 | Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
 | Factor diagnostics | `.github/workflows/factor-review-v2-hosted-artifact.yml` | GitHub-hosted factor review from a retained full research snapshot artifact |
 | Legacy factor diagnostics | `.github/workflows/factor-review-v2.yml` | Fresh DB/snapshot fallback on `ploy-ci-1`; avoid when a full snapshot artifact already exists |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,43 @@
+# Rust-First CI Language Boundary (2026-05-20)
+
+## Goal
+
+Keep the required PR `Test` workflow focused on the Rust-first platform
+contract while preserving legacy Python helper compatibility in an isolated,
+path-scoped workflow.
+
+Evidence stage: `workflow_contract`.
+
+## Files / Ownership
+
+- `.github/workflows/test.yml`
+  - Owner: required Rust-first CI gate.
+- `.github/workflows/legacy-python-tools.yml`
+  - Owner: non-required compatibility checks for legacy Python helpers.
+- `docs/runbooks/ci-language-policy.md`
+  - Owner: language-boundary policy and migration rule.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: research workflow map reference to the isolated legacy Python gate.
+- `tasks/todo.md`
+  - Owner: current session tracking for this extracted PR slice.
+
+## Tasks
+
+- [x] Create a clean worktree from current `origin/main`.
+- [x] Extract only the CI language-boundary changes from the dirty source
+      worktree.
+- [x] Validate workflow syntax and static policy expectations.
+- [x] Commit a focused CI language-boundary change.
+- [ ] Push and open a focused PR.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`,
+  `rtk git diff --check`, and a static search confirming Python unittest
+  discovery now appears only in `.github/workflows/legacy-python-tools.yml`.
+- 2026-05-20: Committed on branch `docs/ci-language-policy`.
+
 # FactorEvolve Daily Search Snapshot Quote-Age Fix (2026-05-19)
 
 ## Goal


### PR DESCRIPTION
## Summary
- remove legacy Python unittest discovery from the required Rust-first Test workflow
- add a path-scoped Legacy Python Tools workflow for compatibility checks
- document the CI language boundary and link it from the strategy research workflow map

## Verification
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- rtk git diff --check
- rg -n "python-script-tests|Run Python unittest suite|python3 -m unittest discover" .github/workflows/test.yml .github/workflows/legacy-python-tools.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized CI workflows to isolate legacy Python compatibility checks from the primary Rust-focused testing pipeline.

* **Documentation**
  * Added documentation outlining CI gating expectations and workflow organization strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->