### PR TITLE
Route Research Manager candidates through runtime contracts

### DIFF
--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -137,9 +137,9 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
     )
     .fetch_all(pool)
     .await?;
-    let recent: Vec<(String, String, String, String, String, Value)> = sqlx::query_as(
+    let recent: Vec<(String, String, String, String, String, Value, Value)> = sqlx::query_as(
         r#"
-        SELECT factor_name, dsl_hash, target, horizon, status, runtime_contract
+        SELECT factor_name, dsl_hash, target, horizon, status, runtime_contract, blockers_json
         FROM factor_registry
         ORDER BY created_at DESC
         LIMIT $1
@@ -162,6 +162,7 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
                 "horizon": row.3,
                 "status": row.4,
                 "runtime_contract": row.5,
+                "blockers": row.6,
             })
         }).collect::<Vec<_>>()
     }))

--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -107,6 +107,20 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
         ));
     }
 
+    if has_unblocked_runtime_candidate(&input.factor_registry_summary) {
+        return Ok(plan(
+            "candidate_to_runtime_replay",
+            1,
+            0,
+            "high",
+            &input.evidence_stage,
+            vec![
+                "build_runtime_candidate_replay",
+                "write_runtime_replay_trace_artifact",
+            ],
+        ));
+    }
+
     if contains_string(
         &input.latest_runs,
         &[
@@ -189,6 +203,50 @@ fn has_any_key_value(
         serde_json::Value::Array(items) => items
             .iter()
             .any(|item| has_any_key_value(item, keys, expected_values)),
+        _ => false,
+    }
+}
+
+fn has_unblocked_runtime_candidate(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            let status = map
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            let candidate_status = status.is_empty() || matches!(status, "candidate" | "watchlist");
+            let empty_row_blockers = json_array_empty(map.get("blockers"));
+            let contract = map.get("runtime_contract");
+            let unblocked_contract =
+                contract
+                    .and_then(serde_json::Value::as_object)
+                    .is_some_and(|contract| {
+                        let version_ok =
+                            contract.get("version").and_then(serde_json::Value::as_str)
+                                == Some("autofactor_runtime_contract_v1");
+                        version_ok
+                            && contract
+                                .get("runtime_score")
+                                .and_then(serde_json::Value::as_str)
+                                .is_some_and(|score| !score.is_empty())
+                            && contract
+                                .get("strategy_profile")
+                                .and_then(serde_json::Value::as_str)
+                                .is_some_and(|profile| !profile.is_empty())
+                            && json_array_empty(contract.get("blockers"))
+                    });
+            (candidate_status && empty_row_blockers && unblocked_contract)
+                || map.values().any(has_unblocked_runtime_candidate)
+        }
+        serde_json::Value::Array(items) => items.iter().any(has_unblocked_runtime_candidate),
+        _ => false,
+    }
+}
+
+fn json_array_empty(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::Array(items)) => items.is_empty(),
+        Some(serde_json::Value::Null) | None => true,
         _ => false,
     }
 }
@@ -291,6 +349,43 @@ mod tests {
         assert!(
             plan.actions
                 .contains(&"generate_typed_llm_prior_json".to_string())
+        );
+    }
+
+    #[test]
+    fn planner_routes_unblocked_runtime_candidate_to_candidate_replay() {
+        let mut input = input(
+            "walk_forward",
+            serde_json::json!({}),
+            serde_json::json!({
+                "missing_blocks_promotion": true,
+                "critical_missing": false,
+                "promotion_blockers": [
+                    {"surface": "clob_orderbook_snapshots", "reason": "required_execution_surface_is_sampled_snapshot"}
+                ]
+            }),
+        );
+        input.factor_registry_summary = serde_json::json!({
+            "recent_factors": [{
+                "factor_name": "auto_settlement_conservative_settlement_edge",
+                "status": "candidate",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "blockers": [],
+                "runtime_contract": {
+                    "version": "autofactor_runtime_contract_v1",
+                    "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "strategy_profile": "settlement_probability",
+                    "blockers": []
+                }
+            }]
+        });
+
+        let plan = plan_next_research(&input).expect("plan");
+        assert_eq!(plan.theme, "candidate_to_runtime_replay");
+        assert!(
+            plan.actions
+                .contains(&"build_runtime_candidate_replay".to_string())
         );
     }
 }

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -89,3 +89,7 @@ collection behavior.
   Artifact-backed research starts with `research-snapshot.yml`, routes through
   hosted factor review/walk-forward workflows, persists Research OS trace, and
   lets `research-trace-plan.yml` produce the next bounded research action.
+- Treat `--allow-direct-db-debug` and `--allow-legacy-snapshot-build` as
+  audited manual exceptions. They may reproduce old evidence or debug a data
+  incident, but they must not feed promotion, handoff issues, config PRs, or
+  Research Manager "ready" decisions.

--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -24,7 +24,7 @@ reserved for `executable_replay` evidence.
 | Alpha-search | Hosted artifact walk-forward emits registry previews, typed runtime contracts, MCTS tree, search feedback, promotion/handoff artifacts | Usable for factor discovery and attribution |
 | Candidate replay | `candidate_replay_tapes` exists and `persist_research_trace` can link replay artifacts to factor evaluations | Durable replay identity now exists; true runtime replay evidence must still be supplied per candidate |
 | Durable trace | Hosted walk-forward defaults to trace persistence and writes Research OS rows when DB secrets and deployed binaries are available | Current `main` run `26336054813` persisted trace and uploaded `research-trace/persisted.env` |
-| Research Manager | `research_trace_plan` can read durable DB trace and emit next-plan JSON | Current `main` run `26336127621` produced a `fix_data` plan; executor exists but automatic closed-loop execution is still unproven |
+| Research Manager | `research_trace_plan` can read durable DB trace and emit next-plan JSON; `research-manager-execute-plan.yml` can dispatch bounded follow-up evidence | Main run `26340671822` proved executor dispatch for runtime candidate replay and recorded replay parity |
 | Legacy research paths | Factor routers and Event ML rolling evidence are artifact-backed only | Former direct `ploy-ci-1` DB execution/export branches have been removed from the active research chain |
 | Diagnostic backtest | `backtest.yml` now emits `evidence-stage` artifacts with `promotion_ready=false` | Useful diagnostic replay/backtest surface; not promotion evidence |
 
@@ -91,6 +91,10 @@ reserved for `executable_replay` evidence.
 | --- | --- | --- | --- |
 | `26336054813` | `main` at `a5234cbfdf3cb93c22aa013888e418b83d308399` | Hosted walk-forward succeeded; `persisted=true`; stages `factor_attribution,walk_forward` | Snapshot -> walk-forward -> durable trace path is working from current main |
 | `26336127621` | `main` Research Trace Plan | Succeeded; `schema_version=research_trace_plan.v1`; `theme=fix_data`; `candidate_count=0` | Research Manager can read trace and produce a typed next plan |
+| `26340352094` | `main` deploy to `tango-1-1` | Succeeded; SSH path passed and Cloud Assistant fallback skipped | Runtime repair/deploy path is healthy from CI-built artifacts |
+| `26340671822` | `main` Research Manager executor | Succeeded; dispatched runtime candidate replay `26340673836` and recorded replay parity `26340674276` | Closed-loop evidence dispatch is proven |
+| `26340674276` | recorded replay parity | Succeeded; `strict_parity_ready=true` with no shared-row mismatches | Dry-run/runtime parity proof is available for the checked recording slice |
+| `26340673836` | runtime candidate replay | Succeeded but blocked; `updates_processed=43721`, `intents_submitted=0`, `orders=0`, `fills=0` | Current AutoFactor runtime candidate is not tradable and should be revised/rejected |
 
 The current walk-forward evidence is deliberately blocked:
 
@@ -106,13 +110,16 @@ The current walk-forward evidence is deliberately blocked:
 
 ## Remaining Problems
 
-1. **Research Manager is not proven closed-loop automation.**
+1. **Research Manager dispatch is proven, but strategy discovery is not.**
 
    `research_trace_plan` produces a typed plan from DB trace, and
-   `research-manager-execute-plan.yml` can dry-run bounded follow-up actions.
-   The missing proof is an executed loop that reads the plan, dispatches the
-   next research workflow, attaches evidence, and updates the next issue/run
-   without manual artifact interpretation.
+   `research-manager-execute-plan.yml` has executed bounded follow-up actions.
+   The current result is a blocked runtime candidate with zero runtime
+   orders/fills, not a dry-run handoff. The remaining automation gap is
+   candidate generation: positive factor/search rows must naturally become
+   runtime candidate replay requests through typed runtime contracts, and known
+   blocked runtime scores must feed back into the next prior instead of being
+   replayed repeatedly.
 
 2. **Feature snapshots are still sampled research products, not full execution
    tapes.**
@@ -158,7 +165,7 @@ The current walk-forward evidence is deliberately blocked:
 
 | Priority | Work | Done when |
 | --- | --- | --- |
-| P0 | Execute the Research Manager `fix_data` plan in dry-run and then bounded execute mode | Executor artifact dispatches the next snapshot/data-audit or hosted walk-forward run and records issue/run linkage |
+| P0 | Keep Research Manager candidate replay contract-driven | Executor replays only explicit or trace-derived unblocked runtime contracts and fails closed without one |
 | P0 | Repair or replace sampled execution-surface evidence | Full-depth CLOB lake or runtime replay evidence replaces sampled `clob_orderbook_snapshots` for executable handoff |
 | P0 | Explain why latest trace plan had empty factor registry/latest run arrays | Query path either links run `26336054813` rows or records why no runtime-mappable factor rows were persisted |
 | P1 | Promote runtime input canonicalization to a generated shared contract | Rust runtime scoring, Rust alpha-search, and Python promotion/replay use one source of truth instead of mirrored catalogs |
@@ -173,26 +180,26 @@ have separate evidence stages and the old direct-DB factor execution branch has
 been cut out of the active workflows.
 
 The research chain has been restored through durable trace planning, but not
-through strategy discovery or dry-run handoff. The proven sequence is:
+through profitable strategy discovery or dry-run handoff. The proven sequence is:
 
 ```text
 research-snapshot.yml
   -> factor-walk-forward-v2-hosted-artifact.yml
   -> persist Research OS trace
   -> research-trace-plan.yml
+  -> research-manager-execute-plan.yml
+  -> runtime-candidate-replay.yml / recorded-replay-parity.yml
 ```
 
-The missing sequence is:
+The missing sequence is now:
 
 ```text
-research-trace-plan.yml
-  -> research-manager-execute-plan.yml
-  -> next bounded snapshot/data-audit or hosted walk-forward run
-  -> issue/evidence update
-  -> revised candidate or explicit rejection
+blocked runtime candidate
+  -> closed-loop prior revision / new runtime-mappable candidate
+  -> runtime_market_update_replay with executable orders/fills
+  -> handoff only if full-depth execution, official settlement, ROI, fillability, and parity gates pass
 ```
 
-Only after that loop runs without manual artifact interpretation should the
-system be described as automatic research/backtest/strategy discovery. Today it
-is a separated, trace-backed research architecture whose current result is
-`fix_data` with zero qualified candidates, not a tradable strategy.
+The system can now automatically research, persist trace, dispatch replay/parity
+evidence, and reject a weak candidate. It should not be described as having
+found an automatically tradable strategy yet.

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -199,7 +199,12 @@ id. It defaults to `mode=dry_run`, uploads a machine-readable executor artifact,
 and only dispatches follow-up research workflows when `mode=execute` and
 `execute_ack=execute-research-manager-plan` are both set. The executor is a
 research-only surface: it can dispatch snapshot refreshes or hosted
-walk-forward continuations, but it does not deploy, trade, or create config PRs.
+walk-forward continuations, runtime candidate replay, and recorded replay
+parity checks, but it does not deploy, trade, or create config PRs. Runtime
+candidate replay must be selected from an explicit workflow input or from a
+typed, unblocked runtime contract in the Research Trace Plan
+`factor_registry_summary`; when no such contract exists, the executor fails
+closed instead of replaying a hardcoded default score.
 
 The current architecture review is
 `docs/reviews/research-data-architecture-review-2026-05-23.md`.

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -257,6 +257,81 @@ def _recorded_replay_parity_dispatch(
     }
 
 
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _runtime_candidate_from_plan(
+    plan_payload: dict[str, Any],
+    *,
+    strategy_profile: str,
+    source_target: str,
+    source_horizon: str,
+) -> dict[str, str] | None:
+    """Select the newest typed, unblocked runtime contract from the trace plan."""
+
+    summary = ((plan_payload.get("input") or {}).get("factor_registry_summary") or {})
+    recent = summary.get("recent_factors")
+    if not isinstance(recent, list):
+        return None
+    for item in recent:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "")
+        if status and status not in {"candidate", "watchlist"}:
+            continue
+        contract = item.get("runtime_contract")
+        if not isinstance(contract, dict):
+            continue
+        blockers = set(_string_list(item.get("blockers"))) | set(
+            _string_list(contract.get("blockers"))
+        )
+        if blockers:
+            continue
+        if contract.get("version") != "autofactor_runtime_contract_v1":
+            continue
+        runtime_score = str(contract.get("runtime_score") or "")
+        contract_profile = str(contract.get("strategy_profile") or "")
+        contract_target = str(contract.get("target") or item.get("target") or "")
+        contract_horizon = str(contract.get("horizon") or item.get("horizon") or "")
+        if not runtime_score or not contract_profile:
+            continue
+        if strategy_profile and contract_profile != strategy_profile:
+            continue
+        if source_target and contract_target and contract_target != source_target:
+            continue
+        if source_horizon and contract_horizon and contract_horizon != source_horizon:
+            continue
+        return {
+            "factor_name": str(item.get("factor_name") or item.get("name") or ""),
+            "runtime_score": runtime_score,
+            "strategy_profile": contract_profile,
+            "source_target": contract_target or source_target,
+            "source_horizon": contract_horizon or source_horizon,
+        }
+    return None
+
+
+def _runtime_replay_args(args: argparse.Namespace, plan_payload: dict[str, Any]) -> dict[str, Any]:
+    selected = _runtime_candidate_from_plan(
+        plan_payload,
+        strategy_profile=args.runtime_strategy_profile,
+        source_target=args.runtime_source_target,
+        source_horizon=args.runtime_source_horizon,
+    )
+    return {
+        "runtime_score": args.runtime_score or (selected or {}).get("runtime_score", ""),
+        "strategy_profile": args.runtime_strategy_profile
+        or (selected or {}).get("strategy_profile", ""),
+        "source_target": (selected or {}).get("source_target") or args.runtime_source_target,
+        "source_horizon": (selected or {}).get("source_horizon") or args.runtime_source_horizon,
+        "selected_factor_name": (selected or {}).get("factor_name", ""),
+        "extra_blockers": [] if args.runtime_score or selected else ["missing_runtime_candidate_contract"],
+    }
+
+
 def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any]) -> dict[str, Any]:
     if plan_payload.get("schema_version") != "research_trace_plan.v1":
         raise SystemExit("research_trace_plan schema mismatch")
@@ -293,22 +368,29 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             )
         )
 
-    if "compare_runtime_scorer_contract" in actions:
+    if "compare_runtime_scorer_contract" in actions or "build_runtime_candidate_replay" in actions:
+        replay_args = _runtime_replay_args(args, plan_payload)
         dispatches.append(
             _runtime_candidate_replay_dispatch(
                 deployment_id=args.runtime_deployment_id,
                 config_path=args.runtime_config_path,
                 recording_path=args.runtime_recording_path,
-                runtime_score=args.runtime_score,
-                strategy_profile=args.runtime_strategy_profile,
+                runtime_score=replay_args["runtime_score"],
+                strategy_profile=replay_args["strategy_profile"],
                 issue_number=args.runtime_issue_number,
                 min_trade_count=args.runtime_min_trade_count,
                 min_fill_rate=args.runtime_min_fill_rate,
                 min_roi=args.runtime_min_roi,
-                source_target=args.runtime_source_target,
-                source_horizon=args.runtime_source_horizon,
+                source_target=replay_args["source_target"],
+                source_horizon=replay_args["source_horizon"],
             )
         )
+        if replay_args["extra_blockers"]:
+            dispatches[-1]["blockers"].extend(replay_args["extra_blockers"])
+            dispatches[-1]["blockers"] = sorted(set(dispatches[-1]["blockers"]))
+            dispatches[-1]["ready"] = False
+        if replay_args["selected_factor_name"]:
+            dispatches[-1]["selected_factor_name"] = replay_args["selected_factor_name"]
 
     if "run_recorded_replay_parity" in actions:
         dispatches.append(
@@ -384,7 +466,9 @@ def render_markdown(payload: dict[str, Any]) -> str:
     for item in payload["dispatches"]:
         status = "ready" if item["ready"] else "blocked"
         blockers = ", ".join(item["blockers"]) if item["blockers"] else "<none>"
-        lines.append(f"- `{item['workflow']}`: `{status}`; blockers: `{blockers}`")
+        selected = item.get("selected_factor_name")
+        suffix = f"; selected factor: `{selected}`" if selected else ""
+        lines.append(f"- `{item['workflow']}`: `{status}`; blockers: `{blockers}`{suffix}")
     if payload.get("typed_prior"):
         lines.extend(["", "## Typed Prior", "", "- `research_manager_typed_prior.v1` generated"])
     if payload.get("dispatch_attempts"):
@@ -421,7 +505,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--runtime-score",
-        default="autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike",
+        default="",
     )
     parser.add_argument("--runtime-strategy-profile", default="settlement_probability")
     parser.add_argument("--runtime-issue-number", default="538")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,6 +15,13 @@ strategy promotion.
 - [x] Validate workflow/script syntax and targeted tests.
 - [x] Use the restored Research Manager `fix_runtime` plan to run or repair
       runtime scorer contract / recorded replay parity.
+- [x] Remove the weak hardcoded runtime replay default from Research Manager
+      execution; runtime candidate replay now requires an explicit score or an
+      unblocked typed runtime contract from the trace plan.
+- [x] Promote unblocked runtime-contract candidates to a first-class Research
+      Manager `candidate_to_runtime_replay` plan action.
+- [x] Refresh the research/data architecture review with the successful
+      executor/parity runs and the blocked zero-order candidate replay.
 
 ### Review
 
@@ -33,6 +40,12 @@ strategy promotion.
   the successful-poll window was scoped to the fallback restart timestamp.
   The PM trade successful-poll check now uses the whole current deploy window
   (`DEPLOY_STARTED_AT`) while the error guard remains recent.
+- 2026-05-24: Research Manager executor run `26340671822` proved closed-loop
+  evidence dispatch from `main`; runtime candidate replay `26340673836` was
+  correctly blocked with `0` intents/orders/fills, while recorded replay parity
+  `26340674276` reported strict parity ready. The executor no longer falls back
+  to the previously hardcoded weak AutoFactor score and instead derives replay
+  candidates from unblocked typed runtime contracts or fails closed.
 
 ## Goal
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -12,14 +12,15 @@ from scripts.research_manager_execute_plan import (
 )
 
 
-def plan_payload(theme: str, actions: list[str]) -> dict:
+def plan_payload(theme: str, actions: list[str], factor_registry_summary: dict | None = None) -> dict:
     return {
         "schema_version": "research_trace_plan.v1",
         "input": {
             "market_data_health": {
                 "dataset_start_ts": "2026-04-21T00:00:00Z",
                 "dataset_end_ts": "2026-04-23T00:00:00Z",
-            }
+            },
+            "factor_registry_summary": factor_registry_summary or {},
         },
         "plan": {
             "theme": theme,
@@ -171,6 +172,67 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
 
         self.assertEqual(0, payload["executable_dispatch_count"])
         self.assertIn("missing_runtime_score", payload["blocked_dispatches"][0]["blockers"])
+        self.assertIn(
+            "missing_runtime_candidate_contract",
+            payload["blocked_dispatches"][0]["blockers"],
+        )
+
+    def test_fix_runtime_derives_candidate_replay_score_from_plan_contract(self) -> None:
+        payload = build_executor_payload(
+            Namespace(
+                mode="dry_run",
+                execute_ack="",
+                git_ref="main",
+                snapshot_run_id="",
+                symbols="BTCUSDT",
+                stake_usd="15",
+                chain_remaining=1,
+                max_snapshot_window_days=2,
+                runtime_deployment_id="pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+                runtime_config_path="/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+                runtime_recording_path="/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+                runtime_score="",
+                runtime_strategy_profile="settlement_probability",
+                runtime_issue_number="538",
+                runtime_min_trade_count="50",
+                runtime_min_fill_rate="0.30",
+                runtime_min_roi="0",
+                runtime_source_target="full_depth_settlement_executable_pnl",
+                runtime_source_horizon="5m",
+            ),
+            plan_payload(
+                "candidate_to_runtime_replay",
+                ["build_runtime_candidate_replay"],
+                {
+                    "recent_factors": [
+                        {
+                            "factor_name": "auto_settlement_conservative_settlement_edge",
+                            "status": "candidate",
+                            "target": "full_depth_settlement_executable_pnl",
+                            "horizon": "5m",
+                            "blockers": [],
+                            "runtime_contract": {
+                                "version": "autofactor_runtime_contract_v1",
+                                "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                                "strategy_profile": "settlement_probability",
+                                "target": "full_depth_settlement_executable_pnl",
+                                "horizon": "5m",
+                                "blockers": [],
+                            },
+                        }
+                    ]
+                },
+            ),
+        )
+
+        self.assertEqual(1, payload["executable_dispatch_count"])
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("auto_settlement_conservative_settlement_edge", dispatch["selected_factor_name"])
+        self.assertEqual(
+            "autofactor_formula:auto_settlement_conservative_settlement_edge",
+            dispatch["fields"]["runtime_score"],
+        )
 
     def test_cli_writes_executor_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -227,6 +289,8 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
                     "execute",
                     "--execute-ack",
                     EXECUTE_ACK,
+                    "--runtime-score",
+                    "autofactor_formula:auto_settlement_conservative_settlement_edge",
                 ]
                 with patch(
                     "scripts.research_manager_execute_plan._dispatch_gh_workflow",


### PR DESCRIPTION
## Summary
- derive runtime candidate replay dispatches from typed, unblocked Research Trace Plan runtime contracts instead of a hardcoded AutoFactor score
- add `candidate_to_runtime_replay` as a first-class Research Manager plan action when a runtime-mappable candidate exists
- refresh research/data architecture docs with current executor, parity, and blocked candidate evidence

## Verification
- `python3 -m unittest discover -s tests`
- `python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract`
- `python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py`
- `CARGO_TARGET_DIR=/tmp/ploy-research-manager-candidate-replay rtk cargo test --locked -p ploy-research research_os::manager --lib`
- `CARGO_TARGET_DIR=/tmp/ploy-research-trace-plan-check rtk cargo check --locked -p ploy-research --features db --example research_trace_plan`
- `CARGO_TARGET_DIR=/tmp/ploy-workflow-security-runtime-manager rtk cargo test --locked --test workflow_security`
- `rustfmt --edition 2024 --check crates/ploy-research/src/research_os/manager.rs crates/ploy-research/examples/research_trace_plan.rs`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime candidate replay now selects candidates based on unblocked typed contracts from factor registry, eliminating hardcoded defaults and failing safely when no eligible contract is found.

* **Documentation**
  * Clarified executor constraints: runtime candidate replay is research-only and requires explicit contracts; documented proven research dispatch capabilities and remaining work on strategy discovery and market updates.

* **Tests**
  * Added tests for runtime candidate contract derivation and improved validation of blocker handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->