### PR TITLE
Label factor review as attribution evidence

### DIFF
--- a/.github/scripts/research-issue-labels.js
+++ b/.github/scripts/research-issue-labels.js
@@ -43,6 +43,10 @@ const LABEL_DEFINITIONS = {
     color: "1d76db",
     description: "Issue has factor review workflow evidence",
   },
+  "evidence:factor-attribution": {
+    color: "1d76db",
+    description: "Issue has factor attribution evidence; not deployable by itself",
+  },
   "evidence:walk-forward": {
     color: "1d76db",
     description: "Issue has walk-forward workflow evidence",

--- a/.github/workflows/factor-evolve-daily-research.yml
+++ b/.github/workflows/factor-evolve-daily-research.yml
@@ -93,7 +93,15 @@ jobs:
               "replay_parity_ready": False,
           }
           payload = {
+              "evidence_stage": "factor_attribution",
               "latest_runs": latest_runs,
+              "trace_provenance": {
+                  "source": "factor-evolve-daily-research",
+                  "run_mode": run_mode,
+                  "snapshot_run_id": os.environ.get("SNAPSHOT_RUN_ID", "").strip(),
+                  "candidate_replay_ref": "",
+                  "trace_manifest_uri": "",
+              },
               "factor_registry_summary": {},
               "rejected_factor_patterns": {},
               "market_data_health": {
@@ -139,6 +147,9 @@ jobs:
               f"- Symbols: `{os.environ.get('SYMBOLS') or 'BTCUSDT,ETHUSDT'}`",
               f"- Plan theme: `{plan['theme']}`",
               f"- Evidence stage: `{plan['evidence_stage']}`",
+              "- Candidate replay ref: `none`",
+              "- Trace manifest URI: `pending:factor-walk-forward-v2-hosted-artifact`",
+              "- Trace persistence: `required-for-search-mode`",
               f"- Candidate count: `{plan['candidate_count']}`",
               f"- Search depth: `{plan['search_depth']}`",
               "",
@@ -169,6 +180,7 @@ jobs:
               "chain_next_run": False,
               "chain_remaining": 0,
               "create_handoff_issue": False,
+              "persist_research_trace": True,
               "fail_if_blocked": False,
               "data_quality_mode": "event_complete",
               "max_quote_age_secs": max_quote_age_secs,

--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -375,6 +375,7 @@ jobs:
             const issue_number = Number(issueNumberRaw);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let decision = "fix-workflow-or-artifact";
+            const evidenceStage = "factor_attribution";
             let riskFlags = ["missing_evaluation_artifact"];
             let bucketSummary = "unavailable";
             if (fs.existsSync("artifacts/factor-review-v2/evaluation.json")) {
@@ -396,7 +397,7 @@ jobs:
                   t_stat: bucket.t_stat
                 }))
               });
-              decision = supported.length > 0 ? "candidate-for-oos-replay-gate" : "no-deploy-factor-review-only";
+              decision = supported.length > 0 ? "continue-to-walk-forward" : "continue-diagnostic-only";
             }
             const body = [
               "Factor review evidence:",
@@ -409,6 +410,7 @@ jobs:
               `- Artifact: \`factor-review-v2-${process.env.GITHUB_RUN_ID}\``,
               `- Runner: \`ubuntu-latest\``,
               `- Source snapshot run: \`${{ github.event.inputs.snapshot_run_id }}\``,
+              `- Evidence stage: \`${evidenceStage}\``,
               `- Executable EV buckets: \`${bucketSummary}\``,
               `- Risk flags: \`${riskFlags.join(", ") || "none"}\``,
               `- Decision: ${decision}`
@@ -424,5 +426,5 @@ jobs:
               context,
               core,
               issue_number,
-              labels: ["evidence:factor-review", ...labelsForDecision(decision), ...(riskFlags.includes("missing_evaluation_artifact") ? ["evidence:missing-artifact"] : [])]
+              labels: ["evidence:factor-review", "evidence:factor-attribution", ...labelsForDecision(decision), ...(riskFlags.includes("missing_evaluation_artifact") ? ["evidence:missing-artifact"] : [])]
             });

--- a/.github/workflows/factor-review-v2.yml
+++ b/.github/workflows/factor-review-v2.yml
@@ -625,6 +625,7 @@ jobs:
             const issue_number = Number(issueNumberRaw);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let decision = "fix-workflow-or-artifact";
+            const evidenceStage = "factor_attribution";
             let riskFlags = ["missing_evaluation_artifact"];
             let bucketSummary = "unavailable";
             if (fs.existsSync("artifacts/factor-review-v2/evaluation.json")) {
@@ -646,7 +647,7 @@ jobs:
                   t_stat: bucket.t_stat
                 }))
               });
-              decision = supported.length > 0 ? "candidate-for-oos-replay-gate" : "no-deploy-factor-review-only";
+              decision = supported.length > 0 ? "continue-to-walk-forward" : "continue-diagnostic-only";
             }
             const body = [
               "Factor review evidence:",
@@ -657,6 +658,7 @@ jobs:
               `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
               `- Symbols: ${{ github.event.inputs.symbols }}`,
               `- Artifact: \`factor-review-v2-${process.env.GITHUB_RUN_ID}\``,
+              `- Evidence stage: \`${evidenceStage}\``,
               `- Executable EV buckets: \`${bucketSummary}\``,
               `- Risk flags: \`${riskFlags.join(", ") || "none"}\``,
               `- Decision: ${decision}`
@@ -672,5 +674,5 @@ jobs:
               context,
               core,
               issue_number,
-              labels: ["evidence:factor-review", ...labelsForDecision(decision), ...(riskFlags.includes("missing_evaluation_artifact") ? ["evidence:missing-artifact"] : [])]
+              labels: ["evidence:factor-review", "evidence:factor-attribution", ...labelsForDecision(decision), ...(riskFlags.includes("missing_evaluation_artifact") ? ["evidence:missing-artifact"] : [])]
             });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -191,6 +191,39 @@ Evidence stage: `executable_replay` plumbing for `runtime_market_update_replay`.
   promotion because runtime replay ROI was negative:
   `roi=-0.03889562973253067`, `total_pnl=-29.171722299398`.
 
+# Research Evidence Stage Cleanup (2026-05-23)
+
+## Goal
+
+Keep daily Research Manager and factor-review outputs from implying
+deployable/replay readiness before executable replay exists.
+
+Evidence stage: `factor_attribution` for factor review and daily search
+planning.
+
+## Tasks
+
+- [x] Add explicit `factor_attribution` evidence-stage fields to FactorEvolve
+      daily manager input and summary.
+- [x] Require daily search dispatches to request durable trace persistence.
+- [x] Change factor-review issue comments from legacy candidate/deploy wording
+      to `continue-to-walk-forward` / `continue-diagnostic-only`.
+- [x] Add `evidence:factor-attribution` issue label support.
+- [x] Add workflow security guards for the evidence-stage comment contract.
+
+## Review
+
+- 2026-05-23: Factor review issue comments now state
+  `Evidence stage: factor_attribution`, label issues with
+  `evidence:factor-attribution`, and no longer emit
+  `candidate-for-oos-replay-gate` or `no-deploy-factor-review-only`.
+- 2026-05-23: FactorEvolve daily search plan input includes
+  `evidence_stage=factor_attribution` and trace provenance placeholders, while
+  hosted search options set `persist_research_trace=true`.
+- 2026-05-23: Focused validation passed: YAML parse for touched workflows,
+  `rtk cargo test --locked --test workflow_security`, a label-helper smoke
+  check, and `rtk git diff --check`.
+
 # Settlement Probability PRD Gate Snapshot Contract (2026-05-23)
 
 ## Goal

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -132,9 +132,15 @@ fn factor_evolve_daily_search_passes_snapshot_quote_age() {
     let mut offenders = Vec::new();
 
     for needle in [
+        "\"evidence_stage\": \"factor_attribution\"",
+        "\"trace_provenance\"",
+        "\"candidate_replay_ref\": \"\"",
+        "\"trace_manifest_uri\": \"\"",
         "max_quote_age_secs:",
         "MAX_QUOTE_AGE_SECS: ${{ github.event.inputs.max_quote_age_secs }}",
         "\"max_quote_age_secs\": max_quote_age_secs",
+        "\"persist_research_trace\": True",
+        "- Trace persistence: `required-for-search-mode`",
         "-f options_json=\"$(cat artifacts/factor-evolve-daily/hosted-options.json)\"",
     ] {
         if !workflow.contains(needle) {
@@ -770,6 +776,7 @@ fn research_issue_workflows_apply_decision_labels() {
         "decision:pending",
         "decision:fix-data",
         "decision:fix-runtime",
+        "evidence:factor-attribution",
         "evidence:missing-metrics",
         "parity:blocked",
     ] {
@@ -808,6 +815,46 @@ fn research_issue_workflows_apply_decision_labels() {
     assert!(
         offenders.is_empty(),
         "research issue label guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn factor_review_comments_are_factor_attribution_not_deployable_candidates() {
+    let hosted = workflow_contents(".github/workflows/factor-review-v2-hosted-artifact.yml");
+    let legacy = workflow_contents(".github/workflows/factor-review-v2.yml");
+    let mut offenders = Vec::new();
+
+    for (name, content) in [
+        ("factor-review-v2-hosted-artifact.yml", hosted.as_str()),
+        ("factor-review-v2.yml", legacy.as_str()),
+    ] {
+        for needle in [
+            "const evidenceStage = \"factor_attribution\"",
+            "- Evidence stage:",
+            "continue-to-walk-forward",
+            "continue-diagnostic-only",
+            "\"evidence:factor-attribution\"",
+        ] {
+            if !content.contains(needle) {
+                offenders.push(format!("{name}: missing `{needle}`"));
+            }
+        }
+        for forbidden in [
+            "candidate-for-oos-replay-gate",
+            "no-deploy-factor-review-only",
+        ] {
+            if content.contains(forbidden) {
+                offenders.push(format!(
+                    "{name}: still contains legacy decision `{forbidden}`"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "factor review evidence-stage comment guard failed:\n{}",
         offenders.join("\n")
     );
 }


### PR DESCRIPTION
## Summary
- mark FactorEvolve daily plans as factor_attribution evidence with trace provenance placeholders
- require daily search dispatches to request durable trace persistence
- change factor-review issue comments from legacy candidate/deploy wording to attribution-stage decisions
- add evidence:factor-attribution label support and workflow security guards

## Validation
- YAML parse for factor-evolve-daily-research.yml, factor-review-v2-hosted-artifact.yml, factor-review-v2.yml
- CARGO_TARGET_DIR=/tmp/ploy-evidence-stage-workflow-security /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security
- label helper smoke check
- rtk git diff --check