### PR TITLE
Fix PRD gate snapshot sampling contract

### DIFF
--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -303,9 +303,21 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--min-event-complete-events", default="20")
     parser.add_argument("--min-event-complete-rows", default="40")
-    parser.add_argument("--lob-sample-secs", default="30")
-    parser.add_argument("--observation-sample-secs", default="30")
-    parser.add_argument("--max-quote-age-secs", default="30")
+    parser.add_argument(
+        "--lob-sample-secs",
+        default="",
+        help="Override LOB sampling seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+    )
+    parser.add_argument(
+        "--observation-sample-secs",
+        default="",
+        help="Override observation sampling seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+    )
+    parser.add_argument(
+        "--max-quote-age-secs",
+        default="",
+        help="Override quote-age seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+    )
     parser.add_argument("--train-window-days", default="2")
     parser.add_argument("--test-window-days", default="1")
     parser.add_argument("--step-days", default="1")
@@ -341,9 +353,9 @@ def main() -> int:
         )
     else:
         snapshot_options = {
-            "lob_sample_secs": int(args.lob_sample_secs),
-            "observation_sample_secs": int(args.observation_sample_secs),
-            "max_quote_age_secs": int(args.max_quote_age_secs),
+            "lob_sample_secs": int(args.lob_sample_secs or "30"),
+            "observation_sample_secs": int(args.observation_sample_secs or "30"),
+            "max_quote_age_secs": int(args.max_quote_age_secs or "30"),
             "optimizer_data_dir": "/tmp/ploy-parquet",
             "data_profile": "pm5d-vol",
             "custom_required_sources": "",
@@ -410,9 +422,11 @@ def main() -> int:
         "train_window_days": int(args.train_window_days),
         "test_window_days": int(args.test_window_days),
         "step_days": int(args.step_days),
-        "lob_sample_secs": int(args.lob_sample_secs),
-        "observation_sample_secs": int(args.observation_sample_secs),
-        "max_quote_age_secs": int(args.max_quote_age_secs),
+        "lob_sample_secs": int(args.lob_sample_secs) if args.lob_sample_secs else "",
+        "observation_sample_secs": (
+            int(args.observation_sample_secs) if args.observation_sample_secs else ""
+        ),
+        "max_quote_age_secs": int(args.max_quote_age_secs) if args.max_quote_age_secs else "",
         "top_n": int(args.top_n),
         "min_observations": int(args.min_observations),
         "top_quantile": float(args.top_quantile),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,49 @@
+# Settlement Probability PRD Gate Snapshot Contract (2026-05-23)
+
+## Goal
+
+Keep the settlement-probability PRD gate aligned with retained full research
+snapshot manifests instead of overriding snapshot-bound sampling fields with
+legacy defaults.
+
+Evidence stage: `walk_forward` gate orchestration after `runtime_parity`
+evidence is supplied.
+
+## Files / Ownership
+
+- `scripts/run_settlement_probability_prd_gate.py`
+  - Owner: PRD gate orchestration and hosted walk-forward options.
+- `tests/test_settlement_probability_prd_gate.py`
+  - Owner: regression coverage for existing-snapshot vs legacy-snapshot
+    sampling defaults.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+## Tasks
+
+- [x] Confirm project semantics and event ML workflow gates.
+- [x] Reproduce the hosted failure as a snapshot contract mismatch.
+- [x] Leave snapshot-bound sampling options empty for retained snapshot runs.
+- [x] Keep legacy snapshot builds on explicit 30-second sampling defaults.
+- [x] Run focused validation.
+- [ ] Commit, push, merge, and rerun the PRD gate from `main`.
+
+## Review
+
+- 2026-05-23: The retained full snapshot `26285446382` was compiled with
+  `lob_sample_secs=120`, `observation_sample_secs=120`, and
+  `max_quote_age_secs=120`. The PRD gate helper was still sending `30` for
+  those fields, causing hosted factor walk-forward run `26305481049` to fail
+  closed before strategy evaluation. The fix keeps those options blank when an
+  existing snapshot is supplied so the hosted workflow can resolve them from
+  `artifacts/research-snapshot/manifest.json`; legacy snapshot creation still
+  materializes the historical 30-second defaults.
+- 2026-05-23: Focused validation passed:
+  `python3 -m unittest discover -s tests -p 'test_settlement_probability_prd_gate.py'`,
+  `python3 -m py_compile scripts/run_settlement_probability_prd_gate.py tests/test_settlement_probability_prd_gate.py`,
+  dry-run dispatch payload inspection confirming blank snapshot-bound sampling
+  fields for snapshot `26285446382`, and `rtk git diff --check`.
+
 # PM Book Archive Snapshot Repair (2026-05-22)
 
 ## Goal

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -1,0 +1,95 @@
+import json
+import sys
+import unittest
+from unittest import mock
+
+from scripts import run_settlement_probability_prd_gate as gate
+
+
+class SettlementProbabilityPrdGateTests(unittest.TestCase):
+    def run_main(self, argv, *, dispatch):
+        with mock.patch.object(sys, "argv", ["run_settlement_probability_prd_gate.py", *argv]):
+            with mock.patch.object(
+                gate,
+                "refresh_run",
+                return_value=gate.WorkflowRun(
+                    database_id=12345,
+                    status="completed",
+                    conclusion="success",
+                    url="https://example.invalid/run/12345",
+                    created_at=gate.parse_created_at("2026-05-22T00:00:00Z"),
+                ),
+            ):
+                with mock.patch.object(gate, "dispatch_workflow", side_effect=dispatch):
+                    return gate.main()
+
+    def test_existing_snapshot_leaves_snapshot_bound_sampling_for_manifest_resolution(self):
+        dispatches = []
+
+        def capture_dispatch(workflow, fields, *, workflow_ref, dry_run):
+            dispatches.append((workflow, fields, workflow_ref, dry_run))
+            return None
+
+        status = self.run_main(
+            [
+                "--git-ref",
+                "main",
+                "--start-date",
+                "2026-05-16",
+                "--end-date",
+                "2026-05-20",
+                "--snapshot-run-id",
+                "12345",
+                "--replay-parity-run-id",
+                "26301157711:recorded-replay-parity-26301157711",
+                "--dry-run",
+            ],
+            dispatch=capture_dispatch,
+        )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(len(dispatches), 1)
+        workflow, fields, _, _ = dispatches[0]
+        self.assertEqual(workflow, gate.HOSTED_WALK_FORWARD_WORKFLOW)
+        options = json.loads(fields["options_json"])
+        self.assertEqual(options["lob_sample_secs"], "")
+        self.assertEqual(options["observation_sample_secs"], "")
+        self.assertEqual(options["max_quote_age_secs"], "")
+        self.assertEqual(options["replay_parity_run_id"], "26301157711")
+        self.assertEqual(
+            options["replay_parity_artifact_name"],
+            "recorded-replay-parity-26301157711",
+        )
+
+    def test_legacy_snapshot_build_keeps_default_sampling_values(self):
+        dispatches = []
+
+        def capture_dispatch(workflow, fields, *, workflow_ref, dry_run):
+            dispatches.append((workflow, fields, workflow_ref, dry_run))
+            return None
+
+        status = self.run_main(
+            [
+                "--git-ref",
+                "main",
+                "--start-date",
+                "2026-05-16",
+                "--end-date",
+                "2026-05-20",
+                "--dry-run",
+            ],
+            dispatch=capture_dispatch,
+        )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(len(dispatches), 1)
+        workflow, fields, _, _ = dispatches[0]
+        self.assertEqual(workflow, gate.RESEARCH_SNAPSHOT_WORKFLOW)
+        options = json.loads(fields["options_json"])
+        self.assertEqual(options["lob_sample_secs"], 30)
+        self.assertEqual(options["observation_sample_secs"], 30)
+        self.assertEqual(options["max_quote_age_secs"], 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep snapshot-bound sampling options empty when reusing an existing research snapshot so hosted walk-forward resolves them from manifest.json
- preserve 30-second defaults only for legacy snapshot creation
- add focused regression coverage and task evidence notes

## Verification
- python3 -m unittest discover -s tests -p 'test_settlement_probability_prd_gate.py'\n- python3 -m py_compile scripts/run_settlement_probability_prd_gate.py tests/test_settlement_probability_prd_gate.py\n- python3 scripts/run_settlement_probability_prd_gate.py --git-ref main --start-date 2026-05-16 --end-date 2026-05-20 --snapshot-run-id 26285446382 --replay-parity-run-id 26301157711:recorded-replay-parity-26301157711 --data-quality-mode event-complete --dry-run\n- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for CLI argument handling in snapshot orchestration, validating inheritance of sampling settings from existing manifests and default values for legacy snapshot creation.

* **Documentation**
  * Added documentation detailing snapshot contract alignment goals and validation procedures.

* **Chores**
  * Enhanced CLI argument handling to support inheriting sampling and quote-age settings from existing snapshot manifests when override flags are not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->