### PR TITLE
Gate sampled snapshot execution claims

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -134,6 +134,9 @@ jobs:
           if [ -n "${SOURCE_FACTOR_REGISTRY_PREVIEW_PATH:-}" ]; then
             args+=(--factor-registry-preview-json "${SOURCE_FACTOR_REGISTRY_PREVIEW_PATH}" --require-runtime-contract)
           fi
+          if [ -n "${SOURCE_SNAPSHOT_MANIFEST_PATH:-}" ]; then
+            args+=(--snapshot-manifest-json "${SOURCE_SNAPSHOT_MANIFEST_PATH}")
+          fi
           if [ "${{ github.event.inputs.fail_if_blocked }}" = "true" ]; then
             args+=(--fail-if-blocked)
           fi

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -423,6 +423,7 @@ jobs:
             --binary ./target/fast/examples/factor_walk_forward_v2
             --evaluator scripts/evaluate_autofactor_strategy_promotion.py
             --snapshot-dir artifacts/research-snapshot
+            --snapshot-manifest-json artifacts/research-snapshot/manifest.json
             --output-dir artifacts/factor-walk-forward-v2
             --symbols "${{ github.event.inputs.symbols }}"
             --start-ts "${WALK_START_TS}"

--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -95,10 +95,12 @@ reserved for `executable_replay` evidence.
    tapes.**
 
    Snapshot manifests carry source surfaces, cadence, `raw_full_fidelity`,
-   `snapshot_sampled`, and `gate_category`, but the hard boundary still needs
-   to be enforced at every promotion/handoff consumer. Full-depth execution
-   claims must cite candidate replay or full-depth lake evidence, not only
-   sampled snapshot rows.
+   `snapshot_sampled`, and `gate_category`. AutoFactor promotion and aggregate
+   candidate replay now consume that manifest and attach blocking flags when a
+   `required_for_execution` surface is sampled, so sampled rows cannot suppress
+   full-depth fillability blockers. The remaining data-layer gap is the
+   positive replacement: durable full-depth lake/runtime replay evidence must
+   become the normal executable handoff source.
 
 5. **Runtime input canonicalization is now gated for AutoFactor promotion/replay,
    but not yet a shared cross-language source of truth.**
@@ -134,7 +136,7 @@ reserved for `executable_replay` evidence.
 | P0 | Run `research-trace-plan.yml` against the fresh trace | Plan JSON references latest trace rows and returns `continue_search`, `revise_prior`, `fix_data`, `fix_runtime`, or `fix_workflow` |
 | P1 | Add Research Manager action executor | Plan output can open/link issues and dispatch bounded hosted research reruns without manual artifact reading |
 | P1 | Promote runtime input canonicalization to a shared generated contract | Rust runtime scoring, Rust alpha-search, and Python promotion/replay use one source of truth instead of mirrored catalogs |
-| P1 | Harden feature snapshot contract at consumers | Sampled snapshots cannot be consumed as full-depth execution evidence |
+| P1 | Complete full-depth executable evidence layer | Runtime replay or full-depth lake evidence replaces sampled snapshot rows for executable handoff |
 | P1 | Enforce multi-horizon accounting at persisted approval layer | Multi-decision or horizon-mixed artifacts are blocked before handoff |
 
 ## Verdict

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -137,6 +137,14 @@ unsupported inputs, semantic input mismatches, or placeholder runtime fields
 block promotion/replay handoff instead of falling back to factor-name
 inference.
 
+AutoFactor promotion and candidate replay must also consume the source
+snapshot manifest. If a `required_for_execution` surface is marked
+`snapshot_sampled=true`, the run can remain factor-search evidence but cannot
+suppress global full-depth fillability blockers or claim full-depth executable
+handoff from sampled rows. The blocking flag must stay attached to promotion,
+handoff, and candidate replay artifacts until replaced by runtime replay or
+full-depth lake evidence.
+
 Hosted walk-forward runs the writer by default and requires a protected
 database secret unless the dispatch explicitly sets
 `options_json.persist_research_trace=false` for a read-only diagnostic run. It

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from autofactor_runtime_contract import RuntimeContractResolver
+from research_snapshot_contract import load_snapshot_execution_contract
 
 
 DEFAULT_ALLOWED_TARGETS = {
@@ -158,7 +159,9 @@ def build_artifact(
     min_trade_count: int,
     min_fill_rate: float,
     min_roi: float,
+    snapshot_contract: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    snapshot_contract = snapshot_contract or {}
     if row is None:
         identity = replay_identity(
             runtime_score="",
@@ -185,6 +188,7 @@ def build_artifact(
                 "full_depth_entry": True,
                 "stake_usd": stake_usd,
             },
+            "source_snapshot_contract": snapshot_contract,
             "metrics": {},
             "blocking_risk_flags": blockers,
         }
@@ -213,6 +217,7 @@ def build_artifact(
 
     artifact_blockers = list(blockers)
     artifact_blockers.append("requires_runtime_replay_not_top_bucket_aggregate")
+    artifact_blockers.extend(snapshot_contract.get("blocking_risk_flags", []))
     if top_bucket_n < min_trade_count:
         artifact_blockers.append(f"trade_count_too_small:{top_bucket_n}<{min_trade_count}")
     if unique_events < min(top_bucket_n, min_trade_count):
@@ -240,6 +245,7 @@ def build_artifact(
         "promotion_decision": "blocked",
         "evidence": evidence,
         "source_factor": source_factor,
+        "source_snapshot_contract": snapshot_contract,
         "decision_contract": {
             "event_level": True,
             "one_decision_per_event": True,
@@ -312,6 +318,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--evidence", default="")
     parser.add_argument("--factor-registry-preview-json", default="")
     parser.add_argument("--require-runtime-contract", action="store_true")
+    parser.add_argument("--snapshot-manifest-json", default="")
     return parser.parse_args()
 
 
@@ -338,6 +345,7 @@ def main() -> int:
         min_trade_count=args.min_trade_count,
         min_fill_rate=args.min_fill_rate,
         min_roi=args.min_roi,
+        snapshot_contract=load_snapshot_execution_contract(args.snapshot_manifest_json or None),
     )
     output_json = Path(args.output_json)
     output_json.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -35,6 +35,10 @@ from pathlib import Path
 from typing import Any
 
 from autofactor_runtime_contract import RuntimeContractResolver
+from research_snapshot_contract import (
+    load_snapshot_execution_contract,
+    snapshot_blocks_execution_claim,
+)
 
 
 DEFAULT_ALLOWED_TARGETS = (
@@ -525,10 +529,13 @@ def evaluate(
     min_replay_trade_count: int,
     min_replay_fill_rate: float,
     min_replay_roi: float,
+    snapshot_contract: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     gate = parse_promotion_gate(report_text)
     quality = parse_execution_quality(report_text)
     rows = parse_autofactor_rows(report_text)
+    snapshot_contract = snapshot_contract or {}
+    sampled_snapshot_blocks_execution = snapshot_blocks_execution_claim(snapshot_contract)
     evaluated: list[EvaluatedFactor] = []
 
     for row in rows:
@@ -539,11 +546,17 @@ def evaluate(
         formula_specific = is_autofactor_formula(mapping)
         suppress_global_fillability = (
             formula_specific
+            and not sampled_snapshot_blocks_execution
             and row.top_bucket_full_depth_entry_fill_rate == row.top_bucket_full_depth_entry_fill_rate
             and row.top_bucket_full_depth_entry_fill_rate >= min_top_bucket_entry_fill_rate
             and row.top_bucket_avg_entry_sweep_slip_bps is not None
             and row.top_bucket_avg_entry_sweep_levels is not None
         )
+        if not gate.ready and formula_specific and sampled_snapshot_blocks_execution:
+            blockers.extend(
+                f"snapshot_contract_blocks_execution_claim:{item}"
+                for item in snapshot_contract.get("blocking_risk_flags", [])
+            )
         blockers.extend(
             global_gate_blockers(
                 gate,
@@ -643,6 +656,7 @@ def evaluate(
         },
         "promotion_gate": asdict(gate),
         "execution_quality": asdict(quality),
+        "source_snapshot_contract": snapshot_contract,
         "candidate_strategy_replay": asdict(candidate_strategy_replay),
         "qualified_strategies": [
             {
@@ -724,6 +738,7 @@ def build_strategy_handoff(result: dict[str, Any]) -> dict[str, Any]:
         "allowed_targets": result["allowed_targets"],
         "promotion_gate": result["promotion_gate"],
         "execution_quality": result["execution_quality"],
+        "source_snapshot_contract": result["source_snapshot_contract"],
         "candidate_strategy_replay": result["candidate_strategy_replay"],
         "strategies": strategies,
         "blocked_factor_count": sum(
@@ -886,6 +901,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--runtime-mapping-json", default="")
     parser.add_argument("--factor-registry-preview-json", default="")
     parser.add_argument("--require-runtime-contract", action="store_true")
+    parser.add_argument("--snapshot-manifest-json", default="")
     parser.add_argument(
         "--candidate-strategy-replay-json",
         default="",
@@ -936,6 +952,7 @@ def main() -> int:
         min_replay_trade_count=args.min_replay_trade_count,
         min_replay_fill_rate=args.min_replay_fill_rate,
         min_replay_roi=args.min_replay_roi,
+        snapshot_contract=load_snapshot_execution_contract(args.snapshot_manifest_json or None),
     )
 
     if args.output_json:

--- a/scripts/research_snapshot_contract.py
+++ b/scripts/research_snapshot_contract.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Research snapshot contract helpers for promotion consumers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_snapshot_execution_contract(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    manifest_path = Path(path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    surfaces = payload.get("source_surfaces") or []
+    sampled_required_execution_surfaces: list[str] = []
+    raw_full_fidelity_required_execution_surfaces: list[str] = []
+    for surface in surfaces:
+        if not isinstance(surface, dict):
+            continue
+        if surface.get("gate_category") != "required_for_execution":
+            continue
+        name = str(surface.get("name") or "<unknown>")
+        if surface.get("raw_full_fidelity") is True:
+            raw_full_fidelity_required_execution_surfaces.append(name)
+        if surface.get("snapshot_sampled") is True:
+            sampled_required_execution_surfaces.append(name)
+    blocking_flags = [
+        f"sampled_snapshot_required_for_execution_surface:{name}"
+        for name in sorted(sampled_required_execution_surfaces)
+    ]
+    return {
+        "manifest_path": str(manifest_path),
+        "schema_version": payload.get("schema_version", ""),
+        "snapshot_hash": payload.get("snapshot_hash", ""),
+        "source_kind": payload.get("source_kind", ""),
+        "sampled_required_execution_surfaces": sorted(sampled_required_execution_surfaces),
+        "raw_full_fidelity_required_execution_surfaces": sorted(
+            raw_full_fidelity_required_execution_surfaces
+        ),
+        "blocking_risk_flags": blocking_flags,
+    }
+
+
+def snapshot_blocks_execution_claim(snapshot_contract: dict[str, Any]) -> bool:
+    return bool(snapshot_contract.get("blocking_risk_flags"))

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -184,6 +184,8 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
         variant_dir / "candidate-strategy-replay.json"
     )
     command.extend(["--candidate-strategy-replay-json", replay_json])
+    if args.snapshot_manifest_json:
+        command.extend(["--snapshot-manifest-json", args.snapshot_manifest_json])
     registry_preview = factor_registry_preview_path(variant_dir)
     if registry_preview:
         command.extend(["--factor-registry-preview-json", str(registry_preview)])
@@ -218,6 +220,8 @@ def candidate_replay_args(
     if registry_preview:
         command.extend(["--factor-registry-preview-json", str(registry_preview)])
         command.append("--require-runtime-contract")
+    if args.snapshot_manifest_json:
+        command.extend(["--snapshot-manifest-json", args.snapshot_manifest_json])
     for target in args.allowed_target:
         command.extend(["--allowed-target", target])
     return command
@@ -530,6 +534,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--stake-usd", required=True)
     parser.add_argument("--replay-parity-json", default="")
     parser.add_argument("--candidate-strategy-replay-json", default="")
+    parser.add_argument("--snapshot-manifest-json", default="")
     parser.add_argument("--alpha-search-output-dir", default="")
     parser.add_argument("--alpha-search-plan-json", default="")
     parser.add_argument("--alpha-search-state-json", default="")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -60,8 +60,10 @@ trace, not dry-run promotion.
 - [x] Add an AutoFactor runtime input canonicalization gate so promotion and
       candidate replay prefer typed registry contracts and fail closed on
       missing, blocked, or semantically mismatched runtime inputs.
+- [x] Apply feature snapshot hard gates so sampled required-for-execution
+      surfaces cannot suppress full-depth executable blockers.
 - [ ] Apply remaining high-priority data/research cleanup based on audit
-      results: feature snapshot hard gates and multi-horizon accounting gates.
+      results: multi-horizon accounting gates and side-effect replay validators.
 
 ## Review
 
@@ -159,6 +161,11 @@ trace, not dry-run promotion.
   placeholder `iv_change_1m` instead of falling back to factor-name inference.
   Rust alpha-search registry previews now emit the same blockers and no longer
   mark unsupported predictive suffixes as runtime-mappable.
+- 2026-05-23: Added a snapshot execution-contract gate for AutoFactor
+  promotion and aggregate candidate replay. Hosted sweep and standalone
+  promotion now pass `manifest.json`; sampled `required_for_execution` surfaces
+  add blocking risk flags and prevent top-bucket sampled fillability from
+  suppressing global full-depth fillability blockers.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -209,6 +209,20 @@ DEFAULT_REPLAY_PAYLOAD = {
     "blocking_risk_flags": [],
 }
 
+SAMPLED_EXECUTION_SNAPSHOT_MANIFEST = {
+    "schema_version": "research_snapshot_manifest_v1",
+    "snapshot_hash": "snapshot:sampled-execution",
+    "source_kind": "complete_sampled_research_snapshot",
+    "source_surfaces": [
+        {
+            "name": "clob_orderbook_snapshots",
+            "gate_category": "required_for_execution",
+            "raw_full_fidelity": True,
+            "snapshot_sampled": True,
+        }
+    ],
+}
+
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
     def run_script(
@@ -218,11 +232,13 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         check=True,
         replay_payload=DEFAULT_REPLAY_PAYLOAD,
         registry_preview_payload=None,
+        snapshot_manifest_payload=None,
     ):
         with tempfile.TemporaryDirectory() as tmp:
             report_path = Path(tmp) / "report.txt"
             replay_path = Path(tmp) / "candidate-strategy-replay.json"
             registry_path = Path(tmp) / "factor-registry-preview.json"
+            snapshot_manifest_path = Path(tmp) / "manifest.json"
             output_json = Path(tmp) / "promotion.json"
             output_registry = Path(tmp) / "registry.json"
             output_handoff = Path(tmp) / "handoff.json"
@@ -246,6 +262,13 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     str(registry_path),
                     "--require-runtime-contract",
                 ]
+            snapshot_args = []
+            if snapshot_manifest_payload is not None:
+                snapshot_manifest_path.write_text(
+                    json.dumps(snapshot_manifest_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                snapshot_args = ["--snapshot-manifest-json", str(snapshot_manifest_path)]
             result = subprocess.run(
                 [
                     sys.executable,
@@ -262,6 +285,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     str(output_handoff_md),
                     *replay_args,
                     *registry_args,
+                    *snapshot_args,
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -472,6 +496,37 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(handoff["status"], "ready")
         blockers = payload["qualified_strategies"][0].get("blockers", [])
         self.assertNotIn("global_full_depth_entry_fillability", ",".join(blockers))
+
+    def test_sampled_execution_snapshot_blocks_top_bucket_fillability_override(self):
+        _, payload, _, handoff, _ = self.run_script(
+            LOW_SLIPPAGE_HEALTH
+            + GLOBAL_FILLABILITY_BLOCKED_GATE
+            + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT,
+            snapshot_manifest_payload=SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        self.assertEqual(
+            payload["source_snapshot_contract"]["blocking_risk_flags"],
+            ["sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots"],
+        )
+        self.assertEqual(
+            handoff["source_snapshot_contract"]["blocking_risk_flags"],
+            ["sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots"],
+        )
+        blockers = payload["evaluated_factors"][0]["blockers"]
+        self.assertIn(
+            "snapshot_contract_blocks_execution_claim:"
+            "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots",
+            blockers,
+        )
+        self.assertIn(
+            "global_promotion_gate_not_ready:"
+            "global_full_depth_entry_fillability: "
+            "global_full_depth_entry_fill_rate=0.1311 min_required=0.3000",
+            blockers,
+        )
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -9,6 +9,7 @@ from tests.test_autofactor_strategy_promotion import (
     AUTOFACTOR_REPORT,
     AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT,
     AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+    SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
 )
 
 
@@ -22,6 +23,7 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
         report: str,
         *extra_args: str,
         registry_preview_payload: dict | None = None,
+        snapshot_manifest_payload: dict | None = None,
     ) -> tuple[dict, str]:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -41,6 +43,14 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                     str(registry_path),
                     "--require-runtime-contract",
                 ]
+            snapshot_args = []
+            if snapshot_manifest_payload is not None:
+                snapshot_manifest_path = tmp_path / "manifest.json"
+                snapshot_manifest_path.write_text(
+                    json.dumps(snapshot_manifest_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                snapshot_args = ["--snapshot-manifest-json", str(snapshot_manifest_path)]
             subprocess.run(
                 [
                     sys.executable,
@@ -52,6 +62,7 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                     "--output-md",
                     str(output_md),
                     *registry_args,
+                    *snapshot_args,
                     *extra_args,
                 ],
                 cwd=ROOT,
@@ -175,6 +186,22 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
             payload["blocking_risk_flags"],
         )
         self.assertIn("Promotion ready: `false`", markdown)
+
+    def test_sampled_execution_snapshot_adds_blocking_risk_flag(self):
+        payload, _ = self.run_script(
+            AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            snapshot_manifest_payload=SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertEqual(
+            payload["source_snapshot_contract"]["blocking_risk_flags"],
+            ["sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots"],
+        )
+        self.assertIn(
+            "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots",
+            payload["blocking_risk_flags"],
+        )
 
     def test_blocks_when_only_candidate_is_wrong_profile(self):
         payload, markdown = self.run_script(

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -459,6 +459,62 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--factor-name-filter \"${WALK_FACTOR_NAME_FILTER}\"", workflow)
         self.assertIn("--train-window-hours \"${WALK_TRAIN_WINDOW_HOURS}\"", workflow)
         self.assertIn("--candidate-strategy-replay-json", workflow)
+        self.assertIn("--snapshot-manifest-json artifacts/research-snapshot/manifest.json", workflow)
+
+    def test_snapshot_manifest_passes_to_candidate_replay_and_promotion(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            snapshot_dir = tmp / "snapshot"
+            snapshot_dir.mkdir()
+            manifest = snapshot_dir / "manifest.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "research_snapshot_manifest_v1",
+                        "snapshot_hash": "snapshot:sampled-execution",
+                        "source_kind": "complete_sampled_research_snapshot",
+                        "source_surfaces": [
+                            {
+                                "name": "clob_orderbook_snapshots",
+                                "gate_category": "required_for_execution",
+                                "raw_full_fidelity": True,
+                                "snapshot_sampled": True,
+                            }
+                        ],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            binary = self.fake_binary(tmp)
+            subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--snapshot-manifest-json",
+                    str(manifest),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            replay = json.loads(
+                (tmp / "out" / "candidate-strategy-replay.json").read_text(encoding="utf-8")
+            )
+            promotion = json.loads(
+                (tmp / "out" / "autofactor-strategy-promotion.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        expected_flags = [
+            "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots"
+        ]
+        self.assertEqual(replay["source_snapshot_contract"]["blocking_risk_flags"], expected_flags)
+        self.assertEqual(
+            promotion["source_snapshot_contract"]["blocking_risk_flags"], expected_flags
+        )
 
     def test_alpha_search_prior_and_state_args_pass_through_to_factor_binary(self):
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -159,6 +159,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "--handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json",
             "--candidate-replay-json",
             "candidate-strategy-replay/candidate-strategy-replay.json",
+            "--snapshot-manifest-json artifacts/research-snapshot/manifest.json",
             "factor walk-forward report is required for durable trace persistence.",
         ]
         for snippet in required_snippets:
@@ -169,9 +170,11 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         workflow = AUTOFACTOR_PROMOTION.read_text(encoding="utf-8")
         required_snippets = [
             "SOURCE_TRACE_MARKER_PATH",
+            "SOURCE_SNAPSHOT_MANIFEST_PATH",
             "*/research-trace/persisted.env",
             "*/snapshot-provenance/source.txt",
             "*/snapshot-provenance/manifest.json",
+            "--snapshot-manifest-json",
             "AutoFactor promotion side effects require successful durable Research OS trace persistence.",
             "AutoFactor promotion side effects reject legacy/debug/self-hosted source artifacts.",
             "direct_db_debug=true|canonical_result=no|registry=runner-local|runner=self-hosted|runner=ploy-ci-1",


### PR DESCRIPTION
## Summary
- add a shared research snapshot execution-contract loader for AutoFactor promotion consumers
- pass snapshot manifest provenance through hosted walk-forward sweep and standalone AutoFactor promotion
- block sampled required-for-execution surfaces from suppressing full-depth fillability gates, while keeping aggregate candidate replay diagnostic-only
- update research runbook/review/task tracker with the sampled snapshot boundary

## Verification
- python3 -m py_compile scripts/research_snapshot_contract.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py
- python3 -m unittest tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_persist_research_trace_contract
- YAML parse: autofactor-strategy-promotion.yml, factor-walk-forward-v2-hosted-artifact.yml, research-manager-execute-plan.yml
- rtk cargo test --locked --test workflow_security
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strategy promotion and candidate replay workflows now support snapshot manifest input
  * Blocking flags from sampled execution surfaces are tracked to prevent incomplete data from suppressing full-depth fillability blockers

* **Documentation**
  * Updated runbooks and architecture documentation to clarify snapshot manifest consumption and blocking flag propagation requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->