### PR TITLE
Fix PM trade postflight poll window

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -412,7 +412,7 @@ jobs:
               local message="\$3"
               local attempts="\${4:-20}"
               local sleep_secs="\${5:-3}"
-              local since="\${DEPLOY_VERIFY_SINCE:-\${DEPLOY_STARTED_AT}}"
+              local since="\${DEPLOY_STARTED_AT}"
 
               for _ in \$(seq 1 "\${attempts}"); do
                 if journalctl -u "\${unit}" --since "\${since}" --no-pager | grep -E -q "\${pattern}"; then

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -128,7 +128,7 @@ wait_for_recent_log() {{
   local message="$3"
   local attempts="${{4:-20}}"
   local sleep_secs="${{5:-3}}"
-  local since="${{DEPLOY_VERIFY_SINCE:-${{DEPLOY_STARTED_AT}}}}"
+  local since="${{DEPLOY_STARTED_AT}}"
   for _ in $(seq 1 "${{attempts}}"); do
     if journalctl -u "${{unit}}" --since "${{since}}" --no-pager | grep -E -q "${{pattern}}"; then
       return 0

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,6 +28,11 @@ strategy promotion.
   bounded follow-up evidence dispatches: `compare_runtime_scorer_contract`
   builds a `runtime-candidate-replay.yml` plan, and
   `run_recorded_replay_parity` builds a `recorded-replay-parity.yml` plan.
+- 2026-05-24: Deploy run `26339975164` proved the SSH path passes the new
+  PM trade postflight, but the Cloud Assistant fallback still failed because
+  the successful-poll window was scoped to the fallback restart timestamp.
+  The PM trade successful-poll check now uses the whole current deploy window
+  (`DEPLOY_STARTED_AT`) while the error guard remains recent.
 
 ## Goal
 

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -89,6 +89,10 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
             self.assertIn("Polymarket trade collector poll complete", text)
             self.assertIn("pm trade collector did not complete a healthy poll after deploy", text)
             self.assertIn("pm trade collector failed after deploy", text)
+            if path.name == "deploy-tango-1-1.yml":
+                self.assertIn('local since="\\${DEPLOY_STARTED_AT}"', text)
+            else:
+                self.assertIn('local since="${{DEPLOY_STARTED_AT}}"', text)
             self.assertNotIn(
                 "clob_trade_ticks WHERE received_at >= NOW() - INTERVAL '5 minutes'",
                 text,


### PR DESCRIPTION
## Summary
- widen PM trade collector successful-poll health check to the current deploy window
- keep the recent error-log guard scoped to post-restart verification
- record deploy run 26339975164 evidence in tasks/todo.md

## Validation
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py
- python3 -m unittest tests.test_runtime_market_data_boundary
- YAML parse: deploy-tango-1-1.yml
- rtk cargo test --test workflow_security tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows -- --exact
- rtk git diff --check