### PR TITLE
Fix sweep registry preview target selection

### DIFF
--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -250,9 +250,6 @@ def factor_registry_preview_path(variant_dir: Path, allowed_targets: list[str]) 
             if payload.get("target") == target:
                 return preview
 
-    if len(previews) == 1:
-        return previews[0]
-
     available = ", ".join(str(path.relative_to(alpha_root).parent) for path in previews)
     requested = ", ".join(targets)
     raise SystemExit(

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -186,7 +186,7 @@ def promotion_args(args: argparse.Namespace, report: Path, variant_dir: Path) ->
     command.extend(["--candidate-strategy-replay-json", replay_json])
     if args.snapshot_manifest_json:
         command.extend(["--snapshot-manifest-json", args.snapshot_manifest_json])
-    registry_preview = factor_registry_preview_path(variant_dir)
+    registry_preview = factor_registry_preview_path(variant_dir, args.allowed_target)
     if registry_preview:
         command.extend(["--factor-registry-preview-json", str(registry_preview)])
         command.append("--require-runtime-contract")
@@ -216,7 +216,7 @@ def candidate_replay_args(
         "--evidence",
         str(report),
     ]
-    registry_preview = factor_registry_preview_path(variant_dir)
+    registry_preview = factor_registry_preview_path(variant_dir, args.allowed_target)
     if registry_preview:
         command.extend(["--factor-registry-preview-json", str(registry_preview)])
         command.append("--require-runtime-contract")
@@ -227,12 +227,38 @@ def candidate_replay_args(
     return command
 
 
-def factor_registry_preview_path(variant_dir: Path) -> Path | None:
+def factor_registry_preview_path(variant_dir: Path, allowed_targets: list[str]) -> Path | None:
     alpha_root = variant_dir / "alpha-search"
     if not alpha_root.exists():
         return None
     previews = sorted(alpha_root.rglob("factor-registry-preview.json"))
-    return previews[0] if previews else None
+    if not previews:
+        return None
+
+    targets = allowed_targets or ["full_depth_settlement_executable_pnl"]
+    for target in targets:
+        exact = alpha_root / target / "factor-registry-preview.json"
+        if exact.exists():
+            return exact
+
+    for target in targets:
+        for preview in previews:
+            try:
+                payload = json.loads(preview.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as err:
+                raise SystemExit(f"invalid factor registry preview {preview}: {err}") from err
+            if payload.get("target") == target:
+                return preview
+
+    if len(previews) == 1:
+        return previews[0]
+
+    available = ", ".join(str(path.relative_to(alpha_root).parent) for path in previews)
+    requested = ", ".join(targets)
+    raise SystemExit(
+        "no factor registry preview matched allowed target(s): "
+        f"{requested}; available target dirs: {available}"
+    )
 
 
 def ranked_factor_rows(promotion: dict[str, Any], allowed_targets: set[str]) -> list[dict[str, Any]]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,28 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Sweep Target Registry Preview Fix (2026-05-24)
+
+Evidence stage: `factor_attribution` / `walk_forward` recovery with
+`runtime_parity` gate wiring, not strategy promotion.
+
+### Tasks
+
+- [x] Reconfirm project semantics and event ML AutoFactor workflow gates.
+- [x] Root-cause hosted sweep promotion missing runtime contracts after PR #638.
+- [x] Make sweep registry preview selection target-aware for candidate replay
+      and promotion.
+- [x] Add regression coverage for multiple alpha-search target previews.
+- [ ] Commit, push, merge, and rerun hosted walk-forward from `main`.
+
+### Review
+
+- 2026-05-24: Hosted walk-forward run `26343153749` persisted durable trace and
+  produced unblocked typed runtime contracts for
+  `tradeable_full_depth_settlement_pnl`, but promotion/candidate replay still
+  reported `missing_runtime_contract:*`. Root cause was the sweep wrapper
+  selecting the first `alpha-search/**/factor-registry-preview.json` by sorted
+  path instead of the preview matching `--allowed-target`.
+
 ## Current Session - Runtime Chain Data Review (2026-05-24)
 
 Evidence stage: `runtime_parity` recovery / deploy data-layer health, not

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -471,6 +471,57 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         )
         self.assertNotIn(f"missing_runtime_contract:{factor_name}", evaluated["blockers"])
 
+    def test_runtime_contract_preview_selection_fails_closed_on_target_mismatch(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = tmp / "fake_factor_walk_forward.py"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "if '--alpha-search-output-dir' in args:\n"
+                "    root = pathlib.Path(args[args.index('--alpha-search-output-dir') + 1])\n"
+                "    out = root / 'full_depth_settlement_executable_pnl'\n"
+                "    out.mkdir(parents=True, exist_ok=True)\n"
+                "    (out / 'factor-registry-preview.json').write_text(\n"
+                "        json.dumps({\n"
+                "            'version': 'alpha_search_artifacts_v1',\n"
+                "            'target': 'full_depth_settlement_executable_pnl',\n"
+                "            'horizon': '5m',\n"
+                "            'factors': [],\n"
+                "        }),\n"
+                "        encoding='utf-8',\n"
+                "    )\n"
+                f"{FAKE_TRADEABLE_HARD_GATE_BY_FILTER}\n",
+                encoding="utf-8",
+            )
+            binary.chmod(0o755)
+
+            result = subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--factor-name-filter",
+                    "external_move",
+                    "--allowed-target",
+                    "tradeable_full_depth_settlement_pnl",
+                    "--alpha-search-output-dir",
+                    str(tmp / "out" / "alpha-search"),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "no factor registry preview matched allowed target(s): "
+            "tradeable_full_depth_settlement_pnl",
+            result.stderr,
+        )
+        self.assertIn("full_depth_settlement_executable_pnl", result.stderr)
+
     def test_summary_marks_predictive_formula_mutation_runtime_mappable(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -374,6 +374,103 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertEqual(first_marker, "<empty>")
         self.assertEqual(second_marker, "auto_settlement")
 
+    def test_runtime_contract_preview_selection_matches_allowed_target(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            factor_name = "mut_spread_adjusted_external_move_full_depth_entry_gate"
+            binary = tmp / "fake_factor_walk_forward.py"
+            binary.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "if '--alpha-search-output-dir' in args:\n"
+                "    root = pathlib.Path(args[args.index('--alpha-search-output-dir') + 1])\n"
+                "    def write_preview(target, factors):\n"
+                "        out = root / target\n"
+                "        out.mkdir(parents=True, exist_ok=True)\n"
+                "        (out / 'factor-registry-preview.json').write_text(\n"
+                "            json.dumps({\n"
+                "                'version': 'alpha_search_artifacts_v1',\n"
+                "                'target': target,\n"
+                "                'horizon': '5m',\n"
+                "                'factors': factors,\n"
+                "            }, indent=2, sort_keys=True),\n"
+                "            encoding='utf-8',\n"
+                "        )\n"
+                "    contract = {\n"
+                "        'version': 'autofactor_runtime_contract_v1',\n"
+                "        'dsl_hash': 'dsl:tradeable',\n"
+                "        'ast_json': {'op': 'mul'},\n"
+                "        'runtime_score': 'autofactor_formula:"
+                f"{factor_name}',\n"
+                "        'strategy_profile': 'settlement_probability',\n"
+                "        'strategy_family': 'predictive_settlement_probability',\n"
+                "        'input_names': ['external_move_since_poly_update'],\n"
+                "        'ast_input_names': ['external_move_since_poly_update'],\n"
+                "        'runtime_input_names': ['direction_sign', 'drift_30s'],\n"
+                "        'input_mappings': [\n"
+                "            {'ast_input': 'external_move_since_poly_update', 'runtime_input': 'direction_sign'},\n"
+                "            {'ast_input': 'external_move_since_poly_update', 'runtime_input': 'drift_30s'},\n"
+                "        ],\n"
+                "        'blockers': [],\n"
+                "    }\n"
+                "    write_preview('full_depth_settlement_executable_pnl', [\n"
+                "        {'factor_name': 'auto_settlement_conservative_settlement_edge', 'blockers': []}\n"
+                "    ])\n"
+                "    write_preview('tradeable_full_depth_settlement_pnl', [\n"
+                f"        {{'factor_name': {factor_name!r}, 'runtime_contract': contract, 'blockers': []}}\n"
+                "    ])\n"
+                f"{FAKE_TRADEABLE_HARD_GATE_BY_FILTER}\n",
+                encoding="utf-8",
+            )
+            binary.chmod(0o755)
+
+            subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--factor-name-filter",
+                    "external_move",
+                    "--allowed-target",
+                    "tradeable_full_depth_settlement_pnl",
+                    "--alpha-search-output-dir",
+                    str(tmp / "out" / "alpha-search"),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+            replay = json.loads(
+                (tmp / "out" / "candidate-strategy-replay.json").read_text(encoding="utf-8")
+            )
+            promotion = json.loads(
+                (tmp / "out" / "autofactor-strategy-promotion.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(
+            replay["runtime_score"],
+            f"autofactor_formula:{factor_name}",
+        )
+        self.assertNotIn(
+            f"missing_runtime_contract:{factor_name}",
+            replay["blocking_risk_flags"],
+        )
+        self.assertEqual(
+            summary["variants"][0]["best_runtime_mappable_factor"]["name"],
+            factor_name,
+        )
+        evaluated = promotion["evaluated_factors"][0]
+        self.assertEqual(evaluated["factor"]["name"], factor_name)
+        self.assertEqual(
+            evaluated["runtime_mapping"]["runtime_score"],
+            f"autofactor_formula:{factor_name}",
+        )
+        self.assertNotIn(f"missing_runtime_contract:{factor_name}", evaluated["blockers"])
+
     def test_summary_marks_predictive_formula_mutation_runtime_mappable(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)


### PR DESCRIPTION
## Summary
- select alpha-search factor-registry-preview.json by allowed target before candidate replay and promotion
- fail closed when multiple registry previews exist but none match the requested target
- add regression coverage for tradeable target runtime contract selection

## Evidence
- Evidence stage: factor_attribution / walk_forward recovery with runtime_parity gate wiring, not strategy promotion
- python3 -m py_compile scripts/run_factor_walk_forward_sweep.py tests/test_factor_walk_forward_sweep.py
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_factor_walk_forward_sweep
- rtk git diff --check