### PR TITLE
Default recorded replay parity to deployed runner

### DIFF
--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -43,9 +43,17 @@ on:
         options:
           - "true"
           - "false"
+      runner_source:
+        description: "Runner binary source: deployed for runtime parity, workflow_ref for branch regression"
+        required: false
+        default: "deployed"
+        type: choice
+        options:
+          - "deployed"
+          - "workflow_ref"
 
 concurrency:
-  group: recorded-replay-parity-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.since }}-${{ github.event.inputs.until }}
+  group: recorded-replay-parity-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.since }}-${{ github.event.inputs.until }}-${{ github.event.inputs.runner_source }}
   cancel-in-progress: false
 
 permissions:
@@ -69,6 +77,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build replay runner from workflow ref
+        if: ${{ github.event.inputs.runner_source == 'workflow_ref' }}
         run: |
           set -euo pipefail
           cargo build --release --locked \
@@ -133,6 +142,7 @@ jobs:
           SINCE: ${{ github.event.inputs.since }}
           UNTIL: ${{ github.event.inputs.until }}
           SKIP_SETTLEMENT_EXITS: ${{ github.event.inputs.skip_settlement_exits }}
+          RUNNER_SOURCE: ${{ github.event.inputs.runner_source }}
           REMOTE_DIR: /opt/ploy/tmp/recorded-replay-parity-${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -142,8 +152,14 @@ jobs:
           set -euo pipefail
           mkdir -p "$1"
           EOF
-          scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" \
-            tango-1-1:"${REMOTE_DIR}/ploy-runner"
+          case "${RUNNER_SOURCE}" in
+            deployed) ;;
+            workflow_ref)
+              scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" \
+                tango-1-1:"${REMOTE_DIR}/ploy-runner"
+              ;;
+            *) echo "runner_source must be deployed or workflow_ref" >&2; exit 1 ;;
+          esac
           scp scripts/enrich_recording_official_settlement.py \
             tango-1-1:"${REMOTE_DIR}/enrich_recording_official_settlement.py"
           scp scripts/enrich_replay_runtime_evidence.py \
@@ -163,7 +179,8 @@ jobs:
             "${REMOTE_DIR}" \
             "${SINCE}" \
             "${UNTIL}" \
-            "${SKIP_SETTLEMENT_EXITS}" <<'EOF'
+            "${SKIP_SETTLEMENT_EXITS}" \
+            "${RUNNER_SOURCE}" <<'EOF'
           set -euo pipefail
           deployment_id="$1"
           config_path="$2"
@@ -172,14 +189,25 @@ jobs:
           since_ts="$5"
           until_ts="$6"
           skip_settlement_exits="$7"
+          runner_source="$8"
           case "${skip_settlement_exits}" in
             true|false) ;;
             *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;
           esac
+          case "${runner_source}" in
+            deployed|workflow_ref) ;;
+            *) echo "runner_source must be deployed or workflow_ref" >&2; exit 1 ;;
+          esac
+          runner_path="/opt/ploy/bin/ploy-runner"
+          if [ "${runner_source}" = "workflow_ref" ]; then
+            runner_path="${remote_dir}/ploy-runner"
+          fi
 
           mkdir -p "${remote_dir}"
-          chmod +x "${remote_dir}/ploy-runner"
-          test -x "${remote_dir}/ploy-runner"
+          if [ "${runner_source}" = "workflow_ref" ]; then
+            chmod +x "${runner_path}"
+          fi
+          test -x "${runner_path}"
           test -r "${config_path}"
           test -r "${recording_path}"
           test -r "${remote_dir}/enrich_recording_official_settlement.py"
@@ -341,7 +369,7 @@ jobs:
               handle.write("\n".join(lines) + "\n")
           PY
 
-          timeout 600 "${remote_dir}/ploy-runner" run \
+          timeout 600 "${runner_path}" run \
             --config "${replay_config}" \
             --deployment-id "${deployment_id}" \
             --output-json "${remote_dir}/replay-evaluation.json"
@@ -411,6 +439,7 @@ jobs:
             echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
             echo "- Config: \`${{ github.event.inputs.config_path }}\`"
             echo "- Recording: \`${{ github.event.inputs.recording_path }}\`"
+            echo "- Runner source: \`${{ github.event.inputs.runner_source }}\`"
             echo "- Requested window: \`${{ github.event.inputs.since }} -> ${{ github.event.inputs.until }}\`"
             echo "- Resolved window: \`${resolved_since} -> ${resolved_until}\`"
             echo "- Window mode: \`${resolved_mode}\`"
@@ -488,6 +517,7 @@ jobs:
               `- Deployment: \`${{ github.event.inputs.deployment_id }}\``,
               `- Config: \`${{ github.event.inputs.config_path }}\``,
               `- Recording: \`${{ github.event.inputs.recording_path }}\``,
+              `- Runner source: \`${{ github.event.inputs.runner_source }}\``,
               `- Requested window: \`${{ github.event.inputs.since }} -> ${{ github.event.inputs.until }}\``,
               `- Resolved window: \`${resolvedWindow.since} -> ${resolvedWindow.until}\``,
               `- Window mode: \`${resolvedWindow.mode || "manual"}\``,

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -88,12 +88,16 @@ closed dry-run rows when available, and falls back to current open rows when a
 fresh recording has not yet accumulated closed events. The workflow records the resolved window in the workflow summary, issue comment, and
 `resolved-window.json` artifact. Manual timestamps remain supported for
 reproducing a known incident window or an older research issue.
-The workflow is read-only evidence generation: it builds `new-ploy-runner` on
-the GitHub runner from the requested workflow ref, copies that temporary binary
-to the replay scratch directory on `tango-1-1`, and uses a temporary replay
-config plus report/database reads. It does not deploy artifacts, restart
-services, replace `/opt/ploy/bin/ploy-runner`, or enable live orders. Its
-`approval_environment` input therefore defaults to
+The workflow is read-only evidence generation. `runner_source=deployed` is the
+default because runtime parity should compare the deployed dry-run report with
+the deployed `/opt/ploy/bin/ploy-runner` on the same host. Use
+`runner_source=workflow_ref` only as the branch-regression mode: it builds
+`new-ploy-runner` on the GitHub runner from the requested workflow ref, copies
+that temporary binary to the replay scratch directory on `tango-1-1`, and
+compares that branch binary against the deployed config/recording. Both modes
+use a temporary replay config plus report/database reads. The workflow does not
+deploy artifacts, restart services, replace `/opt/ploy/bin/ploy-runner`, or
+enable live orders. Its `approval_environment` input therefore defaults to
 `tango-1-1-build-only` so parity checks can run without the protected live
 deploy approval gate. Use `approval_environment=tango-1-1` only when an operator
 explicitly wants the protected environment approval for an incident replay.

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -311,12 +311,23 @@ fn recorded_replay_parity_supports_auto_window() {
     for needle in [
         "approval_environment:",
         "default: \"tango-1-1-build-only\"",
+        "runner_source:",
+        "Runner binary source: deployed for runtime parity, workflow_ref for branch regression",
+        "default: \"deployed\"",
+        "- \"deployed\"",
+        "- \"workflow_ref\"",
         "Build replay runner from workflow ref",
+        "if: ${{ github.event.inputs.runner_source == 'workflow_ref' }}",
         "--features new-ploy-runner/full",
         "-p new-ploy-runner",
         "target/${PLATFORM_TARGET}/release/new-ploy-runner",
         "tango-1-1:\"${REMOTE_DIR}/ploy-runner\"",
-        "timeout 600 \"${remote_dir}/ploy-runner\" run",
+        "RUNNER_SOURCE",
+        "runner_source must be deployed or workflow_ref",
+        "runner_path=\"/opt/ploy/bin/ploy-runner\"",
+        "runner_path=\"${remote_dir}/ploy-runner\"",
+        "timeout 600 \"${runner_path}\" run",
+        "Runner source",
         "skip_settlement_exits:",
         "Skip settlement exits for entry-only dry-run parity",
         "SKIP_SETTLEMENT_EXITS",
@@ -360,8 +371,9 @@ fn recorded_replay_parity_supports_auto_window() {
         }
     }
     for needle in [
-        "builds `new-ploy-runner` on\n",
-        "does not deploy artifacts, restart\nservices, replace `/opt/ploy/bin/ploy-runner`, or enable live orders",
+        "`runner_source=deployed` is the\ndefault",
+        "`runner_source=workflow_ref` only as the branch-regression mode",
+        "does not\ndeploy artifacts, restart services, replace `/opt/ploy/bin/ploy-runner`, or\nenable live orders",
     ] {
         if !runbook.contains(needle) {
             offenders.push(format!(


### PR DESCRIPTION
## Summary
- add runner_source to recorded-replay-parity.yml
- default runtime parity to the deployed tango runner at /opt/ploy/bin/ploy-runner
- keep workflow_ref as an explicit branch-regression mode that builds/scps a temporary runner
- include runner source in summaries and issue comments

## Evidence
- deployed-runner recorded replay parity run: https://github.com/proerror77/ploy/actions/runs/26300730181
- strict parity ready: true
- shared events/orders/fills: 4/4/4
- blocking/advisory flags: none

## Local validation
- Ruby YAML parse for .github/workflows/recorded-replay-parity.yml
- rtk git diff --check HEAD^..HEAD
- CARGO_TARGET_DIR=/tmp/ploy-recorded-runner-source-clean /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy recorded_replay_parity_supports_auto_window --test workflow_security -- --exact --nocapture
- CARGO_TARGET_DIR=/tmp/ploy-recorded-runner-source-clean /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy workflow_dispatch_inputs_stay_lintable --test workflow_security -- --exact --nocapture