### PR TITLE
fix: reuse research DB secret for trace persistence

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -481,7 +481,7 @@ jobs:
       - name: Persist Research OS trace
         if: always()
         env:
-          RESEARCH_TRACE_DB_URL: ${{ secrets.RESEARCH_OS_DATABASE_URL || secrets.PLOY_DATABASE_URL }}
+          RESEARCH_TRACE_DB_URL: ${{ secrets.RESEARCH_OS_DATABASE_URL || secrets.PLOY_DATABASE_URL || secrets.PLOY_RESEARCH_DATABASE_URL || secrets.PLOY_DB_URL }}
         run: |
           set -euo pipefail
           if [ "${WALK_PERSIST_RESEARCH_TRACE}" != "true" ]; then
@@ -489,7 +489,8 @@ jobs:
             exit 0
           fi
           if [ -z "${RESEARCH_TRACE_DB_URL}" ]; then
-            echo "persist_research_trace requested but RESEARCH_OS_DATABASE_URL/PLOY_DATABASE_URL secret is not available." >&2
+            echo "persist_research_trace requested but no Research OS database secret is available." >&2
+            echo "Expected one of: RESEARCH_OS_DATABASE_URL, PLOY_DATABASE_URL, PLOY_RESEARCH_DATABASE_URL, PLOY_DB_URL." >&2
             exit 2
           fi
           if [ ! -f artifacts/research-snapshot/manifest.json ]; then

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -131,7 +131,8 @@ snapshot identity.
 
 Hosted walk-forward can run the writer automatically only when explicitly
 requested with `options_json.persist_research_trace=true` and a protected
-`RESEARCH_OS_DATABASE_URL` or `PLOY_DATABASE_URL` secret is available. The
+database secret is available. It checks `RESEARCH_OS_DATABASE_URL`,
+`PLOY_DATABASE_URL`, `PLOY_RESEARCH_DATABASE_URL`, then `PLOY_DB_URL`. The
 default remains false so ordinary research runs stay read-only artifact
 generation.
 

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -76,6 +76,8 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "Persist Research OS trace",
             "RESEARCH_OS_DATABASE_URL",
             "PLOY_DATABASE_URL",
+            "PLOY_RESEARCH_DATABASE_URL",
+            "PLOY_DB_URL",
             "--alpha-search-dir artifacts/factor-walk-forward-v2/alpha-search",
             "--registry-json artifacts/factor-walk-forward-v2/autofactor-factor-registry.json",
             "--promotion-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json",


### PR DESCRIPTION
## Summary
- let hosted Research OS trace persistence use existing research DB secret names (`PLOY_RESEARCH_DATABASE_URL` / `PLOY_DB_URL`) as fallbacks
- update the runbook and static contract test so this does not regress

## Test Plan
- python3 -m unittest tests.test_persist_research_trace_contract
- YAML parse for factor-walk-forward-v2-hosted-artifact.yml
- rtk git diff --check

## Context
The first persisted hosted walk-forward run reached the new persistence step but failed because `RESEARCH_TRACE_DB_URL` was empty. The repo already uses `PLOY_RESEARCH_DATABASE_URL` / `PLOY_DB_URL` for research DB access, so the trace writer should reuse those instead of requiring a brand-new secret before the data path can be validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runbook to document expanded database secret fallback configuration options.

* **Chores**
  * Enhanced CI/CD workflow to support additional database credential secret name variants for improved flexibility across deployment environments.
  * Updated infrastructure tests to verify extended secret configuration support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->