### PR TITLE
Fix runtime avoid factor family matching

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -1074,6 +1074,10 @@ fn normalized_factor_family(raw: &str) -> String {
     let suffixes = [
         "_runtime_pass_through_add_spread_penalty",
         "_runtime_pass_through_add_capacity_gate",
+        "_add_spread_penalty",
+        "_add_capacity_gate",
+        "_add_feature_gate",
+        "_entry_price_quality",
         "_full_depth_entry_gate",
         "_spread_adjusted",
         "_near_strike",
@@ -1464,13 +1468,14 @@ mod tests {
 
     #[test]
     fn typed_prior_runtime_avoid_list_filters_failed_family_variants() {
-        let mut squashed = sample_report("mut_spread_adjusted_external_move_squashed");
+        let mut squashed =
+            sample_report("llm_mut_spread_adjusted_external_move_squashed_add_capacity_gate");
         squashed.spearman_ic = 0.95;
         squashed.icir = 3.0;
         squashed.top_bucket_avg_label = 3.0;
 
         let mut spread_adjusted =
-            sample_report("mcts_spread_adjusted_external_move_spread_adjusted");
+            sample_report("mcts_spread_adjusted_external_move_spread_adjusted_entry_price_quality");
         spread_adjusted.spearman_ic = 0.90;
         spread_adjusted.icir = 2.5;
         spread_adjusted.top_bucket_avg_label = 2.5;

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -281,6 +281,10 @@ def factor_family(raw: str) -> str:
     suffixes = (
         "_runtime_pass_through_add_spread_penalty",
         "_runtime_pass_through_add_capacity_gate",
+        "_add_spread_penalty",
+        "_add_capacity_gate",
+        "_add_feature_gate",
+        "_entry_price_quality",
         "_full_depth_entry_gate",
         "_spread_adjusted",
         "_near_strike",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -41,6 +41,14 @@ Evidence stage: `walk_forward / runtime_parity`.
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-feedback-avoidlist-example /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2`,
   and `rtk git diff --check`. The cargo check completed with existing warnings
   in strategy modules, but no errors.
+- 2026-05-20: Hosted validation run `26144939837` showed the avoid-list was
+  emitted but LLM/MCTS suffixes such as `_add_capacity_gate` and
+  `_entry_price_quality` still escaped family matching. Tightened runtime
+  family normalization and added focused regressions. Validation passed:
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
+  `CARGO_TARGET_DIR=/tmp/ploy-runtime-avoid-family-suffix /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib`,
+  and `rtk git diff --check`.
 
 # Research Snapshot Empty Timestamp SSH Fix (2026-05-20)
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -741,6 +741,12 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 prior["runtime_avoid_factors"][0]["factor_family"],
                 "spread_adjusted_external_move",
             )
+            self.assertEqual(
+                agent.factor_family(
+                    "llm_mut_spread_adjusted_external_move_squashed_add_capacity_gate"
+                ),
+                "spread_adjusted_external_move",
+            )
 
     def test_runtime_avoid_factors_accumulate_from_search_feedback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- strip LLM/MCTS suffixes such as `_add_capacity_gate` and `_entry_price_quality` when deriving runtime avoid factor families
- add regressions for the exact escaped names observed in hosted run `26144939837`
- keep the closed-loop avoid-list semantics unchanged; this only fixes matching breadth

## Evidence stage
`walk_forward / runtime_parity`

## Validation
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `CARGO_TARGET_DIR=/tmp/ploy-runtime-avoid-family-suffix /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib`
- `rtk git diff --check`