### PR TITLE
Promote hosted AutoFactor handoff into dry-run config

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike"
+three_layer_autofactor_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_near_strike"
 three_layer_min_entry_score = 0.25
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30


### PR DESCRIPTION
## Summary
- applies the ready hosted AutoFactor handoff to the settlement-probability BTC/ETH dry-run config
- changes only `three_layer_autofactor_runtime_score` to `autofactor_formula:mut_spread_adjusted_external_move_near_strike`
- leaves execution, risk, stake, thresholds, and live paths unchanged

## Evidence stage
- dry_run_candidate config handoff after executable runtime replay
- Source hosted walk-forward run: https://github.com/proerror77/ploy/actions/runs/26248437574
- Source snapshot run: `26135455846`
- Runtime candidate replay: https://github.com/proerror77/ploy/actions/runs/26246930228
- Research issue: #578

## Validation
- `factor-walk-forward-v2-hosted-artifact.yml` create_config_pr path passed
- Workflow step ran `python3 -m unittest tests.test_apply_autofactor_handoff_to_config`
- Workflow step ran `cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`

This PR does not deploy and does not enable live trading.