### PR TITLE
Require retained snapshot for PRD gate

### DIFF
--- a/.github/workflows/settlement-probability-prd-gate.yml
+++ b/.github/workflows/settlement-probability-prd-gate.yml
@@ -22,8 +22,8 @@ on:
         required: true
         default: "15"
       snapshot_run_id:
-        description: "Existing run id with a complete sampled research-snapshot artifact; skips legacy ploy-ci-1 snapshot build"
-        required: false
+        description: "Required run id with a complete sampled research-snapshot artifact"
+        required: true
         default: ""
       issue_number:
         description: "Issue number for posting gate evidence; leave empty to skip comments"
@@ -120,7 +120,7 @@ jobs:
             echo "- Window: \`${{ github.event.inputs.start_date }}..${{ github.event.inputs.end_date }}\`"
             echo "- Symbols: \`${{ github.event.inputs.symbols }}\`"
             echo "- Stake: \`${{ github.event.inputs.stake_usd }}u\`"
-            echo "- Snapshot source run: \`${{ github.event.inputs.snapshot_run_id || 'legacy-build' }}\`"
+            echo "- Snapshot source run: \`${{ github.event.inputs.snapshot_run_id || 'missing-required-snapshot' }}\`"
             echo "- Walk-forward runner: \`ubuntu-latest\` via \`factor-walk-forward-v2-hosted-artifact.yml\`"
             audit_lookback_hours="${{ github.event.inputs.audit_lookback_hours }}"
             data_quality_mode="strict-continuous"

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -371,11 +371,12 @@ gh workflow run settlement-probability-prd-gate.yml \
   -f replay_parity_run_id=<optional-replay-parity-run-id>
 ```
 
-With `snapshot_run_id` set, the gate skips the legacy `ploy-ci-1` snapshot
-build and dispatches `factor-walk-forward-v2-hosted-artifact.yml` on
-`ubuntu-latest`. If `snapshot_run_id` is omitted, the orchestrator still falls
-back to `research-snapshot.yml`; that path remains a legacy DB-adjacent path
-until snapshot export is moved to a hosted-safe data source.
+The gate requires `snapshot_run_id` by default and dispatches
+`factor-walk-forward-v2-hosted-artifact.yml` on `ubuntu-latest`. If
+`snapshot_run_id` is omitted, the orchestrator fails before dispatch instead of
+falling back to the legacy DB-adjacent `research-snapshot.yml` path. Direct CLI
+callers can still use `--allow-legacy-snapshot-build` as a manual exception
+while snapshot export is moved to a hosted-safe data source.
 When replay parity evidence uses a non-default artifact name, encode the input
 as `replay_parity_run_id=<run-id>:<artifact-name>` so the workflow stays within
 GitHub's 10-input dispatch limit.

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -3,9 +3,9 @@
 
 The default gate is intentionally strict:
 
-1. Reuse a retained complete sampled research snapshot artifact when --snapshot-run-id is
-   supplied, or build a portable pm5d-vol research snapshot as a legacy
-   fallback.
+1. Reuse a retained complete sampled research snapshot artifact supplied with
+   --snapshot-run-id. The legacy pm5d-vol snapshot build path is an explicit
+   manual exception, not the default PRD gate.
 2. Feed that snapshot artifact into the GitHub-hosted Factor Walk-Forward V2
    artifact workflow.
 3. Optionally attach a replay/dry-run parity artifact to the promotion gate.
@@ -284,8 +284,16 @@ def parse_args() -> argparse.Namespace:
         default="",
         help=(
             "Existing workflow run id that owns a complete sampled research-snapshot artifact. "
-            "When supplied, skip the legacy ploy-ci-1 snapshot workflow and run "
-            "the hosted artifact-only walk-forward path."
+            "Required for the default gate so walk-forward consumes a retained "
+            "snapshot contract."
+        ),
+    )
+    parser.add_argument(
+        "--allow-legacy-snapshot-build",
+        action="store_true",
+        help=(
+            "Manual exception only: build a legacy pm5d-vol snapshot when no "
+            "--snapshot-run-id is supplied."
         ),
     )
     parser.add_argument(
@@ -357,6 +365,19 @@ def main() -> int:
             flush=True,
         )
     else:
+        if not args.allow_legacy_snapshot_build:
+            message = "\n".join(
+                [
+                    "Settlement probability PRD gate blocked before dispatch:",
+                    "",
+                    "- Missing required `--snapshot-run-id` for a retained complete sampled research snapshot.",
+                    "- The legacy pm5d-vol snapshot build path is disabled by default.",
+                    "- Decision: dispatch or select a research-snapshot artifact first, then rerun the PRD gate.",
+                ]
+            )
+            print(message, flush=True)
+            issue_comment(args.issue_number, message, dry_run=args.dry_run)
+            return 2
         snapshot_options = {
             "lob_sample_secs": int(args.lob_sample_secs or "30"),
             "pm_book_sample_secs": int(args.pm_book_sample_secs or "30"),

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -1,9 +1,14 @@
 import json
 import sys
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from scripts import run_settlement_probability_prd_gate as gate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "settlement-probability-prd-gate.yml"
 
 
 class SettlementProbabilityPrdGateTests(unittest.TestCase):
@@ -62,7 +67,7 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
             "recorded-replay-parity-26301157711",
         )
 
-    def test_legacy_snapshot_build_keeps_default_sampling_values(self):
+    def test_blocks_missing_snapshot_by_default(self):
         dispatches = []
 
         def capture_dispatch(workflow, fields, *, workflow_ref, dry_run):
@@ -82,6 +87,30 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
             dispatch=capture_dispatch,
         )
 
+        self.assertEqual(status, 2)
+        self.assertEqual(dispatches, [])
+
+    def test_explicit_legacy_snapshot_build_keeps_default_sampling_values(self):
+        dispatches = []
+
+        def capture_dispatch(workflow, fields, *, workflow_ref, dry_run):
+            dispatches.append((workflow, fields, workflow_ref, dry_run))
+            return None
+
+        status = self.run_main(
+            [
+                "--git-ref",
+                "main",
+                "--start-date",
+                "2026-05-16",
+                "--end-date",
+                "2026-05-20",
+                "--allow-legacy-snapshot-build",
+                "--dry-run",
+            ],
+            dispatch=capture_dispatch,
+        )
+
         self.assertEqual(status, 0)
         self.assertEqual(len(dispatches), 1)
         workflow, fields, _, _ = dispatches[0]
@@ -91,6 +120,15 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
         self.assertEqual(options["pm_book_sample_secs"], 30)
         self.assertEqual(options["observation_sample_secs"], 30)
         self.assertEqual(options["max_quote_age_secs"], 30)
+
+    def test_workflow_requires_snapshot_and_does_not_expose_legacy_build(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("Required run id with a complete sampled research-snapshot artifact", workflow)
+        self.assertIn("required: true", workflow)
+        self.assertIn("missing-required-snapshot", workflow)
+        self.assertNotIn("legacy-build", workflow)
+        self.assertNotIn("--allow-legacy-snapshot-build", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- block settlement PRD gate before dispatch when no retained snapshot_run_id is supplied
- keep legacy pm5d-vol snapshot build behind an explicit CLI-only manual exception
- update workflow summary/docs/tests so the main PRD gate no longer advertises legacy-build fallback

## Evidence stage
- walk_forward orchestration guard; this is not dry-run promotion

## Validation
- ruby YAML parse for settlement-probability-prd-gate.yml
- python3 -m py_compile scripts/run_settlement_probability_prd_gate.py tests/test_settlement_probability_prd_gate.py
- python3 -m unittest tests.test_settlement_probability_prd_gate
- python3 -m unittest tests.test_persist_research_trace_contract tests.test_settlement_probability_prd_gate
- rtk cargo test --locked --test workflow_security
- rtk git diff --check