### PR TITLE
Avoid argv limit for archived PM book query

### DIFF
--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -622,12 +622,21 @@ LIMIT {row_limit}
 "#
     );
 
+    let sql_path = std::env::temp_dir().join(format!(
+        "ploy-archive-pm-books-{}-{}.sql",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&sql_path, sql)
+        .with_context(|| format!("write DuckDB archive query {}", sql_path.display()))?;
+    let sql_file = File::open(&sql_path)
+        .with_context(|| format!("open DuckDB archive query {}", sql_path.display()))?;
     let output = Command::new("duckdb")
         .arg("-json")
-        .arg("-c")
-        .arg(sql)
+        .stdin(sql_file)
         .output()
         .context("run duckdb for archived PM book snapshots")?;
+    let _ = fs::remove_file(&sql_path);
     if !output.status.success() {
         anyhow::bail!(
             "duckdb archived PM book load failed: {}",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,7 +23,8 @@ Evidence stage: `execution_quality`.
 - [x] Add archived parquet PM book recovery to research snapshot compilation.
 - [x] Record PM book raw source/cadence metadata in snapshot manifest.
 - [x] Add focused tests and run validation.
-- [ ] Push PR, rerun snapshot, and invalidate old `$15 fillability=0.1282`
+- [x] Fix archived PM book DuckDB execution to avoid OS argv length limits.
+- [ ] Push PR, deploy, rerun snapshot, and invalidate old `$15 fillability=0.1282`
       evidence.
 
 ## Review
@@ -48,6 +49,15 @@ Evidence stage: `execution_quality`.
   `cargo build --locked -p ploy-research --example research_snapshot_compile --features db`,
   remote DuckDB syntax probe against the 2026-05-19 hour=23 archive, and
   `rtk git diff --check`.
+- 2026-05-22: First post-deploy 1-day snapshot run reached archive loading but
+  failed because the DuckDB SQL was passed through `duckdb -c` and exceeded the
+  OS argument-length limit. The loader now writes the generated SQL to a
+  temporary file and streams it through DuckDB stdin, preserving the same query
+  semantics while allowing large token/window contracts. Validation passed:
+  `rtk git diff --check`,
+  `cargo test --locked -p ploy-research --features db research_snapshot --lib`,
+  and
+  `cargo build --locked -p ploy-research --example research_snapshot_compile --features db`.
 
 # AutoFactor Candidate Fillability Gate Repair (2026-05-22)
 


### PR DESCRIPTION
## Summary
- stream archived PM book DuckDB SQL through stdin instead of passing it through argv
- keep the archive query semantics unchanged while allowing large token/window contracts
- record the 1-day snapshot failure and fix in tasks/todo.md

## Validation
- rtk git diff --check
- cargo test --locked -p ploy-research --features db research_snapshot --lib
- cargo build --locked -p ploy-research --example research_snapshot_compile --features db

Evidence stage: execution_quality. This fixes snapshot construction only; strategy profitability still requires fresh snapshot and walk-forward/runtime evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved failures in archived PM book sampling when processing large datasets by optimizing SQL query execution, eliminating command-line length constraint issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->