### PR TITLE
Fix factor registry migration deduplication

### DIFF
--- a/migrations/042_factor_research_os_registry.sql
+++ b/migrations/042_factor_research_os_registry.sql
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS factor_registry (
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_factor_registry_dsl_hash
-    ON factor_registry(dsl_hash);
+-- A DSL hash can be reused across distinct targets or horizons. Migration 043
+-- owns the durable uniqueness contract after cleaning historical duplicates.
 CREATE INDEX IF NOT EXISTS idx_factor_registry_status_family
     ON factor_registry(status, factor_family, created_at DESC);
 

--- a/migrations/043_research_os_trace_constraints.sql
+++ b/migrations/043_research_os_trace_constraints.sql
@@ -5,6 +5,68 @@ ALTER TABLE factor_registry
 
 DROP INDEX IF EXISTS idx_factor_registry_dsl_hash;
 
+-- Historical preview runs could insert competing rows before the durable
+-- identity became (dsl_hash, target, horizon). Keep the most promoted row, then
+-- the newest row, and repoint evaluations before enforcing the final key.
+DROP TABLE IF EXISTS tmp_factor_registry_dedup;
+
+CREATE TEMP TABLE tmp_factor_registry_dedup AS
+WITH ranked AS (
+    SELECT
+        factor_id,
+        first_value(factor_id) OVER (
+            PARTITION BY dsl_hash, target, horizon
+            ORDER BY
+                CASE status
+                    WHEN 'production' THEN 0
+                    WHEN 'approved' THEN 1
+                    WHEN 'dry_run' THEN 2
+                    WHEN 'candidate' THEN 3
+                    WHEN 'evaluated' THEN 4
+                    WHEN 'compiled' THEN 5
+                    WHEN 'draft' THEN 6
+                    WHEN 'deprecated' THEN 7
+                    ELSE 8
+                END,
+                created_at DESC,
+                factor_id
+        ) AS survivor_factor_id,
+        row_number() OVER (
+            PARTITION BY dsl_hash, target, horizon
+            ORDER BY
+                CASE status
+                    WHEN 'production' THEN 0
+                    WHEN 'approved' THEN 1
+                    WHEN 'dry_run' THEN 2
+                    WHEN 'candidate' THEN 3
+                    WHEN 'evaluated' THEN 4
+                    WHEN 'compiled' THEN 5
+                    WHEN 'draft' THEN 6
+                    WHEN 'deprecated' THEN 7
+                    ELSE 8
+                END,
+                created_at DESC,
+                factor_id
+        ) AS row_num
+    FROM factor_registry
+)
+SELECT
+    factor_id AS duplicate_factor_id,
+    survivor_factor_id
+FROM ranked
+WHERE row_num > 1;
+
+UPDATE factor_evaluations
+SET factor_id = tmp_factor_registry_dedup.survivor_factor_id
+FROM tmp_factor_registry_dedup
+WHERE factor_evaluations.factor_id = tmp_factor_registry_dedup.duplicate_factor_id;
+
+DELETE FROM factor_registry
+USING tmp_factor_registry_dedup
+WHERE factor_registry.factor_id = tmp_factor_registry_dedup.duplicate_factor_id;
+
+DROP TABLE tmp_factor_registry_dedup;
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_factor_registry_dsl_target_horizon
     ON factor_registry(dsl_hash, target, horizon);
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18899,6 +18899,45 @@ Evidence stage: `walk_forward / runtime_parity`.
   `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`,
   and `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); puts "ok"'`.
 
+# Factor Registry Migration Dedup (2026-05-23)
+
+## Goal
+
+Unblock `deploy-tango-1-1` after Research Manager blocker classification landed
+by making the durable factor registry migrations compatible with historical
+duplicate `dsl_hash` rows.
+
+Evidence stage: `infrastructure/runtime planning repair`; no strategy promotion
+or dry-run readiness is implied.
+
+## Files / Ownership
+
+- `migrations/042_factor_research_os_registry.sql`
+  - Owner: base table creation without invalid `dsl_hash`-only uniqueness.
+- `migrations/043_research_os_trace_constraints.sql`
+  - Owner: historical duplicate consolidation and durable
+    `(dsl_hash, target, horizon)` uniqueness.
+- `tests/test_factor_research_os_registry.py`
+  - Owner: static regression coverage for migration contract.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Remove the obsolete `dsl_hash`-only unique index from migration 042.
+- [x] Add migration 043 deduplication before creating the composite unique
+      index.
+- [x] Run focused migration/static tests.
+- [ ] Commit, push, open PR, wait for CI, merge, and redeploy main.
+- [ ] Re-run Research Trace Plan after the fixed binary reaches tango-1-1.
+
+## Review
+
+- 2026-05-23: Validation passed:
+  `python3 -m unittest tests.test_factor_research_os_registry tests.test_persist_research_trace_contract`,
+  `python3 -m py_compile tests/test_factor_research_os_registry.py`, and
+  `rtk git diff --check`.
+
 # Runtime Replay Request Candidate Selection (2026-05-20)
 
 ## Goal

--- a/tests/test_factor_research_os_registry.py
+++ b/tests/test_factor_research_os_registry.py
@@ -34,6 +34,9 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
             r"status TEXT NOT NULL CHECK .*draft.*compiled.*evaluated.*candidate.*dry_run.*approved.*production.*deprecated",
         )
         self.assertIn("dsl_hash TEXT NOT NULL", sql)
+        self.assertNotIn("idx_factor_registry_dsl_hash", MIGRATION_042.read_text(encoding="utf-8"))
+        self.assertIn("tmp_factor_registry_dedup", sql)
+        self.assertIn("UPDATE factor_evaluations", sql)
         self.assertIn("idx_factor_registry_dsl_target_horizon", sql)
         self.assertIn("ON factor_registry(dsl_hash, target, horizon)", sql)
         self.assertIn("ast_json JSONB NOT NULL", sql)


### PR DESCRIPTION
## Summary
- remove obsolete dsl_hash-only unique index from migration 042
- deduplicate historical factor_registry rows before enforcing (dsl_hash, target, horizon)
- add migration contract regression coverage

## Validation
- python3 -m unittest tests.test_factor_research_os_registry tests.test_persist_research_trace_contract
- python3 -m py_compile tests/test_factor_research_os_registry.py
- rtk git diff --check

Evidence stage: infrastructure/runtime planning repair only; this does not promote any strategy.