### PR TITLE
Harden research data gates and archive legacy debug scripts

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -53,6 +53,7 @@ env:
     042_factor_research_os_registry.sql
     043_research_os_trace_constraints.sql
     044_candidate_replay_tapes.sql
+    045_candidate_replay_basis_stage_constraint.sql
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/research-manager-execute-plan.yml
+++ b/.github/workflows/research-manager-execute-plan.yml
@@ -1,0 +1,117 @@
+name: Research Manager Execute Plan
+
+on:
+  workflow_dispatch:
+    inputs:
+      plan_run_id:
+        description: "Research Trace Plan workflow run id"
+        required: true
+      plan_artifact_name:
+        description: "Plan artifact name; defaults to research-trace-plan-<plan_run_id>"
+        required: false
+        default: ""
+      mode:
+        description: "dry_run or execute"
+        required: true
+        default: "dry_run"
+      execute_ack:
+        description: "Required value for execute mode: execute-research-manager-plan"
+        required: false
+        default: ""
+      git_ref:
+        description: "Git ref for follow-up research dispatches"
+        required: true
+        default: "main"
+      snapshot_run_id:
+        description: "Optional snapshot run id for hosted walk-forward continuations"
+        required: false
+        default: ""
+      symbols:
+        description: "Comma-separated symbols for follow-up research dispatches"
+        required: false
+        default: "BTCUSDT,ETHUSDT,SOLUSDT"
+      stake_usd:
+        description: "Fixed notional for follow-up research dispatches"
+        required: true
+        default: "15"
+      chain_remaining:
+        description: "Maximum remaining chained hosted walk-forward dispatches"
+        required: true
+        default: "1"
+      issue_number:
+        description: "Optional issue to comment with executor summary"
+        required: false
+        default: ""
+
+concurrency:
+  group: research-manager-execute-plan-${{ github.event.inputs.plan_run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+jobs:
+  execute-plan:
+    name: Build bounded Research Manager executor plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout orchestration code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Download Research Trace Plan artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PLAN_RUN_ID: ${{ github.event.inputs.plan_run_id }}
+          PLAN_ARTIFACT_NAME: ${{ github.event.inputs.plan_artifact_name }}
+        run: |
+          set -euo pipefail
+          artifact_name="${PLAN_ARTIFACT_NAME}"
+          if [ -z "${artifact_name}" ]; then
+            artifact_name="research-trace-plan-${PLAN_RUN_ID}"
+          fi
+          rm -rf artifacts/research-trace-plan
+          python3 scripts/download_github_artifact.py \
+            --run-id "${PLAN_RUN_ID}" \
+            --name "${artifact_name}" \
+            --output-dir artifacts/research-trace-plan \
+            --require research-trace-plan.json
+
+      - name: Build executor artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/research_manager_execute_plan.py \
+            --plan-json artifacts/research-trace-plan/research-trace-plan.json \
+            --output-dir artifacts/research-manager-executor \
+            --mode "${{ github.event.inputs.mode }}" \
+            --execute-ack "${{ github.event.inputs.execute_ack }}" \
+            --git-ref "${{ github.event.inputs.git_ref }}" \
+            --snapshot-run-id "${{ github.event.inputs.snapshot_run_id }}" \
+            --symbols "${{ github.event.inputs.symbols }}" \
+            --stake-usd "${{ github.event.inputs.stake_usd }}" \
+            --chain-remaining "${{ github.event.inputs.chain_remaining }}"
+          cat artifacts/research-manager-executor/research-manager-executor.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload executor artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: research-manager-executor-${{ github.run_id }}
+          path: artifacts/research-manager-executor
+          if-no-files-found: error
+
+      - name: Comment executor plan on issue
+        if: ${{ github.event.inputs.issue_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body-file artifacts/research-manager-executor/research-manager-executor.md

--- a/crates/ploy-research/examples/persist_research_trace.rs
+++ b/crates/ploy-research/examples/persist_research_trace.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use ploy_research::ResearchSnapshotManifest;
 use ploy_research::autofactor_target_horizon;
@@ -422,13 +422,17 @@ fn candidate_replay_row(
     let artifact_sha256 = file_sha256(path)?;
     let basis = string_field(&artifact_json, "basis")
         .with_context(|| format!("{} missing basis", path.display()))?;
-    let evidence_stage = string_field(&artifact_json, "evidence_stage").unwrap_or_else(|| {
-        if basis == "factor_walk_forward_top_bucket_aggregate" {
-            "diagnostic".to_string()
-        } else {
-            "executable_replay".to_string()
-        }
-    });
+    let evidence_stage = canonical_candidate_replay_evidence_stage(
+        &basis,
+        string_field(&artifact_json, "evidence_stage").as_deref(),
+    )
+    .with_context(|| {
+        format!(
+            "{} has invalid candidate replay basis/evidence_stage",
+            path.display()
+        )
+    })?
+    .to_string();
     let candidate_replay_id = string_field(&artifact_json, "candidate_replay_id")
         .unwrap_or_else(|| format!("candidate_replay:{}", &artifact_sha256[..32]));
     let source_factor = artifact_json
@@ -516,6 +520,25 @@ fn candidate_replay_row(
         promotion_decision,
         artifact_path: path.to_path_buf(),
     })
+}
+
+fn canonical_candidate_replay_evidence_stage(
+    basis: &str,
+    explicit_evidence_stage: Option<&str>,
+) -> Result<&'static str> {
+    let canonical = match basis {
+        "runtime_market_update_replay" => "executable_replay",
+        "factor_walk_forward_top_bucket_aggregate" => "diagnostic",
+        other => bail!("unsupported candidate replay basis: {other}"),
+    };
+    if let Some(explicit) = explicit_evidence_stage {
+        if explicit != canonical {
+            bail!(
+                "candidate replay evidence_stage {explicit} contradicts basis {basis}; expected {canonical}"
+            );
+        }
+    }
+    Ok(canonical)
 }
 
 fn factor_name_from_runtime_score(value: &Value) -> Option<String> {
@@ -1341,6 +1364,36 @@ mod tests {
             &json!({"blockers": ["a", "c"]}),
         );
         assert_eq!(blockers, json!(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn candidate_replay_stage_is_derived_from_basis() {
+        assert_eq!(
+            canonical_candidate_replay_evidence_stage("runtime_market_update_replay", None)
+                .expect("runtime basis"),
+            "executable_replay"
+        );
+        assert_eq!(
+            canonical_candidate_replay_evidence_stage(
+                "factor_walk_forward_top_bucket_aggregate",
+                None
+            )
+            .expect("diagnostic basis"),
+            "diagnostic"
+        );
+    }
+
+    #[test]
+    fn candidate_replay_rejects_stage_basis_mismatch() {
+        let err = canonical_candidate_replay_evidence_stage(
+            "factor_walk_forward_top_bucket_aggregate",
+            Some("executable_replay"),
+        )
+        .expect_err("stage spoofing must fail");
+        assert!(
+            err.to_string().contains("contradicts basis"),
+            "unexpected error: {err:#}"
+        );
     }
 
     fn preview_plan(alpha_search_dir: PathBuf) -> TracePlan {

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -62,7 +62,6 @@ collection behavior.
 | --- | --- | --- |
 | `scripts/collect_data.py` | archive candidate | Generic historical kline collector overlaps with current DB/export paths. |
 | `scripts/collect_klines.sh` | archive candidate | Same overlap as `collect_data.py`. |
-| `scripts/simulate_backtest.py` | archive candidate | Legacy Python simulation should not be primary backtest path. |
 | `scripts/reverse_engineered_strategy_dry_run.py` | archive candidate | Research prototype, not canonical runtime. |
 | `scripts/copycat_dry_run.py` | archive candidate | Research prototype; future copy-trading work should use canonical `MarketUpdate`/runtime path. |
 | `scripts/discover_new_markets.py` | archive candidate | Discovery belongs in Rust market-data/scanner once parity is proven. |
@@ -70,7 +69,14 @@ collection behavior.
 | `scripts/deploy_7_symbols.sh` | archive candidate | Deployment should use manifests/workflows. |
 | `scripts/deploy-ploy-runner.sh` | archive candidate | Prefer CI-built artifacts and deploy workflows. |
 | `scripts/install-service.sh` / `scripts/install-platform-service.sh` | archive candidate | Keep only if runbooks still reference them; otherwise workflow/systemd install owns service deployment. |
-| `scripts/train_crypto_*_onnx_from_db.py` | research prototype | Keep only while ML lane is active; otherwise archive under research prototypes. |
+| `scripts/train_crypto_*_onnx_from_db.py` | research prototype | Keep only while ML lane is active; otherwise archive under research prototypes. `scripts/train_crypto_lob_mlp_onnx_from_db.py` has been archived in favor of `scripts/train_crypto_lob_tcn_onnx_from_db.py`. |
+
+## Archived Legacy Research Scripts
+
+| Surface | Archived Path | Reason |
+| --- | --- | --- |
+| `scripts/simulate_backtest.py` | `scripts/archive/research-debug/simulate_backtest.py` | Legacy standalone simulator; canonical evidence is produced by Rust/backtest and hosted snapshot-backed workflows. |
+| `scripts/train_crypto_lob_mlp_onnx_from_db.py` | `scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py` | Self-deprecated MLP trainer; active LOB ML docs point to the TCN training entry. |
 
 ## Guardrails
 

--- a/docs/operations/tango-1-1-db-schema-code-map.md
+++ b/docs/operations/tango-1-1-db-schema-code-map.md
@@ -153,7 +153,7 @@ Referenced files:
 - `migrations/014_multi_account_and_collector_targets.sql`
 - `scripts/ploy_maintenance.sh`
 - `scripts/report_drawdown.py`
-- `scripts/train_crypto_lob_mlp_onnx_from_db.py`
+- `scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py`
 - `scripts/train_crypto_lob_tcn_onnx_from_db.py`
 - `src/cli/strategy.rs`
 - `src/coordinator/bootstrap.rs`
@@ -587,7 +587,7 @@ Referenced files:
 - `migrations/015_pm_token_settlements.sql`
 - `migrations/018_training_data_tables.sql`
 - `scripts/train_crypto_binance_threshold_tcn_onnx_from_db.py`
-- `scripts/train_crypto_lob_mlp_onnx_from_db.py`
+- `scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py`
 - `scripts/train_crypto_lob_tcn_onnx_from_db.py`
 - `scripts/train_crypto_lob_tick_settlement_onnx_from_db.py`
 - `src/cli/strategy.rs`
@@ -760,7 +760,7 @@ Referenced files:
 Referenced files:
 
 - `migrations/018_training_data_tables.sql`
-- `scripts/train_crypto_lob_mlp_onnx_from_db.py`
+- `scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py`
 - `scripts/train_crypto_lob_tcn_onnx_from_db.py`
 - `src/collector/sync_collector.rs`
 - `src/coordinator/bootstrap.rs`

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -162,6 +162,14 @@ research database, uploads `research-trace-plan.json` / `.md`, and can attach
 the plan to a research issue. It is read-only and does not build Rust or mutate
 runtime state.
 
+To convert a Research Manager plan into bounded follow-up actions, dispatch
+`.github/workflows/research-manager-execute-plan.yml` with the trace-plan run
+id. It defaults to `mode=dry_run`, uploads a machine-readable executor artifact,
+and only dispatches follow-up research workflows when `mode=execute` and
+`execute_ack=execute-research-manager-plan` are both set. The executor is a
+research-only surface: it can dispatch snapshot refreshes or hosted
+walk-forward continuations, but it does not deploy, trade, or create config PRs.
+
 The current architecture review is
 `docs/reviews/research-data-architecture-review-2026-05-23.md`.
 

--- a/migrations/044_candidate_replay_tapes.sql
+++ b/migrations/044_candidate_replay_tapes.sql
@@ -48,6 +48,17 @@ CREATE TABLE IF NOT EXISTS candidate_replay_tapes (
                 'live_candidate'
             )
         ),
+    CONSTRAINT chk_candidate_replay_tapes_basis_evidence_stage
+        CHECK (
+            (
+                basis = 'runtime_market_update_replay'
+                AND evidence_stage = 'executable_replay'
+            )
+            OR (
+                basis = 'factor_walk_forward_top_bucket_aggregate'
+                AND evidence_stage = 'diagnostic'
+            )
+        ),
     CONSTRAINT chk_candidate_replay_tapes_blockers_array
         CHECK (jsonb_typeof(blocking_risk_flags_json) = 'array'),
     CONSTRAINT chk_candidate_replay_tapes_promotion_decision

--- a/migrations/045_candidate_replay_basis_stage_constraint.sql
+++ b/migrations/045_candidate_replay_basis_stage_constraint.sql
@@ -1,0 +1,23 @@
+-- Migration 045: Prevent candidate replay artifacts from spoofing evidence stage.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_candidate_replay_tapes_basis_evidence_stage'
+    ) THEN
+        ALTER TABLE candidate_replay_tapes
+            ADD CONSTRAINT chk_candidate_replay_tapes_basis_evidence_stage
+            CHECK (
+                (
+                    basis = 'runtime_market_update_replay'
+                    AND evidence_stage = 'executable_replay'
+                )
+                OR (
+                    basis = 'factor_walk_forward_top_bucket_aggregate'
+                    AND evidence_stage = 'diagnostic'
+                )
+            ) NOT VALID;
+    END IF;
+END $$;

--- a/scripts/archive/research-debug/simulate_backtest.py
+++ b/scripts/archive/research-debug/simulate_backtest.py
@@ -6,7 +6,7 @@ Uses historical K-line data to simulate Polymarket 15-minute crypto markets
 and tests the volatility arbitrage strategy.
 
 Usage:
-    python scripts/simulate_backtest.py --klines ./data/klines.csv --output ./results/
+    python scripts/archive/research-debug/simulate_backtest.py --klines ./data/klines.csv --output ./results/
 """
 
 import argparse

--- a/scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py
+++ b/scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-DEPRECATED: prefer `scripts/train_crypto_lob_tcn_onnx_from_db.py`.
+ARCHIVED/DEPRECATED: prefer `scripts/train_crypto_lob_tcn_onnx_from_db.py`.
 
 Train a small MLP (DL) to predict y_up (Polymarket official settlement) from
 Binance LOB-derived features, and export the model to ONNX.

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Turn a Research Manager plan artifact into bounded research follow-up actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+EXECUTE_ACK = "execute-research-manager-plan"
+SCHEMA_VERSION = "research_manager_executor.v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _date_from_ts(raw: str | None) -> str:
+    if not raw:
+        return "auto"
+    return raw.split("T", 1)[0]
+
+
+def _parse_symbols(raw: str) -> list[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _dispatch_gh_workflow(workflow: str, ref: str, fields: dict[str, str]) -> None:
+    cmd = ["gh", "workflow", "run", workflow, "--ref", ref]
+    for key, value in fields.items():
+        cmd.extend(["-f", f"{key}={value}"])
+    subprocess.run(cmd, check=True)
+
+
+def _research_snapshot_dispatch(
+    *,
+    plan: dict[str, Any],
+    git_ref: str,
+    symbols: str,
+    stake_usd: str,
+) -> dict[str, Any]:
+    market_data = ((plan.get("input") or {}).get("market_data_health") or {})
+    start_date = _date_from_ts(market_data.get("dataset_start_ts"))
+    end_date = _date_from_ts(market_data.get("dataset_end_ts"))
+    options = {
+        "data_profile": "pm5d-execution",
+        "data_gate": "warn",
+        "upload_full_snapshot": True,
+    }
+    blockers: list[str] = []
+    if not _parse_symbols(symbols):
+        blockers.append("missing_symbols")
+    fields = {
+        "git_ref": git_ref,
+        "start_date": start_date,
+        "end_date": end_date,
+        "symbols": symbols,
+        "stake_usd": stake_usd,
+        "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
+    }
+    return {
+        "workflow": "research-snapshot.yml",
+        "reason": "refresh snapshot/data audit for Research Manager fix_data plan",
+        "ready": not blockers,
+        "blockers": blockers,
+        "fields": fields,
+    }
+
+
+def _walk_forward_dispatch(
+    *,
+    git_ref: str,
+    snapshot_run_id: str,
+    symbols: str,
+    stake_usd: str,
+    chain_remaining: int,
+) -> dict[str, Any]:
+    blockers: list[str] = []
+    if not snapshot_run_id:
+        blockers.append("missing_snapshot_run_id")
+    if not _parse_symbols(symbols):
+        blockers.append("missing_symbols")
+    options = {
+        "chain_next_run": chain_remaining > 0,
+        "chain_remaining": max(chain_remaining - 1, 0),
+        "create_config_pr": False,
+        "create_handoff_issue": False,
+        "fail_if_blocked": False,
+        "persist_research_trace": True,
+    }
+    fields = {
+        "git_ref": git_ref,
+        "snapshot_run_id": snapshot_run_id,
+        "start_date": "auto",
+        "end_date": "auto",
+        "symbols": symbols,
+        "stake_usd": stake_usd,
+        "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
+    }
+    return {
+        "workflow": "factor-walk-forward-v2-hosted-artifact.yml",
+        "reason": "bounded hosted walk-forward continuation from Research Manager plan",
+        "ready": not blockers,
+        "blockers": blockers,
+        "fields": fields,
+    }
+
+
+def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any]) -> dict[str, Any]:
+    if plan_payload.get("schema_version") != "research_trace_plan.v1":
+        raise SystemExit("research_trace_plan schema mismatch")
+    plan = plan_payload.get("plan") or {}
+    actions = [str(action) for action in plan.get("actions") or []]
+    dispatches: list[dict[str, Any]] = []
+    typed_prior: dict[str, Any] | None = None
+
+    if plan.get("theme") == "fix_data" or any(
+        action in {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
+        for action in actions
+    ):
+        dispatches.append(
+            _research_snapshot_dispatch(
+                plan=plan_payload,
+                git_ref=args.git_ref,
+                symbols=args.symbols,
+                stake_usd=args.stake_usd,
+            )
+        )
+
+    if any(
+        action in {"continue_hosted_alpha_search", "rerun_alpha_search_with_bounded_mutations"}
+        for action in actions
+    ):
+        dispatches.append(
+            _walk_forward_dispatch(
+                git_ref=args.git_ref,
+                snapshot_run_id=args.snapshot_run_id,
+                symbols=args.symbols,
+                stake_usd=args.stake_usd,
+                chain_remaining=args.chain_remaining,
+            )
+        )
+
+    if plan.get("theme") == "revise_prior" or "generate_typed_llm_prior_json" in actions:
+        typed_prior = {
+            "schema_version": "research_manager_typed_prior.v1",
+            "source": "research_trace_plan",
+            "evidence_stage": plan.get("evidence_stage", ""),
+            "theme": plan.get("theme", ""),
+            "actions": actions,
+            "constraints": [
+                "reuse only runtime-contract-mappable inputs",
+                "do not promote without runtime_market_update_replay evidence",
+                "preserve one-event-one-decision accounting",
+            ],
+        }
+
+    executable_dispatches = [item for item in dispatches if item["ready"]]
+    blocked_dispatches = [item for item in dispatches if not item["ready"]]
+    mode = "execute" if args.mode == "execute" and args.execute_ack == EXECUTE_ACK else "dry_run"
+    if args.mode == "execute" and args.execute_ack != EXECUTE_ACK:
+        blocked_dispatches.append(
+            {
+                "workflow": "<all>",
+                "reason": "execute mode requested without ACK",
+                "ready": False,
+                "blockers": ["missing_execute_ack"],
+                "fields": {},
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "mode": mode,
+        "source_plan": {
+            "schema_version": plan_payload.get("schema_version"),
+            "theme": plan.get("theme", ""),
+            "priority": plan.get("priority", ""),
+            "evidence_stage": plan.get("evidence_stage", ""),
+            "actions": actions,
+        },
+        "dispatches": dispatches,
+        "executable_dispatch_count": len(executable_dispatches),
+        "blocked_dispatches": blocked_dispatches,
+        "typed_prior": typed_prior,
+        "side_effects_enabled": mode == "execute",
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Research Manager Executor",
+        "",
+        f"- Mode: `{payload['mode']}`",
+        f"- Source theme: `{payload['source_plan']['theme']}`",
+        f"- Source evidence stage: `{payload['source_plan']['evidence_stage']}`",
+        f"- Executable dispatches: `{payload['executable_dispatch_count']}`",
+        "",
+        "## Dispatch Plan",
+        "",
+    ]
+    if not payload["dispatches"]:
+        lines.append("- `<none>`")
+    for item in payload["dispatches"]:
+        status = "ready" if item["ready"] else "blocked"
+        blockers = ", ".join(item["blockers"]) if item["blockers"] else "<none>"
+        lines.append(f"- `{item['workflow']}`: `{status}`; blockers: `{blockers}`")
+    if payload.get("typed_prior"):
+        lines.extend(["", "## Typed Prior", "", "- `research_manager_typed_prior.v1` generated"])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan-json", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--mode", choices=["dry_run", "execute"], default="dry_run")
+    parser.add_argument("--execute-ack", default="")
+    parser.add_argument("--git-ref", default="main")
+    parser.add_argument("--snapshot-run-id", default="")
+    parser.add_argument("--symbols", default="")
+    parser.add_argument("--stake-usd", default="15")
+    parser.add_argument("--chain-remaining", type=int, default=1)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    payload = build_executor_payload(args, _load_json(args.plan_json))
+    _write_json(args.output_dir / "research-manager-executor.json", payload)
+    (args.output_dir / "research-manager-executor.md").write_text(
+        render_markdown(payload),
+        encoding="utf-8",
+    )
+    if payload.get("typed_prior"):
+        _write_json(args.output_dir / "next-llm-prior.json", payload["typed_prior"])
+
+    if payload["side_effects_enabled"]:
+        for item in payload["dispatches"]:
+            if item["ready"]:
+                _dispatch_gh_workflow(item["workflow"], args.git_ref, item["fields"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -55,10 +55,11 @@ trace, not dry-run promotion.
       `scripts/` root.
 - [x] Add a durable trace hard gate so candidate replay `basis` and
       `evidence_stage` cannot contradict each other.
+- [x] Add a default-dry-run Research Manager executor workflow that turns
+      trace-plan actions into auditable bounded follow-up research dispatches.
 - [ ] Apply remaining high-priority data/research cleanup based on audit
-      results: Research Manager action executor, runtime input
-      canonicalization, feature snapshot hard gates, and multi-horizon
-      accounting gates.
+      results: runtime input canonicalization, feature snapshot hard gates, and
+      multi-horizon accounting gates.
 
 ## Review
 
@@ -119,6 +120,13 @@ trace, not dry-run promotion.
   artifacts claiming `executable_replay`. Migration
   `045_candidate_replay_basis_stage_constraint.sql` adds the same DB-level
   guard for future rows.
+- 2026-05-23: Added `research-manager-execute-plan.yml` plus
+  `scripts/research_manager_execute_plan.py`. The executor reads
+  `research-trace-plan.json`, writes `research-manager-executor.json/.md`, can
+  generate a typed-prior artifact, and remains dry-run unless
+  `execute_ack=execute-research-manager-plan` is provided. Execute mode is
+  limited to research workflows such as snapshot refresh and hosted
+  walk-forward continuation.
 - 2026-05-23: Active workflow/docs/script contracts now call retained
   snapshots `complete sampled research snapshot` artifacts instead of `full`
   snapshots/full payloads. Added a regression test so active docs, workflows,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -49,6 +49,12 @@ trace, not dry-run promotion.
 - [x] Refresh the research/data architecture review to reflect PR #610-#615,
       candidate replay trace durability, diagnostic-only backtest evidence, and
       the remaining deploy/rerun blockers.
+- [x] Rerun hosted walk-forward from current `main` with durable trace
+      persistence after the trace-gate merge.
+- [x] Archive immediately-safe legacy research/debug scripts from the active
+      `scripts/` root.
+- [x] Add a durable trace hard gate so candidate replay `basis` and
+      `evidence_stage` cannot contradict each other.
 - [ ] Apply remaining high-priority data/research cleanup based on audit
       results: Research Manager action executor, runtime input
       canonicalization, feature snapshot hard gates, and multi-horizon
@@ -96,6 +102,23 @@ trace, not dry-run promotion.
   --example factor_review_v2 --example factor_walk_forward_v2`; and `rtk git
   diff --check`. `actionlint` was not installed in this worktree/PATH, so it
   was not run for this slice.
+- 2026-05-23: Fresh hosted walk-forward from current `main` initially failed in
+  run `26333356769` because snapshot `26327019766` only contained
+  `BTCUSDT,ETHUSDT,SOLUSDT` while the dispatch requested six symbols. Rerun
+  `26333447143` with the snapshot-scoped symbols succeeded, uploaded
+  `research-trace/persisted.env`, and recorded
+  `evidence_stages=factor_attribution,walk_forward`.
+- 2026-05-23: Archived `scripts/simulate_backtest.py` and the self-deprecated
+  `scripts/train_crypto_lob_mlp_onnx_from_db.py` under
+  `scripts/archive/research-debug/`. Kept `run_factor_research*.sh` as
+  explicit break-glass and left quote backfill scripts untouched pending repair
+  completion evidence.
+- 2026-05-23: Added candidate replay stage/basis hardening.
+  `persist_research_trace` now derives canonical replay `evidence_stage` from
+  `basis` and rejects spoofed contradictions such as top-bucket diagnostic
+  artifacts claiming `executable_replay`. Migration
+  `045_candidate_replay_basis_stage_constraint.sql` adds the same DB-level
+  guard for future rows.
 - 2026-05-23: Active workflow/docs/script contracts now call retained
   snapshots `complete sampled research snapshot` artifacts instead of `full`
   snapshots/full payloads. Added a regression test so active docs, workflows,

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -48,6 +48,8 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("evaluation_kind = 'candidate_replay'", source)
         self.assertIn("candidate_replay_id = $3", source)
         self.assertIn("ON CONFLICT (candidate_replay_id) DO UPDATE", source)
+        self.assertIn("canonical_candidate_replay_evidence_stage", source)
+        self.assertIn("contradicts basis", source)
         self.assertIn('"promotion_registry" | "autofactor_promotion" | "strategy_handoff" => "walk_forward"', source)
         self.assertIn("preview_factors(&preview)", source)
         self.assertIn("target_from_preview_path(&path)", source)
@@ -190,6 +192,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("--example persist_research_trace", workflow)
         self.assertIn("--example research_trace_plan", workflow)
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
+        self.assertIn("045_candidate_replay_basis_stage_constraint.sql", workflow)
 
     def test_research_trace_plan_reads_durable_tables(self) -> None:
         source = TRACE_PLAN.read_text(encoding="utf-8")

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -1,0 +1,115 @@
+import json
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+from scripts.research_manager_execute_plan import (
+    EXECUTE_ACK,
+    build_executor_payload,
+    main,
+)
+
+
+def plan_payload(theme: str, actions: list[str]) -> dict:
+    return {
+        "schema_version": "research_trace_plan.v1",
+        "input": {
+            "market_data_health": {
+                "dataset_start_ts": "2026-04-21T00:00:00Z",
+                "dataset_end_ts": "2026-04-23T00:00:00Z",
+            }
+        },
+        "plan": {
+            "theme": theme,
+            "priority": "high",
+            "evidence_stage": "factor_attribution",
+            "actions": actions,
+        },
+    }
+
+
+class ResearchManagerExecutePlanTest(unittest.TestCase):
+    def test_fix_data_plan_creates_snapshot_dispatch_in_dry_run(self) -> None:
+        payload = build_executor_payload(
+            Namespace(
+                mode="dry_run",
+                execute_ack="",
+                git_ref="main",
+                snapshot_run_id="",
+                symbols="BTCUSDT,ETHUSDT",
+                stake_usd="15",
+                chain_remaining=1,
+            ),
+            plan_payload("fix_data", ["rerun_snapshot_data_audit"]),
+        )
+        self.assertEqual("research_manager_executor.v1", payload["schema_version"])
+        self.assertEqual("dry_run", payload["mode"])
+        self.assertEqual(1, payload["executable_dispatch_count"])
+        self.assertEqual("research-snapshot.yml", payload["dispatches"][0]["workflow"])
+        self.assertEqual("2026-04-21", payload["dispatches"][0]["fields"]["start_date"])
+
+    def test_execute_mode_requires_ack(self) -> None:
+        payload = build_executor_payload(
+            Namespace(
+                mode="execute",
+                execute_ack="wrong",
+                git_ref="main",
+                snapshot_run_id="123",
+                symbols="BTCUSDT",
+                stake_usd="15",
+                chain_remaining=1,
+            ),
+            plan_payload("continue_search", ["continue_hosted_alpha_search"]),
+        )
+        self.assertEqual("dry_run", payload["mode"])
+        self.assertIn("missing_execute_ack", payload["blocked_dispatches"][-1]["blockers"])
+
+    def test_continue_search_maps_to_bounded_walk_forward(self) -> None:
+        payload = build_executor_payload(
+            Namespace(
+                mode="execute",
+                execute_ack=EXECUTE_ACK,
+                git_ref="main",
+                snapshot_run_id="26327019766",
+                symbols="BTCUSDT",
+                stake_usd="15",
+                chain_remaining=2,
+            ),
+            plan_payload("continue_search", ["continue_hosted_alpha_search"]),
+        )
+        self.assertEqual("execute", payload["mode"])
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("factor-walk-forward-v2-hosted-artifact.yml", dispatch["workflow"])
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertTrue(options["chain_next_run"])
+        self.assertEqual(1, options["chain_remaining"])
+
+    def test_cli_writes_executor_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plan = root / "plan.json"
+            out = root / "out"
+            plan.write_text(json.dumps(plan_payload("revise_prior", ["generate_typed_llm_prior_json"])))
+            import sys
+
+            argv = sys.argv
+            try:
+                sys.argv = [
+                    "research_manager_execute_plan.py",
+                    "--plan-json",
+                    str(plan),
+                    "--output-dir",
+                    str(out),
+                ]
+                main()
+            finally:
+                sys.argv = argv
+            self.assertTrue((out / "research-manager-executor.json").exists())
+            self.assertTrue((out / "research-manager-executor.md").exists())
+            self.assertTrue((out / "next-llm-prior.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce candidate replay basis/evidence_stage consistency in persist_research_trace and DB migration 045
- include migration 045 in tango deploy migrations
- archive legacy simulate_backtest.py and deprecated LOB MLP trainer under scripts/archive/research-debug
- add default-dry-run Research Manager executor workflow to turn trace-plan actions into auditable bounded research dispatches
- record fresh walk-forward evidence and remaining data/research gates in tasks/todo.md

## Verification
- python3 -m unittest tests.test_persist_research_trace_contract
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract
- python3 -m py_compile scripts/archive/research-debug/simulate_backtest.py scripts/archive/research-debug/train_crypto_lob_mlp_onnx_from_db.py
- python3 -m py_compile scripts/research_manager_execute_plan.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "yaml ok"'
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-manager-execute-plan.yml"); puts "executor yaml ok"'
- git diff --check
- rtk cargo test --locked -p ploy-research --example persist_research_trace --features db --no-default-features candidate_replay
- dry-run executor smoke against prior Research Trace Plan artifact 26328161347

## External evidence
- Hosted walk-forward run 26333447143 succeeded from main and uploaded research-trace/persisted.env
- Research Trace Plan run 26333501793 is waiting on protected tango-1-1 environment approval