### PR TITLE
Fix research snapshot empty timestamp args

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -295,14 +295,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          empty_arg="__ploy_empty__"
           ssh tango-1-1 /bin/bash -s -- \
             "${DEPLOY_ROOT}" \
             "${REMOTE_DIR}" \
             "${{ github.event.inputs.symbols }}" \
             "${{ github.event.inputs.start_date }}" \
             "${{ github.event.inputs.end_date }}" \
-            "${SNAPSHOT_START_TS}" \
-            "${SNAPSHOT_END_TS}" \
+            "${SNAPSHOT_START_TS:-${empty_arg}}" \
+            "${SNAPSHOT_END_TS:-${empty_arg}}" \
             "${{ github.event.inputs.stake_usd }}" \
             "${SNAPSHOT_LOB_SAMPLE_SECS}" \
             "${SNAPSHOT_PM_BOOK_SAMPLE_SECS}" \
@@ -329,6 +330,12 @@ jobs:
           required_sources="${14}"
           data_audit_status="${15}"
           include_deribit="${16}"
+          if [ "${start_ts}" = "__ploy_empty__" ]; then
+            start_ts=""
+          fi
+          if [ "${end_ts}" = "__ploy_empty__" ]; then
+            end_ts=""
+          fi
 
           set -a
           . "${deploy_root}/.env"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# Research Snapshot Empty Timestamp SSH Fix (2026-05-20)
+
+## Goal
+
+Prevent `research-snapshot.yml` from dropping empty `start_ts` / `end_ts`
+arguments when invoking the remote compiler over SSH.
+
+Evidence stage: `workflow_contract`.
+
+## Files / Ownership
+
+- `.github/workflows/research-snapshot.yml`
+  - Owner: preserve empty timestamp options across the SSH boundary.
+- `tests/workflow_security.rs`
+  - Owner: static regression for the empty timestamp sentinel contract.
+- `tasks/todo.md`
+  - Owner: current session tracking for this workflow fix.
+
+## Tasks
+
+- [x] Reproduce the failure from run `26133466284`.
+- [x] Confirm explicit timestamp workaround with successful run `26135455846`.
+- [x] Patch the workflow so default empty timestamps remain safe.
+- [x] Validate YAML, workflow security test, and whitespace.
+- [ ] Push, open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml"); puts "ok"'`,
+  `CARGO_TARGET_DIR=/tmp/ploy-workflow-security-empty-ts /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security`,
+  and `rtk git diff --check`.
+
 # Hosted Walk-Forward Candidate Replay Feedback (2026-05-20)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -103,6 +103,30 @@ fn workflow_dispatch_inputs_stay_lintable() {
 }
 
 #[test]
+fn research_snapshot_preserves_empty_timestamp_args_over_ssh() {
+    let workflow = workflow_contents(".github/workflows/research-snapshot.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "empty_arg=\"__ploy_empty__\"",
+        "\"${SNAPSHOT_START_TS:-${empty_arg}}\"",
+        "\"${SNAPSHOT_END_TS:-${empty_arg}}\"",
+        "if [ \"${start_ts}\" = \"__ploy_empty__\" ]; then",
+        "if [ \"${end_ts}\" = \"__ploy_empty__\" ]; then",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!("research-snapshot.yml: missing `{needle}`"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research snapshot SSH empty timestamp guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn factor_evolve_daily_search_passes_snapshot_quote_age() {
     let workflow = workflow_contents(".github/workflows/factor-evolve-daily-research.yml");
     let mut offenders = Vec::new();


### PR DESCRIPTION
## Summary
- preserve empty `start_ts` / `end_ts` options across the SSH boundary in `research-snapshot.yml`
- restore empty timestamp sentinels before choosing date-vs-timestamp compiler args
- add workflow security coverage for the empty timestamp path

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml"); puts "ok"'`\n- `CARGO_TARGET_DIR=/tmp/ploy-workflow-security-empty-ts /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security`\n- `rtk git diff --check`\n\n## Evidence\n- Run `26133466284` failed with `/bin/bash: line 16: 15: unbound variable` when timestamp options were empty.\n- Run `26135455846` succeeded when explicit `start_ts` / `end_ts` were supplied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp parameter handling in snapshot generation to properly preserve optional timestamps across communication boundaries.

* **Tests**
  * Added validation test to verify correct timestamp argument behavior in snapshot workflows.

* **Chores**
  * Updated internal task tracking documentation for snapshot improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->