### PR TITLE
Research: rename sampled snapshot contract knobs

### DIFF
--- a/.github/workflows/factor-review-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-review-v2-hosted-artifact.yml
@@ -344,7 +344,7 @@ jobs:
           {
             echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
             echo "producer_run_id=${GITHUB_RUN_ID}"
-            echo "full_snapshot_embedded=false"
+            echo "sampled_snapshot_embedded=false"
             echo "runner=ubuntu-latest"
           } > artifacts/factor-review-v2-upload/snapshot-provenance/source.txt
           cat > artifacts/factor-review-v2-upload/evidence-stage.json <<EOF

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -837,7 +837,7 @@ jobs:
           {
             echo "source_snapshot_run_id=${{ github.event.inputs.snapshot_run_id }}"
             echo "producer_run_id=${GITHUB_RUN_ID}"
-            echo "full_snapshot_embedded=false"
+            echo "sampled_snapshot_embedded=false"
             echo "runner=ubuntu-latest"
             echo "source=snapshot_artifact"
           } > artifacts/factor-walk-forward-v2-upload/snapshot-provenance/source.txt

--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -26,7 +26,7 @@ on:
       options_json:
         description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, and optional complete sampled snapshot upload"
         required: false
-        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_full_snapshot":true}'
+        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_sampled_snapshot":true}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -78,9 +78,12 @@ jobs:
               "audit_lookback_hours": "168",
               "data_gate": "never",
               "snapshot_registry_dir": "",
-              "upload_full_snapshot": "true",
+              "upload_sampled_snapshot": "true",
           }
-          bool_keys = {"upload_full_snapshot"}
+          legacy_aliases = {
+              "upload_" + "full_snapshot": "upload_sampled_snapshot",
+          }
+          bool_keys = {"upload_sampled_snapshot"}
           choices = {
               "data_profile": {"pm5d-execution", "pm5d-vol", "all", "custom"},
               "data_gate": {"critical", "warn", "never"},
@@ -89,9 +92,16 @@ jobs:
           data = json.loads(raw) if raw else {}
           if not isinstance(data, dict):
               raise SystemExit("options_json must be a JSON object")
-          unknown = sorted(set(data) - set(defaults))
+          unknown = sorted(set(data) - set(defaults) - set(legacy_aliases))
           if unknown:
               raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+          for legacy_key, canonical_key in legacy_aliases.items():
+              if legacy_key in data:
+                  if canonical_key in data:
+                      raise SystemExit(
+                          f"options_json cannot include both {legacy_key} and {canonical_key}"
+                      )
+                  data[canonical_key] = data.pop(legacy_key)
 
           values = dict(defaults)
           for key, value in data.items():
@@ -115,7 +125,7 @@ jobs:
                       raise SystemExit(f"options_json value for {key} must be single-line")
                   handle.write(f"SNAPSHOT_{key.upper()}={value}\n")
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-              handle.write(f"upload_full_snapshot={values['upload_full_snapshot']}\n")
+              handle.write(f"upload_sampled_snapshot={values['upload_sampled_snapshot']}\n")
           PY
 
       - name: Configure SSH
@@ -452,14 +462,14 @@ jobs:
           done
           {
             echo "run_id=${GITHUB_RUN_ID}"
-            echo "full_snapshot_embedded=${SNAPSHOT_UPLOAD_FULL_SNAPSHOT}"
+            echo "sampled_snapshot_embedded=${SNAPSHOT_UPLOAD_SAMPLED_SNAPSHOT}"
             echo "registry=tango-remote"
             echo "execution_host=tango-1-1"
             echo "workflow_runner=ubuntu-latest"
           } > artifacts/research-snapshot-provenance/source.txt
 
       - name: Upload complete sampled snapshot artifact
-        if: ${{ steps.snapshot_options.outputs.upload_full_snapshot == 'true' }}
+        if: ${{ steps.snapshot_options.outputs.upload_sampled_snapshot == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: research-snapshot-${{ github.run_id }}

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -53,7 +53,7 @@ def _research_snapshot_dispatch(
     options = {
         "data_profile": "pm5d-execution",
         "data_gate": "warn",
-        "upload_full_snapshot": True,
+        "upload_sampled_snapshot": True,
     }
     blockers: list[str] = []
     if not _parse_symbols(symbols):

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -412,7 +412,7 @@ def main() -> int:
             "audit_lookback_hours": int(args.audit_lookback_hours),
             "data_gate": snapshot_data_gate,
             "snapshot_registry_dir": "",
-            "upload_full_snapshot": True,
+            "upload_sampled_snapshot": True,
         }
         snapshot_fields = {
             "git_ref": git_ref,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -94,13 +94,13 @@
   - After boot, use Cloud Assistant if needed to run `systemctl enable --now actions.runner.proerror77-ploy.ploy-ci-1.service`.
   - Confirm queued workflow runs move to `in_progress` before assuming ploy-ci work has actually started.
 
-- Pattern: AutoFactor / settlement-probability PRD downstream evidence does not need a live self-hosted runner once a full research snapshot artifact exists.
+- Pattern: AutoFactor / settlement-probability PRD downstream evidence does not need a live self-hosted runner once a complete sampled research snapshot artifact exists.
 - Rule: Prefer GitHub-hosted `ubuntu-latest` artifact workflows for AutoFactor mining, promotion, and dry-run handoff gates. Treat `ploy-ci-1` as a legacy DB-adjacent fallback only for fresh snapshot/export work that still requires Tango private-network database access.
 - Migration guardrail:
   - Do not describe `ploy-ci-1` as the default research/backtest runner for current PM5D evidence. Name the GitHub-hosted artifact path first, then call out `ploy-ci-1` only if fresh private-network DB export is the actual blocker.
   - Use `factor-walk-forward-v2-hosted-artifact.yml` or `settlement-probability-prd-gate.yml` with `snapshot_run_id` before dispatching legacy `factor-walk-forward-v2.yml`.
   - Do not move a DB/private-endpoint workflow to GitHub-hosted runners by changing only `runs-on`; first replace the data source with a portable artifact or a hosted-safe export path.
-  - When a full snapshot artifact exists, do not block strategy promotion on `ploy-ci-1` availability.
+  - When a complete sampled snapshot artifact exists, do not block strategy promotion on `ploy-ci-1` availability.
 
 ## 2026-03-06
 
@@ -278,7 +278,7 @@
   snapshot manifest.
 - Rule: Artifact-backed research loops should resolve default windows from the
   snapshot manifest and run sub-window searches against the retained artifact.
-  Do not re-export a full snapshot or rely on hidden inclusive-date semantics
+  Do not re-export a sampled snapshot or rely on hidden inclusive-date semantics
   just to test another factor window.
 
 ## 2026-05-13
@@ -295,7 +295,7 @@
   residual runtime orders/fills.
 
 - Pattern: GitHub-hosted artifact workflows are now the default efficient
-  research/search surface once a full snapshot artifact exists, but older notes
+  research/search surface once a complete sampled snapshot artifact exists, but older notes
   and habits still point agents at `ploy-ci-1`.
 - Rule: For PM5D AutoFactor mining, walk-forward promotion, and dry-run handoff
   checks, use GitHub-hosted artifact workflows by default. Treat `ploy-ci-1` as

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -68,7 +68,10 @@ trace, not dry-run promotion.
 - [x] Apply multi-horizon accounting gate so runtime replay target/horizon must
       match the promoted AutoFactor row before handoff.
 - [ ] Apply remaining high-priority cleanup: generated shared label/accounting
-      catalog and legacy terminology/API cleanup.
+      catalog.
+- [x] Rename active sampled snapshot API/provenance away from legacy
+      `full_snapshot` terminology while preserving workflow dispatch alias
+      compatibility.
 
 ## Review
 
@@ -181,6 +184,11 @@ trace, not dry-run promotion.
   target/horizon in `source_factor` / `decision_contract`, and promotion blocks
   replay tapes whose target or horizon differs from the factor row being
   promoted.
+- 2026-05-23: Active research snapshot dispatch now uses
+  `upload_sampled_snapshot`, and provenance now writes
+  `sampled_snapshot_embedded`. The `research-snapshot.yml` parser keeps a
+  backward-compatible alias for old dispatch payloads, but downstream active
+  metadata no longer describes sampled retained artifacts as full snapshots.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -128,6 +128,34 @@ class PersistResearchTraceContractTest(unittest.TestCase):
                         offenders.append(f"{path.relative_to(ROOT)}: {needle}")
         self.assertEqual([], offenders)
 
+    def test_active_sampled_snapshot_api_uses_canonical_names(self) -> None:
+        forbidden_identifiers = [
+            "upload_" + "full_snapshot",
+            "full_" + "snapshot_embedded",
+            "SNAPSHOT_UPLOAD_" + "FULL_SNAPSHOT",
+        ]
+        active_paths = [
+            ROOT / ".github" / "workflows" / "research-snapshot.yml",
+            ROOT / ".github" / "workflows" / "factor-review-v2-hosted-artifact.yml",
+            ROOT / ".github" / "workflows" / "factor-walk-forward-v2-hosted-artifact.yml",
+            ROOT / "scripts" / "research_manager_execute_plan.py",
+            ROOT / "scripts" / "run_settlement_probability_prd_gate.py",
+        ]
+        offenders: list[str] = []
+        for path in active_paths:
+            text = path.read_text(encoding="utf-8")
+            for needle in forbidden_identifiers:
+                if needle in text:
+                    offenders.append(f"{path.relative_to(ROOT)}: {needle}")
+        self.assertEqual([], offenders)
+
+        snapshot_workflow = (ROOT / ".github" / "workflows" / "research-snapshot.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("upload_sampled_snapshot", snapshot_workflow)
+        self.assertIn("sampled_snapshot_embedded=", snapshot_workflow)
+        self.assertIn('"upload_" + "full_snapshot": "upload_sampled_snapshot"', snapshot_workflow)
+
     def test_hosted_walk_forward_persists_trace_by_default(self) -> None:
         workflow = HOSTED_WALK.read_text(encoding="utf-8")
         persist_step = workflow.split("- name: Persist Research OS trace", 1)[1].split(

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -48,6 +48,9 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual(1, payload["executable_dispatch_count"])
         self.assertEqual("research-snapshot.yml", payload["dispatches"][0]["workflow"])
         self.assertEqual("2026-04-21", payload["dispatches"][0]["fields"]["start_date"])
+        options = json.loads(payload["dispatches"][0]["fields"]["options_json"])
+        self.assertTrue(options["upload_sampled_snapshot"])
+        self.assertNotIn("upload_full_snapshot", options)
 
     def test_execute_mode_requires_ack(self) -> None:
         payload = build_executor_payload(

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -157,6 +157,8 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
         self.assertEqual(options["pm_book_sample_secs"], 30)
         self.assertEqual(options["observation_sample_secs"], 30)
         self.assertEqual(options["max_quote_age_secs"], 30)
+        self.assertTrue(options["upload_sampled_snapshot"])
+        self.assertNotIn("upload_full_snapshot", options)
 
     def test_workflow_requires_snapshot_and_does_not_expose_legacy_build(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -127,6 +127,42 @@ fn research_snapshot_preserves_empty_timestamp_args_over_ssh() {
 }
 
 #[test]
+fn research_snapshot_uses_sampled_snapshot_canonical_names_with_legacy_alias() {
+    let workflow = workflow_contents(".github/workflows/research-snapshot.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "\"upload_sampled_snapshot\":true",
+        "\"upload_\" + \"full_snapshot\": \"upload_sampled_snapshot\"",
+        "options_json cannot include both {legacy_key} and {canonical_key}",
+        "handle.write(f\"upload_sampled_snapshot={values['upload_sampled_snapshot']}\\n\")",
+        "echo \"sampled_snapshot_embedded=${SNAPSHOT_UPLOAD_SAMPLED_SNAPSHOT}\"",
+        "steps.snapshot_options.outputs.upload_sampled_snapshot == 'true'",
+    ] {
+        if !workflow.contains(needle) {
+            offenders.push(format!("research-snapshot.yml: missing `{needle}`"));
+        }
+    }
+
+    for forbidden in [
+        "full_snapshot_embedded=${SNAPSHOT_UPLOAD_",
+        "steps.snapshot_options.outputs.upload_full_snapshot == 'true'",
+    ] {
+        if workflow.contains(forbidden) {
+            offenders.push(format!(
+                "research-snapshot.yml: still contains forbidden `{forbidden}`"
+            ));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "research snapshot sampled naming guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn factor_evolve_daily_search_passes_snapshot_quote_age() {
     let workflow = workflow_contents(".github/workflows/factor-evolve-daily-research.yml");
     let mut offenders = Vec::new();


### PR DESCRIPTION
## Summary
- rename active research snapshot option/provenance from full-snapshot wording to sampled-snapshot wording
- keep research-snapshot.yml backward-compatible with legacy upload_full_snapshot dispatch payloads, while rejecting alias + canonical collisions
- update Research Manager / settlement PRD dispatchers and regression guards

## Evidence stage
walk_forward / factor_attribution architecture cleanup, not dry-run promotion

## Verification
- python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_validate_autofactor_handoff_replay_gate tests.test_settlement_probability_prd_gate tests.test_persist_research_trace_contract tests.test_research_manager_execute_plan
- rtk cargo test --locked --test workflow_security
- ruby -e 'require "yaml"; %w[.github/workflows/research-snapshot.yml .github/workflows/factor-review-v2-hosted-artifact.yml .github/workflows/factor-walk-forward-v2-hosted-artifact.yml].each { |p| YAML.load_file(p); puts "ok #{p}" }'
- python3 -m py_compile scripts/research_manager_execute_plan.py scripts/run_settlement_probability_prd_gate.py tests/test_persist_research_trace_contract.py tests/test_research_manager_execute_plan.py tests/test_settlement_probability_prd_gate.py
- rtk git diff --check

actionlint was not available in this local PATH.