### PR TITLE
Surface market data promotion blocker actions

### DIFF
--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -165,7 +165,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
     }
 
     if has_unblocked_runtime_candidate(&input.factor_registry_summary) {
-        return Ok(plan(
+        return Ok(plan_with_blocker_actions(
             "candidate_to_runtime_replay",
             1,
             0,
@@ -175,6 +175,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
                 "build_runtime_candidate_replay",
                 "write_runtime_replay_trace_artifact",
             ],
+            blocker_actions,
         ));
     }
 
@@ -190,7 +191,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
         &input.rejected_factor_patterns,
         &["stagnant", "repeated_rejection"],
     ) {
-        return Ok(plan(
+        return Ok(plan_with_blocker_actions(
             "revise_prior",
             input.research_budget.max_candidates_per_day.min(8),
             2,
@@ -200,6 +201,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
                 "generate_typed_llm_prior_json",
                 "rerun_alpha_search_with_bounded_mutations",
             ],
+            blocker_actions,
         ));
     }
 
@@ -211,7 +213,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
         input.research_budget.max_candidates_per_day.min(4)
     };
 
-    Ok(plan(
+    Ok(plan_with_blocker_actions(
         "continue_search",
         candidate_count,
         2,
@@ -221,6 +223,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
             "continue_hosted_alpha_search",
             "write_registry_preview_and_trace_artifacts",
         ],
+        blocker_actions,
     ))
 }
 
@@ -268,6 +271,7 @@ fn plan_with_blocker_actions(
 fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAction> {
     let mut actions = Vec::new();
     let latest = input.latest_runs.to_string().to_lowercase();
+    let market_data = input.market_data_health.to_string().to_lowercase();
     let rejected = input.rejected_factor_patterns.to_string().to_lowercase();
     let runtime_or_promotion_blockers = format!("{latest} {rejected}");
 
@@ -355,7 +359,37 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
         ));
     }
 
-    actions
+    if contains_any_text(
+        &market_data,
+        &[
+            "required_execution_surface_is_sampled_snapshot",
+            "sampled_snapshot_required_for_execution_surface",
+            "full_depth_missing",
+            "full-depth missing",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "promotion_data_execution_surface",
+            "collect_full_depth_execution_surface",
+            "Research snapshot data health reports sampled execution surface; promotion needs full-depth evidence.",
+        ));
+    }
+    if contains_any_text(
+        &market_data,
+        &[
+            "required_execution_surface_not_materialized",
+            "pm_token_settlements",
+            "official_settlement_missing",
+        ],
+    ) {
+        actions.push(blocker_action(
+            "promotion_data_settlement",
+            "repair_official_settlement_coverage",
+            "Research snapshot data health reports missing or non-materialized official settlement labels.",
+        ));
+    }
+
+    dedupe_blocker_actions(actions)
 }
 
 fn blocker_action(blocker_family: &str, action: &str, reason: &str) -> ResearchBlockerAction {
@@ -368,6 +402,19 @@ fn blocker_action(blocker_family: &str, action: &str, reason: &str) -> ResearchB
 
 fn contains_any_text(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
+}
+
+fn dedupe_blocker_actions(actions: Vec<ResearchBlockerAction>) -> Vec<ResearchBlockerAction> {
+    let mut deduped = Vec::new();
+    for action in actions {
+        if !deduped
+            .iter()
+            .any(|item: &ResearchBlockerAction| item.action == action.action)
+        {
+            deduped.push(action);
+        }
+    }
+    deduped
 }
 
 fn contains_string(value: &serde_json::Value, needles: &[&str]) -> bool {
@@ -498,6 +545,10 @@ mod tests {
         .expect("plan");
         assert_ne!(plan.theme, "fix_data");
         assert!(plan.candidate_count > 0);
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "promotion_data_execution_surface"
+                && item.action == "collect_full_depth_execution_surface"
+        }));
     }
 
     #[test]
@@ -625,6 +676,31 @@ mod tests {
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "data_execution_surface"
                 && item.action == "collect_full_depth_execution_surface"
+        }));
+    }
+
+    #[test]
+    fn planner_surfaces_snapshot_settlement_promotion_blocker_without_forcing_data_repair() {
+        let plan = plan_next_research(&input(
+            "factor_attribution",
+            serde_json::json!({}),
+            serde_json::json!({
+                "missing_blocks_promotion": true,
+                "critical_missing": false,
+                "promotion_blockers": [
+                    {
+                        "surface": "pm_token_settlements",
+                        "reason": "required_execution_surface_not_materialized"
+                    }
+                ]
+            }),
+        ))
+        .expect("plan");
+
+        assert_ne!(plan.theme, "fix_data");
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "promotion_data_settlement"
+                && item.action == "repair_official_settlement_coverage"
         }));
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,32 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Market Data Promotion Blocker Actions (2026-05-24)
+
+Evidence stage: architecture/data-plane cleanup and research workflow planning;
+no strategy promotion and no live data mutation.
+
+### Tasks
+
+- [x] Start a fresh fix branch from current `origin/main`.
+- [x] Reproduce the missing full-depth blocker action from hosted
+      `research-trace-plan` artifact `26346490855`.
+- [x] Map market-data promotion blockers to visible `promotion_data_*`
+      blocker actions without making them alone trigger snapshot reruns.
+- [x] Run focused validation.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+### Review
+
+- 2026-05-24: Hosted trace plan `26346490855` correctly emitted runtime replay
+  blocker actions, but `clob_orderbook_snapshots` sampled execution-surface
+  evidence stayed only in `market_data_health.promotion_blockers`. This fix
+  surfaces those promotion blockers as `promotion_data_execution_surface` /
+  `promotion_data_settlement` actions while preserving the existing rule that
+  promotion-only snapshot blockers do not by themselves cause another snapshot
+  rerun.
+- 2026-05-24: Focused validation passed: `rtk cargo test --locked -p
+  ploy-research research_os::manager --lib`.
+
 ## Current Session - Research Trace Plan Blocker Summary (2026-05-24)
 
 Evidence stage: architecture/data-plane cleanup and research workflow planning;
@@ -11,7 +38,7 @@ no strategy promotion and no live data mutation.
 - [x] Render Research Manager `blocker_actions` in the trace-plan workflow
       summary.
 - [x] Run focused validation.
-- [ ] Commit, push, open PR, wait for CI, and merge.
+- [x] Commit, push, open PR, wait for CI, and merge.
 
 ### Review
 
@@ -22,6 +49,8 @@ no strategy promotion and no live data mutation.
 - 2026-05-24: Focused validation passed: YAML parse for
   `research-trace-plan.yml`, `python3 -m unittest
   tests.test_persist_research_trace_contract`, and `rtk git diff --check`.
+- 2026-05-24: PR #650 merged to `main` at
+  `d5c450634ab9747f873ac5bab6ec8f88f7946d5f`.
 
 ## Current Session - Research Manager Blocker Actions (2026-05-24)
 


### PR DESCRIPTION
## Summary
- surface market-data promotion blockers as `promotion_data_*` Research Manager blocker actions
- preserve the existing rule that promotion-only sampled snapshot blockers do not by themselves trigger another snapshot rerun
- update task evidence with the hosted trace-plan artifact that exposed the missing full-depth action

## Test Plan
- `rtk cargo test --locked -p ploy-research research_os::manager --lib`
- `python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract`
- `rtk git diff --check`