### PR TITLE
Add bounded official settlement repair workflow

### DIFF
--- a/.github/workflows/repair-official-settlement-coverage.yml
+++ b/.github/workflows/repair-official-settlement-coverage.yml
@@ -1,0 +1,255 @@
+name: Repair Official Settlement Coverage
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref for orchestration files"
+        required: true
+        default: "main"
+      start_date:
+        description: "Fallback UTC start date when options_json.start_ts is empty"
+        required: true
+        default: "2026-05-16"
+      end_date:
+        description: "Fallback UTC end date when options_json.end_ts is empty"
+        required: true
+        default: "2026-05-18"
+      symbols:
+        description: "Comma-separated PM5D symbols"
+        required: true
+        default: "BTCUSDT,ETHUSDT,SOLUSDT"
+      options_json:
+        description: "Advanced options JSON: start_ts, end_ts, mode"
+        required: false
+        default: '{"start_ts":"","end_ts":"","mode":"dry_run"}'
+      execute_ack:
+        description: "Required for execute mode: repair-official-settlement-coverage"
+        required: false
+        default: ""
+      issue_number:
+        description: "Optional issue to comment with repair summary"
+        required: false
+        default: ""
+
+concurrency:
+  group: repair-official-settlement-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DEPLOY_HOST: ${{ vars.TANGO_1_1_HOST || vars.ALIYUN_ECS_HOST || secrets.TANGO_1_1_HOST || secrets.ALIYUN_ECS_HOST }}
+  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
+  REMOTE_DIR: /opt/ploy/tmp/repair-official-settlement-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  repair:
+    name: Repair bounded official settlement coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: tango-1-1
+
+    steps:
+      - name: Checkout orchestration code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.git_ref }}
+
+      - name: Parse repair options
+        env:
+          OPTIONS_JSON: ${{ github.event.inputs.options_json }}
+          EXECUTE_ACK: ${{ github.event.inputs.execute_ack }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          defaults = {
+              "start_ts": "",
+              "end_ts": "",
+              "mode": "dry_run",
+          }
+          raw = os.environ.get("OPTIONS_JSON", "").strip()
+          data = json.loads(raw) if raw else {}
+          if not isinstance(data, dict):
+              raise SystemExit("options_json must be a JSON object")
+          unknown = sorted(set(data) - set(defaults))
+          if unknown:
+              raise SystemExit(f"unknown options_json keys: {', '.join(unknown)}")
+          values = dict(defaults)
+          for key, value in data.items():
+              values[key] = str(value).strip()
+          if values["mode"] not in {"dry_run", "execute"}:
+              raise SystemExit("options_json.mode must be dry_run or execute")
+          if (
+              values["mode"] == "execute"
+              and os.environ.get("EXECUTE_ACK") != "repair-official-settlement-coverage"
+          ):
+              raise SystemExit("execute mode requires execute_ack=repair-official-settlement-coverage")
+          if not values["start_ts"]:
+              values["start_ts"] = f"{os.environ['START_DATE']}T00:00:00Z"
+          if not values["end_ts"]:
+              values["end_ts"] = f"{os.environ['END_DATE']}T00:00:00Z"
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
+              for key, value in values.items():
+                  if "\n" in value:
+                      raise SystemExit(f"options_json value for {key} must be single-line")
+                  handle.write(f"SETTLEMENT_{key.upper()}={value}\n")
+          PY
+
+      - name: Configure SSH
+        env:
+          TANGO_1_1_SSH_KEY: ${{ secrets.TANGO_1_1_SSH_KEY }}
+          TANGO_SSH_KEY: ${{ secrets.TANGO_SSH_KEY }}
+          ALIYUN_ECS_SSH_KEY: ${{ secrets.ALIYUN_ECS_SSH_KEY }}
+          TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "${DEPLOY_HOST}"
+          install -m 700 -d ~/.ssh
+          if [ -z "${TANGO_1_1_KNOWN_HOSTS}" ]; then
+            echo "TANGO_1_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
+            exit 1
+          fi
+          selected_key=""
+          if [ -n "${TANGO_1_1_SSH_KEY}" ]; then
+            selected_key="${TANGO_1_1_SSH_KEY}"
+          elif [ -n "${TANGO_SSH_KEY}" ]; then
+            selected_key="${TANGO_SSH_KEY}"
+          elif [ -n "${ALIYUN_ECS_SSH_KEY}" ]; then
+            selected_key="${ALIYUN_ECS_SSH_KEY}"
+          else
+            echo "No SSH key secret found for tango-1-1 in this workflow context." >&2
+            exit 1
+          fi
+          printf '%s\n' "${selected_key}" > ~/.ssh/tango_1_1_key
+          chmod 600 ~/.ssh/tango_1_1_key
+          ssh-keygen -y -f ~/.ssh/tango_1_1_key >/dev/null
+          printf '%s\n' "${TANGO_1_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<EOF
+          Host tango-1-1
+            HostName ${DEPLOY_HOST}
+            User root
+            IdentityFile ~/.ssh/tango_1_1_key
+            HostKeyAlias tango-1-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
+            ConnectTimeout 30
+          EOF
+
+      - name: Run bounded settlement repair on tango-1-1
+        env:
+          SYMBOLS: ${{ github.event.inputs.symbols }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/official-settlement-repair
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}" <<'EOF'
+          set -euo pipefail
+          mkdir -p "$1"
+          EOF
+          scp scripts/backfill_settlements.py tango-1-1:"${REMOTE_DIR}/backfill_settlements.py"
+
+          ssh tango-1-1 /bin/bash -s -- \
+            "${DEPLOY_ROOT}" \
+            "${REMOTE_DIR}" \
+            "${SETTLEMENT_START_TS}" \
+            "${SETTLEMENT_END_TS}" \
+            "${SYMBOLS}" \
+            "${SETTLEMENT_MODE}" <<'EOF'
+          set -euo pipefail
+          deploy_root="$1"
+          remote_dir="$2"
+          start_ts="$3"
+          end_ts="$4"
+          symbols="$5"
+          mode="$6"
+          set -a
+          . "${deploy_root}/.env"
+          set +a
+          : "${PLOY_DATABASE__URL:?PLOY_DATABASE__URL missing in ${deploy_root}/.env}"
+          case "${mode}" in
+            dry_run|execute) ;;
+            *) echo "mode must be dry_run or execute" >&2; exit 2 ;;
+          esac
+          python_bin="python3"
+          if [ -x "${deploy_root}/.venv/bin/python" ]; then
+            python_bin="${deploy_root}/.venv/bin/python"
+          elif [ -x "${deploy_root}/venv/bin/python" ]; then
+            python_bin="${deploy_root}/venv/bin/python"
+          fi
+          "${python_bin}" - <<'PY'
+          import asyncpg
+          import httpx
+          PY
+          args=(
+            "${remote_dir}/backfill_settlements.py"
+            --db-url "${PLOY_DATABASE__URL}"
+            --start-ts "${start_ts}"
+            --end-ts "${end_ts}"
+            --symbols "${symbols}"
+            --report-json "${remote_dir}/official-settlement-repair.json"
+          )
+          if [ "${mode}" = "dry_run" ]; then
+            args+=(--dry-run)
+          fi
+          "${python_bin}" "${args[@]}"
+          python3 - <<'PY' "${remote_dir}/official-settlement-repair.json" "${remote_dir}/official-settlement-repair.md"
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          lines = [
+              "# Official Settlement Repair",
+              "",
+              f"- Mode: `{'dry_run' if payload.get('dry_run') else 'execute'}`",
+              f"- Window: `{payload.get('start_ts')} -> {payload.get('end_ts')}`",
+              f"- Symbols: `{','.join(payload.get('symbols') or [])}`",
+              f"- Candidate markets: `{payload.get('candidate_market_count')}`",
+              f"- Would settle: `{payload.get('would_settle_count')}`",
+              f"- Settled: `{payload.get('settled_count')}`",
+              f"- Active reset: `{payload.get('active_reset_count')}`",
+              f"- Skipped: `{payload.get('skipped_count')}`",
+              f"- Errors: `{payload.get('error_count')}`",
+          ]
+          Path(sys.argv[2]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+          EOF
+
+          scp "tango-1-1:${REMOTE_DIR}/official-settlement-repair.json" artifacts/official-settlement-repair/
+          scp "tango-1-1:${REMOTE_DIR}/official-settlement-repair.md" artifacts/official-settlement-repair/
+          cat artifacts/official-settlement-repair/official-settlement-repair.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup remote workspace
+        if: always()
+        run: |
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}" <<'EOF' || true
+          set -euo pipefail
+          rm -rf "$1"
+          EOF
+
+      - name: Upload settlement repair artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: official-settlement-repair-${{ github.run_id }}
+          path: artifacts/official-settlement-repair
+          if-no-files-found: error
+
+      - name: Comment settlement repair on issue
+        if: ${{ github.event.inputs.issue_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body-file artifacts/official-settlement-repair/official-settlement-repair.md

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -220,9 +220,11 @@ Full-depth execution-surface collection is a separate lane from sampled research
 snapshot refresh: `collect_full_depth_execution_surface` dispatches
 `.github/workflows/collect-full-depth-execution-surface.yml`, which uses the
 deployed CLOB archive exporter on `tango-1-1` and emits
-`full_depth_execution_surface.v1`. Official-settlement repair remains blocked
-in the executor until there is a bounded, ACK-safe repair workflow; do not treat
-a sampled snapshot rerun as settlement repair.
+`full_depth_execution_surface.v1`. `repair_official_settlement_coverage`
+dispatches `.github/workflows/repair-official-settlement-coverage.yml`, which
+defaults to `mode=dry_run` and only mutates `pm_token_settlements` when the
+Research Manager executor itself is run with execute mode plus the required ACK.
+Do not treat a sampled snapshot rerun as settlement repair.
 
 `recorded-replay-parity.yml` defaults `since=auto` and `until=auto`. In auto
 mode it scans the target recording on `tango-1-1`, intersects that recording

--- a/scripts/backfill_settlements.py
+++ b/scripts/backfill_settlements.py
@@ -1,128 +1,251 @@
 #!/usr/bin/env python3
-"""
-Backfill settlement data for expired events using the official Gamma market API.
-Falls back to skipping unresolved markets instead of inferring settlement from
-last trade price.
-"""
+"""Backfill official Polymarket settlement rows for bounded PM5D windows."""
+
+from __future__ import annotations
+
+import argparse
 import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
 import asyncpg
 import httpx
-import json
-import sys
 
-DB_URL = sys.argv[1] if len(sys.argv) > 1 else "postgresql://postgres:postgres@localhost:15432/ploy"
 
-async def main():
-    conn = await asyncpg.connect(DB_URL)
+DEFAULT_SYMBOLS = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT"
 
-    # Get all unsettled binary markets from expired events
-    rows = await conn.fetch("""
+
+def parse_symbols(raw: str) -> list[str]:
+    return [item.strip().upper() for item in raw.split(",") if item.strip()]
+
+
+def parser() -> argparse.ArgumentParser:
+    parsed = argparse.ArgumentParser()
+    parsed.add_argument("legacy_db_url", nargs="?", default="")
+    parsed.add_argument("--db-url", default="")
+    parsed.add_argument("--start-ts", default="2026-04-05T00:00:00Z")
+    parsed.add_argument("--end-ts", default="")
+    parsed.add_argument("--symbols", default=DEFAULT_SYMBOLS)
+    parsed.add_argument("--dry-run", action="store_true")
+    parsed.add_argument("--report-json", type=Path)
+    return parsed
+
+
+async def load_candidate_markets(
+    conn: asyncpg.Connection,
+    *,
+    start_ts: str,
+    end_ts: str,
+    symbols: list[str],
+) -> list[asyncpg.Record]:
+    return await conn.fetch(
+        """
         WITH event_tokens AS (
             SELECT
                 market_slug,
-                trim(both '"' from ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>0)) as up_token,
-                trim(both '"' from ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>1)) as down_token
+                trim(both '"' from ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>0)) AS up_token,
+                trim(both '"' from ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>1)) AS down_token
             FROM pm_market_metadata
-            WHERE end_time >= '2026-04-05' AND end_time < NOW()
-              AND symbol IN ('BTCUSDT','ETHUSDT','SOLUSDT','XRPUSDT','DOGEUSDT','HYPEUSDT','BNBUSDT')
+            WHERE end_time >= $1::timestamptz
+              AND ($2::timestamptz IS NULL OR end_time < $2::timestamptz)
+              AND symbol = ANY($3::text[])
         )
         SELECT DISTINCT et.market_slug, et.up_token, et.down_token
         FROM event_tokens et
+        WHERE et.market_slug IS NOT NULL
+          AND et.up_token IS NOT NULL
+          AND et.down_token IS NOT NULL
+          AND et.up_token <> ''
+          AND et.down_token <> ''
         ORDER BY et.market_slug
-    """)
+        """,
+        start_ts,
+        end_ts or None,
+        symbols,
+    )
 
-    print(f"Found {len(rows)} unsettled markets")
 
-    settled = 0
-    errors = 0
-    skipped = 0
+def settlement_rows_from_gamma(
+    data: dict[str, Any],
+    *,
+    up_token: str,
+    down_token: str,
+) -> list[tuple[str, str, float]]:
+    if data.get("closed") is not True:
+        return []
+    try:
+        token_ids = json.loads(data.get("clobTokenIds") or "[]")
+        outcome_prices = json.loads(data.get("outcomePrices") or "[]")
+    except json.JSONDecodeError:
+        return []
+    if len(token_ids) != 2 or len(outcome_prices) != 2:
+        return []
 
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        for i, row in enumerate(rows):
-            market_id = row['market_slug']
-            up_token = row['up_token']
-            down_token = row['down_token']
+    settlements = []
+    for token_id, raw_price in zip(token_ids, outcome_prices):
+        price = float(raw_price)
+        if price >= 0.95:
+            settlements.append((str(token_id), "winner", 1.0))
+        elif price <= 0.05:
+            settlements.append((str(token_id), "loser", 0.0))
+        else:
+            return []
 
-            try:
-                resp = await client.get(
-                    f"https://gamma-api.polymarket.com/markets/{market_id}",
-                    headers={"User-Agent": "ploy-settlement-backfill/official"},
-                )
-                resp.raise_for_status()
-                data = resp.json()
+    matched = [item for item in settlements if item[0] in {up_token, down_token}]
+    return matched if len(matched) == 2 else []
 
-                closed = data.get('closed')
-                if closed is False:
-                    await conn.execute("""
-                        UPDATE pm_token_settlements
-                        SET settled_price = NULL,
-                            outcome = NULL,
-                            resolved = FALSE,
-                            resolved_at = NULL,
-                            fetched_at = NOW()
-                        WHERE market_slug = $1
-                          AND resolved = TRUE
-                    """, market_id)
-                    skipped += 1
-                    continue
-                if closed is not True:
-                    skipped += 1
-                    continue
 
-                token_ids = json.loads(data.get('clobTokenIds') or '[]')
-                outcome_prices = json.loads(data.get('outcomePrices') or '[]')
-                if len(token_ids) != 2 or len(outcome_prices) != 2:
-                    skipped += 1
-                    continue
+async def upsert_settlement(
+    conn: asyncpg.Connection,
+    *,
+    market_slug: str,
+    token_id: str,
+    outcome: str,
+    settled_price: float,
+) -> bool:
+    result = await conn.execute(
+        """
+        INSERT INTO pm_token_settlements (
+            token_id, market_slug, outcome,
+            settled_price, resolved, resolved_at, fetched_at
+        ) VALUES ($1, $2, $3, $4, true, NOW(), NOW())
+        ON CONFLICT (token_id) DO UPDATE SET
+            settled_price = EXCLUDED.settled_price,
+            outcome = EXCLUDED.outcome,
+            resolved = true,
+            resolved_at = COALESCE(pm_token_settlements.resolved_at, NOW()),
+            fetched_at = NOW()
+        WHERE pm_token_settlements.resolved = false
+           OR pm_token_settlements.settled_price IS DISTINCT FROM EXCLUDED.settled_price
+           OR pm_token_settlements.outcome IS DISTINCT FROM EXCLUDED.outcome
+        """,
+        token_id,
+        market_slug,
+        outcome,
+        settled_price,
+    )
+    return result != "INSERT 0 0"
 
-                settlements = []
-                for token_id, raw_price in zip(token_ids, outcome_prices):
-                    price = float(raw_price)
-                    if price >= 0.95:
-                        settlements.append((token_id, 'winner', 1.0))
-                    elif price <= 0.05:
-                        settlements.append((token_id, 'loser', 0.0))
-                    else:
-                        settlements = []
-                        break
 
-                if len(settlements) != 2:
-                    skipped += 1
-                    continue
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    db_url = args.db_url or args.legacy_db_url
+    if not db_url:
+        db_url = "postgresql://postgres:postgres@localhost:15432/ploy"
+    symbols = parse_symbols(args.symbols)
+    if not symbols:
+        raise SystemExit("--symbols must include at least one symbol")
 
-                for token_id, outcome, settled_price in settlements:
-                    if token_id not in (up_token, down_token):
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await load_candidate_markets(
+            conn,
+            start_ts=args.start_ts,
+            end_ts=args.end_ts,
+            symbols=symbols,
+        )
+
+        settled = 0
+        would_settle = 0
+        errors = 0
+        skipped = 0
+        active_reset = 0
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            for i, row in enumerate(rows):
+                market_slug = row["market_slug"]
+                up_token = row["up_token"]
+                down_token = row["down_token"]
+
+                try:
+                    resp = await client.get(
+                        f"https://gamma-api.polymarket.com/markets/{market_slug}",
+                        headers={"User-Agent": "ploy-settlement-backfill/official"},
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+
+                    if data.get("closed") is False:
+                        if not args.dry_run:
+                            await conn.execute(
+                                """
+                                UPDATE pm_token_settlements
+                                SET settled_price = NULL,
+                                    outcome = NULL,
+                                    resolved = FALSE,
+                                    resolved_at = NULL,
+                                    fetched_at = NOW()
+                                WHERE market_slug = $1
+                                  AND resolved = TRUE
+                                """,
+                                market_slug,
+                            )
+                        active_reset += 1
+                        skipped += 1
                         continue
 
-                    result = await conn.execute("""
-                        INSERT INTO pm_token_settlements (
-                            token_id, market_slug, outcome,
-                            settled_price, resolved, resolved_at, fetched_at
-                        ) VALUES ($1, $2, $3, $4, true, NOW(), NOW())
-                        ON CONFLICT (token_id) DO UPDATE SET
-                            settled_price = EXCLUDED.settled_price,
-                            outcome = EXCLUDED.outcome,
-                            resolved = true,
-                            resolved_at = COALESCE(pm_token_settlements.resolved_at, NOW()),
-                            fetched_at = NOW()
-                        WHERE pm_token_settlements.resolved = false
-                           OR pm_token_settlements.settled_price IS DISTINCT FROM EXCLUDED.settled_price
-                           OR pm_token_settlements.outcome IS DISTINCT FROM EXCLUDED.outcome
-                    """, token_id, market_id, outcome, settled_price)
+                    settlements = settlement_rows_from_gamma(
+                        data,
+                        up_token=up_token,
+                        down_token=down_token,
+                    )
+                    if not settlements:
+                        skipped += 1
+                        continue
 
-                    if result != 'INSERT 0 0':
-                        settled += 1
+                    for token_id, outcome, settled_price in settlements:
+                        if args.dry_run:
+                            would_settle += 1
+                        elif await upsert_settlement(
+                            conn,
+                            market_slug=market_slug,
+                            token_id=token_id,
+                            outcome=outcome,
+                            settled_price=settled_price,
+                        ):
+                            settled += 1
 
-            except Exception as e:
-                errors += 1
+                except Exception:
+                    errors += 1
 
-            if (i + 1) % 100 == 0:
-                print(f"  Progress: {i+1}/{len(rows)} | settled={settled} skipped={skipped} errors={errors}")
+                if (i + 1) % 100 == 0:
+                    print(
+                        "Progress: "
+                        f"{i + 1}/{len(rows)} settled={settled} "
+                        f"would_settle={would_settle} skipped={skipped} errors={errors}"
+                    )
 
-            # Rate limit: 5 req/sec
-            await asyncio.sleep(0.2)
+                await asyncio.sleep(0.2)
 
-    print(f"\nDone: {settled} settled, {skipped} skipped (active/no data), {errors} errors")
-    await conn.close()
+        return {
+            "schema_version": "official_settlement_repair.v1",
+            "dry_run": args.dry_run,
+            "start_ts": args.start_ts,
+            "end_ts": args.end_ts,
+            "symbols": symbols,
+            "candidate_market_count": len(rows),
+            "settled_count": settled,
+            "would_settle_count": would_settle,
+            "active_reset_count": active_reset,
+            "skipped_count": skipped,
+            "error_count": errors,
+        }
+    finally:
+        await conn.close()
 
-asyncio.run(main())
+
+async def main_async() -> None:
+    args = parser().parse_args()
+    report = await run(args)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.report_json:
+        args.report_json.write_text(text, encoding="utf-8")
+    print(text)
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -191,18 +191,40 @@ def _full_depth_execution_surface_dispatch(
     }
 
 
-def _blocked_followup_dispatch(
+def _official_settlement_repair_dispatch(
     *,
-    workflow: str,
-    reason: str,
-    blocker: str,
+    plan: dict[str, Any],
+    git_ref: str,
+    symbols: str,
+    execute: bool,
 ) -> dict[str, Any]:
+    market_data = ((plan.get("input") or {}).get("market_data_health") or {})
+    window = _bounded_snapshot_window(market_data, max_window_days=2)
+    options = {
+        "start_ts": window["start_ts"],
+        "end_ts": window["end_ts"],
+        "mode": "execute" if execute else "dry_run",
+    }
+    blockers: list[str] = []
+    if not window["start_ts"] or not window["end_ts"]:
+        blockers.append("missing_dataset_window")
+    if not _parse_symbols(symbols):
+        blockers.append("missing_symbols")
+    fields = {
+        "git_ref": git_ref,
+        "start_date": window["start_date"],
+        "end_date": window["end_date"],
+        "symbols": symbols,
+        "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
+        "execute_ack": "repair-official-settlement-coverage" if execute else "",
+    }
     return {
-        "workflow": workflow,
-        "reason": reason,
-        "ready": False,
-        "blockers": [blocker],
-        "fields": {},
+        "workflow": "repair-official-settlement-coverage.yml",
+        "reason": "repair bounded official Polymarket settlement coverage for replay-traded events",
+        "ready": not blockers,
+        "blockers": blockers,
+        "fields": fields,
+        "bounded_window": window,
     }
 
 
@@ -458,6 +480,7 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     blocker_actions = _blocker_actions(plan)
     dispatches: list[dict[str, Any]] = []
     typed_prior: dict[str, Any] | None = None
+    side_effect_mode = args.mode == "execute" and args.execute_ack == EXECUTE_ACK
 
     action_names = {item["action"] for item in blocker_actions}
     snapshot_actions = {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
@@ -490,13 +513,11 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
         "repair_official_settlement_coverage" in action_names
     ):
         dispatches.append(
-            _blocked_followup_dispatch(
-                workflow="repair-official-settlement-coverage.yml",
-                reason=(
-                    "official settlement repair is required, but no bounded ACK-safe "
-                    "Research Manager settlement repair workflow exists yet"
-                ),
-                blocker="missing_bounded_settlement_repair_workflow",
+            _official_settlement_repair_dispatch(
+                plan=plan_payload,
+                git_ref=args.git_ref,
+                symbols=args.symbols,
+                execute=side_effect_mode,
             )
         )
 
@@ -565,7 +586,7 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
 
     executable_dispatches = [item for item in dispatches if item["ready"]]
     blocked_dispatches = [item for item in dispatches if not item["ready"]]
-    mode = "execute" if args.mode == "execute" and args.execute_ack == EXECUTE_ACK else "dry_run"
+    mode = "execute" if side_effect_mode else "dry_run"
     if args.mode == "execute" and args.execute_ack != EXECUTE_ACK:
         blocked_dispatches.append(
             {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -65,8 +65,7 @@ no strategy promotion and no live trading.
 - [x] Add a bounded full-depth execution-surface workflow over the existing
       CLOB archive exporter.
 - [x] Map Research Manager full-depth blocker actions to the new workflow.
-- [x] Keep official-settlement repair explicit as blocked until it has a
-      bounded ACK-safe workflow.
+- [x] Add bounded dry-run/execute official-settlement repair workflow.
 - [ ] Commit, push, open PR, wait for CI, and merge.
 
 ### Review
@@ -79,7 +78,8 @@ no strategy promotion and no live trading.
   full-depth execution-surface collection. `rerun_snapshot_data_audit` still
   dispatches `research-snapshot.yml`; `collect_full_depth_execution_surface`
   dispatches `collect-full-depth-execution-surface.yml`; official settlement
-  repair remains a blocked follow-up until a bounded mutation workflow exists.
+  repair now dispatches `repair-official-settlement-coverage.yml` in dry-run
+  mode unless the executor itself is run with the required execute ACK.
 
 ## Current Session - Research Manager Blocker Actions (2026-05-24)
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -372,10 +372,27 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual("2026-04-21T00:00:00Z", full_depth_options["start_ts"])
         self.assertEqual("2026-04-21T12:00:00Z", full_depth_options["end_ts"])
         self.assertEqual(12, full_depth_options["max_hours"])
-        self.assertFalse(payload["dispatches"][2]["ready"])
-        self.assertIn(
-            "missing_bounded_settlement_repair_workflow",
-            payload["dispatches"][2]["blockers"],
+        self.assertTrue(payload["dispatches"][2]["ready"])
+        settlement_options = json.loads(payload["dispatches"][2]["fields"]["options_json"])
+        self.assertEqual("dry_run", settlement_options["mode"])
+        self.assertEqual("", payload["dispatches"][2]["fields"]["execute_ack"])
+        self.assertEqual("2026-04-21T00:00:00Z", settlement_options["start_ts"])
+        self.assertEqual("2026-04-23T00:00:00Z", settlement_options["end_ts"])
+
+    def test_execute_mode_passes_execute_to_settlement_repair_after_ack(self) -> None:
+        plan = plan_payload("fix_data", ["repair_official_settlement_coverage"])
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK),
+            plan,
+        )
+
+        self.assertEqual("execute", payload["mode"])
+        self.assertEqual("repair-official-settlement-coverage.yml", payload["dispatches"][0]["workflow"])
+        settlement_options = json.loads(payload["dispatches"][0]["fields"]["options_json"])
+        self.assertEqual("execute", settlement_options["mode"])
+        self.assertEqual(
+            "repair-official-settlement-coverage",
+            payload["dispatches"][0]["fields"]["execute_ack"],
         )
 
     def test_full_depth_action_without_snapshot_rerun_does_not_dispatch_sampled_snapshot(self) -> None:


### PR DESCRIPTION
## Summary
- make `scripts/backfill_settlements.py` bounded by window/symbols and add dry-run/report output
- add protected `repair-official-settlement-coverage.yml` workflow with execute-mode ACK
- map Research Manager settlement blocker actions to the workflow, defaulting executor dry-runs to settlement dry-run mode
- update runbook/task notes for the full-depth and settlement repair lanes

## Evidence
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_extract_official_settlement_evidence tests.test_enrich_recording_official_settlement
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py scripts/backfill_settlements.py
- workflow YAML parse for .github/workflows/*.yml
- rtk cargo test --locked --test workflow_security
- rtk git diff --check
- local executor dry-run against hosted trace-plan artifact 26346793100 produced ready settlement repair dry-run dispatch