### PR TITLE
Clarify sampled research snapshot contracts

### DIFF
--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "main"
       snapshot_run_id:
-        description: "Research Snapshot or downstream run id that owns a full research snapshot artifact"
+        description: "Research Snapshot or downstream run id that owns a complete sampled research snapshot artifact"
         required: true
       snapshot_artifact_name:
         description: "Snapshot artifact name; defaults to research-snapshot-<snapshot_run_id>"
@@ -134,7 +134,7 @@ jobs:
               --require quality.md
           fi
 
-      - name: Validate full snapshot payload
+      - name: Validate complete sampled snapshot payload
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -153,10 +153,10 @@ jobs:
           missing = [path for path in required if not path or not (root / path).exists()]
           if missing:
               raise SystemExit(
-                  "research snapshot artifact has manifest/quality but is missing full payload: "
+                  "research snapshot artifact has manifest/quality but is missing complete sampled payload: "
                   + ", ".join(missing)
               )
-          print("full research snapshot payload present: " + ", ".join(required))
+          print("complete sampled research snapshot payload present: " + ", ".join(required))
           PY
 
       - name: Resolve snapshot-bound options

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "main"
       snapshot_run_id:
-        description: "Research Snapshot or downstream run id that owns a full research snapshot artifact"
+        description: "Research Snapshot or downstream run id that owns a complete sampled research snapshot artifact"
         required: true
       snapshot_artifact_name:
         description: "Snapshot artifact name; defaults to research-snapshot-<snapshot_run_id>"
@@ -207,7 +207,7 @@ jobs:
               --require quality.md
           fi
 
-      - name: Validate full snapshot payload
+      - name: Validate complete sampled snapshot payload
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -227,10 +227,10 @@ jobs:
           missing = [path for path in required if not path or not (root / path).exists()]
           if missing:
               raise SystemExit(
-                  "research snapshot artifact has manifest/quality but is missing full payload: "
+                  "research snapshot artifact has manifest/quality but is missing complete sampled payload: "
                   + ", ".join(missing)
               )
-          print("full research snapshot payload present: " + ", ".join(required))
+          print("complete sampled research snapshot payload present: " + ", ".join(required))
           PY
 
       - name: Resolve snapshot-bound options

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -24,7 +24,7 @@ on:
         required: true
         default: "15"
       options_json:
-        description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, and optional full snapshot upload"
+        description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, and optional complete sampled snapshot upload"
         required: false
         default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
 
@@ -458,7 +458,7 @@ jobs:
             echo "workflow_runner=ubuntu-latest"
           } > artifacts/research-snapshot-provenance/source.txt
 
-      - name: Upload full snapshot artifact
+      - name: Upload complete sampled snapshot artifact
         if: ${{ steps.snapshot_options.outputs.upload_full_snapshot == 'true' }}
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -22,7 +22,7 @@ on:
         required: true
         default: "15"
       snapshot_run_id:
-        description: "Existing run id with a full research-snapshot artifact; skips legacy ploy-ci-1 snapshot build"
+        description: "Existing run id with a complete sampled research-snapshot artifact; skips legacy ploy-ci-1 snapshot build"
         required: false
         default: ""
       issue_number:

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -42,7 +42,7 @@ promotion half:
 - `factor-walk-forward-v2.yml`: self-hosted research path for fresh DB-adjacent
   snapshot and walk-forward evidence.
 - `factor-walk-forward-v2-hosted-artifact.yml`: GitHub-hosted path that consumes
-  a retained full research snapshot artifact, emits alpha-search artifacts, and
+  a retained complete sampled research snapshot artifact, emits alpha-search artifacts, and
   can chain bounded follow-up search runs.
 - `autofactor-strategy-promotion.yml`: evaluator for existing
   `factor-walk-forward-v2-*` artifacts.
@@ -347,7 +347,7 @@ dimension such as capacity, stability, or overfit risk.
 ## Workflow Roles
 
 - `factor-walk-forward-v2-hosted-artifact.yml` should be the default efficient
-  search surface once a full snapshot artifact exists.
+  search surface once a complete sampled snapshot artifact exists.
 - `factor-walk-forward-v2.yml` should be used when a fresh DB-adjacent snapshot
   or data audit is required.
 - `pm5d-execution` settlement-probability searches should not require Deribit by

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -308,15 +308,16 @@ compiles a new snapshot. It downloads `research-snapshot-<snapshot-run-id>` by
 default, with downstream embedded snapshot fallbacks from
 `factor-walk-forward-v2-<snapshot-run-id>` or
 `factor-review-v2-<snapshot-run-id>`. It fails before the Rust build if the
-artifact only has provenance files and is missing the full payload required by
-`load_research_snapshot`: observations, Deribit rows, and Polymarket full-book
-rows.
+artifact only has provenance files and is missing the complete sampled payload
+required by `load_research_snapshot`: observations, Deribit rows, and
+Polymarket full-book rows.
 
 The legacy `factor-walk-forward-v2.yml` entrypoint now follows the same rule:
 when `snapshot_run_id` is supplied it does not run the self-hosted job, and
 instead dispatches `factor-walk-forward-v2-hosted-artifact.yml` from
 `ubuntu-latest`. The self-hosted `ploy-ci-1` branch remains only for fresh
-DB/private-network snapshot compilation when no full snapshot artifact exists.
+DB/private-network snapshot compilation when no complete sampled snapshot
+artifact exists.
 `factor-review-v2.yml` has the same routing behavior for snapshot-backed factor
 diagnostics.
 
@@ -361,7 +362,7 @@ promotion run on GitHub-hosted runners:
 ```bash
 gh workflow run settlement-probability-prd-gate.yml \
   -f git_ref=main \
-  -f snapshot_run_id=<full-snapshot-run-id> \
+  -f snapshot_run_id=<sampled-snapshot-run-id> \
   -f start_date=2026-05-01 \
   -f end_date=2026-05-05 \
   -f symbols=BTCUSDT,ETHUSDT \

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -53,7 +53,7 @@ when the mismatch is understood and tracked as a follow-up issue.
 | PR validation | `.github/workflows/test.yml` | Required Rust-first Platform CI gate for code, contracts, frontend, integration, dependency audit, and workflow lint |
 | Legacy Python compatibility | `.github/workflows/legacy-python-tools.yml` | Isolated, path-scoped checks for remaining Python helper scripts; not part of the Rust-first required CI contract |
 | Research snapshot | `.github/workflows/research-snapshot.yml` | Compile reusable research evidence from remote data |
-| Factor diagnostics | `.github/workflows/factor-review-v2-hosted-artifact.yml` | GitHub-hosted factor review from a retained full research snapshot artifact |
+| Factor diagnostics | `.github/workflows/factor-review-v2-hosted-artifact.yml` | GitHub-hosted factor review from a retained complete sampled research snapshot artifact |
 | Legacy factor diagnostics | `.github/workflows/factor-review-v2.yml` | Compatibility router to hosted artifacts; direct `ploy-ci-1` DB mode is debug-only and blocked by default |
 | Walk-forward diagnostics | `.github/workflows/factor-walk-forward-v2.yml` | Compatibility router to hosted artifacts; direct `ploy-ci-1` DB mode is debug-only and blocked by default |
 | Parameter optimization | `.github/workflows/optimize.yml` | Bounded train/validation optimization from a snapshot or explicit debug data source |
@@ -343,7 +343,7 @@ different.
   Use `factor-review-v2-hosted-artifact.yml`,
   `factor-walk-forward-v2-hosted-artifact.yml`, or
   `settlement-probability-prd-gate.yml` with `snapshot_run_id`, when a retained
-  full research snapshot artifact already exists.
+  complete sampled research snapshot artifact already exists.
 - For settlement-probability searches using the `pm5d-execution` data profile,
   Deribit IV/Greeks are not a required promotion surface. Set
   `options_json.require_deribit=true` only for PRD or volatility hypotheses that
@@ -359,8 +359,8 @@ different.
   touch `ploy-ci-1`.
 - `ploy-ci-1` is now a legacy DB-adjacent fallback for compiling fresh research
   snapshots from Tango PostgreSQL. Do not route AutoFactor mining,
-  walk-forward promotion, or dry-run handoff checks to `ploy-ci-1` when a full
-  snapshot artifact can be reused on `ubuntu-latest`.
+  walk-forward promotion, or dry-run handoff checks to `ploy-ci-1` when a
+  complete sampled snapshot artifact can be reused on `ubuntu-latest`.
 - Legacy `ploy-ci-1` research workflows read Tango PostgreSQL through GitHub
   Actions secrets `PLOY_RESEARCH_DATABASE_URL` and `PLOY_DB_URL`; verify the
   private endpoint with Aliyun CLI before changing those secrets.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -36,6 +36,8 @@ trace, not dry-run promotion.
       cannot be silently reused for full-depth execution claims.
 - [x] Trace-gate standalone AutoFactor promotion side effects so old/debug
       artifacts can no longer create handoff issues or config PRs.
+- [x] Remove misleading `full snapshot` / `full payload` language from active
+      sampled research snapshot contracts.
 - [ ] Apply remaining high-priority data/research cleanup based on audit results.
 
 ## Review
@@ -80,6 +82,12 @@ trace, not dry-run promotion.
   --example factor_review_v2 --example factor_walk_forward_v2`; and `rtk git
   diff --check`. `actionlint` was not installed in this worktree/PATH, so it
   was not run for this slice.
+- 2026-05-23: Active workflow/docs/script contracts now call retained
+  snapshots `complete sampled research snapshot` artifacts instead of `full`
+  snapshots/full payloads. Added a regression test so active docs, workflows,
+  scripts, crates, and tests do not reintroduce that language. Validation
+  passed: YAML parse for touched workflows, `python3 -m unittest
+  tests.test_persist_research_trace_contract`, and `rtk git diff --check`.
 
 # Runtime Candidate Replay Empty Override Repair (2026-05-23)
 

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -69,6 +69,30 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         ]:
             self.assertIn(category, source)
 
+    def test_sampled_snapshot_contract_avoids_full_data_language(self) -> None:
+        forbidden = [
+            "full research snapshot",
+            "full snapshot",
+            "full-snapshot",
+            "full payload",
+            "full research-snapshot",
+        ]
+        roots = ["docs", ".github", "scripts", "crates", "tests"]
+        offenders: list[str] = []
+        for root in roots:
+            for path in (ROOT / root).rglob("*"):
+                if path == Path(__file__):
+                    continue
+                if not path.is_file() or "target" in path.parts:
+                    continue
+                if path.suffix not in {".md", ".py", ".rs", ".yml", ".yaml", ".js"}:
+                    continue
+                text = path.read_text(encoding="utf-8", errors="ignore").lower()
+                for needle in forbidden:
+                    if needle in text:
+                        offenders.append(f"{path.relative_to(ROOT)}: {needle}")
+        self.assertEqual([], offenders)
+
     def test_hosted_walk_forward_can_persist_trace_when_explicitly_enabled(self) -> None:
         workflow = HOSTED_WALK.read_text(encoding="utf-8")
         required_snippets = [


### PR DESCRIPTION
## Summary

- replace misleading `full snapshot` / `full payload` wording in active workflow and runbook contracts
- describe retained snapshot artifacts as complete sampled research snapshots
- add a regression test so active docs/workflows/scripts/crates/tests do not reintroduce full-data language for sampled snapshots

## Evidence stage

Research/data contract cleanup. No runtime or deployment behavior change.

## Validation

- YAML parse for touched workflows
- `python3 -m unittest tests.test_persist_research_trace_contract`
- `rtk git diff --check`
