### PR TITLE
Fix Research Manager bounded snapshot dispatch

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,46 @@ def _date_from_ts(raw: str | None) -> str:
     return raw.split("T", 1)[0]
 
 
+def _parse_utc_ts(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_utc_ts(ts: datetime) -> str:
+    return ts.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _bounded_snapshot_window(
+    market_data: dict[str, Any],
+    max_window_days: int,
+) -> dict[str, Any]:
+    start = _parse_utc_ts(market_data.get("dataset_start_ts"))
+    end = _parse_utc_ts(market_data.get("dataset_end_ts"))
+    if not start or not end or end <= start:
+        return {
+            "start_date": _date_from_ts(market_data.get("dataset_start_ts")),
+            "end_date": _date_from_ts(market_data.get("dataset_end_ts")),
+            "start_ts": market_data.get("dataset_start_ts") or "",
+            "end_ts": market_data.get("dataset_end_ts") or "",
+            "truncated": False,
+            "max_window_days": max_window_days,
+        }
+    capped_end = min(end, start + timedelta(days=max_window_days))
+    return {
+        "start_date": start.date().isoformat(),
+        "end_date": capped_end.date().isoformat(),
+        "start_ts": _format_utc_ts(start),
+        "end_ts": _format_utc_ts(capped_end),
+        "truncated": capped_end < end,
+        "max_window_days": max_window_days,
+        "source_end_ts": _format_utc_ts(end),
+    }
+
+
 def _parse_symbols(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
@@ -46,11 +87,16 @@ def _research_snapshot_dispatch(
     git_ref: str,
     symbols: str,
     stake_usd: str,
+    max_snapshot_window_days: int,
 ) -> dict[str, Any]:
     market_data = ((plan.get("input") or {}).get("market_data_health") or {})
-    start_date = _date_from_ts(market_data.get("dataset_start_ts"))
-    end_date = _date_from_ts(market_data.get("dataset_end_ts"))
+    window = _bounded_snapshot_window(
+        market_data,
+        max_window_days=max(1, max_snapshot_window_days),
+    )
     options = {
+        "start_ts": window["start_ts"],
+        "end_ts": window["end_ts"],
         "data_profile": "pm5d-execution",
         "data_gate": "warn",
         "upload_sampled_snapshot": True,
@@ -60,8 +106,8 @@ def _research_snapshot_dispatch(
         blockers.append("missing_symbols")
     fields = {
         "git_ref": git_ref,
-        "start_date": start_date,
-        "end_date": end_date,
+        "start_date": window["start_date"],
+        "end_date": window["end_date"],
         "symbols": symbols,
         "stake_usd": stake_usd,
         "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
@@ -72,6 +118,7 @@ def _research_snapshot_dispatch(
         "ready": not blockers,
         "blockers": blockers,
         "fields": fields,
+        "bounded_window": window,
     }
 
 
@@ -132,6 +179,7 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                 git_ref=args.git_ref,
                 symbols=args.symbols,
                 stake_usd=args.stake_usd,
+                max_snapshot_window_days=args.max_snapshot_window_days,
             )
         )
 
@@ -229,6 +277,7 @@ def main() -> None:
     parser.add_argument("--symbols", default="")
     parser.add_argument("--stake-usd", default="15")
     parser.add_argument("--chain-remaining", type=int, default=1)
+    parser.add_argument("--max-snapshot-window-days", type=int, default=2)
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -80,6 +80,8 @@ trace, not dry-run promotion.
       execute mode.
 - [x] Fix research snapshot data audit so it uses the requested dataset window
       instead of a moving `now()-lookback` window.
+- [x] Fix Research Manager snapshot dispatch so exact timestamp windows and
+      short bounded compile windows are part of the machine contract.
 
 ## Review
 
@@ -254,6 +256,22 @@ trace, not dry-run promotion.
   `rtk cargo test --locked --test workflow_security`, `python3 -m py_compile
   scripts/audit_market_data_gaps.py tests/test_market_data_gap_audit_scope.py`,
   and `rtk git diff --check`.
+- 2026-05-23: Post-deploy executor run `26336977024` dispatched snapshot run
+  `26336990239` from `main` commit
+  `06d57e2bcdf14a449a475e0751dd1b133cab49b9`. The market-data audit step now
+  passed with `audit_window_start_ts=2026-05-16T00:00:00Z` and
+  `audit_window_end_ts=2026-05-21T00:00:00Z`, proving the moving-window audit
+  bug was fixed. The run then timed out/cancelled in `Compile snapshot on
+  tango-1-1` at the 60-minute job limit and uploaded provenance only, so the
+  next blocker is snapshot compile boundedness and exact dispatch window
+  semantics, not data audit coverage.
+- 2026-05-23: Research Manager executor now passes exact `start_ts` /
+  `end_ts` through `options_json` and caps fix-data snapshot refreshes to a
+  default 2-day compile window. Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan tests.test_market_data_gap_audit_scope`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py`,
+  `rtk git diff --check`, and a dry-run against trace-plan run `26336127621`
+  produced `2026-05-16T00:00:00Z -> 2026-05-18T00:00:00Z` dispatch options.
 
 # Candidate Replay Durable Trace (2026-05-23)
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -40,6 +40,7 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
                 symbols="BTCUSDT,ETHUSDT",
                 stake_usd="15",
                 chain_remaining=1,
+                max_snapshot_window_days=2,
             ),
             plan_payload("fix_data", ["rerun_snapshot_data_audit"]),
         )
@@ -48,8 +49,11 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual(1, payload["executable_dispatch_count"])
         self.assertEqual("research-snapshot.yml", payload["dispatches"][0]["workflow"])
         self.assertEqual("2026-04-21", payload["dispatches"][0]["fields"]["start_date"])
+        self.assertEqual("2026-04-23", payload["dispatches"][0]["fields"]["end_date"])
         options = json.loads(payload["dispatches"][0]["fields"]["options_json"])
         self.assertTrue(options["upload_sampled_snapshot"])
+        self.assertEqual("2026-04-21T00:00:00Z", options["start_ts"])
+        self.assertEqual("2026-04-23T00:00:00Z", options["end_ts"])
         self.assertNotIn("upload_full_snapshot", options)
 
     def test_execute_mode_requires_ack(self) -> None:
@@ -62,6 +66,7 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
                 symbols="BTCUSDT",
                 stake_usd="15",
                 chain_remaining=1,
+                max_snapshot_window_days=2,
             ),
             plan_payload("continue_search", ["continue_hosted_alpha_search"]),
         )
@@ -78,6 +83,7 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
                 symbols="BTCUSDT",
                 stake_usd="15",
                 chain_remaining=2,
+                max_snapshot_window_days=2,
             ),
             plan_payload("continue_search", ["continue_hosted_alpha_search"]),
         )
@@ -112,6 +118,43 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             self.assertTrue((out / "research-manager-executor.json").exists())
             self.assertTrue((out / "research-manager-executor.md").exists())
             self.assertTrue((out / "next-llm-prior.json").exists())
+
+    def test_fix_data_snapshot_dispatch_caps_large_dataset_window(self) -> None:
+        payload = build_executor_payload(
+            Namespace(
+                mode="dry_run",
+                execute_ack="",
+                git_ref="main",
+                snapshot_run_id="",
+                symbols="BTCUSDT,ETHUSDT,SOLUSDT",
+                stake_usd="15",
+                chain_remaining=1,
+                max_snapshot_window_days=2,
+            ),
+            {
+                "schema_version": "research_trace_plan.v1",
+                "input": {
+                    "market_data_health": {
+                        "dataset_start_ts": "2026-05-16T00:00:00Z",
+                        "dataset_end_ts": "2026-05-21T00:00:00Z",
+                    }
+                },
+                "plan": {
+                    "theme": "fix_data",
+                    "priority": "high",
+                    "evidence_stage": "factor_attribution",
+                    "actions": ["rerun_snapshot_data_audit"],
+                },
+            },
+        )
+
+        dispatch = payload["dispatches"][0]
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertEqual("2026-05-16", dispatch["fields"]["start_date"])
+        self.assertEqual("2026-05-18", dispatch["fields"]["end_date"])
+        self.assertEqual("2026-05-16T00:00:00Z", options["start_ts"])
+        self.assertEqual("2026-05-18T00:00:00Z", options["end_ts"])
+        self.assertTrue(dispatch["bounded_window"]["truncated"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- pass exact Research Manager dataset timestamps through snapshot options
- cap fix-data snapshot refreshes to a default 2-day compile window
- record the post-audit compile timeout evidence in tasks/todo.md

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_market_data_gap_audit_scope
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- rtk git diff --check
- dry-run executor against trace-plan run 26336127621 produced 2026-05-16T00:00:00Z -> 2026-05-18T00:00:00Z snapshot options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Research Manager now bounds snapshot refresh windows to a configurable maximum duration (default: 2 days) to prevent excessive dataset processing.
  * Snapshot requests include exact start and end timestamps for improved accuracy.

* **Bug Fixes**
  * Fixed moving-window behavior in snapshot refresh processing.

* **Tests**
  * Added validation tests for snapshot window capping behavior with large datasets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->