### PR TITLE
Add Research Manager blocker actions

### DIFF
--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -30,6 +30,15 @@ pub struct ResearchManagerPlan {
     pub priority: String,
     pub evidence_stage: String,
     pub actions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocker_actions: Vec<ResearchBlockerAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResearchBlockerAction {
+    pub blocker_family: String,
+    pub action: String,
+    pub reason: String,
 }
 
 fn default_evidence_stage() -> String {
@@ -65,7 +74,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
         &["missing", "stale", "critical_missing"],
         &[true.into(), "true".into(), "critical".into()],
     ) {
-        return Ok(plan(
+        return Ok(plan_with_blocker_actions(
             "fix_data",
             0,
             0,
@@ -75,6 +84,36 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
                 "repair_or_exclude_missing_data_surface",
                 "rerun_snapshot_data_audit",
             ],
+            derive_blocker_actions(input),
+        ));
+    }
+
+    let blocker_actions = derive_blocker_actions(input);
+    if blocker_actions
+        .iter()
+        .any(|item| item.blocker_family.starts_with("data_"))
+    {
+        let mut actions = vec!["rerun_snapshot_data_audit"];
+        if blocker_actions
+            .iter()
+            .any(|item| item.action == "repair_official_settlement_coverage")
+        {
+            actions.insert(0, "repair_official_settlement_coverage");
+        }
+        if blocker_actions
+            .iter()
+            .any(|item| item.action == "collect_full_depth_execution_surface")
+        {
+            actions.insert(0, "collect_full_depth_execution_surface");
+        }
+        return Ok(plan_with_blocker_actions(
+            "fix_data",
+            0,
+            0,
+            "high",
+            &input.evidence_stage,
+            actions,
+            blocker_actions,
         ));
     }
 
@@ -94,7 +133,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
         &["replay_parity_ready", "runtime_parity_ready"],
         &[false.into(), "false".into()],
     ) {
-        return Ok(plan(
+        return Ok(plan_with_blocker_actions(
             "fix_runtime",
             0,
             0,
@@ -104,6 +143,24 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
                 "run_recorded_replay_parity",
                 "compare_runtime_scorer_contract",
             ],
+            blocker_actions,
+        ));
+    }
+
+    if blocker_actions.iter().any(|item| {
+        item.blocker_family == "search_power" || item.blocker_family == "execution_fillability"
+    }) {
+        return Ok(plan_with_blocker_actions(
+            "revise_prior",
+            input.research_budget.max_candidates_per_day.min(8),
+            2,
+            "high",
+            &input.evidence_stage,
+            vec![
+                "generate_typed_llm_prior_json",
+                "rerun_alpha_search_with_bounded_mutations",
+            ],
+            blocker_actions,
         ));
     }
 
@@ -182,7 +239,135 @@ fn plan(
         priority: priority.to_string(),
         evidence_stage: evidence_stage.to_string(),
         actions: actions.into_iter().map(str::to_string).collect(),
+        blocker_actions: Vec::new(),
     }
+}
+
+fn plan_with_blocker_actions(
+    theme: &str,
+    candidate_count: usize,
+    search_depth: usize,
+    priority: &str,
+    evidence_stage: &str,
+    actions: Vec<&str>,
+    blocker_actions: Vec<ResearchBlockerAction>,
+) -> ResearchManagerPlan {
+    ResearchManagerPlan {
+        blocker_actions,
+        ..plan(
+            theme,
+            candidate_count,
+            search_depth,
+            priority,
+            evidence_stage,
+            actions,
+        )
+    }
+}
+
+fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAction> {
+    let mut actions = Vec::new();
+    let latest = input.latest_runs.to_string().to_lowercase();
+    let rejected = input.rejected_factor_patterns.to_string().to_lowercase();
+    let runtime_or_promotion_blockers = format!("{latest} {rejected}");
+
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &[
+            "official_settlement_missing",
+            "missing_official_settlement",
+            "settlement_labels_missing",
+            "official settlement",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "data_settlement",
+            "repair_official_settlement_coverage",
+            "Runtime replay traded events are missing official settlement labels.",
+        ));
+    }
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &[
+            "sampled_snapshot_required_for_execution_surface",
+            "required_execution_surface_is_sampled_snapshot",
+            "full_depth_missing",
+            "full-depth missing",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "data_execution_surface",
+            "collect_full_depth_execution_surface",
+            "Promotion requires full-depth executable evidence instead of sampled snapshots.",
+        ));
+    }
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &["trade_count_too_small", "min_trade_count", "too_few_trades"],
+    ) {
+        actions.push(blocker_action(
+            "search_power",
+            "increase_distinct_event_coverage_or_reduce_selectivity",
+            "Runtime replay did not produce enough distinct event-level trades.",
+        ));
+    }
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &[
+            "fillability",
+            "fill_rate_too_low",
+            "entry_fill_rate_too_low",
+            "capacity_too_low",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "execution_fillability",
+            "prefer_high_fillability_depth_filters",
+            "Candidate selection must avoid thin depth or low-fillability entry surfaces.",
+        ));
+    }
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &[
+            "missing_runtime_contract",
+            "runtime_contract_unmapped_factor",
+            "missing_runtime_strategy_mapping",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "runtime_contract",
+            "repair_runtime_contract_mapping",
+            "Factor needs a typed unblocked runtime contract before replay or promotion.",
+        ));
+    }
+    if contains_any_text(
+        &runtime_or_promotion_blockers,
+        &[
+            "candidate_strategy_replay_not_runtime_replay",
+            "requires_runtime_replay_not_top_bucket_aggregate",
+            "candidate_strategy_replay_identity_basis_mismatch",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "runtime_replay",
+            "build_runtime_market_update_replay",
+            "Top-bucket aggregate evidence must be replaced by ordered runtime MarketUpdate replay.",
+        ));
+    }
+
+    actions
+}
+
+fn blocker_action(blocker_family: &str, action: &str, reason: &str) -> ResearchBlockerAction {
+    ResearchBlockerAction {
+        blocker_family: blocker_family.to_string(),
+        action: action.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn contains_any_text(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
 }
 
 fn contains_string(value: &serde_json::Value, needles: &[&str]) -> bool {
@@ -346,10 +531,9 @@ mod tests {
         ))
         .expect("plan");
         assert_eq!(plan.theme, "revise_prior");
-        assert!(
-            plan.actions
-                .contains(&"generate_typed_llm_prior_json".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
     }
 
     #[test]
@@ -383,9 +567,64 @@ mod tests {
 
         let plan = plan_next_research(&input).expect("plan");
         assert_eq!(plan.theme, "candidate_to_runtime_replay");
-        assert!(
-            plan.actions
-                .contains(&"build_runtime_candidate_replay".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"build_runtime_candidate_replay".to_string()));
+    }
+
+    #[test]
+    fn planner_turns_runtime_replay_trade_count_blocker_into_typed_prior_action() {
+        let plan = plan_next_research(&input(
+            "executable_replay",
+            serde_json::json!({
+                "candidate_strategy_replay": {
+                    "blocking_risk_flags": ["trade_count_too_small:29<50"]
+                }
+            }),
+            serde_json::json!({}),
+        ))
+        .expect("plan");
+
+        assert_eq!(plan.theme, "revise_prior");
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "search_power"
+                && item.action == "increase_distinct_event_coverage_or_reduce_selectivity"
+        }));
+    }
+
+    #[test]
+    fn planner_turns_runtime_replay_data_blockers_into_data_actions() {
+        let plan = plan_next_research(&input(
+            "executable_replay",
+            serde_json::json!({
+                "candidate_strategy_replay": {
+                    "blocking_risk_flags": [
+                        "official_settlement_missing:25<29",
+                        "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots"
+                    ]
+                }
+            }),
+            serde_json::json!({}),
+        ))
+        .expect("plan");
+
+        assert_eq!(plan.theme, "fix_data");
+        assert!(plan
+            .actions
+            .contains(&"repair_official_settlement_coverage".to_string()));
+        assert!(plan
+            .actions
+            .contains(&"collect_full_depth_execution_surface".to_string()));
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "data_settlement"
+                && item.action == "repair_official_settlement_coverage"
+        }));
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "data_execution_surface"
+                && item.action == "collect_full_depth_execution_surface"
+        }));
     }
 }

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -209,6 +209,14 @@ closed instead of replaying a hardcoded default score.
 The current architecture review is
 `docs/reviews/research-data-architecture-review-2026-05-23.md`.
 
+Research Manager plans also carry machine-readable `blocker_actions` when
+runtime replay or promotion evidence explains why a candidate stayed blocked.
+Current actions include official-settlement repair, full-depth execution-surface
+collection, broader distinct-event coverage, and high-fillability/depth-filter
+mutation. `scripts/research_manager_execute_plan.py` copies those actions into
+`research_manager_typed_prior.v1` so the next hosted search can consume the
+constraint instead of relying on a human to reinterpret the markdown blocker.
+
 `recorded-replay-parity.yml` defaults `since=auto` and `until=auto`. In auto
 mode it scans the target recording on `tango-1-1`, intersects that recording
 coverage with the dry-run report for the target deployment, prefers the latest

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -332,11 +332,54 @@ def _runtime_replay_args(args: argparse.Namespace, plan_payload: dict[str, Any])
     }
 
 
+def _blocker_actions(plan: dict[str, Any]) -> list[dict[str, str]]:
+    raw = plan.get("blocker_actions")
+    if not isinstance(raw, list):
+        return []
+    actions: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        blocker_family = str(item.get("blocker_family") or "")
+        action = str(item.get("action") or "")
+        reason = str(item.get("reason") or "")
+        if blocker_family and action:
+            actions.append(
+                {
+                    "blocker_family": blocker_family,
+                    "action": action,
+                    "reason": reason,
+                }
+            )
+    return actions
+
+
+def _typed_prior_constraints(blocker_actions: list[dict[str, str]]) -> list[str]:
+    constraints = [
+        "reuse only runtime-contract-mappable inputs",
+        "do not promote without runtime_market_update_replay evidence",
+        "preserve one-event-one-decision accounting",
+    ]
+    action_names = {item["action"] for item in blocker_actions}
+    if "increase_distinct_event_coverage_or_reduce_selectivity" in action_names:
+        constraints.append("prefer candidates with broader distinct-event coverage and avoid ultra-narrow buckets")
+    if "prefer_high_fillability_depth_filters" in action_names:
+        constraints.append("prefer candidates with stronger full-depth fillability and capacity filters")
+    if "collect_full_depth_execution_surface" in action_names:
+        constraints.append("block promotion until full-depth execution-surface evidence replaces sampled snapshots")
+    if "repair_official_settlement_coverage" in action_names:
+        constraints.append("block promotion until official settlement coverage exists for all replay-traded events")
+    if "repair_runtime_contract_mapping" in action_names:
+        constraints.append("only select factors with typed unblocked runtime contracts")
+    return constraints
+
+
 def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any]) -> dict[str, Any]:
     if plan_payload.get("schema_version") != "research_trace_plan.v1":
         raise SystemExit("research_trace_plan schema mismatch")
     plan = plan_payload.get("plan") or {}
     actions = [str(action) for action in plan.get("actions") or []]
+    blocker_actions = _blocker_actions(plan)
     dispatches: list[dict[str, Any]] = []
     typed_prior: dict[str, Any] | None = None
 
@@ -409,11 +452,8 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             "evidence_stage": plan.get("evidence_stage", ""),
             "theme": plan.get("theme", ""),
             "actions": actions,
-            "constraints": [
-                "reuse only runtime-contract-mappable inputs",
-                "do not promote without runtime_market_update_replay evidence",
-                "preserve one-event-one-decision accounting",
-            ],
+            "blocker_actions": blocker_actions,
+            "constraints": _typed_prior_constraints(blocker_actions),
         }
 
     executable_dispatches = [item for item in dispatches if item["ready"]]
@@ -439,6 +479,7 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             "priority": plan.get("priority", ""),
             "evidence_stage": plan.get("evidence_stage", ""),
             "actions": actions,
+            "blocker_actions": blocker_actions,
         },
         "dispatches": dispatches,
         "executable_dispatch_count": len(executable_dispatches),
@@ -471,6 +512,11 @@ def render_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- `{item['workflow']}`: `{status}`; blockers: `{blockers}`{suffix}")
     if payload.get("typed_prior"):
         lines.extend(["", "## Typed Prior", "", "- `research_manager_typed_prior.v1` generated"])
+        blocker_actions = payload["typed_prior"].get("blocker_actions") or []
+        if blocker_actions:
+            lines.extend(["", "### Blocker Actions", ""])
+            for item in blocker_actions:
+                lines.append(f"- `{item['blocker_family']}` -> `{item['action']}`")
     if payload.get("dispatch_attempts"):
         lines.extend(["", "## Dispatch Attempts", ""])
         for item in payload["dispatch_attempts"]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,36 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Blocker Actions (2026-05-24)
+
+Evidence stage: architecture/data-plane cleanup and research workflow planning;
+no strategy promotion and no live data mutation.
+
+### Tasks
+
+- [x] Start a fresh implementation branch from current `origin/main`.
+- [x] Reconfirm project semantics and Event ML / AutoFactor workflow gates.
+- [x] Add machine-readable Research Manager blocker actions for runtime replay
+      and promotion blockers.
+- [x] Propagate blocker actions into the executor typed prior artifact.
+- [x] Run focused validation.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+### Review
+
+- 2026-05-24: Runtime replay blockers such as small distinct-event trade count,
+  missing official settlement, sampled execution surface, and low fillability
+  now become explicit Research Manager `blocker_actions`. The executor carries
+  those actions into `research_manager_typed_prior.v1` constraints so the next
+  hosted search can mutate around the blocker rather than repeating the same
+  candidate loop.
+- 2026-05-24: Focused validation passed: `rtk cargo test --locked -p
+  ploy-research research_os::manager --lib`, `python3 -m unittest
+  tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract`,
+  and `rtk git diff --check`. Full-workspace `cargo fmt --check` was not used
+  as a pass/fail gate because the current repo has pre-existing unrelated
+  rustfmt drift outside this slice; the touched Rust file was formatted with
+  `rustfmt`.
+
 ## Current Session - Legacy Crypto Trainer Cleanup (2026-05-24)
 
 Evidence stage: architecture/data-plane cleanup; no strategy promotion and no
@@ -15,7 +46,7 @@ live data mutation.
       checklist, or test callers.
 - [x] Keep the documented LOB TCN training entrypoint active.
 - [x] Run focused validation.
-- [ ] Commit, push, open PR, wait for CI, and merge.
+- [x] Commit, push, open PR, wait for CI, and merge.
 
 ### Review
 
@@ -29,6 +60,8 @@ live data mutation.
   archived trainer names, Python compile for the two archived trainers plus the
   retained LOB TCN trainer, `python3 -m unittest
   tests.test_persist_research_trace_contract`, and `rtk git diff --check`.
+- 2026-05-24: PR #648 merged to `main` at
+  `72daf3488fa06788785dc0716ed6c0f3b78257ec`.
 
 ## Current Session - Quote Backfill Legacy Cleanup (2026-05-24)
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -31,6 +31,32 @@ def plan_payload(theme: str, actions: list[str], factor_registry_summary: dict |
     }
 
 
+def base_args(**overrides):
+    values = {
+        "mode": "dry_run",
+        "execute_ack": "",
+        "git_ref": "main",
+        "snapshot_run_id": "",
+        "symbols": "BTCUSDT",
+        "stake_usd": "15",
+        "chain_remaining": 1,
+        "max_snapshot_window_days": 2,
+        "runtime_deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+        "runtime_config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+        "runtime_recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+        "runtime_score": "",
+        "runtime_strategy_profile": "settlement_probability",
+        "runtime_issue_number": "538",
+        "runtime_min_trade_count": "50",
+        "runtime_min_fill_rate": "0.30",
+        "runtime_min_roi": "0",
+        "runtime_source_target": "full_depth_settlement_executable_pnl",
+        "runtime_source_horizon": "5m",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
 class ResearchManagerExecutePlanTest(unittest.TestCase):
     def test_fix_data_plan_creates_snapshot_dispatch_in_dry_run(self) -> None:
         payload = build_executor_payload(
@@ -257,6 +283,34 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             self.assertTrue((out / "research-manager-executor.json").exists())
             self.assertTrue((out / "research-manager-executor.md").exists())
             self.assertTrue((out / "next-llm-prior.json").exists())
+
+    def test_typed_prior_carries_machine_readable_blocker_actions(self) -> None:
+        plan = plan_payload("revise_prior", ["generate_typed_llm_prior_json"])
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "search_power",
+                "action": "increase_distinct_event_coverage_or_reduce_selectivity",
+                "reason": "Runtime replay did not produce enough distinct event trades.",
+            },
+            {
+                "blocker_family": "execution_fillability",
+                "action": "prefer_high_fillability_depth_filters",
+                "reason": "Candidate selected low-fillability entries.",
+            },
+        ]
+        payload = build_executor_payload(base_args(), plan)
+
+        prior = payload["typed_prior"]
+        self.assertIsNotNone(prior)
+        self.assertEqual(plan["plan"]["blocker_actions"], prior["blocker_actions"])
+        self.assertIn(
+            "prefer candidates with broader distinct-event coverage and avoid ultra-narrow buckets",
+            prior["constraints"],
+        )
+        self.assertIn(
+            "prefer candidates with stronger full-depth fillability and capacity filters",
+            prior["constraints"],
+        )
 
     def test_cli_records_dispatch_failures_without_dropping_executor_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add typed `blocker_actions` to Research Manager plans for replay/promotion blockers such as small event trade counts, missing official settlement, sampled execution surfaces, and low fillability
- propagate those actions into `research_manager_typed_prior.v1` constraints so follow-up hosted searches can mutate around blockers instead of repeating the same candidate loop
- document the blocker-action contract in the strategy research CI/CD runbook

## Test Plan
- `rustfmt crates/ploy-research/src/research_os/manager.rs`
- `rtk cargo test --locked -p ploy-research research_os::manager --lib`
- `python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract`
- `rtk git diff --check`

Note: full-workspace `cargo fmt --check` currently reports pre-existing unrelated rustfmt drift outside this slice, so it was not used as the pass/fail gate.