### PR TITLE
Fix AutoFactor runtime input contracts

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::autofactor::{
-    autofactor_target_horizon, factor_expr_hash, AutoFactorDecision, AutoFactorOptions,
-    AutoFactorReport, FactorExpr, LlmPriorSpec,
+    AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr, LlmPriorSpec,
+    autofactor_target_horizon, factor_expr_hash,
 };
 
 const ALPHA_SEARCH_ARTIFACT_VERSION: &str = "alpha_search_artifacts_v1";
@@ -287,6 +287,20 @@ struct FactorRegistryPreviewArtifact {
     target: String,
     horizon: String,
     factors: Vec<FactorRegistryPreviewRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeInputMapping {
+    ast_input_name: String,
+    runtime_input_names: Vec<String>,
+    projection: &'static str,
+}
+
+#[derive(Debug)]
+struct RuntimeInputProjection {
+    runtime_input_names: Vec<String>,
+    mappings: Vec<RuntimeInputMapping>,
+    blockers: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -645,13 +659,14 @@ fn runtime_contract_for_report(
     ast_json: &serde_json::Value,
     horizon: &str,
 ) -> serde_json::Value {
-    let input_names = factor_input_names(&report.expr);
+    let ast_input_names = factor_input_names(&report.expr);
+    let input_projection = runtime_input_projection(&ast_input_names);
     let mut blockers = Vec::new();
     let mapping = inferred_runtime_mapping(&report.name);
     if mapping.runtime_score.is_empty() || mapping.strategy_profile.is_empty() {
         blockers.push("runtime_contract_unmapped_factor".to_string());
     }
-    blockers.extend(runtime_input_blockers(&input_names));
+    blockers.extend(input_projection.blockers.clone());
     blockers.extend(runtime_formula_blockers(&report.name));
     blockers.sort();
     blockers.dedup();
@@ -665,7 +680,10 @@ fn runtime_contract_for_report(
         "factor_family": normalized_factor_family(&report.name),
         "target": report.target.as_deref().unwrap_or("unknown"),
         "horizon": horizon,
-        "input_names": input_names,
+        "input_names": ast_input_names,
+        "ast_input_names": ast_input_names,
+        "runtime_input_names": input_projection.runtime_input_names,
+        "input_mappings": input_projection.mappings,
         "blockers": blockers,
     })
 }
@@ -710,31 +728,84 @@ fn inferred_runtime_mapping(name: &str) -> RuntimeMapping {
     RuntimeMapping::default()
 }
 
-fn runtime_input_blockers(input_names: &[String]) -> Vec<String> {
+fn runtime_input_projection(ast_input_names: &[String]) -> RuntimeInputProjection {
+    let mut runtime_inputs = BTreeSet::new();
+    let mut mappings = Vec::new();
     let mut blockers = Vec::new();
-    for input in input_names {
-        match input.as_str() {
-            "conservative_settlement_edge"
-            | "full_depth_settlement_edge"
-            | "model_conservative_settlement_edge"
-            | "model_full_depth_settlement_edge"
-            | "settlement_edge"
-            | "entry_price"
-            | "distance_over_sigma"
-            | "direction_sign"
-            | "drift_30s"
-            | "sigma_horizon"
-            | "entry_capacity_ratio"
-            | "side_spread"
-            | "pm_lag_secs" => {}
-            "external_pressure" => {
-                blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string())
+    for input in ast_input_names {
+        match runtime_input_mapping(input) {
+            Ok((runtime_input_names, projection)) => {
+                for runtime_input in &runtime_input_names {
+                    runtime_inputs.insert(runtime_input.clone());
+                }
+                mappings.push(RuntimeInputMapping {
+                    ast_input_name: input.clone(),
+                    runtime_input_names,
+                    projection,
+                });
             }
-            "iv_change_1m" => blockers.push("runtime_input_not_supplied:iv_change_1m".to_string()),
-            other => blockers.push(format!("runtime_input_unsupported:{other}")),
+            Err(blocker) => blockers.push(blocker),
         }
     }
-    blockers
+    blockers.sort();
+    blockers.dedup();
+    RuntimeInputProjection {
+        runtime_input_names: runtime_inputs.into_iter().collect(),
+        mappings,
+        blockers,
+    }
+}
+
+fn runtime_input_mapping(input: &str) -> Result<(Vec<String>, &'static str), String> {
+    let runtime_inputs = match input {
+        "conservative_settlement_edge"
+        | "full_depth_settlement_edge"
+        | "model_conservative_settlement_edge"
+        | "model_full_depth_settlement_edge"
+        | "settlement_edge" => (
+            vec!["settlement_edge".to_string()],
+            "settlement_edge_projection",
+        ),
+        "near_strike_score" => (
+            vec![
+                "direction_sign".to_string(),
+                "distance_over_sigma".to_string(),
+            ],
+            "runtime_near_strike_score",
+        ),
+        "entry_capacity_score" => (
+            vec!["entry_capacity_ratio".to_string()],
+            "runtime_entry_capacity_score",
+        ),
+        "full_depth_entry_fillable_gate" => (
+            vec!["entry_capacity_ratio".to_string()],
+            "runtime_full_depth_entry_gate",
+        ),
+        "entry_price_quality_score" => (
+            vec!["entry_price".to_string()],
+            "runtime_entry_price_quality_score",
+        ),
+        "external_move_since_poly_update" | "cex_return_30s_side" => (
+            vec!["direction_sign".to_string(), "drift_30s".to_string()],
+            "runtime_side_drift_30s",
+        ),
+        "sigma_horizon_pos" => (vec!["sigma_horizon".to_string()], "runtime_sigma_horizon"),
+        "poly_quote_age" => (vec!["pm_lag_secs".to_string()], "runtime_quote_age"),
+        "side_spread"
+        | "entry_price"
+        | "distance_over_sigma"
+        | "direction_sign"
+        | "drift_30s"
+        | "sigma_horizon"
+        | "entry_capacity_ratio"
+        | "pm_lag_secs" => (vec![input.to_string()], "runtime_native_input"),
+        "external_pressure" => {
+            return Err("runtime_input_semantics_mismatch:external_pressure".to_string());
+        }
+        "iv_change_1m" => return Err("runtime_input_not_supplied:iv_change_1m".to_string()),
+        other => return Err(format!("runtime_input_unsupported:{other}")),
+    };
+    Ok(runtime_inputs)
 }
 
 fn runtime_formula_blockers(name: &str) -> Vec<String> {
@@ -1324,11 +1395,7 @@ fn normalized_positive(value: f64) -> f64 {
 }
 
 fn finite_or_zero(value: f64) -> f64 {
-    if value.is_finite() {
-        value
-    } else {
-        0.0
-    }
+    if value.is_finite() { value } else { 0.0 }
 }
 
 fn ratio_usize(numerator: usize, denominator: usize) -> f64 {
@@ -1580,18 +1647,22 @@ mod tests {
         )
         .expect("write artifacts");
         assert_eq!(summary.candidate_count, 1);
-        assert!(tmp
-            .join("full_depth_settlement_executable_pnl/search-space.json")
-            .exists());
-        assert!(tmp
-            .join("full_depth_settlement_executable_pnl/tree-trace.json")
-            .exists());
-        assert!(tmp
-            .join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
-            .exists());
-        assert!(tmp
-            .join("full_depth_settlement_executable_pnl/mcts-state.json")
-            .exists());
+        assert!(
+            tmp.join("full_depth_settlement_executable_pnl/search-space.json")
+                .exists()
+        );
+        assert!(
+            tmp.join("full_depth_settlement_executable_pnl/tree-trace.json")
+                .exists()
+        );
+        assert!(
+            tmp.join("full_depth_settlement_executable_pnl/mcts-expansion-plan.json")
+                .exists()
+        );
+        assert!(
+            tmp.join("full_depth_settlement_executable_pnl/mcts-state.json")
+                .exists()
+        );
         let registry_preview =
             tmp.join("full_depth_settlement_executable_pnl/factor-registry-preview.json");
         assert!(registry_preview.exists());
@@ -1621,7 +1692,60 @@ mod tests {
             rows[0]["runtime_contract"]["input_names"],
             serde_json::json!(["conservative_settlement_edge"])
         );
+        assert_eq!(
+            rows[0]["runtime_contract"]["ast_input_names"],
+            serde_json::json!(["conservative_settlement_edge"])
+        );
+        assert_eq!(
+            rows[0]["runtime_contract"]["runtime_input_names"],
+            serde_json::json!(["settlement_edge"])
+        );
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn runtime_contract_canonicalizes_supported_research_inputs() {
+        let report = AutoFactorReport {
+            name: "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+                .to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Mul(
+                Box::new(FactorExpr::Mul(
+                    Box::new(FactorExpr::Input(
+                        "model_full_depth_settlement_edge".to_string(),
+                    )),
+                    Box::new(FactorExpr::Input("near_strike_score".to_string())),
+                )),
+                Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+            ),
+            ..sample_report(
+                "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity",
+            )
+        };
+        let contract =
+            runtime_contract_for_report(&report, "dsl-hash", &serde_json::json!({}), "5m");
+        assert_eq!(
+            contract["runtime_score"],
+            "autofactor_formula:auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+        );
+        assert_eq!(
+            contract["ast_input_names"],
+            serde_json::json!([
+                "entry_capacity_score",
+                "model_full_depth_settlement_edge",
+                "near_strike_score"
+            ])
+        );
+        assert_eq!(
+            contract["runtime_input_names"],
+            serde_json::json!([
+                "direction_sign",
+                "distance_over_sigma",
+                "entry_capacity_ratio",
+                "settlement_edge"
+            ])
+        );
+        assert_eq!(contract["blockers"], serde_json::json!([]));
     }
 
     #[test]
@@ -1667,9 +1791,11 @@ mod tests {
             "5m",
         );
         let blockers = contract["blockers"].as_array().expect("blockers");
-        assert!(blockers
-            .iter()
-            .any(|item| item.as_str() == Some("runtime_input_not_supplied:iv_change_1m")));
+        assert!(
+            blockers
+                .iter()
+                .any(|item| item.as_str() == Some("runtime_input_not_supplied:iv_change_1m"))
+        );
     }
 
     #[test]
@@ -1679,9 +1805,11 @@ mod tests {
             runtime_contract_for_report(&unsupported, "dsl-hash", &serde_json::json!({}), "5m");
         assert_eq!(contract["runtime_score"], "");
         let blockers = contract["blockers"].as_array().expect("blockers");
-        assert!(blockers
-            .iter()
-            .any(|item| item.as_str() == Some("runtime_contract_unmapped_factor")));
+        assert!(
+            blockers
+                .iter()
+                .any(|item| item.as_str() == Some("runtime_contract_unmapped_factor"))
+        );
         assert!(blockers.iter().any(|item| {
             item.as_str() == Some("runtime_contract_unsupported_predictive_suffix")
         }));
@@ -1899,10 +2027,12 @@ mod tests {
         let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
-        assert!(!plan
-            .selected_nodes
-            .iter()
-            .any(|node| node.factor_name == "mcts_spread_adjusted_external_move_near_strike"));
+        assert!(
+            !plan
+                .selected_nodes
+                .iter()
+                .any(|node| node.factor_name == "mcts_spread_adjusted_external_move_near_strike")
+        );
         assert_eq!(
             plan.selected_nodes
                 .first()
@@ -1948,10 +2078,11 @@ mod tests {
         let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
-        assert!(plan
-            .selected_nodes
-            .iter()
-            .all(|node| !node.factor_name.contains("spread_adjusted_external_move")));
+        assert!(
+            plan.selected_nodes
+                .iter()
+                .all(|node| !node.factor_name.contains("spread_adjusted_external_move"))
+        );
         assert_eq!(
             plan.selected_nodes
                 .first()

--- a/scripts/autofactor_runtime_contract.py
+++ b/scripts/autofactor_runtime_contract.py
@@ -105,8 +105,8 @@ SUPPORTED_RUNTIME_INPUT_NAMES = {
 # them from non-equivalent or placeholder values. Treat them as blocked until
 # research and runtime share the same source definition.
 BLOCKED_RUNTIME_INPUT_NAMES = {
-    "external_pressure": "runtime_input_not_canonical:external_pressure",
-    "iv_change_1m": "runtime_input_placeholder:iv_change_1m",
+    "external_pressure": "runtime_input_semantics_mismatch:external_pressure",
+    "iv_change_1m": "runtime_input_not_supplied:iv_change_1m",
 }
 
 
@@ -198,6 +198,16 @@ def runtime_input_blockers(input_names: list[str]) -> list[str]:
     return blockers
 
 
+def runtime_contract_input_names(contract: dict[str, Any]) -> list[str]:
+    runtime_input_names = contract.get("runtime_input_names")
+    if isinstance(runtime_input_names, list) and runtime_input_names:
+        return [str(v) for v in runtime_input_names if str(v)]
+    legacy_input_names = contract.get("input_names")
+    if isinstance(legacy_input_names, list) and legacy_input_names:
+        return [str(v) for v in legacy_input_names if str(v)]
+    return []
+
+
 @dataclass
 class RuntimeContractResolution:
     factor_name: str
@@ -258,11 +268,10 @@ class RuntimeContractResolver:
             if contract.get("version") != "autofactor_runtime_contract_v1":
                 blockers.append("unsupported_runtime_contract_version")
             blockers.extend(str(v) for v in contract.get("blockers") or [] if str(v))
-            input_names = contract.get("input_names")
-            if not isinstance(input_names, list) or not input_names:
+            input_names = runtime_contract_input_names(contract)
+            if not input_names:
                 blockers.append(f"missing_runtime_contract_input_names:{name}")
-                input_names = []
-            blockers.extend(runtime_input_blockers([str(v) for v in input_names]))
+            blockers.extend(runtime_input_blockers(input_names))
             mapping = {
                 "strategy_profile": str(contract.get("strategy_profile") or ""),
                 "strategy_family": str(contract.get("strategy_family") or ""),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19063,3 +19063,60 @@ Evidence stage: `walk_forward / runtime_parity`.
   `CARGO_TARGET_DIR=/tmp/ploy-runtime-executable-objective-example /opt/homebrew/bin/timeout 300 rtk cargo check --locked -p ploy-research --features db --example factor_walk_forward_v2`,
   and `rtk git diff --check`. The cargo check completed with existing warnings
   in strategy modules, but no errors.
+
+# Runtime-Supported AutoFactor Contract Lane (2026-05-24)
+
+## Goal
+
+Restore the AutoFactor research chain by making registry preview contracts
+distinguish research AST input names from canonical runtime scorer inputs, so
+promotion and candidate replay can advance only factors the runtime can actually
+score while still fail-closing unsupported inputs.
+
+Evidence stage: `factor_attribution` with `runtime_parity` gates.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/alpha_search.rs`
+  - Owner: typed AutoFactor runtime contract input canonicalization and
+    registry preview blocker semantics.
+- `scripts/autofactor_runtime_contract.py`
+  - Owner: shared promotion/candidate replay resolver for registry-preview
+    runtime input validation.
+- `tests/test_persist_research_trace_contract.py`
+  - Owner: static contract coverage for registry preview fields.
+- `tests/test_autofactor_strategy_promotion.py` and
+  `tests/test_build_autofactor_candidate_strategy_replay.py`
+  - Owner: fail-closed Python resolver behavior.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Add canonical runtime input names to alpha-search registry contracts while
+      preserving AST input names for auditability.
+- [x] Keep `external_pressure`, `iv_change_1m`, Bayesian formulas, and unknown
+      research-only inputs blocked until runtime semantics are canonical.
+- [x] Make promotion and candidate replay validate `runtime_input_names` when
+      present, falling back to legacy `input_names` only for old artifacts.
+- [x] Run focused Rust/Python/static verification.
+- [ ] Commit, push, open PR, wait for CI, and merge if checks pass.
+
+## Review
+
+- 2026-05-24: Alpha-search registry preview now emits `ast_input_names`,
+  canonical `runtime_input_names`, and explicit `input_mappings`. Runtime
+  contract validation keeps unsupported research-only inputs blocked, but no
+  longer treats runtime-equivalent research helper columns such as
+  `near_strike_score`, `entry_capacity_score`, and
+  `full_depth_entry_fillable_gate` as unsupported when the contract provides
+  canonical runtime inputs.
+- 2026-05-24: Promotion and candidate replay now prefer
+  `runtime_input_names` from `autofactor_runtime_contract_v1`, with legacy
+  `input_names` fallback for older registry artifacts.
+- 2026-05-24: Focused verification passed:
+  `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_persist_research_trace_contract`,
+  `CARGO_TARGET_DIR=/tmp/ploy-runtime-supported-autofactor rtk cargo test --locked -p ploy-research alpha_search --lib`,
+  `python3 -m py_compile scripts/autofactor_runtime_contract.py tests/test_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_persist_research_trace_contract.py`,
+  `rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs`,
+  and `rtk git diff --check`.

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -383,6 +383,71 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         self.assertEqual(registry["entries"][0]["runtime_contract"]["input_names"][-1], "iv_change_1m")
         self.assertEqual(handoff["status"], "blocked")
 
+    def test_registry_contract_uses_canonical_runtime_inputs_for_promotion(self):
+        report = """=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+recorded_replay_parity,true,blocking_flags=<none>
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,9966,1,5
+"""
+        runtime_score = (
+            "autofactor_formula:"
+            "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+        )
+        _, payload, registry, handoff, _ = self.run_script(
+            report,
+            replay_payload=replay_for_target(runtime_score),
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [
+                    {
+                        "factor_name": (
+                            "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+                        ),
+                        "runtime_contract": {
+                            "version": "autofactor_runtime_contract_v1",
+                            "runtime_score": runtime_score,
+                            "strategy_profile": "settlement_probability",
+                            "strategy_family": "settlement_probability",
+                            "input_names": [
+                                "entry_capacity_score",
+                                "model_full_depth_settlement_edge",
+                                "near_strike_score",
+                            ],
+                            "ast_input_names": [
+                                "entry_capacity_score",
+                                "model_full_depth_settlement_edge",
+                                "near_strike_score",
+                            ],
+                            "runtime_input_names": [
+                                "direction_sign",
+                                "distance_over_sigma",
+                                "entry_capacity_ratio",
+                                "settlement_edge",
+                            ],
+                            "blockers": [],
+                        },
+                        "blockers": [],
+                    }
+                ],
+            },
+        )
+
+        first = payload["evaluated_factors"][0]
+        self.assertTrue(first["qualified"])
+        self.assertNotIn("runtime_input_unsupported:near_strike_score", first["blockers"])
+        self.assertNotIn("runtime_input_unsupported:entry_capacity_score", first["blockers"])
+        self.assertEqual(registry["entries"][0]["runtime_contract"]["runtime_input_names"][-1], "settlement_edge")
+        self.assertEqual(handoff["status"], "ready")
+
     def test_blocks_candidate_when_runtime_profile_is_not_required_profile(self):
         _, payload, registry, handoff, handoff_md = self.run_script(
             READY_GATE + AUTOFACTOR_REPORT

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -159,6 +159,62 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
             payload["blocking_risk_flags"],
         )
 
+    def test_registry_contract_prefers_canonical_runtime_inputs(self):
+        report = """# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity,full_depth_settlement_executable_pnl,candidate,passed,49831,0.110842,0.150273,43,1.064178,0.9535,6,0.8333,1.0000,9966,2.666226,0.6836,0.9000,9966,1,5
+"""
+        runtime_score = (
+            "autofactor_formula:"
+            "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+        )
+        payload, _ = self.run_script(
+            report,
+            registry_preview_payload={
+                "version": "alpha_search_artifacts_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "factors": [
+                    {
+                        "factor_name": (
+                            "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+                        ),
+                        "runtime_contract": {
+                            "version": "autofactor_runtime_contract_v1",
+                            "runtime_score": runtime_score,
+                            "strategy_profile": "settlement_probability",
+                            "strategy_family": "settlement_probability",
+                            "input_names": [
+                                "entry_capacity_score",
+                                "model_full_depth_settlement_edge",
+                                "near_strike_score",
+                            ],
+                            "runtime_input_names": [
+                                "direction_sign",
+                                "distance_over_sigma",
+                                "entry_capacity_ratio",
+                                "settlement_edge",
+                            ],
+                            "blockers": [],
+                        },
+                        "blockers": [],
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(payload["runtime_score"], runtime_score)
+        self.assertIn(
+            "requires_runtime_replay_not_top_bucket_aggregate",
+            payload["blocking_risk_flags"],
+        )
+        self.assertNotIn(
+            "runtime_input_unsupported:near_strike_score",
+            payload["blocking_risk_flags"],
+        )
+
     def test_builds_blocked_aggregate_for_runtime_mappable_settlement_candidate(self):
         payload, markdown = self.run_script(AUTOFACTOR_SETTLEMENT_AUTO_REPORT)
 

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -71,7 +71,11 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "autofactor_runtime_contract_v1",
             '"runtime_score": mapping.runtime_score',
             '"strategy_profile": mapping.strategy_profile',
-            '"input_names": input_names',
+            '"input_names": ast_input_names',
+            '"ast_input_names": ast_input_names',
+            '"runtime_input_names": input_projection.runtime_input_names',
+            '"input_mappings": input_projection.mappings',
+            "runtime_input_projection",
             "runtime_contract_unmapped_factor",
         ]
         for snippet in required:


### PR DESCRIPTION
## Summary
- emit AutoFactor registry preview contracts with separate AST input names and canonical runtime input names
- make promotion and candidate replay prefer runtime_input_names while preserving legacy input_names fallback
- keep unsupported/noncanonical inputs fail-closed and add regression coverage for canonical runtime inputs

## Evidence stage
factor_attribution with runtime_parity gates; this is not dry-run or live promotion evidence.

## Tests
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_persist_research_trace_contract
- python3 -m unittest tests.test_factor_research_os_registry tests.test_research_manager_execute_plan
- CARGO_TARGET_DIR=/tmp/ploy-runtime-supported-autofactor rtk cargo test --locked -p ploy-research alpha_search --lib
- python3 -m py_compile scripts/autofactor_runtime_contract.py tests/test_autofactor_strategy_promotion.py tests/test_build_autofactor_candidate_strategy_replay.py tests/test_persist_research_trace_contract.py
- rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime contracts now include enhanced input metadata, including detailed input mappings and canonical input names.
  * Improved input classification and validation throughout the factor evaluation workflow.

* **Tests**
  * Added tests to validate new runtime contract fields and verify canonical input handling during promotion and candidate replay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->