### PR TITLE
Normalize compact DuckDB hour offsets

### DIFF
--- a/crates/ploy-research/src/research_snapshot.rs
+++ b/crates/ploy-research/src/research_snapshot.rs
@@ -408,8 +408,25 @@ struct PmBookTokenWindow {
 
 #[cfg(feature = "db")]
 fn parse_duckdb_timestamptz(raw: &str) -> Result<DateTime<Utc>> {
+    let compact_hour_offset = raw
+        .len()
+        .checked_sub(3)
+        .and_then(|idx| raw.get(idx..))
+        .filter(|suffix| {
+            let bytes = suffix.as_bytes();
+            matches!(bytes.first(), Some(b'+') | Some(b'-'))
+                && bytes.get(1).is_some_and(u8::is_ascii_digit)
+                && bytes.get(2).is_some_and(u8::is_ascii_digit)
+        })
+        .map(|_| format!("{raw}:00"));
     DateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f%:z")
         .or_else(|_| DateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f%z"))
+        .or_else(|_| {
+            compact_hour_offset
+                .as_deref()
+                .map(|normalized| DateTime::parse_from_str(normalized, "%Y-%m-%d %H:%M:%S%.f%:z"))
+                .unwrap_or_else(|| DateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f%:z"))
+        })
         .or_else(|_| DateTime::parse_from_rfc3339(raw))
         .map(|ts| ts.with_timezone(&Utc))
         .with_context(|| format!("parse duckdb timestamp {raw:?}"))
@@ -1343,6 +1360,15 @@ mod tests {
             hours,
             vec![("2026-05-19".to_string(), 0), ("2026-05-19".to_string(), 1)]
         );
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn parse_duckdb_timestamptz_accepts_compact_hour_offset() {
+        let parsed = parse_duckdb_timestamptz("2026-05-19 06:55:13.870644+08")
+            .expect("compact offset timestamp");
+
+        assert_eq!(parsed.to_rfc3339(), "2026-05-18T22:55:13.870644+00:00");
     }
 
     #[cfg(feature = "db")]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -60,10 +60,11 @@ Evidence stage: `execution_quality`.
   `cargo test --locked -p ploy-research --features db research_snapshot --lib`,
   and
   `cargo build --locked -p ploy-research --example research_snapshot_compile --features db`.
-- 2026-05-22: The bounded 6-hour smoke run no longer pinned tango; it failed
-  quickly on timestamp parsing because DuckDB emitted an archived
-  `TIMESTAMPTZ` value with compact `+08` offset instead of `+08:00`. The
-  timestamp parser now accepts both forms before falling back to RFC3339.
+- 2026-05-22: The bounded 6-hour smoke runs no longer pinned tango; they failed
+  quickly on timestamp parsing because DuckDB emitted archived `TIMESTAMPTZ`
+  values with compact `+08` offsets instead of `+08:00` or `+0800`. The
+  timestamp parser now normalizes bare-hour offsets before falling back to
+  other accepted forms.
 - 2026-05-22: A follow-up 1-day snapshot run crossed the argv limit but then
   pinned tango while scanning the full archived day in one DuckDB query; the run
   was canceled and tango was rebooted. The archive loader now executes one


### PR DESCRIPTION
## Summary
- normalize DuckDB TIMESTAMPTZ values ending in bare hour offsets such as +08 before parsing
- add focused coverage for archived PM book timestamp parsing
- update task notes with the bounded smoke failure mode

## Validation
- rtk git diff --check
- cargo test --locked -p ploy-research --features db research_snapshot --lib

Evidence stage: execution_quality. This follows the bounded hourly archive loader and unblocks parsing the 6h smoke snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp parsing to handle timestamps with compact hour offset notation (e.g., `+08` instead of `+08:00`), normalizing them to standard format.

* **Tests**
  * Added unit test verifying successful parsing of timestamps with compact hour offsets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->