### PR TITLE
Fix runtime candidate replay empty threshold override

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -228,7 +228,7 @@ jobs:
           remote_dir="$4"
           runtime_score="$5"
           skip_settlement_exits="$6"
-          min_entry_score_override="$7"
+          min_entry_score_override="${7:-}"
           case "${skip_settlement_exits}" in
             true|false) ;;
             *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
+# Runtime Candidate Replay Empty Override Repair (2026-05-23)
+
+## Goal
+
+Let runtime candidate replay run with the deployed config's current
+`three_layer_min_entry_score` when no diagnostic override is requested.
+
+Evidence stage: `executable_replay` plumbing for `runtime_market_update_replay`.
+
+## Files / Ownership
+
+- `.github/workflows/runtime-candidate-replay.yml`
+  - Owner: remote replay invocation and optional entry-score override handling.
+- `tests/workflow_security.rs`
+  - Owner: workflow contract regression guard.
+- `tasks/todo.md`
+  - Owner: session tracking and rerun evidence.
+
+## Tasks
+
+- [x] Reproduce runtime candidate replay failure as empty `$7` under `set -u`.
+- [x] Make `three_layer_min_entry_score` override optional in the remote script.
+- [x] Run focused validation.
+- [ ] Commit, push, merge, and rerun runtime replay.
+
+## Review
+
+- 2026-05-23: Runtime candidate replay run `26306267258` failed before strategy
+  replay with `/bin/bash: line 8: $7: unbound variable`. The requested replay
+  did not pass a `three_layer_min_entry_score` override, so the workflow should
+  keep the deployed config's existing threshold. The remote script now reads
+  `${7:-}` to preserve strict mode while treating the override as optional.
+- 2026-05-23: Focused validation passed: YAML parse for
+  `.github/workflows/runtime-candidate-replay.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-workflow-security rtk cargo test --locked --test workflow_security runtime_candidate_replay_allows_empty_entry_score_override`,
+  and `rtk git diff --check`.
+
 # Settlement Probability PRD Gate Snapshot Contract (2026-05-23)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -609,6 +609,15 @@ fn hosted_factor_walk_forward_has_candidate_replay_feedback_input() {
 }
 
 #[test]
+fn runtime_candidate_replay_allows_empty_entry_score_override() {
+    let workflow = workflow_contents(".github/workflows/runtime-candidate-replay.yml");
+    assert!(
+        workflow.contains("min_entry_score_override=\"${7:-}\""),
+        "runtime-candidate-replay.yml must tolerate an omitted three_layer_min_entry_score override"
+    );
+}
+
+#[test]
 fn tango_deploy_keeps_pm5d_live_paused() {
     let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
     let cloud_assist = workflow_contents("scripts/ci/deploy_tango_cloud_assist.py");


### PR DESCRIPTION
## Summary
- allow runtime-candidate-replay remote script to omit three_layer_min_entry_score override while keeping set -u
- add workflow contract regression guard
- record runtime replay failure and validation evidence in tasks/todo.md

## Verification
- python3 YAML parse for .github/workflows/runtime-candidate-replay.yml
- CARGO_TARGET_DIR=/tmp/ploy-workflow-security rtk cargo test --locked --test workflow_security runtime_candidate_replay_allows_empty_entry_score_override
- rtk git diff --check