### PR TITLE
Fix settlement repair timestamp binding

### DIFF
--- a/scripts/backfill_settlements.py
+++ b/scripts/backfill_settlements.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,15 @@ DEFAULT_SYMBOLS = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT"
 
 def parse_symbols(raw: str) -> list[str]:
     return [item.strip().upper() for item in raw.split(",") if item.strip()]
+
+
+def parse_utc_ts(raw: str) -> datetime | None:
+    if not raw:
+        return None
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -35,8 +45,8 @@ def parser() -> argparse.ArgumentParser:
 async def load_candidate_markets(
     conn: asyncpg.Connection,
     *,
-    start_ts: str,
-    end_ts: str,
+    start_ts: datetime,
+    end_ts: datetime | None,
     symbols: list[str],
 ) -> list[asyncpg.Record]:
     return await conn.fetch(
@@ -61,7 +71,7 @@ async def load_candidate_markets(
         ORDER BY et.market_slug
         """,
         start_ts,
-        end_ts or None,
+        end_ts,
         symbols,
     )
 
@@ -135,13 +145,17 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
     symbols = parse_symbols(args.symbols)
     if not symbols:
         raise SystemExit("--symbols must include at least one symbol")
+    start_ts = parse_utc_ts(args.start_ts)
+    if start_ts is None:
+        raise SystemExit("--start-ts is required")
+    end_ts = parse_utc_ts(args.end_ts)
 
     conn = await asyncpg.connect(db_url)
     try:
         rows = await load_candidate_markets(
             conn,
-            start_ts=args.start_ts,
-            end_ts=args.end_ts,
+            start_ts=start_ts,
+            end_ts=end_ts,
             symbols=symbols,
         )
 

--- a/scripts/backfill_settlements.py
+++ b/scripts/backfill_settlements.py
@@ -8,10 +8,10 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-import asyncpg
-import httpx
+if TYPE_CHECKING:
+    import asyncpg
 
 
 DEFAULT_SYMBOLS = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT"
@@ -43,7 +43,7 @@ def parser() -> argparse.ArgumentParser:
 
 
 async def load_candidate_markets(
-    conn: asyncpg.Connection,
+    conn: "asyncpg.Connection",
     *,
     start_ts: datetime,
     end_ts: datetime | None,
@@ -107,7 +107,7 @@ def settlement_rows_from_gamma(
 
 
 async def upsert_settlement(
-    conn: asyncpg.Connection,
+    conn: "asyncpg.Connection",
     *,
     market_slug: str,
     token_id: str,
@@ -149,6 +149,8 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
     if start_ts is None:
         raise SystemExit("--start-ts is required")
     end_ts = parse_utc_ts(args.end_ts)
+    import asyncpg
+    import httpx
 
     conn = await asyncpg.connect(db_url)
     try:

--- a/tests/test_backfill_settlements.py
+++ b/tests/test_backfill_settlements.py
@@ -1,0 +1,35 @@
+import unittest
+from datetime import datetime, timezone
+
+from scripts.backfill_settlements import parse_utc_ts, settlement_rows_from_gamma
+
+
+class BackfillSettlementsTest(unittest.TestCase):
+    def test_parse_utc_ts_returns_timezone_aware_datetime(self) -> None:
+        parsed = parse_utc_ts("2026-05-16T00:00:00Z")
+
+        self.assertEqual(datetime(2026, 5, 16, tzinfo=timezone.utc), parsed)
+        self.assertIs(timezone.utc, parsed.tzinfo)
+
+    def test_parse_utc_ts_accepts_empty_optional_end(self) -> None:
+        self.assertIsNone(parse_utc_ts(""))
+
+    def test_settlement_rows_from_gamma_requires_closed_binary_payouts(self) -> None:
+        rows = settlement_rows_from_gamma(
+            {
+                "closed": True,
+                "clobTokenIds": '["up-token", "down-token"]',
+                "outcomePrices": '["1", "0"]',
+            },
+            up_token="up-token",
+            down_token="down-token",
+        )
+
+        self.assertEqual(
+            [("up-token", "winner", 1.0), ("down-token", "loser", 0.0)],
+            rows,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse settlement repair start/end timestamps into timezone-aware datetimes before binding with asyncpg
- add regression coverage for UTC timestamp parsing and Gamma settlement row extraction

## Evidence
- python3 -m unittest tests.test_backfill_settlements tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/backfill_settlements.py tests/test_backfill_settlements.py
- rtk git diff --check

## Root Cause
Hosted dry-run 26347475149 failed before querying because asyncpg expected datetime values for timestamptz bind parameters but received ISO timestamp strings.