### PR TITLE
Add Research Manager full-depth execution surface lane

### DIFF
--- a/.github/workflows/collect-full-depth-execution-surface.yml
+++ b/.github/workflows/collect-full-depth-execution-surface.yml
@@ -1,0 +1,297 @@
+name: Collect Full-Depth Execution Surface
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref for orchestration files"
+        required: true
+        default: "main"
+      start_date:
+        description: "Fallback UTC start date when options_json.start_ts is empty"
+        required: true
+        default: "2026-05-16"
+      end_date:
+        description: "Fallback UTC end date when options_json.end_ts is empty"
+        required: true
+        default: "2026-05-18"
+      options_json:
+        description: "Advanced options JSON: start_ts, end_ts, max_hours, archive_root, fail_if_incomplete"
+        required: false
+        default: '{"start_ts":"","end_ts":"","max_hours":12,"archive_root":"/opt/ploy/data/lake","fail_if_incomplete":false}'
+      issue_number:
+        description: "Optional issue to comment with collection summary"
+        required: false
+        default: ""
+
+concurrency:
+  group: full-depth-execution-surface-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DEPLOY_HOST: ${{ vars.TANGO_1_1_HOST || vars.ALIYUN_ECS_HOST || secrets.TANGO_1_1_HOST || secrets.ALIYUN_ECS_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+  REMOTE_DIR: /opt/ploy/tmp/full-depth-execution-surface-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  collect:
+    name: Collect full-fidelity CLOB execution surface
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout orchestration code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Parse collection options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "start_ts": "",
+              "end_ts": "",
+              "max_hours": "12",
+              "archive_root": "/opt/ploy/data/lake",
+              "fail_if_incomplete": "false",
+          }
+          bool_keys = {"fail_if_incomplete"}
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+
+          values = dict(defaults)
+          for key, value in data.items():
+              if key in bool_keys:
+                  if isinstance(value, bool):
+                      values[key] = "true" if value else "false"
+                  elif str(value).lower() in {"true", "false"}:
+                      values[key] = str(value).lower()
+                  else:
+                      raise SystemExit(f"options_json value for {key} must be boolean")
+              else:
+                  values[key] = str(value).strip()
+
+          if not values["start_ts"]:
+              values["start_ts"] = f"{os.environ['START_DATE']}T00:00:00Z"
+          if not values["end_ts"]:
+              values["end_ts"] = f"{os.environ['END_DATE']}T00:00:00Z"
+          if not values["max_hours"].isdigit() or int(values["max_hours"]) < 1:
+              raise SystemExit("options_json.max_hours must be a positive integer")
+          if "\n" in values["archive_root"] or not values["archive_root"].startswith("/"):
+              raise SystemExit("options_json.archive_root must be an absolute single-line path")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"SURFACE_{key.upper()}={value}\n")
+          PY
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
+          TANGO_SSH_KEY: ${{ secrets.TANGO_SSH_KEY }}
+          ALIYUN_ECS_SSH_KEY: ${{ secrets.ALIYUN_ECS_SSH_KEY }}
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "${DEPLOY_HOST}"
+          install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          selected_key=""
+          if [ -n "${TANGO_1_1_SSH_KEY}" ]; then
+            selected_key="${TANGO_1_1_SSH_KEY}"
+          elif [ -n "${TANGO_SSH_KEY}" ]; then
+            selected_key="${TANGO_SSH_KEY}"
+          elif [ -n "${ALIYUN_ECS_SSH_KEY}" ]; then
+            selected_key="${ALIYUN_ECS_SSH_KEY}"
+          else
+            echo "No SSH key secret found for tango-1-1 in this workflow context." >&2
+            exit 1
+          fi
+          printf '%s\n' "${selected_key}" > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          ssh-keygen -y -f ~/.ssh/tango_1_1_key >/dev/null
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Collect full-depth archive hours on tango-1-1
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/full-depth-execution-surface
+          ssh tango-1-1 /bin/bash -s -- \
+            "${DEPLOY_ROOT}" \
+            "${REMOTE_DIR}" \
+            "${SURFACE_START_TS}" \
+            "${SURFACE_END_TS}" \
+            "${SURFACE_MAX_HOURS}" \
+            "${SURFACE_ARCHIVE_ROOT}" \
+            "${SURFACE_FAIL_IF_INCOMPLETE}" <<'EOF'
+          set -euo pipefail
+          deploy_root="$1"
+          remote_dir="$2"
+          start_ts="$3"
+          end_ts="$4"
+          max_hours="$5"
+          archive_root="$6"
+          fail_if_incomplete="$7"
+          mkdir -p "${remote_dir}/manifests"
+          set -a
+          . "${deploy_root}/.env"
+          set +a
+          : "${PLOY_DATABASE__URL:?PLOY_DATABASE__URL missing in ${deploy_root}/.env}"
+          export DATABASE_URL="${PLOY_DATABASE__URL}"
+
+          export_script="${deploy_root}/scripts/export_clob_orderbook_snapshots_parquet.sh"
+          test -x "${export_script}"
+          start_epoch="$(date -u -d "${start_ts}" +%s)"
+          end_epoch="$(date -u -d "${end_ts}" +%s)"
+          if [ "${end_epoch}" -le "${start_epoch}" ]; then
+            echo "end_ts must be after start_ts" >&2
+            exit 2
+          fi
+
+          checked=0
+          exported=0
+          existing=0
+          incomplete=false
+          current="${start_epoch}"
+          while [ "${current}" -lt "${end_epoch}" ]; do
+            if [ "${checked}" -ge "${max_hours}" ]; then
+              incomplete=true
+              break
+            fi
+            checked=$((checked + 1))
+            export_date="$(TZ=Asia/Shanghai date -d "@${current}" +%Y-%m-%d)"
+            export_hour="$(TZ=Asia/Shanghai date -d "@${current}" +%H)"
+            hour_dir="${archive_root}/orderbook_snapshots/date=${export_date}/hour=${export_hour}"
+            marker="${hour_dir}/_SUCCESS"
+            if [ -f "${marker}" ]; then
+              existing=$((existing + 1))
+            else
+              nice -n 10 ionice -c2 -n7 \
+                "${export_script}" --date "${export_date}" --hour "${export_hour}" --out-dir "${archive_root}"
+              exported=$((exported + 1))
+            fi
+            cp "${hour_dir}/manifest.json" "${remote_dir}/manifests/${export_date}-${export_hour}.json"
+            current=$((current + 3600))
+          done
+
+          python3 - <<'PY' "${remote_dir}" "${start_ts}" "${end_ts}" "${max_hours}" "${archive_root}" "${checked}" "${existing}" "${exported}" "${incomplete}"
+          import json
+          import sys
+          from pathlib import Path
+
+          remote_dir = Path(sys.argv[1])
+          manifests = []
+          for path in sorted((remote_dir / "manifests").glob("*.json")):
+              payload = json.loads(path.read_text(encoding="utf-8"))
+              payload["manifest_path"] = str(path)
+              manifests.append(payload)
+          row_count = sum(int(item.get("row_count") or 0) for item in manifests)
+          out = {
+              "schema_version": "full_depth_execution_surface.v1",
+              "surface": "clob_orderbook_snapshots",
+              "source": "orderbook_snapshot_archive",
+              "start_ts": sys.argv[2],
+              "end_ts": sys.argv[3],
+              "max_hours": int(sys.argv[4]),
+              "archive_root": sys.argv[5],
+              "checked_hours": int(sys.argv[6]),
+              "existing_hours": int(sys.argv[7]),
+              "exported_hours": int(sys.argv[8]),
+              "incomplete": sys.argv[9] == "true",
+              "full_fidelity": all(item.get("full_fidelity") is True for item in manifests),
+              "row_count": row_count,
+              "manifests": manifests,
+          }
+          (remote_dir / "full-depth-execution-surface.json").write_text(
+              json.dumps(out, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          lines = [
+              "# Full-Depth Execution Surface",
+              "",
+              f"- Surface: `{out['surface']}`",
+              f"- Source: `{out['source']}`",
+              f"- Window: `{out['start_ts']} -> {out['end_ts']}`",
+              f"- Checked hours: `{out['checked_hours']}`",
+              f"- Existing hours: `{out['existing_hours']}`",
+              f"- Exported hours: `{out['exported_hours']}`",
+              f"- Incomplete: `{out['incomplete']}`",
+              f"- Full fidelity: `{out['full_fidelity']}`",
+              f"- Rows: `{out['row_count']}`",
+          ]
+          (remote_dir / "full-depth-execution-surface.md").write_text(
+              "\n".join(lines) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+          if [ "${fail_if_incomplete}" = "true" ] && [ "${incomplete}" = "true" ]; then
+            echo "full-depth execution-surface collection incomplete" >&2
+            exit 3
+          fi
+          EOF
+
+          scp "tango-1-1:${REMOTE_DIR}/full-depth-execution-surface.json" artifacts/full-depth-execution-surface/
+          scp "tango-1-1:${REMOTE_DIR}/full-depth-execution-surface.md" artifacts/full-depth-execution-surface/
+          cat artifacts/full-depth-execution-surface/full-depth-execution-surface.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup remote workspace
+        if: always()
+        run: |
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}" <<'EOF' || true
+          set -euo pipefail
+          rm -rf "$1"
+          EOF
+
+      - name: Upload execution surface artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-depth-execution-surface-${{ github.run_id }}
+          path: artifacts/full-depth-execution-surface
+          if-no-files-found: error
+
+      - name: Comment execution surface on issue
+        if: ${{ github.event.inputs.issue_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body-file artifacts/full-depth-execution-surface/full-depth-execution-surface.md

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -216,6 +216,13 @@ collection, broader distinct-event coverage, and high-fillability/depth-filter
 mutation. `scripts/research_manager_execute_plan.py` copies those actions into
 `research_manager_typed_prior.v1` so the next hosted search can consume the
 constraint instead of relying on a human to reinterpret the markdown blocker.
+Full-depth execution-surface collection is a separate lane from sampled research
+snapshot refresh: `collect_full_depth_execution_surface` dispatches
+`.github/workflows/collect-full-depth-execution-surface.yml`, which uses the
+deployed CLOB archive exporter on `tango-1-1` and emits
+`full_depth_execution_surface.v1`. Official-settlement repair remains blocked
+in the executor until there is a bounded, ACK-safe repair workflow; do not treat
+a sampled snapshot rerun as settlement repair.
 
 `recorded-replay-parity.yml` defaults `since=auto` and `until=auto`. In auto
 mode it scans the target recording on `tango-1-1`, intersects that recording

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -130,6 +130,82 @@ def _research_snapshot_dispatch(
     }
 
 
+def _bounded_execution_surface_window(
+    market_data: dict[str, Any],
+    max_hours: int,
+) -> dict[str, Any]:
+    start = _parse_utc_ts(market_data.get("dataset_start_ts"))
+    end = _parse_utc_ts(market_data.get("dataset_end_ts"))
+    max_hours = max(1, max_hours)
+    if not start or not end or end <= start:
+        return {
+            "start_date": _date_from_ts(market_data.get("dataset_start_ts")),
+            "end_date": _date_from_ts(market_data.get("dataset_end_ts")),
+            "start_ts": market_data.get("dataset_start_ts") or "",
+            "end_ts": market_data.get("dataset_end_ts") or "",
+            "truncated": False,
+            "max_hours": max_hours,
+        }
+    capped_end = min(end, start + timedelta(hours=max_hours))
+    return {
+        "start_date": start.date().isoformat(),
+        "end_date": capped_end.date().isoformat(),
+        "start_ts": _format_utc_ts(start),
+        "end_ts": _format_utc_ts(capped_end),
+        "truncated": capped_end < end,
+        "max_hours": max_hours,
+        "source_end_ts": _format_utc_ts(end),
+    }
+
+
+def _full_depth_execution_surface_dispatch(
+    *,
+    plan: dict[str, Any],
+    git_ref: str,
+    max_hours: int,
+) -> dict[str, Any]:
+    market_data = ((plan.get("input") or {}).get("market_data_health") or {})
+    window = _bounded_execution_surface_window(market_data, max_hours=max_hours)
+    options = {
+        "start_ts": window["start_ts"],
+        "end_ts": window["end_ts"],
+        "max_hours": window["max_hours"],
+        "fail_if_incomplete": False,
+    }
+    blockers: list[str] = []
+    if not window["start_ts"] or not window["end_ts"]:
+        blockers.append("missing_dataset_window")
+    fields = {
+        "git_ref": git_ref,
+        "start_date": window["start_date"],
+        "end_date": window["end_date"],
+        "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
+    }
+    return {
+        "workflow": "collect-full-depth-execution-surface.yml",
+        "reason": "materialize full-fidelity Polymarket CLOB archive evidence for promotion surface",
+        "ready": not blockers,
+        "blockers": blockers,
+        "fields": fields,
+        "bounded_window": window,
+    }
+
+
+def _blocked_followup_dispatch(
+    *,
+    workflow: str,
+    reason: str,
+    blocker: str,
+) -> dict[str, Any]:
+    return {
+        "workflow": workflow,
+        "reason": reason,
+        "ready": False,
+        "blockers": [blocker],
+        "fields": {},
+    }
+
+
 def _walk_forward_dispatch(
     *,
     git_ref: str,
@@ -383,9 +459,11 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     dispatches: list[dict[str, Any]] = []
     typed_prior: dict[str, Any] | None = None
 
-    if plan.get("theme") == "fix_data" or any(
-        action in {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
-        for action in actions
+    action_names = {item["action"] for item in blocker_actions}
+    snapshot_actions = {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
+
+    if any(action in snapshot_actions for action in actions) or (
+        plan.get("theme") == "fix_data" and not actions
     ):
         dispatches.append(
             _research_snapshot_dispatch(
@@ -394,6 +472,31 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                 symbols=args.symbols,
                 stake_usd=args.stake_usd,
                 max_snapshot_window_days=args.max_snapshot_window_days,
+            )
+        )
+
+    if "collect_full_depth_execution_surface" in actions or (
+        "collect_full_depth_execution_surface" in action_names
+    ):
+        dispatches.append(
+            _full_depth_execution_surface_dispatch(
+                plan=plan_payload,
+                git_ref=args.git_ref,
+                max_hours=getattr(args, "max_full_depth_surface_hours", 12),
+            )
+        )
+
+    if "repair_official_settlement_coverage" in actions or (
+        "repair_official_settlement_coverage" in action_names
+    ):
+        dispatches.append(
+            _blocked_followup_dispatch(
+                workflow="repair-official-settlement-coverage.yml",
+                reason=(
+                    "official settlement repair is required, but no bounded ACK-safe "
+                    "Research Manager settlement repair workflow exists yet"
+                ),
+                blocker="missing_bounded_settlement_repair_workflow",
             )
         )
 
@@ -541,6 +644,7 @@ def main() -> None:
     parser.add_argument("--stake-usd", default="15")
     parser.add_argument("--chain-remaining", type=int, default=1)
     parser.add_argument("--max-snapshot-window-days", type=int, default=2)
+    parser.add_argument("--max-full-depth-surface-hours", type=int, default=12)
     parser.add_argument(
         "--runtime-deployment-id",
         default="pm5d.threelayer.settlement-probability-btc-eth.dryrun",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -52,6 +52,35 @@ no strategy promotion and no live data mutation.
 - 2026-05-24: PR #650 merged to `main` at
   `d5c450634ab9747f873ac5bab6ec8f88f7946d5f`.
 
+## Current Session - Research Manager Data Repair Lanes (2026-05-24)
+
+Evidence stage: architecture/data-plane cleanup and research workflow planning;
+no strategy promotion and no live trading.
+
+### Tasks
+
+- [x] Verify hosted trace-plan and executor artifacts after PRs #651/#652.
+- [x] Confirm sampled research snapshots cannot satisfy the full-depth
+      execution-surface promotion blocker.
+- [x] Add a bounded full-depth execution-surface workflow over the existing
+      CLOB archive exporter.
+- [x] Map Research Manager full-depth blocker actions to the new workflow.
+- [x] Keep official-settlement repair explicit as blocked until it has a
+      bounded ACK-safe workflow.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+### Review
+
+- 2026-05-24: Hosted trace-plan run `26346793100` now emits
+  `promotion_data_execution_surface -> collect_full_depth_execution_surface`.
+  Hosted executor run `26346912326` generated `research_manager_typed_prior.v1`
+  with full-depth, settlement, search-power, and runtime-contract constraints.
+- 2026-05-24: The executor now separates sampled snapshot audit refresh from
+  full-depth execution-surface collection. `rerun_snapshot_data_audit` still
+  dispatches `research-snapshot.yml`; `collect_full_depth_execution_surface`
+  dispatches `collect-full-depth-execution-surface.yml`; official settlement
+  repair remains a blocked follow-up until a bounded mutation workflow exists.
+
 ## Current Session - Research Manager Blocker Actions (2026-05-24)
 
 Evidence stage: architecture/data-plane cleanup and research workflow planning;

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -41,6 +41,7 @@ def base_args(**overrides):
         "stake_usd": "15",
         "chain_remaining": 1,
         "max_snapshot_window_days": 2,
+        "max_full_depth_surface_hours": 12,
         "runtime_deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
         "runtime_config_path": "/opt/ploy/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
         "runtime_recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
@@ -339,6 +340,54 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertIn(
             "block promotion until official settlement coverage exists for all replay-traded events",
             prior["constraints"],
+        )
+
+    def test_blocker_actions_map_to_full_depth_and_settlement_followups(self) -> None:
+        plan = plan_payload("fix_data", ["rerun_snapshot_data_audit"])
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "promotion_data_execution_surface",
+                "action": "collect_full_depth_execution_surface",
+                "reason": "Research snapshot data health reports sampled execution surface.",
+            },
+            {
+                "blocker_family": "data_settlement",
+                "action": "repair_official_settlement_coverage",
+                "reason": "Runtime replay traded events are missing official settlement labels.",
+            },
+        ]
+        payload = build_executor_payload(base_args(), plan)
+
+        workflows = [item["workflow"] for item in payload["dispatches"]]
+        self.assertEqual(
+            [
+                "research-snapshot.yml",
+                "collect-full-depth-execution-surface.yml",
+                "repair-official-settlement-coverage.yml",
+            ],
+            workflows,
+        )
+        self.assertTrue(payload["dispatches"][1]["ready"])
+        full_depth_options = json.loads(payload["dispatches"][1]["fields"]["options_json"])
+        self.assertEqual("2026-04-21T00:00:00Z", full_depth_options["start_ts"])
+        self.assertEqual("2026-04-21T12:00:00Z", full_depth_options["end_ts"])
+        self.assertEqual(12, full_depth_options["max_hours"])
+        self.assertFalse(payload["dispatches"][2]["ready"])
+        self.assertIn(
+            "missing_bounded_settlement_repair_workflow",
+            payload["dispatches"][2]["blockers"],
+        )
+
+    def test_full_depth_action_without_snapshot_rerun_does_not_dispatch_sampled_snapshot(self) -> None:
+        payload = build_executor_payload(
+            base_args(),
+            plan_payload("fix_data", ["collect_full_depth_execution_surface"]),
+        )
+
+        self.assertEqual(1, len(payload["dispatches"]))
+        self.assertEqual(
+            "collect-full-depth-execution-surface.yml",
+            payload["dispatches"][0]["workflow"],
         )
 
     def test_cli_records_dispatch_failures_without_dropping_executor_artifact(self) -> None:


### PR DESCRIPTION
## Summary
- add a protected `collect-full-depth-execution-surface.yml` workflow that materializes full-fidelity CLOB archive evidence on tango-1-1
- map Research Manager `collect_full_depth_execution_surface` blocker actions to that workflow instead of relying on sampled snapshot refresh
- keep official settlement repair explicit as a blocked follow-up until a bounded ACK-safe repair workflow exists
- document the sampled snapshot vs full-depth lane split

## Evidence
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- workflow YAML parse for .github/workflows/*.yml
- rtk cargo test --locked --test workflow_security
- rtk git diff --check
- local executor dry-run against hosted trace-plan artifact 26346793100 produced research-snapshot, collect-full-depth-execution-surface, and blocked settlement follow-up dispatches