### PR TITLE
Report research snapshot Cloud Assistant failures

### DIFF
--- a/scripts/ci/run_tango_research_snapshot_cloud_assist.py
+++ b/scripts/ci/run_tango_research_snapshot_cloud_assist.py
@@ -8,6 +8,7 @@ and OSS but cannot complete an SSH banner exchange with tango-1-1.
 from __future__ import annotations
 
 import json
+import base64
 import os
 import shlex
 import subprocess
@@ -237,7 +238,6 @@ def main() -> int:
     invoke_id = result["InvokeId"]
     print(f"Cloud Assistant research snapshot invoke_id={invoke_id}")
 
-    exit_code = -1
     for _ in range(150):
         status_result = run_json(
             [
@@ -258,11 +258,24 @@ def main() -> int:
         status = row.get("InvocationStatus")
         exit_code = int(row.get("ExitCode", -1))
         print(f"Cloud Assistant research snapshot status={status} exit={exit_code}")
-        if status in {"Success", "Failed", "Stopped", "Timeout"}:
-            break
-        time.sleep(5)
+        if status in {"Pending", "Running"}:
+            time.sleep(5)
+            continue
+
+        output = base64.b64decode((row.get("Output") or "").encode()).decode(
+            "utf-8",
+            "replace",
+        )
+        if output:
+            print(output)
+        if status != "Success":
+            return 1
+        break
     else:
-        print("Cloud Assistant research snapshot did not finish before polling timeout", file=sys.stderr)
+        print(
+            "Cloud Assistant research snapshot did not finish before polling timeout",
+            file=sys.stderr,
+        )
         return 1
 
     try:


### PR DESCRIPTION
## Summary\n- treat non-running Cloud Assistant statuses such as Aborted as terminal\n- print decoded Cloud Assistant output for research snapshot fallback failures\n\n## Verification\n- python3 -m py_compile scripts/ci/run_tango_research_snapshot_cloud_assist.py\n- python3 -m unittest tests.test_market_data_gap_audit_scope tests.test_audit_market_data_gaps\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/research-snapshot.yml"); puts "yaml ok"'\n- rtk git diff --check\n\n## Context\nRun 26350015238 reached the Cloud Assistant fallback but returned Aborted without decoded remote output. This makes the next run actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Cloud Assistant invocation output handling in continuous integration pipeline
  * Improved error detection for failed invocations during deployment process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->