### PR TITLE
Retry research snapshot SSH transfers

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -225,15 +225,16 @@ jobs:
           audit_start_ts="${SNAPSHOT_START_TS:-${{ github.event.inputs.start_date }}}"
           audit_end_ts="${SNAPSHOT_END_TS:-${{ github.event.inputs.end_date }}}"
 
-          ssh tango-1-1 /bin/bash -s -- \
-            "${DEPLOY_ROOT}" \
-            "${REMOTE_DIR}" \
-            "${remote_audit}" \
-            "${SNAPSHOT_AUDIT_LOOKBACK_HOURS}" \
-            "${audit_start_ts}" \
-            "${audit_end_ts}" \
-            "${{ github.event.inputs.symbols }}" \
-            "${REQUIRED_SOURCES}" <<'EOF'
+          for attempt in 1 2 3; do
+            if ssh tango-1-1 /bin/bash -s -- \
+              "${DEPLOY_ROOT}" \
+              "${REMOTE_DIR}" \
+              "${remote_audit}" \
+              "${SNAPSHOT_AUDIT_LOOKBACK_HOURS}" \
+              "${audit_start_ts}" \
+              "${audit_end_ts}" \
+              "${{ github.event.inputs.symbols }}" \
+              "${REQUIRED_SOURCES}" <<'EOF'
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
@@ -263,8 +264,26 @@ jobs:
               --format json \
               --fail-on never > "${remote_audit}"
           EOF
+            then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "remote snapshot data audit failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
 
-          scp "tango-1-1:${remote_audit}" artifacts/research-snapshot/data-gap-audit.json
+          for attempt in 1 2 3; do
+            if scp "tango-1-1:${remote_audit}" artifacts/research-snapshot/data-gap-audit.json; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "copying snapshot data audit report failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
           python3 <<'PY'
           import json
           import os
@@ -316,23 +335,24 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts
           empty_arg="__ploy_empty__"
-          ssh tango-1-1 /bin/bash -s -- \
-            "${DEPLOY_ROOT}" \
-            "${REMOTE_DIR}" \
-            "${{ github.event.inputs.symbols }}" \
-            "${{ github.event.inputs.start_date }}" \
-            "${{ github.event.inputs.end_date }}" \
-            "${SNAPSHOT_START_TS:-${empty_arg}}" \
-            "${SNAPSHOT_END_TS:-${empty_arg}}" \
-            "${{ github.event.inputs.stake_usd }}" \
-            "${SNAPSHOT_LOB_SAMPLE_SECS}" \
-            "${SNAPSHOT_PM_BOOK_SAMPLE_SECS}" \
-            "${SNAPSHOT_OBSERVATION_SAMPLE_SECS}" \
-            "${SNAPSHOT_MAX_QUOTE_AGE_SECS}" \
-            "${SNAPSHOT_OPTIMIZER_DATA_DIR}" \
-            "${REQUIRED_SOURCES}" \
-            "${DATA_AUDIT_STATUS}" \
-            "${INCLUDE_DERIBIT}" <<'EOF'
+          for attempt in 1 2 3; do
+            if ssh tango-1-1 /bin/bash -s -- \
+              "${DEPLOY_ROOT}" \
+              "${REMOTE_DIR}" \
+              "${{ github.event.inputs.symbols }}" \
+              "${{ github.event.inputs.start_date }}" \
+              "${{ github.event.inputs.end_date }}" \
+              "${SNAPSHOT_START_TS:-${empty_arg}}" \
+              "${SNAPSHOT_END_TS:-${empty_arg}}" \
+              "${{ github.event.inputs.stake_usd }}" \
+              "${SNAPSHOT_LOB_SAMPLE_SECS}" \
+              "${SNAPSHOT_PM_BOOK_SAMPLE_SECS}" \
+              "${SNAPSHOT_OBSERVATION_SAMPLE_SECS}" \
+              "${SNAPSHOT_MAX_QUOTE_AGE_SECS}" \
+              "${SNAPSHOT_OPTIMIZER_DATA_DIR}" \
+              "${REQUIRED_SOURCES}" \
+              "${DATA_AUDIT_STATUS}" \
+              "${INCLUDE_DERIBIT}" <<'EOF'
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
@@ -402,8 +422,26 @@ jobs:
           tar -C "${remote_dir}" -cf "${remote_dir}/research-snapshot.tar" research-snapshot
           ls -lh "${remote_dir}/research-snapshot.tar"
           EOF
+            then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "remote snapshot compile failed before artifact copy after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
 
-          scp "tango-1-1:${REMOTE_DIR}/research-snapshot.tar" artifacts/research-snapshot.tar
+          for attempt in 1 2 3; do
+            if scp "tango-1-1:${REMOTE_DIR}/research-snapshot.tar" artifacts/research-snapshot.tar; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "copying research snapshot tar failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
           rm -rf artifacts/research-snapshot
           mkdir -p artifacts/research-snapshot
           tar -C artifacts -xf artifacts/research-snapshot.tar

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -143,6 +143,9 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         self.assertIn('--end-ts "${audit_end_ts}"', workflow)
         self.assertIn("Gate mode: `{payload.get('gate_mode', 'unknown')}`", workflow)
         self.assertIn("Audit window: `{payload.get('audit_window_start_ts') or '<lookback-start>'}", workflow)
+        self.assertIn("remote snapshot data audit failed after ${attempt} attempts", workflow)
+        self.assertIn("copying snapshot data audit report failed after ${attempt} attempts", workflow)
+        self.assertIn("copying research snapshot tar failed after ${attempt} attempts", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- retry research snapshot remote audit SSH calls and audit artifact copy\n- retry remote snapshot compile SSH call and tarball copy\n- cover retry strings in the market-data audit scope test\n\n## Verification\n- python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_audit_market_data_gaps\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml"); puts "yaml ok"'\n- rtk git diff --check\n\n## Context\nRun 26349540522 failed twice on SSH banner timeout before data audit could complete. This keeps research-snapshot fail-closed for data quality while making transient SSH transport failures retry.