### PR TITLE
Fix poly lag AutoFactor runtime mapping

### DIFF
--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -833,7 +833,9 @@ venue = "sportsbook"
                 || runtime_score
                     == "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate"
                 || runtime_score
-                    == "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate",
+                    == "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate"
+                || runtime_score
+                    == "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
             "settlement probability dry-run config should use a supported settlement AutoFactor formula, got {runtime_score}"
         );
         let raw = auto_settlement_formula_score(
@@ -848,6 +850,7 @@ venue = "sportsbook"
                 entry_capacity_ratio: 3.0,
                 side_spread: 0.03,
                 external_pressure: 1.0,
+                pm_lag_secs: 6.0,
                 iv_change_1m: 1.0,
             },
         )

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -566,6 +566,7 @@ fn autofactor_formula_entry_score(
     let base_formula_name = normalized_autofactor_formula_name(formula_name);
     let (threshold, scale) = if base_formula_name
         .starts_with("amplitude_weighted_momentum_30s_sigma")
+        || base_formula_name.starts_with("poly_lag_pressure")
         || base_formula_name.starts_with("spread_adjusted_external_move")
     {
         (0.0, 0.02)
@@ -607,6 +608,7 @@ fn is_predictive_settlement_autofactor_runtime_score(runtime_score: &str) -> boo
 
 fn is_predictive_settlement_autofactor_name(name: &str) -> bool {
     name.starts_with("amplitude_weighted_momentum_30s_sigma")
+        || name.starts_with("poly_lag_pressure")
         || (name.starts_with("spread_adjusted_external_move")
             && name != "spread_adjusted_external_move")
 }
@@ -1947,6 +1949,7 @@ impl ThreeLayerStrategy {
                         entry_capacity_ratio,
                         side_spread,
                         external_pressure: confirmation_score,
+                        pm_lag_secs: quote_age.max(0) as f64,
                         iv_change_1m: 0.0,
                     };
                     let Some((raw, normalized)) =
@@ -4536,6 +4539,7 @@ mod tests {
             entry_capacity_ratio: 3.0,
             side_spread: 0.03,
             external_pressure: 0.0,
+            pm_lag_secs: 0.0,
             iv_change_1m: 0.0,
         };
         let (raw, score) = autofactor_formula_entry_score(
@@ -5023,6 +5027,9 @@ mod tests {
             "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
         ));
         assert!(is_settlement_autofactor_runtime_score(
+            "autofactor_formula:mut_poly_lag_pressure_spread_adjusted"
+        ));
+        assert!(is_settlement_autofactor_runtime_score(
             "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate"
         ));
         assert!(!is_settlement_autofactor_runtime_score(
@@ -5105,6 +5112,7 @@ mod tests {
             entry_capacity_ratio: 3.0,
             side_spread: 0.03,
             external_pressure: 0.0,
+            pm_lag_secs: 0.0,
             iv_change_1m: 0.0,
         };
         let far_inputs = AutoSettlementFactorInputs {
@@ -5146,6 +5154,7 @@ mod tests {
             entry_capacity_ratio: 3.0,
             side_spread: 0.03,
             external_pressure: 0.0,
+            pm_lag_secs: 0.0,
             iv_change_1m: 0.0,
         };
         let low_ticket_inputs = AutoSettlementFactorInputs {
@@ -5187,6 +5196,7 @@ mod tests {
             entry_capacity_ratio: 3.0,
             side_spread: 0.03,
             external_pressure: 0.0,
+            pm_lag_secs: 0.0,
             iv_change_1m: 0.0,
         };
         let opposed = AutoSettlementFactorInputs {
@@ -5214,6 +5224,43 @@ mod tests {
     }
 
     #[test]
+    fn predictive_poly_lag_pressure_formula_uses_quote_age_pressure_and_drift() {
+        let config = test_config();
+        let inputs = AutoSettlementFactorInputs {
+            settlement_edge: -0.01,
+            entry_price: 0.48,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            drift_30s: 0.006,
+            sigma_horizon: 4.0,
+            entry_capacity_ratio: 3.0,
+            side_spread: 0.03,
+            external_pressure: 0.80,
+            pm_lag_secs: 6.0,
+            iv_change_1m: 0.0,
+        };
+
+        let (raw, score) = autofactor_formula_entry_score(
+            "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+            inputs,
+            config.min_edge,
+        )
+        .expect("poly lag pressure predictive formula should score finite inputs");
+
+        assert!(raw > 0.0);
+        assert!(score > 0.0);
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+            AutoSettlementFactorInputs {
+                pm_lag_secs: f64::NAN,
+                ..inputs
+            },
+            config.min_edge,
+        )
+        .is_none());
+    }
+
+    #[test]
     fn predictive_autofactor_formula_supports_full_depth_entry_gate() {
         let config = test_config();
         let fillable = AutoSettlementFactorInputs {
@@ -5226,6 +5273,7 @@ mod tests {
             entry_capacity_ratio: 1.20,
             side_spread: 0.03,
             external_pressure: 0.0,
+            pm_lag_secs: 0.0,
             iv_change_1m: 0.0,
         };
         let unfillable = AutoSettlementFactorInputs {

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -60,6 +60,7 @@ pub struct AutoSettlementFactorInputs {
     pub entry_capacity_ratio: f64,
     pub side_spread: f64,
     pub external_pressure: f64,
+    pub pm_lag_secs: f64,
     pub iv_change_1m: f64,
 }
 
@@ -224,6 +225,8 @@ fn normalize_autofactor_formula_name(mut name: &str) -> &str {
 fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> Option<f64> {
     let base = if name.starts_with("amplitude_weighted_momentum_30s_sigma") {
         "amplitude_weighted_momentum_30s_sigma"
+    } else if name.starts_with("poly_lag_pressure") {
+        "poly_lag_pressure"
     } else if name.starts_with("spread_adjusted_external_move") {
         "spread_adjusted_external_move"
     } else {
@@ -239,6 +242,18 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
                 return None;
             }
             inputs.drift_30s * inputs.direction_sign * inputs.sigma_horizon.abs().ln_1p()
+        }
+        "poly_lag_pressure" => {
+            if !inputs.external_pressure.is_finite()
+                || !inputs.drift_30s.is_finite()
+                || !inputs.direction_sign.is_finite()
+                || !inputs.pm_lag_secs.is_finite()
+            {
+                return None;
+            }
+            inputs.external_pressure
+                * (inputs.drift_30s * inputs.direction_sign).abs().ln_1p()
+                * (inputs.pm_lag_secs.max(0.0) / 3.0).tanh()
         }
         "spread_adjusted_external_move" => spread_adjusted_external_move_score(
             inputs.drift_30s * inputs.direction_sign,

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -32,6 +32,7 @@ FORMULA_RUNTIME_MAPPED_NAMES = {
 
 PREDICTIVE_FORMULA_BASES = (
     "amplitude_weighted_momentum_30s_sigma",
+    "poly_lag_pressure",
     "spread_adjusted_external_move",
 )
 

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -152,6 +152,7 @@ BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
 
 PREDICTIVE_FORMULA_BASES = (
     "amplitude_weighted_momentum_30s_sigma",
+    "poly_lag_pressure",
     "spread_adjusted_external_move",
 )
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,50 @@
+# Poly Lag Pressure Runtime Mapping (2026-05-20)
+
+## Goal
+
+Let the next non-avoided AutoFactor candidate family
+`poly_lag_pressure*` either replay through the runtime settlement AutoFactor
+path or fail closed with an explicit unsupported-runtime boundary.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: candidate replay runtime mapping for `poly_lag_pressure*`.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: promotion/runtime mapping inference for `poly_lag_pressure*`.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs`
+  - Owner: pure runtime formula scoring for `poly_lag_pressure*`.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer.rs`
+  - Owner: settlement AutoFactor classification and runtime inputs.
+- Tests under `tests/` and Rust strategy tests
+  - Owner: mapping and runtime scorer regression coverage.
+
+## Tasks
+
+- [x] Create a clean branch from current `origin/main`.
+- [x] Add `poly_lag_pressure*` to runtime mapping inference.
+- [x] Add runtime formula scoring and settlement AutoFactor classification.
+- [x] Add focused tests.
+- [x] Run focused validation.
+- [ ] PR, CI, merge, and rerun hosted walk-forward validation.
+
+## Review
+
+- 2026-05-20: Added `poly_lag_pressure*` to AutoFactor candidate replay and
+  promotion runtime mapping, runtime settlement AutoFactor classification, and
+  the pure formula scorer. Runtime approximates the research DSL
+  `external_pressure * log1p(abs(external_move_since_poly_update)) *
+  tanh(poly_quote_age / 3.0)` with side-aligned `drift_30s` and PM quote age.
+  Validation passed:
+  `python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py`,
+  `python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion`,
+  `CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles poly_lag --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib`,
+  and
+  `CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`.
+
 # Runtime Feedback Avoid-List For Alpha Search (2026-05-20)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -106,6 +106,14 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 2,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,529,0.214428,0.141198,4,1.412625,1.0000,2,1.0000,1.0000,106,3.710549,0.6981,1.0000,23.70,1.40,106,1,5
 """
 
+AUTOFACTOR_POLY_LAG_PRESSURE_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_poly_lag_pressure_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.181235,0.107332,4,1.568090,1.0000,2,1.0000,0.7500,106,3.083066,0.6681,1.0000,18.51,1.42,106,1,8
+"""
+
 AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
@@ -403,6 +411,29 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "runtime_profile_mismatch:repricing_momentum!=settlement_probability",
             bare_spread["blockers"],
         )
+
+    def test_qualifies_poly_lag_pressure_predictive_formula_mutation(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+        }
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_POLY_LAG_PRESSURE_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(
+            handoff["strategies"][0]["runtime_score"],
+            "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+        )
+        self.assertEqual(
+            handoff["strategies"][0]["strategy_family"],
+            "predictive_settlement_probability",
+        )
+        self.assertIn("mut_poly_lag_pressure_spread_adjusted", handoff_md)
 
     def test_qualifies_tradeable_hard_gate_predictive_formula_when_gate_is_ready(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -133,6 +133,30 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
             "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
         )
 
+    def test_selects_poly_lag_pressure_predictive_formula_mutation(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=false
+gate,passed,evidence
+recorded_replay_parity,false,post-dry-run gate pending
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_poly_lag_pressure_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.181235,0.107332,4,1.568090,1.0000,2,1.0000,0.7500,106,3.083066,0.6681,1.0000,18.51,1.42,106,1,8
+"""
+        payload, _ = self.run_script(report)
+
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "mut_poly_lag_pressure_spread_adjusted",
+        )
+        self.assertEqual(payload["strategy_profile"], "settlement_probability")
+
     def test_keeps_bare_spread_adjusted_external_move_in_repricing_lane(self):
         payload, _ = self.run_script(
             AUTOFACTOR_REPORT,


### PR DESCRIPTION
## Summary
- map poly_lag_pressure* AutoFactor candidates to settlement runtime replay requests
- add runtime scorer/classification support using quote-age pressure, side-aligned drift, and external pressure
- cover candidate replay, promotion evaluator, runtime scorer, and config smoke paths

## Evidence stage
walk_forward / runtime_parity

## Validation
- python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion
- CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles poly_lag --lib
- CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib
- CARGO_TARGET_DIR=/tmp/ploy-poly-lag-runtime /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new settlement formula calculation variant with enhanced timing parameters

* **Tests**
  * Expanded test coverage for new formula behavior and evaluation scenarios
  * Added automated validation for settlement configuration and formula selection

* **Chores**
  * Updated development task documentation and progress tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->