### PR TITLE
Allow runtime replay research plan theme

### DIFF
--- a/.github/workflows/research-trace-plan.yml
+++ b/.github/workflows/research-trace-plan.yml
@@ -161,7 +161,7 @@ jobs:
               raise SystemExit("research trace plan schema mismatch")
           plan = payload.get("plan") or {}
           theme = plan.get("theme", "")
-          if theme not in {"continue_search", "revise_prior", "fix_data", "fix_runtime", "fix_workflow"}:
+          if theme not in {"candidate_to_runtime_replay", "continue_search", "revise_prior", "fix_data", "fix_runtime", "fix_workflow"}:
               raise SystemExit(f"unsupported research plan theme: {theme}")
           actions = plan.get("actions") or []
           lines = [

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -242,6 +242,12 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("source_surface_blockers", source)
         self.assertIn("missing_blocks_promotion", source)
 
+    def test_trace_plan_workflow_accepts_candidate_runtime_replay_theme(self) -> None:
+        workflow = TRACE_PLAN_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("candidate_to_runtime_replay", workflow)
+        self.assertIn("continue_search", workflow)
+        self.assertIn("fix_runtime", workflow)
+
     def test_research_trace_plan_workflow_uses_deployed_tango_binary(self) -> None:
         workflow = TRACE_PLAN_WORKFLOW.read_text(encoding="utf-8")
         required = [


### PR DESCRIPTION
## Summary
- allow Research Trace Plan workflow summaries to render the new candidate_to_runtime_replay manager theme
- add a contract test so the workflow accepts the runtime replay continuation emitted by Research Manager

## Evidence
- python3 -m unittest tests.test_persist_research_trace_contract tests.test_research_manager_execute_plan
- YAML parse: .github/workflows/research-trace-plan.yml
- rtk git diff --check