### PR TITLE
Improve predictive AutoFactor strategy discovery

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -23,6 +23,10 @@ on:
         description: "Expected strategy profile"
         required: true
         default: "settlement_probability"
+      issue_number:
+        description: "GitHub issue to receive replay evidence comments; defaults to the runtime evidence issue"
+        required: false
+        default: "538"
       min_trade_count:
         description: "Minimum filled entry trades required"
         required: false
@@ -35,22 +39,10 @@ on:
         description: "Minimum replay ROI required"
         required: false
         default: "0"
-      full_depth_entry:
-        description: "Confirm this replay config uses full-depth executable entry accounting"
+      options_json:
+        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits"
         required: false
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
-      skip_settlement_exits:
-        description: "Skip settlement exits while replaying; false is required for settlement PnL evidence"
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+        default: '{"full_depth_entry":true,"skip_settlement_exits":false}'
 concurrency:
   group: runtime-candidate-replay-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.runtime_score }}
   cancel-in-progress: false
@@ -63,7 +55,7 @@ env:
   CARGO_TERM_COLOR: always
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
   DEPLOY_HOST: ${{ secrets.TANGO_1_1_HOST }}
-  REPLAY_EVIDENCE_ISSUE: "538"
+  REPLAY_EVIDENCE_ISSUE: ${{ github.event.inputs.issue_number || '538' }}
 
 jobs:
   runtime-candidate-replay:
@@ -75,6 +67,47 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Parse advanced options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "full_depth_entry": "true",
+              "skip_settlement_exits": "false",
+          }
+          bool_keys = set(defaults)
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          for key, value in data.items():
+              if key in bool_keys:
+                  if isinstance(value, bool):
+                      values[key] = "true" if value else "false"
+                  elif str(value).lower() in {"true", "false"}:
+                      values[key] = str(value).lower()
+                  else:
+                      raise SystemExit(f"options_json value for {key} must be boolean")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              handle.write(f"REPLAY_FULL_DEPTH_ENTRY={values['full_depth_entry']}\n")
+              handle.write(f"REPLAY_SKIP_SETTLEMENT_EXITS={values['skip_settlement_exits']}\n")
+          print(
+              "resolved runtime replay options: "
+              + ", ".join(f"{key}={value}" for key, value in sorted(values.items()))
+          )
+          PY
 
       - name: Build replay runner from workflow ref
         run: |
@@ -139,7 +172,7 @@ jobs:
           CONFIG_PATH: ${{ github.event.inputs.config_path }}
           RECORDING_PATH: ${{ github.event.inputs.recording_path }}
           RUNTIME_SCORE: ${{ github.event.inputs.runtime_score }}
-          SKIP_SETTLEMENT_EXITS: ${{ github.event.inputs.skip_settlement_exits }}
+          SKIP_SETTLEMENT_EXITS: ${{ env.REPLAY_SKIP_SETTLEMENT_EXITS }}
           REMOTE_DIR: /opt/ploy/tmp/runtime-candidate-replay-${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -331,7 +364,7 @@ jobs:
           MIN_TRADE_COUNT: ${{ github.event.inputs.min_trade_count }}
           MIN_FILL_RATE: ${{ github.event.inputs.min_fill_rate }}
           MIN_ROI: ${{ github.event.inputs.min_roi }}
-          FULL_DEPTH_ENTRY: ${{ github.event.inputs.full_depth_entry }}
+          FULL_DEPTH_ENTRY: ${{ env.REPLAY_FULL_DEPTH_ENTRY }}
         run: |
           set -euo pipefail
           args=(
@@ -385,6 +418,9 @@ jobs:
           script: |
             const fs = require("fs");
             const issue_number = Number(process.env.REPLAY_EVIDENCE_ISSUE);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              throw new Error(`REPLAY_EVIDENCE_ISSUE must be a positive integer, got ${process.env.REPLAY_EVIDENCE_ISSUE}`);
+            }
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let ready = false;
             let metrics = {};

--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -40,7 +40,7 @@ on:
         required: false
         default: "0"
       options_json:
-        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits"
+        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits, three_layer_min_entry_score"
         required: false
         default: '{"full_depth_entry":true,"skip_settlement_exits":false}'
 concurrency:
@@ -76,12 +76,16 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          from decimal import Decimal, InvalidOperation
 
           defaults = {
               "full_depth_entry": "true",
               "skip_settlement_exits": "false",
+              "three_layer_min_entry_score": "",
           }
-          bool_keys = set(defaults)
+          bool_keys = {"full_depth_entry", "skip_settlement_exits"}
+          threshold_keys = {"three_layer_min_entry_score"}
+          allowed_thresholds = {Decimal("0.05"), Decimal("0.10"), Decimal("0.15"), Decimal("0.25")}
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
           if not isinstance(data, dict):
@@ -99,10 +103,26 @@ jobs:
                       values[key] = str(value).lower()
                   else:
                       raise SystemExit(f"options_json value for {key} must be boolean")
+              elif key in threshold_keys:
+                  if value in (None, ""):
+                      values[key] = ""
+                      continue
+                  try:
+                      threshold = Decimal(str(value))
+                  except (InvalidOperation, ValueError):
+                      raise SystemExit(f"options_json value for {key} must be decimal") from None
+                  if threshold not in allowed_thresholds:
+                      allowed = ", ".join(str(item) for item in sorted(allowed_thresholds))
+                      raise SystemExit(f"options_json value for {key} must be one of: {allowed}")
+                  values[key] = format(threshold, "f")
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
               handle.write(f"REPLAY_FULL_DEPTH_ENTRY={values['full_depth_entry']}\n")
               handle.write(f"REPLAY_SKIP_SETTLEMENT_EXITS={values['skip_settlement_exits']}\n")
+              handle.write(
+                  "REPLAY_THREE_LAYER_MIN_ENTRY_SCORE="
+                  f"{values['three_layer_min_entry_score']}\n"
+              )
           print(
               "resolved runtime replay options: "
               + ", ".join(f"{key}={value}" for key, value in sorted(values.items()))
@@ -173,6 +193,7 @@ jobs:
           RECORDING_PATH: ${{ github.event.inputs.recording_path }}
           RUNTIME_SCORE: ${{ github.event.inputs.runtime_score }}
           SKIP_SETTLEMENT_EXITS: ${{ env.REPLAY_SKIP_SETTLEMENT_EXITS }}
+          MIN_ENTRY_SCORE_OVERRIDE: ${{ env.REPLAY_THREE_LAYER_MIN_ENTRY_SCORE }}
           REMOTE_DIR: /opt/ploy/tmp/runtime-candidate-replay-${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -198,7 +219,8 @@ jobs:
             "${RECORDING_PATH}" \
             "${REMOTE_DIR}" \
             "${RUNTIME_SCORE}" \
-            "${SKIP_SETTLEMENT_EXITS}" <<'EOF'
+            "${SKIP_SETTLEMENT_EXITS}" \
+            "${MIN_ENTRY_SCORE_OVERRIDE}" <<'EOF'
           set -euo pipefail
           deployment_id="$1"
           config_path="$2"
@@ -206,6 +228,7 @@ jobs:
           remote_dir="$4"
           runtime_score="$5"
           skip_settlement_exits="$6"
+          min_entry_score_override="$7"
           case "${skip_settlement_exits}" in
             true|false) ;;
             *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;
@@ -287,11 +310,11 @@ jobs:
           test -s "${enriched_recording}"
 
           replay_config="${remote_dir}/replay.toml"
-          python3 - "${config_path}" "${enriched_recording}" "${replay_config}" "${runtime_score}" "${skip_settlement_exits}" <<'PY'
+          python3 - "${config_path}" "${enriched_recording}" "${replay_config}" "${runtime_score}" "${skip_settlement_exits}" "${min_entry_score_override}" <<'PY'
           import json
           import sys
 
-          src, recording, dst, runtime_score, skip_settlement_exits = sys.argv[1:]
+          src, recording, dst, runtime_score, skip_settlement_exits, min_entry_score_override = sys.argv[1:]
           if not runtime_score:
               raise SystemExit("runtime_score is required")
           if "\n" in runtime_score or "\r" in runtime_score:
@@ -299,6 +322,7 @@ jobs:
           lines = []
           inserted_replay_path = False
           wrote_runtime_score = False
+          wrote_min_entry_score = False
           source_lines = open(src, encoding="utf-8").read().splitlines()
           has_runtime_score = any(
               line.strip().startswith("three_layer_autofactor_runtime_score")
@@ -326,6 +350,10 @@ jobs:
                   lines.append(runtime_score_line)
                   wrote_runtime_score = True
                   continue
+              if min_entry_score_override and stripped.startswith("three_layer_min_entry_score"):
+                  lines.append(f"three_layer_min_entry_score = {min_entry_score_override}")
+                  wrote_min_entry_score = True
+                  continue
               lines.append(raw)
               if stripped.startswith("strategy_profile") and not has_runtime_score:
                   lines.append(runtime_score_line)
@@ -334,6 +362,8 @@ jobs:
               raise SystemExit("runtime mode line not found in source config")
           if not wrote_runtime_score:
               raise SystemExit("strategy_profile/runtime score location not found in source config")
+          if min_entry_score_override and not wrote_min_entry_score:
+              raise SystemExit("three_layer_min_entry_score override requested but source config has no three_layer_min_entry_score line")
           with open(dst, "w", encoding="utf-8") as handle:
               handle.write("\n".join(lines) + "\n")
           PY
@@ -365,6 +395,7 @@ jobs:
           MIN_FILL_RATE: ${{ github.event.inputs.min_fill_rate }}
           MIN_ROI: ${{ github.event.inputs.min_roi }}
           FULL_DEPTH_ENTRY: ${{ env.REPLAY_FULL_DEPTH_ENTRY }}
+          CONFIGURED_ENTRY_THRESHOLD: ${{ env.REPLAY_THREE_LAYER_MIN_ENTRY_SCORE || '0.25' }}
         run: |
           set -euo pipefail
           args=(
@@ -374,6 +405,7 @@ jobs:
             --min-trade-count "${MIN_TRADE_COUNT}"
             --min-fill-rate "${MIN_FILL_RATE}"
             --min-roi "${MIN_ROI}"
+            --configured-entry-threshold "${CONFIGURED_ENTRY_THRESHOLD}"
             --evidence "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             --output-json artifacts/runtime-replay/candidate-strategy-replay.json
             --output-md artifacts/runtime-replay/candidate-strategy-replay.md

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -388,6 +388,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
                 "RollingMean",
                 "RollingStd",
                 "ZScore",
+                "Gate",
             ],
             limits: SearchLimits {
                 min_observations: options.min_observations,

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -12,6 +12,13 @@ use crate::factors_v2::FactorObservationV2;
 const EPS: f64 = 1e-9;
 const MAX_DETERMINISTIC_MUTATION_DEPTH: usize = 2;
 const MAX_DETERMINISTIC_MUTATION_CANDIDATES: usize = 160;
+const SELECTOR_GATE_THRESHOLDS: [f64; 3] = [0.25, 0.50, 0.75];
+const SELECTOR_GATE_FEATURES: [&str; 4] = [
+    "near_strike_score",
+    "entry_price_quality_score",
+    "entry_capacity_score",
+    "full_depth_entry_fillable_gate",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FactorExpr {
@@ -1343,6 +1350,30 @@ fn deterministic_mutation_layer(
             );
         }
 
+        if settlement_target {
+            for feature in SELECTOR_GATE_FEATURES {
+                if !input_names.contains(feature) {
+                    continue;
+                }
+                for threshold in SELECTOR_GATE_THRESHOLDS {
+                    push_mutation(
+                        &mut out,
+                        seed,
+                        depth,
+                        &format!(
+                            "select_{}_ge_{:03}",
+                            selector_gate_suffix(feature),
+                            (threshold * 100.0).round() as usize
+                        ),
+                        gate(seed.expr.clone(), input(feature), threshold),
+                        &format!(
+                            "add_feature_gate: discovery-only selector requiring {feature} >= {threshold:.2}; promotion still requires runtime replay.",
+                        ),
+                    );
+                }
+            }
+        }
+
         if !settlement_target && input_names.contains("poly_quote_age") {
             push_mutation(
                 &mut out,
@@ -1361,6 +1392,16 @@ fn deterministic_mutation_layer(
         }
     }
     out
+}
+
+fn selector_gate_suffix(feature: &str) -> &str {
+    match feature {
+        "near_strike_score" => "near_strike",
+        "entry_price_quality_score" => "entry_price_quality",
+        "entry_capacity_score" => "entry_capacity",
+        "full_depth_entry_fillable_gate" => "full_depth_entry",
+        _ => feature,
+    }
 }
 
 fn push_mutation(
@@ -2604,6 +2645,41 @@ mod tests {
             hard_gate.notes[0].contains("execution gate"),
             "hard fillability should be documented as execution gating"
         );
+    }
+
+    #[test]
+    fn settlement_mutations_include_bounded_selector_threshold_grid() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let matrix = autofactor_matrix_from_v2(&rows).expect("matrix");
+        let seeds = vec![NamedFactorExpr {
+            name: "predictive_seed".to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: input("external_move_since_poly_update"),
+            notes: vec![],
+        }];
+
+        let mutations = deterministic_mutation_layer(
+            &matrix.input_names(),
+            &seeds,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            1,
+        );
+
+        for expected in [
+            "mut_predictive_seed_select_near_strike_ge_025",
+            "mut_predictive_seed_select_near_strike_ge_050",
+            "mut_predictive_seed_select_near_strike_ge_075",
+            "mut_predictive_seed_select_entry_price_quality_ge_050",
+            "mut_predictive_seed_select_entry_capacity_ge_050",
+            "mut_predictive_seed_select_full_depth_entry_ge_050",
+        ] {
+            let candidate = mutations
+                .iter()
+                .find(|candidate| candidate.name == expected)
+                .unwrap_or_else(|| panic!("missing selector mutation {expected}"));
+            assert!(matches!(candidate.expr, FactorExpr::Gate { .. }));
+            assert!(candidate.notes[0].contains("discovery-only selector"));
+        }
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -5478,6 +5478,58 @@ mod tests {
     }
 
     #[test]
+    fn predictive_autofactor_formula_supports_selector_threshold_gate() {
+        let config = test_config();
+        let near = AutoSettlementFactorInputs {
+            settlement_edge: -0.01,
+            entry_price: 0.48,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            drift_30s: 0.006,
+            sigma_horizon: 4.0,
+            entry_capacity_ratio: 1.20,
+            side_spread: 0.03,
+            external_pressure: 0.0,
+            pm_lag_secs: 0.0,
+            iv_change_1m: 0.0,
+        };
+        let far = AutoSettlementFactorInputs {
+            distance_over_sigma: 4.0,
+            ..near
+        };
+
+        let (raw, score) = autofactor_formula_entry_score(
+            "autofactor_formula:mut_spread_adjusted_external_move_select_near_strike_ge_075",
+            near,
+            config.min_edge,
+        )
+        .expect("selector-gated predictive formula should score rows passing the selector");
+        assert!(raw > 0.0);
+        assert!(score > 0.0);
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mut_spread_adjusted_external_move_select_near_strike_ge_075",
+            far,
+            config.min_edge,
+        )
+        .is_none());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mut_spread_adjusted_external_move_select_entry_price_quality_ge_075",
+            near,
+            config.min_edge,
+        )
+        .is_some());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mut_spread_adjusted_external_move_select_entry_capacity_ge_075",
+            AutoSettlementFactorInputs {
+                entry_capacity_ratio: 0.10,
+                ..near
+            },
+            config.min_edge,
+        )
+        .is_none());
+    }
+
+    #[test]
     fn edge_score_returns_continuous_value() {
         let config = test_config();
         // ask=0.35 → fee≈0.00455, edge=0.55-0.35-0.00455≈0.195 → edge_score≈1.95 clamped to 1.0

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -636,6 +636,8 @@ fn normalized_autofactor_formula_name(mut name: &str) -> &str {
             name = stripped;
         } else if let Some(stripped) = name.strip_prefix("mcts_") {
             name = stripped;
+        } else if let Some(stripped) = name.strip_prefix("llm_") {
+            name = stripped;
         } else {
             return name;
         }
@@ -5527,6 +5529,28 @@ mod tests {
             config.min_edge,
         )
         .is_none());
+
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:llm_mut_spread_adjusted_external_move_select_near_strike_ge_075_runtime_pass_through_add_capacity_gate",
+            near,
+            config.min_edge,
+        )
+        .is_some());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:llm_mut_spread_adjusted_external_move_select_near_strike_ge_075_runtime_pass_through_add_capacity_gate",
+            AutoSettlementFactorInputs {
+                entry_capacity_ratio: 0.10,
+                ..near
+            },
+            config.min_edge,
+        )
+        .is_none());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:llm_mut_spread_adjusted_external_move_select_near_strike_ge_075_runtime_pass_through_add_spread_penalty",
+            near,
+            config.min_edge,
+        )
+        .is_some());
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -5551,6 +5551,21 @@ mod tests {
             config.min_edge,
         )
         .is_some());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025",
+            near,
+            config.min_edge,
+        )
+        .is_some());
+        assert!(autofactor_formula_entry_score(
+            "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025",
+            AutoSettlementFactorInputs {
+                entry_capacity_ratio: 0.01,
+                ..near
+            },
+            config.min_edge,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -402,33 +402,36 @@ fn apply_predictive_selector_gate(
     suffix: &str,
     inputs: AutoSettlementFactorInputs,
 ) -> Option<String> {
-    let Some((remaining, selector)) = suffix.split_once("_select_") else {
-        return Some(suffix.to_string());
-    };
-    let (feature, raw_threshold, trailing_suffix) = parse_selector_gate(selector)?;
-    let threshold = parse_selector_threshold(raw_threshold)?;
-    let gate_score = match feature {
-        "near_strike" => {
-            auto_settlement_near_strike_score(inputs.distance_over_sigma, inputs.direction_sign)
-        }
-        "entry_price_quality" => auto_settlement_entry_price_quality_score(inputs.entry_price),
-        "entry_capacity" => auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio),
-        "full_depth_entry" => {
-            if !inputs.entry_capacity_ratio.is_finite() {
-                return None;
+    let mut remaining_suffix = suffix.to_string();
+    while let Some((remaining, selector)) = remaining_suffix.split_once("_select_") {
+        let remaining = remaining.to_string();
+        let selector = selector.to_string();
+        let (feature, raw_threshold, trailing_suffix) = parse_selector_gate(&selector)?;
+        let threshold = parse_selector_threshold(raw_threshold)?;
+        let gate_score = match feature {
+            "near_strike" => {
+                auto_settlement_near_strike_score(inputs.distance_over_sigma, inputs.direction_sign)
             }
-            if inputs.entry_capacity_ratio >= 1.0 {
-                1.0
-            } else {
-                0.0
+            "entry_price_quality" => auto_settlement_entry_price_quality_score(inputs.entry_price),
+            "entry_capacity" => auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio),
+            "full_depth_entry" => {
+                if !inputs.entry_capacity_ratio.is_finite() {
+                    return None;
+                }
+                if inputs.entry_capacity_ratio >= 1.0 {
+                    1.0
+                } else {
+                    0.0
+                }
             }
+            _ => return None,
+        };
+        if !gate_score.is_finite() || gate_score < threshold {
+            return None;
         }
-        _ => return None,
-    };
-    if !gate_score.is_finite() || gate_score < threshold {
-        return None;
+        remaining_suffix = format!("{remaining}{trailing_suffix}");
     }
-    Some(format!("{remaining}{trailing_suffix}"))
+    Some(remaining_suffix)
 }
 
 fn parse_selector_gate(selector: &str) -> Option<(&'static str, &str, String)> {

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -291,6 +291,8 @@ fn normalize_autofactor_formula_name(mut name: &str) -> &str {
             name = stripped;
         } else if let Some(stripped) = name.strip_prefix("mcts_") {
             name = stripped;
+        } else if let Some(stripped) = name.strip_prefix("llm_") {
+            name = stripped;
         } else {
             return name;
         }
@@ -307,7 +309,7 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     } else {
         return None;
     };
-    let suffix = name.strip_prefix(base)?;
+    let suffix = normalize_predictive_llm_suffix(name.strip_prefix(base)?);
     let mut score = match base {
         "amplitude_weighted_momentum_30s_sigma" => {
             if !inputs.drift_30s.is_finite()
@@ -342,7 +344,7 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     if suffix.is_empty() {
         return Some(score);
     }
-    let suffix = apply_predictive_selector_gate(suffix, inputs)?;
+    let suffix = apply_predictive_selector_gate(&suffix, inputs)?;
     if suffix.is_empty() {
         return Some(score);
     }
@@ -383,14 +385,27 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     Some(score)
 }
 
-fn apply_predictive_selector_gate<'a>(
-    suffix: &'a str,
+fn normalize_predictive_llm_suffix(suffix: &str) -> String {
+    suffix
+        .replace(
+            "_runtime_pass_through_add_spread_penalty",
+            "_spread_adjusted",
+        )
+        .replace(
+            "_runtime_pass_through_add_capacity_gate",
+            "_full_depth_entry_gate",
+        )
+        .replace("_add_capacity_gate", "_full_depth_entry_gate")
+}
+
+fn apply_predictive_selector_gate(
+    suffix: &str,
     inputs: AutoSettlementFactorInputs,
-) -> Option<&'a str> {
+) -> Option<String> {
     let Some((remaining, selector)) = suffix.split_once("_select_") else {
-        return Some(suffix);
+        return Some(suffix.to_string());
     };
-    let (feature, raw_threshold) = selector.rsplit_once("_ge_")?;
+    let (feature, raw_threshold, trailing_suffix) = parse_selector_gate(selector)?;
     let threshold = parse_selector_threshold(raw_threshold)?;
     let gate_score = match feature {
         "near_strike" => {
@@ -413,7 +428,27 @@ fn apply_predictive_selector_gate<'a>(
     if !gate_score.is_finite() || gate_score < threshold {
         return None;
     }
-    Some(remaining)
+    Some(format!("{remaining}{trailing_suffix}"))
+}
+
+fn parse_selector_gate(selector: &str) -> Option<(&'static str, &str, String)> {
+    for feature in [
+        "entry_price_quality",
+        "full_depth_entry",
+        "entry_capacity",
+        "near_strike",
+    ] {
+        let prefix = format!("{feature}_ge_");
+        let Some(raw) = selector.strip_prefix(&prefix) else {
+            continue;
+        };
+        let (threshold, trailing_suffix) = match raw.split_once('_') {
+            Some((threshold, trailing)) => (threshold, format!("_{trailing}")),
+            None => (raw, String::new()),
+        };
+        return Some((feature, threshold, trailing_suffix));
+    }
+    None
 }
 
 fn parse_selector_threshold(raw: &str) -> Option<f64> {

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -342,6 +342,10 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     if suffix.is_empty() {
         return Some(score);
     }
+    let suffix = apply_predictive_selector_gate(suffix, inputs)?;
+    if suffix.is_empty() {
+        return Some(score);
+    }
     for mutation in suffix.strip_prefix('_')?.split('_') {
         match mutation {
             "squashed" => score = score.tanh(),
@@ -377,6 +381,48 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
         }
     }
     Some(score)
+}
+
+fn apply_predictive_selector_gate<'a>(
+    suffix: &'a str,
+    inputs: AutoSettlementFactorInputs,
+) -> Option<&'a str> {
+    let Some((remaining, selector)) = suffix.split_once("_select_") else {
+        return Some(suffix);
+    };
+    let (feature, raw_threshold) = selector.rsplit_once("_ge_")?;
+    let threshold = parse_selector_threshold(raw_threshold)?;
+    let gate_score = match feature {
+        "near_strike" => {
+            auto_settlement_near_strike_score(inputs.distance_over_sigma, inputs.direction_sign)
+        }
+        "entry_price_quality" => auto_settlement_entry_price_quality_score(inputs.entry_price),
+        "entry_capacity" => auto_settlement_entry_capacity_score(inputs.entry_capacity_ratio),
+        "full_depth_entry" => {
+            if !inputs.entry_capacity_ratio.is_finite() {
+                return None;
+            }
+            if inputs.entry_capacity_ratio >= 1.0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        _ => return None,
+    };
+    if !gate_score.is_finite() || gate_score < threshold {
+        return None;
+    }
+    Some(remaining)
+}
+
+fn parse_selector_threshold(raw: &str) -> Option<f64> {
+    let threshold = if raw.contains('.') {
+        raw.parse().ok()?
+    } else {
+        raw.parse::<f64>().ok()? / 100.0
+    };
+    (threshold.is_finite() && (0.0..=1.0).contains(&threshold)).then_some(threshold)
 }
 
 /// Normal CDF approximation (Abramowitz & Stegun).

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -634,8 +634,11 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
                 "min_trade_count": "50",
                 "min_fill_rate": "0.30",
                 "min_roi": "0",
-                "full_depth_entry": "true",
-                "skip_settlement_exits": "false",
+                "options_json": json.dumps(
+                    {"full_depth_entry": True, "skip_settlement_exits": False},
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
             },
         }
     return None
@@ -717,8 +720,11 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
             "min_trade_count": "50",
             "min_fill_rate": "0.30",
             "min_roi": "0",
-            "full_depth_entry": "true",
-            "skip_settlement_exits": "false",
+            "options_json": json.dumps(
+                {"full_depth_entry": True, "skip_settlement_exits": False},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
         },
     }
 
@@ -1033,8 +1039,11 @@ def write_markdown(decision: dict[str, Any], path: Path, prior_path: Path | None
             "recording_path",
             "runtime_score",
             "strategy_profile",
-            "full_depth_entry",
-            "skip_settlement_exits",
+            "issue_number",
+            "min_trade_count",
+            "min_fill_rate",
+            "min_roi",
+            "options_json",
         ):
             if key in inputs:
                 lines.append(f"- {key}: `{inputs[key]}`")

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -178,11 +178,14 @@ def runtime_mapping(name: str) -> dict[str, str]:
 
 
 def row_score(row: dict[str, Any]) -> tuple[float, ...]:
+    rank = parse_int(row.get("rank", ""), default=10_000)
     return (
-        parse_float(row.get("top_bucket_avg_label", "")),
         parse_float(row.get("icir", "")),
         parse_float(row.get("positive_window_ratio", "")),
+        parse_float(row.get("symbol_positive_ratio", "")),
         parse_float(row.get("spearman_ic", "")),
+        -float(rank),
+        parse_float(row.get("top_bucket_avg_label", "")),
     )
 
 

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -69,7 +69,18 @@ def int_metric(payload: dict[str, Any], key: str) -> int:
         return 0
 
 
-def score_counterfactual(diagnostics: dict[str, Any]) -> dict[str, Any]:
+def normalize_counterfactual_threshold(raw: str) -> str:
+    value = decimal_arg(raw, "--configured-entry-threshold")
+    for label, _suffix in COUNTERFACTUAL_THRESHOLDS:
+        if value == Decimal(label):
+            return label
+    allowed = ", ".join(label for label, _suffix in COUNTERFACTUAL_THRESHOLDS)
+    raise SystemExit(f"--configured-entry-threshold must be one of: {allowed}")
+
+
+def score_counterfactual(
+    diagnostics: dict[str, Any], configured_entry_threshold: str
+) -> dict[str, Any]:
     if not diagnostics:
         return {}
     formula_evaluations = int_metric(diagnostics, "settlement_autofactor_formula_evaluations")
@@ -87,8 +98,9 @@ def score_counterfactual(diagnostics: dict[str, Any]) -> dict[str, Any]:
     if not formula_evaluations and not any(direct.values()) and not any(reverse.values()):
         return {}
 
-    configured_direct = direct["0.25"]
-    configured_reverse = reverse["0.25"]
+    threshold_label = normalize_counterfactual_threshold(configured_entry_threshold)
+    configured_direct = direct[threshold_label]
+    configured_reverse = reverse[threshold_label]
     if configured_reverse > configured_direct:
         diagnosis = "reverse_direction_stronger_at_configured_threshold"
     elif configured_direct == 0 and any(value > 0 for key, value in direct.items() if key != "0.25"):
@@ -102,7 +114,7 @@ def score_counterfactual(diagnostics: dict[str, Any]) -> dict[str, Any]:
         "formula_evaluations": formula_evaluations,
         "depth_fillable": int_metric(diagnostics, "settlement_autofactor_depth_fillable"),
         "entry_score_skips": int_metric(diagnostics, "skip_entry_score"),
-        "configured_entry_threshold": "0.25",
+        "configured_entry_threshold": threshold_label,
         "direct_pass_counts": direct,
         "reverse_direction_pass_counts": reverse,
         "diagnosis": diagnosis,
@@ -162,6 +174,7 @@ def build_artifact(
     min_trade_count: int,
     min_fill_rate: Decimal,
     min_roi: Decimal,
+    configured_entry_threshold: str,
     evidence: str,
 ) -> dict[str, Any]:
     evidence_rows = runtime_evidence(runtime_eval)
@@ -245,7 +258,7 @@ def build_artifact(
         blocking_flags.append("zero_runtime_orders_and_fills")
 
     diagnostics = runtime_eval.get("strategy_diagnostics") or result.get("strategy_diagnostics") or {}
-    counterfactual = score_counterfactual(diagnostics)
+    counterfactual = score_counterfactual(diagnostics, configured_entry_threshold)
 
     artifact = {
         "schema_version": 1,
@@ -357,6 +370,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-trade-count", type=int, default=50)
     parser.add_argument("--min-fill-rate", default="0.30")
     parser.add_argument("--min-roi", default="0")
+    parser.add_argument("--configured-entry-threshold", default="0.25")
     parser.add_argument("--evidence", default="")
     parser.add_argument("--output-json", required=True)
     parser.add_argument("--output-md", default="")
@@ -376,6 +390,7 @@ def main() -> int:
         min_trade_count=args.min_trade_count,
         min_fill_rate=decimal_arg(args.min_fill_rate, "--min-fill-rate"),
         min_roi=decimal_arg(args.min_roi, "--min-roi"),
+        configured_entry_threshold=args.configured_entry_threshold,
         evidence=args.evidence or str(runtime_path),
     )
     output_json = Path(args.output_json)

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -35,6 +35,16 @@ def decimal_value(raw: Any, default: Decimal = Decimal("0")) -> Decimal:
         return default
 
 
+def decimal_arg(raw: Any, name: str) -> Decimal:
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, ValueError):
+        raise SystemExit(f"{name} must be a decimal value: {raw!r}") from None
+    if not value.is_finite():
+        raise SystemExit(f"{name} must be finite: {raw!r}")
+    return value
+
+
 def is_closed_settlement(raw: Any) -> bool:
     if raw is None:
         return False
@@ -253,6 +263,12 @@ def build_artifact(
             "full_depth_entry": full_depth_entry,
             "stake_usd": float(stake_usd),
         },
+        "acceptance_criteria": {
+            "min_trade_count": min_trade_count,
+            "min_fill_rate": float(min_fill_rate),
+            "min_roi": float(min_roi),
+            "full_depth_entry": full_depth_entry,
+        },
         "metrics": {
             "updates_processed": int(result.get("updates_processed") or 0),
             "intents_submitted": intent_count,
@@ -293,9 +309,19 @@ def render_markdown(artifact: dict[str, Any]) -> str:
         f"- Total PnL: `{metrics.get('total_pnl')}`",
         f"- ROI: `{metrics.get('roi')}`",
         "",
-        "## Blocking Risk Flags",
+        "## Acceptance Criteria",
         "",
     ]
+    criteria = artifact.get("acceptance_criteria") or {}
+    for key in ("min_trade_count", "min_fill_rate", "min_roi", "full_depth_entry"):
+        lines.append(f"- {key}: `{criteria.get(key)}`")
+    lines.extend(
+        [
+            "",
+            "## Blocking Risk Flags",
+            "",
+        ]
+    )
     lines.extend(f"- `{flag}`" for flag in flags) if flags else lines.append("- `<none>`")
     counterfactual = artifact.get("score_counterfactual")
     if isinstance(counterfactual, dict):
@@ -345,11 +371,11 @@ def main() -> int:
         runtime_eval,
         runtime_score=args.runtime_score,
         strategy_profile=args.strategy_profile,
-        stake_usd=decimal_value(args.stake_usd),
+        stake_usd=decimal_arg(args.stake_usd, "--stake-usd"),
         full_depth_entry=args.full_depth_entry,
         min_trade_count=args.min_trade_count,
-        min_fill_rate=decimal_value(args.min_fill_rate),
-        min_roi=decimal_value(args.min_roi),
+        min_fill_rate=decimal_arg(args.min_fill_rate, "--min-fill-rate"),
+        min_roi=decimal_arg(args.min_roi, "--min-roi"),
         evidence=args.evidence or str(runtime_path),
     )
     output_json = Path(args.output_json)

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -254,12 +254,18 @@ def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> 
     return rows
 
 
-def _factor_score(item: dict[str, Any]) -> tuple[float, float, float, float]:
+def _factor_score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float]:
+    try:
+        rank = float(item.get("rank") or 10_000)
+    except (TypeError, ValueError):
+        rank = 10_000.0
     return (
         1.0 if item["decision"] == "candidate" and item["reason"] == "passed" else 0.0,
         float(item.get("positive_window_ratio") or 0.0),
         float(item.get("symbol_positive_ratio") or 0.0),
+        float(item.get("icir") or 0.0),
         float(item.get("spearman_ic") or 0.0),
+        -rank,
     )
 
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -122,6 +122,21 @@ Evidence stage: `walk_forward / runtime_parity`.
   `reverse_direction_stronger_at_configured_threshold`, with direct/reverse pass
   counts `35/59` at `0.15`; run `26262629518` is testing `0.10` to determine
   whether the extra pass-through improves or dilutes realized EV.
+- 2026-05-22: Threshold replay run `26262629518` with
+  `three_layer_min_entry_score=0.10` improved further to `39` trades, fill rate
+  `1.0`, total PnL `56.87549434398724`, and ROI `0.09722306725467904`, but was
+  still blocked by `official_settlement_missing:38<39`. The lower-bound
+  threshold run `26262853743` with `three_layer_min_entry_score=0.05` produced
+  more trades (`46`) but negative ROI `-0.010946529804138783`, so `0.05` is too
+  loose for this candidate.
+- 2026-05-22: Re-running the `0.10` threshold after settlement freshness caught
+  up produced promotion-ready executable replay run `26263054204`:
+  `39` trades on `39` unique events, one decision per event, fill rate `1.0`,
+  official settlement `39/39`, total PnL `77.06391934398724`, ROI
+  `0.13173319545980725`, and no blocking flags. This is the first short-window
+  runtime replay artifact in this loop that passes the current pre-dry-run
+  executable replay gates; next work should be a separate implementation issue
+  or PR for a dry-run candidate config rather than expanding this tooling PR.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -89,6 +89,12 @@ Evidence stage: `walk_forward / runtime_parity`.
   those LLM suffixes to supported `spread_adjusted` and
   `full_depth_entry_gate` semantics and allows selector gates to be followed by
   additional mutations.
+- 2026-05-22: Prior-feedback run `26261893965` moved the best runtime-mappable
+  candidate to
+  `mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025`.
+  Runtime scoring now supports multiple `_select_*_ge_*` gates in one formula
+  name so this candidate can be replayed instead of getting stuck at research
+  artifact selection.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,62 @@
+# Short-Window Strategy Discovery Repair (2026-05-22)
+
+## Goal
+
+Improve PM5D short-window strategy discovery after the initial 1d/2d AutoFactor
+run showed that single-factor discovery over-selected external-move variants and
+did not reliably translate into positive runtime replay EV.
+
+Evidence stage: `walk_forward / runtime_parity`.
+
+## Files / Ownership
+
+- `.github/workflows/runtime-candidate-replay.yml`
+  - Owner: let runtime replay evidence attach to the active research issue.
+- `crates/ploy-research/examples/factor_walk_forward_v2.rs` and
+  `crates/ploy-research/src/factors_v2.rs`
+  - Owner: inspect existing selector/combo discovery path before adding more
+    search machinery.
+- `tasks/todo.md`
+  - Owner: current session tracking and evidence summary.
+
+## Tasks
+
+- [x] Record that the first short-window replay batch rejected
+      `mut_spread_adjusted_external_move_full_depth_entry_gate` despite perfect
+      fill rate because runtime replay ROI was negative.
+- [x] Add a caller-provided issue number to `runtime-candidate-replay.yml`
+      while preserving the existing #538 default and GitHub's dispatch input
+      limit.
+- [x] Run short-window `report_suite=full` selector/combo evidence against issue
+      #581.
+- [x] Add bounded AutoFactor selector/threshold discovery mutations without
+      relaxing promotion gates.
+- [x] Decide whether the next implementation should promote a combo/selector
+      artifact into a typed runtime contract, or only tune thresholds around
+      the positive but sparse `near_strike` baseline.
+
+## Review
+
+- 2026-05-22: Runtime replay comparators from issue #581 showed:
+  `mut_spread_adjusted_external_move_full_depth_entry_gate` had 28 trades,
+  fill rate `1.0`, and ROI `-0.005590`; `mut_spread_adjusted_external_move_near_strike`
+  had 8 trades, fill rate `1.0`, and ROI `0.060188`; and
+  `mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted` emitted no trades
+  at configured thresholds. This makes the next search a selector/threshold
+  problem, not a simple "pick the highest IC single factor" problem.
+- 2026-05-22: Hosted full-report runs `26260172640` and `26260179765` exposed
+  the existing `Combo V1` selector path that earlier `report_suite=core` runs
+  skipped. The 1d combo diagnostic had 1 positive window, total test PnL
+  `1165.1388`, fill rate `0.8768`, and avg component count `12`. The 2d combo
+  diagnostic had 3 windows, positive-window ratio `0.6667`, total test PnL
+  `1511.9387`, and one negative test window. This is promising but still
+  diagnostic-only until a typed selector runtime contract and replay path exist.
+- 2026-05-22: Decision: do not promote the sparse `near_strike` runtime replay
+  result by threshold tuning alone. The next research slice should validate
+  selector/combo candidates as typed runtime contracts with acceptance criteria
+  attached to issue #581, because the weakness is strategy selection and
+  executable gating, not another single-factor mutation.
+
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -95,6 +95,24 @@ Evidence stage: `walk_forward / runtime_parity`.
   Runtime scoring now supports multiple `_select_*_ge_*` gates in one formula
   name so this candidate can be replayed instead of getting stuck at research
   artifact selection.
+- 2026-05-22: Runtime candidate replay run `26262036674` improved but still did
+  not pass promotion gates for
+  `autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025`.
+  It processed `1037301` updates, emitted `18` trades on `18` unique events,
+  had fill rate `1.0`, total PnL `11.28650819509724`, and ROI
+  `0.04180188220406385`; blockers were `trade_count_too_small:18<20` and
+  `official_settlement_missing:17<18`. The counterfactual still reported
+  `reverse_direction_stronger_at_configured_threshold`, with direct/reverse
+  pass counts `18/35` at threshold `0.25`, `42/64` at `0.15`, `51/79` at
+  `0.10`, and `76/94` at `0.05`.
+- 2026-05-22: Follow-up code lets `runtime-candidate-replay.yml` override
+  `three_layer_min_entry_score` through fail-closed `options_json` values
+  `0.05`, `0.10`, `0.15`, or `0.25`, and records the configured threshold in
+  the candidate replay artifact. This is a diagnostic replay knob only; it does
+  not mutate the remote dry-run config. If lower-threshold replay still fails or
+  shows worse ROI, stop iterating the `external_move` family and switch the next
+  search to settlement-native runtime-mappable formulas such as
+  `auto_settlement_model_conservative_settlement_edge*`.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -113,6 +113,15 @@ Evidence stage: `walk_forward / runtime_parity`.
   shows worse ROI, stop iterating the `external_move` family and switch the next
   search to settlement-native runtime-mappable formulas such as
   `auto_settlement_model_conservative_settlement_edge*`.
+- 2026-05-22: Threshold diagnostic replay run `26262423629` with
+  `three_layer_min_entry_score=0.15` materially improved runtime evidence for
+  the same multi-selector formula: `35` trades on `35` unique events, fill rate
+  `1.0`, total PnL `42.00878575784524`, and ROI `0.08001673477684808`. It still
+  is not promotion-ready because official settlement was available for only
+  `34/35` traded events. The counterfactual remained
+  `reverse_direction_stronger_at_configured_threshold`, with direct/reverse pass
+  counts `35/59` at `0.15`; run `26262629518` is testing `0.10` to determine
+  whether the extra pass-through improves or dilutes realized EV.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -56,6 +56,23 @@ Evidence stage: `walk_forward / runtime_parity`.
   selector/combo candidates as typed runtime contracts with acceptance criteria
   attached to issue #581, because the weakness is strategy selection and
   executable gating, not another single-factor mutation.
+- 2026-05-22: PR #582 run `26260888380` validated the new selector search on
+  snapshot `26135455846` for `BTCUSDT,ETHUSDT`. The best
+  `full_depth_settlement_executable_pnl` candidate was
+  `mut_spread_adjusted_external_move_select_near_strike_ge_075` with `n=1226`,
+  ICIR `2.161689`, positive-window ratio `1.0`, top-bucket label `3.060470`,
+  top-bucket fill rate `1.0`, `246` unique events, and max event decisions `1`.
+  It remains blocked from promotion until runtime MarketUpdate replay proves the
+  same selector scorer.
+- 2026-05-22: Follow-up code teaches the candidate replay builder and sweep
+  summary to prefer selector-quality candidates over raw top-bucket PnL, and
+  teaches the runtime predictive AutoFactor scorer to execute
+  `_select_<feature>_ge_<threshold>` gates. Local replay-builder verification
+  now selects
+  `autofactor_formula:mut_spread_adjusted_external_move_select_near_strike_ge_075`
+  from the run artifact, with aggregate `246` trades, fill rate `1.0`, total PnL
+  `752.87562`, and ROI `0.204031`; this is still an aggregate artifact, not a
+  promotion.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -73,6 +73,22 @@ Evidence stage: `walk_forward / runtime_parity`.
   from the run artifact, with aggregate `246` trades, fill rate `1.0`, total PnL
   `752.87562`, and ROI `0.204031`; this is still an aggregate artifact, not a
   promotion.
+- 2026-05-22: Runtime candidate replay run `26261449534` rejected
+  `autofactor_formula:mut_spread_adjusted_external_move_select_near_strike_ge_075`.
+  It processed `973390` updates, emitted `8` filled trades on `8` unique events,
+  had fill rate `1.0`, total PnL `-8.153820616012`, ROI `-0.06794850513343334`,
+  and blockers `trade_count_too_small:8<20`, `official_settlement_missing:7<8`,
+  and `roi_too_low`. Counterfactual diagnosis was
+  `reverse_direction_stronger_at_configured_threshold`, so this selector should
+  be used as negative runtime feedback for the next search, not promoted.
+- 2026-05-22: Replay-feedback walk-forward run `26261684452` correctly kept the
+  selector blocked and generated `revise_prior` with
+  `runtime_pass_through_collapse`. The next typed prior includes
+  `runtime_pass_through_add_spread_penalty` and
+  `runtime_pass_through_add_capacity_gate` mutations, so runtime now canonicalizes
+  those LLM suffixes to supported `spread_adjusted` and
+  `full_depth_entry_gate` semantics and allows selector gates to be followed by
+  additional mutations.
 
 # Predictive AutoFactor Runtime Entry Edge (2026-05-20)
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -573,6 +573,10 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(request["git_ref"], "main")
             self.assertEqual(request["inputs"]["runtime_score"], runtime_score)
             self.assertEqual(request["inputs"]["strategy_profile"], "settlement_probability")
+            self.assertEqual(
+                json.loads(request["inputs"]["options_json"]),
+                {"full_depth_entry": True, "skip_settlement_exits": False},
+            )
 
     def test_fix_runtime_request_uses_best_current_runtime_mappable_factor(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1217,6 +1221,7 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(decision["decision"], "fix_runtime")
             self.assertIn("## Runtime Replay Request", markdown)
             self.assertIn(f"- runtime_score: `{runtime_score}`", markdown)
+            self.assertIn("- options_json: `", markdown)
 
     def test_missing_feedback_routes_to_fix_data(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -134,6 +134,30 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
             "mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
         )
 
+    def test_prefers_selector_gate_candidate_over_higher_top_bucket_label(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=false stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=false
+gate,passed,evidence
+recorded_replay_parity,false,post-dry-run gate pending
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_avg_entry_sweep_slip_bps,top_bucket_avg_entry_sweep_levels,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_spread_adjusted_external_move_select_near_strike_ge_075,full_depth_settlement_executable_pnl,candidate,passed,1226,0.072616,0.051222,8,2.161689,1.0000,2,1.0000,0.7500,246,3.060470,0.6707,1.0000,12.32,1.46,246,1,7
+2,mut_spread_adjusted_external_move_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,1249,0.140001,0.082941,8,0.994307,0.8750,2,1.0000,0.7500,250,3.369123,0.7080,1.0000,11.41,1.41,250,1,9
+"""
+        payload, _ = self.run_script(report)
+
+        self.assertEqual(
+            payload["runtime_score"],
+            "autofactor_formula:mut_spread_adjusted_external_move_select_near_strike_ge_075",
+        )
+        self.assertEqual(
+            payload["source_factor"]["name"],
+            "mut_spread_adjusted_external_move_select_near_strike_ge_075",
+        )
+
     def test_selects_llm_runtime_pass_through_predictive_formula_mutation(self):
         payload, _ = self.run_script(AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT)
 

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -145,8 +145,18 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(payload["metrics"]["settlement_event_count"], 2)
         self.assertEqual(payload["metrics"]["entry_fill_rate"], 1.0)
         self.assertGreater(payload["metrics"]["roi"], 0)
+        self.assertEqual(
+            payload["acceptance_criteria"],
+            {
+                "full_depth_entry": True,
+                "min_fill_rate": 0.3,
+                "min_roi": 0.0,
+                "min_trade_count": 2,
+            },
+        )
         self.assertEqual(payload["blocking_risk_flags"], [])
         self.assertIn("Promotion ready: `true`", markdown)
+        self.assertIn("## Acceptance Criteria", markdown)
 
     def test_blocks_zero_intent_runtime_replay_with_diagnostics(self):
         payload, _ = self.run_script(
@@ -362,6 +372,33 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(artifact["metrics"]["settlement_event_count"], 2)
         self.assertEqual(artifact["metrics"]["total_pnl"], 12.0)
         self.assertEqual(artifact["metrics"]["entry_fill_rate"], 1.0)
+
+    def test_invalid_decimal_gate_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runtime_json = tmp_path / "runtime-eval.json"
+            output_json = tmp_path / "candidate-strategy-replay.json"
+            runtime_json.write_text(json.dumps(runtime_eval_payload()), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--runtime-evaluation-json",
+                    str(runtime_json),
+                    "--runtime-score",
+                    "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "--output-json",
+                    str(output_json),
+                    "--min-roi",
+                    "not-a-decimal",
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--min-roi must be a decimal value", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -237,6 +237,86 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertIn("## Score Counterfactual", markdown)
         self.assertIn("| `0.15` | `3` | `0` |", markdown)
 
+    def test_counterfactual_uses_configured_entry_threshold(self):
+        payload, _ = self.run_script(
+            {
+                "result": {
+                    "updates_processed": 1000,
+                    "intents_submitted": 0,
+                    "strategy_diagnostics": {
+                        "settlement_autofactor_formula_evaluations": 20,
+                        "settlement_autofactor_predictive_score_ge_005": 12,
+                        "settlement_autofactor_predictive_score_ge_010": 8,
+                        "settlement_autofactor_predictive_score_ge_015": 3,
+                        "settlement_autofactor_predictive_score_ge_025": 0,
+                        "settlement_autofactor_predictive_reverse_score_ge_005": 14,
+                        "settlement_autofactor_predictive_reverse_score_ge_010": 10,
+                        "settlement_autofactor_predictive_reverse_score_ge_015": 4,
+                        "settlement_autofactor_predictive_reverse_score_ge_025": 0,
+                    },
+                },
+                "runtime_evidence": {
+                    "basis": "trading_runtime_snapshot",
+                    "events": [],
+                    "orders": [],
+                    "fills": [],
+                    "intents": [],
+                },
+            },
+            "--full-depth-entry",
+            "--configured-entry-threshold",
+            "0.15",
+            "--min-trade-count",
+            "2",
+        )
+
+        counterfactual = payload["score_counterfactual"]
+        self.assertEqual(counterfactual["configured_entry_threshold"], "0.15")
+        self.assertEqual(
+            counterfactual["diagnosis"],
+            "reverse_direction_stronger_at_configured_threshold",
+        )
+
+    def test_rejects_unknown_counterfactual_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runtime_json = tmp_path / "runtime-eval.json"
+            output_json = tmp_path / "candidate-strategy-replay.json"
+            runtime_json.write_text(
+                json.dumps(
+                    {
+                        "result": {
+                            "strategy_diagnostics": {
+                                "settlement_autofactor_formula_evaluations": 1,
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--runtime-evaluation-json",
+                    str(runtime_json),
+                    "--runtime-score",
+                    "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "--output-json",
+                    str(output_json),
+                    "--configured-entry-threshold",
+                    "0.20",
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn(
+                "--configured-entry-threshold must be one of",
+                completed.stderr + completed.stdout,
+            )
+
     def test_blocks_open_settlement_and_unconfirmed_depth(self):
         payload, _ = self.run_script(
             runtime_eval_payload(settled=False),


### PR DESCRIPTION
## Summary
- add bounded selector gate mutations to AutoFactor discovery so settlement candidates can learn when not to trade
- keep promotion fail-closed by preserving runtime replay gates and explicit acceptance criteria
- move runtime replay advanced booleans into validated options_json so issue comments can target active research issues without exceeding workflow_dispatch input limits

## Evidence Stage
- walk_forward / runtime_parity

## Validation
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_alpha_search_closed_loop_agent
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runtime-candidate-replay.yml"); puts "yaml ok"'\n- CARGO_TARGET_DIR=/tmp/ploy-selector-gates rtk cargo test --locked -p ploy-research selector_threshold_grid --lib\n- CARGO_TARGET_DIR=/tmp/ploy-alpha-search-gate rtk cargo test --locked -p ploy-research alpha_search --lib\n- CARGO_TARGET_DIR=/tmp/ploy-workflow-security rtk cargo test --locked -p ploy --test workflow_security workflow_dispatch_inputs_stay_lintable -- --exact --nocapture\n- CARGO_TARGET_DIR=/tmp/ploy-factor-wf-check rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2\n- rtk git diff --check\n\n## Caveat\nThis does not promote a strategy. It expands discovery and hardens replay evidence so the next #581 run can evaluate selector/combo candidates before any dry-run handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selector gate mutations for deterministic candidate generation
  * Added acceptance criteria tracking (trade count, fill rate, ROI, entry depth) in artifacts
  * Added configurable entry threshold support in counterfactual scoring
  * Enhanced workflow inputs with JSON-based configuration and issue number tracking

* **Refactor**
  * Restructured workflow dispatch inputs for cleaner configuration management
  * Improved formula name normalization for additional prefix variants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->