### PR TITLE
Feed runtime pass-through diagnostics into alpha prior

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -654,6 +654,15 @@ jobs:
                 "artifacts/factor-walk-forward-v2-upload/snapshot-provenance/${file}"
             fi
           done
+          candidate_strategy_replay_json="${WALK_CANDIDATE_STRATEGY_REPLAY_JSON}"
+          if [ -z "${candidate_strategy_replay_json}" ] && [ -f artifacts/candidate-strategy-replay/candidate-strategy-replay.json ]; then
+            candidate_strategy_replay_json="artifacts/candidate-strategy-replay/candidate-strategy-replay.json"
+          fi
+          if [ -n "${candidate_strategy_replay_json}" ] && [ -f "${candidate_strategy_replay_json}" ]; then
+            mkdir -p artifacts/factor-walk-forward-v2-upload/candidate-strategy-replay
+            cp "${candidate_strategy_replay_json}" \
+              artifacts/factor-walk-forward-v2-upload/candidate-strategy-replay/candidate-strategy-replay.json
+          fi
 
       - name: Prepare alpha search chain decision
         if: always()

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -457,6 +457,14 @@ Execution blockers also take priority over runtime mapping blockers. For
 example, `one_event_decision_violation`, top-bucket slippage, or fillability
 problems mean the candidate is still a search/prior problem; the classifier
 returns `revise_prior` even if the same factor also lacks a runtime mapping.
+When a runtime candidate replay artifact is present, the hosted workflow keeps
+the full `candidate-strategy-replay.json` in the uploaded artifact bundle so
+the classifier can inspect runtime diagnostics, not only promotion blockers.
+If the score has many direct threshold passes but runtime entry signals still
+collapse at executable edge, min-edge, side, or depth gates, the classifier
+returns `revise_prior` with a runtime pass-through typed-prior draft. That
+prevents the next search from repeating factors that look strong in aggregate
+top-bucket diagnostics but cannot survive the executable runtime decision path.
 
 This is the current closed-loop boundary: a failed or stagnant search now
 produces a machine-readable next action and, when appropriate, a bounded typed

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -85,6 +85,15 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
     if chain is None:
         chain = optional_json(root.parent / "alpha-search-chain" / "chain-decision.json")
     chain = chain or {}
+    candidate_strategy_replay = optional_json(
+        path / "candidate-strategy-replay" / "candidate-strategy-replay.json"
+    )
+    if candidate_strategy_replay is None:
+        candidate_strategy_replay = optional_json(
+            root.parent / "candidate-strategy-replay" / "candidate-strategy-replay.json"
+        )
+    if candidate_strategy_replay is None:
+        candidate_strategy_replay = optional_json(root / "candidate-strategy-replay.json")
     return {
         "artifact_dir": str(path),
         "root": root,
@@ -97,6 +106,7 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
         "promotion": optional_json(root / "autofactor-strategy-promotion.json") or {},
         "chain": chain,
         "search_space": optional_json(alpha_root / "search-space.json") or {},
+        "candidate_strategy_replay": candidate_strategy_replay or {},
     }
 
 
@@ -225,6 +235,123 @@ def classify_blockers(blockers: list[str]) -> str | None:
     return None
 
 
+def runtime_replay_payload(run: dict[str, Any]) -> dict[str, Any]:
+    replay = run.get("candidate_strategy_replay")
+    if isinstance(replay, dict) and replay:
+        return replay
+    promotion = run.get("promotion")
+    if isinstance(promotion, dict):
+        replay = promotion.get("candidate_strategy_replay")
+        if isinstance(replay, dict):
+            return replay
+    handoff = run.get("handoff")
+    if isinstance(handoff, dict):
+        replay = handoff.get("candidate_strategy_replay")
+        if isinstance(replay, dict):
+            return replay
+    return {}
+
+
+def runtime_score_base_factor(runtime_score: str) -> str:
+    prefix = "autofactor_formula:"
+    if runtime_score.startswith(prefix):
+        return runtime_score[len(prefix) :]
+    return runtime_score
+
+
+def configured_direct_passes(counterfactual: dict[str, Any]) -> int | None:
+    threshold = str(counterfactual.get("configured_entry_threshold") or "")
+    counts = counterfactual.get("direct_pass_counts")
+    if not threshold or not isinstance(counts, dict):
+        return None
+    value = counts.get(threshold)
+    if value is None:
+        try:
+            value = counts.get(f"{float(threshold):.2f}")
+        except ValueError:
+            value = None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def runtime_pass_through_feedback(run: dict[str, Any]) -> dict[str, Any]:
+    replay = runtime_replay_payload(run)
+    if not replay:
+        return {}
+    metrics = replay.get("metrics") if isinstance(replay.get("metrics"), dict) else {}
+    diagnostics = (
+        replay.get("strategy_diagnostics")
+        if isinstance(replay.get("strategy_diagnostics"), dict)
+        else {}
+    )
+    counterfactual = (
+        replay.get("score_counterfactual")
+        if isinstance(replay.get("score_counterfactual"), dict)
+        else {}
+    )
+    runtime_score = str(replay.get("runtime_score") or "").strip()
+    formula_evaluations = int(
+        as_float(diagnostics.get("settlement_autofactor_formula_evaluations"))
+        or as_float(counterfactual.get("formula_evaluations"))
+        or 0
+    )
+    depth_fillable = int(
+        as_float(diagnostics.get("settlement_autofactor_depth_fillable"))
+        or as_float(counterfactual.get("depth_fillable"))
+        or 0
+    )
+    executable_edge_pass = int(
+        as_float(diagnostics.get("settlement_autofactor_executable_edge_pass_min_edge"))
+        or 0
+    )
+    entry_signals = int(
+        as_float(diagnostics.get("entry_signals"))
+        or as_float(metrics.get("trade_count"))
+        or 0
+    )
+    direct_passes = configured_direct_passes(counterfactual)
+    if direct_passes is None:
+        direct_passes = int(
+            as_float(diagnostics.get("settlement_autofactor_predictive_score_ge_025"))
+            or 0
+        )
+
+    blockers: list[str] = []
+    if direct_passes >= 50 and entry_signals < 50:
+        blockers.append(
+            f"runtime_entry_pass_through_too_low:{entry_signals}/{direct_passes}<50"
+        )
+    if formula_evaluations >= 500 and executable_edge_pass < 50:
+        blockers.append(
+            "runtime_executable_edge_pass_min_edge_too_low:"
+            f"{executable_edge_pass}/{formula_evaluations}<50"
+        )
+    if depth_fillable >= 500 and entry_signals < 50:
+        blockers.append(
+            f"runtime_depth_fillable_to_entry_signal_collapse:{entry_signals}/{depth_fillable}<50"
+        )
+    if not blockers:
+        return {}
+    return {
+        "reason": "runtime_pass_through_collapse",
+        "runtime_score": runtime_score,
+        "base_factor": runtime_score_base_factor(runtime_score),
+        "metrics": {
+            "entry_signals": entry_signals,
+            "direct_passes_at_configured_threshold": direct_passes,
+            "formula_evaluations": formula_evaluations,
+            "depth_fillable": depth_fillable,
+            "executable_edge_pass_min_edge": executable_edge_pass,
+            "skip_entry_score": diagnostics.get("skip_entry_score"),
+            "skip_edge_score": diagnostics.get("skip_edge_score"),
+            "skip_settlement_side_score": diagnostics.get("skip_settlement_side_score"),
+        },
+        "blockers": blockers,
+    }
+
+
 def latest_run(runs: list[dict[str, Any]]) -> dict[str, Any]:
     return runs[-1]
 
@@ -248,7 +375,11 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     plan = current["plan"]
     target_blockers = target_blocker_strings(current["promotion"], current["target"])
     handoff_blockers = blocker_strings(handoff)
-    blockers = target_blockers or handoff_blockers
+    runtime_feedback = runtime_pass_through_feedback(current)
+    runtime_blockers = runtime_feedback.get("blockers") if runtime_feedback else []
+    blockers = list(target_blockers or handoff_blockers)
+    if isinstance(runtime_blockers, list):
+        blockers.extend(str(item) for item in runtime_blockers)
     blocker_action = classify_blockers(blockers)
 
     candidate_count = int(feedback.get("candidate_count") or 0)
@@ -265,6 +396,9 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     if handoff.get("status") == "ready":
         action = "ready_handoff"
         reason = "autofactor_strategy_handoff_ready"
+    elif runtime_feedback:
+        action = "revise_prior"
+        reason = str(runtime_feedback.get("reason") or "runtime_pass_through_collapse")
     elif blocker_action in {"fix_runtime", "fix_data", "fix_workflow", "revise_prior"}:
         action = blocker_action
         reason = f"promotion_blockers_require_{blocker_action}"
@@ -338,6 +472,7 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "next_steps": next_steps(action),
         "prior_revision_required": action == "revise_prior",
         "runtime_replay_request": runtime_request,
+        "runtime_pass_through_feedback": runtime_feedback,
     }
 
 
@@ -526,7 +661,29 @@ def mutation_from_node(node: dict[str, Any]) -> str:
 def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int) -> dict[str, Any]:
     current = latest_run(runs)
     mutations = []
+    runtime_feedback = decision.get("runtime_pass_through_feedback")
+    if isinstance(runtime_feedback, dict) and runtime_feedback:
+        base_factor = str(runtime_feedback.get("base_factor") or "")
+        if base_factor:
+            for mutation_type in ("add_spread_penalty", "add_capacity_gate"):
+                if len(mutations) >= limit:
+                    break
+                item: dict[str, Any] = {
+                    "base_factor": base_factor,
+                    "mutation_type": mutation_type,
+                    "name": f"llm_{base_factor}_runtime_pass_through_{mutation_type}",
+                    "feedback_reason": runtime_feedback.get("reason"),
+                    "runtime_metrics": runtime_feedback.get("metrics"),
+                }
+                feature = choose_feature(current["search_space"], mutation_type)
+                if feature:
+                    item["feature"] = feature
+                if mutation_type == "add_spread_penalty":
+                    item["constant"] = 0.01
+                mutations.append(item)
     for node in selected_nodes(current["plan"])[:limit]:
+        if len(mutations) >= limit:
+            break
         base_factor = str(node.get("factor_name") or "")
         if not base_factor:
             continue

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17757,3 +17757,45 @@ Evidence stage: `runtime_parity / diagnostic`.
   Direct and reverse-direction pass counts were `0` at `0.05`, `0.10`,
   `0.15`, and `0.25`, so the current candidate should be revised/rejected
   rather than promoted or rescued with a simple threshold cut.
+
+# Runtime Pass-Through Closed-Loop Feedback (2026-05-20)
+
+## Goal
+
+Feed runtime candidate replay diagnostics back into the alpha-search closed-loop
+prior so the next search penalizes candidates that look good in top-bucket
+research diagnostics but collapse before executable runtime entry.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml`
+  - Owner: preserve the full runtime candidate replay artifact in the hosted
+    walk-forward upload bundle.
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: classify runtime pass-through collapse as `revise_prior` and emit a
+    typed prior draft from runtime diagnostics.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: regression coverage for replay-diagnostic feedback.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document the closed-loop boundary.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Create a clean worktree from current `origin/main`.
+- [x] Preserve `candidate-strategy-replay.json` in hosted walk-forward artifacts.
+- [x] Teach the closed-loop agent to detect runtime entry pass-through collapse.
+- [x] Generate runtime-diagnostic typed-prior mutations before generic MCTS
+      selected-node mutations.
+- [x] Run focused Python/workflow validation.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  and `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -25,6 +25,7 @@ def artifact(
     selected_nodes: list[dict] | None = None,
     feedback: dict | None = None,
     promotion: dict | None = None,
+    candidate_strategy_replay: dict | None = None,
     write_feedback: bool = True,
 ) -> Path:
     target = "full_depth_settlement_executable_pnl"
@@ -91,6 +92,11 @@ def artifact(
             "should_dispatch": should_dispatch,
         },
     )
+    if candidate_strategy_replay is not None:
+        write_json(
+            root / "candidate-strategy-replay" / "candidate-strategy-replay.json",
+            candidate_strategy_replay,
+        )
     return root
 
 
@@ -576,6 +582,83 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 "mut_spread_adjusted_external_move_spread_adjusted",
             )
             self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
+
+    def test_runtime_pass_through_collapse_generates_targeted_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_squashed"
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                candidate_strategy_replay={
+                    "basis": "runtime_market_update_replay",
+                    "promotion_ready": False,
+                    "runtime_score": runtime_score,
+                    "metrics": {
+                        "trade_count": 2,
+                        "unique_event_count": 2,
+                        "roi": -0.22916199066660334,
+                    },
+                    "score_counterfactual": {
+                        "configured_entry_threshold": "0.25",
+                        "depth_fillable": 2918,
+                        "direct_pass_counts": {
+                            "0.05": 1188,
+                            "0.10": 1059,
+                            "0.15": 936,
+                            "0.25": 744,
+                        },
+                        "formula_evaluations": 2918,
+                    },
+                    "strategy_diagnostics": {
+                        "entry_signals": 2,
+                        "settlement_autofactor_depth_fillable": 2918,
+                        "settlement_autofactor_executable_edge_pass_min_edge": 5,
+                        "settlement_autofactor_formula_evaluations": 2918,
+                        "skip_edge_score": 742,
+                        "skip_entry_score": 2174,
+                        "skip_settlement_side_score": 2017,
+                    },
+                },
+                promotion={
+                    "decision": "blocked",
+                    "candidate_strategy_replay": {
+                        "basis": "runtime_market_update_replay",
+                        "ready": False,
+                        "runtime_score": runtime_score,
+                        "metrics": {"trade_count": 2, "roi": -0.22916199066660334},
+                        "blockers": [
+                            "trade_count_too_small:2<50",
+                            "roi_too_low:-0.229162<0.000000",
+                        ],
+                    },
+                    "evaluated_factors": [],
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(decision["reason"], "runtime_pass_through_collapse")
+            self.assertIn(
+                "runtime_entry_pass_through_too_low:2/744<50",
+                decision["promotion_blockers"],
+            )
+            self.assertEqual(
+                decision["runtime_pass_through_feedback"]["metrics"][
+                    "executable_edge_pass_min_edge"
+                ],
+                5,
+            )
+            self.assertEqual(
+                prior["mutations"][0]["base_factor"],
+                "mut_spread_adjusted_external_move_squashed",
+            )
+            self.assertEqual(prior["mutations"][0]["mutation_type"], "add_spread_penalty")
+            self.assertEqual(prior["mutations"][0]["feature"], "side_spread")
+            self.assertEqual(prior["mutations"][1]["mutation_type"], "add_capacity_gate")
 
     def test_cli_markdown_includes_runtime_replay_request(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- preserve the full `candidate-strategy-replay.json` in hosted factor walk-forward uploads
- teach `alpha_search_closed_loop_agent.py` to detect runtime entry pass-through collapse from replay diagnostics
- generate typed prior mutations against the replayed runtime score before generic MCTS selected-node mutations

## Context

Fresh runtime replay for `autofactor_formula:mut_spread_adjusted_external_move_squashed` produced many direct score threshold passes, but only 2 runtime entries. The blocker is now the runtime executable decision path, especially min-edge / side / depth pass-through, not a missing score.

## Safety

Research workflow only. This does not deploy, mutate runtime config, or enable live trading.

## Tested

- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`
- `rtk git diff --check`
