### PR TITLE
Publish factor review evidence stage contract

### DIFF
--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -289,6 +289,9 @@ jobs:
             echo "- Stake: ${{ github.event.inputs.stake_usd }}U"
             echo "- Runner: \`ubuntu-latest\`"
             echo "- Factor filter: ${FACTOR_FACTOR_NAME_FILTER:-<none>}"
+            echo "- Evidence stage: \`factor_attribution\`"
+            echo "- Promotion ready: \`false\`"
+            echo "- Promotion decision: \`do_not_promote_from_factor_review\`"
             if [ -f artifacts/research-snapshot/quality.md ]; then
               echo ""
               echo "### Snapshot Quality"
@@ -344,6 +347,34 @@ jobs:
             echo "full_snapshot_embedded=false"
             echo "runner=ubuntu-latest"
           } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
+          cat > artifacts/factor-review-v2-upload/evidence-stage.json <<EOF
+          {
+            "schema_version": 1,
+            "kind": "research_evidence_stage",
+            "workflow": "factor-review-v2-hosted-artifact.yml",
+            "run_id": "${GITHUB_RUN_ID}",
+            "source_snapshot_run_id": "${{ github.event.inputs.snapshot_run_id }}",
+            "evidence_stage": "factor_attribution",
+            "promotion_ready": false,
+            "promotion_decision": "do_not_promote_from_factor_review",
+            "allowed_next_stage": "walk_forward",
+            "blocked_next_stages": ["dry_run_candidate", "live_candidate"],
+            "reason": "Factor review ranks attribution buckets only; promotion requires walk-forward, executable replay, and runtime parity."
+          }
+          EOF
+          cat > artifacts/factor-review-v2-upload/evidence-stage.md <<EOF
+          # Factor Review Evidence Stage
+
+          - Evidence stage: \`factor_attribution\`
+          - Promotion ready: \`false\`
+          - Promotion decision: \`do_not_promote_from_factor_review\`
+          - Allowed next stage: \`walk_forward\`
+          - Blocked next stages: \`dry_run_candidate\`, \`live_candidate\`
+
+          Factor review ranks attribution buckets only. It is not a dry-run or
+          live promotion input without walk-forward, executable replay, and
+          runtime parity evidence.
+          EOF
           for file in manifest.json quality.md data-gap-audit.md data-gap-audit.json compile.log; do
             if [ -f "artifacts/research-snapshot/${file}" ]; then
               cp "artifacts/research-snapshot/${file}" \

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -851,6 +851,20 @@ fn factor_review_comments_are_factor_attribution_not_deployable_candidates() {
             }
         }
     }
+    for needle in [
+        "evidence-stage.json",
+        "\"kind\": \"research_evidence_stage\"",
+        "\"promotion_ready\": false",
+        "\"promotion_decision\": \"do_not_promote_from_factor_review\"",
+        "\"allowed_next_stage\": \"walk_forward\"",
+        "\"blocked_next_stages\": [\"dry_run_candidate\", \"live_candidate\"]",
+    ] {
+        if !hosted.contains(needle) {
+            offenders.push(format!(
+                "factor-review-v2-hosted-artifact.yml: missing artifact stage contract `{needle}`"
+            ));
+        }
+    }
 
     assert!(
         offenders.is_empty(),


### PR DESCRIPTION
## Summary
- add machine-readable evidence-stage.json and reviewable evidence-stage.md to factor-review hosted artifacts
- mark factor review as factor_attribution only with promotion_ready=false
- guard the artifact-stage contract in workflow_security

## Evidence stage
- factor_attribution artifact contract; this is not promotion evidence

## Validation
- ruby YAML parse for factor-review-v2-hosted-artifact, factor-review-v2, factor-walk-forward-v2
- rtk cargo test --locked --test workflow_security factor_review_comments_are_factor_attribution_not_deployable_candidates
- rtk cargo test --locked --test workflow_security
- rtk git diff --check