### PR TITLE
Gate research trace persistence on walk-forward output

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -487,7 +487,6 @@ jobs:
           python3 scripts/run_factor_walk_forward_sweep.py "${args[@]}"
 
       - name: Persist Research OS trace
-        if: always()
         env:
           RESEARCH_TRACE_DB_URL: ${{ secrets.RESEARCH_OS_DATABASE_URL || secrets.PLOY_DATABASE_URL || secrets.PLOY_RESEARCH_DATABASE_URL || secrets.PLOY_DB_URL }}
           TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
@@ -507,6 +506,10 @@ jobs:
           fi
           if [ ! -f artifacts/research-snapshot/manifest.json ]; then
             echo "research snapshot manifest is required for durable trace persistence." >&2
+            exit 2
+          fi
+          if [ ! -f artifacts/factor-walk-forward-v2/report.txt ]; then
+            echo "factor walk-forward report is required for durable trace persistence." >&2
             exit 2
           fi
 

--- a/crates/ploy-research/examples/persist_research_trace.rs
+++ b/crates/ploy-research/examples/persist_research_trace.rs
@@ -365,18 +365,45 @@ fn collect_factor_preview_rows(plan: &TracePlan) -> Result<Vec<FactorPreviewRow>
     if let Some(alpha_dir) = &plan.alpha_search_dir {
         for path in find_named_files(alpha_dir, "factor-registry-preview.json")? {
             let preview: Value = read_json(&path)?;
-            let target = string_field(&preview, "target").unwrap_or_else(|| "unknown".to_string());
-            let factors = preview
-                .get("factors")
-                .and_then(Value::as_array)
+            let target = string_field(&preview, "target")
+                .or_else(|| target_from_preview_path(&path))
+                .unwrap_or_else(|| "unknown".to_string());
+            let horizon = string_field(&preview, "horizon")
+                .unwrap_or_else(|| default_horizon_for_target(&target));
+            let factors = preview_factors(&preview)
                 .with_context(|| format!("{} missing factors array", path.display()))?;
             for factor in factors {
-                rows.push(factor_preview_row(factor, &target, &path)?);
+                rows.push(factor_preview_row(factor, &target, &horizon, &path)?);
             }
         }
     }
     rows.sort_by(|left, right| left.dsl_hash.cmp(&right.dsl_hash));
     Ok(rows)
+}
+
+fn preview_factors(preview: &Value) -> Option<&Vec<Value>> {
+    if let Some(factors) = preview.get("factors").and_then(Value::as_array) {
+        return Some(factors);
+    }
+    preview.as_array()
+}
+
+fn target_from_preview_path(path: &Path) -> Option<String> {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|item| item.to_str())
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn default_horizon_for_target(target: &str) -> String {
+    if target.contains("10s") {
+        "10s".to_string()
+    } else if target.contains("30s") {
+        "30s".to_string()
+    } else {
+        FACTOR_HORIZON.to_string()
+    }
 }
 
 fn collect_candidate_replay_rows(
@@ -509,6 +536,7 @@ fn factor_name_from_runtime_score(value: &Value) -> Option<String> {
 fn factor_preview_row(
     factor: &Value,
     default_target: &str,
+    default_horizon: &str,
     path: &Path,
 ) -> Result<FactorPreviewRow> {
     let factor_name = string_field(factor, "factor_name")
@@ -536,6 +564,9 @@ fn factor_preview_row(
         .filter(|value| !value.is_empty())
         .unwrap_or("autofactor")
         .to_string();
+    let horizon = string_field(factor, "horizon")
+        .or_else(|| string_field(&runtime_contract, "horizon"))
+        .unwrap_or_else(|| default_horizon.to_string());
 
     Ok(FactorPreviewRow {
         factor_name,
@@ -544,7 +575,7 @@ fn factor_preview_row(
         ast_json,
         runtime_contract,
         factor_family,
-        horizon: FACTOR_HORIZON.to_string(),
+        horizon,
         registry_status: decision.registry_status,
         promotion_decision: decision.promotion_decision,
         promotion_status: decision.promotion_status,
@@ -1315,5 +1346,121 @@ mod tests {
             &json!({"blockers": ["a", "c"]}),
         );
         assert_eq!(blockers, json!(["a", "b", "c"]));
+    }
+
+    fn preview_plan(alpha_search_dir: PathBuf) -> TracePlan {
+        TracePlan {
+            run_id: "test-run".to_string(),
+            snapshot_dir: PathBuf::from("/tmp/unused-snapshot"),
+            alpha_search_dir: Some(alpha_search_dir),
+            registry_json: None,
+            promotion_json: None,
+            handoff_json: None,
+            candidate_replay_jsons: Vec::new(),
+            dry_run: true,
+        }
+    }
+
+    fn write_preview(path: &Path, value: &Value) {
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(
+            path,
+            serde_json::to_string_pretty(value).expect("serialize preview"),
+        )
+        .expect("write preview");
+    }
+
+    #[test]
+    fn reads_versioned_factor_registry_preview_envelope() {
+        let root = std::env::temp_dir().join(format!(
+            "ploy-trace-preview-envelope-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let preview_path = root
+            .join("full_depth_settlement_executable_pnl")
+            .join("factor-registry-preview.json");
+        write_preview(
+            &preview_path,
+            &json!({
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [{
+                    "factor_name": "auto_settlement_conservative_settlement_edge",
+                    "dsl_hash": "abc123",
+                    "ast_json": {"Input": "conservative_settlement_edge"},
+                    "horizon": "5m",
+                    "status": "candidate",
+                    "runtime_contract": {
+                        "strategy_family": "settlement_probability",
+                        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                        "horizon": "5m",
+                        "blockers": []
+                    },
+                    "blockers": [],
+                    "metrics": {"reward": 1.0}
+                }]
+            }),
+        );
+
+        let rows = collect_factor_preview_rows(&preview_plan(root.clone())).expect("rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].target, "full_depth_settlement_executable_pnl");
+        assert_eq!(rows[0].horizon, "5m");
+        assert_eq!(rows[0].factor_family, "settlement_probability");
+        assert_eq!(rows[0].promotion_decision, "continue");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn reads_legacy_top_level_array_preview_and_uses_parent_target() {
+        let root = std::env::temp_dir().join(format!(
+            "ploy-trace-preview-legacy-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let preview_path = root
+            .join("full_depth_reprice_pnl_10s")
+            .join("factor-registry-preview.json");
+        write_preview(
+            &preview_path,
+            &json!([{
+                "factor_name": "legacy_factor",
+                "dsl_hash": "legacy123",
+                "ast_json": {"Input": "external_move_since_poly_update"},
+                "status": "watchlist",
+                "blockers": [],
+                "metrics": {"reward": 0.2}
+            }]),
+        );
+
+        let rows = collect_factor_preview_rows(&preview_plan(root.clone())).expect("rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].target, "full_depth_reprice_pnl_10s");
+        assert_eq!(rows[0].horizon, "10s");
+        assert_eq!(rows[0].promotion_status, "watchlist");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn malformed_preview_without_factors_still_fails_closed() {
+        let root = std::env::temp_dir().join(format!(
+            "ploy-trace-preview-bad-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let preview_path = root
+            .join("full_depth_settlement_executable_pnl")
+            .join("factor-registry-preview.json");
+        write_preview(
+            &preview_path,
+            &json!({"target": "full_depth_settlement_executable_pnl"}),
+        );
+
+        let error = collect_factor_preview_rows(&preview_plan(root.clone()))
+            .expect_err("bad preview should fail");
+        assert!(error.to_string().contains("missing factors array"));
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/crates/ploy-research/examples/persist_research_trace.rs
+++ b/crates/ploy-research/examples/persist_research_trace.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use ploy_research::ResearchSnapshotManifest;
+use ploy_research::autofactor_target_horizon;
 use ploy_research::research_os::trace::trace_hash;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -397,13 +398,7 @@ fn target_from_preview_path(path: &Path) -> Option<String> {
 }
 
 fn default_horizon_for_target(target: &str) -> String {
-    if target.contains("10s") {
-        "10s".to_string()
-    } else if target.contains("30s") {
-        "30s".to_string()
-    } else {
-        FACTOR_HORIZON.to_string()
-    }
+    autofactor_target_horizon(target).to_string()
 }
 
 fn collect_candidate_replay_rows(
@@ -1462,5 +1457,17 @@ mod tests {
             .expect_err("bad preview should fail");
         assert!(error.to_string().contains("missing factors array"));
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn default_horizon_uses_shared_autofactor_target_catalog() {
+        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_5s"), "5s");
+        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_30s"), "30s");
+        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_60s"), "60s");
+        assert_eq!(
+            default_horizon_for_target("tradeable_full_depth_settlement_pnl"),
+            "5m"
+        );
+        assert_eq!(default_horizon_for_target("unknown_target"), "unknown");
     }
 }

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::autofactor::{
     AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr, LlmPriorSpec,
-    factor_expr_hash,
+    autofactor_target_horizon, factor_expr_hash,
 };
 
 const ALPHA_SEARCH_ARTIFACT_VERSION: &str = "alpha_search_artifacts_v1";
@@ -633,13 +633,7 @@ fn registry_blockers(
 }
 
 fn factor_horizon(target: &str) -> String {
-    if target.contains("10s") {
-        "10s".to_string()
-    } else if target.contains("30s") {
-        "30s".to_string()
-    } else {
-        "5m".to_string()
-    }
+    autofactor_target_horizon(target).to_string()
 }
 
 fn runtime_contract_for_report(

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::Path;
 
@@ -272,11 +272,21 @@ struct RuntimeAvoidance {
 struct FactorRegistryPreviewRow {
     factor_name: String,
     target: Option<String>,
+    horizon: String,
     dsl_hash: String,
     ast_json: serde_json::Value,
+    runtime_contract: serde_json::Value,
     status: &'static str,
     metrics: serde_json::Value,
     blockers: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct FactorRegistryPreviewArtifact {
+    version: &'static str,
+    target: String,
+    horizon: String,
+    factors: Vec<FactorRegistryPreviewRow>,
 }
 
 #[derive(Debug, Serialize)]
@@ -461,7 +471,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
     write_json(&output_dir.join("node-metrics.json"), &node_metrics)?;
     write_json(
         &output_dir.join("factor-registry-preview.json"),
-        &factor_registry_preview_rows(reports, &node_metrics)?,
+        &factor_registry_preview_artifact(target, reports, &node_metrics)?,
     )?;
     let mcts_state = mcts_search_state(target, &node_metrics, prior_state);
     write_json(&output_dir.join("mcts-state.json"), &mcts_state)?;
@@ -550,24 +560,46 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
 }
 
 fn factor_registry_preview_rows(
+    target: &str,
     reports: &[AutoFactorReport],
     node_metrics: &[NodeMetric],
 ) -> Result<Vec<FactorRegistryPreviewRow>, AlphaSearchArtifactError> {
+    let horizon = factor_horizon(target);
     reports
         .iter()
         .zip(node_metrics.iter())
         .map(|(report, metric)| {
+            let dsl_hash = factor_expr_hash(&report.expr)?;
+            let ast_json = serde_json::to_value(&report.expr)?;
+            let runtime_contract =
+                runtime_contract_for_report(report, &dsl_hash, &ast_json, &horizon);
+            let blockers = registry_blockers(report, &runtime_contract);
             Ok(FactorRegistryPreviewRow {
                 factor_name: report.name.clone(),
                 target: report.target.clone(),
-                dsl_hash: factor_expr_hash(&report.expr)?,
-                ast_json: serde_json::to_value(&report.expr)?,
+                horizon: horizon.clone(),
+                dsl_hash,
+                ast_json,
+                runtime_contract,
                 status: registry_status(report.decision),
                 metrics: serde_json::to_value(metric)?,
-                blockers: registry_blockers(report),
+                blockers,
             })
         })
         .collect()
+}
+
+fn factor_registry_preview_artifact(
+    target: &str,
+    reports: &[AutoFactorReport],
+    node_metrics: &[NodeMetric],
+) -> Result<FactorRegistryPreviewArtifact, AlphaSearchArtifactError> {
+    Ok(FactorRegistryPreviewArtifact {
+        version: ALPHA_SEARCH_ARTIFACT_VERSION,
+        target: target.to_string(),
+        horizon: factor_horizon(target),
+        factors: factor_registry_preview_rows(target, reports, node_metrics)?,
+    })
 }
 
 fn registry_status(decision: AutoFactorDecision) -> &'static str {
@@ -578,11 +610,194 @@ fn registry_status(decision: AutoFactorDecision) -> &'static str {
     }
 }
 
-fn registry_blockers(report: &AutoFactorReport) -> Vec<String> {
-    if report.decision == AutoFactorDecision::Candidate {
-        Vec::new()
+fn registry_blockers(
+    report: &AutoFactorReport,
+    runtime_contract: &serde_json::Value,
+) -> Vec<String> {
+    let mut blockers = Vec::new();
+    if report.decision != AutoFactorDecision::Candidate {
+        blockers.push(report.reason.clone());
+    }
+    if let Some(items) = runtime_contract.get("blockers").and_then(serde_json::Value::as_array) {
+        blockers.extend(
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter(|item| !item.is_empty())
+                .map(ToOwned::to_owned),
+        );
+    }
+    blockers.sort();
+    blockers.dedup();
+    blockers
+}
+
+fn factor_horizon(target: &str) -> String {
+    if target.contains("10s") {
+        "10s".to_string()
+    } else if target.contains("30s") {
+        "30s".to_string()
     } else {
-        vec![report.reason.clone()]
+        "5m".to_string()
+    }
+}
+
+fn runtime_contract_for_report(
+    report: &AutoFactorReport,
+    dsl_hash: &str,
+    ast_json: &serde_json::Value,
+    horizon: &str,
+) -> serde_json::Value {
+    let input_names = factor_input_names(&report.expr);
+    let mut blockers = Vec::new();
+    let mapping = inferred_runtime_mapping(&report.name);
+    if mapping.runtime_score.is_empty() || mapping.strategy_profile.is_empty() {
+        blockers.push("runtime_contract_unmapped_factor".to_string());
+    }
+    serde_json::json!({
+        "version": "autofactor_runtime_contract_v1",
+        "dsl_hash": dsl_hash,
+        "ast_json": ast_json,
+        "runtime_score": mapping.runtime_score,
+        "strategy_profile": mapping.strategy_profile,
+        "strategy_family": mapping.strategy_family,
+        "factor_family": normalized_factor_family(&report.name),
+        "target": report.target.as_deref().unwrap_or("unknown"),
+        "horizon": horizon,
+        "input_names": input_names,
+        "blockers": blockers,
+    })
+}
+
+#[derive(Debug, Default)]
+struct RuntimeMapping {
+    strategy_profile: String,
+    strategy_family: String,
+    runtime_score: String,
+}
+
+fn inferred_runtime_mapping(name: &str) -> RuntimeMapping {
+    let normalized = normalized_factor_key(name);
+    if normalized == "spread_adjusted_external_move" {
+        return RuntimeMapping {
+            strategy_profile: "repricing_momentum".to_string(),
+            strategy_family: "repricing".to_string(),
+            runtime_score: "spread_adjusted_external_move_score".to_string(),
+        };
+    }
+    if normalized == "repricing_gap_side_10s" {
+        return RuntimeMapping {
+            strategy_profile: "repricing_momentum".to_string(),
+            strategy_family: "repricing".to_string(),
+            runtime_score: "repricing_gap_side_10s".to_string(),
+        };
+    }
+    if is_settlement_formula(&normalized) {
+        return RuntimeMapping {
+            strategy_profile: "settlement_probability".to_string(),
+            strategy_family: "settlement_probability".to_string(),
+            runtime_score: format!("autofactor_formula:{name}"),
+        };
+    }
+    if [
+        "amplitude_weighted_momentum_30s_sigma",
+        "poly_lag_pressure",
+        "spread_adjusted_external_move",
+    ]
+    .iter()
+    .any(|base| normalized.starts_with(base))
+    {
+        return RuntimeMapping {
+            strategy_profile: "settlement_probability".to_string(),
+            strategy_family: "predictive_settlement_probability".to_string(),
+            runtime_score: format!("autofactor_formula:{name}"),
+        };
+    }
+    RuntimeMapping::default()
+}
+
+fn is_settlement_formula(normalized: &str) -> bool {
+    [
+        "auto_settlement_full_depth_settlement_edge",
+        "auto_settlement_conservative_settlement_edge",
+        "auto_settlement_model_full_depth_settlement_edge",
+        "auto_settlement_model_conservative_settlement_edge",
+    ]
+    .iter()
+    .any(|base| {
+        normalized
+            .strip_prefix(base)
+            .map(settlement_formula_suffix_supported)
+            .unwrap_or(false)
+    })
+}
+
+fn settlement_formula_suffix_supported(suffix: &str) -> bool {
+    if suffix.is_empty() {
+        return true;
+    }
+    let mut applied = BTreeSet::new();
+    for token in suffix.trim_start_matches('_').split('_') {
+        let effect = match token {
+            "strike" => Some("near_strike"),
+            "capacity" => Some("capacity"),
+            "quality" => Some("entry_price_quality"),
+            "adjusted" => Some("spread_adjusted"),
+            "pressure" => Some("external_pressure"),
+            "change" => Some("iv_change"),
+            "gate" => Some("full_depth_entry_gate"),
+            "squashed" => Some("squashed"),
+            _ => None,
+        };
+        if let Some(effect) = effect {
+            if !applied.insert(effect) {
+                return false;
+            }
+            continue;
+        }
+        if !matches!(
+            token,
+            "x" | "near" | "full" | "depth" | "entry" | "price" | "spread" | "external" | "iv"
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+fn factor_input_names(expr: &FactorExpr) -> Vec<String> {
+    let mut names = BTreeSet::new();
+    collect_factor_input_names(expr, &mut names);
+    names.into_iter().collect()
+}
+
+fn collect_factor_input_names(expr: &FactorExpr, names: &mut BTreeSet<String>) {
+    match expr {
+        FactorExpr::Input(name) => {
+            names.insert(name.clone());
+        }
+        FactorExpr::Const(_) => {}
+        FactorExpr::Add(lhs, rhs)
+        | FactorExpr::Sub(lhs, rhs)
+        | FactorExpr::Mul(lhs, rhs)
+        | FactorExpr::SafeDiv(lhs, rhs)
+        | FactorExpr::Max(lhs, rhs)
+        | FactorExpr::Min(lhs, rhs) => {
+            collect_factor_input_names(lhs, names);
+            collect_factor_input_names(rhs, names);
+        }
+        FactorExpr::Tanh(expr)
+        | FactorExpr::Log1pAbs(expr)
+        | FactorExpr::SqrtAbs(expr)
+        | FactorExpr::Clip { expr, .. }
+        | FactorExpr::Delta { expr, .. }
+        | FactorExpr::RollingMean { expr, .. }
+        | FactorExpr::RollingStd { expr, .. }
+        | FactorExpr::ZScore { expr, .. } => collect_factor_input_names(expr, names),
+        FactorExpr::Gate { expr, gate, .. } => {
+            collect_factor_input_names(expr, names);
+            collect_factor_input_names(gate, names);
+        }
     }
 }
 
@@ -1233,15 +1448,35 @@ mod tests {
         let registry_preview =
             tmp.join("full_depth_settlement_executable_pnl/factor-registry-preview.json");
         assert!(registry_preview.exists());
-        let rows: serde_json::Value =
+        let preview: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(registry_preview).expect("read preview"))
                 .expect("preview json");
+        assert_eq!(preview["version"], ALPHA_SEARCH_ARTIFACT_VERSION);
+        assert_eq!(
+            preview["target"],
+            "full_depth_settlement_executable_pnl"
+        );
+        assert_eq!(preview["horizon"], "5m");
+        let rows = preview["factors"].as_array().expect("factors array");
         assert_eq!(
             rows[0]["factor_name"],
             "auto_settlement_conservative_settlement_edge"
         );
+        assert_eq!(rows[0]["horizon"], "5m");
         assert_eq!(rows[0]["status"], "candidate");
         assert!(rows[0]["dsl_hash"].as_str().expect("dsl hash").len() >= 32);
+        assert_eq!(
+            rows[0]["runtime_contract"]["runtime_score"],
+            "autofactor_formula:auto_settlement_conservative_settlement_edge"
+        );
+        assert_eq!(
+            rows[0]["runtime_contract"]["strategy_profile"],
+            "settlement_probability"
+        );
+        assert_eq!(
+            rows[0]["runtime_contract"]["input_names"],
+            serde_json::json!(["conservative_settlement_edge"])
+        );
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -368,6 +368,19 @@ impl AutoFactorV2Target {
     }
 }
 
+pub fn autofactor_target_horizon(target: &str) -> &'static str {
+    match target {
+        "reprice_pnl_5s" | "full_depth_reprice_pnl_5s" => "5s",
+        "reprice_pnl_10s" | "full_depth_reprice_pnl_10s" => "10s",
+        "reprice_pnl_30s" | "full_depth_reprice_pnl_30s" => "30s",
+        "reprice_pnl_60s" | "full_depth_reprice_pnl_60s" => "60s",
+        "settlement_executable_pnl"
+        | "full_depth_settlement_executable_pnl"
+        | "tradeable_full_depth_settlement_pnl" => "5m",
+        _ => "unknown",
+    }
+}
+
 #[derive(Debug, Clone)]
 struct BucketSummary {
     n: usize,
@@ -3542,5 +3555,29 @@ mod tests {
         let formatted = format_autofactor_reports(&reports, reports.len());
         assert!(formatted.contains("reprice_pnl_30s"));
         assert!(!formatted.contains("reprice_pnl_10s"));
+    }
+
+    #[test]
+    fn autofactor_target_horizon_covers_repricing_and_settlement_catalog() {
+        for target in ["reprice_pnl_5s", "full_depth_reprice_pnl_5s"] {
+            assert_eq!(autofactor_target_horizon(target), "5s");
+        }
+        for target in ["reprice_pnl_10s", "full_depth_reprice_pnl_10s"] {
+            assert_eq!(autofactor_target_horizon(target), "10s");
+        }
+        for target in ["reprice_pnl_30s", "full_depth_reprice_pnl_30s"] {
+            assert_eq!(autofactor_target_horizon(target), "30s");
+        }
+        for target in ["reprice_pnl_60s", "full_depth_reprice_pnl_60s"] {
+            assert_eq!(autofactor_target_horizon(target), "60s");
+        }
+        for target in [
+            "settlement_executable_pnl",
+            "full_depth_settlement_executable_pnl",
+            "tradeable_full_depth_settlement_pnl",
+        ] {
+            assert_eq!(autofactor_target_horizon(target), "5m");
+        }
+        assert_eq!(autofactor_target_horizon("experimental_target"), "unknown");
     }
 }

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -92,12 +92,12 @@ pub use alpha_search::{
 };
 pub use attribution::{factor_pnl, regime_pnl, AttributionReport, RegimePnl};
 pub use autofactor::{
-    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_windows_from_v2,
-    domain_seed_candidates, evaluate_named_factor, format_autofactor_reports, mine_autofactors,
-    mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_guidance,
-    mine_domain_autofactors_from_v2_with_mcts_plan, AutoFactorDecision, AutoFactorError,
-    AutoFactorMatrix, AutoFactorOptions, AutoFactorReport, AutoFactorV2Target, FactorExpr,
-    LlmMutationSpec, LlmPriorSpec, NamedFactorExpr,
+    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_target_horizon,
+    autofactor_windows_from_v2, domain_seed_candidates, evaluate_named_factor,
+    format_autofactor_reports, mine_autofactors, mine_domain_autofactors_from_v2,
+    mine_domain_autofactors_from_v2_with_guidance, mine_domain_autofactors_from_v2_with_mcts_plan,
+    AutoFactorDecision, AutoFactorError, AutoFactorMatrix, AutoFactorOptions, AutoFactorReport,
+    AutoFactorV2Target, FactorExpr, LlmMutationSpec, LlmPriorSpec, NamedFactorExpr,
 };
 pub use backtest::{run_binary_backtest, BacktestMetrics, SimulatedFill};
 pub use factors_new::{

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -49,6 +49,29 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("candidate_replay_id = $3", source)
         self.assertIn("ON CONFLICT (candidate_replay_id) DO UPDATE", source)
         self.assertIn('"promotion_registry" | "autofactor_promotion" | "strategy_handoff" => "walk_forward"', source)
+        self.assertIn("preview_factors(&preview)", source)
+        self.assertIn("target_from_preview_path(&path)", source)
+        self.assertIn("default_horizon_for_target(&target)", source)
+        self.assertIn("string_field(factor, \"horizon\")", source)
+
+    def test_alpha_search_registry_preview_is_versioned_runtime_contract(self) -> None:
+        source = (ROOT / "crates" / "ploy-research" / "src" / "alpha_search.rs").read_text(
+            encoding="utf-8"
+        )
+        required = [
+            "struct FactorRegistryPreviewArtifact",
+            "version: ALPHA_SEARCH_ARTIFACT_VERSION",
+            "target: target.to_string()",
+            "factors: factor_registry_preview_rows",
+            "runtime_contract_for_report",
+            "autofactor_runtime_contract_v1",
+            '"runtime_score": mapping.runtime_score',
+            '"strategy_profile": mapping.strategy_profile',
+            '"input_names": input_names',
+            "runtime_contract_unmapped_factor",
+        ]
+        for snippet in required:
+            self.assertIn(snippet, source)
 
     def test_promotion_mapping_is_fail_closed(self) -> None:
         source = EXAMPLE.read_text(encoding="utf-8")

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -52,6 +52,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("preview_factors(&preview)", source)
         self.assertIn("target_from_preview_path(&path)", source)
         self.assertIn("default_horizon_for_target(&target)", source)
+        self.assertIn("autofactor_target_horizon(target)", source)
         self.assertIn("string_field(factor, \"horizon\")", source)
 
     def test_alpha_search_registry_preview_is_versioned_runtime_contract(self) -> None:
@@ -60,6 +61,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         )
         required = [
             "struct FactorRegistryPreviewArtifact",
+            "autofactor_target_horizon(target)",
             "version: ALPHA_SEARCH_ARTIFACT_VERSION",
             "target: target.to_string()",
             "factors: factor_registry_preview_rows",

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -103,6 +103,10 @@ class PersistResearchTraceContractTest(unittest.TestCase):
 
     def test_hosted_walk_forward_persists_trace_by_default(self) -> None:
         workflow = HOSTED_WALK.read_text(encoding="utf-8")
+        persist_step = workflow.split("- name: Persist Research OS trace", 1)[1].split(
+            "- name: Create config PR from ready handoff",
+            1,
+        )[0]
         required_snippets = [
             '"persist_research_trace":true',
             '"persist_research_trace": "true"',
@@ -128,9 +132,11 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "--handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json",
             "--candidate-replay-json",
             "candidate-strategy-replay/candidate-strategy-replay.json",
+            "factor walk-forward report is required for durable trace persistence.",
         ]
         for snippet in required_snippets:
             self.assertIn(snippet, workflow)
+        self.assertNotIn("if: always()", persist_step)
 
     def test_standalone_autofactor_promotion_side_effects_require_trace(self) -> None:
         workflow = AUTOFACTOR_PROMOTION.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- stop durable Research OS trace persistence from running after earlier hosted walk-forward failures
- require the factor walk-forward report before writing `persisted.env`
- add static contract coverage for the fail-closed behavior

## Validation
- `python3 -m unittest tests.test_persist_research_trace_contract`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "yaml ok"'`\n- `rtk git diff --check`\n\n## Context\nRun `26331951065` proved the previous `if: always()` allowed trace persistence after `Resolve walk-forward window` failed. This PR prevents partial failed runs from becoming durable Research OS evidence.