### PR TITLE
Fail closed on zero coverage snapshot audits

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -459,6 +459,7 @@ jobs:
             --evaluator scripts/evaluate_autofactor_strategy_promotion.py
             --snapshot-dir artifacts/research-snapshot
             --snapshot-manifest-json artifacts/research-snapshot/manifest.json
+            --snapshot-data-audit-json artifacts/research-snapshot/data-gap-audit.json
             --output-dir artifacts/factor-walk-forward-v2
             --symbols "${{ github.event.inputs.symbols }}"
             --start-ts "${WALK_START_TS}"

--- a/scripts/build_autofactor_candidate_strategy_replay.py
+++ b/scripts/build_autofactor_candidate_strategy_replay.py
@@ -323,6 +323,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--factor-registry-preview-json", default="")
     parser.add_argument("--require-runtime-contract", action="store_true")
     parser.add_argument("--snapshot-manifest-json", default="")
+    parser.add_argument("--snapshot-data-audit-json", default="")
     parser.add_argument("--full-depth-execution-surface-json", default="")
     return parser.parse_args()
 
@@ -353,6 +354,7 @@ def main() -> int:
         snapshot_contract=load_snapshot_execution_contract(
             args.snapshot_manifest_json or None,
             full_depth_execution_surface_json=args.full_depth_execution_surface_json or None,
+            data_audit_report_json=args.snapshot_data_audit_json or None,
         ),
     )
     output_json = Path(args.output_json)

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -940,6 +940,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--factor-registry-preview-json", default="")
     parser.add_argument("--require-runtime-contract", action="store_true")
     parser.add_argument("--snapshot-manifest-json", default="")
+    parser.add_argument("--snapshot-data-audit-json", default="")
     parser.add_argument("--full-depth-execution-surface-json", default="")
     parser.add_argument(
         "--candidate-strategy-replay-json",
@@ -994,6 +995,7 @@ def main() -> int:
         snapshot_contract=load_snapshot_execution_contract(
             args.snapshot_manifest_json or None,
             full_depth_execution_surface_json=args.full_depth_execution_surface_json or None,
+            data_audit_report_json=args.snapshot_data_audit_json or None,
         ),
     )
 

--- a/scripts/research_snapshot_contract.py
+++ b/scripts/research_snapshot_contract.py
@@ -100,10 +100,57 @@ def _load_full_depth_execution_surface_proof(
     }
 
 
+def _load_data_audit_contract(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    audit_path = Path(path)
+    payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    required_sources = {str(item) for item in payload.get("required_sources") or []}
+    blockers: list[str] = []
+    checked_sources: list[dict[str, Any]] = []
+    for item in (payload.get("gap_audits") or []) + (payload.get("window_audits") or []):
+        if not isinstance(item, dict):
+            continue
+        source_id = str(item.get("source_id") or "")
+        if required_sources and source_id not in required_sources:
+            continue
+        try:
+            expected_buckets = int(item.get("expected_buckets") or 0)
+            present_buckets = int(item.get("present_buckets") or 0)
+        except (TypeError, ValueError):
+            expected_buckets = 0
+            present_buckets = 0
+        if expected_buckets > 0 and present_buckets == 0:
+            blockers.append(
+                f"data_audit_zero_coverage:{source_id}:0<{expected_buckets}"
+            )
+        checked_sources.append(
+            {
+                "source_id": source_id,
+                "status": item.get("status", ""),
+                "coverage_status": item.get("coverage_status", ""),
+                "expected_buckets": expected_buckets,
+                "present_buckets": present_buckets,
+                "missing_buckets": item.get("missing_buckets"),
+                "coverage_pct": item.get("coverage_pct"),
+            }
+        )
+    return {
+        "path": str(audit_path),
+        "overall_status": payload.get("overall_status", ""),
+        "audit_window_start_ts": payload.get("audit_window_start_ts", ""),
+        "audit_window_end_ts": payload.get("audit_window_end_ts", ""),
+        "required_sources": sorted(required_sources),
+        "checked_sources": checked_sources,
+        "blocking_risk_flags": sorted(set(blockers)),
+    }
+
+
 def load_snapshot_execution_contract(
     path: str | None,
     *,
     full_depth_execution_surface_json: str | None = None,
+    data_audit_report_json: str | None = None,
 ) -> dict[str, Any]:
     if not path:
         return {}
@@ -139,6 +186,8 @@ def load_snapshot_execution_contract(
         f"sampled_snapshot_required_for_execution_surface:{name}"
         for name in sorted(unsatisfied_sampled_surfaces)
     ]
+    data_audit_contract = _load_data_audit_contract(data_audit_report_json)
+    blocking_flags.extend(data_audit_contract.get("blocking_risk_flags") or [])
     for item in execution_surface_proofs:
         if item.get("valid"):
             continue
@@ -158,6 +207,7 @@ def load_snapshot_execution_contract(
         ),
         "satisfied_execution_surfaces": sorted(satisfied_execution_surfaces),
         "full_depth_execution_surface_proofs": execution_surface_proofs,
+        "data_audit_contract": data_audit_contract,
         "blocking_risk_flags": blocking_flags,
     }
 

--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -191,6 +191,8 @@ def promotion_args(
     command.extend(["--candidate-strategy-replay-json", replay_json])
     if args.snapshot_manifest_json:
         command.extend(["--snapshot-manifest-json", args.snapshot_manifest_json])
+    if args.snapshot_data_audit_json:
+        command.extend(["--snapshot-data-audit-json", args.snapshot_data_audit_json])
     if args.full_depth_execution_surface_json:
         command.extend(
             ["--full-depth-execution-surface-json", args.full_depth_execution_surface_json]
@@ -231,6 +233,8 @@ def candidate_replay_args(
         command.append("--require-runtime-contract")
     if args.snapshot_manifest_json:
         command.extend(["--snapshot-manifest-json", args.snapshot_manifest_json])
+    if args.snapshot_data_audit_json:
+        command.extend(["--snapshot-data-audit-json", args.snapshot_data_audit_json])
     if args.full_depth_execution_surface_json:
         command.extend(
             ["--full-depth-execution-surface-json", args.full_depth_execution_surface_json]
@@ -663,6 +667,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--replay-parity-json", default="")
     parser.add_argument("--candidate-strategy-replay-json", default="")
     parser.add_argument("--snapshot-manifest-json", default="")
+    parser.add_argument("--snapshot-data-audit-json", default="")
     parser.add_argument("--full-depth-execution-surface-json", default="")
     parser.add_argument("--alpha-search-output-dir", default="")
     parser.add_argument("--alpha-search-plan-json", default="")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -161,6 +161,45 @@ decision.
   `bash -n` for root shell scripts, active workflow YAML parse, `rtk cargo test
   --locked --test workflow_security`, retired archive reference scan, and `rtk
   git diff --check`.
+- 2026-05-24: PR `#662` merged to `main` as
+  `ba8d06a25e6cfcf32c7eedb1814854b69cd25f2a`. CI was green; the follow-up
+  issue job was intentionally skipped.
+- 2026-05-24: Real replay-fed hosted walk-forward run `26352511938` succeeded
+  from `main@ba8d06a25e6cfcf32c7eedb1814854b69cd25f2a` and proved stale
+  candidate replay is now downgraded to a variant-local blocked aggregate replay.
+  It also exposed that retained old snapshot artifacts can still carry
+  `polymarket_orderbooks` zero coverage with `status=ok`, so the consumer-side
+  snapshot contract must validate data audit contradictions too.
+
+## Current Session - Snapshot Data Audit Consumer Gate (2026-05-24)
+
+Evidence stage: `walk_forward` / `executable_replay` data-contract gate repair.
+This is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Reproduce the retained snapshot data-audit contradiction from real
+      walk-forward run `26352511938`.
+- [x] Add snapshot-contract consumer validation for zero-covered required data
+      audit sources.
+- [x] Pass `data-gap-audit.json` from hosted walk-forward into candidate replay
+      and promotion consumers.
+- [x] Add focused promotion, replay-builder, workflow, and audit tests.
+- [x] Run focused validation.
+- [ ] Commit, push, open PR, wait for CI, and merge.
+
+### Review
+
+- 2026-05-24: Local replay of run `26352511938` artifacts through the updated
+  promotion evaluator now blocks on
+  `data_audit_zero_coverage:polymarket_orderbooks:0<288` even when the retained
+  artifact's own `overall_status` is `ok` and full-depth execution proof is
+  present.
+- 2026-05-24: Focused validation passed: `python3 -m unittest discover -s tests
+  -p 'test_*.py'` (`269` tests), targeted AutoFactor/audit tests (`77` tests),
+  Python compile for touched scripts and `scripts/*.py` / `scripts/ci/*.py`,
+  hosted walk-forward YAML parse, `rtk cargo test --locked --test
+  workflow_security`, and `rtk git diff --check`.
 
 ## Current Session - Market Data Promotion Blocker Actions (2026-05-24)
 

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -258,6 +258,24 @@ VALID_FULL_DEPTH_EXECUTION_SURFACE = {
     "incomplete": False,
 }
 
+ZERO_COVERAGE_DATA_AUDIT = {
+    "overall_status": "ok",
+    "audit_window_start_ts": "2026-05-17T00:00:00Z",
+    "audit_window_end_ts": "2026-05-18T00:00:00Z",
+    "required_sources": ["polymarket_orderbooks"],
+    "gap_audits": [
+        {
+            "source_id": "polymarket_orderbooks",
+            "status": "ok",
+            "coverage_status": "ok",
+            "expected_buckets": 288,
+            "present_buckets": 0,
+            "missing_buckets": 288,
+            "coverage_pct": 0.0,
+        }
+    ],
+}
+
 
 class AutoFactorStrategyPromotionTests(unittest.TestCase):
     def run_script(
@@ -268,6 +286,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
         replay_payload=DEFAULT_REPLAY_PAYLOAD,
         registry_preview_payload=None,
         snapshot_manifest_payload=None,
+        snapshot_data_audit_payload=None,
         full_depth_execution_surface_payload=None,
     ):
         with tempfile.TemporaryDirectory() as tmp:
@@ -275,6 +294,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
             replay_path = Path(tmp) / "candidate-strategy-replay.json"
             registry_path = Path(tmp) / "factor-registry-preview.json"
             snapshot_manifest_path = Path(tmp) / "manifest.json"
+            data_audit_path = Path(tmp) / "data-gap-audit.json"
             execution_surface_path = Path(tmp) / "full-depth-execution-surface.json"
             output_json = Path(tmp) / "promotion.json"
             output_registry = Path(tmp) / "registry.json"
@@ -306,6 +326,13 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     encoding="utf-8",
                 )
                 snapshot_args = ["--snapshot-manifest-json", str(snapshot_manifest_path)]
+            data_audit_args = []
+            if snapshot_data_audit_payload is not None:
+                data_audit_path.write_text(
+                    json.dumps(snapshot_data_audit_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                data_audit_args = ["--snapshot-data-audit-json", str(data_audit_path)]
             execution_surface_args = []
             if full_depth_execution_surface_payload is not None:
                 execution_surface_path.write_text(
@@ -335,6 +362,7 @@ class AutoFactorStrategyPromotionTests(unittest.TestCase):
                     *replay_args,
                     *registry_args,
                     *snapshot_args,
+                    *data_audit_args,
                     *execution_surface_args,
                     *extra_args,
                 ],
@@ -683,6 +711,29 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
             payload["source_snapshot_contract"]["full_depth_execution_surface_proofs"][0][
                 "valid"
             ]
+        )
+
+    def test_zero_coverage_data_audit_blocks_even_with_full_depth_proof(self):
+        _, payload, _, handoff, _ = self.run_script(
+            LOW_SLIPPAGE_HEALTH
+            + GLOBAL_FILLABILITY_BLOCKED_GATE
+            + AUTOFACTOR_TOP_BUCKET_EXECUTION_REPORT,
+            replay_payload=replay_for_target(
+                "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "tradeable_full_depth_settlement_pnl",
+            ),
+            snapshot_manifest_payload=SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
+            snapshot_data_audit_payload=ZERO_COVERAGE_DATA_AUDIT,
+            full_depth_execution_surface_payload=VALID_FULL_DEPTH_EXECUTION_SURFACE,
+        )
+
+        expected = "data_audit_zero_coverage:polymarket_orderbooks:0<288"
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        self.assertIn(expected, payload["source_snapshot_contract"]["blocking_risk_flags"])
+        self.assertIn(
+            f"snapshot_contract_blocks_execution_claim:{expected}",
+            payload["evaluated_factors"][0]["blockers"],
         )
 
     def test_invalid_full_depth_execution_surface_proof_fails_closed(self):

--- a/tests/test_build_autofactor_candidate_strategy_replay.py
+++ b/tests/test_build_autofactor_candidate_strategy_replay.py
@@ -11,6 +11,7 @@ from tests.test_autofactor_strategy_promotion import (
     AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
     SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
     VALID_FULL_DEPTH_EXECUTION_SURFACE,
+    ZERO_COVERAGE_DATA_AUDIT,
 )
 
 
@@ -25,6 +26,7 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
         *extra_args: str,
         registry_preview_payload: dict | None = None,
         snapshot_manifest_payload: dict | None = None,
+        snapshot_data_audit_payload: dict | None = None,
         full_depth_execution_surface_payload: dict | None = None,
     ) -> tuple[dict, str]:
         with tempfile.TemporaryDirectory() as tmp:
@@ -53,6 +55,14 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                     encoding="utf-8",
                 )
                 snapshot_args = ["--snapshot-manifest-json", str(snapshot_manifest_path)]
+            data_audit_args = []
+            if snapshot_data_audit_payload is not None:
+                data_audit_path = tmp_path / "data-gap-audit.json"
+                data_audit_path.write_text(
+                    json.dumps(snapshot_data_audit_payload, indent=2, sort_keys=True),
+                    encoding="utf-8",
+                )
+                data_audit_args = ["--snapshot-data-audit-json", str(data_audit_path)]
             execution_surface_args = []
             if full_depth_execution_surface_payload is not None:
                 execution_surface_path = tmp_path / "full-depth-execution-surface.json"
@@ -78,6 +88,7 @@ class BuildAutoFactorCandidateStrategyReplayTests(unittest.TestCase):
                     str(output_md),
                     *registry_args,
                     *snapshot_args,
+                    *data_audit_args,
                     *execution_surface_args,
                     *extra_args,
                 ],
@@ -298,6 +309,19 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
             "requires_runtime_replay_not_top_bucket_aggregate",
             payload["blocking_risk_flags"],
         )
+
+    def test_zero_coverage_data_audit_blocks_candidate_replay_contract(self):
+        payload, _ = self.run_script(
+            AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            snapshot_manifest_payload=SAMPLED_EXECUTION_SNAPSHOT_MANIFEST,
+            snapshot_data_audit_payload=ZERO_COVERAGE_DATA_AUDIT,
+            full_depth_execution_surface_payload=VALID_FULL_DEPTH_EXECUTION_SURFACE,
+        )
+
+        expected = "data_audit_zero_coverage:polymarket_orderbooks:0<288"
+        self.assertFalse(payload["promotion_ready"])
+        self.assertIn(expected, payload["source_snapshot_contract"]["blocking_risk_flags"])
+        self.assertIn(expected, payload["blocking_risk_flags"])
 
     def test_invalid_full_depth_execution_surface_proof_remains_blocked(self):
         proof = dict(VALID_FULL_DEPTH_EXECUTION_SURFACE)

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -674,6 +674,7 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--train-window-hours \"${WALK_TRAIN_WINDOW_HOURS}\"", workflow)
         self.assertIn("--candidate-strategy-replay-json", workflow)
         self.assertIn("--snapshot-manifest-json artifacts/research-snapshot/manifest.json", workflow)
+        self.assertIn("--snapshot-data-audit-json artifacts/research-snapshot/data-gap-audit.json", workflow)
         self.assertIn("full_depth_execution_surface_run_id", workflow)
         self.assertIn("Download full-depth execution surface artifact", workflow)
         self.assertIn("--full-depth-execution-surface-json", workflow)


### PR DESCRIPTION
## Summary
- pass retained `data-gap-audit.json` into hosted walk-forward promotion/replay consumers
- make the shared snapshot contract fail closed when a required source has zero covered buckets, even if the retained audit artifact says `status=ok`
- add tests proving zero Polymarket orderbook coverage blocks promotion/replay even when full-depth execution proof is present

## Real artifact check
- run `26352511938` succeeded on `main@ba8d06a25e6cfcf32c7eedb1814854b69cd25f2a`
- its retained snapshot audit still had `polymarket_orderbooks: expected_buckets=288, present_buckets=0, status=ok`
- replaying that artifact through this patch produces `data_audit_zero_coverage:polymarket_orderbooks:0<288`

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` (269 tests)
- `python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_factor_walk_forward_sweep tests.test_audit_market_data_gaps` (77 tests)
- `python3 -m py_compile scripts/research_snapshot_contract.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py scripts/audit_market_data_gaps.py`
- `python3 -m py_compile scripts/*.py scripts/ci/*.py`
- hosted walk-forward YAML parse
- `rtk cargo test --locked --test workflow_security`
- `rtk git diff --check`
