### PR TITLE
Add batch runtime replay requests

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -34,7 +34,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, durable trace persistence, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"persist_research_trace":true,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"persist_research_trace":true,"dispatch_runtime_replay_requests":true,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -119,10 +119,11 @@ jobs:
               "create_handoff_issue": "false",
               "create_config_pr": "false",
               "persist_research_trace": "true",
+              "dispatch_runtime_replay_requests": "true",
               "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
               "fail_if_blocked": "false",
           }
-          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "persist_research_trace", "fail_if_blocked", "require_deribit"}
+          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "persist_research_trace", "dispatch_runtime_replay_requests", "fail_if_blocked", "require_deribit"}
           choices = {
               "report_suite": {"core", "full"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
@@ -1013,6 +1014,82 @@ jobs:
           path: artifacts/factor-walk-forward-v2-upload/
           compression-level: 0
           retention-days: 14
+
+      - name: Dispatch runtime replay requests
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          closed_loop_path="artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json"
+          if [ "${WALK_DISPATCH_RUNTIME_REPLAY_REQUESTS:-true}" != "true" ]; then
+            echo "Runtime replay request dispatch disabled by options_json."
+            exit 0
+          fi
+          if [ ! -f artifacts/research-trace/persisted.env ]; then
+            echo "Runtime replay request dispatch requires successful durable Research OS trace persistence." >&2
+            exit 2
+          fi
+          if [ ! -f "${closed_loop_path}" ]; then
+            echo "Missing closed-loop classifier decision artifact; skipping runtime replay dispatch."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          path = Path("artifacts/factor-walk-forward-v2-upload/alpha-search-chain/closed-loop-decision.json")
+          decision = json.loads(path.read_text(encoding="utf-8"))
+          requests = decision.get("runtime_replay_requests") or []
+          if not isinstance(requests, list) or not requests:
+              print("No runtime replay requests in closed-loop decision.")
+              raise SystemExit(0)
+          if decision.get("action") != "fix_runtime":
+              print(f"Closed-loop action is {decision.get('action')}; skipping runtime replay dispatch.")
+              raise SystemExit(0)
+          for index, request in enumerate(requests, start=1):
+              if not isinstance(request, dict):
+                  continue
+              if request.get("workflow") != "runtime-candidate-replay.yml":
+                  raise SystemExit(f"unsupported runtime replay workflow at index {index}: {request.get('workflow')}")
+              inputs = request.get("inputs")
+              if not isinstance(inputs, dict):
+                  raise SystemExit(f"runtime replay request {index} has no inputs object")
+              required = [
+                  "deployment_id",
+                  "config_path",
+                  "recording_path",
+                  "runtime_score",
+                  "strategy_profile",
+                  "min_trade_count",
+                  "min_fill_rate",
+                  "min_roi",
+                  "options_json",
+              ]
+              missing = [key for key in required if not str(inputs.get(key) or "")]
+              if missing:
+                  raise SystemExit(f"runtime replay request {index} missing inputs: {', '.join(missing)}")
+              command = [
+                  "gh",
+                  "workflow",
+                  "run",
+                  "runtime-candidate-replay.yml",
+                  "--ref",
+                  os.environ["GITHUB_REF_NAME"],
+              ]
+              for key in required:
+                  command.extend(["-f", f"{key}={inputs[key]}"])
+              issue_number = str(inputs.get("issue_number") or os.environ.get("WALK_ISSUE_NUMBER") or "").strip()
+              if issue_number:
+                  command.extend(["-f", f"issue_number={issue_number}"])
+              print(
+                  "Dispatching runtime replay request "
+                  f"{index}/{len(requests)}: {inputs['runtime_score']}"
+              )
+              subprocess.run(command, check=True)
+          PY
 
       - name: Dispatch chained alpha search run
         if: always()

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
 
 DEFAULT_TARGET = "full_depth_settlement_executable_pnl"
 RUN_ID_RE = re.compile(r"(\d{8,})")
+MAX_RUNTIME_REPLAY_REQUESTS = 5
 
 ALLOWED_MUTATIONS = {
     "add_feature_gate",
@@ -592,7 +593,8 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         and chain.get("should_dispatch") is True
     )
     best = best_run(runs)
-    runtime_request = runtime_replay_request(current) if action == "fix_runtime" else None
+    runtime_requests = runtime_replay_requests(current) if action == "fix_runtime" else []
+    runtime_request = runtime_requests[0] if runtime_requests else None
     return {
         "schema_version": 1,
         "kind": "alpha_search_closed_loop_decision",
@@ -613,16 +615,30 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "next_steps": next_steps(action),
         "prior_revision_required": action == "revise_prior",
         "runtime_replay_request": runtime_request,
+        "runtime_replay_requests": runtime_requests,
         "runtime_pass_through_feedback": runtime_feedback,
         "runtime_unmapped_feedback": runtime_unmapped_feedback,
     }
 
 
 def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
-    candidate = runtime_replay_candidate(run)
-    if candidate is not None:
-        return candidate
+    candidates = runtime_replay_requests(run, limit=1)
+    if candidates:
+        return candidates[0]
+    return None
+
+
+def runtime_replay_requests(
+    run: dict[str, Any],
+    *,
+    limit: int = MAX_RUNTIME_REPLAY_REQUESTS,
+) -> list[dict[str, Any]]:
+    candidates = runtime_replay_candidates(run, limit=limit)
+    if candidates:
+        return candidates
     avoided_families = runtime_avoid_families(run)
+    requests: list[dict[str, Any]] = []
+    seen_scores: set[str] = set()
     for source in (run.get("promotion"), run.get("handoff")):
         if not isinstance(source, dict):
             continue
@@ -633,25 +649,22 @@ def runtime_replay_request(run: dict[str, Any]) -> dict[str, Any] | None:
         strategy_profile = str(replay.get("strategy_profile") or "settlement_probability").strip()
         if not runtime_score:
             continue
+        if runtime_score in seen_scores:
+            continue
         if factor_family(runtime_score_base_factor(runtime_score)) in avoided_families:
             continue
-        return {
-            "workflow": "runtime-candidate-replay.yml",
-            "git_ref": "main",
-            "reason": "replace aggregate top-bucket diagnostic with runtime_market_update_replay evidence",
-            "inputs": {
-                "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
-                "config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
-                "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
-                "runtime_score": runtime_score,
-                "strategy_profile": strategy_profile or "settlement_probability",
-                "min_trade_count": "50",
-                "min_fill_rate": "0.30",
-                "min_roi": "0",
-                "options_json": runtime_replay_options_json(str(run.get("target") or DEFAULT_TARGET)),
-            },
-        }
-    return None
+        seen_scores.add(runtime_score)
+        requests.append(
+            runtime_replay_request_payload(
+                target=str(run.get("target") or DEFAULT_TARGET),
+                runtime_score=runtime_score,
+                strategy_profile=strategy_profile or "settlement_probability",
+                source_factor="",
+            )
+        )
+        if len(requests) >= limit:
+            break
+    return requests
 
 
 def runtime_replay_options_json(target: str) -> str:
@@ -667,13 +680,69 @@ def runtime_replay_options_json(target: str) -> str:
     )
 
 
+def runtime_replay_request_payload(
+    *,
+    target: str,
+    runtime_score: str,
+    strategy_profile: str,
+    source_factor: str,
+) -> dict[str, Any]:
+    payload = {
+        "workflow": "runtime-candidate-replay.yml",
+        "git_ref": "main",
+        "reason": "replace aggregate top-bucket diagnostic with runtime_market_update_replay evidence",
+        "inputs": {
+            "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+            "config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+            "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+            "runtime_score": runtime_score,
+            "strategy_profile": strategy_profile or "settlement_probability",
+            "min_trade_count": "50",
+            "min_fill_rate": "0.30",
+            "min_roi": "0",
+            "options_json": runtime_replay_options_json(target),
+        },
+    }
+    if source_factor:
+        payload["source_factor"] = source_factor
+    return payload
+
+
 def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
+    candidates = runtime_replay_candidates(run, limit=1)
+    return candidates[0] if candidates else None
+
+
+def has_runtime_replay_disqualifying_blocker(item: dict[str, Any]) -> bool:
+    blockers = [blocker.lower() for blocker in blocker_strings(item)]
+    disqualifying_tokens = (
+        "missing_runtime_contract",
+        "runtime_contract_blocked",
+        "runtime_input_semantics_mismatch",
+        "unsupported_runtime_input",
+        "unsupported_runtime_inputs",
+        "missing_runtime_score",
+        "missing_runtime_strategy_mapping",
+        "empty_runtime_strategy_profile",
+        "required_strategy_profile_mismatch",
+    )
+    return any(
+        any(token in blocker for token in disqualifying_tokens)
+        for blocker in blockers
+    )
+
+
+def runtime_replay_candidates(
+    run: dict[str, Any],
+    *,
+    limit: int = MAX_RUNTIME_REPLAY_REQUESTS,
+) -> list[dict[str, Any]]:
     promotion = run.get("promotion")
     if not isinstance(promotion, dict):
-        return None
+        return []
     evaluated = promotion.get("evaluated_factors")
     if not isinstance(evaluated, list):
-        return None
+        return []
     target = run.get("target") or DEFAULT_TARGET
     required_profile = str(
         promotion.get("required_strategy_profile") or "settlement_probability"
@@ -686,6 +755,8 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
         factor = item.get("factor")
         runtime_mapping = item.get("runtime_mapping")
         if not isinstance(factor, dict) or not isinstance(runtime_mapping, dict):
+            continue
+        if has_runtime_replay_disqualifying_blocker(item):
             continue
         if factor.get("target") not in {None, target}:
             continue
@@ -701,51 +772,50 @@ def runtime_replay_candidate(run: dict[str, Any]) -> dict[str, Any] | None:
             continue
         candidates.append(item)
     if not candidates:
-        return None
+        return []
 
     best_candidate_name = str((run.get("feedback") or {}).get("best_candidate") or "")
 
-    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float]:
+    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float, float, float]:
         factor = item.get("factor") if isinstance(item.get("factor"), dict) else {}
         return (
             1.0 if best_candidate_name and factor.get("name") == best_candidate_name else 0.0,
             1.0
             if factor.get("decision") == "candidate" and factor.get("reason") == "passed"
             else 0.0,
+            as_float(factor.get("top_bucket_n")) or 0.0,
             as_float(factor.get("top_bucket_avg_label")) or 0.0,
+            as_float(factor.get("top_bucket_full_depth_entry_fill_rate")) or 0.0,
             as_float(factor.get("positive_window_ratio")) or 0.0,
             as_float(factor.get("symbol_positive_ratio")) or 0.0,
             as_float(factor.get("spearman_ic")) or 0.0,
         )
 
-    selected = max(candidates, key=score)
-    factor = selected.get("factor") if isinstance(selected.get("factor"), dict) else {}
-    mapping = (
-        selected.get("runtime_mapping")
-        if isinstance(selected.get("runtime_mapping"), dict)
-        else {}
-    )
-    runtime_score = str(mapping.get("runtime_score") or "").strip()
-    strategy_profile = str(mapping.get("strategy_profile") or required_profile).strip()
-    if not runtime_score:
-        return None
-    return {
-        "workflow": "runtime-candidate-replay.yml",
-        "git_ref": "main",
-        "reason": "replace aggregate top-bucket diagnostic with runtime_market_update_replay evidence",
-        "source_factor": str(factor.get("name") or ""),
-        "inputs": {
-            "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
-            "config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
-            "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
-            "runtime_score": runtime_score,
-            "strategy_profile": strategy_profile or "settlement_probability",
-            "min_trade_count": "50",
-            "min_fill_rate": "0.30",
-            "min_roi": "0",
-            "options_json": runtime_replay_options_json(target),
-        },
-    }
+    requests: list[dict[str, Any]] = []
+    seen_scores: set[str] = set()
+    for selected in sorted(candidates, key=score, reverse=True):
+        factor = selected.get("factor") if isinstance(selected.get("factor"), dict) else {}
+        mapping = (
+            selected.get("runtime_mapping")
+            if isinstance(selected.get("runtime_mapping"), dict)
+            else {}
+        )
+        runtime_score = str(mapping.get("runtime_score") or "").strip()
+        strategy_profile = str(mapping.get("strategy_profile") or required_profile).strip()
+        if not runtime_score or runtime_score in seen_scores:
+            continue
+        seen_scores.add(runtime_score)
+        requests.append(
+            runtime_replay_request_payload(
+                target=str(target),
+                runtime_score=runtime_score,
+                strategy_profile=strategy_profile or "settlement_probability",
+                source_factor=str(factor.get("name") or ""),
+            )
+        )
+        if len(requests) >= limit:
+            break
+    return requests
 
 
 def runtime_avoid_families(run: dict[str, Any]) -> set[str]:
@@ -1066,6 +1136,20 @@ def write_markdown(decision: dict[str, Any], path: Path, prior_path: Path | None
         ):
             if key in inputs:
                 lines.append(f"- {key}: `{inputs[key]}`")
+    runtime_requests = decision.get("runtime_replay_requests")
+    if isinstance(runtime_requests, list) and len(runtime_requests) > 1:
+        lines.extend(["", "## Additional Runtime Replay Requests", ""])
+        for index, request in enumerate(runtime_requests[1:], start=2):
+            if not isinstance(request, dict):
+                continue
+            inputs = request.get("inputs") if isinstance(request.get("inputs"), dict) else {}
+            lines.append(
+                "- {index}. `{source}` -> `{runtime_score}`".format(
+                    index=index,
+                    source=request.get("source_factor") or "<candidate>",
+                    runtime_score=inputs.get("runtime_score", ""),
+                )
+            )
     if decision["promotion_blockers"]:
         lines.extend(["", "## Promotion Blockers", ""])
         lines.extend(f"- `{item}`" for item in decision["promotion_blockers"][:20])

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,32 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Batch Runtime Replay Request Dispatch (2026-05-24)
+
+Evidence stage: `walk_forward` -> `runtime_parity` / `executable_replay`
+request automation, not strategy promotion.
+
+### Tasks
+
+- [x] Preserve the legacy single `runtime_replay_request` field for consumers.
+- [x] Emit a deduped batch of runtime replay requests from unblocked
+      runtime-mapped candidates.
+- [x] Gate hosted runtime replay dispatch on durable trace persistence and
+      closed-loop `fix_runtime` action.
+- [x] Validate the batch request builder against run `26343497815` artifacts.
+- [ ] Commit, push, merge, and rerun hosted walk-forward from `main`.
+
+### Review
+
+- 2026-05-24: The current blocker after PR #639/#640 is no longer missing
+  runtime contracts or closed-loop routing. Runtime replay evidence exists, but
+  each replay still has too few trades for promotion, so the hosted workflow now
+  needs to automatically fan out the top runtime-mappable candidates instead of
+  requiring manual one-by-one dispatch.
+- 2026-05-24: Local simulation against run `26343497815` produced five
+  `runtime-candidate-replay.yml` requests for
+  `tradeable_full_depth_settlement_pnl` / `5m` after filtering
+  contract-blocked runtime input mismatches such as `external_pressure`.
+
 ## Current Session - Sweep Target Registry Preview Fix (2026-05-24)
 
 Evidence stage: `factor_attribution` / `walk_forward` recovery with

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -714,6 +714,101 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
 
+    def test_fix_runtime_includes_batch_runtime_replay_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scores = [
+                (
+                    "mut_settlement_capacity",
+                    "autofactor_formula:mut_settlement_capacity",
+                    6.0,
+                    0.75,
+                    [],
+                ),
+                (
+                    "mut_external_entry_quality",
+                    "autofactor_formula:mut_external_entry_quality",
+                    3.0,
+                    0.90,
+                    [],
+                ),
+                (
+                    "mut_contract_blocked_external_pressure",
+                    "autofactor_formula:mut_contract_blocked_external_pressure",
+                    10.0,
+                    1.00,
+                    ["runtime_input_semantics_mismatch:external_pressure"],
+                ),
+                (
+                    "mut_duplicate_score",
+                    "autofactor_formula:mut_external_entry_quality",
+                    1.0,
+                    0.50,
+                    [],
+                ),
+            ]
+            path = artifact(
+                Path(tmp),
+                target="tradeable_full_depth_settlement_pnl",
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                            ]
+                            + blockers,
+                            "factor": {
+                                "name": name,
+                                "target": "tradeable_full_depth_settlement_pnl",
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_avg_label": avg_label,
+                                "top_bucket_full_depth_entry_fill_rate": fill_rate,
+                                "top_bucket_n": 400,
+                                "positive_window_ratio": 0.75,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.10,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                        for name, runtime_score, avg_label, fill_rate, blockers in scores
+                    ],
+                    "candidate_strategy_replay": {
+                        "basis": "factor_walk_forward_top_bucket_aggregate",
+                        "runtime_score": "autofactor_formula:mut_external_entry_quality",
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, "tradeable_full_depth_settlement_pnl")]
+            )
+            requests = decision["runtime_replay_requests"]
+
+        self.assertEqual(decision["decision"], "fix_runtime")
+        self.assertEqual([item["source_factor"] for item in requests], [
+            "mut_settlement_capacity",
+            "mut_external_entry_quality",
+        ])
+        self.assertEqual(
+            [item["inputs"]["runtime_score"] for item in requests],
+            [
+                "autofactor_formula:mut_settlement_capacity",
+                "autofactor_formula:mut_external_entry_quality",
+            ],
+        )
+        for request in requests:
+            self.assertEqual(
+                json.loads(request["inputs"]["options_json"])["source_target"],
+                "tradeable_full_depth_settlement_pnl",
+            )
+
     def test_fix_runtime_request_prefers_feedback_best_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             best_runtime_score = "autofactor_formula:mut_spread_adjusted_external_move_near_strike"

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -745,6 +745,41 @@ fn factor_research_workflows_thread_pm_book_sample_cadence() {
 }
 
 #[test]
+fn hosted_factor_walk_forward_dispatches_runtime_replay_requests() {
+    let hosted = workflow_contents(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml");
+    let mut offenders = Vec::new();
+
+    for needle in [
+        "dispatch_runtime_replay_requests",
+        "Dispatch runtime replay requests",
+        "runtime_replay_requests",
+        "runtime-candidate-replay.yml",
+        "Runtime replay request dispatch requires successful durable Research OS trace persistence",
+        "decision.get(\"action\") != \"fix_runtime\"",
+        "gh",
+        "workflow",
+        "run",
+        "--ref",
+        "GITHUB_REF_NAME",
+        "deployment_id",
+        "runtime_score",
+        "options_json",
+    ] {
+        if !hosted.contains(needle) {
+            offenders.push(format!(
+                "factor-walk-forward-v2-hosted-artifact.yml: missing `{needle}`"
+            ));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "hosted runtime replay request dispatch guard failed:\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
 fn runtime_candidate_replay_allows_empty_entry_score_override() {
     let workflow = workflow_contents(".github/workflows/runtime-candidate-replay.yml");
     assert!(


### PR DESCRIPTION
## Summary
- emit a deduped batch of runtime replay requests from the closed-loop AutoFactor classifier while preserving the legacy single request field
- skip runtime-contract/input/profile hard blockers before dispatching replay jobs
- let hosted factor walk-forward dispatch runtime-candidate-replay workflows only after durable trace persistence and fix_runtime action

## Evidence stage
walk_forward -> runtime_parity / executable_replay request automation; no strategy promotion implied.

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- YAML parse for .github/workflows/factor-walk-forward-v2-hosted-artifact.yml
- rtk cargo test --locked --test workflow_security hosted_factor_walk_forward_dispatches_runtime_replay_requests
- rtk git diff --check
- simulated closed-loop output against run 26343497815 artifact: action=fix_runtime, 5 runtime replay requests, source_target=tradeable_full_depth_settlement_pnl, source_horizon=5m, contract-blocked external_pressure candidate excluded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now generates and dispatches multiple runtime replay requests for enhanced verification coverage.
  * Added workflow automation to batch-dispatch runtime replay requests with validation and deduplication.

* **Tests**
  * Added test coverage for batch runtime replay request generation and dispatch functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->