### PR TITLE
backtest: mark replay evidence as non-promotional

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -20,11 +20,11 @@ on:
         required: true
         default: "config/strategies/02-pm5d-threelayer.unified.toml"
       data_dir:
-        description: "Local Parquet data dir (leave empty to use DB)"
+        description: "Diagnostic Parquet stream dir (leave empty to use DB; not full-depth lake replay)"
         required: false
         default: ""
       sync_parquet_data:
-        description: "Sync the full Parquet tree from Tango before running"
+        description: "Sync legacy quote-tick Parquet from Tango before running"
         required: false
         default: "false"
       issue_number:
@@ -151,7 +151,7 @@ jobs:
               echo "- Artifact: \`backtest-evaluation-${{ github.run_id }}\`"
               echo ""
               echo '```json'
-              python3 -c 'import json; data=json.load(open("artifacts/backtest/evaluation.json")); print(json.dumps({"producer": data.get("producer"), "replay_mode": data.get("replay_mode"), "canonical_result": data.get("canonical_result"), "metrics": data.get("metrics"), "risk_flags": data.get("risk_flags")}, indent=2, sort_keys=True))'
+              python3 -c 'import json; data=json.load(open("artifacts/backtest/evaluation.json")); print(json.dumps({"producer": data.get("producer"), "replay_mode": data.get("replay_mode"), "evidence_stage": data.get("evidence_stage"), "promotion_ready": data.get("promotion_ready"), "promotion_decision": data.get("promotion_decision"), "canonical_result": data.get("canonical_result"), "source": data.get("source"), "data_surfaces": data.get("data_surfaces"), "metrics": data.get("metrics"), "risk_flags": data.get("risk_flags"), "blocking_risk_flags": data.get("blocking_risk_flags"), "advisory_flags": data.get("advisory_flags")}, indent=2, sort_keys=True))'
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -176,17 +176,28 @@ jobs:
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let metrics = null;
             let riskFlags = [];
+            let blockingRiskFlags = [];
+            let advisoryFlags = [];
+            let evidenceStage = "unknown";
+            let promotionReady = false;
             let decision = "pending replay/dry-run parity review";
             if (fs.existsSync("artifacts/backtest/evaluation.json")) {
               const data = JSON.parse(fs.readFileSync("artifacts/backtest/evaluation.json", "utf8"));
               metrics = data.metrics || null;
               riskFlags = data.risk_flags || [];
+              blockingRiskFlags = data.blocking_risk_flags || [];
+              advisoryFlags = data.advisory_flags || [];
+              evidenceStage = data.evidence_stage || "unknown";
+              promotionReady = data.promotion_ready === true;
+              decision = data.promotion_decision || decision;
               if (!metrics || Object.keys(metrics).length === 0) {
                 riskFlags.push("missing_headline_metrics");
+                blockingRiskFlags.push("missing_headline_metrics");
                 decision = "fix-workflow-or-artifact";
               }
             } else {
               riskFlags.push("missing_evaluation_artifact");
+              blockingRiskFlags.push("missing_evaluation_artifact");
               decision = "fix-workflow-or-data-source";
             }
             const headlineMetrics = metrics && Object.keys(metrics).length > 0
@@ -201,8 +212,12 @@ jobs:
               `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
               `- Config: \`${{ github.event.inputs.config }}\``,
               `- Artifact: \`backtest-evaluation-${process.env.GITHUB_RUN_ID}\``,
+              `- Evidence stage: \`${evidenceStage}\``,
+              `- Promotion ready: \`${promotionReady}\``,
               `- Headline metrics: \`${headlineMetrics}\``,
-              `- Caveats: \`${riskFlags.join(", ") || "none"}\``,
+              `- Artifact caveats: \`${riskFlags.join(", ") || "none"}\``,
+              `- Blocking promotion flags: \`${blockingRiskFlags.join(", ") || "none"}\``,
+              `- Advisory flags: \`${advisoryFlags.join(", ") || "none"}\``,
               `- Decision: ${decision}`
             ].join("\n");
             await github.rest.issues.createComment({
@@ -212,6 +227,9 @@ jobs:
               body
             });
             const labels = ["evidence:backtest", ...labelsForDecision(decision)];
+            if (blockingRiskFlags.some((flag) => String(flag).includes("parity"))) {
+              labels.push("parity:blocked");
+            }
             if (riskFlags.includes("missing_headline_metrics")) {
               labels.push("evidence:missing-metrics");
             }

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -40,7 +40,7 @@ on:
         required: false
         default: ""
       options_json:
-        description: "Advanced options JSON: timestamps, data_dir, limits, preflight_only, timeout, local snapshot registry, min_trades"
+        description: "Advanced options JSON: timestamps, diagnostic data_dir, limits, preflight_only, timeout, local snapshot registry, min_trades"
         required: false
         default: '{"train_start_ts":"","train_end_ts":"","val_start_ts":"","val_end_ts":"","data_dir":"/tmp/ploy-parquet","max_preflight_rows":15000000,"max_preflight_bytes":"80GiB","max_symbols":6,"max_days":8,"allow_large_window":false,"preflight_only":false,"max_updates":"","duckdb_memory_limit":"6GB","optimize_timeout_minutes":90,"allow_live_parquet_debug":false,"issue_number":"","snapshot_registry_dir":"","min_trades":""}'
 

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -13,12 +13,12 @@
 //! If no --db-url is given, uses synthetic market data.
 
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use ploy_feed_loaders::{HistoricalLoadOptions, load_from_database_with_options};
+use ploy_feed_loaders::{load_from_database_with_options, HistoricalLoadOptions};
 use ploy_strategy_bundles::strategies::directional::DirectionalConfig;
 use ploy_strategy_bundles::{
-    DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder, ReversalStrategy,
-    RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig, StrategyLogic,
-    StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy, config::FullConfig,
+    config::FullConfig, DirectionalStrategy, HistoricalFeed, MarketUpdate, NullRecorder,
+    ReversalStrategy, RuntimeConfig, RuntimeMode, SimulatedExecutor, SimulatedExecutorConfig,
+    StrategyLogic, StrategyRuntime, ThreeLayerProfile, ThreeLayerStrategy,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -490,14 +490,22 @@ fn main() {
                 output_json.as_deref(),
                 &strategy_variant,
                 config_path.as_deref(),
+                "parquet_stream",
+                Some(dir.as_str()),
                 start_date.as_deref(),
                 end_date.as_deref(),
+                &backtest_options,
                 &result,
                 &snapshot,
             );
         }
     } else {
         let eager_source_load_secs;
+        let source_kind = if db_url.is_some() {
+            "db_eager"
+        } else {
+            "synthetic"
+        };
         let data: Vec<MarketUpdate> = if let Some(ref url) = db_url {
             let from = start_date.as_deref().unwrap_or("2026-03-28");
             let to = end_date.as_deref().unwrap_or("2026-04-03");
@@ -557,7 +565,7 @@ fn main() {
             timing_json.as_deref(),
             json!({
                 "command": "run_backtest",
-                "source": if db_url.is_some() { "db-eager" } else { "synthetic" },
+                "source": source_kind,
                 "config": config_path.as_deref(),
                 "strategy_variant": &strategy_variant,
                 "symbols": &strategy_config.symbols,
@@ -582,8 +590,11 @@ fn main() {
             output_json.as_deref(),
             &strategy_variant,
             config_path.as_deref(),
+            source_kind,
+            None,
             start_date.as_deref(),
             end_date.as_deref(),
+            &backtest_options,
             &result,
             &snapshot,
         );
@@ -594,8 +605,11 @@ fn write_backtest_evaluation_json(
     path: Option<&str>,
     strategy_variant: &str,
     config_path: Option<&str>,
+    source_kind: &str,
+    data_dir: Option<&str>,
     start_date: Option<&str>,
     end_date: Option<&str>,
+    backtest_options: &HistoricalLoadOptions,
     result: &ploy_strategy_bundles::RuntimeResult,
     snapshot: &ploy_trading::TradingRuntimeSnapshot,
 ) {
@@ -605,8 +619,11 @@ fn write_backtest_evaluation_json(
     let artifact = build_backtest_evaluation_artifact(
         strategy_variant,
         config_path,
+        source_kind,
+        data_dir,
         start_date,
         end_date,
+        backtest_options,
         result,
         snapshot,
     );
@@ -632,19 +649,65 @@ fn write_backtest_evaluation_json(
 fn build_backtest_evaluation_artifact(
     strategy_variant: &str,
     config_path: Option<&str>,
+    source_kind: &str,
+    data_dir: Option<&str>,
     start_date: Option<&str>,
     end_date: Option<&str>,
+    backtest_options: &HistoricalLoadOptions,
     result: &ploy_strategy_bundles::RuntimeResult,
     snapshot: &ploy_trading::TradingRuntimeSnapshot,
 ) -> serde_json::Value {
     let cashflow = snapshot.fill_cashflow_summary();
-    let mut risk_flags = Vec::new();
+    let mut artifact_risk_flags = Vec::new();
     if snapshot.orders.is_empty() {
-        risk_flags.push("no_order_level_rows");
+        artifact_risk_flags.push("no_order_level_rows");
     }
     if snapshot.fills.is_empty() {
-        risk_flags.push("no_fill_level_rows");
+        artifact_risk_flags.push("no_fill_level_rows");
     }
+
+    let has_official_settlement_gate = backtest_options.require_official_settlement;
+    let has_full_depth_clob = false;
+    let has_replay_dryrun_parity = false;
+    let has_runtime_scorer_parity = false;
+    let is_synthetic = source_kind == "synthetic";
+
+    let mut blocking_risk_flags = Vec::new();
+    if !has_full_depth_clob {
+        blocking_risk_flags.push("missing_full_depth_clob_fillability");
+    }
+    if !has_official_settlement_gate {
+        blocking_risk_flags.push("missing_official_settlement_gate");
+    }
+    if !has_replay_dryrun_parity {
+        blocking_risk_flags.push("missing_replay_dryrun_parity");
+    }
+    if !has_runtime_scorer_parity {
+        blocking_risk_flags.push("missing_runtime_scorer_parity");
+    }
+    if is_synthetic {
+        blocking_risk_flags.push("synthetic_data_source");
+    }
+    blocking_risk_flags.extend(artifact_risk_flags.iter().copied());
+
+    let mut advisory_flags = Vec::new();
+    if source_kind == "parquet_stream" {
+        advisory_flags.push("parquet_stream_uses_quote_ticks_not_full_clob_lake");
+    }
+    if source_kind == "db_eager" {
+        advisory_flags.push("db_eager_mode_is_debug_or_small_window_only");
+    }
+
+    let evidence_stage = if !is_synthetic && has_official_settlement_gate {
+        "executable_replay"
+    } else {
+        "diagnostic"
+    };
+    let canonical_result = if artifact_risk_flags.is_empty() {
+        "continue"
+    } else {
+        "fix-workflow-or-data-source"
+    };
 
     json!({
         "schema_version": 1,
@@ -652,9 +715,29 @@ fn build_backtest_evaluation_artifact(
         "producer": "run_backtest",
         "generated_at": Utc::now().to_rfc3339(),
         "replay_mode": "backtest",
-        "canonical_result": if risk_flags.is_empty() { "continue" } else { "fix-workflow-or-data-source" },
+        "evidence_stage": evidence_stage,
+        "canonical_result": canonical_result,
+        "promotion_ready": false,
+        "promotion_decision": "pending replay/dry-run parity review",
         "strategy_variant": strategy_variant,
         "config_path": config_path,
+        "source": {
+            "kind": source_kind,
+            "data_dir": data_dir,
+        },
+        "data_surfaces": {
+            "binance_l2_requested": backtest_options.include_l2,
+            "lob_sample_secs": backtest_options.lob_sample_secs,
+            "spot_sample_secs": backtest_options.spot_sample_secs,
+            "official_settlement_required": has_official_settlement_gate,
+            "full_depth_clob_fillability": has_full_depth_clob,
+            "runtime_replay_parity": has_replay_dryrun_parity,
+            "runtime_scorer_parity": has_runtime_scorer_parity,
+        },
+        "gate_notes": [
+            "Backtest evidence alone is not promotion evidence.",
+            "Promotion requires full-depth CLOB fillability, official settlement, replay/dry-run parity, and runtime scorer parity."
+        ],
         "window": {
             "start_date": start_date,
             "end_date": end_date,
@@ -673,7 +756,9 @@ fn build_backtest_evaluation_artifact(
             "gross_sell_proceeds": cashflow.gross_sell_proceeds,
             "elapsed_secs": result.elapsed_secs,
         },
-        "risk_flags": risk_flags,
+        "risk_flags": artifact_risk_flags,
+        "blocking_risk_flags": blocking_risk_flags,
+        "advisory_flags": advisory_flags,
         "runtime_evidence": normalized_runtime_evidence(snapshot),
     })
 }
@@ -841,7 +926,11 @@ fn normalized_runtime_evidence(
 }
 
 fn empty_to_none(value: &str) -> Option<&str> {
-    if value.is_empty() { None } else { Some(value) }
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 fn trade_side_label(side: ploy_trading::TradeSide) -> &'static str {

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -71,6 +71,16 @@ when the mismatch is understood and tracked as a follow-up issue.
 | Trade deploy | `.github/workflows/deploy-trade.yml` | Deploy runner/configs to `ploy-trade-1` through a protected environment |
 | Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
 
+`backtest.yml` emits `strategy_backtest_evaluation` as replay/backtest
+evidence, not as dry-run or live promotion evidence. Its `data_dir` path uses
+the legacy streaming Parquet feed for quote-tick replay; it does not consume the
+full-fidelity CLOB lake under `/opt/ploy/data/lake/orderbook_snapshots` yet.
+Treat profitable backtest metrics as blocked for promotion until the artifact
+also has full-depth CLOB fillability, official settlement, replay/dry-run
+parity, and runtime scorer parity. The machine-readable fields
+`evidence_stage`, `promotion_ready`, `blocking_risk_flags`, and
+`advisory_flags` are the operator-facing source of truth for that distinction.
+
 `recorded-replay-parity.yml` defaults `since=auto` and `until=auto`. In auto
 mode it scans the target recording on `tango-1-1`, intersects that recording
 coverage with the dry-run report for the target deployment, prefers the latest
@@ -152,6 +162,12 @@ Backtest evidence must explicitly state whether it is exploratory diagnostics or
 executable strategy accounting. Event-scoped strategies must not count multiple
 diagnostic rows as multiple deployable trades unless the runtime can execute the
 same entries under the same risk rules.
+
+For PM5D AutoFactor handoff, promotion also requires the AutoFactor report's
+top deployable bucket to expose event-level decision fields. Missing
+`top_bucket_unique_event_count` / `top_bucket_max_event_decisions` blocks
+handoff, and `top_bucket_max_event_decisions > 1` blocks handoff because the
+candidate is still relying on repeated rows from the same event.
 
 ## Decision Labels
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,49 @@
+# Replay Backtest Evidence Stage Hardening (2026-05-20)
+
+## Goal
+
+Make replay/backtest artifacts self-describing enough that profitable backtests
+cannot be mistaken for dry-run or live promotion evidence without full-depth,
+settlement, and parity gates.
+
+Evidence stage: `diagnostic / replay_backtest_contract`.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/examples/run_backtest.rs`
+  - Owner: machine-readable evidence stage, data surface, and promotion blocker
+    fields in `strategy_backtest_evaluation`.
+- `.github/workflows/backtest.yml`
+  - Owner: workflow summary and issue comment surface the same blocker fields.
+- `.github/workflows/optimize.yml`
+  - Owner: input copy preserves diagnostic data source wording.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: operator-facing backtest promotion caveat.
+- `tests/test_replay_backtest_evidence_contract.py`
+  - Owner: lightweight static regression coverage for the evidence contract.
+- `tasks/todo.md`
+  - Owner: current session tracking for this extracted PR slice.
+
+## Tasks
+
+- [x] Create a clean worktree from current `origin/main`.
+- [x] Extract only replay/backtest evidence contract changes from the dirty
+      source worktree.
+- [x] Validate workflow syntax and focused static tests.
+- [x] Commit a focused replay/backtest evidence contract change.
+- [ ] Push and open a focused PR.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `python3 -m unittest tests.test_replay_backtest_evidence_contract`,
+  `ruby -e 'require "yaml"; %w[.github/workflows/backtest.yml .github/workflows/optimize.yml].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`,
+  `rtk git diff --check`, and
+  `CARGO_TARGET_DIR=/tmp/ploy-replay-evidence-check /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-strategy-bundles --example run_backtest`.
+  The cargo check completed with existing warnings in strategy modules, but no
+  errors.
+- 2026-05-20: Committed on branch `fix/replay-backtest-evidence-contract`.
+
 # Rust-First CI Language Boundary (2026-05-20)
 
 ## Goal

--- a/tests/test_replay_backtest_evidence_contract.py
+++ b/tests/test_replay_backtest_evidence_contract.py
@@ -1,0 +1,58 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class ReplayBacktestEvidenceContractTest(unittest.TestCase):
+    def test_run_backtest_artifact_names_promotion_blockers(self):
+        source = (ROOT / "crates/ploy-strategy-bundles/examples/run_backtest.rs").read_text()
+
+        required_snippets = [
+            '"evidence_stage"',
+            '"promotion_ready": false',
+            '"promotion_decision": "pending replay/dry-run parity review"',
+            '"source"',
+            '"data_surfaces"',
+            '"blocking_risk_flags"',
+            '"advisory_flags"',
+            '"missing_full_depth_clob_fillability"',
+            '"missing_replay_dryrun_parity"',
+            '"missing_runtime_scorer_parity"',
+            '"parquet_stream_uses_quote_ticks_not_full_clob_lake"',
+        ]
+        for snippet in required_snippets:
+            self.assertIn(snippet, source)
+
+    def test_backtest_workflow_surfaces_gate_fields(self):
+        workflow = (ROOT / ".github/workflows/backtest.yml").read_text()
+
+        required_snippets = [
+            "not full-depth lake replay",
+            "legacy quote-tick Parquet",
+            "evidence_stage",
+            "promotion_ready",
+            "promotion_decision",
+            "blocking_risk_flags",
+            "Blocking promotion flags",
+            "parity:blocked",
+        ]
+        for snippet in required_snippets:
+            self.assertIn(snippet, workflow)
+
+    def test_research_runbook_preserves_backtest_caveat(self):
+        runbook = (ROOT / "docs/runbooks/strategy-research-cicd.md").read_text()
+
+        required_snippets = [
+            "not as dry-run or live promotion evidence",
+            "/opt/ploy/data/lake/orderbook_snapshots",
+            "full-depth CLOB fillability",
+            "`evidence_stage`, `promotion_ready`, `blocking_risk_flags`, and",
+        ]
+        for snippet in required_snippets:
+            self.assertIn(snippet, runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit evidence-stage, data-surface, and promotion-blocker fields to run_backtest evaluation artifacts
- surface blocking/advisory fields in backtest workflow summaries and issue comments
- document that legacy quote-tick backtests are diagnostic until full-depth CLOB, official settlement, replay/dry-run parity, and scorer parity are proven
- add static regression coverage for the evidence contract

## Verification
- python3 -m unittest tests.test_replay_backtest_evidence_contract
- ruby -e 'require "yaml"; %w[.github/workflows/backtest.yml .github/workflows/optimize.yml].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- rtk git diff --check
- CARGO_TARGET_DIR=/tmp/ploy-replay-evidence-check /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-strategy-bundles --example run_backtest