### PR TITLE
ops: archive CLOB orderbook snapshots before retention

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -190,6 +190,9 @@ jobs:
           cp scripts/report_dryrun_summary.py dist/scripts/report_dryrun_summary.py
           cp scripts/check_dryrun_report_contract.py dist/scripts/check_dryrun_report_contract.py
           cp scripts/import_polymarket_v2_indexer.py dist/scripts/import_polymarket_v2_indexer.py
+          cp scripts/archive_clob_orderbook_snapshots_backfill.sh dist/scripts/archive_clob_orderbook_snapshots_backfill.sh
+          cp scripts/export_clob_orderbook_snapshots_parquet.sh dist/scripts/export_clob_orderbook_snapshots_parquet.sh
+          cp scripts/ploy_orderbook_snapshot_retention.sh dist/scripts/ploy_orderbook_snapshot_retention.sh
           cp scripts/fix_binance_lob_partitions.sql dist/scripts/fix_binance_lob_partitions.sql
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
           cp scripts/fix_clob_trade_partitions.sql dist/scripts/fix_clob_trade_partitions.sql
@@ -209,6 +212,10 @@ jobs:
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
           cp deployment/systemd/ploy-polymarket-v2-indexer-import.service dist/deployment/systemd/ploy-polymarket-v2-indexer-import.service
           cp deployment/systemd/ploy-polymarket-v2-indexer-import.timer dist/deployment/systemd/ploy-polymarket-v2-indexer-import.timer
+          cp deployment/systemd/ploy-orderbook-snapshot-archive.service dist/deployment/systemd/ploy-orderbook-snapshot-archive.service
+          cp deployment/systemd/ploy-orderbook-snapshot-archive.timer dist/deployment/systemd/ploy-orderbook-snapshot-archive.timer
+          cp deployment/systemd/ploy-orderbook-snapshot-retention.service dist/deployment/systemd/ploy-orderbook-snapshot-retention.service
+          cp deployment/systemd/ploy-orderbook-snapshot-retention.timer dist/deployment/systemd/ploy-orderbook-snapshot-retention.timer
           cp deployment/systemd/polymarket-v2-indexer.service dist/deployment/systemd/polymarket-v2-indexer.service
           cp deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf dist/deployment/systemd/ploy-strategy-directional-dryrun.hardening.conf
           cp deployment/env.polymarket-v2-indexer.example dist/deployment/env.polymarket-v2-indexer.example
@@ -479,6 +486,9 @@ jobs:
             install -m 0755 ./scripts/report_dryrun_summary.py ${DEPLOY_ROOT}/scripts/report_dryrun_summary.py
             install -m 0755 ./scripts/check_dryrun_report_contract.py ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
             install -m 0755 ./scripts/import_polymarket_v2_indexer.py ${DEPLOY_ROOT}/scripts/import_polymarket_v2_indexer.py
+            install -m 0755 ./scripts/archive_clob_orderbook_snapshots_backfill.sh ${DEPLOY_ROOT}/scripts/archive_clob_orderbook_snapshots_backfill.sh
+            install -m 0755 ./scripts/export_clob_orderbook_snapshots_parquet.sh ${DEPLOY_ROOT}/scripts/export_clob_orderbook_snapshots_parquet.sh
+            install -m 0755 ./scripts/ploy_orderbook_snapshot_retention.sh ${DEPLOY_ROOT}/scripts/ploy_orderbook_snapshot_retention.sh
             install -m 0644 ./scripts/fix_binance_lob_partitions.sql ${DEPLOY_ROOT}/scripts/fix_binance_lob_partitions.sql
             install -m 0644 ./scripts/fix_deribit_partitions.sql ${DEPLOY_ROOT}/scripts/fix_deribit_partitions.sql
             install -m 0644 ./scripts/fix_clob_trade_partitions.sql ${DEPLOY_ROOT}/scripts/fix_clob_trade_partitions.sql
@@ -500,11 +510,17 @@ jobs:
             install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
             install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.service /etc/systemd/system/ploy-polymarket-v2-indexer-import.service
             install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.timer /etc/systemd/system/ploy-polymarket-v2-indexer-import.timer
+            install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-archive.service /etc/systemd/system/ploy-orderbook-snapshot-archive.service
+            install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-archive.timer /etc/systemd/system/ploy-orderbook-snapshot-archive.timer
+            install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-retention.service /etc/systemd/system/ploy-orderbook-snapshot-retention.service
+            install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-retention.timer /etc/systemd/system/ploy-orderbook-snapshot-retention.timer
             install -m 0644 ./deployment/systemd/polymarket-v2-indexer.service /etc/systemd/system/polymarket-v2-indexer.service
             install -m 0644 ./deployment/env.polymarket-v2-indexer.example ${DEPLOY_ROOT}/env.polymarket-v2-indexer.example
             install -m 0644 ./deployment/systemd/ploy-quote-collector.hardening.conf /etc/systemd/system/ploy-quote-collector.service.d/hardening.conf
             systemctl daemon-reload
             systemctl enable --now ploy-polymarket-v2-indexer-import.timer
+            systemctl enable --now ploy-orderbook-snapshot-archive.timer
+            systemctl enable --now ploy-orderbook-snapshot-retention.timer
 
             # Apply additive runner migrations before restarting services.
             mkdir -p ${DEPLOY_ROOT}/migrations

--- a/deployment/ploy-maintenance.service
+++ b/deployment/ploy-maintenance.service
@@ -17,7 +17,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=true
-ReadWritePaths=/opt/ploy/logs /var/log /var/lib/systemd/coredump
+ReadWritePaths=/opt/ploy/logs /opt/ploy/tmp /opt/ploy/data/recordings /opt/ploy/data/parquet /var/log /var/lib/systemd/coredump
 
 StandardOutput=journal
 StandardError=journal
@@ -25,4 +25,3 @@ SyslogIdentifier=ploy-maintenance
 
 [Install]
 WantedBy=multi-user.target
-

--- a/deployment/systemd/ploy-orderbook-snapshot-archive.service
+++ b/deployment/systemd/ploy-orderbook-snapshot-archive.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Ploy CLOB Orderbook Snapshot Parquet Archive
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/ploy
+EnvironmentFile=-/opt/ploy/.env
+Environment=HOME=/opt/ploy
+ExecStart=/bin/bash /opt/ploy/scripts/archive_clob_orderbook_snapshots_backfill.sh
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/ploy/data/lake
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ploy-orderbook-snapshot-archive
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/systemd/ploy-orderbook-snapshot-archive.timer
+++ b/deployment/systemd/ploy-orderbook-snapshot-archive.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Archive completed CLOB orderbook snapshot hours to Parquet
+
+[Timer]
+OnBootSec=20m
+OnCalendar=*:15:00
+Persistent=true
+Unit=ploy-orderbook-snapshot-archive.service
+
+[Install]
+WantedBy=timers.target

--- a/deployment/systemd/ploy-orderbook-snapshot-retention.service
+++ b/deployment/systemd/ploy-orderbook-snapshot-retention.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Ploy bounded orderbook snapshot retention
+After=network-online.target postgresql.service postgresql@16-main.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/ploy
+Environment=PLOY_ORDERBOOK_SNAPSHOT_RETENTION_DAYS=2
+Environment=PLOY_ORDERBOOK_SNAPSHOT_BATCH_SIZE=25000
+Environment=PLOY_ORDERBOOK_SNAPSHOT_MAX_BATCHES=2
+Environment=PLOY_CLOB_BOOK_REQUIRE_ARCHIVE=true
+ExecStart=/bin/bash /opt/ploy/scripts/ploy_orderbook_snapshot_retention.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ploy-orderbook-snapshot-retention
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/systemd/ploy-orderbook-snapshot-retention.timer
+++ b/deployment/systemd/ploy-orderbook-snapshot-retention.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run bounded orderbook snapshot retention periodically
+
+[Timer]
+OnBootSec=12m
+OnCalendar=hourly
+Persistent=true
+Unit=ploy-orderbook-snapshot-retention.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/runbooks/orderbook-snapshot-archive.md
+++ b/docs/runbooks/orderbook-snapshot-archive.md
@@ -1,0 +1,145 @@
+# CLOB Orderbook Snapshot Archive
+
+## Final Storage Policy
+
+Keep full-fidelity Polymarket CLOB orderbook snapshots, but split storage by
+temperature:
+
+- PostgreSQL `clob_orderbook_snapshots`: hot, short retention, used by live
+  operations and recent diagnostics.
+- `/opt/ploy/data/lake/orderbook_snapshots`: cold, complete Parquet/ZSTD
+  archive, used for research/backtests and long-term retention.
+
+The archive must not sample, coalesce, or drop fields. Each Parquet export keeps:
+
+- `id`
+- `domain`
+- `token_id`
+- `market`
+- `bids`
+- `asks`
+- `book_timestamp`
+- `hash`
+- `source`
+- `context`
+- `received_at`
+
+## Paths
+
+Hourly archive files:
+
+```text
+/opt/ploy/data/lake/orderbook_snapshots/date=YYYY-MM-DD/hour=HH/
+  snapshots.parquet
+  manifest.json
+  _SUCCESS
+```
+
+When all 24 hourly `_SUCCESS` markers exist, the day marker is created:
+
+```text
+/opt/ploy/data/lake/orderbook_snapshots/date=YYYY-MM-DD/_SUCCESS
+```
+
+## Services
+
+Archive timer:
+
+```bash
+systemctl status ploy-orderbook-snapshot-archive.timer
+systemctl status ploy-orderbook-snapshot-archive.service
+```
+
+Retention timer:
+
+```bash
+systemctl status ploy-orderbook-snapshot-retention.timer
+systemctl status ploy-orderbook-snapshot-retention.service
+```
+
+The archive service runs the gap filler:
+
+```bash
+/opt/ploy/scripts/archive_clob_orderbook_snapshots_backfill.sh
+```
+
+The gap filler sequentially exports missing completed hours. Defaults are
+bounded for `tango-1-1`:
+
+- look back 72 hours
+- export at most 6 missing hours per run
+- leave a 1-hour lag so the active hour is not archived
+
+## Safety Rules
+
+Retention is archive-gated by default:
+
+```bash
+PLOY_CLOB_BOOK_REQUIRE_ARCHIVE=true
+```
+
+Old hot rows or partitions may be deleted only when the corresponding archive
+date has a completed day marker. Do not disable this except for emergency
+operator action with separate evidence that the archive is already safe.
+
+DuckDB export is intentionally constrained:
+
+```sql
+SET threads=1;
+SET pg_connection_limit=1;
+SET pg_use_ctid_scan=false;
+```
+
+This avoids the PostgreSQL ctid-parallel scan path that can saturate CPU on the
+trading host.
+
+## Manual Gap Fill
+
+Use a bounded pass first:
+
+```bash
+nice -n 10 ionice -c2 -n7 \
+  env PLOY_CLOB_BOOK_ARCHIVE_LOOKBACK_HOURS=80 \
+      PLOY_CLOB_BOOK_ARCHIVE_MAX_HOURS_PER_RUN=8 \
+  /opt/ploy/scripts/archive_clob_orderbook_snapshots_backfill.sh
+```
+
+Repeat bounded passes until the target day has 24 hour markers and a day marker.
+
+## Verification
+
+Check archive completeness:
+
+```bash
+base=/opt/ploy/data/lake/orderbook_snapshots/date=YYYY-MM-DD
+find "$base" -mindepth 2 -maxdepth 2 -name _SUCCESS | wc -l
+test -f "$base/_SUCCESS"
+duckdb -noheader -csv -c "SELECT count(*) FROM read_parquet('$base/hour=*/snapshots.parquet');"
+```
+
+Compare against the hot partition before deletion:
+
+```bash
+PGPASSWORD=postgres psql -U postgres -d ploy -tAc \
+  "SELECT count(*) FROM clob_orderbook_snapshots_v2_YYYYMMDD;"
+```
+
+Dry-run retention:
+
+```bash
+PLOY_ORDERBOOK_SNAPSHOT_DRY_RUN=true \
+  /opt/ploy/scripts/ploy_orderbook_snapshot_retention.sh
+```
+
+Only proceed when the archive row count matches the PostgreSQL row count and
+dry-run shows `archive_complete = t` for the old partition.
+
+Health checks after retention:
+
+```bash
+systemctl --failed --no-pager
+systemctl is-active ploy-quote-collector.service ployd.service
+curl -fsS http://127.0.0.1:8081/health
+df -h /
+sar -u 1 3
+```

--- a/scripts/archive_clob_orderbook_snapshots_backfill.sh
+++ b/scripts/archive_clob_orderbook_snapshots_backfill.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCHIVE_ROOT="${PLOY_ORDERBOOK_ARCHIVE_ROOT:-/opt/ploy/data/lake}"
+LOOKBACK_HOURS="${PLOY_CLOB_BOOK_ARCHIVE_LOOKBACK_HOURS:-72}"
+MAX_HOURS_PER_RUN="${PLOY_CLOB_BOOK_ARCHIVE_MAX_HOURS_PER_RUN:-6}"
+LAG_HOURS="${PLOY_CLOB_BOOK_ARCHIVE_LAG_HOURS:-1}"
+EXPORT_SCRIPT="${PLOY_CLOB_BOOK_EXPORT_SCRIPT:-/opt/ploy/scripts/export_clob_orderbook_snapshots_parquet.sh}"
+
+usage() {
+  cat <<'USAGE'
+Usage: archive_clob_orderbook_snapshots_backfill.sh [--lookback-hours N] [--max-hours N] [--lag-hours N] [--out-dir DIR]
+
+Sequentially exports missing completed clob_orderbook_snapshots hours. Existing
+hour directories with _SUCCESS are skipped. Defaults are intentionally bounded
+for a live trading host.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lookback-hours)
+      LOOKBACK_HOURS="${2:?missing --lookback-hours value}"
+      shift 2
+      ;;
+    --max-hours)
+      MAX_HOURS_PER_RUN="${2:?missing --max-hours value}"
+      shift 2
+      ;;
+    --lag-hours)
+      LAG_HOURS="${2:?missing --lag-hours value}"
+      shift 2
+      ;;
+    --out-dir)
+      ARCHIVE_ROOT="${2:?missing --out-dir value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for value_name in LOOKBACK_HOURS MAX_HOURS_PER_RUN LAG_HOURS; do
+  value="${!value_name}"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "invalid ${value_name}: ${value}" >&2
+    exit 2
+  fi
+done
+
+if [[ ! -x "$EXPORT_SCRIPT" ]]; then
+  echo "export script is not executable: $EXPORT_SCRIPT" >&2
+  exit 2
+fi
+
+completed=0
+checked=0
+
+echo "archive_clob_orderbook_snapshots_backfill: archive_root=${ARCHIVE_ROOT} lookback_hours=${LOOKBACK_HOURS} max_hours_per_run=${MAX_HOURS_PER_RUN} lag_hours=${LAG_HOURS}"
+
+for (( offset = LOOKBACK_HOURS; offset >= LAG_HOURS; offset-- )); do
+  export_date="$(date -d "${offset} hours ago" +%Y-%m-%d)"
+  export_hour="$(date -d "${offset} hours ago" +%H)"
+  marker="${ARCHIVE_ROOT}/orderbook_snapshots/date=${export_date}/hour=${export_hour}/_SUCCESS"
+  checked=$((checked + 1))
+
+  if [[ -f "$marker" ]]; then
+    continue
+  fi
+
+  if (( completed >= MAX_HOURS_PER_RUN )); then
+    echo "archive_clob_orderbook_snapshots_backfill: reached max_hours_per_run=${MAX_HOURS_PER_RUN}"
+    break
+  fi
+
+  echo "archive_clob_orderbook_snapshots_backfill: exporting missing date=${export_date} hour=${export_hour}"
+  "$EXPORT_SCRIPT" --date "$export_date" --hour "$export_hour" --out-dir "$ARCHIVE_ROOT"
+  completed=$((completed + 1))
+done
+
+echo "archive_clob_orderbook_snapshots_backfill: done checked=${checked} exported=${completed}"

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -187,6 +187,7 @@ install -m 0755 ./bin/optimize-backtest "${{DEPLOY_ROOT}}/bin/optimize-backtest"
 install -m 0644 ./config/strategies/*.toml "${{DEPLOY_ROOT}}/config/strategies/"
 install -m 0644 ./config/deployments/*.json "${{DEPLOY_ROOT}}/config/deployments/"
 install -m 0755 ./scripts/*.py "${{DEPLOY_ROOT}}/scripts/"
+install -m 0755 ./scripts/*.sh "${{DEPLOY_ROOT}}/scripts/"
 install -m 0644 ./scripts/*.sql "${{DEPLOY_ROOT}}/scripts/"
 install -m 0755 ./scripts/drills/*.sh "${{DEPLOY_ROOT}}/scripts/drills/"
 for migration in ${{DEPLOY_MIGRATIONS}}; do
@@ -205,11 +206,17 @@ install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/
 install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
 install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.service /etc/systemd/system/ploy-polymarket-v2-indexer-import.service
 install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.timer /etc/systemd/system/ploy-polymarket-v2-indexer-import.timer
+install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-archive.service /etc/systemd/system/ploy-orderbook-snapshot-archive.service
+install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-archive.timer /etc/systemd/system/ploy-orderbook-snapshot-archive.timer
+install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-retention.service /etc/systemd/system/ploy-orderbook-snapshot-retention.service
+install -m 0644 ./deployment/systemd/ploy-orderbook-snapshot-retention.timer /etc/systemd/system/ploy-orderbook-snapshot-retention.timer
 install -m 0644 ./deployment/systemd/polymarket-v2-indexer.service /etc/systemd/system/polymarket-v2-indexer.service
 install -m 0644 ./deployment/env.polymarket-v2-indexer.example "${{DEPLOY_ROOT}}/env.polymarket-v2-indexer.example"
 install -m 0644 ./deployment/systemd/ploy-quote-collector.hardening.conf /etc/systemd/system/ploy-quote-collector.service.d/hardening.conf
 systemctl daemon-reload
 systemctl enable --now ploy-polymarket-v2-indexer-import.timer
+systemctl enable --now ploy-orderbook-snapshot-archive.timer
+systemctl enable --now ploy-orderbook-snapshot-retention.timer
 
 for migration in ${{DEPLOY_MIGRATIONS}}; do
   migration="$(printf '%s' "${{migration}}" | xargs)"

--- a/scripts/export_clob_orderbook_snapshots_parquet.sh
+++ b/scripts/export_clob_orderbook_snapshots_parquet.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/ploy}"
+OUT_DIR="${PLOY_ORDERBOOK_ARCHIVE_ROOT:-/opt/ploy/data/lake}"
+LAG_HOURS="${PLOY_CLOB_BOOK_ARCHIVE_LAG_HOURS:-1}"
+
+EXPORT_DATE=""
+EXPORT_HOUR=""
+
+usage() {
+  cat <<'USAGE'
+Usage: export_clob_orderbook_snapshots_parquet.sh [--date YYYY-MM-DD --hour HH] [--lag-hours N] [--out-dir DIR]
+
+Exports one completed hour of clob_orderbook_snapshots to Parquet/ZSTD without
+sampling or dropping fields. Defaults to the most recently completed hour.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date)
+      EXPORT_DATE="${2:?missing --date value}"
+      shift 2
+      ;;
+    --hour)
+      EXPORT_HOUR="${2:?missing --hour value}"
+      shift 2
+      ;;
+    --lag-hours)
+      LAG_HOURS="${2:?missing --lag-hours value}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:?missing --out-dir value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$EXPORT_DATE" || -z "$EXPORT_HOUR" ]]; then
+  if ! [[ "$LAG_HOURS" =~ ^[0-9]+$ ]]; then
+    echo "invalid --lag-hours value: $LAG_HOURS" >&2
+    exit 2
+  fi
+  EXPORT_DATE="$(date -d "${LAG_HOURS} hours ago" +%Y-%m-%d)"
+  EXPORT_HOUR="$(date -d "${LAG_HOURS} hours ago" +%H)"
+fi
+
+if ! [[ "$EXPORT_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "invalid --date value: $EXPORT_DATE" >&2
+  exit 2
+fi
+if ! [[ "$EXPORT_HOUR" =~ ^[0-9]{2}$ ]] || (( 10#$EXPORT_HOUR > 23 )); then
+  echo "invalid --hour value: $EXPORT_HOUR" >&2
+  exit 2
+fi
+
+START_TS="${EXPORT_DATE} ${EXPORT_HOUR}:00:00+08"
+END_TS="$(date -d "${START_TS} +1 hour" '+%Y-%m-%d %H:%M:%S%:z')"
+BASE_DIR="${OUT_DIR}/orderbook_snapshots/date=${EXPORT_DATE}"
+HOUR_DIR="${BASE_DIR}/hour=${EXPORT_HOUR}"
+TMP_DIR="${HOUR_DIR}.tmp.$$"
+PARQUET_FILE="${TMP_DIR}/snapshots.parquet"
+MANIFEST_FILE="${TMP_DIR}/manifest.json"
+
+mkdir -p "$TMP_DIR"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "export_clob_orderbook_snapshots: date=${EXPORT_DATE} hour=${EXPORT_HOUR} start=${START_TS} end=${END_TS} out=${HOUR_DIR}"
+
+duckdb -c "
+SET home_directory='/opt/ploy';
+SET threads=1;
+INSTALL postgres_scanner; LOAD postgres_scanner;
+SET pg_connection_limit=1;
+SET pg_use_ctid_scan=false;
+ATTACH '${DB_URL}' AS pg (TYPE POSTGRES, READ_ONLY);
+
+COPY (
+  SELECT
+    id,
+    domain,
+    token_id,
+    market,
+    bids,
+    asks,
+    book_timestamp,
+    hash,
+    source,
+    context,
+    received_at
+  FROM pg.clob_orderbook_snapshots
+  WHERE received_at >= TIMESTAMPTZ '${START_TS}'
+    AND received_at < TIMESTAMPTZ '${END_TS}'
+) TO '${PARQUET_FILE}' (FORMAT PARQUET, COMPRESSION ZSTD);
+"
+
+row_count="$(duckdb -noheader -csv -c "SELECT count(*) FROM read_parquet('${PARQUET_FILE}');")"
+file_bytes="$(wc -c < "$PARQUET_FILE" | tr -d '[:space:]')"
+sha256="$(sha256sum "$PARQUET_FILE" | awk '{print $1}')"
+created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+cat > "$MANIFEST_FILE" <<JSON
+{
+  "table": "clob_orderbook_snapshots",
+  "format": "parquet",
+  "compression": "zstd",
+  "date": "${EXPORT_DATE}",
+  "hour": "${EXPORT_HOUR}",
+  "start_ts": "${START_TS}",
+  "end_ts": "${END_TS}",
+  "row_count": ${row_count},
+  "file": "snapshots.parquet",
+  "file_bytes": ${file_bytes},
+  "sha256": "${sha256}",
+  "created_at": "${created_at}",
+  "full_fidelity": true,
+  "columns": ["id", "domain", "token_id", "market", "bids", "asks", "book_timestamp", "hash", "source", "context", "received_at"]
+}
+JSON
+touch "${TMP_DIR}/_SUCCESS"
+
+rm -rf "$HOUR_DIR"
+mv "$TMP_DIR" "$HOUR_DIR"
+trap - EXIT
+
+complete_hours="$(
+  find "$BASE_DIR" -mindepth 2 -maxdepth 2 -type f -name _SUCCESS 2>/dev/null \
+    | sed -E 's#.*/hour=([0-9]{2})/_SUCCESS#\1#' \
+    | sort -u \
+    | wc -l \
+    | tr -d '[:space:]'
+)"
+if [[ "$complete_hours" == "24" ]]; then
+  touch "${BASE_DIR}/_SUCCESS"
+fi
+
+echo "export_clob_orderbook_snapshots: complete rows=${row_count} file_bytes=${file_bytes} sha256=${sha256}"

--- a/scripts/ploy_maintenance.sh
+++ b/scripts/ploy_maintenance.sh
@@ -11,6 +11,10 @@ set -euo pipefail
 
 DB_NAME="${PLOY_DB_NAME:-ploy}"
 LOG_DIR="${LOG_DIR:-/opt/ploy/logs}"
+DATA_DIR="${PLOY_DATA_DIR:-/opt/ploy/data}"
+TMP_DIR="${PLOY_TMP_DIR:-/opt/ploy/tmp}"
+EXTRA_LOG_DIRS="${PLOY_EXTRA_LOG_DIRS:-/var/log/ploy}"
+CLOB_BOOK_ARCHIVE_DIR="${PLOY_CLOB_BOOK_ARCHIVE_DIR:-$DATA_DIR/lake/orderbook_snapshots}"
 
 RETENTION_CLOB_TICKS_DAYS="${PLOY_RETENTION_CLOB_TICKS_DAYS:-7}"
 RETENTION_CLOB_BOOK_DAYS="${PLOY_RETENTION_CLOB_BOOK_DAYS:-7}"
@@ -20,12 +24,26 @@ RETENTION_CLOB_ALERTS_DAYS="${PLOY_RETENTION_CLOB_ALERTS_DAYS:-7}"
 RETENTION_BINANCE_TICKS_DAYS="${PLOY_RETENTION_BINANCE_TICKS_DAYS:-7}"
 RETENTION_BINANCE_AGGTRADE_DAYS="${PLOY_RETENTION_BINANCE_AGGTRADE_DAYS:-7}"
 RETENTION_BINANCE_LOB_DAYS="${PLOY_RETENTION_BINANCE_LOB_DAYS:-7}"
+RETENTION_DERIBIT_IV_DAYS="${PLOY_RETENTION_DERIBIT_IV_DAYS:-7}"
 RETENTION_NBA_OBS_DAYS="${PLOY_RETENTION_NBA_OBS_DAYS:-7}"
 RETENTION_ORDER_EXEC_DAYS="${PLOY_RETENTION_ORDER_EXEC_DAYS:-7}"
 RETENTION_LOG_DAYS="${PLOY_RETENTION_LOG_DAYS:-7}"
+RETENTION_TMP_DAYS="${PLOY_RETENTION_TMP_DAYS:-2}"
+RETENTION_RECORDING_DAYS="${PLOY_RETENTION_RECORDING_DAYS:-7}"
+RETENTION_PARQUET_DAYS="${PLOY_RETENTION_PARQUET_DAYS:-14}"
+RETENTION_LOG_MAX_FILE_MB="${PLOY_RETENTION_LOG_MAX_FILE_MB:-512}"
+RETENTION_LOG_MAX_DIR_MB="${PLOY_RETENTION_LOG_MAX_DIR_MB:-1024}"
+RETENTION_TMP_MAX_DIR_MB="${PLOY_RETENTION_TMP_MAX_DIR_MB:-1024}"
+RETENTION_RECORDING_MAX_DIR_MB="${PLOY_RETENTION_RECORDING_MAX_DIR_MB:-4096}"
+RETENTION_PARQUET_MAX_DIR_MB="${PLOY_RETENTION_PARQUET_MAX_DIR_MB:-8192}"
+CLOB_BOOK_DELETE_BATCH_SIZE="${PLOY_CLOB_BOOK_DELETE_BATCH_SIZE:-100000}"
+CLOB_BOOK_DELETE_MAX_BATCHES="${PLOY_CLOB_BOOK_DELETE_MAX_BATCHES:-20}"
 JOURNAL_VACUUM_SIZE="${PLOY_JOURNAL_VACUUM_SIZE:-200M}"
 DERIBIT_PARTITION_LOOKBACK_DAYS="${PLOY_DERIBIT_PARTITION_LOOKBACK_DAYS:-7}"
 DERIBIT_PARTITION_LOOKAHEAD_DAYS="${PLOY_DERIBIT_PARTITION_LOOKAHEAD_DAYS:-14}"
+REFRESH_RESEARCH_WINDOWS="${PLOY_REFRESH_RESEARCH_WINDOWS:-false}"
+LOGS_ONLY="${PLOY_MAINTENANCE_LOGS_ONLY:-false}"
+REQUIRE_CLOB_BOOK_ARCHIVE="${PLOY_CLOB_BOOK_REQUIRE_ARCHIVE:-true}"
 
 is_uint() {
   [[ "${1:-}" =~ ^[0-9]+$ ]]
@@ -63,6 +81,10 @@ if ! is_uint "$RETENTION_BINANCE_LOB_DAYS"; then
   echo "invalid PLOY_RETENTION_BINANCE_LOB_DAYS: $RETENTION_BINANCE_LOB_DAYS" >&2
   exit 2
 fi
+if ! is_uint "$RETENTION_DERIBIT_IV_DAYS"; then
+  echo "invalid PLOY_RETENTION_DERIBIT_IV_DAYS: $RETENTION_DERIBIT_IV_DAYS" >&2
+  exit 2
+fi
 if ! is_uint "$RETENTION_NBA_OBS_DAYS"; then
   echo "invalid PLOY_RETENTION_NBA_OBS_DAYS: $RETENTION_NBA_OBS_DAYS" >&2
   exit 2
@@ -75,6 +97,46 @@ if ! is_uint "$RETENTION_LOG_DAYS"; then
   echo "invalid PLOY_RETENTION_LOG_DAYS: $RETENTION_LOG_DAYS" >&2
   exit 2
 fi
+if ! is_uint "$RETENTION_TMP_DAYS"; then
+  echo "invalid PLOY_RETENTION_TMP_DAYS: $RETENTION_TMP_DAYS" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_RECORDING_DAYS"; then
+  echo "invalid PLOY_RETENTION_RECORDING_DAYS: $RETENTION_RECORDING_DAYS" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_PARQUET_DAYS"; then
+  echo "invalid PLOY_RETENTION_PARQUET_DAYS: $RETENTION_PARQUET_DAYS" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_LOG_MAX_FILE_MB"; then
+  echo "invalid PLOY_RETENTION_LOG_MAX_FILE_MB: $RETENTION_LOG_MAX_FILE_MB" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_LOG_MAX_DIR_MB"; then
+  echo "invalid PLOY_RETENTION_LOG_MAX_DIR_MB: $RETENTION_LOG_MAX_DIR_MB" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_TMP_MAX_DIR_MB"; then
+  echo "invalid PLOY_RETENTION_TMP_MAX_DIR_MB: $RETENTION_TMP_MAX_DIR_MB" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_RECORDING_MAX_DIR_MB"; then
+  echo "invalid PLOY_RETENTION_RECORDING_MAX_DIR_MB: $RETENTION_RECORDING_MAX_DIR_MB" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_PARQUET_MAX_DIR_MB"; then
+  echo "invalid PLOY_RETENTION_PARQUET_MAX_DIR_MB: $RETENTION_PARQUET_MAX_DIR_MB" >&2
+  exit 2
+fi
+if ! is_uint "$CLOB_BOOK_DELETE_BATCH_SIZE"; then
+  echo "invalid PLOY_CLOB_BOOK_DELETE_BATCH_SIZE: $CLOB_BOOK_DELETE_BATCH_SIZE" >&2
+  exit 2
+fi
+if ! is_uint "$CLOB_BOOK_DELETE_MAX_BATCHES"; then
+  echo "invalid PLOY_CLOB_BOOK_DELETE_MAX_BATCHES: $CLOB_BOOK_DELETE_MAX_BATCHES" >&2
+  exit 2
+fi
 if ! is_uint "$DERIBIT_PARTITION_LOOKBACK_DAYS"; then
   echo "invalid PLOY_DERIBIT_PARTITION_LOOKBACK_DAYS: $DERIBIT_PARTITION_LOOKBACK_DAYS" >&2
   exit 2
@@ -84,23 +146,119 @@ if ! is_uint "$DERIBIT_PARTITION_LOOKAHEAD_DAYS"; then
   exit 2
 fi
 
-echo "ploy_maintenance: db=${DB_NAME} log_dir=${LOG_DIR} clob_ticks_days=${RETENTION_CLOB_TICKS_DAYS} clob_book_days=${RETENTION_CLOB_BOOK_DAYS} clob_obh_days=${RETENTION_CLOB_ORDERBOOK_HISTORY_DAYS} clob_trades_days=${RETENTION_CLOB_TRADES_DAYS} clob_alerts_days=${RETENTION_CLOB_ALERTS_DAYS} binance_ticks_days=${RETENTION_BINANCE_TICKS_DAYS} binance_aggtrade_days=${RETENTION_BINANCE_AGGTRADE_DAYS} binance_lob_days=${RETENTION_BINANCE_LOB_DAYS} nba_obs_days=${RETENTION_NBA_OBS_DAYS} order_exec_days=${RETENTION_ORDER_EXEC_DAYS} log_days=${RETENTION_LOG_DAYS} deribit_partition_lookback_days=${DERIBIT_PARTITION_LOOKBACK_DAYS} deribit_partition_lookahead_days=${DERIBIT_PARTITION_LOOKAHEAD_DAYS}"
+echo "ploy_maintenance: db=${DB_NAME} log_dir=${LOG_DIR} data_dir=${DATA_DIR} tmp_dir=${TMP_DIR} extra_log_dirs=${EXTRA_LOG_DIRS} clob_book_archive_dir=${CLOB_BOOK_ARCHIVE_DIR} clob_book_require_archive=${REQUIRE_CLOB_BOOK_ARCHIVE} clob_ticks_days=${RETENTION_CLOB_TICKS_DAYS} clob_book_days=${RETENTION_CLOB_BOOK_DAYS} clob_obh_days=${RETENTION_CLOB_ORDERBOOK_HISTORY_DAYS} clob_trades_days=${RETENTION_CLOB_TRADES_DAYS} clob_alerts_days=${RETENTION_CLOB_ALERTS_DAYS} binance_ticks_days=${RETENTION_BINANCE_TICKS_DAYS} binance_aggtrade_days=${RETENTION_BINANCE_AGGTRADE_DAYS} binance_lob_days=${RETENTION_BINANCE_LOB_DAYS} deribit_iv_days=${RETENTION_DERIBIT_IV_DAYS} nba_obs_days=${RETENTION_NBA_OBS_DAYS} order_exec_days=${RETENTION_ORDER_EXEC_DAYS} log_days=${RETENTION_LOG_DAYS} tmp_days=${RETENTION_TMP_DAYS} recording_days=${RETENTION_RECORDING_DAYS} parquet_days=${RETENTION_PARQUET_DAYS} log_max_file_mb=${RETENTION_LOG_MAX_FILE_MB} log_max_dir_mb=${RETENTION_LOG_MAX_DIR_MB} tmp_max_dir_mb=${RETENTION_TMP_MAX_DIR_MB} recording_max_dir_mb=${RETENTION_RECORDING_MAX_DIR_MB} parquet_max_dir_mb=${RETENTION_PARQUET_MAX_DIR_MB} clob_book_delete_batch_size=${CLOB_BOOK_DELETE_BATCH_SIZE} clob_book_delete_max_batches=${CLOB_BOOK_DELETE_MAX_BATCHES} deribit_partition_lookback_days=${DERIBIT_PARTITION_LOOKBACK_DAYS} deribit_partition_lookahead_days=${DERIBIT_PARTITION_LOOKAHEAD_DAYS} refresh_research_windows=${REFRESH_RESEARCH_WINDOWS} logs_only=${LOGS_ONLY}"
 
-if [[ -n "${DATABASE_URL:-}" ]]; then
-  PSQL=(psql "$DATABASE_URL" -v ON_ERROR_STOP=1)
-elif command -v runuser >/dev/null 2>&1; then
-  PSQL=(runuser -u postgres -- psql -d "$DB_NAME" -v ON_ERROR_STOP=1)
-else
-  # Fallback for minimal distros.
-  PSQL=(su -s /bin/bash postgres -c "psql -d \"$DB_NAME\" -v ON_ERROR_STOP=1")
-fi
+archived_clob_book_dates_select() {
+  local marker day
+  local values=()
 
-echo "==> DB retention"
-"${PSQL[@]}" <<SQL
+  if [[ -d "$CLOB_BOOK_ARCHIVE_DIR" ]]; then
+    while IFS= read -r marker; do
+      day="${marker%/_SUCCESS}"
+      day="${day##*/date=}"
+      if [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        values+=("('${day}'::date)")
+      fi
+    done < <(find "$CLOB_BOOK_ARCHIVE_DIR" -mindepth 2 -maxdepth 2 -type f -name _SUCCESS | sort)
+  fi
+
+  if (( ${#values[@]} == 0 )); then
+    printf "SELECT NULL::date AS archive_day WHERE false"
+    return 0
+  fi
+
+  local joined
+  joined="$(IFS=,; printf '%s' "${values[*]}")"
+  printf "SELECT archive_day FROM (VALUES %s) AS archived(archive_day)" "$joined"
+}
+
+prune_log_dir() {
+  local dir="$1"
+  local current_mb entry path size timestamp
+
+  [[ -d "$dir" ]] || return 0
+
+  echo "Pruning logs in ${dir}"
+  find "$dir" -maxdepth 1 -type f -mtime +"$RETENTION_LOG_DAYS" \
+    \( -name '*.log' -o -name '*.log.*' -o -name '*.log.*.gz' -o -name 'ploy.log*' -o -name 'platform.log*' \) \
+    -delete
+  find "$dir" -maxdepth 1 -type f -mtime +1 -size +"${RETENTION_LOG_MAX_FILE_MB}"M \
+    \( -name '*.log.*' -o -name '*.log.*.gz' -o -name 'ploy.log.*' -o -name 'platform.log.*' \) \
+    -delete
+  find "$dir" -maxdepth 1 -type f -mtime +1 ! -name '*.gz' \
+    \( -name '*.log' -o -name '*.log.*' -o -name 'ploy.log*' -o -name 'platform.log*' \) \
+    -print0 | xargs -0 -r gzip -9
+  find "$dir" -maxdepth 1 -type f -name '*.gz' -mtime +"$RETENTION_LOG_DAYS" -delete
+
+  current_mb=$(du -sm "$dir" | awk '{print $1}')
+  while (( current_mb > RETENTION_LOG_MAX_DIR_MB )); do
+    entry=$(find "$dir" -maxdepth 1 -type f \
+      \( -name '*.log' -o -name '*.log.*' -o -name '*.log.*.gz' -o -name 'ploy.log*' -o -name 'platform.log*' \) \
+      -printf '%s %T@ %p\n' | sort -nr | head -1)
+    [[ -n "$entry" ]] || break
+    size="${entry%% *}"
+    entry="${entry#* }"
+    timestamp="${entry%% *}"
+    path="${entry#* }"
+    echo "Deleting ${path} (${size} bytes, ts=${timestamp})"
+    rm -f -- "$path"
+    current_mb=$(du -sm "$dir" | awk '{print $1}')
+  done
+  echo "Log dir ${dir} is now ${current_mb}M"
+}
+
+prune_tree_dir() {
+  local dir="$1"
+  local label="$2"
+  local days="$3"
+  local max_mb="$4"
+  local current_mb entry path size timestamp
+
+  [[ -d "$dir" ]] || return 0
+
+  echo "Pruning ${label} in ${dir}: days=${days} max_mb=${max_mb}"
+  find "$dir" -mindepth 1 -maxdepth 1 -mtime +"$days" -print -exec rm -rf {} +
+
+  current_mb=$(du -sm "$dir" | awk '{print $1}')
+  while (( current_mb > max_mb )); do
+    entry=$(find "$dir" -mindepth 1 -maxdepth 1 -exec du -sm {} + | sort -nr | head -1)
+    [[ -n "$entry" ]] || break
+    size="${entry%%[[:space:]]*}"
+    path="${entry#*[[:space:]]}"
+    echo "Deleting ${label} artifact ${path} (${size}M)"
+    rm -rf -- "$path"
+    current_mb=$(du -sm "$dir" | awk '{print $1}')
+  done
+  echo "${label} dir ${dir} is now ${current_mb}M"
+}
+
+if [[ "$LOGS_ONLY" != "true" ]]; then
+  if [[ -n "${DATABASE_URL:-}" ]]; then
+    PSQL=(psql "$DATABASE_URL" -v ON_ERROR_STOP=1)
+  elif command -v runuser >/dev/null 2>&1; then
+    PSQL=(runuser -u postgres -- psql -d "$DB_NAME" -v ON_ERROR_STOP=1)
+  else
+    # Fallback for minimal distros.
+    PSQL=(su -s /bin/bash postgres -c "psql -d \"$DB_NAME\" -v ON_ERROR_STOP=1")
+  fi
+
+  ARCHIVED_CLOB_BOOK_DATES_SQL="$(archived_clob_book_dates_select)"
+
+  echo "==> DB retention"
+  if [[ "$REFRESH_RESEARCH_WINDOWS" == "true" ]]; then
+    "${PSQL[@]}" <<SQL
 -- Refresh research valid windows materialized view (if it exists).
 -- CONCURRENTLY avoids locking reads during refresh; requires the UNIQUE index.
 SELECT 'REFRESH MATERIALIZED VIEW CONCURRENTLY research_valid_windows;'
 WHERE to_regclass('public.research_valid_windows') IS NOT NULL \\gexec
+SQL
+  else
+    echo "Skipping research_valid_windows refresh; set PLOY_REFRESH_RESEARCH_WINDOWS=true to enable."
+  fi
+
+  "${PSQL[@]}" <<SQL
+CREATE TEMP TABLE archived_clob_book_days AS
+${ARCHIVED_CLOB_BOOK_DATES_SQL};
 
 DO \$\$
 DECLARE
@@ -166,15 +324,130 @@ BEGIN
 END
 \$\$;
 
--- High-volume tick table
-DELETE FROM clob_quote_ticks
-WHERE received_at < NOW() - INTERVAL '${RETENTION_CLOB_TICKS_DAYS} days';
+DO \$\$
+DECLARE
+  partition_day date := current_date - ${DERIBIT_PARTITION_LOOKBACK_DAYS};
+  end_day date := current_date + ${DERIBIT_PARTITION_LOOKAHEAD_DAYS};
+  partition_name text;
+BEGIN
+  IF to_regclass('public.clob_trade_ticks') IS NOT NULL THEN
+    WHILE partition_day <= end_day LOOP
+      partition_name := format('clob_trade_ticks_new_%s', to_char(partition_day, 'YYYYMMDD'));
+      BEGIN
+        EXECUTE format(
+          'CREATE TABLE IF NOT EXISTS %I PARTITION OF clob_trade_ticks FOR VALUES FROM (%L) TO (%L);',
+          partition_name,
+          format('%s 00:00:00+08', partition_day),
+          format('%s 00:00:00+08', partition_day + 1)
+        );
+      EXCEPTION
+        WHEN duplicate_table THEN
+          NULL;
+        WHEN OTHERS THEN
+          IF position('would overlap partition' in SQLERRM) > 0 THEN
+            NULL;
+          ELSE
+            RAISE;
+          END IF;
+      END;
+      partition_day := partition_day + 1;
+    END LOOP;
+  END IF;
+END
+\$\$;
 
--- CLOB order book snapshots (optional; table may not exist on all hosts)
+DO \$\$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT parent.relname AS parent_name, child.relname AS child_name
+    FROM pg_inherits
+    JOIN pg_class child ON child.oid = inhrelid
+    JOIN pg_class parent ON parent.oid = inhparent
+    WHERE (
+        parent.relname = 'binance_lob_ticks'
+        AND to_date(substring(child.relname from '(20[0-9]{6})$'), 'YYYYMMDD')
+          < current_date - ${RETENTION_BINANCE_LOB_DAYS}
+      ) OR (
+        parent.relname = 'clob_trade_ticks'
+        AND to_date(substring(child.relname from '(20[0-9]{6})$'), 'YYYYMMDD')
+          < current_date - ${RETENTION_CLOB_TRADES_DAYS}
+      ) OR (
+        parent.relname = 'deribit_iv_ticks'
+        AND to_date(substring(child.relname from '(20[0-9]{6})$'), 'YYYYMMDD')
+          < current_date - ${RETENTION_DERIBIT_IV_DAYS}
+      ) OR (
+        parent.relname = 'clob_orderbook_snapshots'
+        AND to_date(substring(child.relname from '(20[0-9]{6})$'), 'YYYYMMDD')
+          < current_date - ${RETENTION_CLOB_BOOK_DAYS}
+        AND (
+          '${REQUIRE_CLOB_BOOK_ARCHIVE}' <> 'true'
+          OR to_date(substring(child.relname from '(20[0-9]{6})$'), 'YYYYMMDD') IN (
+            SELECT archive_day FROM archived_clob_book_days
+          )
+        )
+      )
+    ORDER BY parent.relname, child.relname
+  LOOP
+    RAISE NOTICE 'dropping old partition %.%', 'public', r.child_name;
+    EXECUTE format('DROP TABLE IF EXISTS %I.%I', 'public', r.child_name);
+  END LOOP;
+END
+\$\$;
+
+-- TimescaleDB hypertables: drop old chunks so disk can be released without
+-- long row-wise deletes.
 SELECT format(
-  'DELETE FROM clob_orderbook_snapshots WHERE received_at < NOW() - INTERVAL ''%s days'';',
-  ${RETENTION_CLOB_BOOK_DAYS}
-) WHERE to_regclass('public.clob_orderbook_snapshots') IS NOT NULL \\gexec
+  'SELECT drop_chunks(%L::regclass, older_than => INTERVAL ''%s days'');',
+  'public.clob_quote_ticks',
+  ${RETENTION_CLOB_TICKS_DAYS}
+) WHERE to_regclass('public.clob_quote_ticks') IS NOT NULL \\gexec
+
+SELECT format(
+  'SELECT drop_chunks(%L::regclass, older_than => INTERVAL ''%s days'');',
+  'public.binance_price_ticks',
+  ${RETENTION_BINANCE_TICKS_DAYS}
+) WHERE to_regclass('public.binance_price_ticks') IS NOT NULL \\gexec
+
+SELECT format(
+  'SELECT drop_chunks(%L::regclass, older_than => INTERVAL ''%s days'');',
+  'public.binance_agg_trade_ticks',
+  ${RETENTION_BINANCE_AGGTRADE_DAYS}
+) WHERE to_regclass('public.binance_agg_trade_ticks') IS NOT NULL \\gexec
+
+-- Keep snapshot cleanup bounded and archive-gated. On non-partitioned hosts,
+-- this deletes only dates that already have a completed Parquet day marker.
+DO \$\$
+DECLARE
+  batch_no integer := 0;
+  deleted_rows integer := 0;
+BEGIN
+  IF to_regclass('public.clob_orderbook_snapshots') IS NOT NULL THEN
+    LOOP
+      WITH doomed AS (
+        SELECT id
+        FROM clob_orderbook_snapshots
+        WHERE received_at < NOW() - INTERVAL '${RETENTION_CLOB_BOOK_DAYS} days'
+          AND (
+            '${REQUIRE_CLOB_BOOK_ARCHIVE}' <> 'true'
+            OR received_at::date IN (SELECT archive_day FROM archived_clob_book_days)
+          )
+        ORDER BY received_at
+        LIMIT ${CLOB_BOOK_DELETE_BATCH_SIZE}
+      )
+      DELETE FROM clob_orderbook_snapshots s
+      USING doomed
+      WHERE s.id = doomed.id;
+
+      GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+      batch_no := batch_no + 1;
+      RAISE NOTICE 'clob_orderbook_snapshots retention batch %, deleted % rows', batch_no, deleted_rows;
+      EXIT WHEN deleted_rows = 0 OR batch_no >= ${CLOB_BOOK_DELETE_MAX_BATCHES};
+    END LOOP;
+  END IF;
+END
+\$\$;
 
 -- CLOB orderbook-history L2 ticks (optional; table may not exist on all hosts)
 SELECT format(
@@ -182,35 +455,11 @@ SELECT format(
   ${RETENTION_CLOB_ORDERBOOK_HISTORY_DAYS}
 ) WHERE to_regclass('public.clob_orderbook_history_ticks') IS NOT NULL \\gexec
 
--- CLOB trade ticks (optional; table may not exist on all hosts)
-SELECT format(
-  'DELETE FROM clob_trade_ticks WHERE received_at < NOW() - INTERVAL ''%s days'';',
-  ${RETENTION_CLOB_TRADES_DAYS}
-) WHERE to_regclass('public.clob_trade_ticks') IS NOT NULL \\gexec
-
 -- Trade alerts (optional; table may not exist on all hosts)
 SELECT format(
   'DELETE FROM clob_trade_alerts WHERE created_at < NOW() - INTERVAL ''%s days'';',
   ${RETENTION_CLOB_ALERTS_DAYS}
 ) WHERE to_regclass('public.clob_trade_alerts') IS NOT NULL \\gexec
-
--- Binance spot price ticks (optional; table may not exist on all hosts)
-SELECT format(
-  'DELETE FROM binance_price_ticks WHERE received_at < NOW() - INTERVAL ''%s days'';',
-  ${RETENTION_BINANCE_TICKS_DAYS}
-) WHERE to_regclass('public.binance_price_ticks') IS NOT NULL \\gexec
-
--- Binance aggTrade ticks (optional; table may not exist on all hosts)
-SELECT format(
-  'DELETE FROM binance_agg_trade_ticks WHERE received_at < NOW() - INTERVAL ''%s days'';',
-  ${RETENTION_BINANCE_AGGTRADE_DAYS}
-) WHERE to_regclass('public.binance_agg_trade_ticks') IS NOT NULL \\gexec
-
--- Binance LOB ticks (optional; table may not exist on all hosts)
-SELECT format(
-  'DELETE FROM binance_lob_ticks WHERE event_time < NOW() - INTERVAL ''%s days'';',
-  ${RETENTION_BINANCE_LOB_DAYS}
-) WHERE to_regclass('public.binance_lob_ticks') IS NOT NULL \\gexec
 
 -- Sports observations (moderate volume)
 DELETE FROM nba_live_observations
@@ -222,46 +471,36 @@ SELECT format(
   ${RETENTION_ORDER_EXEC_DAYS}
 ) WHERE to_regclass('public.agent_order_executions') IS NOT NULL \\gexec
 
-VACUUM (ANALYZE) clob_quote_ticks;
-SELECT 'VACUUM (ANALYZE) clob_orderbook_snapshots;' WHERE to_regclass('public.clob_orderbook_snapshots') IS NOT NULL \\gexec
+ANALYZE clob_quote_ticks;
+SELECT 'ANALYZE clob_orderbook_snapshots;' WHERE to_regclass('public.clob_orderbook_snapshots') IS NOT NULL \\gexec
 SELECT 'VACUUM (ANALYZE) clob_orderbook_history_ticks;' WHERE to_regclass('public.clob_orderbook_history_ticks') IS NOT NULL \\gexec
-SELECT 'VACUUM (ANALYZE) clob_trade_ticks;' WHERE to_regclass('public.clob_trade_ticks') IS NOT NULL \\gexec
+SELECT 'ANALYZE clob_trade_ticks;' WHERE to_regclass('public.clob_trade_ticks') IS NOT NULL \\gexec
 SELECT 'VACUUM (ANALYZE) clob_trade_alerts;' WHERE to_regclass('public.clob_trade_alerts') IS NOT NULL \\gexec
-SELECT 'VACUUM (ANALYZE) binance_price_ticks;' WHERE to_regclass('public.binance_price_ticks') IS NOT NULL \\gexec
-SELECT 'VACUUM (ANALYZE) binance_agg_trade_ticks;' WHERE to_regclass('public.binance_agg_trade_ticks') IS NOT NULL \\gexec
-SELECT 'VACUUM (ANALYZE) binance_lob_ticks;' WHERE to_regclass('public.binance_lob_ticks') IS NOT NULL \\gexec
+SELECT 'ANALYZE binance_price_ticks;' WHERE to_regclass('public.binance_price_ticks') IS NOT NULL \\gexec
+SELECT 'ANALYZE binance_agg_trade_ticks;' WHERE to_regclass('public.binance_agg_trade_ticks') IS NOT NULL \\gexec
+SELECT 'ANALYZE binance_lob_ticks;' WHERE to_regclass('public.binance_lob_ticks') IS NOT NULL \\gexec
 VACUUM (ANALYZE) nba_live_observations;
 SELECT 'VACUUM (ANALYZE) agent_order_executions;' WHERE to_regclass('public.agent_order_executions') IS NOT NULL \\gexec
 SQL
+else
+  echo "Skipping DB retention because PLOY_MAINTENANCE_LOGS_ONLY=true"
+fi
 
 echo "==> Log retention"
-if [[ -d "$LOG_DIR" ]]; then
-  if cutoff_epoch=$(date -d "today - $((RETENTION_LOG_DAYS - 1)) days" +%s 2>/dev/null); then
-    while IFS= read -r -d '' path; do
-      basename="${path##*/}"
-      if [[ "$basename" =~ ([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
-        file_date="${BASH_REMATCH[1]}"
-        file_epoch=$(date -d "${file_date} 00:00:00" +%s 2>/dev/null || echo 0)
-        if (( file_epoch > 0 && file_epoch < cutoff_epoch )); then
-          rm -f -- "$path"
-        fi
-      fi
-    done < <(
-      find "$LOG_DIR" -maxdepth 1 -type f \
-        \( -name 'ploy.log.*' -o -name 'ploy.log.*.gz' \) \
-        -print0
-    )
-  else
-    echo "Skipping filename-date log pruning because GNU date -d is unavailable"
-  fi
+seen_log_dirs=" "
+for dir in "$LOG_DIR" $EXTRA_LOG_DIRS; do
+  [[ -n "${dir:-}" ]] || continue
+  case "$seen_log_dirs" in
+    *" $dir "*) continue ;;
+  esac
+  seen_log_dirs="${seen_log_dirs}${dir} "
+  prune_log_dir "$dir"
+done
 
-  # Compress older uncompressed logs.
-  find "$LOG_DIR" -maxdepth 1 -type f -name 'ploy.log.*' -mtime +1 ! -name '*.gz' -print0 \
-    | xargs -0 -r gzip -9
-
-  # Delete old compressed logs.
-  find "$LOG_DIR" -maxdepth 1 -type f -name 'ploy.log.*.gz' -mtime +"$RETENTION_LOG_DAYS" -delete
-fi
+echo "==> Data artifact retention"
+prune_tree_dir "$TMP_DIR" "tmp" "$RETENTION_TMP_DAYS" "$RETENTION_TMP_MAX_DIR_MB"
+prune_tree_dir "$DATA_DIR/recordings" "recordings" "$RETENTION_RECORDING_DAYS" "$RETENTION_RECORDING_MAX_DIR_MB"
+prune_tree_dir "$DATA_DIR/parquet" "parquet" "$RETENTION_PARQUET_DAYS" "$RETENTION_PARQUET_MAX_DIR_MB"
 
 echo "==> Journald vacuum"
 if command -v journalctl >/dev/null 2>&1; then

--- a/scripts/ploy_orderbook_snapshot_retention.sh
+++ b/scripts/ploy_orderbook_snapshot_retention.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_NAME="${PLOY_DB_NAME:-ploy}"
+RETENTION_DAYS="${PLOY_ORDERBOOK_SNAPSHOT_RETENTION_DAYS:-2}"
+LOOKAHEAD_DAYS="${PLOY_ORDERBOOK_SNAPSHOT_LOOKAHEAD_DAYS:-3}"
+BATCH_SIZE="${PLOY_ORDERBOOK_SNAPSHOT_BATCH_SIZE:-25000}"
+MAX_BATCHES="${PLOY_ORDERBOOK_SNAPSHOT_MAX_BATCHES:-2}"
+ARCHIVE_DIR="${PLOY_CLOB_BOOK_ARCHIVE_DIR:-/opt/ploy/data/lake/orderbook_snapshots}"
+REQUIRE_ARCHIVE="${PLOY_CLOB_BOOK_REQUIRE_ARCHIVE:-true}"
+DRY_RUN="${PLOY_ORDERBOOK_SNAPSHOT_DRY_RUN:-false}"
+
+is_uint() { [[ "${1:-}" =~ ^[0-9]+$ ]]; }
+for value_name in RETENTION_DAYS LOOKAHEAD_DAYS BATCH_SIZE MAX_BATCHES; do
+  value="${!value_name}"
+  if ! is_uint "$value"; then
+    echo "invalid ${value_name}: ${value}" >&2
+    exit 2
+  fi
+done
+
+archived_dates_select() {
+  local marker day
+  local values=()
+
+  if [[ -d "$ARCHIVE_DIR" ]]; then
+    while IFS= read -r marker; do
+      day="${marker%/_SUCCESS}"
+      day="${day##*/date=}"
+      if [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        values+=("('${day}'::date)")
+      fi
+    done < <(find "$ARCHIVE_DIR" -mindepth 2 -maxdepth 2 -type f -name _SUCCESS | sort)
+  fi
+
+  if (( ${#values[@]} == 0 )); then
+    printf "SELECT NULL::date AS archive_day WHERE false"
+    return 0
+  fi
+
+  local joined
+  joined="$(IFS=,; printf '%s' "${values[*]}")"
+  printf "SELECT archive_day FROM (VALUES %s) AS archived(archive_day)" "$joined"
+}
+
+PSQL=(psql -h 127.0.0.1 -U postgres -d "$DB_NAME" -v ON_ERROR_STOP=1)
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+ARCHIVED_DATES_SQL="$(archived_dates_select)"
+
+echo "ploy_orderbook_snapshot_retention: retention_days=${RETENTION_DAYS} lookahead_days=${LOOKAHEAD_DAYS} archive_dir=${ARCHIVE_DIR} require_archive=${REQUIRE_ARCHIVE} dry_run=${DRY_RUN}"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  "${PSQL[@]}" <<SQL
+CREATE TEMP TABLE archived_clob_book_days AS
+${ARCHIVED_DATES_SQL};
+
+SELECT c.relkind, coalesce(pt.partstrat::text, '') AS partstrat
+FROM pg_class c
+LEFT JOIN pg_partitioned_table pt ON pt.partrelid = c.oid
+WHERE c.oid = 'public.clob_orderbook_snapshots'::regclass;
+
+SELECT
+  parent.relname AS parent,
+  child.relname AS old_partition,
+  to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') AS partition_day,
+  to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') IN (
+    SELECT archive_day FROM archived_clob_book_days
+  ) AS archive_complete
+FROM pg_inherits
+JOIN pg_class child ON child.oid = inhrelid
+JOIN pg_class parent ON parent.oid = inhparent
+WHERE parent.relname = 'clob_orderbook_snapshots'
+  AND substring(child.relname FROM '(20[0-9]{6})$') IS NOT NULL
+  AND to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') < current_date - ${RETENTION_DAYS}
+ORDER BY child.relname;
+SQL
+  exit 0
+fi
+
+"${PSQL[@]}" <<SQL
+SET lock_timeout = '3s';
+SET statement_timeout = '5min';
+SET client_min_messages = warning;
+
+CREATE TEMP TABLE archived_clob_book_days AS
+${ARCHIVED_DATES_SQL};
+
+DO \$\$
+DECLARE
+  is_partitioned boolean;
+  d date;
+  end_day date;
+  part_name text;
+  r record;
+  batch_no integer := 0;
+  deleted_rows integer := 0;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_partitioned_table
+    WHERE partrelid = 'public.clob_orderbook_snapshots'::regclass
+  ) INTO is_partitioned;
+
+  IF is_partitioned THEN
+    d := current_date - ${RETENTION_DAYS};
+    end_day := current_date + ${LOOKAHEAD_DAYS};
+    WHILE d <= end_day LOOP
+      part_name := format('clob_orderbook_snapshots_%s', to_char(d, 'YYYYMMDD'));
+      BEGIN
+        EXECUTE format(
+          'CREATE TABLE IF NOT EXISTS %I PARTITION OF public.clob_orderbook_snapshots FOR VALUES FROM (%L) TO (%L);',
+          part_name,
+          format('%s 00:00:00+08', d),
+          format('%s 00:00:00+08', d + 1)
+        );
+      EXCEPTION
+        WHEN duplicate_table THEN
+          NULL;
+        WHEN OTHERS THEN
+          IF position('would overlap partition' in SQLERRM) > 0 THEN
+            NULL;
+          ELSE
+            RAISE;
+          END IF;
+      END;
+      d := d + 1;
+    END LOOP;
+
+    FOR r IN
+      SELECT
+        child.relname AS child_name,
+        to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') AS partition_day
+      FROM pg_inherits
+      JOIN pg_class child ON child.oid = inhrelid
+      JOIN pg_class parent ON parent.oid = inhparent
+      WHERE parent.relname = 'clob_orderbook_snapshots'
+        AND substring(child.relname FROM '(20[0-9]{6})$') IS NOT NULL
+        AND to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') < current_date - ${RETENTION_DAYS}
+        AND (
+          '${REQUIRE_ARCHIVE}' <> 'true'
+          OR to_date(substring(child.relname FROM '(20[0-9]{6})$'), 'YYYYMMDD') IN (
+            SELECT archive_day FROM archived_clob_book_days
+          )
+        )
+      ORDER BY child.relname
+    LOOP
+      RAISE WARNING 'dropping archived orderbook snapshot partition %.% day=%', 'public', r.child_name, r.partition_day;
+      EXECUTE format('DROP TABLE IF EXISTS %I.%I', 'public', r.child_name);
+    END LOOP;
+  ELSE
+    LOOP
+      WITH doomed AS (
+        SELECT id
+        FROM clob_orderbook_snapshots
+        WHERE received_at < now() - interval '${RETENTION_DAYS} days'
+          AND (
+            '${REQUIRE_ARCHIVE}' <> 'true'
+            OR received_at::date IN (SELECT archive_day FROM archived_clob_book_days)
+          )
+        ORDER BY received_at
+        LIMIT ${BATCH_SIZE}
+      )
+      DELETE FROM clob_orderbook_snapshots s
+      USING doomed
+      WHERE s.id = doomed.id;
+
+      GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+      batch_no := batch_no + 1;
+      RAISE WARNING 'fallback row retention batch %, deleted % rows', batch_no, deleted_rows;
+      EXIT WHEN deleted_rows = 0 OR batch_no >= ${MAX_BATCHES};
+    END LOOP;
+    ANALYZE clob_orderbook_snapshots;
+  END IF;
+END
+\$\$;
+SQL
+
+echo "ploy_orderbook_snapshot_retention: done"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,56 @@
+# CLOB Orderbook Archive And Archive-Gated Retention (2026-05-20)
+
+## Goal
+
+Preserve full-fidelity Polymarket CLOB orderbook snapshots in a cold Parquet
+archive before allowing hot Postgres snapshot retention to delete old rows or
+partitions.
+
+Evidence stage: `operational_data_retention`.
+
+## Files / Ownership
+
+- `scripts/export_clob_orderbook_snapshots_parquet.sh`
+  - Owner: one completed-hour full-fidelity Parquet/ZSTD export.
+- `scripts/archive_clob_orderbook_snapshots_backfill.sh`
+  - Owner: bounded sequential gap filler for missing completed archive hours.
+- `scripts/ploy_orderbook_snapshot_retention.sh`
+  - Owner: split orderbook snapshot retention with archive-complete gate.
+- `scripts/ploy_maintenance.sh`
+  - Owner: general maintenance cleanup, archive-gated orderbook cleanup, and
+    bounded artifact/log retention.
+- `deployment/systemd/ploy-orderbook-snapshot-archive.*`
+  - Owner: archive timer/service.
+- `deployment/systemd/ploy-orderbook-snapshot-retention.*`
+  - Owner: retention timer/service.
+- `.github/workflows/deploy-tango-1-1.yml` and
+  `scripts/ci/deploy_tango_cloud_assist.py`
+  - Owner: ship scripts/units and enable timers during Tango deploys.
+- `docs/runbooks/orderbook-snapshot-archive.md`
+  - Owner: operator policy and verification commands.
+- `tests/test_ploy_maintenance_defaults.py`
+  - Owner: static regression coverage for safe defaults.
+- `tasks/todo.md`
+  - Owner: current session tracking for this extracted PR slice.
+
+## Tasks
+
+- [x] Create a clean worktree from current `origin/main`.
+- [x] Extract only orderbook archive/retention changes from the dirty source
+      worktree.
+- [x] Validate shell syntax, workflow syntax, and maintenance tests.
+- [x] Commit a focused orderbook archive/retention change.
+- [ ] Push and open a focused PR.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `bash -n scripts/export_clob_orderbook_snapshots_parquet.sh scripts/archive_clob_orderbook_snapshots_backfill.sh scripts/ploy_orderbook_snapshot_retention.sh scripts/ploy_maintenance.sh`,
+  `python3 -m unittest tests.test_ploy_maintenance_defaults`,
+  `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "deploy workflow yaml ok"'`,
+  and `rtk git diff --check`.
+- 2026-05-20: Committed on branch `fix/orderbook-archive-retention`.
+
 # Replay Backtest Evidence Stage Hardening (2026-05-20)
 
 ## Goal

--- a/tests/test_ploy_maintenance_defaults.py
+++ b/tests/test_ploy_maintenance_defaults.py
@@ -4,6 +4,27 @@ import unittest
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ploy_maintenance.sh"
+ORDERBOOK_RETENTION_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "ploy_orderbook_snapshot_retention.sh"
+)
+ORDERBOOK_EXPORT_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "export_clob_orderbook_snapshots_parquet.sh"
+)
+ORDERBOOK_BACKFILL_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "archive_clob_orderbook_snapshots_backfill.sh"
+)
+ORDERBOOK_ARCHIVE_SERVICE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "deployment"
+    / "systemd"
+    / "ploy-orderbook-snapshot-archive.service"
+)
 DB_RETENTION_VARS = [
     "RETENTION_CLOB_TICKS_DAYS",
     "RETENTION_CLOB_BOOK_DAYS",
@@ -11,9 +32,16 @@ DB_RETENTION_VARS = [
     "RETENTION_CLOB_TRADES_DAYS",
     "RETENTION_CLOB_ALERTS_DAYS",
     "RETENTION_BINANCE_TICKS_DAYS",
+    "RETENTION_BINANCE_AGGTRADE_DAYS",
     "RETENTION_BINANCE_LOB_DAYS",
+    "RETENTION_DERIBIT_IV_DAYS",
     "RETENTION_NBA_OBS_DAYS",
     "RETENTION_ORDER_EXEC_DAYS",
+]
+ARTIFACT_RETENTION_VARS = [
+    "RETENTION_TMP_DAYS",
+    "RETENTION_RECORDING_DAYS",
+    "RETENTION_PARQUET_DAYS",
 ]
 
 
@@ -38,6 +66,68 @@ class PloyMaintenanceDefaultsTest(unittest.TestCase):
         script = SCRIPT_PATH.read_text()
         self.assertIn('if [[ -n "${DATABASE_URL:-}" ]]; then', script)
         self.assertIn('PSQL=(psql "$DATABASE_URL" -v ON_ERROR_STOP=1)', script)
+
+    def test_artifact_retention_defaults_are_bounded(self) -> None:
+        defaults = _defaults_by_var()
+        self.assertEqual(defaults["RETENTION_TMP_DAYS"], "2")
+        self.assertEqual(defaults["RETENTION_RECORDING_DAYS"], "7")
+        self.assertEqual(defaults["RETENTION_PARQUET_DAYS"], "14")
+
+    def test_partition_retention_drops_old_children(self) -> None:
+        script = SCRIPT_PATH.read_text()
+        self.assertIn("DROP TABLE IF EXISTS %I.%I", script)
+        self.assertIn("parent.relname = 'binance_lob_ticks'", script)
+        self.assertIn("parent.relname = 'clob_trade_ticks'", script)
+        self.assertIn("parent.relname = 'deribit_iv_ticks'", script)
+
+    def test_clob_orderbook_snapshot_cleanup_is_bounded(self) -> None:
+        script = SCRIPT_PATH.read_text()
+        self.assertIn("CLOB_BOOK_DELETE_BATCH_SIZE", script)
+        self.assertIn("CLOB_BOOK_DELETE_MAX_BATCHES", script)
+        self.assertIn("$DATA_DIR/lake/orderbook_snapshots", script)
+        self.assertIn("LIMIT ${CLOB_BOOK_DELETE_BATCH_SIZE}", script)
+        self.assertIn("archived_clob_book_days", script)
+        self.assertIn("PLOY_CLOB_BOOK_REQUIRE_ARCHIVE", script)
+        self.assertIn("received_at::date IN (SELECT archive_day", script)
+        self.assertNotIn(
+            "DELETE FROM clob_orderbook_snapshots WHERE received_at <",
+            script,
+        )
+        self.assertNotIn("VACUUM (ANALYZE) clob_orderbook_snapshots", script)
+        self.assertIn("ANALYZE clob_orderbook_snapshots", script)
+
+    def test_runtime_artifact_dirs_are_pruned(self) -> None:
+        script = SCRIPT_PATH.read_text()
+        self.assertIn('prune_tree_dir "$TMP_DIR" "tmp"', script)
+        self.assertIn('prune_tree_dir "$DATA_DIR/recordings" "recordings"', script)
+        self.assertIn('prune_tree_dir "$DATA_DIR/parquet" "parquet"', script)
+
+    def test_clob_orderbook_partition_drop_is_archive_gated(self) -> None:
+        script = SCRIPT_PATH.read_text()
+        self.assertIn("parent.relname = 'clob_orderbook_snapshots'", script)
+        self.assertIn("SELECT archive_day FROM archived_clob_book_days", script)
+
+    def test_split_orderbook_retention_is_archive_gated(self) -> None:
+        script = ORDERBOOK_RETENTION_SCRIPT_PATH.read_text()
+        self.assertIn("PLOY_CLOB_BOOK_REQUIRE_ARCHIVE", script)
+        self.assertIn("/opt/ploy/data/lake/orderbook_snapshots", script)
+        self.assertIn("archived_clob_book_days", script)
+        self.assertIn("archive_complete", script)
+        self.assertIn("received_at::date IN (SELECT archive_day", script)
+
+    def test_orderbook_archive_export_is_single_threaded(self) -> None:
+        script = ORDERBOOK_EXPORT_SCRIPT_PATH.read_text()
+        self.assertIn("SET threads=1", script)
+        self.assertIn("SET pg_connection_limit=1", script)
+        self.assertIn("SET pg_use_ctid_scan=false", script)
+
+    def test_orderbook_archive_timer_runs_gap_filler(self) -> None:
+        script = ORDERBOOK_BACKFILL_SCRIPT_PATH.read_text()
+        service = ORDERBOOK_ARCHIVE_SERVICE_PATH.read_text()
+        self.assertIn("PLOY_CLOB_BOOK_ARCHIVE_LOOKBACK_HOURS", script)
+        self.assertIn("PLOY_CLOB_BOOK_ARCHIVE_MAX_HOURS_PER_RUN", script)
+        self.assertIn("hour=${export_hour}/_SUCCESS", script)
+        self.assertIn("archive_clob_orderbook_snapshots_backfill.sh", service)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add full-fidelity hourly Parquet/ZSTD archive export for clob_orderbook_snapshots
- add bounded archive gap filler and archive-gated orderbook snapshot retention scripts
- ship archive/retention systemd units through Tango deploy and Cloud Assistant fallback
- harden maintenance cleanup with archive gates, bounded DB deletes, and runtime artifact/log retention
- document operator verification and add static maintenance default tests

## Verification
- bash -n scripts/export_clob_orderbook_snapshots_parquet.sh scripts/archive_clob_orderbook_snapshots_backfill.sh scripts/ploy_orderbook_snapshot_retention.sh scripts/ploy_maintenance.sh
- python3 -m unittest tests.test_ploy_maintenance_defaults
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "deploy workflow yaml ok"'
- rtk git diff --check

## Safety
- no local DB commands were run
- no tango deploy was triggered by this PR