### PR TITLE
Fix runtime replay request avoidlist

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -566,6 +566,7 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
     required_profile = str(
         promotion.get("required_strategy_profile") or "settlement_probability"
     )
+    avoided_families = runtime_avoid_families(run)
     candidates: list[dict[str, Any]] = []
     for item in evaluated:
         if not isinstance(item, dict):
@@ -577,6 +578,9 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
         if factor.get("target") not in {None, target}:
             continue
         if factor.get("decision") != "candidate" or factor.get("reason") != "passed":
+            continue
+        factor_name = str(factor.get("name") or "")
+        if factor_family(factor_name) in avoided_families:
             continue
         if runtime_mapping.get("strategy_profile") != required_profile:
             continue
@@ -631,6 +635,23 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
             "skip_settlement_exits": "false",
         },
     }
+
+
+def runtime_avoid_families(run: dict[str, Any]) -> set[str]:
+    feedback = run.get("feedback") if isinstance(run, dict) else {}
+    raw_items = feedback.get("runtime_avoid_factors") if isinstance(feedback, dict) else None
+    if not isinstance(raw_items, list):
+        return set()
+    families: set[str] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        family = str(item.get("factor_family") or "").strip()
+        if not family:
+            family = factor_family(str(item.get("base_factor") or ""))
+        if family:
+            families.add(family)
+    return families
 
 
 def summarize_run(run: dict[str, Any]) -> dict[str, Any]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -49,6 +49,14 @@ Evidence stage: `walk_forward / runtime_parity`.
   `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-avoid-family-suffix /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib`,
   and `rtk git diff --check`.
+- 2026-05-20: Hosted validation run `26145597100` showed search selection
+  avoided failed runtime families, but the closed-loop runtime replay request
+  still selected an avoided promotion candidate from `evaluated_factors`.
+  Runtime replay request selection now skips `runtime_avoid_factors` families.
+  Validation passed:
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`, and
+  `rtk git diff --check`.
 
 # Research Snapshot Empty Timestamp SSH Fix (2026-05-20)
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -661,6 +661,81 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(request["inputs"]["runtime_score"], best_runtime_score)
 
+    def test_fix_runtime_request_skips_runtime_avoid_families(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            avoided_runtime_score = (
+                "autofactor_formula:mut_spread_adjusted_external_move_spread_adjusted"
+            )
+            next_runtime_score = "autofactor_formula:mut_poly_lag_pressure_spread_adjusted"
+            path = artifact(
+                Path(tmp),
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 20,
+                    "rejected_count": 5,
+                    "passed_count": 2,
+                    "best_candidate": "mut_poly_lag_pressure_spread_adjusted",
+                    "best_reward": 4.12,
+                    "runtime_avoid_factors": [
+                        {
+                            "base_factor": "mut_spread_adjusted_external_move_near_strike",
+                            "factor_family": "spread_adjusted_external_move",
+                            "runtime_score": "autofactor_formula:mut_spread_adjusted_external_move_near_strike",
+                            "reason": "runtime_pass_through_collapse",
+                        }
+                    ],
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": ["requires_runtime_replay_not_top_bucket_aggregate"],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.50,
+                                "top_bucket_avg_label": 3.0,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": avoided_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                        {
+                            "blockers": ["requires_runtime_replay_not_top_bucket_aggregate"],
+                            "factor": {
+                                "name": "mut_poly_lag_pressure_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "positive_window_ratio": 0.8,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.10,
+                                "top_bucket_avg_label": 1.0,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": next_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        },
+                    ],
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+            request = decision["runtime_replay_request"]
+
+            self.assertEqual(decision["decision"], "fix_runtime")
+            self.assertEqual(request["source_factor"], "mut_poly_lag_pressure_spread_adjusted")
+            self.assertEqual(request["inputs"]["runtime_score"], next_runtime_score)
+
     def test_runtime_pass_through_collapse_generates_targeted_prior(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_squashed"


### PR DESCRIPTION
## Summary
- make closed-loop runtime replay request selection skip factor families listed in `search-feedback.runtime_avoid_factors`
- add a regression for the hosted-run failure mode where search selected a new family but replay request fell back to an avoided promotion candidate
- keep the search and promotion evidence stages unchanged; this only prevents replaying known runtime-collapsed families

## Evidence stage
`walk_forward / runtime_parity`

## Validation
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `rtk git diff --check`