### PR TITLE
Document runtime replay chain evidence

### DIFF
--- a/docs/reviews/research-data-architecture-review-2026-05-23.md
+++ b/docs/reviews/research-data-architecture-review-2026-05-23.md
@@ -22,9 +22,9 @@ reserved for `executable_replay` evidence.
 | Raw source surfaces | Tango PostgreSQL plus cold lake paths for CLOB/orderbook data | Exists, but not all research runners consume raw/full-resolution surfaces directly |
 | Research snapshot | `research_snapshot_compile` emits immutable complete sampled artifacts with source-surface metadata and canonical `gate_category` values | Canonical factor-search input; not full-resolution execution replay evidence |
 | Alpha-search | Hosted artifact walk-forward emits registry previews, typed runtime contracts, MCTS tree, search feedback, promotion/handoff artifacts | Usable for factor discovery and attribution |
-| Candidate replay | `candidate_replay_tapes` exists and `persist_research_trace` can link replay artifacts to factor evaluations | Durable replay identity now exists; true runtime replay evidence must still be supplied per candidate |
-| Durable trace | Hosted walk-forward defaults to trace persistence and writes Research OS rows when DB secrets and deployed binaries are available | Current `main` run `26336054813` persisted trace and uploaded `research-trace/persisted.env` |
-| Research Manager | `research_trace_plan` can read durable DB trace and emit next-plan JSON; `research-manager-execute-plan.yml` can dispatch bounded follow-up evidence | Main run `26340671822` proved executor dispatch for runtime candidate replay and recorded replay parity |
+| Candidate replay | `candidate_replay_tapes` exists and `persist_research_trace` can link replay artifacts to factor evaluations | Durable replay identity exists, and hosted walk-forward can now fan out runtime replay requests from unblocked runtime contracts |
+| Durable trace | Hosted walk-forward defaults to trace persistence and writes Research OS rows when DB secrets and deployed binaries are available | Current `main` run `26344749058` persisted trace and uploaded `research-trace/persisted.env` |
+| Research Manager | `research_trace_plan` can read durable DB trace and emit next-plan JSON; `research-manager-execute-plan.yml` and hosted walk-forward can dispatch bounded follow-up evidence | Main runs have proven executor dispatch, recorded replay parity, and closed-loop runtime replay fan-out |
 | Legacy research paths | Factor routers and Event ML rolling evidence are artifact-backed only | Former direct `ploy-ci-1` DB execution/export branches have been removed from the active research chain |
 | Diagnostic backtest | `backtest.yml` now emits `evidence-stage` artifacts with `promotion_ready=false` | Useful diagnostic replay/backtest surface; not promotion evidence |
 
@@ -85,6 +85,15 @@ reserved for `executable_replay` evidence.
    compatible input alias for older dispatch payloads, but downstream artifacts
    no longer describe retained sampled products as unsampled source data.
 
+9. **Closed-loop runtime replay fan-out is automated.**
+
+   Hosted walk-forward now emits a deduped `runtime_replay_requests` batch while
+   preserving the legacy single `runtime_replay_request` field. Dispatch is
+   gated on successful durable trace persistence and closed-loop
+   `action=fix_runtime`. Contract-blocked candidates, including runtime input
+   semantic mismatches such as `external_pressure`, are excluded before
+   dispatch.
+
 ## Current Verified Runs
 
 | Run | Git ref / source | Result | Meaning |
@@ -95,13 +104,18 @@ reserved for `executable_replay` evidence.
 | `26340671822` | `main` Research Manager executor | Succeeded; dispatched runtime candidate replay `26340673836` and recorded replay parity `26340674276` | Closed-loop evidence dispatch is proven |
 | `26340674276` | recorded replay parity | Succeeded; `strict_parity_ready=true` with no shared-row mismatches | Dry-run/runtime parity proof is available for the checked recording slice |
 | `26340673836` | runtime candidate replay | Succeeded but blocked; `updates_processed=43721`, `intents_submitted=0`, `orders=0`, `fills=0` | Current AutoFactor runtime candidate is not tradable and should be revised/rejected |
+| `26344523079` | `main` at `a74f030b7e8c288144b5fd5a35a75da9b589bc78` | Hosted walk-forward succeeded; `persisted=true`; dispatched five runtime replay requests from `runtime_replay_requests` | Snapshot -> walk-forward -> durable trace -> runtime replay fan-out is working |
+| `26344588318` / `26344588684` / `26344589064` / `26344589439` / `26344589743` | runtime candidate replay batch | All succeeded with `basis=runtime_market_update_replay`; trade counts were `29`, `29`, `8`, `16`, and `15`; fill rate was `1.0` for all | Runtime replay automation works, but every candidate remains below the 50-trade promotion gate |
+| `26344749058` | `main` hosted walk-forward with replay `26344588318` | Succeeded; consumed true runtime replay evidence; closed-loop action became `fix_data` with zero replay requests | Promotion now sees runtime replay evidence and blocks on data/trade-count/settlement gates instead of runtime provenance |
 
-The current walk-forward evidence is deliberately blocked:
+The current walk-forward/runtime replay evidence is deliberately blocked:
 
-- `sweep-summary.json` reports `decision=blocked` and `qualified_count=0`.
-- Candidate replay remains a diagnostic aggregate
-  (`basis=factor_walk_forward_top_bucket_aggregate`) and is blocked by
-  `no_runtime_mappable_candidate`.
+- `sweep-summary.json` still reports `decision=blocked`.
+- Candidate replay is no longer only a diagnostic aggregate for the selected
+  replay-fed run: it uses `basis=runtime_market_update_replay`, but remains
+  blocked by `trade_count_too_small:29<50`,
+  `official_settlement_missing:25<29`, and
+  `candidate_strategy_replay_missing_contract:official_settlement`.
 - Snapshot contract blockers include
   `sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots`,
   so the run cannot make full-depth executable handoff claims.
@@ -110,16 +124,17 @@ The current walk-forward evidence is deliberately blocked:
 
 ## Remaining Problems
 
-1. **Research Manager dispatch is proven, but strategy discovery is not.**
+1. **Runtime replay dispatch is proven, but strategy discovery is not.**
 
    `research_trace_plan` produces a typed plan from DB trace, and
    `research-manager-execute-plan.yml` has executed bounded follow-up actions.
-   The current result is a blocked runtime candidate with zero runtime
-   orders/fills, not a dry-run handoff. The remaining automation gap is
-   candidate generation: positive factor/search rows must naturally become
-   runtime candidate replay requests through typed runtime contracts, and known
-   blocked runtime scores must feed back into the next prior instead of being
-   replayed repeatedly.
+   Hosted walk-forward now turns positive runtime-mapped rows into bounded
+   `runtime-candidate-replay.yml` requests without manual artifact
+   interpretation. The current result is still not a dry-run handoff: the best
+   fresh runtime replay has 29 trades, complete fills, positive ROI, and
+   incomplete official settlement coverage, so promotion correctly blocks. The
+   remaining discovery gap is denser candidate formation over more event tape,
+   not lowering thresholds.
 
 2. **Feature snapshots are still sampled research products, not full execution
    tapes.**
@@ -165,9 +180,10 @@ The current walk-forward evidence is deliberately blocked:
 
 | Priority | Work | Done when |
 | --- | --- | --- |
-| P0 | Keep Research Manager candidate replay contract-driven | Executor replays only explicit or trace-derived unblocked runtime contracts and fails closed without one |
+| P0 | Increase runtime replay event density without lowering promotion gates | Runtime replay candidates naturally reach the 50-trade minimum on distinct events, or the candidate family is rejected/revised |
 | P0 | Repair or replace sampled execution-surface evidence | Full-depth CLOB lake or runtime replay evidence replaces sampled `clob_orderbook_snapshots` for executable handoff |
-| P0 | Explain why latest trace plan had empty factor registry/latest run arrays | Query path either links run `26336054813` rows or records why no runtime-mappable factor rows were persisted |
+| P0 | Complete official settlement coverage for runtime replay candidates | Runtime replay artifacts include official settlement for all traded events before any handoff can become ready |
+| P0 | Keep Research Manager candidate replay contract-driven | Executor replays only explicit or trace-derived unblocked runtime contracts and fails closed without one |
 | P1 | Promote runtime input canonicalization to a generated shared contract | Rust runtime scoring, Rust alpha-search, and Python promotion/replay use one source of truth instead of mirrored catalogs |
 | P1 | Complete full-depth executable evidence layer | Runtime replay or full-depth lake evidence replaces sampled snapshot rows for executable handoff |
 | P1 | Generate shared non-AutoFactor label contracts | Runtime, research, replay, and trace persistence derive 30s / 60s / 5m / 15m label definitions from one source |
@@ -186,6 +202,7 @@ through profitable strategy discovery or dry-run handoff. The proven sequence is
 research-snapshot.yml
   -> factor-walk-forward-v2-hosted-artifact.yml
   -> persist Research OS trace
+  -> closed-loop runtime replay request batch
   -> research-trace-plan.yml
   -> research-manager-execute-plan.yml
   -> runtime-candidate-replay.yml / recorded-replay-parity.yml
@@ -196,7 +213,7 @@ The missing sequence is now:
 ```text
 blocked runtime candidate
   -> closed-loop prior revision / new runtime-mappable candidate
-  -> runtime_market_update_replay with executable orders/fills
+  -> runtime_market_update_replay with at least 50 distinct event trades
   -> handoff only if full-depth execution, official settlement, ROI, fillability, and parity gates pass
 ```
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,7 +13,10 @@ request automation, not strategy promotion.
 - [x] Gate hosted runtime replay dispatch on durable trace persistence and
       closed-loop `fix_runtime` action.
 - [x] Validate the batch request builder against run `26343497815` artifacts.
-- [ ] Commit, push, merge, and rerun hosted walk-forward from `main`.
+- [x] Commit, push, merge, and rerun hosted walk-forward from `main`.
+- [x] Feed the best fresh runtime replay artifact back into hosted promotion.
+- [x] Refresh the research/data architecture review with the runtime replay
+      fan-out evidence and remaining blockers.
 
 ### Review
 
@@ -26,6 +29,17 @@ request automation, not strategy promotion.
   `runtime-candidate-replay.yml` requests for
   `tradeable_full_depth_settlement_pnl` / `5m` after filtering
   contract-blocked runtime input mismatches such as `external_pressure`.
+- 2026-05-24: PR #641 merged as
+  `a74f030b7e8c288144b5fd5a35a75da9b589bc78`. Hosted walk-forward run
+  `26344523079` persisted trace and automatically dispatched five runtime
+  candidate replay runs: `26344588318`, `26344588684`, `26344589064`,
+  `26344589439`, and `26344589743`.
+- 2026-05-24: The replay batch succeeded with `basis=runtime_market_update_replay`
+  and fill rate `1.0`, but trade counts were still too small:
+  `29`, `29`, `8`, `16`, and `15` trades. Replay-fed promotion run
+  `26344749058` consumed run `26344588318` and correctly changed the
+  closed-loop blocker to `fix_data`: sampled CLOB execution surface, 29<50
+  trades, and missing official settlement for 4 of 29 traded events.
 
 ## Current Session - Sweep Target Registry Preview Fix (2026-05-24)
 
@@ -39,7 +53,7 @@ Evidence stage: `factor_attribution` / `walk_forward` recovery with
 - [x] Make sweep registry preview selection target-aware for candidate replay
       and promotion.
 - [x] Add regression coverage for multiple alpha-search target previews.
-- [ ] Commit, push, merge, and rerun hosted walk-forward from `main`.
+- [x] Commit, push, merge, and rerun hosted walk-forward from `main`.
 
 ### Review
 
@@ -66,7 +80,7 @@ promotion.
       the aggregate artifact lacks runtime replay provenance fields.
 - [x] Include source target/horizon in generated runtime replay requests.
 - [x] Dispatch `runtime-candidate-replay.yml` for the selected runtime score.
-- [ ] Commit, push, merge, and feed runtime replay evidence back into promotion.
+- [x] Commit, push, merge, and feed runtime replay evidence back into promotion.
 
 ### Review
 


### PR DESCRIPTION
## Summary
- record PR #641 / run 26344523079 runtime replay fan-out evidence
- record the five automatically dispatched runtime replay results and the replay-fed promotion run 26344749058
- update remaining data/research blockers: sampled CLOB execution surface, trade count below 50, incomplete official settlement coverage

## Evidence stage
walk_forward -> runtime_parity / executable_replay evidence review; no dry-run or live promotion implied.

## Validation
- rtk git diff --check
