### PR TITLE
fix: accept predictive AutoFactor handoff scores

### DIFF
--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -827,15 +827,29 @@ venue = "sportsbook"
             .three_layer_autofactor_runtime_score
             .as_deref()
             .expect("settlement probability dry-run config should carry an AutoFactor handoff");
+        let formula_name = runtime_score
+            .strip_prefix("autofactor_formula:")
+            .unwrap_or(runtime_score);
+        let mut normalized_name = formula_name;
+        loop {
+            if let Some(stripped) = normalized_name.strip_prefix("mut2_") {
+                normalized_name = stripped;
+            } else if let Some(stripped) = normalized_name.strip_prefix("mut_") {
+                normalized_name = stripped;
+            } else if let Some(stripped) = normalized_name.strip_prefix("mcts_") {
+                normalized_name = stripped;
+            } else {
+                break;
+            }
+        }
+        let supported_settlement_family = runtime_score.starts_with("autofactor_formula:")
+            && (normalized_name.starts_with("auto_settlement_")
+                || normalized_name.starts_with("amplitude_weighted_momentum_30s_sigma")
+                || normalized_name.starts_with("poly_lag_pressure")
+                || (normalized_name.starts_with("spread_adjusted_external_move")
+                    && normalized_name != "spread_adjusted_external_move"));
         assert!(
-            runtime_score.starts_with("autofactor_formula:auto_settlement_")
-                || runtime_score == "autofactor_formula:amplitude_weighted_momentum_30s_sigma"
-                || runtime_score
-                    == "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate"
-                || runtime_score
-                    == "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate"
-                || runtime_score
-                    == "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
+            supported_settlement_family,
             "settlement probability dry-run config should use a supported settlement AutoFactor formula, got {runtime_score}"
         );
         let raw = auto_settlement_formula_score(


### PR DESCRIPTION
## Summary
- updates the settlement-probability config gate to accept predictive AutoFactor runtime-score families after mutation-prefix normalization
- keeps the gate fail-closed by still requiring the `autofactor_formula:` prefix and a finite score from the runtime scorer
- unblocks the ready AutoFactor handoff config-PR path after runtime candidate replay evidence for issue #578

## Evidence stage
- runtime_parity / dry_run_candidate handoff plumbing only
- no deploy or live trading changes

## Validation
- `rustfmt crates/ploy-strategy-bundles/src/config.rs --edition 2021 --check`
- `python3 -m unittest tests.test_apply_autofactor_handoff_to_config`
- `CARGO_TARGET_DIR=/tmp/ploy-autofactor-config-gate rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`
- `rtk git diff --check`

Related evidence: runtime replay run 26246930228 and ready evaluator run 26247564206.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced settlement-probability validation logic to dynamically extract and normalize formula names, improving robustness of configuration handling across formula variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->