### PR TITLE
Prefer best candidate for runtime replay request

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -542,12 +542,16 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
     if not candidates:
         return None
 
-    def score(item: dict[str, Any]) -> tuple[float, float, float, float]:
+    best_candidate_name = str((run.get("feedback") or {}).get("best_candidate") or "")
+
+    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float]:
         factor = item.get("factor") if isinstance(item.get("factor"), dict) else {}
         return (
+            1.0 if best_candidate_name and factor.get("name") == best_candidate_name else 0.0,
             1.0
             if factor.get("decision") == "candidate" and factor.get("reason") == "passed"
             else 0.0,
+            as_float(factor.get("top_bucket_avg_label")) or 0.0,
             as_float(factor.get("positive_window_ratio")) or 0.0,
             as_float(factor.get("symbol_positive_ratio")) or 0.0,
             as_float(factor.get("spearman_ic")) or 0.0,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17799,3 +17799,38 @@ Evidence stage: `walk_forward / runtime_parity`.
   `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
   `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
   and `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`.
+
+# Runtime Replay Request Candidate Selection (2026-05-20)
+
+## Goal
+
+Make closed-loop runtime replay requests target the current run's best
+runtime-mappable candidate instead of falling back to a lower-priority candidate
+with stronger generic IC-style tie-breakers.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: runtime replay request candidate ranking.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: regression coverage for best-candidate preference.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Prefer `search-feedback.best_candidate` when selecting a runtime replay
+      request.
+- [x] Add a regression test where the best candidate has lower Spearman IC than
+      another candidate.
+- [x] Run focused validation.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+## Review
+
+- 2026-05-20: Validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  and `rtk git diff --check`.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -583,6 +583,84 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
 
+    def test_fix_runtime_request_prefers_feedback_best_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            best_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_near_strike"
+            higher_ic_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_squashed"
+            path = artifact(
+                Path(tmp),
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 20,
+                    "rejected_count": 5,
+                    "passed_count": 2,
+                    "best_candidate": "mut_spread_adjusted_external_move_near_strike",
+                    "best_reward": 6.75,
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                            ],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_squashed",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.40,
+                                "top_bucket_avg_label": 2.88,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": higher_ic_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                            ],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_near_strike",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.20,
+                                "top_bucket_avg_label": 3.01,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": best_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": higher_ic_runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            request = decision["runtime_replay_request"]
+
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(
+                request["source_factor"],
+                "mut_spread_adjusted_external_move_near_strike",
+            )
+            self.assertEqual(request["inputs"]["runtime_score"], best_runtime_score)
+
     def test_runtime_pass_through_collapse_generates_targeted_prior(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_squashed"


### PR DESCRIPTION
## Summary

- prefer `search-feedback.best_candidate` when choosing the runtime replay request candidate
- keep existing candidate ranking as fallback when the current best candidate is not runtime-mappable
- add regression coverage for a best candidate with lower Spearman IC than another candidate

## Context

Run `26137083406` used the new runtime pass-through prior and selected `mut_spread_adjusted_external_move_near_strike` as the current best candidate, but the closed-loop replay request still chose `mut_spread_adjusted_external_move_squashed`. This would repeat the stale replay path instead of testing the latest search output.

## Safety

Research workflow only. This does not deploy, mutate runtime config, or enable live trading.

## Tested

- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `rtk git diff --check`
