### PR TITLE
Persist factor registry blockers column

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -54,6 +54,7 @@ env:
     043_research_os_trace_constraints.sql
     044_candidate_replay_tapes.sql
     045_candidate_replay_basis_stage_constraint.sql
+    046_factor_registry_blockers.sql
 
 jobs:
   build-and-deploy:

--- a/crates/ploy-research/examples/persist_research_trace.rs
+++ b/crates/ploy-research/examples/persist_research_trace.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use ploy_research::ResearchSnapshotManifest;
 use ploy_research::autofactor_target_horizon;
@@ -768,12 +768,13 @@ async fn upsert_factor_registry(pool: &PgPool, row: &FactorPreviewRow) -> Result
             dsl_hash,
             ast_json,
             runtime_contract,
+            blockers_json,
             target,
             horizon,
             created_by_agent,
             metadata
         )
-        VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11, $12, $13, $14::jsonb)
+        VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11::jsonb, $12, $13, $14, $15::jsonb)
         ON CONFLICT (dsl_hash, target, horizon) DO UPDATE SET
             factor_name = EXCLUDED.factor_name,
             factor_family = EXCLUDED.factor_family,
@@ -786,6 +787,7 @@ async fn upsert_factor_registry(pool: &PgPool, row: &FactorPreviewRow) -> Result
             dsl_source = EXCLUDED.dsl_source,
             ast_json = EXCLUDED.ast_json,
             runtime_contract = EXCLUDED.runtime_contract,
+            blockers_json = EXCLUDED.blockers_json,
             target = EXCLUDED.target,
             horizon = EXCLUDED.horizon,
             metadata = EXCLUDED.metadata
@@ -805,6 +807,7 @@ async fn upsert_factor_registry(pool: &PgPool, row: &FactorPreviewRow) -> Result
     .bind(&row.dsl_hash)
     .bind(row.ast_json.to_string())
     .bind(row.runtime_contract.to_string())
+    .bind(row.blockers.to_string())
     .bind(&row.target)
     .bind(&row.horizon)
     .bind(WRITER_AGENT)
@@ -1463,10 +1466,8 @@ mod tests {
 
     #[test]
     fn reads_legacy_top_level_array_preview_and_uses_parent_target() {
-        let root = std::env::temp_dir().join(format!(
-            "ploy-trace-preview-legacy-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("ploy-trace-preview-legacy-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         let preview_path = root
             .join("full_depth_reprice_pnl_10s")
@@ -1493,10 +1494,8 @@ mod tests {
 
     #[test]
     fn malformed_preview_without_factors_still_fails_closed() {
-        let root = std::env::temp_dir().join(format!(
-            "ploy-trace-preview-bad-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("ploy-trace-preview-bad-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         let preview_path = root
             .join("full_depth_settlement_executable_pnl")
@@ -1514,9 +1513,18 @@ mod tests {
 
     #[test]
     fn default_horizon_uses_shared_autofactor_target_catalog() {
-        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_5s"), "5s");
-        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_30s"), "30s");
-        assert_eq!(default_horizon_for_target("full_depth_reprice_pnl_60s"), "60s");
+        assert_eq!(
+            default_horizon_for_target("full_depth_reprice_pnl_5s"),
+            "5s"
+        );
+        assert_eq!(
+            default_horizon_for_target("full_depth_reprice_pnl_30s"),
+            "30s"
+        );
+        assert_eq!(
+            default_horizon_for_target("full_depth_reprice_pnl_60s"),
+            "60s"
+        );
         assert_eq!(
             default_horizon_for_target("tradeable_full_depth_settlement_pnl"),
             "5m"

--- a/migrations/046_factor_registry_blockers.sql
+++ b/migrations/046_factor_registry_blockers.sql
@@ -1,0 +1,25 @@
+-- Migration 046: Promote factor registry blockers to a typed queryable column.
+
+ALTER TABLE factor_registry
+    ADD COLUMN IF NOT EXISTS blockers_json JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+UPDATE factor_registry
+SET blockers_json = metadata->'blockers'
+WHERE blockers_json = '[]'::jsonb
+  AND metadata ? 'blockers'
+  AND jsonb_typeof(metadata->'blockers') = 'array';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_factor_registry_blockers_array'
+          AND conrelid = 'factor_registry'::regclass
+    ) THEN
+        ALTER TABLE factor_registry
+            ADD CONSTRAINT chk_factor_registry_blockers_array
+            CHECK (jsonb_typeof(blockers_json) = 'array')
+            NOT VALID;
+    END IF;
+END $$;

--- a/tests/test_factor_research_os_registry.py
+++ b/tests/test_factor_research_os_registry.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MIGRATION_042 = ROOT / "migrations" / "042_factor_research_os_registry.sql"
 MIGRATION_043 = ROOT / "migrations" / "043_research_os_trace_constraints.sql"
 MIGRATION_044 = ROOT / "migrations" / "044_candidate_replay_tapes.sql"
+MIGRATION_046 = ROOT / "migrations" / "046_factor_registry_blockers.sql"
 
 
 def research_os_sql() -> str:
@@ -14,6 +15,7 @@ def research_os_sql() -> str:
             MIGRATION_042.read_text(encoding="utf-8"),
             MIGRATION_043.read_text(encoding="utf-8"),
             MIGRATION_044.read_text(encoding="utf-8"),
+            MIGRATION_046.read_text(encoding="utf-8"),
         ]
     )
 
@@ -41,6 +43,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         self.assertIn("ON factor_registry(dsl_hash, target, horizon)", sql)
         self.assertIn("ast_json JSONB NOT NULL", sql)
         self.assertIn("runtime_contract JSONB NOT NULL DEFAULT '{}'::jsonb", sql)
+        self.assertIn("chk_factor_registry_blockers_array", sql)
         self.assertIn("source_surfaces_json JSONB NOT NULL DEFAULT '[]'::jsonb", sql)
         self.assertIn("input_artifacts_json JSONB NOT NULL DEFAULT '[]'::jsonb", sql)
         self.assertIn("dataset_start_ts TIMESTAMPTZ", sql)
@@ -115,6 +118,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         self.assertIn("042_factor_research_os_registry.sql", workflow)
         self.assertIn("043_research_os_trace_constraints.sql", workflow)
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
+        self.assertIn("046_factor_registry_blockers.sql", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -77,6 +77,12 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         for snippet in required:
             self.assertIn(snippet, source)
 
+    def test_persist_research_trace_writes_factor_registry_blockers(self) -> None:
+        source = EXAMPLE.read_text(encoding="utf-8")
+        self.assertIn("blockers_json", source)
+        self.assertIn("blockers_json = EXCLUDED.blockers_json", source)
+        self.assertIn("row.blockers.to_string()", source)
+
     def test_promotion_mapping_is_fail_closed(self) -> None:
         source = EXAMPLE.read_text(encoding="utf-8")
         self.assertIn('promotion_decision: "continue"', source)


### PR DESCRIPTION
## Summary
- add migration 046 to promote factor registry blockers into a typed blockers_json column
- backfill blockers from existing factor_registry.metadata.blockers
- write blockers_json directly from persist_research_trace so research_trace_plan can query durable registry contracts
- include migration 046 in tango deploy

## Evidence
- python3 -m unittest tests.test_factor_research_os_registry tests.test_persist_research_trace_contract
- CARGO_TARGET_DIR=/tmp/ploy-persist-trace-blockers rtk cargo check --locked -p ploy-research --features db --example persist_research_trace --example research_trace_plan
- rustfmt --edition 2024 --check crates/ploy-research/examples/persist_research_trace.rs crates/ploy-research/examples/research_trace_plan.rs
- YAML parse: .github/workflows/deploy-tango-1-1.yml
- rtk git diff --check