### PR TITLE
Gate AutoFactor runtime contracts

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -82,6 +82,7 @@ jobs:
           trace_marker_path="$(find artifacts/source -path '*/research-trace/persisted.env' -print -quit)"
           snapshot_provenance_path="$(find artifacts/source -path '*/snapshot-provenance/source.txt' -print -quit)"
           snapshot_manifest_path="$(find artifacts/source -path '*/snapshot-provenance/manifest.json' -print -quit)"
+          registry_preview_path="$(find artifacts/source -path '*/factor-registry-preview.json' -print -quit)"
           side_effect_requested="false"
           if [ "${{ github.event.inputs.create_handoff_issue }}" = "true" ] || [ "${{ github.event.inputs.create_config_pr }}" = "true" ]; then
             side_effect_requested="true"
@@ -110,6 +111,7 @@ jobs:
             echo "SOURCE_TRACE_MARKER_PATH=${trace_marker_path}"
             echo "SOURCE_SNAPSHOT_PROVENANCE_PATH=${snapshot_provenance_path}"
             echo "SOURCE_SNAPSHOT_MANIFEST_PATH=${snapshot_manifest_path}"
+            echo "SOURCE_FACTOR_REGISTRY_PREVIEW_PATH=${registry_preview_path}"
           } >> "$GITHUB_ENV"
 
       - name: Evaluate AutoFactor strategy promotion
@@ -128,6 +130,9 @@ jobs:
           )
           if [ -n "${CANDIDATE_STRATEGY_REPLAY_PATH:-}" ]; then
             args+=(--candidate-strategy-replay-json "${CANDIDATE_STRATEGY_REPLAY_PATH}")
+          fi
+          if [ -n "${SOURCE_FACTOR_REGISTRY_PREVIEW_PATH:-}" ]; then
+            args+=(--factor-registry-preview-json "${SOURCE_FACTOR_REGISTRY_PREVIEW_PATH}" --require-runtime-contract)
           fi
           if [ "${{ github.event.inputs.fail_if_blocked }}" = "true" ]; then
             args+=(--fail-if-blocked)

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::autofactor::{
-    AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr, LlmPriorSpec,
-    autofactor_target_horizon, factor_expr_hash,
+    autofactor_target_horizon, factor_expr_hash, AutoFactorDecision, AutoFactorOptions,
+    AutoFactorReport, FactorExpr, LlmPriorSpec,
 };
 
 const ALPHA_SEARCH_ARTIFACT_VERSION: &str = "alpha_search_artifacts_v1";
@@ -618,7 +618,10 @@ fn registry_blockers(
     if report.decision != AutoFactorDecision::Candidate {
         blockers.push(report.reason.clone());
     }
-    if let Some(items) = runtime_contract.get("blockers").and_then(serde_json::Value::as_array) {
+    if let Some(items) = runtime_contract
+        .get("blockers")
+        .and_then(serde_json::Value::as_array)
+    {
         blockers.extend(
             items
                 .iter()
@@ -648,6 +651,10 @@ fn runtime_contract_for_report(
     if mapping.runtime_score.is_empty() || mapping.strategy_profile.is_empty() {
         blockers.push("runtime_contract_unmapped_factor".to_string());
     }
+    blockers.extend(runtime_input_blockers(&input_names));
+    blockers.extend(runtime_formula_blockers(&report.name));
+    blockers.sort();
+    blockers.dedup();
     serde_json::json!({
         "version": "autofactor_runtime_contract_v1",
         "dsl_hash": dsl_hash,
@@ -693,14 +700,7 @@ fn inferred_runtime_mapping(name: &str) -> RuntimeMapping {
             runtime_score: format!("autofactor_formula:{name}"),
         };
     }
-    if [
-        "amplitude_weighted_momentum_30s_sigma",
-        "poly_lag_pressure",
-        "spread_adjusted_external_move",
-    ]
-    .iter()
-    .any(|base| normalized.starts_with(base))
-    {
+    if is_predictive_settlement_formula(&normalized) {
         return RuntimeMapping {
             strategy_profile: "settlement_probability".to_string(),
             strategy_family: "predictive_settlement_probability".to_string(),
@@ -708,6 +708,158 @@ fn inferred_runtime_mapping(name: &str) -> RuntimeMapping {
         };
     }
     RuntimeMapping::default()
+}
+
+fn runtime_input_blockers(input_names: &[String]) -> Vec<String> {
+    let mut blockers = Vec::new();
+    for input in input_names {
+        match input.as_str() {
+            "conservative_settlement_edge"
+            | "full_depth_settlement_edge"
+            | "model_conservative_settlement_edge"
+            | "model_full_depth_settlement_edge"
+            | "settlement_edge"
+            | "entry_price"
+            | "distance_over_sigma"
+            | "direction_sign"
+            | "drift_30s"
+            | "sigma_horizon"
+            | "entry_capacity_ratio"
+            | "side_spread"
+            | "pm_lag_secs" => {}
+            "external_pressure" => {
+                blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string())
+            }
+            "iv_change_1m" => blockers.push("runtime_input_not_supplied:iv_change_1m".to_string()),
+            other => blockers.push(format!("runtime_input_unsupported:{other}")),
+        }
+    }
+    blockers
+}
+
+fn runtime_formula_blockers(name: &str) -> Vec<String> {
+    let normalized = normalized_factor_key(name);
+    let mut blockers = Vec::new();
+    if normalized.starts_with("auto_settlement_bayes_") {
+        blockers.push("runtime_contract_unmapped_bayes_formula".to_string());
+    }
+    if normalized.starts_with("poly_lag_pressure") {
+        blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string());
+    }
+    if normalized.contains("external_pressure") {
+        blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string());
+    }
+    if normalized.contains("iv_change") {
+        blockers.push("runtime_input_not_supplied:iv_change_1m".to_string());
+    }
+    if is_predictive_formula_base(&normalized) && !is_predictive_settlement_formula(&normalized) {
+        blockers.push("runtime_contract_unsupported_predictive_suffix".to_string());
+    }
+    blockers
+}
+
+fn is_predictive_formula_base(normalized: &str) -> bool {
+    [
+        "amplitude_weighted_momentum_30s_sigma",
+        "poly_lag_pressure",
+        "spread_adjusted_external_move",
+    ]
+    .iter()
+    .any(|base| normalized.starts_with(base))
+}
+
+fn is_predictive_settlement_formula(normalized: &str) -> bool {
+    let Some(base) = [
+        "amplitude_weighted_momentum_30s_sigma",
+        "poly_lag_pressure",
+        "spread_adjusted_external_move",
+    ]
+    .iter()
+    .find(|base| normalized.starts_with(**base)) else {
+        return false;
+    };
+    let suffix = normalized.strip_prefix(base).unwrap_or("");
+    predictive_formula_suffix_supported(suffix)
+}
+
+fn predictive_formula_suffix_supported(suffix: &str) -> bool {
+    let suffix = suffix
+        .replace(
+            "_runtime_pass_through_add_spread_penalty",
+            "_spread_adjusted",
+        )
+        .replace(
+            "_runtime_pass_through_add_capacity_gate",
+            "_full_depth_entry_gate",
+        )
+        .replace("_add_capacity_gate", "_full_depth_entry_gate");
+    let Some(suffix) = strip_predictive_selector_gates(&suffix) else {
+        return false;
+    };
+    if suffix.is_empty() {
+        return true;
+    }
+    for token in suffix.trim_start_matches('_').split('_') {
+        if !matches!(
+            token,
+            "squashed"
+                | "near"
+                | "strike"
+                | "capacity"
+                | "full"
+                | "depth"
+                | "entry"
+                | "gate"
+                | "price"
+                | "quality"
+                | "spread"
+                | "adjusted"
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+fn strip_predictive_selector_gates(suffix: &str) -> Option<String> {
+    let mut remaining_suffix = suffix.to_string();
+    while let Some((remaining, selector)) = remaining_suffix.split_once("_select_") {
+        let (_feature, raw_threshold, trailing_suffix) = parse_predictive_selector_gate(selector)?;
+        if parse_predictive_selector_threshold(raw_threshold).is_none() {
+            return None;
+        }
+        remaining_suffix = format!("{remaining}{trailing_suffix}");
+    }
+    Some(remaining_suffix)
+}
+
+fn parse_predictive_selector_gate(selector: &str) -> Option<(&'static str, &str, String)> {
+    for feature in [
+        "entry_price_quality",
+        "full_depth_entry",
+        "entry_capacity",
+        "near_strike",
+    ] {
+        let prefix = format!("{feature}_ge_");
+        let Some(raw) = selector.strip_prefix(&prefix) else {
+            continue;
+        };
+        let (threshold, trailing_suffix) = match raw.split_once('_') {
+            Some((threshold, trailing)) => (threshold, format!("_{trailing}")),
+            None => (raw, String::new()),
+        };
+        return Some((feature, threshold, trailing_suffix));
+    }
+    None
+}
+
+fn parse_predictive_selector_threshold(raw: &str) -> Option<f64> {
+    let threshold = if raw.contains('.') {
+        raw.parse().ok()?
+    } else {
+        raw.parse::<f64>().ok()? / 100.0
+    };
+    (threshold.is_finite() && (0.0..=1.0).contains(&threshold)).then_some(threshold)
 }
 
 fn is_settlement_formula(normalized: &str) -> bool {
@@ -1172,7 +1324,11 @@ fn normalized_positive(value: f64) -> f64 {
 }
 
 fn finite_or_zero(value: f64) -> f64 {
-    if value.is_finite() { value } else { 0.0 }
+    if value.is_finite() {
+        value
+    } else {
+        0.0
+    }
 }
 
 fn ratio_usize(numerator: usize, denominator: usize) -> f64 {
@@ -1325,7 +1481,8 @@ fn normalized_factor_key(raw: &str) -> String {
         .to_string();
     loop {
         let next = value
-            .strip_prefix("llm_")
+            .strip_prefix("mut2_")
+            .or_else(|| value.strip_prefix("llm_"))
             .or_else(|| value.strip_prefix("mcts_"))
             .or_else(|| value.strip_prefix("mut_"));
         let Some(stripped) = next else {
@@ -1423,22 +1580,18 @@ mod tests {
         )
         .expect("write artifacts");
         assert_eq!(summary.candidate_count, 1);
-        assert!(
-            tmp.join("full_depth_settlement_executable_pnl/search-space.json")
-                .exists()
-        );
-        assert!(
-            tmp.join("full_depth_settlement_executable_pnl/tree-trace.json")
-                .exists()
-        );
-        assert!(
-            tmp.join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
-                .exists()
-        );
-        assert!(
-            tmp.join("full_depth_settlement_executable_pnl/mcts-state.json")
-                .exists()
-        );
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/search-space.json")
+            .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/tree-trace.json")
+            .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
+            .exists());
+        assert!(tmp
+            .join("full_depth_settlement_executable_pnl/mcts-state.json")
+            .exists());
         let registry_preview =
             tmp.join("full_depth_settlement_executable_pnl/factor-registry-preview.json");
         assert!(registry_preview.exists());
@@ -1446,10 +1599,7 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(registry_preview).expect("read preview"))
                 .expect("preview json");
         assert_eq!(preview["version"], ALPHA_SEARCH_ARTIFACT_VERSION);
-        assert_eq!(
-            preview["target"],
-            "full_depth_settlement_executable_pnl"
-        );
+        assert_eq!(preview["target"], "full_depth_settlement_executable_pnl");
         assert_eq!(preview["horizon"], "5m");
         let rows = preview["factors"].as_array().expect("factors array");
         assert_eq!(
@@ -1472,6 +1622,69 @@ mod tests {
             serde_json::json!(["conservative_settlement_edge"])
         );
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn runtime_contract_blocks_noncanonical_runtime_inputs() {
+        let external_pressure_report = AutoFactorReport {
+            name: "auto_settlement_model_full_depth_settlement_edge_x_external_pressure"
+                .to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Mul(
+                Box::new(FactorExpr::Input(
+                    "model_full_depth_settlement_edge".to_string(),
+                )),
+                Box::new(FactorExpr::Input("external_pressure".to_string())),
+            ),
+            ..sample_report("auto_settlement_model_full_depth_settlement_edge_x_external_pressure")
+        };
+        let contract = runtime_contract_for_report(
+            &external_pressure_report,
+            "dsl-hash",
+            &serde_json::json!({}),
+            "5m",
+        );
+        let blockers = contract["blockers"].as_array().expect("blockers");
+        assert!(blockers.iter().any(|item| {
+            item.as_str() == Some("runtime_input_semantics_mismatch:external_pressure")
+        }));
+
+        let iv_change_report = AutoFactorReport {
+            name: "auto_settlement_conservative_settlement_edge_x_iv_change".to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Mul(
+                Box::new(FactorExpr::Input(
+                    "conservative_settlement_edge".to_string(),
+                )),
+                Box::new(FactorExpr::Input("iv_change_1m".to_string())),
+            ),
+            ..sample_report("auto_settlement_conservative_settlement_edge_x_iv_change")
+        };
+        let contract = runtime_contract_for_report(
+            &iv_change_report,
+            "dsl-hash",
+            &serde_json::json!({}),
+            "5m",
+        );
+        let blockers = contract["blockers"].as_array().expect("blockers");
+        assert!(blockers
+            .iter()
+            .any(|item| item.as_str() == Some("runtime_input_not_supplied:iv_change_1m")));
+    }
+
+    #[test]
+    fn runtime_contract_blocks_unsupported_predictive_suffixes() {
+        let unsupported = sample_report("llm_amplitude_weighted_momentum_30s_sigma_feature_gate");
+        let contract =
+            runtime_contract_for_report(&unsupported, "dsl-hash", &serde_json::json!({}), "5m");
+        assert_eq!(contract["runtime_score"], "");
+        let blockers = contract["blockers"].as_array().expect("blockers");
+        assert!(blockers
+            .iter()
+            .any(|item| item.as_str() == Some("runtime_contract_unmapped_factor")));
+        assert!(blockers.iter().any(|item| {
+            item.as_str() == Some("runtime_contract_unsupported_predictive_suffix")
+        }));
     }
 
     #[test]
@@ -1686,12 +1899,10 @@ mod tests {
         let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
-        assert!(
-            !plan
-                .selected_nodes
-                .iter()
-                .any(|node| node.factor_name == "mcts_spread_adjusted_external_move_near_strike")
-        );
+        assert!(!plan
+            .selected_nodes
+            .iter()
+            .any(|node| node.factor_name == "mcts_spread_adjusted_external_move_near_strike"));
         assert_eq!(
             plan.selected_nodes
                 .first()
@@ -1737,11 +1948,10 @@ mod tests {
         let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
-        assert!(
-            plan.selected_nodes
-                .iter()
-                .all(|node| !node.factor_name.contains("spread_adjusted_external_move"))
-        );
+        assert!(plan
+            .selected_nodes
+            .iter()
+            .all(|node| !node.factor_name.contains("spread_adjusted_external_move")));
         assert_eq!(
             plan.selected_nodes
                 .first()

--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -100,11 +100,15 @@ reserved for `executable_replay` evidence.
    claims must cite candidate replay or full-depth lake evidence, not only
    sampled snapshot rows.
 
-5. **Runtime input canonicalization remains incomplete.**
+5. **Runtime input canonicalization is now gated for AutoFactor promotion/replay,
+   but not yet a shared cross-language source of truth.**
 
-   Factor registry contracts now carry typed runtime metadata, but research and
-   runtime still need a single canonical input gate for feature names, horizons,
-   LOB surfaces, blocker semantics, and strategy profile/family mapping.
+   Factor registry contracts now carry typed runtime metadata, and Python
+   promotion/replay consumers fail closed when registry previews are present
+   but contracts are missing, blocked, or semantically mismatched. The remaining
+   gap is deeper: Rust runtime scoring and Rust/Python contract catalogs still
+   need one generated/shared source for feature names, horizons, LOB surfaces,
+   blocker semantics, and strategy profile/family mapping.
 
 6. **Multi-horizon label/accounting is not a single hard gate yet.**
 
@@ -129,7 +133,7 @@ reserved for `executable_replay` evidence.
 | P0 | Run one hosted walk-forward from current `main` with default trace persistence | DB contains current-run rows across Research OS trace tables |
 | P0 | Run `research-trace-plan.yml` against the fresh trace | Plan JSON references latest trace rows and returns `continue_search`, `revise_prior`, `fix_data`, `fix_runtime`, or `fix_workflow` |
 | P1 | Add Research Manager action executor | Plan output can open/link issues and dispatch bounded hosted research reruns without manual artifact reading |
-| P1 | Add runtime input canonicalization gate | Unsupported or mismatched research/runtime feature inputs fail closed before promotion/replay |
+| P1 | Promote runtime input canonicalization to a shared generated contract | Rust runtime scoring, Rust alpha-search, and Python promotion/replay use one source of truth instead of mirrored catalogs |
 | P1 | Harden feature snapshot contract at consumers | Sampled snapshots cannot be consumed as full-depth execution evidence |
 | P1 | Enforce multi-horizon accounting at persisted approval layer | Multi-decision or horizon-mixed artifacts are blocked before handoff |
 

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -154,7 +154,9 @@ python3 scripts/evaluate_autofactor_strategy_promotion.py \
   --output-md /tmp/autofactor-strategy-promotion.md \
   --output-registry-json /tmp/autofactor-factor-registry.json \
   --output-handoff-json /tmp/autofactor-strategy-handoff.json \
-  --output-handoff-md /tmp/autofactor-strategy-handoff.md
+  --output-handoff-md /tmp/autofactor-strategy-handoff.md \
+  --factor-registry-preview-json /tmp/factor-registry-preview.json \
+  --require-runtime-contract
 ```
 
 The evaluator requires all of the following before a dry-run handoff:
@@ -164,6 +166,8 @@ The evaluator requires all of the following before a dry-run handoff:
 - the target is an allowed executable target, defaulting to
   `full_depth_settlement_executable_pnl`;
 - the factor has an explicit runtime strategy-profile mapping; and
+- when a factor-registry preview exists, the factor has a typed, unblocked
+  runtime contract with canonical runtime inputs; and
 - the runtime profile matches the requested promotion lane, defaulting to
   `settlement_probability`; and
 - a candidate strategy executable replay artifact is ready for the exact same

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -130,6 +130,13 @@ attached through the later gates. Candidate replay tapes must use their own
 `candidate_replay_id` instead of being collapsed into the sampled research
 snapshot identity.
 
+AutoFactor promotion and aggregate candidate-replay builders must prefer the
+typed `factor-registry-preview.json` runtime contract when it is available.
+When that preview is present, missing runtime contracts, contract blockers,
+unsupported inputs, semantic input mismatches, or placeholder runtime fields
+block promotion/replay handoff instead of falling back to factor-name
+inference.
+
 Hosted walk-forward runs the writer by default and requires a protected
 database secret unless the dispatch explicitly sets
 `options_json.persist_research_trace=false` for a read-only diagnostic run. It

--- a/scripts/autofactor_runtime_contract.py
+++ b/scripts/autofactor_runtime_contract.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Shared AutoFactor runtime contract loading and validation.
+
+Factor discovery may infer many research-side expressions, but promotion and
+candidate replay must only advance rows that carry a typed runtime contract
+when a registry preview is present. The fallback name mapping below exists only
+for legacy artifacts that predate registry contracts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+SETTLEMENT_RUNTIME_MAPPING = {
+    "strategy_profile": "settlement_probability",
+    "strategy_family": "settlement_probability",
+}
+
+PREDICTIVE_FORMULA_BASES = (
+    "amplitude_weighted_momentum_30s_sigma",
+    "poly_lag_pressure",
+    "spread_adjusted_external_move",
+)
+
+SETTLEMENT_FORMULA_BASES = (
+    "auto_settlement_full_depth_settlement_edge",
+    "auto_settlement_conservative_settlement_edge",
+    "auto_settlement_model_full_depth_settlement_edge",
+    "auto_settlement_model_conservative_settlement_edge",
+)
+
+LEGACY_BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
+    "spread_adjusted_external_move": {
+        "strategy_profile": "repricing_momentum",
+        "strategy_family": "repricing",
+        "runtime_score": "spread_adjusted_external_move_score",
+    },
+    "repricing_gap_side_10s": {
+        "strategy_profile": "repricing_momentum",
+        "strategy_family": "repricing",
+        "runtime_score": "repricing_gap_side_10s",
+    },
+    "amplitude_weighted_momentum_30s_sigma": {
+        "strategy_profile": "settlement_probability",
+        "strategy_family": "predictive_settlement_probability",
+        "runtime_score": "autofactor_formula:amplitude_weighted_momentum_30s_sigma",
+    },
+    "mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate": {
+        "strategy_profile": "settlement_probability",
+        "strategy_family": "predictive_settlement_probability",
+        "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
+    },
+    "mut_spread_adjusted_external_move_full_depth_entry_gate": {
+        "strategy_profile": "settlement_probability",
+        "strategy_family": "predictive_settlement_probability",
+        "runtime_score": "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate",
+    },
+    "settlement_fair_edge": {
+        "strategy_profile": "",
+        "strategy_family": "settlement_probability",
+        "runtime_score": "",
+    },
+}
+
+for _base in SETTLEMENT_FORMULA_BASES:
+    for _suffix in (
+        "",
+        "_x_near_strike",
+        "_x_capacity",
+        "_x_entry_price_quality",
+        "_x_near_strike_x_capacity",
+        "_x_near_strike_x_capacity_x_entry_price_quality",
+        "_spread_adjusted",
+        "_x_external_pressure",
+        "_x_iv_change",
+    ):
+        _name = f"{_base}{_suffix}"
+        LEGACY_BUILTIN_RUNTIME_MAPPINGS[_name] = {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "runtime_score": f"autofactor_formula:{_name}",
+        }
+
+
+SUPPORTED_RUNTIME_INPUT_NAMES = {
+    "conservative_settlement_edge",
+    "full_depth_settlement_edge",
+    "model_conservative_settlement_edge",
+    "model_full_depth_settlement_edge",
+    "settlement_edge",
+    "entry_price",
+    "distance_over_sigma",
+    "direction_sign",
+    "drift_30s",
+    "sigma_horizon",
+    "entry_capacity_ratio",
+    "side_spread",
+    "pm_lag_secs",
+}
+
+# These fields exist in the Rust scoring struct, but the current runtime fills
+# them from non-equivalent or placeholder values. Treat them as blocked until
+# research and runtime share the same source definition.
+BLOCKED_RUNTIME_INPUT_NAMES = {
+    "external_pressure": "runtime_input_not_canonical:external_pressure",
+    "iv_change_1m": "runtime_input_placeholder:iv_change_1m",
+}
+
+
+def normalize_formula_name(name: str) -> str:
+    while True:
+        for prefix in ("llm_", "mut2_", "mut_", "mcts_"):
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        else:
+            return name
+
+
+def settlement_formula_suffix_supported(suffix: str) -> bool:
+    if not suffix:
+        return True
+    tokens = suffix.removeprefix("_").split("_")
+    applied: set[str] = set()
+    for token in tokens:
+        effect = {
+            "strike": "near_strike",
+            "capacity": "capacity",
+            "quality": "entry_price_quality",
+            "adjusted": "spread_adjusted",
+            "pressure": "external_pressure",
+            "change": "iv_change",
+            "gate": "full_depth_entry_gate",
+            "squashed": "squashed",
+        }.get(token)
+        if effect:
+            if effect in applied:
+                return False
+            applied.add(effect)
+            continue
+        if token not in {
+            "x",
+            "near",
+            "full",
+            "depth",
+            "entry",
+            "price",
+            "spread",
+            "external",
+            "iv",
+        }:
+            return False
+    return True
+
+
+def is_settlement_formula(name: str) -> bool:
+    normalized = normalize_formula_name(name)
+    for base in SETTLEMENT_FORMULA_BASES:
+        if normalized.startswith(base):
+            return settlement_formula_suffix_supported(normalized[len(base) :])
+    return False
+
+
+def is_settlement_predictive_formula(name: str) -> bool:
+    normalized = normalize_formula_name(name)
+    if normalized == "spread_adjusted_external_move":
+        return False
+    return any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES)
+
+
+def inferred_runtime_mapping(name: str) -> dict[str, str] | None:
+    if name in LEGACY_BUILTIN_RUNTIME_MAPPINGS:
+        return dict(LEGACY_BUILTIN_RUNTIME_MAPPINGS[name])
+    if is_settlement_formula(name):
+        return {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "runtime_score": f"autofactor_formula:{name}",
+        }
+    if is_settlement_predictive_formula(name):
+        return {
+            **SETTLEMENT_RUNTIME_MAPPING,
+            "strategy_family": "predictive_settlement_probability",
+            "runtime_score": f"autofactor_formula:{name}",
+        }
+    return None
+
+
+def runtime_input_blockers(input_names: list[str]) -> list[str]:
+    blockers: list[str] = []
+    for name in sorted({str(item) for item in input_names if str(item)}):
+        if name in BLOCKED_RUNTIME_INPUT_NAMES:
+            blockers.append(BLOCKED_RUNTIME_INPUT_NAMES[name])
+        elif name not in SUPPORTED_RUNTIME_INPUT_NAMES:
+            blockers.append(f"runtime_input_unsupported:{name}")
+    return blockers
+
+
+@dataclass
+class RuntimeContractResolution:
+    factor_name: str
+    runtime_mapping: dict[str, str] | None = None
+    runtime_contract: dict[str, Any] | None = None
+    blockers: list[str] = field(default_factory=list)
+    source: str = "legacy_inference"
+
+
+class RuntimeContractResolver:
+    def __init__(
+        self,
+        *,
+        registry_preview_json: str | None = None,
+        runtime_mapping_json: str | None = None,
+        require_runtime_contract: bool = False,
+    ) -> None:
+        self.registry_preview_json = registry_preview_json
+        self.require_runtime_contract = require_runtime_contract
+        self.registry_contracts: dict[str, RuntimeContractResolution] = {}
+        self.legacy_mappings = dict(LEGACY_BUILTIN_RUNTIME_MAPPINGS)
+        if runtime_mapping_json:
+            self._load_legacy_runtime_mapping(runtime_mapping_json)
+        if registry_preview_json:
+            self._load_registry_preview(registry_preview_json)
+
+    @property
+    def registry_present(self) -> bool:
+        return bool(self.registry_preview_json)
+
+    def _load_legacy_runtime_mapping(self, path: str) -> None:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        for name, value in payload.items():
+            if isinstance(value, dict):
+                self.legacy_mappings[str(name)] = {str(k): str(v) for k, v in value.items()}
+
+    def _load_registry_preview(self, path: str) -> None:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        factors = payload.get("factors")
+        if not isinstance(factors, list):
+            raise ValueError(f"runtime registry preview has no factors array: {path}")
+        for item in factors:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("factor_name") or item.get("name") or "")
+            if not name:
+                continue
+            contract = item.get("runtime_contract")
+            blockers = [str(v) for v in item.get("blockers") or [] if str(v)]
+            if not isinstance(contract, dict):
+                blockers.append(f"missing_runtime_contract:{name}")
+                self.registry_contracts[name] = RuntimeContractResolution(
+                    factor_name=name,
+                    blockers=sorted(set(blockers)),
+                    source="registry_preview",
+                )
+                continue
+            if contract.get("version") != "autofactor_runtime_contract_v1":
+                blockers.append("unsupported_runtime_contract_version")
+            blockers.extend(str(v) for v in contract.get("blockers") or [] if str(v))
+            input_names = contract.get("input_names")
+            if not isinstance(input_names, list) or not input_names:
+                blockers.append(f"missing_runtime_contract_input_names:{name}")
+                input_names = []
+            blockers.extend(runtime_input_blockers([str(v) for v in input_names]))
+            mapping = {
+                "strategy_profile": str(contract.get("strategy_profile") or ""),
+                "strategy_family": str(contract.get("strategy_family") or ""),
+                "runtime_score": str(contract.get("runtime_score") or ""),
+            }
+            if not mapping["strategy_profile"] or not mapping["runtime_score"]:
+                blockers.append(f"incomplete_runtime_contract_mapping:{name}")
+            self.registry_contracts[name] = RuntimeContractResolution(
+                factor_name=name,
+                runtime_mapping=mapping,
+                runtime_contract=contract,
+                blockers=sorted(set(blockers)),
+                source="registry_preview",
+            )
+
+    def resolve(self, factor_name: str) -> RuntimeContractResolution:
+        if self.registry_present:
+            resolved = self.registry_contracts.get(factor_name)
+            if resolved:
+                return resolved
+            return RuntimeContractResolution(
+                factor_name=factor_name,
+                blockers=[f"missing_runtime_contract:{factor_name}"],
+                source="registry_preview",
+            )
+        if self.require_runtime_contract:
+            return RuntimeContractResolution(
+                factor_name=factor_name,
+                blockers=["missing_runtime_contract_registry"],
+                source="required_contract_missing_registry",
+            )
+        mapping = self.legacy_mappings.get(factor_name) or inferred_runtime_mapping(factor_name)
+        return RuntimeContractResolution(
+            factor_name=factor_name,
+            runtime_mapping=mapping,
+            runtime_contract=None,
+            blockers=[],
+            source="legacy_inference",
+        )

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -19,6 +19,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from autofactor_runtime_contract import RuntimeContractResolver
+
 
 DEFAULT_ALLOWED_TARGETS = {
     "full_depth_settlement_executable_pnl",
@@ -26,25 +28,6 @@ DEFAULT_ALLOWED_TARGETS = {
 }
 
 AGGREGATE_BASIS = "factor_walk_forward_top_bucket_aggregate"
-
-FORMULA_RUNTIME_MAPPED_NAMES = {
-    "amplitude_weighted_momentum_30s_sigma",
-    "mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
-    "mut_spread_adjusted_external_move_full_depth_entry_gate",
-}
-
-PREDICTIVE_FORMULA_BASES = (
-    "amplitude_weighted_momentum_30s_sigma",
-    "poly_lag_pressure",
-    "spread_adjusted_external_move",
-)
-
-SETTLEMENT_FORMULA_BASES = (
-    "auto_settlement_full_depth_settlement_edge",
-    "auto_settlement_conservative_settlement_edge",
-    "auto_settlement_model_full_depth_settlement_edge",
-    "auto_settlement_model_conservative_settlement_edge",
-)
 
 
 def parse_float(raw: str, default: float = float("nan")) -> float:
@@ -74,68 +57,6 @@ def replay_identity(*, runtime_score: str, strategy_profile: str, evidence: str,
         "evidence": evidence,
         "source_factor": source_factor or {},
     }
-
-
-def normalize_formula_name(name: str) -> str:
-    while True:
-        for prefix in ("llm_", "mut2_", "mut_", "mcts_"):
-            if name.startswith(prefix):
-                name = name[len(prefix) :]
-                break
-        else:
-            return name
-
-
-def is_settlement_predictive_formula(name: str) -> bool:
-    normalized = normalize_formula_name(name)
-    if normalized == "spread_adjusted_external_move":
-        return False
-    return any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES)
-
-
-def is_settlement_formula(name: str) -> bool:
-    normalized = normalize_formula_name(name)
-    for base in SETTLEMENT_FORMULA_BASES:
-        if not normalized.startswith(base):
-            continue
-        return settlement_formula_suffix_supported(normalized[len(base) :])
-    return False
-
-
-def settlement_formula_suffix_supported(suffix: str) -> bool:
-    if not suffix:
-        return True
-    tokens = suffix.removeprefix("_").split("_")
-    applied: set[str] = set()
-    for token in tokens:
-        effect = {
-            "strike": "near_strike",
-            "capacity": "capacity",
-            "quality": "entry_price_quality",
-            "adjusted": "spread_adjusted",
-            "pressure": "external_pressure",
-            "change": "iv_change",
-            "gate": "full_depth_entry_gate",
-            "squashed": "squashed",
-        }.get(token)
-        if effect:
-            if effect in applied:
-                return False
-            applied.add(effect)
-            continue
-        if token not in {
-            "x",
-            "near",
-            "full",
-            "depth",
-            "entry",
-            "price",
-            "spread",
-            "external",
-            "iv",
-        }:
-            return False
-    return True
 
 
 def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
@@ -170,31 +91,6 @@ def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
     return rows
 
 
-def runtime_mapping(name: str) -> dict[str, str]:
-    if name in {
-        "spread_adjusted_external_move",
-        "repricing_gap_side_10s",
-    }:
-        return {
-            "strategy_profile": "repricing_momentum",
-            "runtime_score": (
-                "spread_adjusted_external_move_score"
-                if name == "spread_adjusted_external_move"
-                else name
-            ),
-        }
-    if (
-        is_settlement_formula(name)
-        or name in FORMULA_RUNTIME_MAPPED_NAMES
-        or is_settlement_predictive_formula(name)
-    ):
-        return {
-            "strategy_profile": "settlement_probability",
-            "runtime_score": f"autofactor_formula:{name}",
-        }
-    return {"strategy_profile": "", "runtime_score": ""}
-
-
 def row_score(row: dict[str, Any]) -> tuple[float, ...]:
     rank = parse_int(row.get("rank", ""), default=10_000)
     return (
@@ -212,16 +108,25 @@ def select_candidate(
     *,
     allowed_targets: set[str],
     required_strategy_profile: str,
+    runtime_contracts: RuntimeContractResolver,
 ) -> tuple[dict[str, Any] | None, list[str]]:
     candidates: list[dict[str, Any]] = []
     blockers: list[str] = []
     for row in rows:
-        mapping = runtime_mapping(str(row.get("name", "")))
+        name = str(row.get("name", ""))
+        resolution = runtime_contracts.resolve(name)
+        mapping = resolution.runtime_mapping
         row_target = str(row.get("target", ""))
         if row_target not in allowed_targets:
             continue
         if row.get("decision") != "candidate" or row.get("reason") != "passed":
             blockers.append(f"not_candidate:{row.get('name')}:{row.get('decision')}:{row.get('reason')}")
+            continue
+        if resolution.blockers:
+            blockers.extend(resolution.blockers)
+            continue
+        if not mapping:
+            blockers.append(f"missing_runtime_score:{row.get('name')}")
             continue
         if mapping.get("strategy_profile") != required_strategy_profile:
             blockers.append(
@@ -235,6 +140,8 @@ def select_candidate(
             continue
         row = dict(row)
         row["runtime_mapping"] = mapping
+        if resolution.runtime_contract:
+            row["runtime_contract"] = resolution.runtime_contract
         candidates.append(row)
     if not candidates:
         return None, blockers or ["no_runtime_mappable_candidate"]
@@ -328,6 +235,7 @@ def build_artifact(
         "basis": AGGREGATE_BASIS,
         "strategy_profile": row["runtime_mapping"]["strategy_profile"],
         "runtime_score": runtime_score,
+        "runtime_contract": row.get("runtime_contract") or {},
         "promotion_ready": False,
         "promotion_decision": "blocked",
         "evidence": evidence,
@@ -402,6 +310,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-fill-rate", type=float, default=0.30)
     parser.add_argument("--min-roi", type=float, default=0.0)
     parser.add_argument("--evidence", default="")
+    parser.add_argument("--factor-registry-preview-json", default="")
+    parser.add_argument("--require-runtime-contract", action="store_true")
     return parser.parse_args()
 
 
@@ -414,6 +324,10 @@ def main() -> int:
         rows,
         allowed_targets=allowed_targets,
         required_strategy_profile=args.required_strategy_profile,
+        runtime_contracts=RuntimeContractResolver(
+            registry_preview_json=args.factor_registry_preview_json or None,
+            require_runtime_contract=args.require_runtime_contract,
+        ),
     )
     artifact = build_artifact(
         row,

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -34,155 +34,13 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from autofactor_runtime_contract import RuntimeContractResolver
+
 
 DEFAULT_ALLOWED_TARGETS = (
     "full_depth_settlement_executable_pnl",
     "tradeable_full_depth_settlement_pnl",
 )
-
-SETTLEMENT_RUNTIME_MAPPING = {
-    "strategy_profile": "settlement_probability",
-    "strategy_family": "settlement_probability",
-}
-
-BUILTIN_RUNTIME_MAPPINGS: dict[str, dict[str, str]] = {
-    "spread_adjusted_external_move": {
-        "strategy_profile": "repricing_momentum",
-        "strategy_family": "repricing",
-        "runtime_score": "spread_adjusted_external_move_score",
-    },
-    "repricing_gap_side_10s": {
-        "strategy_profile": "repricing_momentum",
-        "strategy_family": "repricing",
-        "runtime_score": "repricing_gap_side_10s",
-    },
-    "amplitude_weighted_momentum_30s_sigma": {
-        "strategy_profile": "settlement_probability",
-        "strategy_family": "predictive_settlement_probability",
-        "runtime_score": "autofactor_formula:amplitude_weighted_momentum_30s_sigma",
-    },
-    "mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate": {
-        "strategy_profile": "settlement_probability",
-        "strategy_family": "predictive_settlement_probability",
-        "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
-    },
-    "mut_spread_adjusted_external_move_full_depth_entry_gate": {
-        "strategy_profile": "settlement_probability",
-        "strategy_family": "predictive_settlement_probability",
-        "runtime_score": "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate",
-    },
-    "settlement_fair_edge": {
-        "strategy_profile": "",
-        "strategy_family": "settlement_probability",
-        "runtime_score": "",
-    },
-    "auto_settlement_full_depth_settlement_edge": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_near_strike": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_capacity": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_capacity",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_entry_price_quality": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_entry_price_quality",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
-    },
-    "auto_settlement_full_depth_settlement_edge_spread_adjusted": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_spread_adjusted",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_external_pressure": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_external_pressure",
-    },
-    "auto_settlement_full_depth_settlement_edge_x_iv_change": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_iv_change",
-    },
-    "auto_settlement_conservative_settlement_edge": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
-    },
-    "auto_settlement_conservative_settlement_edge_x_near_strike": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike",
-    },
-    "auto_settlement_conservative_settlement_edge_x_capacity": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_capacity",
-    },
-    "auto_settlement_conservative_settlement_edge_x_entry_price_quality": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_entry_price_quality",
-    },
-    "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity",
-    },
-    "auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality",
-    },
-    "auto_settlement_conservative_settlement_edge_spread_adjusted": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_spread_adjusted",
-    },
-    "auto_settlement_conservative_settlement_edge_x_external_pressure": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_external_pressure",
-    },
-    "auto_settlement_conservative_settlement_edge_x_iv_change": {
-        **SETTLEMENT_RUNTIME_MAPPING,
-        "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_iv_change",
-    },
-}
-
-PREDICTIVE_FORMULA_BASES = (
-    "amplitude_weighted_momentum_30s_sigma",
-    "poly_lag_pressure",
-    "spread_adjusted_external_move",
-)
-
-SETTLEMENT_FORMULA_BASES = (
-    "auto_settlement_full_depth_settlement_edge",
-    "auto_settlement_conservative_settlement_edge",
-    "auto_settlement_model_full_depth_settlement_edge",
-    "auto_settlement_model_conservative_settlement_edge",
-)
-
-for _base in (
-    "auto_settlement_model_full_depth_settlement_edge",
-    "auto_settlement_model_conservative_settlement_edge",
-):
-    for _suffix in (
-        "",
-        "_x_near_strike",
-        "_x_capacity",
-        "_x_entry_price_quality",
-        "_x_near_strike_x_capacity",
-        "_x_near_strike_x_capacity_x_entry_price_quality",
-        "_spread_adjusted",
-        "_x_external_pressure",
-        "_x_iv_change",
-    ):
-        _name = f"{_base}{_suffix}"
-        BUILTIN_RUNTIME_MAPPINGS[_name] = {
-            **SETTLEMENT_RUNTIME_MAPPING,
-            "runtime_score": f"autofactor_formula:{_name}",
-        }
 
 
 @dataclass
@@ -249,6 +107,7 @@ class EvaluatedFactor:
     qualified: bool
     blockers: list[str]
     runtime_mapping: dict[str, str] | None
+    runtime_contract: dict[str, Any] | None = None
 
 
 def factor_metrics(row: AutoFactorRow) -> dict[str, Any]:
@@ -581,90 +440,6 @@ def parse_autofactor_rows(report_text: str) -> list[AutoFactorRow]:
     return rows
 
 
-def load_runtime_mappings(path: str | None) -> dict[str, dict[str, str]]:
-    mappings = dict(BUILTIN_RUNTIME_MAPPINGS)
-    if not path:
-        return mappings
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
-    for name, value in payload.items():
-        if isinstance(value, dict):
-            mappings[name] = {str(k): str(v) for k, v in value.items()}
-    return mappings
-
-
-def normalize_formula_name(name: str) -> str:
-    while True:
-        for prefix in ("llm_", "mut2_", "mut_", "mcts_"):
-            if name.startswith(prefix):
-                name = name[len(prefix) :]
-                break
-        else:
-            return name
-
-
-def settlement_formula_suffix_supported(suffix: str) -> bool:
-    if not suffix:
-        return True
-    tokens = suffix.removeprefix("_").split("_")
-    applied: set[str] = set()
-    for token in tokens:
-        effect = {
-            "strike": "near_strike",
-            "capacity": "capacity",
-            "quality": "entry_price_quality",
-            "adjusted": "spread_adjusted",
-            "pressure": "external_pressure",
-            "change": "iv_change",
-            "gate": "full_depth_entry_gate",
-            "squashed": "squashed",
-        }.get(token)
-        if effect:
-            if effect in applied:
-                return False
-            applied.add(effect)
-            continue
-        if token not in {
-            "x",
-            "near",
-            "full",
-            "depth",
-            "entry",
-            "price",
-            "spread",
-            "external",
-            "iv",
-        }:
-            return False
-    return True
-
-
-def is_settlement_formula(name: str) -> bool:
-    normalized = normalize_formula_name(name)
-    for base in SETTLEMENT_FORMULA_BASES:
-        if not normalized.startswith(base):
-            continue
-        return settlement_formula_suffix_supported(normalized[len(base) :])
-    return False
-
-
-def inferred_runtime_mapping(name: str) -> dict[str, str] | None:
-    normalized = normalize_formula_name(name)
-    if normalized == "spread_adjusted_external_move":
-        return None
-    if is_settlement_formula(name):
-        return {
-            **SETTLEMENT_RUNTIME_MAPPING,
-            "runtime_score": f"autofactor_formula:{name}",
-        }
-    if any(normalized.startswith(base) for base in PREDICTIVE_FORMULA_BASES):
-        return {
-            **SETTLEMENT_RUNTIME_MAPPING,
-            "strategy_family": "predictive_settlement_probability",
-            "runtime_score": f"autofactor_formula:{name}",
-        }
-    return None
-
-
 MODEL_SPECIFIC_PRD_GATE_PREFIXES = (
     "symbol_holdout:",
     "walk_forward_oos:",
@@ -740,7 +515,7 @@ def evaluate(
     candidate_strategy_replay: CandidateStrategyReplay,
     allowed_targets: tuple[str, ...],
     required_strategy_profile: str,
-    runtime_mappings: dict[str, dict[str, str]],
+    runtime_contracts: RuntimeContractResolver,
     min_factor_n: int,
     min_top_bucket_n: int,
     min_top_bucket_entry_fill_rate: float,
@@ -758,7 +533,9 @@ def evaluate(
 
     for row in rows:
         blockers: list[str] = []
-        mapping = runtime_mappings.get(row.name) or inferred_runtime_mapping(row.name)
+        resolution = runtime_contracts.resolve(row.name)
+        mapping = resolution.runtime_mapping
+        blockers.extend(resolution.blockers)
         formula_specific = is_autofactor_formula(mapping)
         suppress_global_fillability = (
             formula_specific
@@ -843,6 +620,7 @@ def evaluate(
                 qualified=not blockers,
                 blockers=blockers,
                 runtime_mapping=mapping,
+                runtime_contract=resolution.runtime_contract,
             )
         )
 
@@ -870,6 +648,7 @@ def evaluate(
             {
                 "factor": asdict(item.factor),
                 "runtime_mapping": item.runtime_mapping,
+                "runtime_contract": item.runtime_contract,
             }
             for item in qualified
         ],
@@ -879,6 +658,7 @@ def evaluate(
                 "qualified": item.qualified,
                 "blockers": item.blockers,
                 "runtime_mapping": item.runtime_mapping,
+                "runtime_contract": item.runtime_contract,
             }
             for item in evaluated
         ],
@@ -899,6 +679,7 @@ def build_factor_registry(result: dict[str, Any]) -> dict[str, Any]:
                 "autofactor_reason": factor["reason"],
                 "blockers": item["blockers"],
                 "runtime_mapping": mapping,
+                "runtime_contract": item.get("runtime_contract") or {},
                 "metrics": factor_metrics(AutoFactorRow(**factor)),
             }
         )
@@ -920,6 +701,7 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
     for item in result["qualified_strategies"]:
         factor = item["factor"]
         mapping = item["runtime_mapping"] or {}
+        runtime_contract = item.get("runtime_contract") or {}
         strategies.append(
             {
                 "name": factor["name"],
@@ -927,6 +709,7 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
                 "strategy_profile": mapping.get("strategy_profile", ""),
                 "strategy_family": mapping.get("strategy_family", ""),
                 "runtime_score": mapping.get("runtime_score", ""),
+                "runtime_contract": runtime_contract,
                 "promotion_status": "ready_for_dry_run_handoff",
                 "metrics": factor_metrics(AutoFactorRow(**factor)),
             }
@@ -1101,6 +884,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-handoff-json", default="")
     parser.add_argument("--output-handoff-md", default="")
     parser.add_argument("--runtime-mapping-json", default="")
+    parser.add_argument("--factor-registry-preview-json", default="")
+    parser.add_argument("--require-runtime-contract", action="store_true")
     parser.add_argument(
         "--candidate-strategy-replay-json",
         default="",
@@ -1137,7 +922,11 @@ def main() -> int:
         ),
         allowed_targets=allowed_targets,
         required_strategy_profile=args.required_strategy_profile,
-        runtime_mappings=load_runtime_mappings(args.runtime_mapping_json or None),
+        runtime_contracts=RuntimeContractResolver(
+            registry_preview_json=args.factor_registry_preview_json or None,
+            runtime_mapping_json=args.runtime_mapping_json or None,
+            require_runtime_contract=args.require_runtime_contract,
+        ),
         min_factor_n=args.min_factor_n,
         min_top_bucket_n=args.min_top_bucket_n,
         min_top_bucket_entry_fill_rate=args.min_top_bucket_entry_fill_rate,

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -184,6 +184,10 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
         variant_dir / "candidate-strategy-replay.json"
     )
     command.extend(["--candidate-strategy-replay-json", replay_json])
+    registry_preview = factor_registry_preview_path(variant_dir)
+    if registry_preview:
+        command.extend(["--factor-registry-preview-json", str(registry_preview)])
+        command.append("--require-runtime-contract")
     for target in args.allowed_target:
         command.extend(["--allowed-target", target])
     return command
@@ -210,9 +214,21 @@ def candidate_replay_args(
         "--evidence",
         str(report),
     ]
+    registry_preview = factor_registry_preview_path(variant_dir)
+    if registry_preview:
+        command.extend(["--factor-registry-preview-json", str(registry_preview)])
+        command.append("--require-runtime-contract")
     for target in args.allowed_target:
         command.extend(["--allowed-target", target])
     return command
+
+
+def factor_registry_preview_path(variant_dir: Path) -> Path | None:
+    alpha_root = variant_dir / "alpha-search"
+    if not alpha_root.exists():
+        return None
+    previews = sorted(alpha_root.rglob("factor-registry-preview.json"))
+    return previews[0] if previews else None
 
 
 def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> list[dict[str, Any]]:
@@ -249,12 +265,22 @@ def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> 
                 "qualified": bool(item.get("qualified")),
                 "runtime_mapping": mapping,
                 "runtime_mappable": bool(mapping)
-                and not any(str(blocker).startswith("runtime_profile_mismatch:") for blocker in blockers)
+                and not any(is_runtime_contract_blocker(str(blocker)) for blocker in blockers)
                 and "empty_runtime_strategy_profile" not in blockers,
                 "blockers": blockers,
             }
         )
     return rows
+
+
+def is_runtime_contract_blocker(blocker: str) -> bool:
+    return (
+        blocker.startswith("runtime_profile_mismatch:")
+        or blocker.startswith("runtime_contract_")
+        or blocker.startswith("runtime_input_")
+        or blocker.startswith("missing_runtime_")
+        or blocker.startswith("incomplete_runtime_contract_")
+    )
 
 
 def _factor_score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -57,9 +57,11 @@ trace, not dry-run promotion.
       `evidence_stage` cannot contradict each other.
 - [x] Add a default-dry-run Research Manager executor workflow that turns
       trace-plan actions into auditable bounded follow-up research dispatches.
+- [x] Add an AutoFactor runtime input canonicalization gate so promotion and
+      candidate replay prefer typed registry contracts and fail closed on
+      missing, blocked, or semantically mismatched runtime inputs.
 - [ ] Apply remaining high-priority data/research cleanup based on audit
-      results: runtime input canonicalization, feature snapshot hard gates, and
-      multi-horizon accounting gates.
+      results: feature snapshot hard gates and multi-horizon accounting gates.
 
 ## Review
 
@@ -149,6 +151,14 @@ trace, not dry-run promotion.
   `scripts/run_factor_research_matrix.sh` now require
   `PLOY_ALLOW_DIRECT_FACTOR_RESEARCH=manual-direct-factor-research`, so manual
   DB research cannot be confused with the artifact-backed mainline path.
+- 2026-05-23: Added a shared AutoFactor runtime contract loader for Python
+  promotion/replay consumers and wired hosted sweep / standalone promotion to
+  pass `factor-registry-preview.json` when present. Registry-backed paths now
+  require typed runtime contracts and block missing contracts, contract
+  blockers, unsupported inputs, `external_pressure` semantic mismatch, and
+  placeholder `iv_change_1m` instead of falling back to factor-name inference.
+  Rust alpha-search registry previews now emit the same blockers and no longer
+  mark unsupported predictive suffixes as runtime-mappable.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -211,10 +211,18 @@ DEFAULT_REPLAY_PAYLOAD = {
 
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
-    def run_script(self, report, *extra_args, check=True, replay_payload=DEFAULT_REPLAY_PAYLOAD):
+    def run_script(
+        self,
+        report,
+        *extra_args,
+        check=True,
+        replay_payload=DEFAULT_REPLAY_PAYLOAD,
+        registry_preview_payload=None,
+    ):
         with tempfile.TemporaryDirectory() as tmp:
             report_path = Path(tmp) / "report.txt"
             replay_path = Path(tmp) / "candidate-strategy-replay.json"
+            registry_path = Path(tmp) / "factor-registry-preview.json"
             output_json = Path(tmp) / "promotion.json"
             output_registry = Path(tmp) / "registry.json"
             output_handoff = Path(tmp) / "handoff.json"
@@ -227,6 +235,17 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     encoding="utf-8",
                 )
                 replay_args = ["--candidate-strategy-replay-json", str(replay_path)]
+            registry_args = []
+            if registry_preview_payload is not None:
+                registry_path.write_text(
+                    json.dumps(registry_preview_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                registry_args = [
+                    "--factor-registry-preview-json",
+                    str(registry_path),
+                    "--require-runtime-contract",
+                ]
             result = subprocess.run(
                 [
                     sys.executable,
@@ -242,6 +261,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     "--output-handoff-md",
                     str(output_handoff_md),
                     *replay_args,
+                    *registry_args,
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -254,6 +274,70 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             handoff = json.loads(output_handoff.read_text(encoding="utf-8"))
             handoff_md = output_handoff_md.read_text(encoding="utf-8")
             return result, payload, registry, handoff, handoff_md
+
+    def test_registry_contract_blocks_promotion_name_inference_when_missing(self):
+        _, payload, registry, handoff, _ = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [],
+            },
+        )
+
+        first = payload["evaluated_factors"][0]
+        self.assertFalse(first["qualified"])
+        self.assertIn(
+            "missing_runtime_contract:auto_settlement_conservative_settlement_edge",
+            first["blockers"],
+        )
+        self.assertEqual(registry["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+
+    def test_registry_contract_blocker_prevents_promotion(self):
+        report = (READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT).replace(
+            "auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl",
+            "auto_settlement_conservative_settlement_edge_x_iv_change,full_depth_settlement_executable_pnl",
+        )
+        replay = dict(DEFAULT_REPLAY_PAYLOAD)
+        replay["runtime_score"] = (
+            "autofactor_formula:auto_settlement_conservative_settlement_edge_x_iv_change"
+        )
+        replay["identity"] = dict(DEFAULT_REPLAY_PAYLOAD["identity"])
+        replay["identity"]["runtime_score"] = replay["runtime_score"]
+        _, payload, registry, handoff, _ = self.run_script(
+            report,
+            replay_payload=replay,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [
+                    {
+                        "factor_name": "auto_settlement_conservative_settlement_edge_x_iv_change",
+                        "runtime_contract": {
+                            "version": "autofactor_runtime_contract_v1",
+                            "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_iv_change",
+                            "strategy_profile": "settlement_probability",
+                            "strategy_family": "settlement_probability",
+                            "input_names": [
+                                "conservative_settlement_edge",
+                                "iv_change_1m",
+                            ],
+                            "blockers": ["runtime_input_not_supplied:iv_change_1m"],
+                        },
+                        "blockers": [],
+                    }
+                ],
+            },
+        )
+
+        first = payload["evaluated_factors"][0]
+        self.assertFalse(first["qualified"])
+        self.assertIn("runtime_input_not_supplied:iv_change_1m", first["blockers"])
+        self.assertEqual(registry["entries"][0]["runtime_contract"]["input_names"][-1], "iv_change_1m")
+        self.assertEqual(handoff["status"], "blocked")
 
     def test_blocks_candidate_when_runtime_profile_is_not_required_profile(self):
         _, payload, registry, handoff, handoff_md = self.run_script(

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -17,13 +17,30 @@ SCRIPT = ROOT / "scripts" / "build_autofactor_candidate_strategy_replay.py"
 
 
 class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
-    def run_script(self, report: str, *extra_args: str) -> tuple[dict, str]:
+    def run_script(
+        self,
+        report: str,
+        *extra_args: str,
+        registry_preview_payload: dict | None = None,
+    ) -> tuple[dict, str]:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             report_path = tmp_path / "report.txt"
             output_json = tmp_path / "candidate-strategy-replay.json"
             output_md = tmp_path / "candidate-strategy-replay.md"
             report_path.write_text(report, encoding="utf-8")
+            registry_args = []
+            if registry_preview_payload is not None:
+                registry_path = tmp_path / "factor-registry-preview.json"
+                registry_path.write_text(
+                    json.dumps(registry_preview_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                registry_args = [
+                    "--factor-registry-preview-json",
+                    str(registry_path),
+                    "--require-runtime-contract",
+                ]
             subprocess.run(
                 [
                     sys.executable,
@@ -34,6 +51,7 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                     str(output_json),
                     "--output-md",
                     str(output_md),
+                    *registry_args,
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -45,6 +63,90 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                 json.loads(output_json.read_text(encoding="utf-8")),
                 output_md.read_text(encoding="utf-8"),
             )
+
+    def test_registry_contract_blocks_name_inference_when_missing(self):
+        payload, _ = self.run_script(
+            AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [],
+            },
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["runtime_score"], "")
+        self.assertIn(
+            "missing_runtime_contract:auto_settlement_conservative_settlement_edge",
+            payload["blocking_risk_flags"],
+        )
+
+    def test_registry_contract_blocks_unsupported_contract_version(self):
+        payload, _ = self.run_script(
+            AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [
+                    {
+                        "factor_name": "auto_settlement_conservative_settlement_edge",
+                        "runtime_contract": {
+                            "version": "legacy_runtime_contract",
+                            "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                            "strategy_profile": "settlement_probability",
+                            "strategy_family": "settlement_probability",
+                            "input_names": ["conservative_settlement_edge"],
+                            "blockers": [],
+                        },
+                        "blockers": [],
+                    }
+                ],
+            },
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["runtime_score"], "")
+        self.assertIn("unsupported_runtime_contract_version", payload["blocking_risk_flags"])
+
+    def test_registry_contract_blocks_noncanonical_runtime_input(self):
+        report = AUTOFACTOR_SETTLEMENT_AUTO_REPORT.replace(
+            "auto_settlement_conservative_settlement_edge,full_depth_settlement_executable_pnl",
+            "auto_settlement_conservative_settlement_edge_x_iv_change,full_depth_settlement_executable_pnl",
+        )
+        payload, _ = self.run_script(
+            report,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [
+                    {
+                        "factor_name": "auto_settlement_conservative_settlement_edge_x_iv_change",
+                        "runtime_contract": {
+                            "version": "autofactor_runtime_contract_v1",
+                            "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge_x_iv_change",
+                            "strategy_profile": "settlement_probability",
+                            "strategy_family": "settlement_probability",
+                            "input_names": [
+                                "conservative_settlement_edge",
+                                "iv_change_1m",
+                            ],
+                            "blockers": ["runtime_input_not_supplied:iv_change_1m"],
+                        },
+                        "blockers": [],
+                    }
+                ],
+            },
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(payload["runtime_score"], "")
+        self.assertIn(
+            "runtime_input_not_supplied:iv_change_1m",
+            payload["blocking_risk_flags"],
+        )
 
     def test_builds_blocked_aggregate_for_runtime_mappable_settlement_candidate(self):
         payload, markdown = self.run_script(AUTOFACTOR_SETTLEMENT_AUTO_REPORT)


### PR DESCRIPTION
## Summary
- add a shared AutoFactor runtime contract resolver for Python promotion and aggregate replay builders
- require typed factor-registry preview contracts when present, blocking missing contracts, unsupported inputs, external_pressure semantic mismatch, and placeholder iv_change_1m
- align alpha-search registry preview blockers with the same runtime input contract and stop treating unsupported predictive suffixes as runtime-mappable
- update runbooks/review/task tracker for the remaining feature-snapshot and multi-horizon gates

## Evidence stage
`factor_attribution` / `walk_forward` contract hardening. This does not create dry-run or live promotion evidence.

## Validation
- `python3 -m py_compile scripts/autofactor_runtime_contract.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_autofactor_strategy_promotion.py`
- `python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_persist_research_trace_contract tests.test_alpha_search_closed_loop_agent`
- `ruby -e 'require "yaml"; %w[.github/workflows/autofactor-strategy-promotion.yml .github/workflows/factor-walk-forward-v2-hosted-artifact.yml .github/workflows/research-manager-execute-plan.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n- `rtk cargo test --locked -p ploy-research alpha_search --lib`\n- `rtk cargo test --locked --test workflow_security`\n- `rtk cargo test --locked -p ploy-strategy-bundles autofactor --lib`\n- `rtk git diff --check`