### PR TITLE
Require candidate replay provenance for promotion

### DIFF
--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -204,6 +204,13 @@ class CandidateStrategyReplay:
     runtime_score: str = ""
     strategy_profile: str = ""
     basis: str = ""
+    candidate_replay_id: str = ""
+    identity: dict[str, Any] = field(default_factory=dict)
+    promotion_decision: str = ""
+    source_workflow: str = ""
+    workflow_run_id: str = ""
+    workflow_run_url: str = ""
+    artifact_name: str = ""
     blockers: list[str] = field(default_factory=list)
     metrics: dict[str, Any] = field(default_factory=dict)
     decision_contract: dict[str, Any] = field(default_factory=dict)
@@ -367,6 +374,13 @@ def load_candidate_strategy_replay(path: str | None) -> CandidateStrategyReplay:
         runtime_score=str(payload.get("runtime_score", "")),
         strategy_profile=str(payload.get("strategy_profile", "")),
         basis=str(payload.get("basis", "")),
+        candidate_replay_id=str(payload.get("candidate_replay_id", "")),
+        identity=payload.get("identity") if isinstance(payload.get("identity"), dict) else {},
+        promotion_decision=str(payload.get("promotion_decision", "")),
+        source_workflow=str(payload.get("source_workflow", "")),
+        workflow_run_id=str(payload.get("workflow_run_id", "")),
+        workflow_run_url=str(payload.get("workflow_run_url", "")),
+        artifact_name=str(payload.get("artifact_name", "")),
         blockers=[str(item) for item in blockers],
         metrics=metrics,
         decision_contract=contract,
@@ -403,6 +417,36 @@ def candidate_strategy_replay_blockers(
             "candidate_strategy_replay_not_runtime_replay:"
             f"{replay.basis or '<missing>'}!=runtime_market_update_replay"
         )
+    if not replay.candidate_replay_id:
+        blockers.append("candidate_strategy_replay_missing_candidate_replay_id")
+    elif not replay.candidate_replay_id.startswith("candidate_replay:"):
+        blockers.append(
+            "candidate_strategy_replay_invalid_candidate_replay_id:"
+            f"{replay.candidate_replay_id}"
+        )
+    else:
+        digest = replay.candidate_replay_id.split(":", 1)[1]
+        if len(digest) < 16 or any(ch not in "0123456789abcdef" for ch in digest.lower()):
+            blockers.append(
+                "candidate_strategy_replay_invalid_candidate_replay_id:"
+                f"{replay.candidate_replay_id}"
+            )
+    if not replay.identity:
+        blockers.append("candidate_strategy_replay_missing_identity")
+    elif replay.identity.get("basis") != "runtime_market_update_replay":
+        blockers.append(
+            "candidate_strategy_replay_identity_basis_mismatch:"
+            f"{replay.identity.get('basis') or '<missing>'}!=runtime_market_update_replay"
+        )
+    provenance_fields = {
+        "source_workflow": replay.source_workflow,
+        "workflow_run_id": replay.workflow_run_id,
+        "workflow_run_url": replay.workflow_run_url,
+        "artifact_name": replay.artifact_name,
+    }
+    for field_name, value in provenance_fields.items():
+        if not value:
+            blockers.append(f"candidate_strategy_replay_missing_{field_name}")
 
     if replay.strategy_profile != required_strategy_profile:
         blockers.append(
@@ -915,6 +959,7 @@ def render_handoff_markdown(handoff: dict[str, Any]) -> str:
         f"Allowed targets: `{', '.join(handoff['allowed_targets'])}`",
         f"Avg entry sweep slip bps: `{handoff['execution_quality'].get('avg_entry_sweep_slip_bps')}`",
         f"Candidate strategy replay ready: `{str(handoff['candidate_strategy_replay'].get('ready')).lower()}`",
+        f"Candidate strategy replay id: `{handoff['candidate_strategy_replay'].get('candidate_replay_id')}`",
         f"Candidate strategy replay runtime score: `{handoff['candidate_strategy_replay'].get('runtime_score')}`",
         "",
     ]
@@ -1010,6 +1055,7 @@ def render_markdown(result: dict[str, Any]) -> str:
         "",
         f"- Ready: `{str(result['candidate_strategy_replay']['ready']).lower()}`",
         f"- Evidence: `{result['candidate_strategy_replay']['evidence']}`",
+        f"- Candidate replay id: `{result['candidate_strategy_replay']['candidate_replay_id']}`",
         f"- Runtime score: `{result['candidate_strategy_replay']['runtime_score']}`",
         "",
         "## Qualified Strategies",

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -174,11 +174,23 @@ candidate,bucket,count
 DEFAULT_REPLAY_PAYLOAD = {
     "schema_version": 1,
     "kind": "autofactor_candidate_strategy_replay",
+    "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
+    "identity": {
+        "basis": "runtime_market_update_replay",
+        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        "strategy_profile": "settlement_probability",
+        "workflow_run_id": "26306734877",
+    },
     "evidence_stage": "executable_replay",
     "basis": "runtime_market_update_replay",
     "strategy_profile": "settlement_probability",
     "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
     "promotion_ready": True,
+    "promotion_decision": "promote_to_runtime",
+    "source_workflow": "runtime-candidate-replay.yml",
+    "workflow_run_id": "26306734877",
+    "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
+    "artifact_name": "runtime-candidate-replay-26306734877",
     "decision_contract": {
         "event_level": True,
         "one_decision_per_event": True,
@@ -291,6 +303,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "settlement_probability",
         )
         self.assertIn("Candidate strategy replay ready: `true`", handoff_md)
+        self.assertIn(
+            "Candidate strategy replay id: `candidate_replay:0123456789abcdef0123456789abcdef`",
+            handoff_md,
+        )
         self.assertIn("top bucket avg label", handoff_md)
         self.assertNotIn("top bucket pnl", handoff_md.lower())
         near_strike = next(
@@ -729,6 +745,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         replay = {
             **DEFAULT_REPLAY_PAYLOAD,
             "basis": "factor_walk_forward_top_bucket_aggregate",
+            "identity": {
+                **DEFAULT_REPLAY_PAYLOAD["identity"],
+                "basis": "factor_walk_forward_top_bucket_aggregate",
+            },
         }
 
         _, payload, _, handoff, _ = self.run_script(
@@ -744,6 +764,41 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
             first["blockers"],
         )
+
+    def test_blocks_legacy_runtime_replay_without_durable_provenance(self):
+        replay = {
+            key: value
+            for key, value in DEFAULT_REPLAY_PAYLOAD.items()
+            if key
+            not in {
+                "candidate_replay_id",
+                "identity",
+                "promotion_decision",
+                "source_workflow",
+                "workflow_run_id",
+                "workflow_run_url",
+                "artifact_name",
+            }
+        }
+
+        _, payload, _, handoff, handoff_md = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        first = payload["evaluated_factors"][0]
+        self.assertIn(
+            "candidate_strategy_replay_missing_candidate_replay_id",
+            first["blockers"],
+        )
+        self.assertIn("candidate_strategy_replay_missing_identity", first["blockers"])
+        self.assertIn("candidate_strategy_replay_missing_source_workflow", first["blockers"])
+        self.assertIn("candidate_strategy_replay_missing_workflow_run_id", first["blockers"])
+        self.assertIn("candidate_strategy_replay_missing_workflow_run_url", first["blockers"])
+        self.assertIn("candidate_strategy_replay_missing_artifact_name", first["blockers"])
+        self.assertIn("Candidate strategy replay id: ``", handoff_md)
 
     def test_blocks_replay_without_executable_strategy_contract(self):
         replay = {

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -89,11 +89,23 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                 {
                     "schema_version": 1,
                     "kind": "autofactor_candidate_strategy_replay",
+                    "candidate_replay_id": "candidate_replay:fedcba98765432100123456789abcdef",
+                    "identity": {
+                        "basis": "runtime_market_update_replay",
+                        "runtime_score": runtime_score,
+                        "strategy_profile": "settlement_probability",
+                        "workflow_run_id": "26306734877",
+                    },
                     "evidence_stage": "executable_replay",
                     "basis": "runtime_market_update_replay",
                     "strategy_profile": "settlement_probability",
                     "runtime_score": runtime_score,
                     "promotion_ready": True,
+                    "promotion_decision": "promote_to_runtime",
+                    "source_workflow": "runtime-candidate-replay.yml",
+                    "workflow_run_id": "26306734877",
+                    "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
+                    "artifact_name": "runtime-candidate-replay-26306734877",
                     "decision_contract": {
                         "event_level": True,
                         "one_decision_per_event": True,


### PR DESCRIPTION
## Summary
- require AutoFactor promotion candidate replay artifacts to carry durable candidate replay identity and workflow provenance
- keep legacy runtime-shaped replay JSON blocked even if it claims promotion_ready=true
- expose candidate_replay_id in promotion and handoff markdown for auditability

## Evidence stage
- executable_replay gate hardening; this is not a dry-run promotion

## Validation
- python3 -m py_compile scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_build_autofactor_candidate_strategy_replay
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tracking of candidate strategy promotion provenance with workflow identifiers and decision metadata

* **Improvements**
  * Strengthened validation of strategy replay data integrity and eligibility criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->