### PR TITLE
Default hosted walk-forward to durable trace

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -31,9 +31,9 @@ on:
         required: true
         default: "15"
       options_json:
-        description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, optional trace persistence/issue/config handoff"
+        description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, durable trace persistence, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"persist_research_trace":true,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -117,7 +117,7 @@ jobs:
               "issue_number": "",
               "create_handoff_issue": "false",
               "create_config_pr": "false",
-              "persist_research_trace": "false",
+              "persist_research_trace": "true",
               "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
               "fail_if_blocked": "false",
           }

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -130,15 +130,15 @@ attached through the later gates. Candidate replay tapes must use their own
 `candidate_replay_id` instead of being collapsed into the sampled research
 snapshot identity.
 
-Hosted walk-forward can run the writer automatically only when explicitly
-requested with `options_json.persist_research_trace=true` and a protected
-database secret is available. It checks `RESEARCH_OS_DATABASE_URL`,
-`PLOY_DATABASE_URL`, `PLOY_RESEARCH_DATABASE_URL`, then `PLOY_DB_URL`. The
-default remains false so ordinary research runs stay read-only artifact
-generation. When that database URL targets Tango's private VPC endpoint, the
-hosted workflow ships the trace input artifacts to `tango-1-1` and runs the
-deployed `/opt/ploy/bin/persist-research-trace` binary there; it must not try
-to open a private PostgreSQL connection directly from a GitHub-hosted runner.
+Hosted walk-forward runs the writer by default and requires a protected
+database secret unless the dispatch explicitly sets
+`options_json.persist_research_trace=false` for a read-only diagnostic run. It
+checks `RESEARCH_OS_DATABASE_URL`, `PLOY_DATABASE_URL`,
+`PLOY_RESEARCH_DATABASE_URL`, then `PLOY_DB_URL`. When that database URL
+targets Tango's private VPC endpoint, the hosted workflow ships the trace input
+artifacts to `tango-1-1` and runs the deployed
+`/opt/ploy/bin/persist-research-trace` binary there; it must not try to open a
+private PostgreSQL connection directly from a GitHub-hosted runner.
 Any hosted walk-forward path that mutates follow-up state by dispatching a
 chained alpha-search run, opening a dry-run handoff issue, or creating a config
 PR must first write the durable trace marker for the same run. Artifact-only

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -99,10 +99,11 @@ class PersistResearchTraceContractTest(unittest.TestCase):
                         offenders.append(f"{path.relative_to(ROOT)}: {needle}")
         self.assertEqual([], offenders)
 
-    def test_hosted_walk_forward_can_persist_trace_when_explicitly_enabled(self) -> None:
+    def test_hosted_walk_forward_persists_trace_by_default(self) -> None:
         workflow = HOSTED_WALK.read_text(encoding="utf-8")
         required_snippets = [
-            '"persist_research_trace": "false"',
+            '"persist_research_trace":true',
+            '"persist_research_trace": "true"',
             "WALK_PERSIST_RESEARCH_TRACE",
             "--example persist_research_trace",
             "Persist Research OS trace",


### PR DESCRIPTION
## Summary
- make hosted factor walk-forward persist Research OS trace by default
- keep explicit persist_research_trace=false as the read-only diagnostic exception
- update runbook and contract tests so trace persistence is the standard path

## Evidence stage
- walk_forward / factor_attribution trace persistence; this is not dry-run promotion

## Validation
- ruby YAML parse for factor-walk-forward-v2-hosted-artifact, autofactor-strategy-promotion, research-trace-plan
- python3 -m unittest tests.test_persist_research_trace_contract
- rtk cargo test --locked --test workflow_security
- rtk git diff --check