### PR TITLE
Research: share AutoFactor accounting catalog

### DIFF
--- a/config/autofactor_accounting_catalog.json
+++ b/config/autofactor_accounting_catalog.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "autofactor_accounting_catalog.v1",
+  "targets": {
+    "reprice_pnl_5s": {
+      "horizon": "5s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "quote_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": false
+    },
+    "full_depth_reprice_pnl_5s": {
+      "horizon": "5s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "full_depth_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": true
+    },
+    "reprice_pnl_10s": {
+      "horizon": "10s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "quote_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": false
+    },
+    "full_depth_reprice_pnl_10s": {
+      "horizon": "10s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "full_depth_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": true
+    },
+    "reprice_pnl_30s": {
+      "horizon": "30s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "quote_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": false
+    },
+    "full_depth_reprice_pnl_30s": {
+      "horizon": "30s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "full_depth_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": true
+    },
+    "reprice_pnl_60s": {
+      "horizon": "60s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "quote_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": false
+    },
+    "full_depth_reprice_pnl_60s": {
+      "horizon": "60s",
+      "accounting_lane": "repricing",
+      "strategy_profile": "repricing_momentum",
+      "required_execution_contract": "full_depth_repricing_exit",
+      "event_level_accounting": false,
+      "official_settlement_required": false,
+      "full_depth_entry_required": true
+    },
+    "settlement_executable_pnl": {
+      "horizon": "5m",
+      "accounting_lane": "settlement_probability",
+      "strategy_profile": "settlement_probability",
+      "required_execution_contract": "top_of_book_settlement_entry",
+      "event_level_accounting": true,
+      "official_settlement_required": true,
+      "full_depth_entry_required": false
+    },
+    "full_depth_settlement_executable_pnl": {
+      "horizon": "5m",
+      "accounting_lane": "settlement_probability",
+      "strategy_profile": "settlement_probability",
+      "required_execution_contract": "full_depth_settlement_entry",
+      "event_level_accounting": true,
+      "official_settlement_required": true,
+      "full_depth_entry_required": true
+    },
+    "tradeable_full_depth_settlement_pnl": {
+      "horizon": "5m",
+      "accounting_lane": "settlement_probability",
+      "strategy_profile": "settlement_probability",
+      "required_execution_contract": "full_depth_settlement_entry",
+      "event_level_accounting": true,
+      "official_settlement_required": true,
+      "full_depth_entry_required": true
+    }
+  }
+}

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
+use std::sync::OnceLock;
 
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
@@ -19,6 +20,44 @@ const SELECTOR_GATE_FEATURES: [&str; 4] = [
     "entry_capacity_score",
     "full_depth_entry_fillable_gate",
 ];
+const ACCOUNTING_CATALOG_JSON: &str =
+    include_str!("../../../config/autofactor_accounting_catalog.json");
+const ACCOUNTING_CATALOG_SCHEMA_VERSION: &str = "autofactor_accounting_catalog.v1";
+
+static ACCOUNTING_CATALOG: OnceLock<AutoFactorAccountingCatalog> = OnceLock::new();
+
+#[derive(Debug, Clone, Deserialize)]
+struct AutoFactorAccountingCatalog {
+    schema_version: String,
+    targets: BTreeMap<String, AutoFactorTargetContract>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoFactorTargetContract {
+    pub horizon: String,
+    pub accounting_lane: String,
+    pub strategy_profile: String,
+    pub required_execution_contract: String,
+    pub event_level_accounting: bool,
+    pub official_settlement_required: bool,
+    pub full_depth_entry_required: bool,
+}
+
+fn autofactor_accounting_catalog() -> &'static AutoFactorAccountingCatalog {
+    ACCOUNTING_CATALOG.get_or_init(|| {
+        let catalog: AutoFactorAccountingCatalog = serde_json::from_str(ACCOUNTING_CATALOG_JSON)
+            .expect("AutoFactor accounting catalog JSON must parse");
+        assert_eq!(
+            catalog.schema_version, ACCOUNTING_CATALOG_SCHEMA_VERSION,
+            "unsupported AutoFactor accounting catalog schema"
+        );
+        catalog
+    })
+}
+
+pub fn autofactor_target_contract(target: &str) -> Option<&'static AutoFactorTargetContract> {
+    autofactor_accounting_catalog().targets.get(target)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FactorExpr {
@@ -369,16 +408,9 @@ impl AutoFactorV2Target {
 }
 
 pub fn autofactor_target_horizon(target: &str) -> &'static str {
-    match target {
-        "reprice_pnl_5s" | "full_depth_reprice_pnl_5s" => "5s",
-        "reprice_pnl_10s" | "full_depth_reprice_pnl_10s" => "10s",
-        "reprice_pnl_30s" | "full_depth_reprice_pnl_30s" => "30s",
-        "reprice_pnl_60s" | "full_depth_reprice_pnl_60s" => "60s",
-        "settlement_executable_pnl"
-        | "full_depth_settlement_executable_pnl"
-        | "tradeable_full_depth_settlement_pnl" => "5m",
-        _ => "unknown",
-    }
+    autofactor_target_contract(target)
+        .map(|contract| contract.horizon.as_str())
+        .unwrap_or("unknown")
 }
 
 #[derive(Debug, Clone)]
@@ -3578,6 +3610,17 @@ mod tests {
         ] {
             assert_eq!(autofactor_target_horizon(target), "5m");
         }
+        let contract = autofactor_target_contract("full_depth_settlement_executable_pnl").unwrap();
+        assert_eq!(contract.accounting_lane, "settlement_probability");
+        assert_eq!(contract.strategy_profile, "settlement_probability");
+        assert_eq!(
+            contract.required_execution_contract,
+            "full_depth_settlement_entry"
+        );
+        assert!(contract.event_level_accounting);
+        assert!(contract.official_settlement_required);
+        assert!(contract.full_depth_entry_required);
         assert_eq!(autofactor_target_horizon("experimental_target"), "unknown");
+        assert!(autofactor_target_contract("experimental_target").is_none());
     }
 }

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -92,11 +92,12 @@ pub use alpha_search::{
 };
 pub use attribution::{factor_pnl, regime_pnl, AttributionReport, RegimePnl};
 pub use autofactor::{
-    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_target_horizon,
-    autofactor_windows_from_v2, domain_seed_candidates, evaluate_named_factor,
-    format_autofactor_reports, mine_autofactors, mine_domain_autofactors_from_v2,
-    mine_domain_autofactors_from_v2_with_guidance, mine_domain_autofactors_from_v2_with_mcts_plan,
-    AutoFactorDecision, AutoFactorError, AutoFactorMatrix, AutoFactorOptions, AutoFactorReport,
+    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_target_contract,
+    autofactor_target_horizon, autofactor_windows_from_v2, domain_seed_candidates,
+    evaluate_named_factor, format_autofactor_reports, mine_autofactors,
+    mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_guidance,
+    mine_domain_autofactors_from_v2_with_mcts_plan, AutoFactorDecision, AutoFactorError,
+    AutoFactorMatrix, AutoFactorOptions, AutoFactorReport, AutoFactorTargetContract,
     AutoFactorV2Target, FactorExpr, LlmMutationSpec, LlmPriorSpec, NamedFactorExpr,
 };
 pub use backtest::{run_binary_backtest, BacktestMetrics, SimulatedFill};

--- a/scripts/autofactor_accounting_catalog.py
+++ b/scripts/autofactor_accounting_catalog.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Shared AutoFactor target accounting catalog.
+
+The JSON catalog is the single repo-local contract for mapping an AutoFactor
+target label to its horizon and accounting lane. Promotion, replay builders,
+and Rust alpha-search code should not hand-roll target -> horizon mappings.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+CATALOG_SCHEMA_VERSION = "autofactor_accounting_catalog.v1"
+CATALOG_PATH = Path(__file__).resolve().parents[1] / "config" / "autofactor_accounting_catalog.json"
+
+
+@lru_cache(maxsize=1)
+def load_autofactor_accounting_catalog() -> dict[str, Any]:
+    payload = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != CATALOG_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported AutoFactor accounting catalog schema: "
+            f"{payload.get('schema_version')!r}"
+        )
+    targets = payload.get("targets")
+    if not isinstance(targets, dict):
+        raise ValueError("AutoFactor accounting catalog missing targets object")
+    return payload
+
+
+def autofactor_target_contract(target: str) -> dict[str, Any] | None:
+    targets = load_autofactor_accounting_catalog()["targets"]
+    contract = targets.get(target)
+    if contract is None:
+        return None
+    return dict(contract)
+
+
+def autofactor_target_horizon(target: str) -> str:
+    contract = autofactor_target_contract(target)
+    if contract is None:
+        return "unknown"
+    return str(contract.get("horizon") or "unknown")
+
+
+def validate_autofactor_source_contract(*, target: str, horizon: str) -> list[str]:
+    blockers: list[str] = []
+    if not target:
+        blockers.append("missing_source_target")
+        return blockers
+    contract = autofactor_target_contract(target)
+    if contract is None:
+        blockers.append(f"unknown_source_target:{target}")
+        return blockers
+    expected_horizon = str(contract.get("horizon") or "")
+    if not horizon:
+        blockers.append("missing_source_horizon")
+    elif expected_horizon and horizon != expected_horizon:
+        blockers.append(f"source_horizon_mismatch:{horizon}!={expected_horizon}")
+    return blockers

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -19,6 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from autofactor_accounting_catalog import autofactor_target_horizon
 from autofactor_runtime_contract import RuntimeContractResolver
 from research_snapshot_contract import load_snapshot_execution_contract
 
@@ -58,20 +59,6 @@ def replay_identity(*, runtime_score: str, strategy_profile: str, evidence: str,
         "evidence": evidence,
         "source_factor": source_factor or {},
     }
-
-
-def target_horizon(target: str) -> str:
-    if "reprice_pnl_5s" in target:
-        return "5s"
-    if "reprice_pnl_10s" in target:
-        return "10s"
-    if "reprice_pnl_30s" in target:
-        return "30s"
-    if "reprice_pnl_60s" in target:
-        return "60s"
-    if "settlement" in target:
-        return "5m"
-    return "unknown"
 
 
 def parse_autofactor_rows(report_text: str) -> list[dict[str, Any]]:
@@ -219,7 +206,7 @@ def build_artifact(
     source_factor = {
         "name": row.get("name", ""),
         "target": row.get("target", ""),
-        "horizon": target_horizon(str(row.get("target", ""))),
+        "horizon": autofactor_target_horizon(str(row.get("target", ""))),
         "decision": row.get("decision", ""),
         "reason": row.get("reason", ""),
     }
@@ -267,7 +254,7 @@ def build_artifact(
             "official_settlement": True,
             "full_depth_entry": True,
             "target": row.get("target", ""),
-            "horizon": target_horizon(str(row.get("target", ""))),
+            "horizon": autofactor_target_horizon(str(row.get("target", ""))),
             "stake_usd": stake_usd,
             "entry_policy": "top_scoring_bucket",
         },

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -17,6 +17,11 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
+from autofactor_accounting_catalog import (
+    autofactor_target_horizon,
+    validate_autofactor_source_contract,
+)
+
 
 RUNTIME_REPLAY_BASIS = "runtime_market_update_replay"
 COUNTERFACTUAL_THRESHOLDS = (
@@ -124,6 +129,24 @@ def normalize_counterfactual_threshold(raw: str) -> str:
             return label
     allowed = ", ".join(label for label, _suffix in COUNTERFACTUAL_THRESHOLDS)
     raise SystemExit(f"--configured-entry-threshold must be one of: {allowed}")
+
+
+def resolve_source_horizon(source_target: str, source_horizon: str) -> str:
+    if not source_target and not source_horizon:
+        return ""
+    if source_horizon:
+        blockers = validate_autofactor_source_contract(
+            target=source_target,
+            horizon=source_horizon,
+        )
+        if blockers:
+            raise SystemExit("; ".join(blockers))
+        return source_horizon
+    resolved = autofactor_target_horizon(source_target)
+    if resolved == "unknown":
+        blockers = validate_autofactor_source_contract(target=source_target, horizon="")
+        raise SystemExit("; ".join(blockers))
+    return resolved
 
 
 def score_counterfactual(
@@ -519,7 +542,7 @@ def main() -> int:
         source_factor_name=args.source_factor_name,
         source_dsl_hash=args.source_dsl_hash,
         source_target=args.source_target,
-        source_horizon=args.source_horizon,
+        source_horizon=resolve_source_horizon(args.source_target, args.source_horizon),
         stake_usd=decimal_arg(args.stake_usd, "--stake-usd"),
         full_depth_entry=args.full_depth_entry,
         min_trade_count=args.min_trade_count,

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -34,6 +34,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from autofactor_accounting_catalog import autofactor_target_horizon
 from autofactor_runtime_contract import RuntimeContractResolver
 from research_snapshot_contract import (
     load_snapshot_execution_contract,
@@ -155,20 +156,6 @@ def parse_int(raw: str) -> int:
 
 def finite_or_none(value: float) -> float | None:
     return value if value == value else None
-
-
-def target_horizon(target: str) -> str:
-    if "reprice_pnl_5s" in target:
-        return "5s"
-    if "reprice_pnl_10s" in target:
-        return "10s"
-    if "reprice_pnl_30s" in target:
-        return "30s"
-    if "reprice_pnl_60s" in target:
-        return "60s"
-    if "settlement" in target:
-        return "5m"
-    return "unknown"
 
 
 def parse_promotion_gate(report_text: str) -> PromotionGate:
@@ -664,7 +651,7 @@ def evaluate(
                 candidate_strategy_replay,
                 mapping=mapping,
                 expected_target=row.target,
-                expected_horizon=target_horizon(row.target),
+                expected_horizon=autofactor_target_horizon(row.target),
                 required_strategy_profile=required_strategy_profile,
                 min_replay_trade_count=min_replay_trade_count,
                 min_replay_fill_rate=min_replay_fill_rate,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -67,7 +67,7 @@ trace, not dry-run promotion.
       replay evidence.
 - [x] Apply multi-horizon accounting gate so runtime replay target/horizon must
       match the promoted AutoFactor row before handoff.
-- [ ] Apply remaining high-priority cleanup: generated shared label/accounting
+- [x] Apply remaining high-priority cleanup: generated shared label/accounting
       catalog.
 - [x] Rename active sampled snapshot API/provenance away from legacy
       `full_snapshot` terminology while preserving workflow dispatch alias
@@ -189,6 +189,12 @@ trace, not dry-run promotion.
   `sampled_snapshot_embedded`. The `research-snapshot.yml` parser keeps a
   backward-compatible alias for old dispatch payloads, but downstream active
   metadata no longer describes sampled retained artifacts as full snapshots.
+- 2026-05-23: Added shared `autofactor_accounting_catalog.v1` for AutoFactor
+  target -> horizon -> accounting lane -> required execution contract. Rust
+  alpha-search/persist consumers and Python promotion/replay builders now use
+  the shared catalog instead of hand-rolled target/horizon mappings; runtime
+  candidate replay rejects source horizon mismatches before producing a replay
+  artifact.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_autofactor_accounting_catalog.py
+++ b/tests/test_autofactor_accounting_catalog.py
@@ -1,0 +1,57 @@
+import json
+import unittest
+from pathlib import Path
+
+from scripts.autofactor_accounting_catalog import (
+    CATALOG_SCHEMA_VERSION,
+    autofactor_target_contract,
+    autofactor_target_horizon,
+    validate_autofactor_source_contract,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "config" / "autofactor_accounting_catalog.json"
+
+
+class AutoFactorAccountingCatalogTest(unittest.TestCase):
+    def test_catalog_schema_and_required_targets(self) -> None:
+        payload = json.loads(CATALOG.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], CATALOG_SCHEMA_VERSION)
+        targets = payload["targets"]
+        for target, horizon, lane in [
+            ("reprice_pnl_5s", "5s", "repricing"),
+            ("full_depth_reprice_pnl_30s", "30s", "repricing"),
+            ("full_depth_settlement_executable_pnl", "5m", "settlement_probability"),
+            ("tradeable_full_depth_settlement_pnl", "5m", "settlement_probability"),
+        ]:
+            with self.subTest(target=target):
+                contract = targets[target]
+                self.assertEqual(contract["horizon"], horizon)
+                self.assertEqual(contract["accounting_lane"], lane)
+                self.assertEqual(autofactor_target_horizon(target), horizon)
+                self.assertEqual(autofactor_target_contract(target), contract)
+
+    def test_source_contract_validation_blocks_unknown_or_mismatched_horizon(self) -> None:
+        self.assertEqual(
+            validate_autofactor_source_contract(
+                target="full_depth_settlement_executable_pnl",
+                horizon="5m",
+            ),
+            [],
+        )
+        self.assertEqual(
+            validate_autofactor_source_contract(
+                target="full_depth_settlement_executable_pnl",
+                horizon="30s",
+            ),
+            ["source_horizon_mismatch:30s!=5m"],
+        )
+        self.assertEqual(
+            validate_autofactor_source_contract(target="experimental", horizon="5m"),
+            ["unknown_source_target:experimental"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -173,6 +173,49 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertIn("Promotion ready: `true`", markdown)
         self.assertIn("## Acceptance Criteria", markdown)
 
+    def test_resolves_source_horizon_from_shared_catalog(self):
+        payload, _ = self.run_script(
+            runtime_eval_payload(),
+            "--full-depth-entry",
+            "--min-trade-count",
+            "2",
+            "--source-target",
+            "full_depth_settlement_executable_pnl",
+        )
+
+        self.assertEqual(payload["source_factor"]["horizon"], "5m")
+        self.assertEqual(payload["decision_contract"]["horizon"], "5m")
+
+    def test_blocks_source_horizon_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runtime_json = tmp_path / "runtime-eval.json"
+            output_json = tmp_path / "candidate-strategy-replay.json"
+            runtime_json.write_text(json.dumps(runtime_eval_payload()), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--runtime-evaluation-json",
+                    str(runtime_json),
+                    "--runtime-score",
+                    "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "--output-json",
+                    str(output_json),
+                    "--source-target",
+                    "full_depth_settlement_executable_pnl",
+                    "--source-horizon",
+                    "30s",
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("source_horizon_mismatch:30s!=5m", result.stderr)
+
     def test_blocks_zero_intent_runtime_replay_with_diagnostics(self):
         payload, _ = self.run_script(
             {


### PR DESCRIPTION
## Summary
- add shared autofactor_accounting_catalog.v1 for target -> horizon -> accounting lane -> execution contract
- switch Rust AutoFactor and Python replay/promotion builders to the shared catalog instead of local target-horizon inference
- make runtime candidate replay reject source target/horizon mismatches before emitting artifacts

## Evidence stage
walk_forward / factor_attribution architecture cleanup, not dry-run promotion

## Verification
- python3 -m unittest tests.test_autofactor_accounting_catalog tests.test_build_runtime_candidate_strategy_replay tests.test_build_autofactor_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_factor_walk_forward_sweep tests.test_validate_autofactor_handoff_replay_gate tests.test_settlement_probability_prd_gate tests.test_persist_research_trace_contract tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/autofactor_accounting_catalog.py scripts/build_runtime_candidate_strategy_replay.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_autofactor_accounting_catalog.py tests/test_build_runtime_candidate_strategy_replay.py
- rtk cargo test --locked -p ploy-research autofactor --lib
- rtk cargo test --locked -p ploy-research alpha_search --lib
- rtk cargo check --locked -p ploy-research --features db --example persist_research_trace
- rtk cargo test --locked --test workflow_security
- rtk git diff --check