### PR TITLE
Use candidate fillability for AutoFactor evidence

### DIFF
--- a/.github/scripts/autofactor-walk-forward-evidence.js
+++ b/.github/scripts/autofactor-walk-forward-evidence.js
@@ -22,6 +22,36 @@ function stringifyBlockers(blockers, limit = 3) {
   return `${shown.join("; ")}${suffix}`;
 }
 
+function blockerOutcome(blockers) {
+  const values = Array.isArray(blockers) ? blockers : [];
+  const blockerText = values.join(" ").toLowerCase();
+
+  if (blockerText.includes("data_quality") || blockerText.includes("deribit")) {
+    return {
+      decision: "fix-data",
+      reason: stringifyBlockers(values),
+    };
+  }
+  if (
+    blockerText.includes("replay") ||
+    blockerText.includes("runtime") ||
+    blockerText.includes("mapping") ||
+    blockerText.includes("parity")
+  ) {
+    return {
+      decision: "fix-runtime",
+      reason: stringifyBlockers(values),
+    };
+  }
+  if (values.length > 0) {
+    return {
+      decision: "revise",
+      reason: stringifyBlockers(values),
+    };
+  }
+  return null;
+}
+
 function decisionFromArtifacts({ promotion, handoff }) {
   if (!promotion && !handoff) {
     return {
@@ -37,28 +67,8 @@ function decisionFromArtifacts({ promotion, handoff }) {
     };
   }
 
-  const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
-  const blockedGates = Array.isArray(gate.blocked_gates) ? gate.blocked_gates : [];
-  const blockerText = blockedGates.join(" ").toLowerCase();
-
-  if (blockerText.includes("data_quality") || blockerText.includes("deribit")) {
-    return {
-      decision: "fix-data",
-      reason: stringifyBlockers(blockedGates),
-    };
-  }
-  if (blockerText.includes("replay") || blockerText.includes("runtime") || blockerText.includes("parity")) {
-    return {
-      decision: "fix-runtime",
-      reason: stringifyBlockers(blockedGates),
-    };
-  }
-  if (blockedGates.length > 0) {
-    return {
-      decision: "revise",
-      reason: stringifyBlockers(blockedGates),
-    };
-  }
+  const blockerDecision = blockerOutcome(actionableBlockers({ handoff, promotion }));
+  if (blockerDecision) return blockerDecision;
 
   if (promotion && promotion.decision === "blocked") {
     return {
@@ -86,6 +96,33 @@ function topStrategies(handoff, limit = 3) {
   });
 }
 
+function bestEvaluatedFactor(promotion) {
+  const evaluated = promotion && Array.isArray(promotion.evaluated_factors)
+    ? promotion.evaluated_factors
+    : [];
+  if (evaluated.length === 0) return null;
+
+  const minimums = promotion.minimums || {};
+  const minFill = Number(minimums.top_bucket_full_depth_entry_fill_rate ?? 0.30);
+  const candidates = evaluated
+    .filter((item) => item && item.factor)
+    .map((item, index) => ({ item, index }))
+    .sort((left, right) => {
+      const leftFactor = left.item.factor || {};
+      const rightFactor = right.item.factor || {};
+      return Number(Boolean(right.item.qualified)) - Number(Boolean(left.item.qualified))
+        || Number(rightFactor.decision === "candidate" && rightFactor.reason === "passed")
+          - Number(leftFactor.decision === "candidate" && leftFactor.reason === "passed")
+        || Number((rightFactor.top_bucket_full_depth_entry_fill_rate ?? 0) >= minFill)
+          - Number((leftFactor.top_bucket_full_depth_entry_fill_rate ?? 0) >= minFill)
+        || Number(rightFactor.top_bucket_avg_label ?? -Infinity)
+          - Number(leftFactor.top_bucket_avg_label ?? -Infinity)
+        || Number(rightFactor.icir ?? -Infinity) - Number(leftFactor.icir ?? -Infinity)
+        || left.index - right.index;
+    });
+  return candidates.length > 0 ? candidates[0].item : null;
+}
+
 function actionableBlockers({ handoff, promotion }) {
   const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
   const blockedGates = Array.isArray(gate.blocked_gates) ? gate.blocked_gates : [];
@@ -94,6 +131,27 @@ function actionableBlockers({ handoff, promotion }) {
       const value = String(item || "");
       return !value.startsWith("symbol_holdout:") && !value.startsWith("walk_forward_oos:");
     });
+  }
+  const gateText = blockedGates.join(" ").toLowerCase();
+  if (gateText.includes("data_quality") || gateText.includes("deribit")) {
+    return blockedGates;
+  }
+  const best = bestEvaluatedFactor(promotion);
+  if (best && best.factor) {
+    const minimums = promotion.minimums || {};
+    const minFill = Number(minimums.top_bucket_full_depth_entry_fill_rate ?? 0.30);
+    const fillRate = Number(best.factor.top_bucket_full_depth_entry_fill_rate);
+    const hasCandidateFillability = Number.isFinite(fillRate) && fillRate >= minFill;
+    const candidateBlockers = Array.isArray(best.blockers) ? best.blockers.filter(Boolean) : [];
+    if (hasCandidateFillability && candidateBlockers.length > 0) {
+      const scopedBlockers = candidateBlockers.filter((item) => {
+        const value = String(item || "");
+        return value !== "promotion_gate_not_ready"
+          && !value.startsWith("global_promotion_gate_not_ready:global_full_depth_entry_fillability:")
+          && !value.startsWith("global_full_depth_entry_fillability:");
+      });
+      if (scopedBlockers.length > 0) return scopedBlockers;
+    }
   }
   return blockedGates;
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,49 @@
+# AutoFactor Candidate Fillability Gate Repair (2026-05-22)
+
+## Goal
+
+Stop treating global full-depth fillability as the primary actionable blocker
+for selector/formula AutoFactor candidates when candidate top-bucket and later
+runtime replay fillability are the relevant execution surfaces.
+
+Evidence stage: `factor_attribution` -> `executable_replay` gate hygiene.
+
+## Files / Ownership
+
+- `.github/scripts/autofactor-walk-forward-evidence.js`
+  - Owner: issue/comment evidence summary and actionable blocker selection.
+- `tests/test_autofactor_walk_forward_evidence_js.py`
+  - Owner: regression coverage for low global fillability but high
+    candidate-scoped fillability.
+- `tasks/todo.md`
+  - Owner: session tracking and decision notes.
+
+## Tasks
+
+- [x] Confirm project semantics and identify the fillability blocker source.
+- [x] Make evidence summaries prefer candidate-scoped blockers when present.
+- [x] Add regression tests for global-low/candidate-fillable evidence.
+- [x] Run focused tests and diff checks.
+
+## Review
+
+- 2026-05-22: Root cause hypothesis: `global_full_depth_entry_fillability`
+  comes from `DataHealthReport::full_depth_entry_fill_rate()` over all
+  observation rows. It is useful data-health context, but it is too broad for
+  selector/formula candidates whose top bucket can have
+  `top_bucket_full_depth_entry_fill_rate=1.0`. Strategy promotion should still
+  require candidate top-bucket fillability and true
+  `runtime_market_update_replay` fill rate, not lower the threshold.
+- 2026-05-22: Fixed AutoFactor issue/comment evidence to prefer
+  candidate-scoped blockers when global data quality is otherwise acceptable
+  and the candidate top bucket passes the configured fillability floor. This
+  keeps low global fillability visible in machine artifacts but routes the next
+  action toward missing runtime mapping / missing runtime replay instead of a
+  misleading global-fillability-only blocker. Validation passed:
+  `python3 -m unittest tests/test_autofactor_walk_forward_evidence_js.py` and
+  `rtk git diff --check`. `rtk pytest ...` could not run in this worktree
+  because the `pytest` executable is not installed.
+
 # Bayesian Calibration Audit (2026-05-22)
 
 ## Goal

--- a/tests/test_autofactor_walk_forward_evidence_js.py
+++ b/tests/test_autofactor_walk_forward_evidence_js.py
@@ -1,0 +1,169 @@
+import json
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / ".github" / "scripts" / "autofactor-walk-forward-evidence.js"
+
+
+class AutoFactorWalkForwardEvidenceJsTest(unittest.TestCase):
+    def run_builder(self, artifact_dir: Path) -> dict:
+        js = textwrap.dedent(
+            f"""
+            const {{ buildWalkForwardEvidence }} = require({json.dumps(str(SCRIPT))});
+            const result = buildWalkForwardEvidence({{
+              title: "Hosted factor walk-forward evidence",
+              artifactDir: {json.dumps(str(artifact_dir))},
+              runnerLabel: "runner:test",
+              metadata: {{
+                workflow: "Factor Walk-Forward V2 Hosted Artifact",
+                runUrl: "https://github.example/run/1",
+                gitRef: "test-ref",
+                snapshotRunId: "123",
+                startDate: "2026-05-18T00:00:00Z",
+                endDate: "2026-05-20T00:00:00Z",
+                symbols: "BTCUSDT,ETHUSDT",
+                artifactName: "factor-walk-forward-v2-1",
+              }},
+            }});
+            process.stdout.write(JSON.stringify(result));
+            """
+        )
+        result = subprocess.run(
+            ["node", "-e", js],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_uses_candidate_blockers_when_global_low_but_top_bucket_fills(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact_dir = Path(tmp)
+            (artifact_dir / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "global_full_depth_entry_fillability: "
+                                "global_full_depth_entry_fill_rate=0.1282 "
+                                "min_required=0.3000"
+                            ],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-promotion.json").write_text(
+                json.dumps(
+                    {
+                        "decision": "blocked",
+                        "minimums": {
+                            "top_bucket_full_depth_entry_fill_rate": 0.30,
+                        },
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "global_full_depth_entry_fillability: "
+                                "global_full_depth_entry_fill_rate=0.1282 "
+                                "min_required=0.3000"
+                            ],
+                        },
+                        "evaluated_factors": [
+                            {
+                                "qualified": False,
+                                "blockers": [
+                                    "promotion_gate_not_ready",
+                                    "missing_runtime_strategy_mapping",
+                                    "candidate_strategy_replay_not_runtime_replay:"
+                                    "factor_walk_forward_top_bucket_aggregate!="
+                                    "runtime_market_update_replay",
+                                ],
+                                "factor": {
+                                    "name": (
+                                        "mut_bayes_model_contrarian_"
+                                        "confidence_weighted_edge_"
+                                        "select_entry_price_quality_ge_050"
+                                    ),
+                                    "decision": "candidate",
+                                    "reason": "passed",
+                                    "icir": 1.305048,
+                                    "top_bucket_avg_label": 2.338923,
+                                    "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_builder(artifact_dir)
+
+        self.assertEqual(result["decision"], "fix-runtime")
+        self.assertIn("missing_runtime_strategy_mapping", result["body"])
+        self.assertIn("candidate_strategy_replay_not_runtime_replay", result["body"])
+        self.assertNotIn("global_full_depth_entry_fillability", result["body"])
+
+    def test_keeps_data_quality_gate_as_actionable_blocker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact_dir = Path(tmp)
+            (artifact_dir / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "data_quality: mode=event_complete "
+                                "event_complete_events=0 min_events=20"
+                            ],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-promotion.json").write_text(
+                json.dumps(
+                    {
+                        "decision": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "data_quality: mode=event_complete "
+                                "event_complete_events=0 min_events=20"
+                            ],
+                        },
+                        "evaluated_factors": [
+                            {
+                                "qualified": False,
+                                "blockers": ["missing_runtime_strategy_mapping"],
+                                "factor": {
+                                    "decision": "candidate",
+                                    "reason": "passed",
+                                    "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_builder(artifact_dir)
+
+        self.assertEqual(result["decision"], "fix-data")
+        self.assertIn("data_quality", result["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Treat global full-depth fillability as data-health context, not the primary actionable blocker when an AutoFactor candidate top bucket passes fillability.
- Route hosted walk-forward issue comments toward candidate-scoped blockers such as missing runtime mapping or missing runtime MarketUpdate replay.
- Add Node-backed unittest coverage for the low-global/high-candidate-fillability case and for data-quality blockers.

## Evidence stage

`factor_attribution` -> `executable_replay` gate hygiene. This does not promote a strategy or change dry-run/live config.

## Validation

- `python3 -m unittest tests/test_autofactor_walk_forward_evidence_js.py`
- `rtk git diff --check`

Note: `rtk pytest tests/test_autofactor_walk_forward_evidence_js.py` could not run locally because the `pytest` executable is not installed in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AutoFactor walk-forward evidence generation to use candidate-specific blockers instead of global fillability metrics when actionable factors are identified.
  * Enhanced decision logic and blocker filtering to prioritize qualified candidates based on multiple evaluation criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->