### PR TITLE
Enforce AutoFactor replay horizon accounting

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: "0"
       options_json:
-        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits, three_layer_min_entry_score"
+        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits, three_layer_min_entry_score, source_target, source_horizon"
         required: false
-        default: '{"full_depth_entry":true,"skip_settlement_exits":false}'
+        default: '{"full_depth_entry":true,"skip_settlement_exits":false,"source_target":"full_depth_settlement_executable_pnl","source_horizon":"5m"}'
 concurrency:
   group: runtime-candidate-replay-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.runtime_score }}
   cancel-in-progress: false
@@ -82,9 +82,12 @@ jobs:
               "full_depth_entry": "true",
               "skip_settlement_exits": "false",
               "three_layer_min_entry_score": "",
+              "source_target": "full_depth_settlement_executable_pnl",
+              "source_horizon": "5m",
           }
           bool_keys = {"full_depth_entry", "skip_settlement_exits"}
           threshold_keys = {"three_layer_min_entry_score"}
+          string_keys = {"source_target", "source_horizon"}
           allowed_thresholds = {Decimal("0.05"), Decimal("0.10"), Decimal("0.15"), Decimal("0.25")}
           raw = os.environ.get("OPTIONS_JSON", "").strip()
           data = json.loads(raw) if raw else {}
@@ -115,10 +118,16 @@ jobs:
                       allowed = ", ".join(str(item) for item in sorted(allowed_thresholds))
                       raise SystemExit(f"options_json value for {key} must be one of: {allowed}")
                   values[key] = format(threshold, "f")
+              elif key in string_keys:
+                  values[key] = str(value).strip()
+                  if not values[key]:
+                      raise SystemExit(f"options_json value for {key} must be non-empty")
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
               handle.write(f"REPLAY_FULL_DEPTH_ENTRY={values['full_depth_entry']}\n")
               handle.write(f"REPLAY_SKIP_SETTLEMENT_EXITS={values['skip_settlement_exits']}\n")
+              handle.write(f"REPLAY_SOURCE_TARGET={values['source_target']}\n")
+              handle.write(f"REPLAY_SOURCE_HORIZON={values['source_horizon']}\n")
               handle.write(
                   "REPLAY_THREE_LAYER_MIN_ENTRY_SCORE="
                   f"{values['three_layer_min_entry_score']}\n"
@@ -396,6 +405,8 @@ jobs:
           MIN_ROI: ${{ github.event.inputs.min_roi }}
           FULL_DEPTH_ENTRY: ${{ env.REPLAY_FULL_DEPTH_ENTRY }}
           CONFIGURED_ENTRY_THRESHOLD: ${{ env.REPLAY_THREE_LAYER_MIN_ENTRY_SCORE || '0.25' }}
+          SOURCE_TARGET: ${{ env.REPLAY_SOURCE_TARGET }}
+          SOURCE_HORIZON: ${{ env.REPLAY_SOURCE_HORIZON }}
         run: |
           set -euo pipefail
           args=(
@@ -410,6 +421,8 @@ jobs:
             --config-path "${{ github.event.inputs.config_path }}"
             --runner-source "${GITHUB_WORKFLOW}:${GITHUB_REF_NAME}"
             --runner-git-sha "${GITHUB_SHA}"
+            --source-target "${SOURCE_TARGET}"
+            --source-horizon "${SOURCE_HORIZON}"
             --min-trade-count "${MIN_TRADE_COUNT}"
             --min-fill-rate "${MIN_FILL_RATE}"
             --min-roi "${MIN_ROI}"

--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -113,12 +113,15 @@ reserved for `executable_replay` evidence.
    need one generated/shared source for feature names, horizons, LOB surfaces,
    blocker semantics, and strategy profile/family mapping.
 
-6. **Multi-horizon label/accounting is not a single hard gate yet.**
+6. **Multi-horizon label/accounting now has a promotion handoff gate, but the
+   label engine still needs a shared generated catalog.**
 
-   Reports compute event-level fields such as unique event count and max event
-   decisions, but the final persisted approval layer still needs to enforce the
-   one-event-one-decision accounting contract across 30s / 60s / 5m / 15m
-   horizons.
+   AutoFactor promotion now checks that the candidate runtime replay tape's
+   `source_factor.target/horizon` matches the factor row being promoted, and
+   runtime/aggregate replay artifacts write the same target/horizon into their
+   decision contract. The remaining architecture gap is consolidating 30s /
+   60s / 5m / 15m label definitions into one generated catalog shared by Rust
+   research, runtime replay builders, and persistence.
 
 7. **DuckDB should remain a query accelerator, not durable state.**
 
@@ -138,7 +141,7 @@ reserved for `executable_replay` evidence.
 | P1 | Add Research Manager action executor | Plan output can open/link issues and dispatch bounded hosted research reruns without manual artifact reading |
 | P1 | Promote runtime input canonicalization to a shared generated contract | Rust runtime scoring, Rust alpha-search, and Python promotion/replay use one source of truth instead of mirrored catalogs |
 | P1 | Complete full-depth executable evidence layer | Runtime replay or full-depth lake evidence replaces sampled snapshot rows for executable handoff |
-| P1 | Enforce multi-horizon accounting at persisted approval layer | Multi-decision or horizon-mixed artifacts are blocked before handoff |
+| P1 | Generate shared label/accounting catalog | Runtime, research, replay, and trace persistence derive target/horizon/accounting metadata from one source |
 
 ## Verdict
 

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -286,6 +286,10 @@ top deployable bucket to expose event-level decision fields. Missing
 `top_bucket_unique_event_count` / `top_bucket_max_event_decisions` blocks
 handoff, and `top_bucket_max_event_decisions > 1` blocks handoff because the
 candidate is still relying on repeated rows from the same event.
+The attached runtime replay tape must also carry the same target/horizon as
+the promoted factor row. A 30s repricing replay cannot back a 5m settlement
+handoff, even when the runtime score string and aggregate metrics look
+compatible.
 
 ## Decision Labels
 

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -60,6 +60,20 @@ def replay_identity(*, runtime_score: str, strategy_profile: str, evidence: str,
     }
 
 
+def target_horizon(target: str) -> str:
+    if "reprice_pnl_5s" in target:
+        return "5s"
+    if "reprice_pnl_10s" in target:
+        return "10s"
+    if "reprice_pnl_30s" in target:
+        return "30s"
+    if "reprice_pnl_60s" in target:
+        return "60s"
+    if "settlement" in target:
+        return "5m"
+    return "unknown"
+
+
 def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     in_section = False
@@ -205,6 +219,7 @@ def build_artifact(
     source_factor = {
         "name": row.get("name", ""),
         "target": row.get("target", ""),
+        "horizon": target_horizon(str(row.get("target", ""))),
         "decision": row.get("decision", ""),
         "reason": row.get("reason", ""),
     }
@@ -251,6 +266,8 @@ def build_artifact(
             "one_decision_per_event": True,
             "official_settlement": True,
             "full_depth_entry": True,
+            "target": row.get("target", ""),
+            "horizon": target_horizon(str(row.get("target", ""))),
             "stake_usd": stake_usd,
             "entry_policy": "top_scoring_bucket",
         },

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -373,6 +373,8 @@ def build_artifact(
             "one_decision_per_event": trade_count > 0 and max_event_decisions == 1,
             "official_settlement": trade_count > 0 and settled_event_count >= trade_count,
             "full_depth_entry": full_depth_entry,
+            "target": source_target,
+            "horizon": source_horizon,
             "stake_usd": float(stake_usd),
         },
         "acceptance_criteria": {

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -73,6 +73,7 @@ class CandidateStrategyReplay:
     workflow_run_id: str = ""
     workflow_run_url: str = ""
     artifact_name: str = ""
+    source_factor: dict[str, Any] = field(default_factory=dict)
     blockers: list[str] = field(default_factory=list)
     metrics: dict[str, Any] = field(default_factory=dict)
     decision_contract: dict[str, Any] = field(default_factory=dict)
@@ -154,6 +155,20 @@ def parse_int(raw: str) -> int:
 
 def finite_or_none(value: float) -> float | None:
     return value if value == value else None
+
+
+def target_horizon(target: str) -> str:
+    if "reprice_pnl_5s" in target:
+        return "5s"
+    if "reprice_pnl_10s" in target:
+        return "10s"
+    if "reprice_pnl_30s" in target:
+        return "30s"
+    if "reprice_pnl_60s" in target:
+        return "60s"
+    if "settlement" in target:
+        return "5m"
+    return "unknown"
 
 
 def parse_promotion_gate(report_text: str) -> PromotionGate:
@@ -244,6 +259,9 @@ def load_candidate_strategy_replay(path: str | None) -> CandidateStrategyReplay:
         workflow_run_id=str(payload.get("workflow_run_id", "")),
         workflow_run_url=str(payload.get("workflow_run_url", "")),
         artifact_name=str(payload.get("artifact_name", "")),
+        source_factor=payload.get("source_factor")
+        if isinstance(payload.get("source_factor"), dict)
+        else {},
         blockers=[str(item) for item in blockers],
         metrics=metrics,
         decision_contract=contract,
@@ -267,6 +285,8 @@ def candidate_strategy_replay_blockers(
     replay: CandidateStrategyReplay,
     *,
     mapping: dict[str, str] | None,
+    expected_target: str,
+    expected_horizon: str,
     required_strategy_profile: str,
     min_replay_trade_count: int,
     min_replay_fill_rate: float,
@@ -310,6 +330,35 @@ def candidate_strategy_replay_blockers(
     for field_name, value in provenance_fields.items():
         if not value:
             blockers.append(f"candidate_strategy_replay_missing_{field_name}")
+
+    source_target = str(replay.source_factor.get("target") or "")
+    source_horizon = str(replay.source_factor.get("horizon") or "")
+    if not source_target:
+        blockers.append("candidate_strategy_replay_missing_source_target")
+    elif source_target != expected_target:
+        blockers.append(
+            "candidate_strategy_replay_target_mismatch:"
+            f"{source_target}!={expected_target}"
+        )
+    if not source_horizon:
+        blockers.append("candidate_strategy_replay_missing_source_horizon")
+    elif source_horizon != expected_horizon:
+        blockers.append(
+            "candidate_strategy_replay_horizon_mismatch:"
+            f"{source_horizon}!={expected_horizon}"
+        )
+    contract_target = replay.decision_contract.get("target")
+    contract_horizon = replay.decision_contract.get("horizon")
+    if contract_target is not None and contract_target != expected_target:
+        blockers.append(
+            "candidate_strategy_replay_contract_target_mismatch:"
+            f"{contract_target}!={expected_target}"
+        )
+    if contract_horizon is not None and contract_horizon != expected_horizon:
+        blockers.append(
+            "candidate_strategy_replay_contract_horizon_mismatch:"
+            f"{contract_horizon}!={expected_horizon}"
+        )
 
     if replay.strategy_profile != required_strategy_profile:
         blockers.append(
@@ -614,6 +663,8 @@ def evaluate(
             candidate_strategy_replay_blockers(
                 candidate_strategy_replay,
                 mapping=mapping,
+                expected_target=row.target,
+                expected_horizon=target_horizon(row.target),
                 required_strategy_profile=required_strategy_profile,
                 min_replay_trade_count=min_replay_trade_count,
                 min_replay_fill_rate=min_replay_fill_rate,

--- a/scripts/validate_autofactor_handoff_replay_gate.py
+++ b/scripts/validate_autofactor_handoff_replay_gate.py
@@ -72,6 +72,27 @@ def validate_handoff_payload(handoff: dict[str, Any]) -> list[str]:
     replay_runtime_score = str(replay.get("runtime_score") or "")
     if not replay_runtime_score:
         blockers.append("candidate_strategy_replay_missing_runtime_score")
+    source_factor = replay.get("source_factor")
+    if not isinstance(source_factor, dict):
+        source_factor = {}
+    source_target = str(source_factor.get("target") or "")
+    source_horizon = str(source_factor.get("horizon") or "")
+    if not source_target:
+        blockers.append("candidate_strategy_replay_missing_source_target")
+    if not source_horizon:
+        blockers.append("candidate_strategy_replay_missing_source_horizon")
+    contract_target = str(contract.get("target") or "")
+    contract_horizon = str(contract.get("horizon") or "")
+    if contract_target and source_target and contract_target != source_target:
+        blockers.append(
+            "candidate_strategy_replay_contract_target_mismatch:"
+            f"{contract_target}!={source_target}"
+        )
+    if contract_horizon and source_horizon and contract_horizon != source_horizon:
+        blockers.append(
+            "candidate_strategy_replay_contract_horizon_mismatch:"
+            f"{contract_horizon}!={source_horizon}"
+        )
     for index, strategy in enumerate(strategies, start=1):
         if not isinstance(strategy, dict):
             blockers.append(f"handoff_strategy_{index}_invalid")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -65,8 +65,10 @@ trace, not dry-run promotion.
 - [x] Apply side-effect replay validator so ready AutoFactor handoffs cannot
       create dry-run issues/config PRs or satisfy the PRD gate without runtime
       replay evidence.
-- [ ] Apply remaining high-priority data/research cleanup based on audit
-      results: multi-horizon accounting gates.
+- [x] Apply multi-horizon accounting gate so runtime replay target/horizon must
+      match the promoted AutoFactor row before handoff.
+- [ ] Apply remaining high-priority cleanup: generated shared label/accounting
+      catalog and legacy terminology/API cleanup.
 
 ## Review
 
@@ -174,6 +176,11 @@ trace, not dry-run promotion.
   A ready handoff must now embed a ready `runtime_market_update_replay` from
   `runtime-candidate-replay.yml` with matching selected strategy runtime score
   before it can create dry-run follow-up state.
+- 2026-05-23: Added target/horizon accounting gates to AutoFactor replay
+  handoff. Runtime replay and aggregate diagnostic artifacts now carry
+  target/horizon in `source_factor` / `decision_contract`, and promotion blocks
+  replay tapes whose target or horizon differs from the factor row being
+  promoted.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -191,11 +191,18 @@ DEFAULT_REPLAY_PAYLOAD = {
     "workflow_run_id": "26306734877",
     "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
     "artifact_name": "runtime-candidate-replay-26306734877",
+    "source_factor": {
+        "name": "auto_settlement_conservative_settlement_edge",
+        "target": "full_depth_settlement_executable_pnl",
+        "horizon": "5m",
+    },
     "decision_contract": {
         "event_level": True,
         "one_decision_per_event": True,
         "official_settlement": True,
         "full_depth_entry": True,
+        "target": "full_depth_settlement_executable_pnl",
+        "horizon": "5m",
         "max_sweep_levels": 3,
         "stake_usd": 15,
     },
@@ -208,6 +215,19 @@ DEFAULT_REPLAY_PAYLOAD = {
     },
     "blocking_risk_flags": [],
 }
+
+
+def replay_for_target(runtime_score: str, target: str = "full_depth_settlement_executable_pnl") -> dict:
+    payload = dict(DEFAULT_REPLAY_PAYLOAD)
+    payload["runtime_score"] = runtime_score
+    payload["identity"] = dict(DEFAULT_REPLAY_PAYLOAD["identity"])
+    payload["identity"]["runtime_score"] = runtime_score
+    payload["source_factor"] = dict(DEFAULT_REPLAY_PAYLOAD["source_factor"])
+    payload["source_factor"]["target"] = target
+    payload["decision_contract"] = dict(DEFAULT_REPLAY_PAYLOAD["decision_contract"])
+    payload["decision_contract"]["target"] = target
+    return payload
+
 
 SAMPLED_EXECUTION_SNAPSHOT_MANIFEST = {
     "schema_version": "research_snapshot_manifest_v1",
@@ -465,7 +485,11 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
     def test_uses_top_bucket_execution_quality_before_global_slippage(self):
         _, payload, _, handoff, _ = self.run_script(
-            HIGH_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT
+            HIGH_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT,
+            replay_payload=replay_for_target(
+                "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "tradeable_full_depth_settlement_pnl",
+            ),
         )
 
         self.assertEqual(payload["decision"], "qualified")
@@ -476,7 +500,11 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
 
     def test_blocks_top_bucket_slippage_and_level_count(self):
         _, payload, _, handoff, _ = self.run_script(
-            LOW_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_BAD_EXECUTION_REPORT
+            LOW_SLIPPAGE_HEALTH + READY_GATE + AUTOFACTOR_TOP_BUCKET_BAD_EXECUTION_REPORT,
+            replay_payload=replay_for_target(
+                "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "tradeable_full_depth_settlement_pnl",
+            ),
         )
 
         self.assertEqual(payload["decision"], "blocked")
@@ -489,7 +517,11 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         _, payload, _, handoff, _ = self.run_script(
             LOW_SLIPPAGE_HEALTH
             + GLOBAL_FILLABILITY_BLOCKED_GATE
-            + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT
+            + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT,
+            replay_payload=replay_for_target(
+                "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "tradeable_full_depth_settlement_pnl",
+            ),
         )
 
         self.assertEqual(payload["decision"], "qualified")
@@ -502,6 +534,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             LOW_SLIPPAGE_HEALTH
             + GLOBAL_FILLABILITY_BLOCKED_GATE
             + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT,
+            replay_payload=replay_for_target(
+                "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "tradeable_full_depth_settlement_pnl",
+            ),
             snapshot_manifest_payload=SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
         )
 
@@ -529,10 +565,9 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
 
     def test_qualifies_predictive_external_formula_when_gate_is_ready(self):
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": "autofactor_formula:amplitude_weighted_momentum_30s_sigma",
-        }
+        replay = replay_for_target(
+            "autofactor_formula:amplitude_weighted_momentum_30s_sigma"
+        )
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_PREDICTIVE_EXTERNAL_REPORT,
             replay_payload=replay,
@@ -552,10 +587,9 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("amplitude_weighted_momentum_30s_sigma", handoff_md)
 
     def test_qualifies_runtime_supported_predictive_formula_mutation(self):
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted",
-        }
+        replay = replay_for_target(
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_spread_adjusted"
+        )
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_PREDICTIVE_MUTATION_REPORT,
             replay_payload=replay,
@@ -588,10 +622,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "autofactor_formula:"
             "llm_mut_spread_adjusted_external_move_near_strike_runtime_pass_through_add_spread_penalty"
         )
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": runtime_score,
-        }
+        replay = replay_for_target(runtime_score)
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_LLM_RUNTIME_PASS_THROUGH_MUTATION_REPORT,
             replay_payload=replay,
@@ -612,10 +643,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("runtime_pass_through_add_spread_penalty", handoff_md)
 
     def test_qualifies_poly_lag_pressure_predictive_formula_mutation(self):
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": "autofactor_formula:mut_poly_lag_pressure_spread_adjusted",
-        }
+        replay = replay_for_target("autofactor_formula:mut_poly_lag_pressure_spread_adjusted")
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_POLY_LAG_PRESSURE_REPORT,
             replay_payload=replay,
@@ -639,10 +667,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "autofactor_formula:"
             "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
         )
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": runtime_score,
-        }
+        replay = replay_for_target(runtime_score)
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_COMPOSED_MODEL_REPORT,
             replay_payload=replay,
@@ -662,10 +687,10 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         )
 
     def test_qualifies_tradeable_hard_gate_predictive_formula_when_gate_is_ready(self):
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "runtime_score": "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
-        }
+        replay = replay_for_target(
+            "autofactor_formula:mut_amplitude_weighted_momentum_30s_sigma_full_depth_entry_gate",
+            "tradeable_full_depth_settlement_pnl",
+        )
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_TRADEABLE_HARD_GATE_REPORT,
             replay_payload=replay,
@@ -718,11 +743,13 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertIn("Promote AutoFactor strategy handoff to dry-run", handoff_md)
 
     def test_qualifies_when_allowed_target_and_runtime_profile_match(self):
-        replay = {
-            **DEFAULT_REPLAY_PAYLOAD,
-            "strategy_profile": "repricing_momentum",
-            "runtime_score": "spread_adjusted_external_move_score",
-        }
+        replay = replay_for_target(
+            "spread_adjusted_external_move_score",
+            "full_depth_reprice_pnl_10s",
+        )
+        replay["strategy_profile"] = "repricing_momentum"
+        replay["source_factor"]["horizon"] = "10s"
+        replay["decision_contract"]["horizon"] = "10s"
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_REPORT,
             "--allowed-target",
@@ -903,6 +930,29 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
             first["blockers"],
         )
+
+    def test_blocks_runtime_replay_from_wrong_horizon(self):
+        replay = replay_for_target(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+            "full_depth_reprice_pnl_30s",
+        )
+        replay["source_factor"]["horizon"] = "30s"
+        replay["decision_contract"]["horizon"] = "30s"
+
+        _, payload, _, handoff, _ = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        blockers = payload["evaluated_factors"][0]["blockers"]
+        self.assertIn(
+            "candidate_strategy_replay_target_mismatch:"
+            "full_depth_reprice_pnl_30s!=full_depth_settlement_executable_pnl",
+            blockers,
+        )
+        self.assertIn("candidate_strategy_replay_horizon_mismatch:30s!=5m", blockers)
 
     def test_blocks_legacy_runtime_replay_without_durable_provenance(self):
         replay = {

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -177,6 +177,12 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
         self.assertTrue(payload["decision_contract"]["one_decision_per_event"])
         self.assertTrue(payload["decision_contract"]["official_settlement"])
         self.assertTrue(payload["decision_contract"]["full_depth_entry"])
+        self.assertEqual(payload["source_factor"]["horizon"], "5m")
+        self.assertEqual(
+            payload["decision_contract"]["target"],
+            "full_depth_settlement_executable_pnl",
+        )
+        self.assertEqual(payload["decision_contract"]["horizon"], "5m")
         self.assertEqual(payload["metrics"]["trade_count"], 9966)
         self.assertEqual(payload["metrics"]["unique_event_count"], 9966)
         self.assertGreater(payload["metrics"]["total_pnl"], 0)

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -136,6 +136,10 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
             "--full-depth-entry",
             "--min-trade-count",
             "2",
+            "--source-target",
+            "full_depth_settlement_executable_pnl",
+            "--source-horizon",
+            "5m",
         )
 
         self.assertTrue(payload["promotion_ready"])
@@ -146,6 +150,10 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(payload["source_workflow"], "runtime-candidate-replay.yml")
         self.assertEqual(payload["identity"]["runtime_score"], payload["runtime_score"])
         self.assertEqual(payload["identity"]["basis"], "runtime_market_update_replay")
+        self.assertEqual(payload["source_factor"]["target"], "full_depth_settlement_executable_pnl")
+        self.assertEqual(payload["source_factor"]["horizon"], "5m")
+        self.assertEqual(payload["decision_contract"]["target"], "full_depth_settlement_executable_pnl")
+        self.assertEqual(payload["decision_contract"]["horizon"], "5m")
         self.assertEqual(len(payload["runtime_evaluation_sha256"]), 64)
         self.assertEqual(payload["metrics"]["trade_count"], 2)
         self.assertEqual(payload["metrics"]["unique_event_count"], 2)

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -82,6 +82,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self,
         tmp: Path,
         runtime_score: str = "autofactor_formula:auto_settlement_conservative_settlement_edge",
+        target: str = "full_depth_settlement_executable_pnl",
     ) -> Path:
         replay = tmp / f"candidate-strategy-replay-{runtime_score.replace(':', '_')}.json"
         replay.write_text(
@@ -106,11 +107,17 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                     "workflow_run_id": "26306734877",
                     "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",
                     "artifact_name": "runtime-candidate-replay-26306734877",
+                    "source_factor": {
+                        "target": target,
+                        "horizon": "5m",
+                    },
                     "decision_contract": {
                         "event_level": True,
                         "one_decision_per_event": True,
                         "official_settlement": True,
                         "full_depth_entry": True,
+                        "target": target,
+                        "horizon": "5m",
                     },
                     "metrics": {
                         "trade_count": 100,
@@ -428,6 +435,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                         self.replay_file(
                             tmp,
                             "autofactor_formula:mut_spread_adjusted_external_move_full_depth_entry_gate",
+                            "tradeable_full_depth_settlement_pnl",
                         )
                     ),
                     "--allowed-target",

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -31,11 +31,17 @@ def ready_handoff() -> dict:
             "artifact_name": "runtime-candidate-replay-26306734877",
             "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
             "runtime_score": runtime_score,
+            "source_factor": {
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+            },
             "decision_contract": {
                 "event_level": True,
                 "one_decision_per_event": True,
                 "official_settlement": True,
                 "full_depth_entry": True,
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
             },
         },
         "strategies": [{"runtime_score": runtime_score}],

--- a/tests/test_validate_autofactor_handoff_replay_gate.py
+++ b/tests/test_validate_autofactor_handoff_replay_gate.py
@@ -25,11 +25,17 @@ def ready_handoff() -> dict:
             "artifact_name": "runtime-candidate-replay-26306734877",
             "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
             "runtime_score": runtime_score,
+            "source_factor": {
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+            },
             "decision_contract": {
                 "event_level": True,
                 "one_decision_per_event": True,
                 "official_settlement": True,
                 "full_depth_entry": True,
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
             },
         },
         "strategies": [
@@ -111,6 +117,18 @@ class ValidateAutoFactorHandoffReplayGateTests(unittest.TestCase):
             "candidate_strategy_replay_runtime_score_mismatch:"
             "strategy_1:autofactor_formula:auto_settlement_conservative_settlement_edge!="
             "autofactor_formula:other",
+            payload["blockers"],
+        )
+
+    def test_blocks_contract_horizon_mismatch(self):
+        handoff = ready_handoff()
+        handoff["candidate_strategy_replay"]["decision_contract"]["horizon"] = "30s"
+
+        payload, _ = self.run_script(handoff, check=False)
+
+        self.assertFalse(payload["ready"])
+        self.assertIn(
+            "candidate_strategy_replay_contract_horizon_mismatch:30s!=5m",
             payload["blockers"],
         )
 

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -724,6 +724,8 @@ fn runtime_candidate_replay_allows_empty_entry_score_override() {
         "--config-path",
         "--runner-source",
         "--runner-git-sha",
+        "--source-target",
+        "--source-horizon",
     ] {
         assert!(
             workflow.contains(needle),


### PR DESCRIPTION
## Summary
- require candidate runtime replay target/horizon to match the promoted AutoFactor row
- write target/horizon into runtime replay and aggregate diagnostic replay decision contracts
- pass source target/horizon through runtime-candidate-replay workflow options
- extend side-effect replay validator to reject source/contract horizon mismatches
- update research architecture docs and task tracker

## Verification
- python3 -m py_compile scripts/build_runtime_candidate_strategy_replay.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/validate_autofactor_handoff_replay_gate.py scripts/run_factor_walk_forward_sweep.py
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_validate_autofactor_handoff_replay_gate tests.test_settlement_probability_prd_gate tests.test_persist_research_trace_contract
- YAML parse: runtime-candidate-replay.yml, autofactor-strategy-promotion.yml, factor-walk-forward-v2-hosted-artifact.yml
- rtk cargo test --locked --test workflow_security
- rtk git diff --check