### PR TITLE
Require runtime replay for AutoFactor handoff side effects

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -238,6 +238,8 @@ jobs:
             echo "Handoff status is ${status}; no dry-run issue will be created."
             exit 0
           fi
+          python3 scripts/validate_autofactor_handoff_replay_gate.py \
+            --handoff-json "${handoff_json}"
           title="Promote AutoFactor strategy handoff to dry-run"
           gh issue create \
             --title "${title}" \
@@ -282,6 +284,8 @@ jobs:
             echo "Handoff status is ${status}; no config PR will be created."
             exit 0
           fi
+          python3 scripts/validate_autofactor_handoff_replay_gate.py \
+            --handoff-json "${handoff_json}"
           mkdir -p artifacts/autofactor-config-handoff
           python3 scripts/apply_autofactor_handoff_to_config.py \
             --handoff-json "${handoff_json}" \

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -694,6 +694,8 @@ jobs:
             echo "Handoff status is ${status}; no config PR will be created."
             exit 0
           fi
+          python3 scripts/validate_autofactor_handoff_replay_gate.py \
+            --handoff-json "${handoff_json}"
           mkdir -p artifacts/factor-walk-forward-v2/autofactor-config-handoff
           python3 scripts/apply_autofactor_handoff_to_config.py \
             --handoff-json "${handoff_json}" \
@@ -1167,6 +1169,8 @@ jobs:
             echo "Handoff status is ${status}; no dry-run issue will be created."
             exit 0
           fi
+          python3 scripts/validate_autofactor_handoff_replay_gate.py \
+            --handoff-json "${handoff_json}"
           gh issue create \
             --title "Promote AutoFactor strategy handoff to dry-run" \
             --body-file "${handoff_md}"

--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -52,8 +52,9 @@ reserved for `executable_replay` evidence.
 4. **AutoFactor side effects require durable trace provenance.**
 
    Promotion side effects now require the persisted trace marker plus snapshot
-   provenance and reject direct-DB/debug/self-hosted source markers before
-   handoff issue or config PR creation.
+   provenance, reject direct-DB/debug/self-hosted source markers, and validate
+   that the ready handoff embeds a runtime candidate replay tape before handoff
+   issue or config PR creation.
 
 5. **Legacy factor direct-DB branches are removed.**
 

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -160,6 +160,13 @@ PR must first write the durable trace marker for the same run. Artifact-only
 runs may still produce reports, summaries, and issue comments, but they cannot
 advance the closed loop.
 
+AutoFactor handoff side effects must also pass
+`scripts/validate_autofactor_handoff_replay_gate.py`. A handoff is not allowed
+to open a dry-run issue, create a config PR, or satisfy the settlement PRD gate
+unless its embedded candidate replay is a ready
+`runtime_market_update_replay` from `runtime-candidate-replay.yml` and every
+selected strategy runtime score matches that replay tape.
+
 Use `research_trace_plan` after durable rows exist to generate the next
 Research Manager plan from DB trace:
 

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -33,6 +33,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    from validate_autofactor_handoff_replay_gate import validate_handoff_payload
+except ModuleNotFoundError:  # unittest imports this file as scripts.<module>.
+    from scripts.validate_autofactor_handoff_replay_gate import validate_handoff_payload
+
 
 RESEARCH_SNAPSHOT_WORKFLOW = "research-snapshot.yml"
 HOSTED_WALK_FORWARD_WORKFLOW = "factor-walk-forward-v2-hosted-artifact.yml"
@@ -269,7 +274,25 @@ def download_and_evaluate_promotion_gate(walk_run_id: int) -> PromotionGateEvalu
                 evidence=f"missing report artifact file: {report_path}",
                 blocked_gates=("missing_report_artifact",),
             )
-        return parse_promotion_gate(report_path.read_text(encoding="utf-8"))
+        gate = parse_promotion_gate(report_path.read_text(encoding="utf-8"))
+        if not gate.ready:
+            return gate
+        handoff_path = output_dir / "factor-walk-forward-v2" / "autofactor-strategy-handoff.json"
+        if not handoff_path.is_file():
+            return PromotionGateEvaluation(
+                ready=False,
+                evidence=gate.evidence,
+                blocked_gates=("missing_autofactor_strategy_handoff",),
+            )
+        handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
+        replay_blockers = validate_handoff_payload(handoff)
+        if replay_blockers:
+            return PromotionGateEvaluation(
+                ready=False,
+                evidence=gate.evidence,
+                blocked_gates=tuple(f"handoff_replay_gate:{item}" for item in replay_blockers),
+            )
+        return gate
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/validate_autofactor_handoff_replay_gate.py
+++ b/scripts/validate_autofactor_handoff_replay_gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate that an AutoFactor handoff is backed by runtime replay evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_REPLAY_BASIS = "runtime_market_update_replay"
+REQUIRED_REPLAY_WORKFLOW = "runtime-candidate-replay.yml"
+REQUIRED_ARTIFACT_PREFIX = "runtime-candidate-replay-"
+REQUIRED_CONTRACT_FLAGS = (
+    "event_level",
+    "one_decision_per_event",
+    "official_settlement",
+    "full_depth_entry",
+)
+
+
+def _is_ready_replay(replay: dict[str, Any]) -> bool:
+    return replay.get("ready") is True or replay.get("promotion_ready") is True
+
+
+def validate_handoff_payload(handoff: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if handoff.get("status") != "ready":
+        blockers.append(f"handoff_not_ready:{handoff.get('status') or '<missing>'}")
+
+    strategies = handoff.get("strategies")
+    if not isinstance(strategies, list) or not strategies:
+        blockers.append("handoff_missing_ready_strategies")
+        strategies = []
+
+    replay = handoff.get("candidate_strategy_replay")
+    if not isinstance(replay, dict):
+        blockers.append("handoff_missing_candidate_strategy_replay")
+        replay = {}
+
+    if not _is_ready_replay(replay):
+        blockers.append("candidate_strategy_replay_not_ready")
+    if replay.get("basis") != REQUIRED_REPLAY_BASIS:
+        blockers.append(
+            "candidate_strategy_replay_not_runtime_replay:"
+            f"{replay.get('basis') or '<missing>'}!={REQUIRED_REPLAY_BASIS}"
+        )
+    if replay.get("source_workflow") != REQUIRED_REPLAY_WORKFLOW:
+        blockers.append(
+            "candidate_strategy_replay_source_workflow_mismatch:"
+            f"{replay.get('source_workflow') or '<missing>'}!={REQUIRED_REPLAY_WORKFLOW}"
+        )
+    artifact_name = str(replay.get("artifact_name") or "")
+    if not artifact_name.startswith(REQUIRED_ARTIFACT_PREFIX):
+        blockers.append(
+            "candidate_strategy_replay_artifact_mismatch:"
+            f"{artifact_name or '<missing>'}!={REQUIRED_ARTIFACT_PREFIX}*"
+        )
+    for field in ("workflow_run_id", "workflow_run_url", "candidate_replay_id"):
+        if not replay.get(field):
+            blockers.append(f"candidate_strategy_replay_missing_{field}")
+
+    contract = replay.get("decision_contract")
+    if not isinstance(contract, dict):
+        contract = {}
+    for flag in REQUIRED_CONTRACT_FLAGS:
+        if contract.get(flag) is not True:
+            blockers.append(f"candidate_strategy_replay_missing_contract:{flag}")
+
+    replay_runtime_score = str(replay.get("runtime_score") or "")
+    if not replay_runtime_score:
+        blockers.append("candidate_strategy_replay_missing_runtime_score")
+    for index, strategy in enumerate(strategies, start=1):
+        if not isinstance(strategy, dict):
+            blockers.append(f"handoff_strategy_{index}_invalid")
+            continue
+        strategy_runtime_score = str(strategy.get("runtime_score") or "")
+        if not strategy_runtime_score:
+            blockers.append(f"handoff_strategy_{index}_missing_runtime_score")
+        elif replay_runtime_score and strategy_runtime_score != replay_runtime_score:
+            blockers.append(
+                "candidate_strategy_replay_runtime_score_mismatch:"
+                f"strategy_{index}:{replay_runtime_score}!={strategy_runtime_score}"
+            )
+    return blockers
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handoff-json", required=True)
+    parser.add_argument("--output-json", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    handoff_path = Path(args.handoff_json)
+    handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
+    blockers = validate_handoff_payload(handoff)
+    result = {
+        "schema_version": 1,
+        "kind": "autofactor_handoff_replay_gate",
+        "handoff_json": str(handoff_path),
+        "ready": not blockers,
+        "blockers": blockers,
+    }
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    if blockers:
+        for blocker in blockers:
+            print(f"AutoFactor handoff replay gate blocked: {blocker}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -62,8 +62,11 @@ trace, not dry-run promotion.
       missing, blocked, or semantically mismatched runtime inputs.
 - [x] Apply feature snapshot hard gates so sampled required-for-execution
       surfaces cannot suppress full-depth executable blockers.
+- [x] Apply side-effect replay validator so ready AutoFactor handoffs cannot
+      create dry-run issues/config PRs or satisfy the PRD gate without runtime
+      replay evidence.
 - [ ] Apply remaining high-priority data/research cleanup based on audit
-      results: multi-horizon accounting gates and side-effect replay validators.
+      results: multi-horizon accounting gates.
 
 ## Review
 
@@ -166,6 +169,11 @@ trace, not dry-run promotion.
   promotion now pass `manifest.json`; sampled `required_for_execution` surfaces
   add blocking risk flags and prevent top-bucket sampled fillability from
   suppressing global full-depth fillability blockers.
+- 2026-05-23: Added an AutoFactor handoff replay validator and wired it into
+  hosted/standalone handoff side effects plus the settlement PRD gate helper.
+  A ready handoff must now embed a ready `runtime_market_update_replay` from
+  `runtime-candidate-replay.yml` with matching selected strategy runtime score
+  before it can create dry-run follow-up state.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -160,6 +160,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "--candidate-replay-json",
             "candidate-strategy-replay/candidate-strategy-replay.json",
             "--snapshot-manifest-json artifacts/research-snapshot/manifest.json",
+            "validate_autofactor_handoff_replay_gate.py",
             "factor walk-forward report is required for durable trace persistence.",
         ]
         for snippet in required_snippets:
@@ -175,6 +176,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "*/snapshot-provenance/source.txt",
             "*/snapshot-provenance/manifest.json",
             "--snapshot-manifest-json",
+            "validate_autofactor_handoff_replay_gate.py",
             "AutoFactor promotion side effects require successful durable Research OS trace persistence.",
             "AutoFactor promotion side effects reject legacy/debug/self-hosted source artifacts.",
             "direct_db_debug=true|canonical_result=no|registry=runner-local|runner=self-hosted|runner=ploy-ci-1",

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -10,6 +10,37 @@ from scripts import run_settlement_probability_prd_gate as gate
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "settlement-probability-prd-gate.yml"
 
+READY_REPORT = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.3000 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=100 event_complete_rows=200 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete
+recorded_replay_parity,true,blocking_flags=<none>
+"""
+
+
+def ready_handoff() -> dict:
+    runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
+    return {
+        "status": "ready",
+        "candidate_strategy_replay": {
+            "ready": True,
+            "basis": "runtime_market_update_replay",
+            "source_workflow": "runtime-candidate-replay.yml",
+            "workflow_run_id": "26306734877",
+            "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
+            "artifact_name": "runtime-candidate-replay-26306734877",
+            "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
+            "runtime_score": runtime_score,
+            "decision_contract": {
+                "event_level": True,
+                "one_decision_per_event": True,
+                "official_settlement": True,
+                "full_depth_entry": True,
+            },
+        },
+        "strategies": [{"runtime_score": runtime_score}],
+    }
+
 
 class SettlementProbabilityPrdGateTests(unittest.TestCase):
     def run_main(self, argv, *, dispatch):
@@ -129,6 +160,48 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
         self.assertIn("missing-required-snapshot", workflow)
         self.assertNotIn("legacy-build", workflow)
         self.assertNotIn("--allow-legacy-snapshot-build", workflow)
+
+    def test_download_gate_requires_runtime_replay_handoff(self):
+        def fake_download(args, *, dry_run=False):
+            output_dir = Path(args[args.index("--dir") + 1])
+            artifact = output_dir / "factor-walk-forward-v2"
+            artifact.mkdir(parents=True)
+            (artifact / "report.txt").write_text(READY_REPORT, encoding="utf-8")
+            handoff = ready_handoff()
+            handoff["candidate_strategy_replay"]["basis"] = "factor_walk_forward_top_bucket_aggregate"
+            (artifact / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(handoff, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            return ""
+
+        with mock.patch.object(gate, "run_command", side_effect=fake_download):
+            result = gate.download_and_evaluate_promotion_gate(12345)
+
+        self.assertFalse(result.ready)
+        self.assertIn(
+            "handoff_replay_gate:candidate_strategy_replay_not_runtime_replay:"
+            "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+            result.blocked_gates,
+        )
+
+    def test_download_gate_accepts_runtime_replay_handoff(self):
+        def fake_download(args, *, dry_run=False):
+            output_dir = Path(args[args.index("--dir") + 1])
+            artifact = output_dir / "factor-walk-forward-v2"
+            artifact.mkdir(parents=True)
+            (artifact / "report.txt").write_text(READY_REPORT, encoding="utf-8")
+            (artifact / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(ready_handoff(), indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            return ""
+
+        with mock.patch.object(gate, "run_command", side_effect=fake_download):
+            result = gate.download_and_evaluate_promotion_gate(12345)
+
+        self.assertTrue(result.ready)
+        self.assertEqual(result.blocked_gates, ())
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_autofactor_handoff_replay_gate.py
+++ b/tests/test_validate_autofactor_handoff_replay_gate.py
@@ -1,0 +1,119 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "validate_autofactor_handoff_replay_gate.py"
+
+
+def ready_handoff() -> dict:
+    runtime_score = "autofactor_formula:auto_settlement_conservative_settlement_edge"
+    return {
+        "schema_version": 1,
+        "kind": "autofactor_strategy_handoff",
+        "status": "ready",
+        "candidate_strategy_replay": {
+            "ready": True,
+            "basis": "runtime_market_update_replay",
+            "source_workflow": "runtime-candidate-replay.yml",
+            "workflow_run_id": "26306734877",
+            "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
+            "artifact_name": "runtime-candidate-replay-26306734877",
+            "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
+            "runtime_score": runtime_score,
+            "decision_contract": {
+                "event_level": True,
+                "one_decision_per_event": True,
+                "official_settlement": True,
+                "full_depth_entry": True,
+            },
+        },
+        "strategies": [
+            {
+                "name": "auto_settlement_conservative_settlement_edge",
+                "runtime_score": runtime_score,
+                "strategy_profile": "settlement_probability",
+            }
+        ],
+    }
+
+
+class ValidateAutoFactorHandoffReplayGateTests(unittest.TestCase):
+    def run_script(self, handoff: dict, *, check: bool = True) -> tuple[dict, subprocess.CompletedProcess]:
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            handoff_path = tmp / "handoff.json"
+            output_path = tmp / "gate.json"
+            handoff_path.write_text(json.dumps(handoff, indent=2, sort_keys=True), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--handoff-json",
+                    str(handoff_path),
+                    "--output-json",
+                    str(output_path),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=check,
+            )
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            return payload, result
+
+    def test_accepts_runtime_candidate_replay_handoff(self):
+        payload, result = self.run_script(ready_handoff())
+
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["blockers"], [])
+
+    def test_blocks_aggregate_candidate_replay_handoff(self):
+        handoff = ready_handoff()
+        replay = handoff["candidate_strategy_replay"]
+        replay["basis"] = "factor_walk_forward_top_bucket_aggregate"
+        replay["source_workflow"] = ""
+        replay["artifact_name"] = "factor-walk-forward-v2-26306734877"
+
+        payload, result = self.run_script(handoff, check=False)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertFalse(payload["ready"])
+        self.assertIn(
+            "candidate_strategy_replay_not_runtime_replay:"
+            "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+            payload["blockers"],
+        )
+        self.assertIn(
+            "candidate_strategy_replay_source_workflow_mismatch:"
+            "<missing>!=runtime-candidate-replay.yml",
+            payload["blockers"],
+        )
+        self.assertIn(
+            "candidate_strategy_replay_artifact_mismatch:"
+            "factor-walk-forward-v2-26306734877!=runtime-candidate-replay-*",
+            payload["blockers"],
+        )
+
+    def test_blocks_strategy_runtime_score_mismatch(self):
+        handoff = ready_handoff()
+        handoff["strategies"][0]["runtime_score"] = "autofactor_formula:other"
+
+        payload, _ = self.run_script(handoff, check=False)
+
+        self.assertFalse(payload["ready"])
+        self.assertIn(
+            "candidate_strategy_replay_runtime_score_mismatch:"
+            "strategy_1:autofactor_formula:auto_settlement_conservative_settlement_edge!="
+            "autofactor_formula:other",
+            payload["blockers"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared AutoFactor handoff replay validator for dry-run side effects
- require ready runtime replay evidence from runtime-candidate-replay.yml before handoff issue/config PR creation
- make the settlement PRD gate helper treat report-ready without valid runtime replay as blocked
- document the side-effect boundary and update task/review notes

## Verification
- python3 -m py_compile scripts/validate_autofactor_handoff_replay_gate.py scripts/run_settlement_probability_prd_gate.py scripts/research_snapshot_contract.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py
- python3 -m unittest tests.test_validate_autofactor_handoff_replay_gate tests.test_settlement_probability_prd_gate tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_persist_research_trace_contract
- YAML parse: autofactor-strategy-promotion.yml, factor-walk-forward-v2-hosted-artifact.yml, settlement-probability-prd-gate.yml
- rtk cargo test --locked --test workflow_security
- rtk git diff --check