### PR TITLE
fix: route closed-loop replay to current runtime candidate

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -342,6 +342,9 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
+    candidate = runtime_replay_candidate(run)
+    if candidate is not None:
+        return candidate
     for source in (run.get("promotion"), run.get("handoff")):
         if not isinstance(source, dict):
             continue
@@ -370,6 +373,80 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
             },
         }
     return None
+
+
+def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
+    promotion = run.get("promotion")
+    if not isinstance(promotion, dict):
+        return None
+    evaluated = promotion.get("evaluated_factors")
+    if not isinstance(evaluated, list):
+        return None
+    target = run.get("target") or DEFAULT_TARGET
+    required_profile = str(
+        promotion.get("required_strategy_profile") or "settlement_probability"
+    )
+    candidates: list[dict[str, Any]] = []
+    for item in evaluated:
+        if not isinstance(item, dict):
+            continue
+        factor = item.get("factor")
+        runtime_mapping = item.get("runtime_mapping")
+        if not isinstance(factor, dict) or not isinstance(runtime_mapping, dict):
+            continue
+        if factor.get("target") not in {None, target}:
+            continue
+        if factor.get("decision") != "candidate" or factor.get("reason") != "passed":
+            continue
+        if runtime_mapping.get("strategy_profile") != required_profile:
+            continue
+        runtime_score = str(runtime_mapping.get("runtime_score") or "").strip()
+        if not runtime_score:
+            continue
+        candidates.append(item)
+    if not candidates:
+        return None
+
+    def score(item: dict[str, Any]) -> tuple[float, float, float, float]:
+        factor = item.get("factor") if isinstance(item.get("factor"), dict) else {}
+        return (
+            1.0
+            if factor.get("decision") == "candidate" and factor.get("reason") == "passed"
+            else 0.0,
+            as_float(factor.get("positive_window_ratio")) or 0.0,
+            as_float(factor.get("symbol_positive_ratio")) or 0.0,
+            as_float(factor.get("spearman_ic")) or 0.0,
+        )
+
+    selected = max(candidates, key=score)
+    factor = selected.get("factor") if isinstance(selected.get("factor"), dict) else {}
+    mapping = (
+        selected.get("runtime_mapping")
+        if isinstance(selected.get("runtime_mapping"), dict)
+        else {}
+    )
+    runtime_score = str(mapping.get("runtime_score") or "").strip()
+    strategy_profile = str(mapping.get("strategy_profile") or required_profile).strip()
+    if not runtime_score:
+        return None
+    return {
+        "workflow": "runtime-candidate-replay.yml",
+        "git_ref": "main",
+        "reason": "replace aggregate top-bucket diagnostic with runtime_market_update_replay evidence",
+        "source_factor": str(factor.get("name") or ""),
+        "inputs": {
+            "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+            "config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+            "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+            "runtime_score": runtime_score,
+            "strategy_profile": strategy_profile or "settlement_probability",
+            "min_trade_count": "50",
+            "min_fill_rate": "0.30",
+            "min_roi": "0",
+            "full_depth_entry": "true",
+            "skip_settlement_exits": "false",
+        },
+    }
 
 
 def summarize_run(run: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -504,6 +504,79 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(request["inputs"]["runtime_score"], runtime_score)
             self.assertEqual(request["inputs"]["strategy_profile"], "settlement_probability")
 
+    def test_fix_runtime_request_uses_best_current_runtime_mappable_factor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stale_runtime_score = (
+                "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
+            )
+            better_runtime_score = (
+                "autofactor_formula:mut_spread_adjusted_external_move_spread_adjusted"
+            )
+            path = artifact(
+                Path(tmp),
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                            ],
+                            "factor": {
+                                "name": "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.10,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": stale_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                                f"candidate_strategy_replay_runtime_score_mismatch:{stale_runtime_score}!={better_runtime_score}",
+                            ],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.22,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": better_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": stale_runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+
+            request = decision["runtime_replay_request"]
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(
+                request["source_factor"],
+                "mut_spread_adjusted_external_move_spread_adjusted",
+            )
+            self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
+
     def test_cli_markdown_includes_runtime_replay_request(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- choose the current best runtime-mappable settlement candidate from evaluated factors when creating closed-loop runtime replay requests
- keep the old candidate_strategy_replay fallback only when evaluated factor mapping is unavailable
- add regression coverage for stale aggregate replay scores causing repeated runtime replay requests

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py
- rtk git diff --check
- simulated closed-loop classifier on run 26133602862 artifact now requests autofactor_formula:mut_spread_adjusted_external_move_spread_adjusted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced runtime candidate selection logic to intelligently prioritize candidates based on multiple scoring factors (pass status, window ratio, symbol positive ratio, and correlation metrics).

* **Tests**
  * Added test coverage validating correct candidate selection when multiple eligible options exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->