### PR TITLE
Fix LLM runtime-pass-through formula mapping

### DIFF
--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -60,7 +60,7 @@ def parse_int(raw: str, default: int = 0) -> int:
 
 def normalize_formula_name(name: str) -> str:
     while True:
-        for prefix in ("mut2_", "mut_", "mcts_"):
+        for prefix in ("llm_", "mut2_", "mut_", "mcts_"):
             if name.startswith(prefix):
                 name = name[len(prefix) :]
                 break

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -550,7 +550,7 @@ def load_runtime_mappings(path: str | None) -> dict[str, dict[str, str]]:
 
 def normalize_formula_name(name: str) -> str:
     while True:
-        for prefix in ("mut2_", "mut_", "mcts_"):
+        for prefix in ("llm_", "mut2_", "mut_", "mcts_"):
             if name.startswith(prefix):
                 name = name[len(prefix) :]
                 break

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -106,6 +106,14 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 2,spread_adjusted_external_move,full_depth_settlement_executable_pnl,candidate,passed,529,0.214428,0.141198,4,1.412625,1.0000,2,1.0000,1.0000,106,3.710549,0.6981,1.0000,23.70,1.40,106,1,5
 """
 
+AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT = """
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,llm_mut_spread_adjusted_external_move_near_strike_runtime_pass_through_add_spread_penalty,full_depth_settlement_executable_pnl,candidate,passed,529,0.139249,0.117332,4,1.668090,0.8750,2,1.0000,0.7500,106,3.669036,0.6981,1.0000,18.51,1.42,106,1,10
+"""
+
 AUTOFACTOR_POLY_LAG_PRESSURE_REPORT = """
 # AutoFactor target=full_depth_settlement_executable_pnl
 === AutoFactor Seed Candidate Report ===
@@ -419,6 +427,34 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "runtime_profile_mismatch:repricing_momentum!=settlement_probability",
             bare_spread["blockers"],
         )
+
+    def test_qualifies_llm_runtime_pass_through_predictive_formula_mutation(self):
+        runtime_score = (
+            "autofactor_formula:"
+            "llm_mut_spread_adjusted_external_move_near_strike_runtime_pass_through_add_spread_penalty"
+        )
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "runtime_score": runtime_score,
+        }
+        _, payload, registry, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "qualified")
+        self.assertEqual(registry["decision"], "qualified")
+        self.assertEqual(handoff["status"], "ready")
+        self.assertEqual(handoff["strategies"][0]["runtime_score"], runtime_score)
+        self.assertEqual(
+            handoff["strategies"][0]["strategy_family"],
+            "predictive_settlement_probability",
+        )
+        self.assertNotIn(
+            "missing_runtime_strategy_mapping",
+            handoff["strategies"][0].get("blockers", []),
+        )
+        self.assertIn("runtime_pass_through_add_spread_penalty", handoff_md)
 
     def test_qualifies_poly_lag_pressure_predictive_formula_mutation(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from tests.test_autofactor_strategy_promotion import (
     AUTOFACTOR_REPORT,
+    AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT,
     AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
 )
 
@@ -131,6 +132,19 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
         self.assertEqual(
             payload["source_factor"]["name"],
             "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
+        )
+
+    def test_selects_llm_runtime_pass_through_predictive_formula_mutation(self):
+        payload, _ = self.run_script(AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT)
+
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:"
+            "llm_mut_spread_adjusted_external_move_near_strike_runtime_pass_through_add_spread_penalty",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "llm_mut_spread_adjusted_external_move_near_strike_runtime_pass_through_add_spread_penalty",
         )
 
     def test_selects_poly_lag_pressure_predictive_formula_mutation(self):


### PR DESCRIPTION
## Summary
- Treat `llm_` generated formula candidates as runtime-mappable formula mutations during AutoFactor promotion evaluation
- Apply the same normalization in aggregate candidate replay selection
- Add regression coverage for `llm_*_runtime_pass_through_*` candidates

## Verification
- `python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py scripts/build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py`
- `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay`
- `rtk git diff --check`