### PR TITLE
Fix runtime replay fallback avoidlist

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -525,6 +525,7 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
     candidate = runtime_replay_candidate(run)
     if candidate is not None:
         return candidate
+    avoided_families = runtime_avoid_families(run)
     for source in (run.get("promotion"), run.get("handoff")):
         if not isinstance(source, dict):
             continue
@@ -534,6 +535,8 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
         runtime_score = str(replay.get("runtime_score") or "").strip()
         strategy_profile = str(replay.get("strategy_profile") or "settlement_probability").strip()
         if not runtime_score:
+            continue
+        if factor_family(runtime_score_base_factor(runtime_score)) in avoided_families:
             continue
         return {
             "workflow": "runtime-candidate-replay.yml",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -57,6 +57,14 @@ Evidence stage: `walk_forward / runtime_parity`.
   `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
   `python3 -m unittest tests.test_alpha_search_closed_loop_agent`, and
   `rtk git diff --check`.
+- 2026-05-20: Hosted validation run `26146003613` showed the direct
+  `evaluated_factors` request path was fixed, but the fallback
+  `candidate_strategy_replay.runtime_score` path could still point to an
+  avoided family. The fallback now skips avoided runtime families as well.
+  Validation passed:
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`, and
+  `rtk git diff --check`.
 
 # Research Snapshot Empty Timestamp SSH Fix (2026-05-20)
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -736,6 +736,46 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(request["source_factor"], "mut_poly_lag_pressure_spread_adjusted")
             self.assertEqual(request["inputs"]["runtime_score"], next_runtime_score)
 
+    def test_fix_runtime_fallback_request_skips_runtime_avoid_families(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            avoided_runtime_score = (
+                "autofactor_formula:mut_spread_adjusted_external_move_spread_adjusted"
+            )
+            path = artifact(
+                Path(tmp),
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 20,
+                    "rejected_count": 5,
+                    "passed_count": 2,
+                    "best_candidate": "mut_poly_lag_pressure_spread_adjusted",
+                    "best_reward": 4.12,
+                    "runtime_avoid_factors": [
+                        {
+                            "base_factor": "mut_spread_adjusted_external_move_near_strike",
+                            "factor_family": "spread_adjusted_external_move",
+                            "runtime_score": "autofactor_formula:mut_spread_adjusted_external_move_near_strike",
+                            "reason": "runtime_pass_through_collapse",
+                        }
+                    ],
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [],
+                    "candidate_strategy_replay": {
+                        "runtime_score": avoided_runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+
+            self.assertIsNone(decision["runtime_replay_request"])
+
     def test_runtime_pass_through_collapse_generates_targeted_prior(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_squashed"


### PR DESCRIPTION
## Summary
- make fallback `candidate_strategy_replay.runtime_score` requests skip avoided runtime families
- add a regression for the hosted-run failure mode where no direct non-avoided candidate request exists but the fallback points to an avoided score

## Evidence stage
`walk_forward / runtime_parity`

## Validation
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `rtk git diff --check`