### PR TITLE
Fix research snapshot audit window

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -222,12 +222,16 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts/research-snapshot
           remote_audit="${REMOTE_DIR}/research-snapshot/data-gap-audit.json"
+          audit_start_ts="${SNAPSHOT_START_TS:-${{ github.event.inputs.start_date }}}"
+          audit_end_ts="${SNAPSHOT_END_TS:-${{ github.event.inputs.end_date }}}"
 
           ssh tango-1-1 /bin/bash -s -- \
             "${DEPLOY_ROOT}" \
             "${REMOTE_DIR}" \
             "${remote_audit}" \
             "${SNAPSHOT_AUDIT_LOOKBACK_HOURS}" \
+            "${audit_start_ts}" \
+            "${audit_end_ts}" \
             "${{ github.event.inputs.symbols }}" \
             "${REQUIRED_SOURCES}" <<'EOF'
           set -euo pipefail
@@ -235,8 +239,10 @@ jobs:
           remote_dir="$2"
           remote_audit="$3"
           audit_lookback_hours="$4"
-          symbols="$5"
-          required_sources="$6"
+          audit_start_ts="$5"
+          audit_end_ts="$6"
+          symbols="$7"
+          required_sources="$8"
 
           set -a
           . "${deploy_root}/.env"
@@ -247,6 +253,8 @@ jobs:
           PLOY_DATABASE__URL="${PLOY_DATABASE__URL}" \
             "${deploy_root}/scripts/audit_market_data_gaps.py" \
               --lookback-hours "${audit_lookback_hours}" \
+              --start-ts "${audit_start_ts}" \
+              --end-ts "${audit_end_ts}" \
               --bucket-minutes 5 \
               --symbols "${symbols}" \
               --required-sources "${required_sources}" \

--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -124,16 +124,27 @@ def gap_query(
     bucket_minutes: int,
     recent_minutes: int,
     statement_timeout_seconds: int,
+    start_ts: Optional[str] = None,
+    end_ts: Optional[str] = None,
 ) -> str:
     table = ident(target.table_name)
     ts_col = ident(target.timestamp_column)
     predicate = target_predicate(target)
+    if start_ts and end_ts:
+        start_expr = f"date_trunc('minute', {sql_literal(start_ts)}::timestamptz)"
+        end_expr = (
+            f"date_trunc('minute', {sql_literal(end_ts)}::timestamptz "
+            f"- interval '{bucket_minutes} minutes')"
+        )
+    else:
+        start_expr = f"date_trunc('minute', now() - interval '{lookback_hours} hours')"
+        end_expr = f"date_trunc('minute', now() - interval '{bucket_minutes} minutes')"
     return f"""
 SET statement_timeout TO '{statement_timeout_seconds}s';
 WITH params AS (
   SELECT
-    date_trunc('minute', now() - interval '{lookback_hours} hours') AS start_at,
-    date_trunc('minute', now() - interval '{bucket_minutes} minutes') AS end_at,
+    {start_expr} AS start_at,
+    {end_expr} AS end_at,
     interval '{bucket_minutes} minutes' AS bucket_width
 ),
 buckets AS (
@@ -283,11 +294,19 @@ def classify_coverage(row: dict[str, Any], target: GapTarget) -> tuple[str, list
 
 
 def classify_gap_for_gate(
-    row: dict[str, Any], target: GapTarget, gate_mode: str
+    row: dict[str, Any], target: GapTarget, gate_mode: str, historical_window: bool = False
 ) -> tuple[str, list[str], str, list[str], str, list[str]]:
     freshness_status, freshness_reasons = classify_freshness(row, target)
     coverage_status, coverage_reasons = classify_coverage(row, target)
-    if gate_mode == "freshness":
+    if historical_window:
+        status = coverage_status
+        reasons = list(coverage_reasons)
+        if freshness_status != "ok":
+            reasons.extend(
+                f"freshness not enforced for historical window: {reason}"
+                for reason in freshness_reasons
+            )
+    elif gate_mode == "freshness":
         status = freshness_status
         reasons = list(freshness_reasons)
         if coverage_status != "ok":
@@ -321,8 +340,11 @@ def audit_gap_target(
     statement_timeout_seconds: int,
     psql_timeout_seconds: int,
     gate_mode: str,
+    start_ts: Optional[str] = None,
+    end_ts: Optional[str] = None,
 ) -> dict[str, Any]:
     started = time.monotonic()
+    historical_window = bool(start_ts and end_ts)
     try:
         row = run_json(
             gap_query(
@@ -331,6 +353,8 @@ def audit_gap_target(
                 bucket_minutes=bucket_minutes,
                 recent_minutes=recent_minutes,
                 statement_timeout_seconds=statement_timeout_seconds,
+                start_ts=start_ts,
+                end_ts=end_ts,
             ),
             psql_timeout_seconds,
         )
@@ -341,7 +365,7 @@ def audit_gap_target(
             freshness_reasons,
             coverage_status,
             coverage_reasons,
-        ) = classify_gap_for_gate(row, target, gate_mode)
+        ) = classify_gap_for_gate(row, target, gate_mode, historical_window)
         row["status"] = status
         row["reasons"] = reasons
         row["freshness_status"] = freshness_status
@@ -364,6 +388,9 @@ def audit_gap_target(
             "coverage_status": "unknown",
             "coverage_reasons": [str(exc)],
         }
+    if historical_window:
+        row["audit_window_start_ts"] = start_ts
+        row["audit_window_end_ts"] = end_ts
     row["query_ms"] = round((time.monotonic() - started) * 1000)
     return row
 
@@ -651,6 +678,17 @@ def parse_source_requirements(raw: str) -> list[str]:
     return out
 
 
+def parse_audit_timestamp(raw: str, *, label: str) -> str:
+    value = raw.strip()
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def source_aliases(target: GapTarget | dict[str, Any]) -> set[str]:
     if isinstance(target, GapTarget):
         source_id = target.source_id
@@ -737,6 +775,16 @@ def print_text(payload: dict[str, Any]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lookback-hours", type=int, default=168)
+    parser.add_argument(
+        "--start-ts",
+        default="",
+        help="optional explicit audit window start timestamp; makes coverage historical",
+    )
+    parser.add_argument(
+        "--end-ts",
+        default="",
+        help="optional explicit audit window end timestamp; makes coverage historical",
+    )
     parser.add_argument("--bucket-minutes", type=int, default=5)
     parser.add_argument("--recent-minutes", type=int, default=15)
     parser.add_argument("--statement-timeout-seconds", type=int, default=20)
@@ -778,6 +826,20 @@ def main() -> int:
         parser.error("--bucket-minutes must be positive")
     if args.recent_minutes <= 0:
         parser.error("--recent-minutes must be positive")
+    start_ts = args.start_ts.strip()
+    end_ts = args.end_ts.strip()
+    if bool(start_ts) != bool(end_ts):
+        parser.error("--start-ts and --end-ts must be provided together")
+    if start_ts and end_ts:
+        try:
+            start_ts = parse_audit_timestamp(start_ts, label="--start-ts")
+            end_ts = parse_audit_timestamp(end_ts, label="--end-ts")
+        except ValueError as exc:
+            parser.error(str(exc))
+        if datetime.fromisoformat(start_ts.replace("Z", "+00:00")) >= datetime.fromisoformat(
+            end_ts.replace("Z", "+00:00")
+        ):
+            parser.error("--start-ts must be before --end-ts")
 
     symbols = parse_symbols(args.symbols)
     source_requirements = parse_source_requirements(args.required_sources)
@@ -793,6 +855,8 @@ def main() -> int:
             statement_timeout_seconds=args.statement_timeout_seconds,
             psql_timeout_seconds=args.psql_timeout_seconds,
             gate_mode=args.gate_mode,
+            start_ts=start_ts or None,
+            end_ts=end_ts or None,
         )
         for target in selected_gap_targets
     ]
@@ -822,6 +886,8 @@ def main() -> int:
         if os.environ.get("PLOY_DATABASE__URL")
         else ("DATABASE_URL" if os.environ.get("DATABASE_URL") else "default-local"),
         "lookback_hours": args.lookback_hours,
+        "audit_window_start_ts": start_ts or None,
+        "audit_window_end_ts": end_ts or None,
         "bucket_minutes": args.bucket_minutes,
         "recent_minutes": args.recent_minutes,
         "gate_mode": args.gate_mode,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -76,6 +76,10 @@ trace, not dry-run promotion.
       `main` trace-plan evidence.
 - [x] Record that the restored chain currently returns `fix_data` with zero
       qualified candidates, not dry-run-ready strategy discovery.
+- [x] Execute the Research Manager `fix_data` plan in dry-run and bounded
+      execute mode.
+- [x] Fix research snapshot data audit so it uses the requested dataset window
+      instead of a moving `now()-lookback` window.
 
 ## Review
 
@@ -229,6 +233,27 @@ trace, not dry-run promotion.
   Research Manager planning, but automatic research/backtest/strategy discovery
   is not proven until `research-manager-execute-plan.yml` drives the next
   bounded run and attaches evidence without manual artifact interpretation.
+- 2026-05-23: Research Manager executor dry-run `26336537960` read trace-plan
+  run `26336127621` and produced one ready dispatch:
+  `research-snapshot.yml` with `start_date=2026-05-16`,
+  `end_date=2026-05-21`, `symbols=BTCUSDT,ETHUSDT,SOLUSDT`,
+  `data_profile=pm5d-execution`, and `upload_sampled_snapshot=true`.
+- 2026-05-23: Research Manager executor execute run `26336555894` dispatched
+  snapshot run `26336559175` from `main` merge commit
+  `945e557afc5eb9766b1ba94c9c86fcabef26d036`. The snapshot run failed in
+  `Audit required market data on tango-1-1`, proving a data-audit window bug:
+  the requested dataset window was `2026-05-16 -> 2026-05-21`, but
+  `audit_market_data_gaps.py` audited `now()-168h` and blocked on Binance gaps
+  from `2026-05-22`, outside the requested dataset window.
+- 2026-05-23: Fixed the snapshot audit path to pass explicit historical
+  `--start-ts` / `--end-ts` bounds from `research-snapshot.yml` into
+  `scripts/audit_market_data_gaps.py`. In explicit historical-window mode,
+  coverage is audited over the requested dataset interval and current
+  freshness is reported but not enforced. Focused validation passed:
+  `python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_research_manager_execute_plan`,
+  `rtk cargo test --locked --test workflow_security`, `python3 -m py_compile
+  scripts/audit_market_data_gaps.py tests/test_market_data_gap_audit_scope.py`,
+  and `rtk git diff --check`.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -7,6 +7,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 AUDIT_SCRIPT = ROOT / "scripts" / "audit_market_data_gaps.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "market-data-gap-audit.yml"
+RESEARCH_SNAPSHOT_WORKFLOW = ROOT / ".github" / "workflows" / "research-snapshot.yml"
 CLOUD_ASSIST_SCRIPT = ROOT / "scripts" / "ci" / "run_tango_market_data_audit_cloud_assist.py"
 
 
@@ -44,6 +45,79 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         requirements = audit.parse_source_requirements("research-windows")
         self.assertEqual(requirements, ["research_valid_windows"])
 
+    def test_gap_query_uses_lookback_without_explicit_window(self) -> None:
+        audit = load_audit_module()
+        target = audit.GapTarget(
+            "binance_price/BTCUSDT",
+            "binance_price_ticks",
+            "trade_time",
+            600,
+            filter_column="symbol",
+            filter_value="BTCUSDT",
+        )
+
+        query = audit.gap_query(
+            target,
+            lookback_hours=168,
+            bucket_minutes=5,
+            recent_minutes=15,
+            statement_timeout_seconds=20,
+        )
+
+        self.assertIn("now() - interval '168 hours'", query)
+        self.assertIn("now() - interval '5 minutes'", query)
+        self.assertNotIn("2026-05-16T00:00:00Z", query)
+
+    def test_gap_query_uses_explicit_historical_window_when_provided(self) -> None:
+        audit = load_audit_module()
+        target = audit.GapTarget(
+            "binance_price/BTCUSDT",
+            "binance_price_ticks",
+            "trade_time",
+            600,
+            filter_column="symbol",
+            filter_value="BTCUSDT",
+        )
+
+        query = audit.gap_query(
+            target,
+            lookback_hours=168,
+            bucket_minutes=5,
+            recent_minutes=15,
+            statement_timeout_seconds=20,
+            start_ts="2026-05-16T00:00:00Z",
+            end_ts="2026-05-21T00:00:00Z",
+        )
+
+        self.assertIn("'2026-05-16T00:00:00Z'::timestamptz", query)
+        self.assertIn("'2026-05-21T00:00:00Z'::timestamptz", query)
+        self.assertIn("- interval '5 minutes'", query)
+        self.assertNotIn("now() - interval '168 hours'", query)
+
+    def test_historical_window_gate_ignores_current_freshness(self) -> None:
+        audit = load_audit_module()
+        target = audit.GapTarget("binance_price/BTCUSDT", "binance_price_ticks", "trade_time", 600)
+        row = {
+            "latest_at": None,
+            "latest_lag_seconds": None,
+            "max_gap_minutes": 0,
+            "missing_buckets": 0,
+        }
+
+        status, reasons, freshness_status, _, coverage_status, _ = audit.classify_gap_for_gate(
+            row,
+            target,
+            "coverage",
+            historical_window=True,
+        )
+
+        self.assertEqual("ok", status)
+        self.assertEqual("critical", freshness_status)
+        self.assertEqual("ok", coverage_status)
+        self.assertTrue(
+            any("freshness not enforced for historical window" in reason for reason in reasons)
+        )
+
     def test_scheduled_workflow_uses_collector_scope(self) -> None:
         workflow = WORKFLOW.read_text()
         self.assertIn("REQUIRED_SOURCES: pm5d-vol", workflow)
@@ -60,6 +134,13 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
             workflow,
         )
         self.assertIn('gate_mode="coverage"', workflow)
+
+    def test_research_snapshot_audit_uses_requested_dataset_window(self) -> None:
+        workflow = RESEARCH_SNAPSHOT_WORKFLOW.read_text()
+        self.assertIn('audit_start_ts="${SNAPSHOT_START_TS:-${{ github.event.inputs.start_date }}}"', workflow)
+        self.assertIn('audit_end_ts="${SNAPSHOT_END_TS:-${{ github.event.inputs.end_date }}}"', workflow)
+        self.assertIn('--start-ts "${audit_start_ts}"', workflow)
+        self.assertIn('--end-ts "${audit_end_ts}"', workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add explicit historical audit window bounds to audit_market_data_gaps.py
- pass the requested research snapshot dataset window into the Tango data-audit step
- record the Research Manager executor run and failed snapshot evidence that exposed the moving lookback bug

## Verification
- python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_research_manager_execute_plan
- rtk cargo test --locked --test workflow_security
- python3 -m py_compile scripts/audit_market_data_gaps.py tests/test_market_data_gap_audit_scope.py
- rtk git diff --check