### PR TITLE
Emit typed prior for Research Manager blocker actions

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -445,7 +445,11 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             )
         )
 
-    if plan.get("theme") == "revise_prior" or "generate_typed_llm_prior_json" in actions:
+    if (
+        plan.get("theme") == "revise_prior"
+        or "generate_typed_llm_prior_json" in actions
+        or blocker_actions
+    ):
         typed_prior = {
             "schema_version": "research_manager_typed_prior.v1",
             "source": "research_trace_plan",

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -312,6 +312,35 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             prior["constraints"],
         )
 
+    def test_fix_data_plan_with_blocker_actions_generates_typed_prior(self) -> None:
+        plan = plan_payload("fix_data", ["collect_full_depth_execution_surface"])
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "promotion_data_execution_surface",
+                "action": "collect_full_depth_execution_surface",
+                "reason": "Research snapshot data health reports sampled execution surface.",
+            },
+            {
+                "blocker_family": "promotion_data_settlement",
+                "action": "repair_official_settlement_coverage",
+                "reason": "Official settlement labels are required for promotion.",
+            },
+        ]
+        payload = build_executor_payload(base_args(), plan)
+
+        prior = payload["typed_prior"]
+        self.assertIsNotNone(prior)
+        self.assertEqual("fix_data", prior["theme"])
+        self.assertEqual(plan["plan"]["blocker_actions"], prior["blocker_actions"])
+        self.assertIn(
+            "block promotion until full-depth execution-surface evidence replaces sampled snapshots",
+            prior["constraints"],
+        )
+        self.assertIn(
+            "block promotion until official settlement coverage exists for all replay-traded events",
+            prior["constraints"],
+        )
+
     def test_cli_records_dispatch_failures_without_dropping_executor_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- generate research_manager_typed_prior.v1 whenever a trace plan carries machine-readable blocker_actions
- keep fix_data snapshot dispatches, but also persist blocker constraints for the next research loop
- add regression coverage for full-depth execution-surface and settlement blocker actions

## Evidence
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- rtk git diff --check
- local executor dry-run against hosted trace-plan artifact 26346793100 produced next-llm-prior.json with full-depth, settlement, search-power, and runtime-contract constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced research plan processing to correctly generate validation constraints when blocker actions are present, ensuring proper execution flow control.

* **Tests**
  * Added test coverage for research plan scenarios with blocker actions to verify proper constraint generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->