### PR TITLE
Align research snapshot PM book cadence

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -26,7 +26,7 @@ on:
       options_json:
         description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, and optional full snapshot upload"
         required: false
-        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":300,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
+        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -69,7 +69,7 @@ jobs:
               "start_ts": "",
               "end_ts": "",
               "lob_sample_secs": "30",
-              "pm_book_sample_secs": "300",
+              "pm_book_sample_secs": "30",
               "observation_sample_secs": "30",
               "max_quote_age_secs": "30",
               "optimizer_data_dir": "/tmp/ploy-parquet",

--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -311,6 +311,32 @@ pub struct ResearchSnapshotBuildOptions {
     pub include_deribit: bool,
 }
 
+fn research_snapshot_quality_flags(
+    observation_count: usize,
+    deribit_snapshot_count: usize,
+    pm_book_snapshot_count: usize,
+    include_deribit: bool,
+    pm_book_sample_secs: i32,
+    max_quote_age_secs: i64,
+) -> Vec<String> {
+    let mut quality_flags = Vec::new();
+    if observation_count == 0 {
+        quality_flags.push("no_factor_observations".to_string());
+    }
+    if include_deribit && deribit_snapshot_count == 0 {
+        quality_flags.push("no_deribit_snapshots".to_string());
+    }
+    if pm_book_snapshot_count == 0 {
+        quality_flags.push("no_pm_book_snapshots".to_string());
+    }
+    if i64::from(pm_book_sample_secs.max(1)) > max_quote_age_secs.max(1) {
+        quality_flags.push(format!(
+            "pm_book_sample_secs_gt_max_quote_age:{pm_book_sample_secs}>{max_quote_age_secs}"
+        ));
+    }
+    quality_flags
+}
+
 #[cfg(feature = "db")]
 pub async fn build_research_snapshot_from_database(
     pool: &sqlx::PgPool,
@@ -432,16 +458,14 @@ pub async fn build_research_snapshot_from_database(
         rows: Some(observations.len()),
     });
 
-    let mut quality_flags = Vec::new();
-    if observations.is_empty() {
-        quality_flags.push("no_factor_observations".to_string());
-    }
-    if options.include_deribit && deribit_snapshots.is_empty() {
-        quality_flags.push("no_deribit_snapshots".to_string());
-    }
-    if all_pm_book_snapshots.is_empty() {
-        quality_flags.push("no_pm_book_snapshots".to_string());
-    }
+    let quality_flags = research_snapshot_quality_flags(
+        observations.len(),
+        deribit_snapshots.len(),
+        all_pm_book_snapshots.len(),
+        options.include_deribit,
+        pm_book_sample_secs,
+        options.max_quote_age_secs,
+    );
 
     Ok(ResearchSnapshot {
         manifest: ResearchSnapshotManifest {
@@ -762,5 +786,23 @@ mod tests {
         assert!(root.join("quality.md").exists());
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn quality_flags_sparse_pm_book_sampling_against_quote_age() {
+        let flags = research_snapshot_quality_flags(100, 0, 10, false, 300, 30);
+
+        assert!(flags.contains(
+            &"pm_book_sample_secs_gt_max_quote_age:300>30".to_string()
+        ));
+        assert!(!flags.contains(&"no_factor_observations".to_string()));
+        assert!(!flags.contains(&"no_pm_book_snapshots".to_string()));
+    }
+
+    #[test]
+    fn quality_flags_accepts_pm_book_sampling_within_quote_age() {
+        let flags = research_snapshot_quality_flags(100, 0, 10, false, 30, 30);
+
+        assert!(flags.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Change `research-snapshot.yml` default `pm_book_sample_secs` from 300 to 30 so PM full-depth book snapshots align with the 30s quote-age/factor observation cadence.
- Add a research snapshot quality flag when PM book sampling is sparser than `max_quote_age_secs`.
- Add focused unit coverage for the sparse PM book sampling guard.

## Root cause

The previous snapshot used `pm_book_sample_secs=300` while full-depth execution lookup accepts only PM books within 30 seconds. That makes most observation rows miss an otherwise available full-depth book and can incorrectly depress `$15` full-depth fillability.

## Evidence stage

`execution_quality` data-contract repair. This does not promote a strategy or change dry-run/live config. Existing snapshots compiled with `pm_book_sample_secs=300` should not be used as decisive `$15` full-depth fillability evidence.

## Validation

- `CARGO_TARGET_DIR=/tmp/ploy-pm-book-cadence /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_snapshot --lib`
- `rtk git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml"); puts "yaml ok"'`