### PR TITLE
Fix runtime collapse prior precedence

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -111,6 +111,10 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
             path / "alpha-search-chain" / "input-alpha-search-plan" / "next-llm-prior.json"
         )
         or {},
+        "input_feedback": optional_json(
+            path / "alpha-search-chain" / "input-alpha-search-plan" / "search-feedback.json"
+        )
+        or {},
     }
 
 
@@ -815,6 +819,9 @@ def collect_runtime_avoid_factors(
 ) -> list[dict[str, Any]]:
     by_family: dict[str, dict[str, Any]] = {}
 
+    def is_runtime_collapse(item: dict[str, Any]) -> bool:
+        return str(item.get("reason") or "") == "runtime_pass_through_collapse"
+
     def add_item(item: dict[str, Any]) -> None:
         base_factor = str(item.get("base_factor") or "").strip()
         family = str(item.get("factor_family") or factor_family(base_factor)).strip()
@@ -828,7 +835,10 @@ def collect_runtime_avoid_factors(
         }
         if item.get("metrics") is not None:
             payload["metrics"] = item.get("metrics")
-        by_family.setdefault(family, payload)
+        existing = by_family.get(family)
+        if existing is not None and is_runtime_collapse(existing) and not is_runtime_collapse(payload):
+            return
+        by_family[family] = payload
 
     for run in runs:
         prior = run.get("input_prior") if isinstance(run, dict) else {}
@@ -837,6 +847,17 @@ def collect_runtime_avoid_factors(
         )
         if isinstance(prior_existing, list):
             for item in prior_existing:
+                if isinstance(item, dict):
+                    add_item(item)
+
+        input_feedback = run.get("input_feedback") if isinstance(run, dict) else {}
+        input_existing = (
+            input_feedback.get("runtime_avoid_factors")
+            if isinstance(input_feedback, dict)
+            else None
+        )
+        if isinstance(input_existing, list):
+            for item in input_existing:
                 if isinstance(item, dict):
                     add_item(item)
 
@@ -867,15 +888,28 @@ def collect_runtime_avoid_factors(
             runtime_unmapped_feedback.get("factor_family") or factor_family(base_factor)
         ).strip()
         if base_factor and family:
-            by_family[family] = {
+            add_item({
                 "base_factor": base_factor,
                 "factor_family": family,
                 "runtime_score": runtime_unmapped_feedback.get("runtime_score") or "",
                 "reason": runtime_unmapped_feedback.get("reason")
                 or "missing_runtime_strategy_mapping",
                 "metrics": runtime_unmapped_feedback.get("metrics"),
-            }
+            })
     return [by_family[key] for key in sorted(by_family)]
+
+
+def runtime_feedback_has_direct_signal(runtime_feedback: dict[str, Any]) -> bool:
+    metrics = runtime_feedback.get("metrics")
+    if not isinstance(metrics, dict):
+        return True
+    direct_passes = as_float(metrics.get("direct_passes_at_configured_threshold"))
+    entry_signals = as_float(metrics.get("entry_signals"))
+    if direct_passes is not None and direct_passes <= 0:
+        return False
+    if entry_signals is not None and entry_signals <= 0 and direct_passes == 0:
+        return False
+    return True
 
 
 def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int) -> dict[str, Any]:
@@ -888,7 +922,11 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
         if isinstance(item, dict)
     }
     runtime_feedback = decision.get("runtime_pass_through_feedback")
-    if isinstance(runtime_feedback, dict) and runtime_feedback:
+    if (
+        isinstance(runtime_feedback, dict)
+        and runtime_feedback
+        and runtime_feedback_has_direct_signal(runtime_feedback)
+    ):
         base_factor = str(runtime_feedback.get("base_factor") or "")
         if base_factor:
             for mutation_type in ("add_spread_penalty", "add_capacity_gate"):

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -933,6 +933,98 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
             )
 
+    def test_zero_direct_signal_collapse_wins_over_unmapped_same_family(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base_factor = (
+                "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
+            )
+            runtime_score = f"autofactor_formula:{base_factor}"
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                selected_nodes=[
+                    {
+                        "factor_name": "mcts_mcts_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted_spread_adjusted",
+                        "selected_dimension": "execution_quality",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
+                    {
+                        "factor_name": "mut_amplitude_weighted_momentum_30s_vol_gap_spread_adjusted",
+                        "selected_dimension": "effectiveness",
+                        "proposed_mutation": "replace_denominator",
+                    },
+                ],
+                candidate_strategy_replay={
+                    "basis": "runtime_market_update_replay",
+                    "promotion_ready": False,
+                    "runtime_score": runtime_score,
+                    "metrics": {"trade_count": 0, "unique_event_count": 0, "roi": 0.0},
+                    "score_counterfactual": {
+                        "configured_entry_threshold": "0.25",
+                        "depth_fillable": 2508,
+                        "direct_pass_counts": {
+                            "0.05": 0,
+                            "0.10": 0,
+                            "0.15": 0,
+                            "0.25": 0,
+                        },
+                        "formula_evaluations": 2508,
+                    },
+                    "strategy_diagnostics": {
+                        "entry_signals": 0,
+                        "settlement_autofactor_depth_fillable": 2508,
+                        "settlement_autofactor_executable_edge_pass_min_edge": 2255,
+                        "settlement_autofactor_formula_evaluations": 2508,
+                        "skip_entry_score": 2508,
+                    },
+                },
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "missing_runtime_strategy_mapping",
+                                "candidate_strategy_replay_not_ready",
+                            ],
+                            "factor": {
+                                "name": "mcts_mcts_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_avg_label": 1.33,
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.19,
+                            },
+                        }
+                    ],
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(decision["reason"], "runtime_pass_through_collapse")
+            self.assertEqual(
+                prior["runtime_avoid_factors"][0]["reason"],
+                "runtime_pass_through_collapse",
+            )
+            self.assertEqual(
+                prior["runtime_avoid_factors"][0]["base_factor"],
+                base_factor,
+            )
+            self.assertNotIn(
+                "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
+                " ".join(item["base_factor"] for item in prior["mutations"]),
+            )
+            self.assertEqual(
+                prior["mutations"][0]["base_factor"],
+                "mut_amplitude_weighted_momentum_30s_vol_gap_spread_adjusted",
+            )
+
     def test_runtime_avoid_factors_accumulate_from_search_feedback(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             near_strike_score = "autofactor_formula:mut_spread_adjusted_external_move_near_strike"
@@ -1036,6 +1128,22 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                     ]
                 },
             )
+            write_json(
+                path
+                / "alpha-search-chain"
+                / "input-alpha-search-plan"
+                / "search-feedback.json",
+                {
+                    "runtime_avoid_factors": [
+                        {
+                            "base_factor": "mut_poly_lag_pressure_spread_adjusted",
+                            "factor_family": "poly_lag_pressure",
+                            "runtime_score": "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+                            "reason": "runtime_pass_through_collapse",
+                        }
+                    ]
+                },
+            )
 
             runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
             decision = agent.closed_loop_decision(runs)
@@ -1047,6 +1155,7 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 [
                     "amplitude_weighted_momentum_30s_sigma",
                     "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
+                    "poly_lag_pressure",
                 ],
             )
             self.assertEqual(len(prior["mutations"]), 1)


### PR DESCRIPTION
## Summary
- carry runtime avoid factors from input alpha-search search-feedback, not only next-llm-prior
- keep runtime_pass_through_collapse higher priority than missing_runtime_strategy_mapping for the same factor family
- stop generating repair mutations for zero-direct-signal runtime collapses

## Evidence stage
walk_forward / runtime_parity

## Tests
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- rtk git diff --check

No config PR, deploy, or live trading path is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced feedback signal validation for runtime decision-making.

* **Bug Fixes**
  * Improved runtime factor aggregation and merge behavior for collapse scenarios.

* **Tests**
  * Added test coverage for runtime collapse and direct-signal validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->