### PR TITLE
Fix cumulative runtime avoid prior

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -663,6 +663,11 @@ jobs:
             cp "${candidate_strategy_replay_json}" \
               artifacts/factor-walk-forward-v2-upload/candidate-strategy-replay/candidate-strategy-replay.json
           fi
+          if [ -d artifacts/alpha-search-plan ]; then
+            mkdir -p artifacts/factor-walk-forward-v2-upload/alpha-search-chain/input-alpha-search-plan
+            cp -R artifacts/alpha-search-plan/. \
+              artifacts/factor-walk-forward-v2-upload/alpha-search-chain/input-alpha-search-plan/
+          fi
 
       - name: Prepare alpha search chain decision
         if: always()

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -107,6 +107,10 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
         "chain": chain,
         "search_space": optional_json(alpha_root / "search-space.json") or {},
         "candidate_strategy_replay": candidate_strategy_replay or {},
+        "input_prior": optional_json(
+            path / "alpha-search-chain" / "input-alpha-search-plan" / "next-llm-prior.json"
+        )
+        or {},
     }
 
 
@@ -807,27 +811,39 @@ def collect_runtime_avoid_factors(
     runs: list[dict[str, Any]], decision: dict[str, Any]
 ) -> list[dict[str, Any]]:
     by_family: dict[str, dict[str, Any]] = {}
+
+    def add_item(item: dict[str, Any]) -> None:
+        base_factor = str(item.get("base_factor") or "").strip()
+        family = str(item.get("factor_family") or factor_family(base_factor)).strip()
+        if not base_factor or not family:
+            return
+        payload = {
+            "base_factor": base_factor,
+            "factor_family": family,
+            "runtime_score": item.get("runtime_score") or "",
+            "reason": item.get("reason") or "runtime_pass_through_collapse",
+        }
+        if item.get("metrics") is not None:
+            payload["metrics"] = item.get("metrics")
+        by_family.setdefault(family, payload)
+
     for run in runs:
+        prior = run.get("input_prior") if isinstance(run, dict) else {}
+        prior_existing = (
+            prior.get("runtime_avoid_factors") if isinstance(prior, dict) else None
+        )
+        if isinstance(prior_existing, list):
+            for item in prior_existing:
+                if isinstance(item, dict):
+                    add_item(item)
+
         feedback = run.get("feedback") if isinstance(run, dict) else {}
         existing = feedback.get("runtime_avoid_factors") if isinstance(feedback, dict) else None
         if not isinstance(existing, list):
             continue
         for item in existing:
-            if not isinstance(item, dict):
-                continue
-            base_factor = str(item.get("base_factor") or "").strip()
-            family = str(item.get("factor_family") or factor_family(base_factor)).strip()
-            if not base_factor or not family:
-                continue
-            by_family.setdefault(
-                family,
-                {
-                    "base_factor": base_factor,
-                    "factor_family": family,
-                    "runtime_score": item.get("runtime_score"),
-                    "reason": item.get("reason") or "runtime_pass_through_collapse",
-                },
-            )
+            if isinstance(item, dict):
+                add_item(item)
 
     runtime_feedback = decision.get("runtime_pass_through_feedback")
     if isinstance(runtime_feedback, dict) and runtime_feedback:
@@ -863,6 +879,11 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
     current = latest_run(runs)
     mutations = []
     runtime_avoid_factors = collect_runtime_avoid_factors(runs, decision)
+    runtime_avoid_families = {
+        str(item.get("factor_family") or "").strip()
+        for item in runtime_avoid_factors
+        if isinstance(item, dict)
+    }
     runtime_feedback = decision.get("runtime_pass_through_feedback")
     if isinstance(runtime_feedback, dict) and runtime_feedback:
         base_factor = str(runtime_feedback.get("base_factor") or "")
@@ -888,6 +909,8 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
             break
         base_factor = str(node.get("factor_name") or "")
         if not base_factor:
+            continue
+        if factor_family(base_factor) in runtime_avoid_families:
             continue
         mutation_type = mutation_from_node(node)
         if mutation_type == "do_not_expand_collect_more_data":

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -985,6 +985,56 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 "mut_spread_adjusted_external_move_near_strike",
             )
 
+    def test_prior_runtime_avoid_factors_carry_forward_and_skip_mutations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                chain_reason="reward_stagnation",
+                selected_nodes=[
+                    {
+                        "factor_name": "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                        "selected_dimension": "exploit",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
+                    {
+                        "factor_name": "mut_spread_adjusted_external_move_squashed",
+                        "selected_dimension": "execution_quality",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
+                ],
+            )
+            write_json(
+                path
+                / "alpha-search-chain"
+                / "input-alpha-search-plan"
+                / "next-llm-prior.json",
+                {
+                    "runtime_avoid_factors": [
+                        {
+                            "base_factor": "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                            "factor_family": "amplitude_weighted_momentum_30s_sigma",
+                            "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+                            "reason": "runtime_pass_through_collapse",
+                        }
+                    ]
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(
+                [item["factor_family"] for item in prior["runtime_avoid_factors"]],
+                ["amplitude_weighted_momentum_30s_sigma"],
+            )
+            self.assertEqual(len(prior["mutations"]), 1)
+            self.assertEqual(
+                prior["mutations"][0]["base_factor"],
+                "mut_spread_adjusted_external_move_squashed",
+            )
+
     def test_cli_markdown_includes_runtime_replay_request(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- preserve the downloaded input alpha-search plan inside hosted walk-forward artifacts
- carry prior runtime_avoid_factors into the next closed-loop typed prior
- skip generating new prior mutations for factor families already marked as runtime avoid

## Evidence stage
walk_forward / runtime_parity

## Tests
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'
- rtk git diff --check

No config PR, deploy, or live trading path is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the optimization pipeline to carry forward and apply runtime-avoid factors across iterations, preventing selection of previously unsuccessful factor families in subsequent mutations.

* **Chores**
  * Improved CI/CD artifact staging to include search plan inputs for downstream pipeline steps.

* **Tests**
  * Added test coverage for runtime-avoid factor propagation across optimization cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->