### PR TITLE
Fix Research Manager blocker classification

### DIFF
--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -211,6 +211,10 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
     Ok(match row {
         Some(row) => {
             let surface_blockers = source_surface_blockers(&row.3);
+            let data_repair_blockers = blockers_by_type(&surface_blockers, "data_repair");
+            let promotion_blockers = blockers_by_type(&surface_blockers, "promotion");
+            let has_surface_blockers = !surface_blockers.is_empty();
+            let has_data_repair_blockers = !data_repair_blockers.is_empty();
             json!({
                 "source": "research_dataset_snapshots",
                 "data_snapshot_id": row.0,
@@ -219,8 +223,10 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
                 "source_surfaces": row.3,
                 "row_counts": row.4,
                 "surface_blockers": surface_blockers,
-                "missing_blocks_promotion": !surface_blockers.is_empty(),
-                "critical_missing": !surface_blockers.is_empty(),
+                "data_repair_blockers": data_repair_blockers,
+                "promotion_blockers": promotion_blockers,
+                "missing_blocks_promotion": has_surface_blockers,
+                "critical_missing": has_data_repair_blockers,
             })
         }
         None => json!({
@@ -229,6 +235,19 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
             "reason": "no_research_dataset_snapshots",
         }),
     })
+}
+
+fn blockers_by_type(blockers: &[Value], blocker_type: &str) -> Vec<Value> {
+    blockers
+        .iter()
+        .filter(|blocker| {
+            blocker
+                .get("blocker_type")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value == blocker_type)
+        })
+        .cloned()
+        .collect()
 }
 
 fn source_surface_blockers(source_surfaces: &Value) -> Vec<Value> {
@@ -257,23 +276,27 @@ fn source_surface_blockers(source_surfaces: &Value) -> Vec<Value> {
                 .unwrap_or(false);
             let requires_execution = gate_category == "required_for_execution";
 
-            let reason = if gate_category == "missing_blocks_promotion" {
-                Some("surface_declared_missing_blocks_promotion")
+            let blocker = if gate_category == "missing_blocks_promotion" {
+                Some(("surface_declared_missing_blocks_promotion", "promotion"))
             } else if requires_execution && row_count == Some(0) {
-                Some("required_execution_surface_empty")
+                Some(("required_execution_surface_empty", "data_repair"))
             } else if requires_execution && row_count.is_none() {
-                Some("required_execution_surface_not_materialized")
+                Some(("required_execution_surface_not_materialized", "promotion"))
             } else if requires_execution && snapshot_sampled {
-                Some("required_execution_surface_is_sampled_snapshot")
+                Some((
+                    "required_execution_surface_is_sampled_snapshot",
+                    "promotion",
+                ))
             } else {
                 None
             };
 
-            reason.map(|reason| {
+            blocker.map(|(reason, blocker_type)| {
                 json!({
                     "surface": name,
                     "gate_category": gate_category,
                     "reason": reason,
+                    "blocker_type": blocker_type,
                 })
             })
         })

--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -62,16 +62,8 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
 
     if has_any_key_value(
         &input.market_data_health,
-        &[
-            "missing",
-            "stale",
-            "critical_missing",
-            "missing_blocks_promotion",
-        ],
+        &["missing", "stale", "critical_missing"],
         &[true.into(), "true".into(), "critical".into()],
-    ) || contains_string(
-        &input.market_data_health,
-        &["missing_blocks_promotion", "stale", "critical_missing"],
     ) {
         return Ok(plan(
             "fix_data",
@@ -88,7 +80,15 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
 
     if contains_string(
         &input.latest_runs,
-        &["replay_parity_missing", "runtime_parity_missing"],
+        &[
+            "replay_parity_missing",
+            "runtime_parity_missing",
+            "candidate_strategy_replay_not_runtime_replay",
+            "candidate_strategy_replay_missing",
+            "missing_runtime_contract",
+            "runtime_contract_unmapped_factor",
+            "missing_runtime_strategy_mapping",
+        ],
     ) || has_any_key_value(
         &input.latest_runs,
         &["replay_parity_ready", "runtime_parity_ready"],
@@ -232,11 +232,40 @@ mod tests {
         let plan = plan_next_research(&input(
             "walk_forward",
             serde_json::json!({}),
-            serde_json::json!({"surfaces": [{"name": "clob", "missing_blocks_promotion": true}]}),
+            serde_json::json!({"critical_missing": true, "surface_blockers": [{"name": "clob", "blocker_type": "data_repair"}]}),
         ))
         .expect("plan");
         assert_eq!(plan.theme, "fix_data");
         assert_eq!(plan.candidate_count, 0);
+    }
+
+    #[test]
+    fn planner_does_not_rerun_snapshot_for_promotion_only_blockers() {
+        let plan = plan_next_research(&input(
+            "factor_attribution",
+            serde_json::json!({}),
+            serde_json::json!({
+                "missing_blocks_promotion": true,
+                "critical_missing": false,
+                "promotion_blockers": [
+                    {"surface": "clob_orderbook_snapshots", "reason": "required_execution_surface_is_sampled_snapshot"}
+                ]
+            }),
+        ))
+        .expect("plan");
+        assert_ne!(plan.theme, "fix_data");
+        assert!(plan.candidate_count > 0);
+    }
+
+    #[test]
+    fn planner_routes_runtime_contract_blockers_to_runtime_repair() {
+        let plan = plan_next_research(&input(
+            "factor_attribution",
+            serde_json::json!({"blockers": ["missing_runtime_contract:auto_settlement_edge"]}),
+            serde_json::json!({"missing_blocks_promotion": true, "critical_missing": false}),
+        ))
+        .expect("plan");
+        assert_eq!(plan.theme, "fix_runtime");
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -82,6 +82,8 @@ trace, not dry-run promotion.
       instead of a moving `now()-lookback` window.
 - [x] Fix Research Manager snapshot dispatch so exact timestamp windows and
       short bounded compile windows are part of the machine contract.
+- [x] Split Research Manager data-repair blockers from promotion/runtime
+      blockers so successful snapshots do not loop back into `fix_data`.
 
 ## Review
 
@@ -272,6 +274,14 @@ trace, not dry-run promotion.
   `python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py`,
   `rtk git diff --check`, and a dry-run against trace-plan run `26336127621`
   produced `2026-05-16T00:00:00Z -> 2026-05-18T00:00:00Z` dispatch options.
+- 2026-05-23: After PR #628 merged, executor run `26338513688` dispatched
+  bounded snapshot `26338516159`, which completed successfully from
+  `2026-05-16T00:00:00Z` to `2026-05-18T00:00:00Z`; hosted walk-forward
+  `26338723709` completed and persisted durable trace with
+  `evidence_stages=factor_attribution,walk_forward`. Trace-plan run
+  `26338820517` still returned `fix_data`, but the blocker was now planner
+  classification: sampled execution surfaces and missing runtime replay are
+  promotion/runtime blockers, not reasons to rerun the same snapshot audit.
 
 # Candidate Replay Durable Trace (2026-05-23)
 


### PR DESCRIPTION
## Summary
- distinguish data-repair blockers from promotion-only blockers in trace-plan snapshot health
- stop routing promotion-only snapshot blockers back to fix_data
- route runtime contract/replay blockers to fix_runtime
- record bounded snapshot and walk-forward evidence in tasks/todo.md

## Validation
- rtk cargo test --locked -p ploy-research research_os::manager --lib
- rtk cargo check --locked -p ploy-research --features db --example research_trace_plan
- rtk git diff --check