### PR TITLE
Fix composed settlement AutoFactor runtime mapping

### DIFF
--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -5181,6 +5181,43 @@ mod tests {
     }
 
     #[test]
+    fn autofactor_composed_model_formula_supports_external_pressure_and_spread() {
+        let mut config = test_config();
+        config.profile = ThreeLayerProfile::SettlementProbability;
+        config.min_edge = 0.02;
+
+        let inputs = AutoSettlementFactorInputs {
+            settlement_edge: 0.06,
+            entry_price: 0.30,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            drift_30s: 0.0,
+            sigma_horizon: 0.0,
+            entry_capacity_ratio: 3.0,
+            side_spread: 0.03,
+            external_pressure: 0.50,
+            pm_lag_secs: 0.0,
+            iv_change_1m: 0.0,
+        };
+
+        let (raw, score) = autofactor_formula_entry_score(
+            "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+            inputs,
+            config.min_edge,
+        )
+        .expect("composed settlement model formula should score");
+
+        assert!((raw - 0.75).abs() < 1e-9);
+        assert!(score > 0.0);
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_near_strike_near_strike",
+            inputs,
+            config.min_edge,
+        )
+        .is_none());
+    }
+
+    #[test]
     fn predictive_autofactor_formula_uses_external_drift_before_pm_edge() {
         let mut config = test_config();
         config.profile = ThreeLayerProfile::SettlementProbability;

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -203,9 +203,84 @@ pub fn auto_settlement_formula_score(
             }
             score *= inputs.iv_change_1m;
         }
-        _ => return None,
+        _ => score = composed_settlement_formula_suffix_score(score, suffix, inputs)?,
     }
     score.is_finite().then_some(score)
+}
+
+fn composed_settlement_formula_suffix_score(
+    mut score: f64,
+    suffix: &str,
+    inputs: AutoSettlementFactorInputs,
+) -> Option<f64> {
+    let mut applied_effects: Vec<&'static str> = Vec::new();
+    for mutation in suffix.strip_prefix('_')?.split('_') {
+        let effect = match mutation {
+            "squashed" => Some("squashed"),
+            "strike" => Some("near_strike"),
+            "capacity" => Some("capacity"),
+            "gate" => Some("full_depth_entry_gate"),
+            "quality" => Some("entry_price_quality"),
+            "adjusted" => Some("spread_adjusted"),
+            "pressure" => Some("external_pressure"),
+            "change" => Some("iv_change"),
+            _ => None,
+        };
+        if let Some(effect) = effect {
+            if applied_effects.contains(&effect) {
+                return None;
+            }
+            applied_effects.push(effect);
+        }
+        match mutation {
+            "x" => continue,
+            "squashed" => score = score.tanh(),
+            "near" => continue,
+            "strike" => {
+                score *= auto_settlement_near_strike_score(
+                    inputs.distance_over_sigma,
+                    inputs.direction_sign,
+                );
+            }
+            "capacity" => {
+                score *= auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio)
+            }
+            "full" | "depth" | "entry" => continue,
+            "gate" => {
+                if !inputs.entry_capacity_ratio.is_finite() || inputs.entry_capacity_ratio < 1.0 {
+                    return None;
+                }
+            }
+            "price" => continue,
+            "quality" => score *= auto_settlement_entry_price_quality_score(inputs.entry_price),
+            "spread" => continue,
+            "adjusted" => {
+                if !inputs.side_spread.is_finite() || inputs.side_spread < 0.0 {
+                    return None;
+                }
+                score /= inputs.side_spread + 0.01;
+            }
+            "external" => continue,
+            "pressure" => {
+                if !inputs.external_pressure.is_finite() {
+                    return None;
+                }
+                score *= inputs.external_pressure;
+            }
+            "iv" => continue,
+            "change" => {
+                if !inputs.iv_change_1m.is_finite() {
+                    return None;
+                }
+                score *= inputs.iv_change_1m;
+            }
+            _ => return None,
+        }
+        if !score.is_finite() {
+            return None;
+        }
+    }
+    Some(score)
 }
 
 fn normalize_autofactor_formula_name(mut name: &str) -> &str {

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -36,6 +36,13 @@ PREDICTIVE_FORMULA_BASES = (
     "spread_adjusted_external_move",
 )
 
+SETTLEMENT_FORMULA_BASES = (
+    "auto_settlement_full_depth_settlement_edge",
+    "auto_settlement_conservative_settlement_edge",
+    "auto_settlement_model_full_depth_settlement_edge",
+    "auto_settlement_model_conservative_settlement_edge",
+)
+
 
 def parse_float(raw: str, default: float = float("nan")) -> float:
     try:
@@ -66,6 +73,51 @@ def is_settlement_predictive_formula(name: str) -> bool:
     if normalized == "spread_adjusted_external_move":
         return False
     return any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES)
+
+
+def is_settlement_formula(name: str) -> bool:
+    normalized = normalize_formula_name(name)
+    for base in SETTLEMENT_FORMULA_BASES:
+        if not normalized.startswith(base):
+            continue
+        return settlement_formula_suffix_supported(normalized[len(base) :])
+    return False
+
+
+def settlement_formula_suffix_supported(suffix: str) -> bool:
+    if not suffix:
+        return True
+    tokens = suffix.removeprefix("_").split("_")
+    applied: set[str] = set()
+    for token in tokens:
+        effect = {
+            "strike": "near_strike",
+            "capacity": "capacity",
+            "quality": "entry_price_quality",
+            "adjusted": "spread_adjusted",
+            "pressure": "external_pressure",
+            "change": "iv_change",
+            "gate": "full_depth_entry_gate",
+            "squashed": "squashed",
+        }.get(token)
+        if effect:
+            if effect in applied:
+                return False
+            applied.add(effect)
+            continue
+        if token not in {
+            "x",
+            "near",
+            "full",
+            "depth",
+            "entry",
+            "price",
+            "spread",
+            "external",
+            "iv",
+        }:
+            return False
+    return True
 
 
 def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
@@ -114,7 +166,7 @@ def runtime_mapping(name: str) -> dict[str, str]:
             ),
         }
     if (
-        name.startswith("auto_settlement_")
+        is_settlement_formula(name)
         or name in FORMULA_RUNTIME_MAPPED_NAMES
         or is_settlement_predictive_formula(name)
     ):

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -156,6 +156,13 @@ PREDICTIVE_FORMULA_BASES = (
     "spread_adjusted_external_move",
 )
 
+SETTLEMENT_FORMULA_BASES = (
+    "auto_settlement_full_depth_settlement_edge",
+    "auto_settlement_conservative_settlement_edge",
+    "auto_settlement_model_full_depth_settlement_edge",
+    "auto_settlement_model_conservative_settlement_edge",
+)
+
 for _base in (
     "auto_settlement_model_full_depth_settlement_edge",
     "auto_settlement_model_conservative_settlement_edge",
@@ -551,10 +558,60 @@ def normalize_formula_name(name: str) -> str:
             return name
 
 
+def settlement_formula_suffix_supported(suffix: str) -> bool:
+    if not suffix:
+        return True
+    tokens = suffix.removeprefix("_").split("_")
+    applied: set[str] = set()
+    for token in tokens:
+        effect = {
+            "strike": "near_strike",
+            "capacity": "capacity",
+            "quality": "entry_price_quality",
+            "adjusted": "spread_adjusted",
+            "pressure": "external_pressure",
+            "change": "iv_change",
+            "gate": "full_depth_entry_gate",
+            "squashed": "squashed",
+        }.get(token)
+        if effect:
+            if effect in applied:
+                return False
+            applied.add(effect)
+            continue
+        if token not in {
+            "x",
+            "near",
+            "full",
+            "depth",
+            "entry",
+            "price",
+            "spread",
+            "external",
+            "iv",
+        }:
+            return False
+    return True
+
+
+def is_settlement_formula(name: str) -> bool:
+    normalized = normalize_formula_name(name)
+    for base in SETTLEMENT_FORMULA_BASES:
+        if not normalized.startswith(base):
+            continue
+        return settlement_formula_suffix_supported(normalized[len(base) :])
+    return False
+
+
 def inferred_runtime_mapping(name: str) -> dict[str, str] | None:
     normalized = normalize_formula_name(name)
     if normalized == "spread_adjusted_external_move":
         return None
+    if is_settlement_formula(name):
+        return {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "runtime_score": f"autofactor_formula:{name}",
+        }
     if any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES):
         return {
             **SETTLEMENT_RUNTIME_MAPPING,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,46 @@
+# Composed Settlement AutoFactor Runtime Mapping (2026-05-20)
+
+## Goal
+
+Let runtime-supported composed settlement AutoFactor formula variants such as
+`mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted`
+produce explicit runtime replay requests instead of being blocked as missing
+runtime mappings.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `scripts/build_autofactor_candidate_strategy_replay.py`
+  - Owner: candidate replay mapping for composed settlement formulas.
+- `scripts/evaluate_autofactor_strategy_promotion.py`
+  - Owner: promotion mapping for composed settlement formulas.
+- `crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs`
+  - Owner: pure runtime scorer support for composed settlement suffixes.
+- Tests under `tests/` and Rust strategy tests
+  - Owner: mapping and scorer regression coverage.
+
+## Tasks
+
+- [x] Reproduce the gap from run `26155447345`.
+- [x] Add composed settlement formula mapping.
+- [x] Add runtime scorer support for composed suffixes.
+- [x] Add focused tests.
+- [x] Run focused validation.
+- [ ] PR, CI, merge, and rerun hosted validation.
+
+## Review
+
+- 2026-05-20: Added mapping and runtime scoring support for composed
+  settlement AutoFactor suffixes such as `_x_external_pressure_spread_adjusted`,
+  while keeping repeated effects such as `_x_near_strike_near_strike`
+  fail-closed. Validation passed:
+  `python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py`,
+  `python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion`,
+  `CARGO_TARGET_DIR=/tmp/ploy-composed-settlement /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_composed_model_formula --lib`,
+  and
+  `CARGO_TARGET_DIR=/tmp/ploy-composed-settlement /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib`.
+
 # Closed-Loop Unmapped Runtime Prior (2026-05-20)
 
 ## Goal

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -114,6 +114,14 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 1,mut_poly_lag_pressure_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.181235,0.107332,4,1.568090,1.0000,2,1.0000,0.7500,106,3.083066,0.6681,1.0000,18.51,1.42,106,1,8
 """
 
+AUTOFACTOR_COMPOSED_MODEL_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.181235,0.107332,4,1.568090,1.0000,2,1.0000,0.7500,106,3.083066,0.6681,1.0000,18.51,1.42,106,1,8
+"""
+
 AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT = """
 # AutoFactor target=tradeable_full_depth_settlement_pnl
 === AutoFactor Seed Candidate Report ===
@@ -434,6 +442,33 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "predictive_settlement_probability",
         )
         self.assertIn("mut_poly_lag_pressure_spread_adjusted", handoff_md)
+
+    def test_qualifies_composed_settlement_model_formula_mutation(self):
+        runtime_score = (
+            "autofactor_formula:"
+            "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
+        )
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": runtime_score,
+        }
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_COMPOSED_MODEL_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(handoff["strategies"][0]["runtime_score"], runtime_score)
+        self.assertEqual(
+            handoff["strategies"][0]["strategy_family"],
+            "settlement_probability",
+        )
+        self.assertIn(
+            "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+            handoff_md,
+        )
 
     def test_qualifies_tradeable_hard_gate_predictive_formula_when_gate_is_ready(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -157,6 +157,30 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
         )
         self.assertEqual(payload["strategy_profile"], "settlement_probability")
 
+    def test_selects_composed_settlement_model_formula_mutation(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=false
+gate,passed,evidence
+recorded_replay_parity,false,post-dry-run gate pending
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,529,0.181235,0.107332,4,1.568090,1.0000,2,1.0000,0.7500,106,3.083066,0.6681,1.0000,18.51,1.42,106,1,8
+"""
+        payload, _ = self.run_script(report)
+
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+        )
+        self.assertEqual(payload["strategy_profile"], "settlement_probability")
+
     def test_keeps_bare_spread_adjusted_external_move_in_repricing_lane(self):
         payload, _ = self.run_script(
             AUTOFACTOR_REPORT,


### PR DESCRIPTION
## Summary
- map composed settlement AutoFactor formula mutations to settlement runtime scores
- support composed settlement runtime suffixes such as external_pressure + spread_adjusted
- keep repeated effects fail-closed, e.g. near_strike_near_strike remains unsupported

## Evidence stage
walk_forward / runtime_parity

## Validation
- python3 -m py_compile scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion
- CARGO_TARGET_DIR=/tmp/ploy-composed-settlement /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_composed_model_formula --lib
- CARGO_TARGET_DIR=/tmp/ploy-composed-settlement /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles autofactor_formula --lib
- rtk git diff --check