### PR TITLE
Fix closed-loop runtime replay request routing

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -16,6 +16,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+try:
+    from autofactor_accounting_catalog import autofactor_target_horizon
+except ModuleNotFoundError:
+    from scripts.autofactor_accounting_catalog import autofactor_target_horizon
+
 
 DEFAULT_TARGET = "full_depth_settlement_executable_pnl"
 RUN_ID_RE = re.compile(r"(\d{8,})")
@@ -210,6 +215,15 @@ def classify_blockers(blockers: list[str]) -> str | None:
     text = " ".join(blockers).lower()
     if not text:
         return None
+    if any(
+        token in text
+        for token in [
+            "candidate_strategy_replay_not_runtime_replay",
+            "requires_runtime_replay_not_top_bucket_aggregate",
+            "candidate_strategy_replay_identity_basis_mismatch",
+        ]
+    ):
+        return "fix_runtime"
     if any(
         token in text
         for token in [
@@ -634,14 +648,23 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
                 "min_trade_count": "50",
                 "min_fill_rate": "0.30",
                 "min_roi": "0",
-                "options_json": json.dumps(
-                    {"full_depth_entry": True, "skip_settlement_exits": False},
-                    separators=(",", ":"),
-                    sort_keys=True,
-                ),
+                "options_json": runtime_replay_options_json(str(run.get("target") or DEFAULT_TARGET)),
             },
         }
     return None
+
+
+def runtime_replay_options_json(target: str) -> str:
+    return json.dumps(
+        {
+            "full_depth_entry": True,
+            "skip_settlement_exits": False,
+            "source_target": target,
+            "source_horizon": autofactor_target_horizon(target),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
@@ -720,11 +743,7 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
             "min_trade_count": "50",
             "min_fill_rate": "0.30",
             "min_roi": "0",
-            "options_json": json.dumps(
-                {"full_depth_entry": True, "skip_settlement_exits": False},
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
+            "options_json": runtime_replay_options_json(target),
         },
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,6 +22,32 @@ Evidence stage: `factor_attribution` / `walk_forward` recovery with
   reported `missing_runtime_contract:*`. Root cause was the sweep wrapper
   selecting the first `alpha-search/**/factor-registry-preview.json` by sorted
   path instead of the preview matching `--allowed-target`.
+- 2026-05-24: PR #639 merged and hosted walk-forward run `26343497815`
+  succeeded from `main`. The allowed target no longer has
+  `missing_runtime_contract:*`; the next blocker is correctly runtime replay,
+  not registry routing.
+
+## Current Session - Closed Loop Runtime Replay Request Fix (2026-05-24)
+
+Evidence stage: `walk_forward` -> `runtime_parity` planning, not strategy
+promotion.
+
+### Tasks
+
+- [x] Re-run closed-loop classification against run `26343497815` artifacts.
+- [x] Reclassify aggregate candidate replay blockers as `fix_runtime` even when
+      the aggregate artifact lacks runtime replay provenance fields.
+- [x] Include source target/horizon in generated runtime replay requests.
+- [x] Dispatch `runtime-candidate-replay.yml` for the selected runtime score.
+- [ ] Commit, push, merge, and feed runtime replay evidence back into promotion.
+
+### Review
+
+- 2026-05-24: Run `26343497815` selected runtime score
+  `autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity`
+  for the next runtime replay request with `source_target=tradeable_full_depth_settlement_pnl`
+  and `source_horizon=5m`. Runtime candidate replay run `26343673505` was
+  dispatched from `main`.
 
 ## Current Session - Runtime Chain Data Review (2026-05-24)
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -19,6 +19,7 @@ def write_json(path: Path, payload: dict) -> None:
 def artifact(
     root: Path,
     *,
+    target: str = "full_depth_settlement_executable_pnl",
     handoff_status: str = "blocked",
     chain_reason: str = "chain_next_run_false",
     should_dispatch: bool = False,
@@ -28,7 +29,6 @@ def artifact(
     candidate_strategy_replay: dict | None = None,
     write_feedback: bool = True,
 ) -> Path:
-    target = "full_depth_settlement_executable_pnl"
     factor_root = root / "factor-walk-forward-v2"
     alpha_root = factor_root / "alpha-search" / target
     if write_feedback:
@@ -575,8 +575,71 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertEqual(request["inputs"]["strategy_profile"], "settlement_probability")
             self.assertEqual(
                 json.loads(request["inputs"]["options_json"]),
-                {"full_depth_entry": True, "skip_settlement_exits": False},
+                {
+                    "full_depth_entry": True,
+                    "skip_settlement_exits": False,
+                    "source_horizon": "5m",
+                    "source_target": agent.DEFAULT_TARGET,
+                },
             )
+
+    def test_aggregate_replay_missing_artifact_fields_still_routes_to_fix_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_select_entry_price_quality_ge_050"
+            path = artifact(
+                Path(tmp),
+                target="tradeable_full_depth_settlement_pnl",
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                                "candidate_strategy_replay_missing_source_workflow",
+                                "candidate_strategy_replay_missing_workflow_run_id",
+                                "candidate_strategy_replay_missing_workflow_run_url",
+                                "candidate_strategy_replay_missing_artifact_name",
+                            ],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_select_entry_price_quality_ge_050",
+                                "target": "tradeable_full_depth_settlement_pnl",
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_avg_label": 3.54,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "basis": "factor_walk_forward_top_bucket_aggregate",
+                        "runtime_score": runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, "tradeable_full_depth_settlement_pnl")]
+            )
+            request = decision["runtime_replay_request"]
+
+        self.assertEqual(decision["decision"], "fix_runtime")
+        self.assertEqual(request["workflow"], "runtime-candidate-replay.yml")
+        self.assertEqual(request["inputs"]["runtime_score"], runtime_score)
+        self.assertEqual(
+            json.loads(request["inputs"]["options_json"]),
+            {
+                "full_depth_entry": True,
+                "skip_settlement_exits": False,
+                "source_horizon": "5m",
+                "source_target": "tradeable_full_depth_settlement_pnl",
+            },
+        )
 
     def test_fix_runtime_request_uses_best_current_runtime_mappable_factor(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- classify aggregate candidate replay blockers as fix_runtime even when the diagnostic artifact lacks runtime replay provenance fields
- include AutoFactor source_target/source_horizon in runtime-candidate-replay request options
- add regression coverage for tradeable target runtime replay request routing

## Evidence
- Evidence stage: walk_forward -> runtime_parity planning, not strategy promotion
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_research_manager_execute_plan tests.test_autofactor_walk_forward_evidence_js
- Local replay of run 26343497815 closed-loop artifact now returns fix_runtime with source_target=tradeable_full_depth_settlement_pnl
- rtk git diff --check