### PR TITLE
Configure reviewed AutoFactor dry-run candidate

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -1,8 +1,8 @@
 # Three-layer settlement-probability dry-run config
-# PRD gate run 25369614389, snapshot 25367212009 / 69e259f6b4469392.
-# Dry-run handoff candidate only: BTC/ETH passed current full-depth,
-# conservative, OOS, symbol-holdout, anti-overfit, and recorded replay parity
-# gates. This is not a live config.
+# Runtime replay gate run 26263054204 selected the current AutoFactor
+# candidate on the BTC/ETH settlement-probability recording with 39/39
+# official settlements, one decision per event, fill_rate=1.0, and ROI=0.1317.
+# Dry-run handoff candidate only. This is not a live config.
 
 [runtime]
 strategy_variant = "three_layer"
@@ -39,8 +39,8 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_near_strike"
-three_layer_min_entry_score = 0.25
+three_layer_autofactor_runtime_score = "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025"
+three_layer_min_entry_score = 0.10
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30
 three_layer_min_confirmation_score = 0.0

--- a/config/strategies/REGISTRY.md
+++ b/config/strategies/REGISTRY.md
@@ -92,7 +92,7 @@ numeric ID used as filename prefix.
 | `02-pm5d-threelayer.obi-hard-dryrun.toml` | **UNIFIED** | Snapshot-profile dry-run candidate; profile `obi_hard` with hard OBI confirmation |
 | `02-pm5d-threelayer.continuation-soft-dryrun.toml` | **UNIFIED** | Holistic snapshot-profile dry-run candidate; profile `continuation_soft` |
 | `02-pm5d-threelayer.repricing-momentum-dryrun.toml` | **UNIFIED** | BTC/ETH/SOL-only full-depth dry-run candidate; profile `repricing_momentum` |
-| `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` | **UNIFIED** | BTC/ETH-only AutoFactor PRD dry-run handoff candidate; profile `settlement_probability`, runtime score `auto_settlement_conservative_settlement_edge` |
+| `02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml` | **UNIFIED** | BTC/ETH-only AutoFactor dry-run handoff candidate; profile `settlement_probability`, runtime score `mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025`, entry score `0.10` |
 
 ### S03 — Pattern Memory
 | File | Format | Notes |

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -71,6 +71,21 @@ class StrategyConfigContractTests(unittest.TestCase):
         )
         self.assertGreaterEqual(deployment_limit, expected_exposure)
 
+    def test_settlement_probability_dryrun_uses_reviewed_autofactor_candidate(self) -> None:
+        strategy = tomllib.loads(
+            (
+                STRATEGY_DIR
+                / "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+            ).read_text()
+        )["strategy"]
+
+        self.assertEqual(strategy["three_layer_strategy_profile"], "settlement_probability")
+        self.assertEqual(
+            strategy["three_layer_autofactor_runtime_score"],
+            "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025",
+        )
+        self.assertEqual(Decimal(str(strategy["three_layer_min_entry_score"])), Decimal("0.10"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Applies the promotion-ready AutoFactor runtime replay candidate from #583 to the BTC/ETH settlement-probability dry-run config.
- Sets `three_layer_autofactor_runtime_score` to the reviewed multi-selector formula.
- Sets `three_layer_min_entry_score = 0.10`, based on the threshold replay curve.
- Updates the strategy registry and adds a config contract test so the reviewed candidate does not silently regress.

## Evidence

- Research issue: #581
- Implementation issue: #583
- Tooling PR: #582
- Promotion-ready replay run: https://github.com/proerror77/ploy/actions/runs/26263054204

Replay metrics from run `26263054204`:

- `promotion_ready=true`
- `39` trades on `39` unique events
- one decision per event
- entry fill rate `1.0`
- official settlement `39/39`
- total PnL `77.06391934398724`
- ROI `0.13173319545980725`
- no blocking flags

Threshold curve:

- `0.25`: too strict; 18 trades, ROI `0.04180188220406385`
- `0.15`: 35 trades, ROI `0.08001673477684808`
- `0.10`: best current replay; 39 trades, ROI `0.13173319545980725`
- `0.05`: too loose; 46 trades, ROI `-0.010946529804138783`

## Validation

- `python3 -m unittest tests.test_strategy_config_contracts tests.test_apply_autofactor_handoff_to_config`
- `CARGO_TARGET_DIR=/tmp/ploy-config-candidate rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`
- `rtk git diff --check`

## Scope

Dry-run candidate config only. This PR does not deploy, does not alter live config, and does not approve live trading. After merge, the next step is protected dry-run config sync/deploy from `main`, followed by recorded replay/dry-run parity.
