### PR TITLE
fix: gate predictive autofactors on normalized score

### DIFF
--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -586,9 +586,7 @@ fn is_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
         || name.starts_with("auto_settlement_conservative_settlement_edge")
         || name.starts_with("auto_settlement_model_full_depth_settlement_edge")
         || name.starts_with("auto_settlement_model_conservative_settlement_edge")
-        || name.starts_with("amplitude_weighted_momentum_30s_sigma")
-        || (name.starts_with("spread_adjusted_external_move")
-            && name != "spread_adjusted_external_move")
+        || is_predictive_settlement_autofactor_name(name)
 }
 
 fn is_model_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
@@ -598,6 +596,34 @@ fn is_model_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
     let name = normalized_autofactor_formula_name(name);
     name.starts_with("auto_settlement_model_full_depth_settlement_edge")
         || name.starts_with("auto_settlement_model_conservative_settlement_edge")
+}
+
+fn is_predictive_settlement_autofactor_runtime_score(runtime_score: &str) -> bool {
+    let name = runtime_score
+        .strip_prefix("autofactor_formula:")
+        .unwrap_or(runtime_score);
+    is_predictive_settlement_autofactor_name(normalized_autofactor_formula_name(name))
+}
+
+fn is_predictive_settlement_autofactor_name(name: &str) -> bool {
+    name.starts_with("amplitude_weighted_momentum_30s_sigma")
+        || (name.starts_with("spread_adjusted_external_move")
+            && name != "spread_adjusted_external_move")
+}
+
+fn settlement_autofactor_entry_score_passes(
+    runtime_score: &str,
+    raw_score: Option<f64>,
+    total_score: f64,
+    config: &ThreeLayerConfig,
+) -> bool {
+    if is_predictive_settlement_autofactor_runtime_score(runtime_score) {
+        total_score >= config.min_entry_score
+    } else {
+        raw_score
+            .map(|score| score >= config.min_edge.max(0.0))
+            .unwrap_or(total_score >= config.min_entry_score)
+    }
 }
 
 fn normalized_autofactor_formula_name(mut name: &str) -> &str {
@@ -1938,10 +1964,15 @@ impl ThreeLayerStrategy {
                     )
                 };
 
-            let entry_score_passes = if uses_settlement_autofactor {
-                autofactor_raw_score
-                    .map(|score| score >= self.config.min_edge.max(0.0))
-                    .unwrap_or(total_score >= self.config.min_entry_score)
+            let entry_score_passes = if let (true, Some(runtime_score)) =
+                (uses_settlement_autofactor, runtime_score.as_deref())
+            {
+                settlement_autofactor_entry_score_passes(
+                    runtime_score,
+                    autofactor_raw_score,
+                    total_score,
+                    &self.config,
+                )
             } else {
                 total_score >= self.config.min_entry_score
             };
@@ -4953,6 +4984,32 @@ mod tests {
         ));
         assert!(!is_settlement_autofactor_runtime_score(
             "autofactor_formula:spread_adjusted_external_move"
+        ));
+    }
+
+    #[test]
+    fn predictive_settlement_autofactor_uses_normalized_entry_gate() {
+        let mut config = test_config();
+        config.min_edge = 0.02;
+        config.min_entry_score = 0.25;
+
+        assert!(settlement_autofactor_entry_score_passes(
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+            Some(0.006),
+            0.30,
+            &config,
+        ));
+        assert!(!settlement_autofactor_entry_score_passes(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+            Some(0.006),
+            0.30,
+            &config,
+        ));
+        assert!(settlement_autofactor_entry_score_passes(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+            Some(0.021),
+            0.30,
+            &config,
         ));
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17603,6 +17603,8 @@ Evidence stage: `runtime_parity / executable_replay_request`.
       updates but emitted 0 intents / 0 trades.
 - [x] Align runtime settlement-lane classification with the promotion mapping
       for predictive formula mutations.
+- [x] Gate predictive formulas on their normalized entry score instead of raw
+      settlement-edge `min_edge`.
 - [x] Preserve bare `autofactor_formula:spread_adjusted_external_move` outside
       settlement AutoFactor classification.
 - [x] Run focused Rust validation and diff validation.
@@ -17615,6 +17617,11 @@ Evidence stage: `runtime_parity / executable_replay_request`.
   `is_settlement_autofactor_runtime_score()` did not classify them as settlement
   AutoFactor scores. Runtime replay therefore selected the legacy direction
   gate before formula scoring and produced no entry intents.
+- 2026-05-20: Second replay `26123152101` confirmed the formula lane was active
+  (`settlement_autofactor_formula_evaluations=2934`), but all entries were
+  blocked by raw-score `min_edge`. Predictive formulas are now gated by their
+  normalized entry score; traditional settlement-edge formulas keep the raw
+  edge gate.
 - 2026-05-20: Validation passed:
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-replay-zero-intents /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib`
   and `rtk git diff --check`.


### PR DESCRIPTION
## Summary
- gate predictive settlement AutoFactor formulas on normalized entry score instead of raw min_edge
- keep traditional settlement-edge AutoFactor formulas gated by raw edge
- document runtime replay 26123152101 evidence that formula lane was active but raw min_edge blocked all entries

## Evidence
- CARGO_TARGET_DIR=/tmp/ploy-predictive-entry-gate /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib
- rtk git diff --check