### PR TITLE
Research Manager durable trace planning workflow

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -615,6 +615,12 @@ jobs:
               ./target/fast/examples/persist_research_trace "${trace_args[@]}" --db-url "${RESEARCH_TRACE_DB_URL}"
               ;;
           esac
+          mkdir -p artifacts/research-trace
+          {
+            echo "persisted=true"
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "evidence_stages=factor_attribution,walk_forward"
+          } > artifacts/research-trace/persisted.env
           {
             echo "### Durable Research OS trace"
             echo ""
@@ -633,6 +639,10 @@ jobs:
           if [ "${WALK_CREATE_CONFIG_PR:-false}" != "true" ]; then
             echo "create_config_pr is not true; skipping config PR creation."
             exit 0
+          fi
+          if [ ! -f artifacts/research-trace/persisted.env ]; then
+            echo "create_config_pr requires successful durable Research OS trace persistence." >&2
+            exit 2
           fi
           handoff_json="artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json"
           if [ ! -f "${handoff_json}" ]; then
@@ -981,6 +991,10 @@ jobs:
             echo "Missing alpha search chain decision artifact; skipping chained dispatch."
             exit 0
           fi
+          if [ "${WALK_CHAIN_NEXT_RUN:-false}" = "true" ] && [ ! -f artifacts/research-trace/persisted.env ]; then
+            echo "chain_next_run requires successful durable Research OS trace persistence." >&2
+            exit 2
+          fi
           closed_loop_path="artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json"
           if [ ! -f "${closed_loop_path}" ]; then
             echo "Missing closed-loop classifier decision artifact; skipping chained dispatch."
@@ -1099,6 +1113,10 @@ jobs:
           if [ "${WALK_CREATE_HANDOFF_ISSUE:-false}" != "true" ]; then
             echo "create_handoff_issue is not true; skipping handoff issue creation."
             exit 0
+          fi
+          if [ ! -f artifacts/research-trace/persisted.env ]; then
+            echo "create_handoff_issue requires successful durable Research OS trace persistence." >&2
+            exit 2
           fi
           handoff_json="artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json"
           handoff_md="artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.md"

--- a/.github/workflows/research-trace-plan.yml
+++ b/.github/workflows/research-trace-plan.yml
@@ -1,0 +1,209 @@
+name: Research Trace Plan
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_stage:
+        description: "Evidence stage to summarize from experiment_trace"
+        required: true
+        default: "factor_attribution"
+      limit:
+        description: "Maximum recent runs/factors/patterns to inspect"
+        required: true
+        default: "20"
+      issue_number:
+        description: "Optional GitHub issue number to comment with the plan"
+        required: false
+        default: ""
+
+concurrency:
+  group: research-trace-plan-${{ github.event.inputs.evidence_stage }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DEPLOY_HOST: ${{ vars.TANGO_1_1_HOST || vars.ALIYUN_ECS_HOST || secrets.TANGO_1_1_HOST || secrets.ALIYUN_ECS_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+
+jobs:
+  plan:
+    name: Build Research Manager plan from durable trace
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: tango-1-1
+
+    steps:
+      - name: Validate inputs
+        env:
+          EVIDENCE_STAGE: ${{ github.event.inputs.evidence_stage }}
+          LIMIT: ${{ github.event.inputs.limit }}
+        run: |
+          set -euo pipefail
+          case "${EVIDENCE_STAGE}" in
+            diagnostic|factor_attribution|executable_replay|walk_forward|runtime_parity|dry_run_candidate|live_candidate) ;;
+            *)
+              echo "unsupported evidence_stage: ${EVIDENCE_STAGE}" >&2
+              exit 2
+              ;;
+          esac
+          python3 - <<'PY'
+          import os
+
+          raw = os.environ["LIMIT"]
+          try:
+              value = int(raw)
+          except ValueError as exc:
+              raise SystemExit(f"limit must be an integer: {raw}") from exc
+          if value < 1 or value > 100:
+              raise SystemExit("limit must be between 1 and 100")
+          PY
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
+          TANGO_SSH_KEY: ${{ secrets.TANGO_SSH_KEY }}
+          ALIYUN_ECS_SSH_KEY: ${{ secrets.ALIYUN_ECS_SSH_KEY }}
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_HOST}" ]; then
+            echo "DEPLOY_HOST is required for research trace planning on tango-1-1." >&2
+            exit 2
+          fi
+          install -m 700 -d ~/.ssh
+          selected_key=""
+          if [ -n "${TANGO_1_1_SSH_KEY}" ]; then
+            selected_key="${TANGO_1_1_SSH_KEY}"
+          elif [ -n "${TANGO_SSH_KEY}" ]; then
+            selected_key="${TANGO_SSH_KEY}"
+          elif [ -n "${ALIYUN_ECS_SSH_KEY}" ]; then
+            selected_key="${ALIYUN_ECS_SSH_KEY}"
+          else
+            echo "No tango SSH key secret is available." >&2
+            exit 2
+          fi
+          printf '%s\n' "${selected_key}" > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          ssh-keygen -y -f ~/.ssh/tango_1_1_key >/dev/null
+          if [ -n "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan "${DEPLOY_HOST}" | sed 's/^[^ ]*/tango-1-1/' > ~/.ssh/known_hosts
+          fi
+          chmod 600 ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Run Research Manager trace plan
+        env:
+          EVIDENCE_STAGE: ${{ github.event.inputs.evidence_stage }}
+          LIMIT: ${{ github.event.inputs.limit }}
+          RESEARCH_TRACE_DB_URL: ${{ secrets.RESEARCH_OS_DATABASE_URL || secrets.PLOY_DATABASE_URL || secrets.PLOY_RESEARCH_DATABASE_URL || secrets.PLOY_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RESEARCH_TRACE_DB_URL}" ]; then
+            echo "Expected one of: RESEARCH_OS_DATABASE_URL, PLOY_DATABASE_URL, PLOY_RESEARCH_DATABASE_URL, PLOY_DB_URL." >&2
+            exit 2
+          fi
+          mkdir -p artifacts/research-trace-plan
+          # shellcheck disable=SC2153
+          remote_dir="${DEPLOY_ROOT}/tmp/research-trace-plan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # shellcheck disable=SC2029
+          ssh tango-1-1 "rm -rf '${remote_dir}' && mkdir -p '${remote_dir}'"
+          # shellcheck disable=SC2029
+          ssh tango-1-1 /bin/bash -s -- \
+            "${remote_dir}" \
+            "${EVIDENCE_STAGE}" \
+            "${LIMIT}" \
+            "${RESEARCH_TRACE_DB_URL}" <<'EOF'
+          set -euo pipefail
+          remote_dir="$1"
+          evidence_stage="$2"
+          limit="$3"
+          db_url="$4"
+          plan_bin="/opt/ploy/bin/research-trace-plan"
+          test -x "${plan_bin}"
+          DATABASE_URL="${db_url}" "${plan_bin}" \
+            --evidence-stage "${evidence_stage}" \
+            --limit "${limit}" \
+            --output "${remote_dir}/research-trace-plan.json"
+          EOF
+          scp "tango-1-1:${remote_dir}/research-trace-plan.json" artifacts/research-trace-plan/research-trace-plan.json
+          # shellcheck disable=SC2029
+          ssh tango-1-1 "rm -rf '${remote_dir}'"
+
+      - name: Render plan summary
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("artifacts/research-trace-plan/research-trace-plan.json")
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          if payload.get("schema_version") != "research_trace_plan.v1":
+              raise SystemExit("research trace plan schema mismatch")
+          plan = payload.get("plan") or {}
+          theme = plan.get("theme", "")
+          if theme not in {"continue_search", "revise_prior", "fix_data", "fix_runtime", "fix_workflow"}:
+              raise SystemExit(f"unsupported research plan theme: {theme}")
+          actions = plan.get("actions") or []
+          lines = [
+              "# Research Trace Plan",
+              "",
+              f"- Run: {os.environ['RUN_URL']}",
+              f"- Evidence stage: `{plan.get('evidence_stage', '')}`",
+              f"- Theme: `{theme}`",
+              f"- Priority: `{plan.get('priority', '')}`",
+              f"- Candidate count: `{plan.get('candidate_count', 0)}`",
+              f"- Search depth: `{plan.get('search_depth', 0)}`",
+              "",
+              "## Actions",
+              "",
+          ]
+          if actions:
+              lines.extend(f"- `{action}`" for action in actions)
+          else:
+              lines.append("- `<none>`")
+          lines.append("")
+          summary = "\n".join(lines)
+          Path("artifacts/research-trace-plan/research-trace-plan.md").write_text(
+              summary,
+              encoding="utf-8",
+          )
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write(summary)
+          PY
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: research-trace-plan-${{ github.run_id }}
+          path: artifacts/research-trace-plan
+          if-no-files-found: error
+
+      - name: Comment plan on issue
+        if: ${{ github.event.inputs.issue_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body-file artifacts/research-trace-plan/research-trace-plan.md

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -64,6 +64,7 @@ when the mismatch is understood and tracked as a follow-up issue.
 | Runtime evidence reset | `.github/workflows/reset-strategy-runtime-evidence.yml` | Backup-first cleanup for contaminated dry-run/paper `strategy_runtime_orders` and `strategy_runtime_fills`; follow `docs/runbooks/strategy-runtime-evidence-reset.md` |
 | Dry-run config sync | `.github/workflows/sync-dryrun-strategy-config-tango-1-1.yml` | Protected config-only sync for a reviewed dry-run strategy TOML; restarts only the target dry-run worker and avoids collector restarts during clean-window waits |
 | Event ML rolling evidence | `.github/workflows/event-ml-rolling-evidence.yml` | Produce event-root rolling ML datasets and compact reports; use `source_dataset_run_id` for the GitHub-hosted artifact path |
+| Research Manager plan | `.github/workflows/research-trace-plan.yml` | Read durable Research OS trace on `tango-1-1` with the deployed `research-trace-plan` binary and emit next-step JSON/Markdown artifacts |
 | Market data audit | `.github/workflows/market-data-gap-audit.yml` | Scheduled/manual Tango data freshness and gap gate |
 | Image build | `.github/workflows/build-push-acr.yml` | Build ACK images; push only immutable checked-out SHA tags |
 | ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` environment |
@@ -138,6 +139,11 @@ generation. When that database URL targets Tango's private VPC endpoint, the
 hosted workflow ships the trace input artifacts to `tango-1-1` and runs the
 deployed `/opt/ploy/bin/persist-research-trace` binary there; it must not try
 to open a private PostgreSQL connection directly from a GitHub-hosted runner.
+Any hosted walk-forward path that mutates follow-up state by dispatching a
+chained alpha-search run, opening a dry-run handoff issue, or creating a config
+PR must first write the durable trace marker for the same run. Artifact-only
+runs may still produce reports, summaries, and issue comments, but they cannot
+advance the closed loop.
 
 Use `research_trace_plan` after durable rows exist to generate the next
 Research Manager plan from DB trace:
@@ -148,6 +154,13 @@ rtk cargo run -p ploy-research --example research_trace_plan --features db -- \
   --evidence-stage factor_attribution \
   --output research-trace-plan.json
 ```
+
+For CI evidence, dispatch `.github/workflows/research-trace-plan.yml` instead
+of running a local DB command. That workflow SSHes to `tango-1-1`, runs the
+deployed `/opt/ploy/bin/research-trace-plan` binary against the protected
+research database, uploads `research-trace-plan.json` / `.md`, and can attach
+the plan to a research issue. It is read-only and does not build Rust or mutate
+runtime state.
 
 The current architecture review is
 `docs/reviews/research-data-architecture-review-2026-05-23.md`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,53 @@
+# Research Trace Plan Manager Workflow (2026-05-23)
+
+## Goal
+
+Turn the durable Research OS trace that was just persisted from hosted
+walk-forward evidence into a runnable Research Manager planning artifact, then
+continue legacy cleanup and data/research review.
+
+Evidence stage: `factor_attribution` / `walk_forward` planning over durable
+trace, not dry-run promotion.
+
+## Files / Ownership
+
+- `.github/workflows/research-trace-plan.yml`
+  - Owner: read-only CI entrypoint that runs deployed `research-trace-plan` on
+    `tango-1-1` and uploads plan artifacts.
+- `docs/runbooks/strategy-research-cicd.md`
+  - Owner: canonical runbook wiring for durable trace -> Research Manager plan.
+- `tests/test_persist_research_trace_contract.py`
+  - Owner: regression coverage that the workflow uses deployed Tango binaries
+    and does not reintroduce local/hosted DB execution.
+- `tasks/todo.md`
+  - Owner: session tracking and final evidence.
+
+## Tasks
+
+- [x] Confirm current project semantics and event ML research workflow gates.
+- [x] Confirm hosted trace persistence succeeded from `main` run `26327836283`.
+- [x] Add read-only `research-trace-plan.yml` workflow.
+- [x] Validate workflow syntax, actionlint, and contract tests.
+- [ ] Merge workflow and dispatch it from `main`.
+- [ ] Verify `research-trace-plan.json` contains a valid next-plan theme.
+- [x] Apply high-priority legacy cleanup: block chain dispatch, handoff issue,
+      and config PR unless durable trace persistence succeeded.
+- [ ] Apply remaining high-priority data/research cleanup based on audit results.
+
+## Review
+
+- 2026-05-23: Hosted walk-forward run `26327836283` succeeded and the
+  `Persist Research OS trace` step printed `persist_research_trace: persisted`.
+- 2026-05-23: Focused validation passed: YAML parse for
+  `.github/workflows/research-trace-plan.yml`,
+  actionlint `v1.7.7`, extracted shell `bash -n`, `python3 -m unittest
+  tests.test_persist_research_trace_contract`, and `rtk git diff --check`.
+- 2026-05-23: Legacy cleanup started from parallel architecture audit. Hosted
+  walk-forward now writes `artifacts/research-trace/persisted.env` only after
+  `persist_research_trace` succeeds. `chain_next_run`, `create_handoff_issue`,
+  and `create_config_pr` fail closed without that marker, so artifact-only
+  research can no longer mutate follow-up state outside durable trace lineage.
+
 # Runtime Candidate Replay Empty Override Repair (2026-05-23)
 
 ## Goal

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -8,6 +8,7 @@ TRACE_PLAN = ROOT / "crates" / "ploy-research" / "examples" / "research_trace_pl
 CARGO = ROOT / "crates" / "ploy-research" / "Cargo.toml"
 RUNBOOK = ROOT / "docs" / "runbooks" / "strategy-research-cicd.md"
 HOSTED_WALK = ROOT / ".github" / "workflows" / "factor-walk-forward-v2-hosted-artifact.yml"
+TRACE_PLAN_WORKFLOW = ROOT / ".github" / "workflows" / "research-trace-plan.yml"
 TANGO_DEPLOY = ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml"
 LEGACY_FACTOR_REVIEW = ROOT / ".github" / "workflows" / "factor-review-v2.yml"
 LEGACY_WALK_FORWARD = ROOT / ".github" / "workflows" / "factor-walk-forward-v2.yml"
@@ -82,6 +83,10 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "tango-1-1:${remote_dir}/input.tar",
             "/opt/ploy/bin/persist-research-trace",
             'DATABASE_URL="${db_url}" "${persist_bin}"',
+            "artifacts/research-trace/persisted.env",
+            "create_config_pr requires successful durable Research OS trace persistence.",
+            "chain_next_run requires successful durable Research OS trace persistence.",
+            "create_handoff_issue requires successful durable Research OS trace persistence.",
             "--alpha-search-dir artifacts/factor-walk-forward-v2/alpha-search",
             "--registry-json artifacts/factor-walk-forward-v2/autofactor-factor-registry.json",
             "--promotion-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json",
@@ -115,6 +120,27 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("GROUP BY run_id", source)
         self.assertIn("source_surface_blockers", source)
         self.assertIn("missing_blocks_promotion", source)
+
+    def test_research_trace_plan_workflow_uses_deployed_tango_binary(self) -> None:
+        workflow = TRACE_PLAN_WORKFLOW.read_text(encoding="utf-8")
+        required = [
+            "Research Trace Plan",
+            "Build Research Manager plan from durable trace",
+            "/opt/ploy/bin/research-trace-plan",
+            "RESEARCH_OS_DATABASE_URL",
+            "PLOY_DATABASE_URL",
+            "PLOY_RESEARCH_DATABASE_URL",
+            "PLOY_DB_URL",
+            "research-trace-plan.json",
+            "research-trace-plan.md",
+            "actions/upload-artifact@v4",
+            "gh issue comment",
+        ]
+        for snippet in required:
+            self.assertIn(snippet, workflow)
+        self.assertNotIn("cargo build", workflow)
+        self.assertNotIn("cargo run", workflow)
+        self.assertNotIn("StrictHostKeyChecking no", workflow)
 
     def test_legacy_db_workflows_are_debug_only(self) -> None:
         for path in [LEGACY_FACTOR_REVIEW, LEGACY_WALK_FORWARD]:


### PR DESCRIPTION
## Summary
- add a read-only Research Trace Plan workflow that runs the deployed research-trace-plan binary on tango-1-1 and uploads JSON/Markdown plan artifacts
- document durable trace -> Research Manager planning in the strategy research runbook
- fail closed for hosted walk-forward side effects: chained alpha search, dry-run handoff issue, and config PR now require successful durable trace persistence

## Verification
- python3 -m unittest tests.test_persist_research_trace_contract
- YAML parse: research-trace-plan.yml and factor-walk-forward-v2-hosted-artifact.yml
- actionlint v1.7.7 on both workflows
- extracted workflow shell scripts: bash -n
- rtk cargo test --locked --test workflow_security workflow_dispatch_inputs_stay_lintable
- rtk git diff --check