### PR TITLE
Fix closed-loop prior for unmapped runtime candidates

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -397,6 +397,68 @@ def runtime_pass_through_feedback(run: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def runtime_mapping_gap_feedback(run: dict[str, Any]) -> dict[str, Any]:
+    promotion = run.get("promotion")
+    if not isinstance(promotion, dict):
+        return {}
+    evaluated = promotion.get("evaluated_factors")
+    if not isinstance(evaluated, list):
+        return {}
+    target = run.get("target") or DEFAULT_TARGET
+    feedback = run.get("feedback") if isinstance(run.get("feedback"), dict) else {}
+    best_candidate = str(feedback.get("best_candidate") or "")
+    plan_nodes = selected_nodes(run.get("plan") if isinstance(run.get("plan"), dict) else {})
+    top_selected = str(plan_nodes[0].get("factor_name") or "") if plan_nodes else ""
+
+    candidates: list[dict[str, Any]] = []
+    for item in evaluated:
+        if not isinstance(item, dict):
+            continue
+        factor = item.get("factor")
+        if not isinstance(factor, dict):
+            continue
+        if factor.get("target") not in {None, target}:
+            continue
+        if factor.get("decision") != "candidate" or factor.get("reason") != "passed":
+            continue
+        blockers = blocker_strings(item)
+        if "missing_runtime_strategy_mapping" not in blockers:
+            continue
+        name = str(factor.get("name") or "")
+        if not name:
+            continue
+        candidates.append({"item": item, "factor": factor, "blockers": blockers, "name": name})
+    if not candidates:
+        return {}
+
+    def score(candidate: dict[str, Any]) -> tuple[float, float, float, float]:
+        factor = candidate["factor"]
+        name = candidate["name"]
+        return (
+            1.0 if best_candidate and name == best_candidate else 0.0,
+            1.0 if top_selected and name == top_selected else 0.0,
+            as_float(factor.get("top_bucket_avg_label")) or 0.0,
+            as_float(factor.get("spearman_ic")) or 0.0,
+        )
+
+    selected = max(candidates, key=score)
+    factor = selected["factor"]
+    base_factor = selected["name"]
+    return {
+        "reason": "missing_runtime_strategy_mapping",
+        "base_factor": base_factor,
+        "factor_family": factor_family(base_factor),
+        "runtime_score": "",
+        "metrics": {
+            "top_bucket_avg_label": factor.get("top_bucket_avg_label"),
+            "positive_window_ratio": factor.get("positive_window_ratio"),
+            "symbol_positive_ratio": factor.get("symbol_positive_ratio"),
+            "spearman_ic": factor.get("spearman_ic"),
+        },
+        "blockers": selected["blockers"],
+    }
+
+
 def latest_run(runs: list[dict[str, Any]]) -> dict[str, Any]:
     return runs[-1]
 
@@ -422,9 +484,15 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     handoff_blockers = blocker_strings(handoff)
     runtime_feedback = runtime_pass_through_feedback(current)
     runtime_blockers = runtime_feedback.get("blockers") if runtime_feedback else []
+    runtime_unmapped_feedback = runtime_mapping_gap_feedback(current)
+    runtime_unmapped_blockers = (
+        runtime_unmapped_feedback.get("blockers") if runtime_unmapped_feedback else []
+    )
     blockers = list(target_blockers or handoff_blockers)
     if isinstance(runtime_blockers, list):
         blockers.extend(str(item) for item in runtime_blockers)
+    if isinstance(runtime_unmapped_blockers, list):
+        blockers.extend(str(item) for item in runtime_unmapped_blockers)
     blocker_action = classify_blockers(blockers)
 
     candidate_count = int(feedback.get("candidate_count") or 0)
@@ -444,6 +512,9 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     elif runtime_feedback:
         action = "revise_prior"
         reason = str(runtime_feedback.get("reason") or "runtime_pass_through_collapse")
+    elif runtime_unmapped_feedback:
+        action = "revise_prior"
+        reason = str(runtime_unmapped_feedback.get("reason") or "missing_runtime_strategy_mapping")
     elif blocker_action in {"fix_runtime", "fix_data", "fix_workflow", "revise_prior"}:
         action = blocker_action
         reason = f"promotion_blockers_require_{blocker_action}"
@@ -518,6 +589,7 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "prior_revision_required": action == "revise_prior",
         "runtime_replay_request": runtime_request,
         "runtime_pass_through_feedback": runtime_feedback,
+        "runtime_unmapped_feedback": runtime_unmapped_feedback,
     }
 
 
@@ -768,6 +840,21 @@ def collect_runtime_avoid_factors(
                 "runtime_score": runtime_feedback.get("runtime_score"),
                 "reason": runtime_feedback.get("reason") or "runtime_pass_through_collapse",
                 "metrics": runtime_feedback.get("metrics"),
+            }
+    runtime_unmapped_feedback = decision.get("runtime_unmapped_feedback")
+    if isinstance(runtime_unmapped_feedback, dict) and runtime_unmapped_feedback:
+        base_factor = str(runtime_unmapped_feedback.get("base_factor") or "").strip()
+        family = str(
+            runtime_unmapped_feedback.get("factor_family") or factor_family(base_factor)
+        ).strip()
+        if base_factor and family:
+            by_family[family] = {
+                "base_factor": base_factor,
+                "factor_family": family,
+                "runtime_score": runtime_unmapped_feedback.get("runtime_score") or "",
+                "reason": runtime_unmapped_feedback.get("reason")
+                or "missing_runtime_strategy_mapping",
+                "metrics": runtime_unmapped_feedback.get("metrics"),
             }
     return [by_family[key] for key in sorted(by_family)]
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,42 @@
+# Closed-Loop Unmapped Runtime Prior (2026-05-20)
+
+## Goal
+
+When the current best AutoFactor candidate has no runtime strategy mapping and
+there is no non-avoided runtime replay request to run, make the closed-loop
+produce a prior revision instead of an unactionable `fix_runtime` decision with
+`runtime_replay_request=null`.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: classify unmapped runtime candidates as prior-revision evidence.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: regression coverage for `fix_runtime` without a replay request.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Reproduce the workflow gap from run `26154725630`.
+- [x] Add unmapped-runtime feedback and avoid-list propagation.
+- [x] Add focused tests.
+- [x] Run focused validation.
+- [ ] PR, CI, merge, and rerun hosted validation.
+
+## Review
+
+- 2026-05-20: Fixed the closed-loop classifier so a best candidate with
+  `missing_runtime_strategy_mapping` and no actionable runtime replay request
+  becomes `revise_prior` instead of an empty `fix_runtime`. The typed prior now
+  carries the unmapped factor family as a runtime avoid item; validation passed:
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`, and a local
+  replay of run `26154725630`'s artifact showing `decision=revise_prior` with
+  `ofi_l5_depth_norm` in `runtime_avoid_factors`.
+
 # Poly Lag Pressure Runtime Mapping (2026-05-20)
 
 ## Goal

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -213,6 +213,70 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(decision["decision"], "fix_runtime")
 
+    def test_unmapped_best_candidate_revises_prior_with_runtime_avoid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                selected_nodes=[
+                    {
+                        "factor_name": "mcts_mcts_ofi_l5_depth_norm_spread_adjusted_capacity",
+                        "selected_dimension": "execution_quality",
+                        "proposed_mutation": "add_capacity_gate",
+                    }
+                ],
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 20,
+                    "rejected_count": 5,
+                    "passed_count": 2,
+                    "best_candidate": "mcts_mcts_ofi_l5_depth_norm_spread_adjusted_capacity",
+                    "best_reward": 5.71,
+                },
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "missing_runtime_strategy_mapping",
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                            ],
+                            "factor": {
+                                "name": "mcts_mcts_ofi_l5_depth_norm_spread_adjusted_capacity",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_avg_label": 5.40,
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.20,
+                            },
+                        }
+                    ],
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(decision["reason"], "missing_runtime_strategy_mapping")
+            self.assertIsNone(decision["runtime_replay_request"])
+            self.assertEqual(
+                decision["runtime_unmapped_feedback"]["base_factor"],
+                "mcts_mcts_ofi_l5_depth_norm_spread_adjusted_capacity",
+            )
+            self.assertEqual(
+                prior["runtime_avoid_factors"][0]["factor_family"],
+                "ofi_l5_depth_norm",
+            )
+            self.assertEqual(
+                prior["runtime_avoid_factors"][0]["reason"],
+                "missing_runtime_strategy_mapping",
+            )
+
     def test_execution_blockers_take_priority_over_runtime_mapping(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(


### PR DESCRIPTION
## Summary
- classify best candidates with missing runtime mapping and no replay request as prior revision
- carry unmapped factor families into runtime_avoid_factors so the next search does not stay stuck on unsupported factors
- add focused regression coverage for the empty fix_runtime request case

## Evidence stage
walk_forward / runtime_parity

## Validation
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- local replay of run 26154725630 artifact: decision=revise_prior and runtime_avoid_factors includes ofi_l5_depth_norm
- rtk git diff --check