### PR TITLE
fix: map autofactor predictive runtime candidates

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -138,7 +138,14 @@ def blocker_strings(payload: Any) -> list[str]:
 def target_blocker_strings(payload: Any, target: str) -> list[str]:
     out: list[str] = []
     eligible: list[str] = []
+    profile_matched: list[str] = []
+    replay_matched: list[str] = []
     if isinstance(payload, dict):
+        required_profile = str(payload.get("required_strategy_profile") or "settlement_probability")
+        replay = payload.get("candidate_strategy_replay")
+        replay_runtime_score = ""
+        if isinstance(replay, dict):
+            replay_runtime_score = str(replay.get("runtime_score") or "")
         evaluated = payload.get("evaluated_factors")
         if isinstance(evaluated, list):
             for item in evaluated:
@@ -162,8 +169,17 @@ def target_blocker_strings(payload: Any, target: str) -> list[str]:
                         and isinstance(runtime_mapping, dict)
                         and runtime_mapping.get("runtime_score")
                     ):
+                        runtime_score = str(runtime_mapping.get("runtime_score") or "")
                         eligible.extend(row_blockers)
+                        if replay_runtime_score and runtime_score == replay_runtime_score:
+                            replay_matched.extend(row_blockers)
+                        if runtime_mapping.get("strategy_profile") == required_profile:
+                            profile_matched.extend(row_blockers)
             payload = {key: value for key, value in payload.items() if key != "evaluated_factors"}
+        if replay_matched:
+            return replay_matched
+        if profile_matched:
+            return profile_matched
         if eligible:
             return eligible
         out.extend(blocker_strings(payload))
@@ -301,6 +317,7 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         and chain.get("should_dispatch") is True
     )
     best = best_run(runs)
+    runtime_request = runtime_replay_request(current) if action == "fix_runtime" else None
     return {
         "schema_version": 1,
         "kind": "alpha_search_closed_loop_decision",
@@ -320,7 +337,39 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "promotion_blockers": blockers,
         "next_steps": next_steps(action),
         "prior_revision_required": action == "revise_prior",
+        "runtime_replay_request": runtime_request,
     }
+
+
+def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
+    for source in (run.get("promotion"), run.get("handoff")):
+        if not isinstance(source, dict):
+            continue
+        replay = source.get("candidate_strategy_replay")
+        if not isinstance(replay, dict):
+            continue
+        runtime_score = str(replay.get("runtime_score") or "").strip()
+        strategy_profile = str(replay.get("strategy_profile") or "settlement_probability").strip()
+        if not runtime_score:
+            continue
+        return {
+            "workflow": "runtime-candidate-replay.yml",
+            "git_ref": "main",
+            "reason": "replace aggregate top-bucket diagnostic with runtime_market_update_replay evidence",
+            "inputs": {
+                "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+                "config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+                "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+                "runtime_score": runtime_score,
+                "strategy_profile": strategy_profile or "settlement_probability",
+                "min_trade_count": "50",
+                "min_fill_rate": "0.30",
+                "min_roi": "0",
+                "full_depth_entry": "true",
+                "skip_settlement_exits": "false",
+            },
+        }
+    return None
 
 
 def summarize_run(run: dict[str, Any]) -> dict[str, Any]:
@@ -368,8 +417,8 @@ def next_steps(action: str) -> list[str]:
         ]
     if action == "fix_runtime":
         return [
-            "Fix runtime scorer/config/parity mapping before promoting any factor.",
-            "Rerun recorded replay/dry-run parity after the runtime fix.",
+            "Run runtime-candidate-replay.yml for the requested runtime score to replace the top-bucket aggregate with runtime_market_update_replay evidence.",
+            "Feed the resulting runtime-candidate-replay artifact back into the AutoFactor promotion evaluator before any dry-run handoff.",
         ]
     return [
         "Repair the workflow artifact bundle before interpreting search quality.",
@@ -471,6 +520,23 @@ def write_markdown(decision: dict[str, Any], path: Path, prior_path: Path | None
     lines.extend(f"- {item}" for item in decision["next_steps"])
     if prior_path is not None:
         lines.extend(["", f"Typed prior draft: `{prior_path}`"])
+    runtime_request = decision.get("runtime_replay_request")
+    if isinstance(runtime_request, dict):
+        lines.extend(["", "## Runtime Replay Request", ""])
+        lines.append(f"- Workflow: `{runtime_request.get('workflow')}`")
+        lines.append(f"- Reason: `{runtime_request.get('reason')}`")
+        inputs = runtime_request.get("inputs") if isinstance(runtime_request.get("inputs"), dict) else {}
+        for key in (
+            "deployment_id",
+            "config_path",
+            "recording_path",
+            "runtime_score",
+            "strategy_profile",
+            "full_depth_entry",
+            "skip_settlement_exits",
+        ):
+            if key in inputs:
+                lines.append(f"- {key}: `{inputs[key]}`")
     if decision["promotion_blockers"]:
         lines.extend(["", "## Promotion Blockers", ""])
         lines.extend(f"- `{item}`" for item in decision["promotion_blockers"][:20])

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -30,6 +30,11 @@ FORMULA_RUNTIME_MAPPED_NAMES = {
     "mut_spread_adjusted_external_move_full_depth_entry_gate",
 }
 
+PREDICTIVE_FORMULA_BASES = (
+    "amplitude_weighted_momentum_30s_sigma",
+    "spread_adjusted_external_move",
+)
+
 
 def parse_float(raw: str, default: float = float("nan")) -> float:
     try:
@@ -43,6 +48,23 @@ def parse_int(raw: str, default: int = 0) -> int:
         return int(raw)
     except (TypeError, ValueError):
         return default
+
+
+def normalize_formula_name(name: str) -> str:
+    while True:
+        for prefix in ("mut2_", "mut_", "mcts_"):
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        else:
+            return name
+
+
+def is_settlement_predictive_formula(name: str) -> bool:
+    normalized = normalize_formula_name(name)
+    if normalized == "spread_adjusted_external_move":
+        return False
+    return any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES)
 
 
 def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
@@ -90,7 +112,11 @@ def runtime_mapping(name: str) -> dict[str, str]:
                 else name
             ),
         }
-    if name.startswith("auto_settlement_") or name in FORMULA_RUNTIME_MAPPED_NAMES:
+    if (
+        name.startswith("auto_settlement_")
+        or name in FORMULA_RUNTIME_MAPPED_NAMES
+        or is_settlement_predictive_formula(name)
+    ):
         return {
             "strategy_profile": "settlement_probability",
             "runtime_score": f"autofactor_formula:{name}",

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -150,6 +150,11 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
     },
 }
 
+PREDICTIVE_FORMULA_BASES = (
+    "amplitude_weighted_momentum_30s_sigma",
+    "spread_adjusted_external_move",
+)
+
 for _base in (
     "auto_settlement_model_full_depth_settlement_edge",
     "auto_settlement_model_conservative_settlement_edge",
@@ -535,6 +540,29 @@ def load_runtime_mappings(path: str | None) -> dict[str, dict[str, str]]:
     return mappings
 
 
+def normalize_formula_name(name: str) -> str:
+    while True:
+        for prefix in ("mut2_", "mut_", "mcts_"):
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        else:
+            return name
+
+
+def inferred_runtime_mapping(name: str) -> dict[str, str] | None:
+    normalized = normalize_formula_name(name)
+    if normalized == "spread_adjusted_external_move":
+        return None
+    if any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES):
+        return {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "strategy_family": "predictive_settlement_probability",
+            "runtime_score": f"autofactor_formula:{name}",
+        }
+    return None
+
+
 MODEL_SPECIFIC_PRD_GATE_PREFIXES = (
     "symbol_holdout:",
     "walk_forward_oos:",
@@ -628,7 +656,7 @@ def evaluate(
 
     for row in rows:
         blockers: list[str] = []
-        mapping = runtime_mappings.get(row.name)
+        mapping = runtime_mappings.get(row.name) or inferred_runtime_mapping(row.name)
         formula_specific = is_autofactor_formula(mapping)
         suppress_global_fillability = (
             formula_specific

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17525,3 +17525,58 @@ trade lifecycle for PM5D binary-option events.
   `.github/workflows/deploy-tango-1-1.yml` did not yet include migration 041 in
   `DEPLOY_MIGRATIONS`; added a separate workflow-only fix before triggering any
   tango deploy.
+
+# AutoFactor Runtime Candidate Replay Mapping (2026-05-20)
+
+## Goal
+
+Map runtime-supported predictive AutoFactor formula mutations to settlement
+runtime scores and make closed-loop `fix_runtime` decisions emit an explicit
+runtime replay request.
+
+Evidence stage: `runtime_parity / executable_replay_request`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: infer settlement runtime mapping for predictive formula mutations
+    while keeping bare `spread_adjusted_external_move` in the repricing lane.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: use the same inferred mapping during promotion evaluation.
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: route blockers to the selected runtime replay candidate and emit
+    `runtime-candidate-replay.yml` inputs.
+- `tests/test_build_autofactor_candidate_strategy_replay.py`,
+  `tests/test_autofactor_strategy_promotion.py`, and
+  `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: focused regression coverage for mapping, blocker selection, and
+    runtime replay request output.
+
+## Tasks
+
+- [x] Infer settlement runtime mapping for predictive formula mutations:
+      `amplitude_weighted_momentum_30s_sigma*` and mutated
+      `spread_adjusted_external_move*`.
+- [x] Preserve the bare `spread_adjusted_external_move` repricing mapping.
+- [x] Keep top-bucket aggregate candidate replay blocked until runtime replay
+      evidence replaces it.
+- [x] Make closed-loop `fix_runtime` output include
+      `runtime-candidate-replay.yml` dispatch inputs for the selected runtime
+      score.
+- [x] Run focused Python tests, py_compile, artifact simulation, and diff
+      validation.
+
+## Review
+
+- 2026-05-20: The hosted walk-forward artifact now maps
+  `mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted` to
+  `runtime_score=autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted`
+  with `strategy_profile=settlement_probability`; the aggregate replay remains
+  blocked by `requires_runtime_replay_not_top_bucket_aggregate`.
+- 2026-05-20: Promotion evaluation stays blocked, but the relevant blockers are
+  now runtime replay blockers instead of missing runtime mapping noise. Closed
+  loop now requests `runtime-candidate-replay.yml` for the selected score.
+- 2026-05-20: Validation passed:
+  `python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_alpha_search_closed_loop_agent`,
+  `python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/alpha_search_closed_loop_agent.py`,
+  local simulation against artifact `26096201040`, and `rtk git diff --check`.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -349,6 +349,215 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(decision["decision"], "fix_workflow")
 
+    def test_profile_matched_runtime_candidate_blockers_take_priority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "runtime_profile_mismatch:spread_adjusted_external_move:repricing_momentum!=settlement_probability"
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": "repricing_momentum",
+                                "strategy_profile": "repricing_momentum",
+                            },
+                        },
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay"
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(
+                decision["promotion_blockers"],
+                [
+                    "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay"
+                ],
+            )
+
+    def test_runtime_replay_candidate_blockers_take_priority_within_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
+            other_runtime_score = "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_capacity"
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "top_bucket_entry_sweep_slippage_too_high:450.00>200.00",
+                                f"candidate_strategy_replay_runtime_score_mismatch:{runtime_score}!={other_runtime_score}",
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": other_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(
+                decision["promotion_blockers"],
+                [
+                    "requires_runtime_replay_not_top_bucket_aggregate",
+                    "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                ],
+            )
+
+    def test_fix_runtime_includes_runtime_replay_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay"
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            request = decision["runtime_replay_request"]
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(request["workflow"], "runtime-candidate-replay.yml")
+            self.assertEqual(request["git_ref"], "main")
+            self.assertEqual(request["inputs"]["runtime_score"], runtime_score)
+            self.assertEqual(request["inputs"]["strategy_profile"], "settlement_probability")
+
+    def test_cli_markdown_includes_runtime_replay_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime_score = "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
+            path = artifact(
+                root,
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay"
+                            ],
+                            "factor": {
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+            output_json = root / "decision.json"
+            output_md = root / "decision.md"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(path),
+                    "--output-json",
+                    str(output_json),
+                    "--output-md",
+                    str(output_md),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            decision = json.loads(output_json.read_text(encoding="utf-8"))
+            markdown = output_md.read_text(encoding="utf-8")
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertIn("## Runtime Replay Request", markdown)
+            self.assertIn(f"- runtime_score: `{runtime_score}`", markdown)
+
     def test_missing_feedback_routes_to_fix_data(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(Path(tmp), write_feedback=False)

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -97,6 +97,15 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 1,amplitude_weighted_momentum_30s_sigma,full_depth_settlement_executable_pnl,candidate,passed,3167,0.083421,0.044219,8,1.102341,0.8750,2,1.0000,1.0000,634,1.471203,0.6120,0.9000,634,1,3
 """
 
+AUTOFACTOR_PREDICTIVE_MUTATION_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.201235,0.117332,4,1.668090,1.0000,2,1.0000,0.7500,106,4.083066,0.6981,1.0000,18.51,1.42,106,1,8
+2,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,529,0.214428,0.141198,4,1.412625,1.0000,2,1.0000,1.0000,106,3.710549,0.6981,1.0000,23.70,1.40,106,1,5
+"""
+
 AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
@@ -362,6 +371,38 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "predictive_settlement_probability",
         )
         self.assertIn("amplitude_weighted_momentum_30s_sigma", handoff_md)
+
+    def test_qualifies_runtime_supported_predictive_formula_mutation(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        }
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_PREDICTIVE_MUTATION_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(
+            handoff["strategies"][0]["runtime_score"],
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
+        self.assertEqual(
+            handoff["strategies"][0]["strategy_family"],
+            "predictive_settlement_probability",
+        )
+        self.assertIn("mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted", handoff_md)
+        bare_spread = next(
+            item
+            for item in payload["evaluated_factors"]
+            if item["factor"]["name"] == "spread_adjusted_external_move"
+        )
+        self.assertIn(
+            "runtime_profile_mismatch:repricing_momentum!=settlement_probability",
+            bare_spread["blockers"],
+        )
 
     def test_qualifies_tradeable_hard_gate_predictive_formula_when_gate_is_ready(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -109,6 +109,43 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
             "auto_settlement_full_depth_settlement_edge_x_near_strike",
         )
 
+    def test_selects_runtime_mappable_predictive_formula_mutation(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=false
+gate,passed,evidence
+recorded_replay_parity,false,post-dry-run gate pending
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.201235,0.117332,4,1.668090,1.0000,2,1.0000,0.7500,106,4.083066,0.6981,1.0000,18.51,1.42,106,1,8
+2,amplitude_weighted_momentum_30s_sigma,full_depth_settlement_executable_pnl,candidate,passed,529,0.165183,0.100246,4,1.474733,1.0000,2,1.0000,1.0000,106,2.366817,0.6321,1.0000,44.93,1.46,106,1,4
+"""
+        payload, _ = self.run_script(report)
+
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
+
+    def test_keeps_bare_spread_adjusted_external_move_in_repricing_lane(self):
+        payload, _ = self.run_script(
+            AUTOFACTOR_REPORT,
+            "--allowed-target",
+            "full_depth_settlement_executable_pnl",
+            "--required-strategy-profile",
+            "settlement_probability",
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["runtime_score"], "")
+        self.assertIn("runtime_profile_mismatch", ",".join(payload["blocking_risk_flags"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -353,7 +353,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(first_marker, "<empty>")
         self.assertEqual(second_marker, "auto_settlement")
 
-    def test_summary_separates_discovery_from_runtime_mappable_candidates(self):
+    def test_summary_marks_predictive_formula_mutation_runtime_mappable(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)
             (tmp / "snapshot").mkdir()
@@ -373,19 +373,23 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
             variant["best_discovery_factor"]["name"],
             "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
         )
-        self.assertIn(
+        self.assertNotIn(
             "missing_runtime_strategy_mapping",
             variant["best_discovery_factor"]["blockers"],
         )
         self.assertEqual(
             variant["best_runtime_mappable_factor"]["name"],
-            "auto_settlement_conservative_settlement_edge",
+            "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
         )
         self.assertEqual(
             variant["best_runtime_mappable_factor"]["top_bucket_avg_label"],
-            2.507843,
+            1.660059,
         )
-        self.assertEqual(variant["best_runtime_mappable_factor"]["complexity"], 1)
+        self.assertEqual(variant["best_runtime_mappable_factor"]["complexity"], 6)
+        self.assertEqual(
+            variant["best_runtime_mappable_factor"]["runtime_mapping"]["runtime_score"],
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
         self.assertEqual(variant["qualified_count"], 0)
         self.assertEqual(variant["decision"], "blocked")
         self.assertIsNone(variant["best_qualified_strategy"])


### PR DESCRIPTION
## Summary
- infer settlement runtime mappings for runtime-supported predictive AutoFactor formula mutations
- keep bare spread_adjusted_external_move in the repricing lane
- emit runtime-candidate-replay.yml request details from closed-loop fix_runtime decisions

## Evidence
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/alpha_search_closed_loop_agent.py
- local simulation against hosted artifact 26096201040
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime replay requests now generated and included in strategy fix decisions
  * Improved formula recognition for runtime mapping eligibility
  * Enhanced decision blocker prioritization based on runtime replay and strategy profile matching
  * Runtime replay request details added to decision reports

* **Documentation**
  * Added task documentation for AutoFactor runtime replay mapping work

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->