### PR TITLE
Fix runtime avoid dangling interaction family

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -1097,6 +1097,10 @@ fn normalized_factor_family(raw: &str) -> String {
                 }
             }
         }
+        if !changed && value.ends_with("_x") && value.len() > 2 {
+            value.truncate(value.len() - 2);
+            changed = true;
+        }
         if !changed {
             break;
         }
@@ -1493,12 +1497,12 @@ mod tests {
                 metrics: serde_json::Value::Null,
             }],
         };
-        let runtime_avoidances = runtime_avoidances(None, Some(&prior));
+        let prior_avoidances = runtime_avoidances(None, Some(&prior));
         let reports = vec![squashed, spread_adjusted, alternative];
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances))
+            .map(|(idx, report)| node_metric(idx, report, &prior_avoidances))
             .collect::<Vec<_>>();
         let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
@@ -1514,5 +1518,33 @@ mod tests {
                 .map(|node| node.factor_name.as_str()),
             Some("auto_settlement_full_depth_settlement_edge_x_capacity")
         );
+
+        let dangling_interaction = sample_report(
+            "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_x_full_depth_entry_gate_spread_adjusted",
+        );
+        let composed_prior = LlmPriorSpec {
+            mutations: Vec::new(),
+            runtime_avoid_factors: vec![crate::autofactor::RuntimeAvoidFactorSpec {
+                base_factor:
+                    "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
+                        .to_string(),
+                factor_family: Some(
+                    "auto_settlement_model_full_depth_settlement_edge_x_external_pressure"
+                        .to_string(),
+                ),
+                runtime_score: Some(
+                    "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
+                        .to_string(),
+                ),
+                reason: Some("runtime_pass_through_collapse".to_string()),
+                metrics: serde_json::Value::Null,
+            }],
+        };
+        let composed_avoidances = runtime_avoidances(None, Some(&composed_prior));
+        assert_eq!(
+            normalized_factor_family(&dangling_interaction.name),
+            "auto_settlement_model_full_depth_settlement_edge_x_external_pressure"
+        );
+        assert!(matching_runtime_avoidance(&dangling_interaction, &composed_avoidances).is_some());
     }
 }

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -305,6 +305,9 @@ def factor_family(raw: str) -> str:
                 value = value[: -len(suffix)]
                 changed = True
                 break
+        if not changed and value.endswith("_x") and len(value) > 2:
+            value = value[:-2]
+            changed = True
     return value
 
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -926,6 +926,12 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 ),
                 "spread_adjusted_external_move",
             )
+            self.assertEqual(
+                agent.factor_family(
+                    "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_x_full_depth_entry_gate_spread_adjusted"
+                ),
+                "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
+            )
 
     def test_runtime_avoid_factors_accumulate_from_search_feedback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1001,6 +1007,11 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                         "selected_dimension": "execution_quality",
                         "proposed_mutation": "add_capacity_gate",
                     },
+                    {
+                        "factor_name": "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_x_full_depth_entry_gate_spread_adjusted",
+                        "selected_dimension": "execution_quality",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
                 ],
             )
             write_json(
@@ -1015,6 +1026,12 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                             "factor_family": "amplitude_weighted_momentum_30s_sigma",
                             "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
                             "reason": "runtime_pass_through_collapse",
+                        },
+                        {
+                            "base_factor": "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+                            "factor_family": "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
+                            "runtime_score": "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted",
+                            "reason": "runtime_pass_through_collapse",
                         }
                     ]
                 },
@@ -1027,7 +1044,10 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(decision["decision"], "revise_prior")
             self.assertEqual(
                 [item["factor_family"] for item in prior["runtime_avoid_factors"]],
-                ["amplitude_weighted_momentum_30s_sigma"],
+                [
+                    "amplitude_weighted_momentum_30s_sigma",
+                    "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
+                ],
             )
             self.assertEqual(len(prior["mutations"]), 1)
             self.assertEqual(


### PR DESCRIPTION
## Summary
- normalize dangling interaction suffixes such as _x_full_depth_entry_gate_spread_adjusted back to the parent runtime avoid family
- apply the same family normalization in Python closed-loop and Rust alpha-search filtering
- add regressions for composed settlement external-pressure variants escaping the avoid-list

## Evidence stage
walk_forward / runtime_parity

## Tests
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- CARGO_TARGET_DIR=/tmp/ploy-runtime-avoid-dangling-x /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib
- rtk git diff --check

No config PR, deploy, or live trading path is changed.