### PR TITLE
Fix PM trade collector deploy postflight

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -673,8 +673,8 @@ jobs:
               "ploy-pm-trade-collector.service" \
               "Polymarket trade collector poll complete" \
               "pm trade collector did not complete a healthy poll after deploy" \
-              20 \
-              3
+              120 \
+              5
 
             if service_exists ployd.service; then
               assert_no_recent_logs \

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -263,6 +263,16 @@ systemctl enable --now ploy-deribit-greeks-collector.service
 systemctl restart ploy-deribit-greeks-collector.service
 systemctl enable --now ploy-market-discovery.service
 systemctl restart ploy-market-discovery.service
+wait_for_recent_rows \\
+  "SELECT EXISTS (SELECT 1 FROM pm_market_catalog WHERE market_family = 'crypto' AND strategy_symbol IS NOT NULL AND end_time >= NOW())" \\
+  "pm_market_catalog has no active crypto markets after market-discovery restart" \\
+  20 \\
+  3
+wait_for_recent_rows \\
+  "SELECT EXISTS (SELECT 1 FROM pm_market_metadata WHERE symbol IS NOT NULL AND end_time >= NOW())" \\
+  "pm_market_metadata has no active crypto markets after market-discovery restart" \\
+  20 \\
+  3
 if service_exists ploy-quote-collector.service; then
   systemctl enable --now ploy-quote-collector.service
   systemctl restart ploy-quote-collector.service
@@ -319,7 +329,9 @@ wait_for_recent_rows \\
 wait_for_recent_log \\
   "ploy-pm-trade-collector.service" \\
   "Polymarket trade collector poll complete" \\
-  "pm trade collector did not complete a healthy poll after deploy"
+  "pm trade collector did not complete a healthy poll after deploy" \\
+  120 \\
+  5
 
 if service_exists ployd.service; then
   assert_no_recent_logs \\

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -67,6 +67,7 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
         self.assertIn("MemoryMax=768M", service_text)
 
         workflow_text = workflow.read_text()
+        cloud_assist_text = (ROOT / "scripts" / "ci" / "deploy_tango_cloud_assist.py").read_text()
         self.assertIn("ploy-market-discovery.service", workflow_text)
         self.assertLess(
             workflow_text.index("systemctl restart ploy-market-discovery.service"),
@@ -78,6 +79,38 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
             workflow_text.index("systemctl restart ploy-pm-trade-collector.service"),
             "market discovery must refresh catalog before trade collector polls",
         )
+        for text, name in (
+            (workflow_text, "deploy-tango-1-1.yml"),
+            (cloud_assist_text, "deploy_tango_cloud_assist.py"),
+        ):
+            discovery_restart = text.index("systemctl restart ploy-market-discovery.service")
+            catalog_wait = text.index(
+                "pm_market_catalog has no active crypto markets after market-discovery restart"
+            )
+            metadata_wait = text.index(
+                "pm_market_metadata has no active crypto markets after market-discovery restart"
+            )
+            trade_restart = text.index("systemctl restart ploy-pm-trade-collector.service")
+            self.assertLess(
+                discovery_restart,
+                catalog_wait,
+                f"{name} must wait for catalog after market discovery restart",
+            )
+            self.assertLess(
+                catalog_wait,
+                trade_restart,
+                f"{name} must wait for catalog before trade collector restart",
+            )
+            self.assertLess(
+                discovery_restart,
+                metadata_wait,
+                f"{name} must wait for metadata after market discovery restart",
+            )
+            self.assertLess(
+                metadata_wait,
+                trade_restart,
+                f"{name} must wait for metadata before trade collector restart",
+            )
 
     def test_pm_trade_deploy_health_uses_collector_poll_not_fresh_insert(self) -> None:
         workflow = ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml"
@@ -89,10 +122,24 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
             self.assertIn("Polymarket trade collector poll complete", text)
             self.assertIn("pm trade collector did not complete a healthy poll after deploy", text)
             self.assertIn("pm trade collector failed after deploy", text)
+            self.assertIn("120", text)
+            self.assertIn("5", text)
             if path.name == "deploy-tango-1-1.yml":
                 self.assertIn('local since="\\${DEPLOY_STARTED_AT}"', text)
+                self.assertIn(
+                    '"pm trade collector did not complete a healthy poll after deploy" \\\n'
+                    "              120 \\\n"
+                    "              5",
+                    text,
+                )
             else:
                 self.assertIn('local since="${{DEPLOY_STARTED_AT}}"', text)
+                self.assertIn(
+                    '"pm trade collector did not complete a healthy poll after deploy" \\\\\n'
+                    "  120 \\\\\n"
+                    "  5",
+                    text,
+                )
             self.assertNotIn(
                 "clob_trade_ticks WHERE received_at >= NOW() - INTERVAL '5 minutes'",
                 text,

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -828,14 +828,19 @@ fn tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows()
             offenders.push(format!("{name}: still requires fresh clob_trade_ticks inserts"));
         }
         if content.contains("clob_trade_ticks is not receiving PM trade prints after deploy") {
-            offenders.push(format!("{name}: still emits stale PM trade freshness failure"));
+            offenders.push(format!(
+                "{name}: still emits stale PM trade freshness failure"
+            ));
         }
         for needle in [
             "systemctl is-active --quiet ploy-pm-trade-collector.service",
             "require_service_guardrails ploy-pm-trade-collector.service",
+            "pm_market_catalog has no active crypto markets after market-discovery restart",
+            "pm_market_metadata has no active crypto markets after market-discovery restart",
             "wait_for_recent_log",
             "journalctl -u",
             "Polymarket trade collector poll complete",
+            "pm trade collector did not complete a healthy poll after deploy",
             "no partition of relation",
             "pm trade collector failed after deploy",
         ] {
@@ -843,6 +848,61 @@ fn tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows()
                 offenders.push(format!("{name}: missing `{needle}`"));
             }
         }
+    }
+
+    for (name, content) in [
+        ("deploy-tango-1-1.yml", workflow.as_str()),
+        ("deploy_tango_cloud_assist.py", cloud_assist.as_str()),
+    ] {
+        let discovery_restart = content.find("systemctl restart ploy-market-discovery.service");
+        let catalog_wait = content
+            .find("pm_market_catalog has no active crypto markets after market-discovery restart");
+        let metadata_wait = content
+            .find("pm_market_metadata has no active crypto markets after market-discovery restart");
+        let trade_restart = content.find("systemctl restart ploy-pm-trade-collector.service");
+        match (
+            discovery_restart,
+            catalog_wait,
+            metadata_wait,
+            trade_restart,
+        ) {
+            (
+                Some(discovery_restart),
+                Some(catalog_wait),
+                Some(metadata_wait),
+                Some(trade_restart),
+            ) => {
+                if !(discovery_restart < catalog_wait && catalog_wait < trade_restart) {
+                    offenders.push(format!(
+                        "{name}: catalog readiness wait must run between market discovery and PM trade collector restart"
+                    ));
+                }
+                if !(discovery_restart < metadata_wait && metadata_wait < trade_restart) {
+                    offenders.push(format!(
+                        "{name}: metadata readiness wait must run between market discovery and PM trade collector restart"
+                    ));
+                }
+            }
+            _ => offenders.push(format!(
+                "{name}: missing market-discovery readiness ordering anchors"
+            )),
+        }
+    }
+
+    if !workflow.contains(
+        "\"pm trade collector did not complete a healthy poll after deploy\" \\\n              120 \\\n              5",
+    ) {
+        offenders.push(
+            "deploy-tango-1-1.yml: PM trade collector healthy-poll wait is too short".to_string(),
+        );
+    }
+    if !cloud_assist.contains(
+        "\"pm trade collector did not complete a healthy poll after deploy\" \\\\\n  120 \\\\\n  5",
+    ) {
+        offenders.push(
+            "deploy_tango_cloud_assist.py: PM trade collector healthy-poll wait is too short"
+                .to_string(),
+        );
     }
 
     assert!(
@@ -921,13 +981,17 @@ fn factor_review_comments_are_factor_attribution_not_deployable_candidates() {
         "\"evidence:factor-attribution\"",
     ] {
         if !hosted.contains(needle) {
-            offenders.push(format!("factor-review-v2-hosted-artifact.yml: missing `{needle}`"));
+            offenders.push(format!(
+                "factor-review-v2-hosted-artifact.yml: missing `{needle}`"
+            ));
         }
     }
     if !router.contains("snapshot-backed router only")
         || !router.contains("factor-review-v2-hosted-artifact.yml")
     {
-        offenders.push("factor-review-v2.yml: router no longer points only at hosted evidence".to_string());
+        offenders.push(
+            "factor-review-v2.yml: router no longer points only at hosted evidence".to_string(),
+        );
     }
     for (name, content) in [
         ("factor-review-v2-hosted-artifact.yml", hosted.as_str()),


### PR DESCRIPTION
## Summary
- extend the PM trade collector healthy-poll wait to cover real full-market poll latency
- align Cloud Assistant fallback with SSH deploy by waiting for PM catalog/metadata readiness before restarting collectors
- add workflow/security contract coverage so SSH and fallback keep the same health semantics

## Evidence
- remote journal showed the collector healthy after timeout: 259 markets, ~45k trades fetched, api_errors=0, persist_errors=0
- python3 -m unittest tests.test_runtime_market_data_boundary tests.test_persist_research_trace_contract
- CARGO_TARGET_DIR=/tmp/ploy-workflow-security-pmtrade-full rtk cargo test --locked --test workflow_security
- YAML parse: .github/workflows/deploy-tango-1-1.yml
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py tests/test_runtime_market_data_boundary.py
- rtk git diff --check