### PR TITLE
fix: add runtime score counterfactual diagnostics

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -364,7 +364,7 @@ jobs:
             if [ -f artifacts/runtime-replay/candidate-strategy-replay.json ]; then
               echo ""
               echo '```json'
-              python3 -c 'import json; data=json.load(open("artifacts/runtime-replay/candidate-strategy-replay.json")); print(json.dumps({"promotion_ready": data.get("promotion_ready"), "basis": data.get("basis"), "metrics": data.get("metrics"), "blocking_risk_flags": data.get("blocking_risk_flags")}, indent=2, sort_keys=True))'
+              python3 -c 'import json; data=json.load(open("artifacts/runtime-replay/candidate-strategy-replay.json")); print(json.dumps({"promotion_ready": data.get("promotion_ready"), "basis": data.get("basis"), "metrics": data.get("metrics"), "score_counterfactual": data.get("score_counterfactual"), "blocking_risk_flags": data.get("blocking_risk_flags")}, indent=2, sort_keys=True))'
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
@@ -388,11 +388,13 @@ jobs:
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let ready = false;
             let metrics = {};
+            let scoreCounterfactual = {};
             let blockers = ["missing_candidate_strategy_replay_artifact"];
             if (fs.existsSync("artifacts/runtime-replay/candidate-strategy-replay.json")) {
               const data = JSON.parse(fs.readFileSync("artifacts/runtime-replay/candidate-strategy-replay.json", "utf8"));
               ready = Boolean(data.promotion_ready);
               metrics = data.metrics || {};
+              scoreCounterfactual = data.score_counterfactual || {};
               blockers = data.blocking_risk_flags || [];
             }
             const body = [
@@ -410,6 +412,7 @@ jobs:
               `- Unique events: \`${metrics.unique_event_count ?? "n/a"}\``,
               `- Entry fill rate: \`${metrics.entry_fill_rate ?? "n/a"}\``,
               `- ROI: \`${metrics.roi ?? "n/a"}\``,
+              `- Score counterfactual: \`${scoreCounterfactual.diagnosis ?? "n/a"}\``,
               `- Blocking flags: \`${blockers.join(", ") || "none"}\``
             ].join("\n");
             await github.rest.issues.createComment({

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -947,6 +947,44 @@ impl ThreeLayerStrategy {
         });
     }
 
+    fn bump_predictive_autofactor_counterfactual_scores(&mut self, raw: f64, score: f64) {
+        if !score.is_finite() {
+            self.bump("settlement_autofactor_predictive_score_nonfinite");
+            return;
+        }
+        let reverse_score =
+            three_layer_model::threshold_score(-raw, 0.0, 0.02, false).clamp(-0.50, 1.0);
+        for (threshold, direct_key, reverse_key) in [
+            (
+                0.05,
+                "settlement_autofactor_predictive_score_ge_005",
+                "settlement_autofactor_predictive_reverse_score_ge_005",
+            ),
+            (
+                0.10,
+                "settlement_autofactor_predictive_score_ge_010",
+                "settlement_autofactor_predictive_reverse_score_ge_010",
+            ),
+            (
+                0.15,
+                "settlement_autofactor_predictive_score_ge_015",
+                "settlement_autofactor_predictive_reverse_score_ge_015",
+            ),
+            (
+                0.25,
+                "settlement_autofactor_predictive_score_ge_025",
+                "settlement_autofactor_predictive_reverse_score_ge_025",
+            ),
+        ] {
+            if score >= threshold {
+                self.bump(direct_key);
+            }
+            if reverse_score >= threshold {
+                self.bump(reverse_key);
+            }
+        }
+    }
+
     fn now(&self) -> DateTime<Utc> {
         self.feed_time.unwrap_or_else(Utc::now)
     }
@@ -1931,6 +1969,11 @@ impl ThreeLayerStrategy {
                             SettlementAutofactorEdgeMetric::RawFormula,
                             raw,
                         );
+                        if is_predictive_settlement_autofactor_runtime_score(runtime_score) {
+                            self.bump_predictive_autofactor_counterfactual_scores(
+                                raw, normalized,
+                            );
+                        }
                         if raw >= self.config.min_edge.max(0.0) {
                             self.bump("settlement_autofactor_raw_score_pass_min_edge");
                         } else {
@@ -5011,6 +5054,39 @@ mod tests {
             0.30,
             &config,
         ));
+    }
+
+    #[test]
+    fn predictive_autofactor_records_direct_and_reverse_threshold_counts() {
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+
+        strategy.bump_predictive_autofactor_counterfactual_scores(0.006, 0.30);
+        strategy.bump_predictive_autofactor_counterfactual_scores(-0.004, -0.20);
+
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            diagnostics.get("settlement_autofactor_predictive_score_ge_005"),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics.get("settlement_autofactor_predictive_score_ge_025"),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics.get("settlement_autofactor_predictive_reverse_score_ge_005"),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics.get("settlement_autofactor_predictive_reverse_score_ge_015"),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics.get("settlement_autofactor_predictive_reverse_score_ge_025"),
+            None
+        );
     }
 
     #[test]

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -18,6 +18,12 @@ from typing import Any
 
 
 RUNTIME_REPLAY_BASIS = "runtime_market_update_replay"
+COUNTERFACTUAL_THRESHOLDS = (
+    ("0.05", "005"),
+    ("0.10", "010"),
+    ("0.15", "015"),
+    ("0.25", "025"),
+)
 
 
 def decimal_value(raw: Any, default: Decimal = Decimal("0")) -> Decimal:
@@ -44,6 +50,53 @@ def runtime_evidence(payload: dict[str, Any]) -> dict[str, Any]:
 def result_payload(payload: dict[str, Any]) -> dict[str, Any]:
     result = payload.get("result")
     return result if isinstance(result, dict) else {}
+
+
+def int_metric(payload: dict[str, Any], key: str) -> int:
+    try:
+        return int(payload.get(key) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def score_counterfactual(diagnostics: dict[str, Any]) -> dict[str, Any]:
+    if not diagnostics:
+        return {}
+    formula_evaluations = int_metric(diagnostics, "settlement_autofactor_formula_evaluations")
+    direct: dict[str, int] = {}
+    reverse: dict[str, int] = {}
+    for label, suffix in COUNTERFACTUAL_THRESHOLDS:
+        direct[label] = int_metric(
+            diagnostics,
+            f"settlement_autofactor_predictive_score_ge_{suffix}",
+        )
+        reverse[label] = int_metric(
+            diagnostics,
+            f"settlement_autofactor_predictive_reverse_score_ge_{suffix}",
+        )
+    if not formula_evaluations and not any(direct.values()) and not any(reverse.values()):
+        return {}
+
+    configured_direct = direct["0.25"]
+    configured_reverse = reverse["0.25"]
+    if configured_reverse > configured_direct:
+        diagnosis = "reverse_direction_stronger_at_configured_threshold"
+    elif configured_direct == 0 and any(value > 0 for key, value in direct.items() if key != "0.25"):
+        diagnosis = "direct_signal_exists_below_configured_threshold"
+    elif configured_direct == 0:
+        diagnosis = "direct_signal_too_weak_at_all_reported_thresholds"
+    else:
+        diagnosis = "direct_signal_passes_configured_threshold"
+
+    return {
+        "formula_evaluations": formula_evaluations,
+        "depth_fillable": int_metric(diagnostics, "settlement_autofactor_depth_fillable"),
+        "entry_score_skips": int_metric(diagnostics, "skip_entry_score"),
+        "configured_entry_threshold": "0.25",
+        "direct_pass_counts": direct,
+        "reverse_direction_pass_counts": reverse,
+        "diagnosis": diagnosis,
+    }
 
 
 def purpose_is_entry(row: dict[str, Any]) -> bool:
@@ -182,8 +235,9 @@ def build_artifact(
         blocking_flags.append("zero_runtime_orders_and_fills")
 
     diagnostics = runtime_eval.get("strategy_diagnostics") or result.get("strategy_diagnostics") or {}
+    counterfactual = score_counterfactual(diagnostics)
 
-    return {
+    artifact = {
         "schema_version": 1,
         "kind": "autofactor_candidate_strategy_replay",
         "evidence_stage": "executable_replay",
@@ -216,6 +270,9 @@ def build_artifact(
         "strategy_diagnostics": diagnostics,
         "blocking_risk_flags": blocking_flags,
     }
+    if counterfactual:
+        artifact["score_counterfactual"] = counterfactual
+    return artifact
 
 
 def render_markdown(artifact: dict[str, Any]) -> str:
@@ -240,6 +297,26 @@ def render_markdown(artifact: dict[str, Any]) -> str:
         "",
     ]
     lines.extend(f"- `{flag}`" for flag in flags) if flags else lines.append("- `<none>`")
+    counterfactual = artifact.get("score_counterfactual")
+    if isinstance(counterfactual, dict):
+        lines.extend(
+            [
+                "",
+                "## Score Counterfactual",
+                "",
+                f"- Diagnosis: `{counterfactual.get('diagnosis')}`",
+                f"- Formula evaluations: `{counterfactual.get('formula_evaluations')}`",
+                f"- Depth-fillable evaluations: `{counterfactual.get('depth_fillable')}`",
+                f"- Entry score skips: `{counterfactual.get('entry_score_skips')}`",
+                "",
+                "| threshold | direct passes | reverse-direction passes |",
+                "| --- | ---: | ---: |",
+            ]
+        )
+        direct = counterfactual.get("direct_pass_counts") or {}
+        reverse = counterfactual.get("reverse_direction_pass_counts") or {}
+        for threshold, _suffix in COUNTERFACTUAL_THRESHOLDS:
+            lines.append(f"| `{threshold}` | `{direct.get(threshold, 0)}` | `{reverse.get(threshold, 0)}` |")
     lines.append("")
     return "\n".join(lines)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17625,3 +17625,51 @@ Evidence stage: `runtime_parity / executable_replay_request`.
 - 2026-05-20: Validation passed:
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-replay-zero-intents /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib`
   and `rtk git diff --check`.
+
+# Runtime Replay Score Counterfactual Diagnostic (2026-05-20)
+
+## Goal
+
+Make runtime replay answer why a predictive AutoFactor candidate emits zero
+entry intents by reporting direct-vs-reverse direction score threshold counts
+from the same MarketUpdate replay.
+
+Evidence stage: `runtime_parity / diagnostic`.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: runtime predictive score counters.
+- `scripts/build_runtime_candidate_strategy_replay.py`
+  - Owner: machine-readable score counterfactual artifact and markdown summary.
+- `.github/workflows/runtime-candidate-replay.yml`
+  - Owner: expose counterfactual diagnosis in workflow summaries and issue
+    comments.
+- `tests/test_build_runtime_candidate_strategy_replay.py`
+  - Owner: Python artifact regression coverage.
+
+## Tasks
+
+- [x] Keep the workflow research-only: no deploy, no config mutation, no live
+      trading.
+- [x] Add runtime counters for direct and reverse predictive scores at
+      `0.05`, `0.10`, `0.15`, and `0.25` normalized entry-score thresholds.
+- [x] Add `score_counterfactual` to the runtime candidate replay artifact.
+- [x] Surface the diagnosis in workflow summary and replay evidence comments.
+- [x] Run focused Rust/Python/workflow validation.
+- [ ] Open PR, wait for CI, merge, then trigger a fresh runtime replay from
+      `main`.
+
+## Review
+
+- 2026-05-20: Previous replay `26123999276` showed the formula lane was active
+  but ended with `intents_submitted=0`, `settlement_autofactor_formula_evaluations=2934`,
+  and `skip_entry_score=2934`. The new diagnostic will distinguish
+  `reverse_direction_stronger_at_configured_threshold` from
+  `direct_signal_exists_below_configured_threshold` and
+  `direct_signal_too_weak_at_all_reported_thresholds`.
+- 2026-05-20: Local validation passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-runtime-counterfactual-diagnostic /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor --lib`,
+  `python3 -m unittest tests.test_build_runtime_candidate_strategy_replay`,
+  `python3 -m py_compile scripts/build_runtime_candidate_strategy_replay.py`,
+  and `rtk git diff --check`.

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -180,6 +180,53 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertIn("zero_runtime_orders_and_fills", payload["blocking_risk_flags"])
         self.assertEqual(payload["strategy_diagnostics"]["skip_edge_score"], 183)
 
+    def test_adds_score_counterfactual_from_runtime_diagnostics(self):
+        payload, markdown = self.run_script(
+            {
+                "result": {
+                    "updates_processed": 1000,
+                    "intents_submitted": 0,
+                    "strategy_diagnostics": {
+                        "settlement_autofactor_formula_evaluations": 20,
+                        "settlement_autofactor_depth_fillable": 18,
+                        "skip_entry_score": 18,
+                        "settlement_autofactor_predictive_score_ge_005": 12,
+                        "settlement_autofactor_predictive_score_ge_010": 8,
+                        "settlement_autofactor_predictive_score_ge_015": 3,
+                        "settlement_autofactor_predictive_score_ge_025": 0,
+                        "settlement_autofactor_predictive_reverse_score_ge_005": 2,
+                        "settlement_autofactor_predictive_reverse_score_ge_010": 1,
+                        "settlement_autofactor_predictive_reverse_score_ge_015": 0,
+                        "settlement_autofactor_predictive_reverse_score_ge_025": 0,
+                    },
+                },
+                "runtime_evidence": {
+                    "basis": "trading_runtime_snapshot",
+                    "events": [],
+                    "orders": [],
+                    "fills": [],
+                    "intents": [],
+                },
+            },
+            "--full-depth-entry",
+            "--min-trade-count",
+            "2",
+        )
+
+        counterfactual = payload["score_counterfactual"]
+        self.assertEqual(counterfactual["formula_evaluations"], 20)
+        self.assertEqual(counterfactual["depth_fillable"], 18)
+        self.assertEqual(counterfactual["entry_score_skips"], 18)
+        self.assertEqual(counterfactual["direct_pass_counts"]["0.15"], 3)
+        self.assertEqual(counterfactual["direct_pass_counts"]["0.25"], 0)
+        self.assertEqual(counterfactual["reverse_direction_pass_counts"]["0.10"], 1)
+        self.assertEqual(
+            counterfactual["diagnosis"],
+            "direct_signal_exists_below_configured_threshold",
+        )
+        self.assertIn("## Score Counterfactual", markdown)
+        self.assertIn("| `0.15` | `3` | `0` |", markdown)
+
     def test_blocks_open_settlement_and_unconfirmed_depth(self):
         payload, _ = self.run_script(
             runtime_eval_payload(settled=False),


### PR DESCRIPTION
## Summary
- add predictive AutoFactor direct/reverse score threshold diagnostics to runtime replay
- include score_counterfactual in candidate replay artifacts, workflow summary, and issue comments
- add focused Rust and Python regression coverage

## Evidence stage
runtime_parity / diagnostic

## Validation
- CARGO_TARGET_DIR=/tmp/ploy-runtime-counterfactual-diagnostic /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor --lib
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay
- python3 -m py_compile scripts/build_runtime_candidate_strategy_replay.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added score counterfactual diagnostics to runtime candidate replay artifacts, providing threshold-based analysis of direct and reverse predictive scores.
  * Extended GitHub workflow output and issue comments to surface counterfactual evidence and diagnostic information.

* **Tests**
  * Expanded test coverage for counterfactual diagnostics computation and markdown rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->