### PR TITLE
Prioritize data blockers in closed loop

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -219,6 +219,17 @@ def classify_blockers(blockers: list[str]) -> str | None:
     if any(
         token in text
         for token in [
+            "data_audit_zero_coverage",
+            "snapshot_contract_blocks_execution_claim",
+            "sampled_snapshot_required_for_execution_surface",
+            "official_settlement_missing",
+            "candidate_strategy_replay_missing_contract:official_settlement",
+        ]
+    ):
+        return "fix_data"
+    if any(
+        token in text
+        for token in [
             "candidate_strategy_replay_not_runtime_replay",
             "requires_runtime_replay_not_top_bucket_aggregate",
             "candidate_strategy_replay_identity_basis_mismatch",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -184,6 +184,8 @@ This is not a dry-run or live promotion decision.
       audit sources.
 - [x] Pass `data-gap-audit.json` from hosted walk-forward into candidate replay
       and promotion consumers.
+- [x] Route closed-loop decisions with data-audit blockers to `fix_data` even
+      when aggregate replay blockers are also present.
 - [x] Add focused promotion, replay-builder, workflow, and audit tests.
 - [x] Run focused validation.
 - [ ] Commit, push, open PR, wait for CI, and merge.
@@ -196,7 +198,8 @@ This is not a dry-run or live promotion decision.
   artifact's own `overall_status` is `ok` and full-depth execution proof is
   present.
 - 2026-05-24: Focused validation passed: `python3 -m unittest discover -s tests
-  -p 'test_*.py'` (`269` tests), targeted AutoFactor/audit tests (`77` tests),
+  -p 'test_*.py'` (`270` tests), targeted closed-loop/AutoFactor/audit tests
+  (`107` tests),
   Python compile for touched scripts and `scripts/*.py` / `scripts/ci/*.py`,
   hosted walk-forward YAML parse, `rtk cargo test --locked --test
   workflow_security`, and `rtk git diff --check`.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -213,6 +213,32 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(decision["decision"], "fix_runtime")
 
+    def test_data_audit_blocker_takes_priority_over_aggregate_replay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                promotion={
+                    "decision": "blocked",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "snapshot_contract_blocks_execution_claim:"
+                                "data_audit_zero_coverage:polymarket_orderbooks:0<288",
+                                "requires_runtime_replay_not_top_bucket_aggregate",
+                            ]
+                        }
+                    ],
+                },
+            )
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+
+        self.assertEqual(decision["decision"], "fix_data")
+        self.assertEqual(decision["reason"], "promotion_blockers_require_fix_data")
+
     def test_unmapped_best_candidate_revises_prior_with_runtime_avoid(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(


### PR DESCRIPTION
## Summary
- route explicit data-audit/snapshot-contract/official-settlement blockers to `fix_data` before aggregate replay/runtime blockers
- add a closed-loop regression test for `data_audit_zero_coverage` plus `requires_runtime_replay_not_top_bucket_aggregate`
- record the follow-up in `tasks/todo.md`

## Context
After #663, real hosted run `26352812057` correctly produced `data_audit_zero_coverage:polymarket_orderbooks:0<288`, but the closed-loop classifier still chose `fix_runtime` because aggregate replay blockers were also present. This makes data repair the next action when the data contract is already known bad.

## Validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` (270 tests)
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_factor_walk_forward_sweep tests.test_audit_market_data_gaps` (107 tests)
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py scripts/research_snapshot_contract.py scripts/build_autofactor_candidate_strategy_replay.py scripts/evaluate_autofactor_strategy_promotion.py scripts/run_factor_walk_forward_sweep.py`
- `python3 -m py_compile scripts/*.py scripts/ci/*.py`
- `rtk cargo test --locked --test workflow_security`
- `rtk git diff --check`
