### PR TITLE
Fix archive-aware snapshot data audit

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -24,9 +24,9 @@ on:
         required: true
         default: "15"
       options_json:
-        description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, and optional complete sampled snapshot upload"
+        description: "Advanced options JSON: optional start_ts/end_ts, sampling, optimizer_data_dir, data_profile, audit gate, orderbook_archive_root, and optional complete sampled snapshot upload"
         required: false
-        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","snapshot_registry_dir":"","upload_sampled_snapshot":true}'
+        default: '{"start_ts":"","end_ts":"","lob_sample_secs":30,"pm_book_sample_secs":30,"observation_sample_secs":30,"max_quote_age_secs":30,"optimizer_data_dir":"/tmp/ploy-parquet","data_profile":"pm5d-execution","custom_required_sources":"","audit_lookback_hours":168,"data_gate":"never","orderbook_archive_root":"/opt/ploy/data/lake","snapshot_registry_dir":"","upload_sampled_snapshot":true}'
 
 concurrency:
   group: research-snapshot-${{ github.event.inputs.git_ref }}-${{ github.event.inputs.start_date }}-${{ github.event.inputs.end_date }}-${{ github.event.inputs.symbols }}
@@ -79,6 +79,7 @@ jobs:
               "custom_required_sources": "",
               "audit_lookback_hours": "168",
               "data_gate": "never",
+              "orderbook_archive_root": "/opt/ploy/data/lake",
               "snapshot_registry_dir": "",
               "upload_sampled_snapshot": "true",
           }
@@ -237,7 +238,8 @@ jobs:
               "${audit_start_ts}" \
               "${audit_end_ts}" \
               "${{ github.event.inputs.symbols }}" \
-              "${REQUIRED_SOURCES}" <<'EOF'
+              "${REQUIRED_SOURCES}" \
+              "${SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT}" <<'EOF'
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
@@ -247,6 +249,7 @@ jobs:
           audit_end_ts="$6"
           symbols="$7"
           required_sources="$8"
+          orderbook_archive_root="$9"
 
           set -a
           . "${deploy_root}/.env"
@@ -262,6 +265,7 @@ jobs:
               --bucket-minutes 5 \
               --symbols "${symbols}" \
               --required-sources "${required_sources}" \
+              --orderbook-archive-root "${orderbook_archive_root}" \
               --statement-timeout-seconds 20 \
               --psql-timeout-seconds 30 \
               --format json \
@@ -358,7 +362,8 @@ jobs:
               "${SNAPSHOT_OPTIMIZER_DATA_DIR}" \
               "${REQUIRED_SOURCES}" \
               "${DATA_AUDIT_STATUS}" \
-              "${INCLUDE_DERIBIT}" <<'EOF'
+              "${INCLUDE_DERIBIT}" \
+              "${SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT}" <<'EOF'
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
@@ -376,6 +381,7 @@ jobs:
           required_sources="${14}"
           data_audit_status="${15}"
           include_deribit="${16}"
+          orderbook_archive_root="${17}"
           if [ "${start_ts}" = "__ploy_empty__" ]; then
             start_ts=""
           fi
@@ -413,6 +419,7 @@ jobs:
             --stake-usd "${stake_usd}" \
             --lob-sample-secs "${lob_sample_secs}" \
             --pm-book-sample-secs "${pm_book_sample_secs}" \
+            --pm-book-archive-dir "${orderbook_archive_root}/orderbook_snapshots" \
             --observation-sample-secs "${observation_sample_secs}" \
             --max-quote-age-secs "${max_quote_age_secs}" \
             --output-dir "${remote_dir}/research-snapshot" \

--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -17,7 +17,8 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Iterable, Optional
 
 DB_URL = (
@@ -29,6 +30,7 @@ DB_URL = (
 DEFAULT_SYMBOLS = "BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,BNBUSDT"
 STATUS_ORDER = {"ok": 0, "warn": 1, "unknown": 2, "critical": 3}
 IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+ORDERBOOK_ARCHIVE_TZ = timezone(timedelta(hours=8))
 
 SOURCE_PROFILES = {
     "all": ["*"],
@@ -109,6 +111,195 @@ def run_json(query: str, timeout: int) -> dict[str, Any]:
     if not raw:
         raise RuntimeError("SQL returned no rows")
     return json.loads(raw)
+
+
+def parse_utc_datetime(raw: str) -> datetime:
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def archive_hour_keys(start_ts: str, end_ts: str) -> list[tuple[str, str]]:
+    start = parse_utc_datetime(start_ts)
+    end = parse_utc_datetime(end_ts)
+    current = start.replace(minute=0, second=0, microsecond=0)
+    keys: list[tuple[str, str]] = []
+    while current < end:
+        local = current.astimezone(ORDERBOOK_ARCHIVE_TZ)
+        keys.append((local.strftime("%Y-%m-%d"), local.strftime("%H")))
+        current += timedelta(hours=1)
+    return keys
+
+
+def audit_orderbook_archive_coverage(
+    *,
+    archive_root: str,
+    start_ts: str,
+    end_ts: str,
+    bucket_minutes: int,
+) -> dict[str, Any]:
+    root = Path(archive_root)
+    base = root / "orderbook_snapshots"
+    hour_keys = archive_hour_keys(start_ts, end_ts)
+    manifests: list[dict[str, Any]] = []
+    missing_hours: list[dict[str, str]] = []
+    invalid_hours: list[dict[str, str]] = []
+    row_count = 0
+    full_fidelity = True
+    for date, hour in hour_keys:
+        hour_dir = base / f"date={date}" / f"hour={hour}"
+        marker = hour_dir / "_SUCCESS"
+        manifest_path = hour_dir / "manifest.json"
+        parquet_path = hour_dir / "snapshots.parquet"
+        if not marker.exists() or not manifest_path.exists() or not parquet_path.exists():
+            missing_hours.append(
+                {
+                    "date": date,
+                    "hour": hour,
+                    "path": str(hour_dir),
+                }
+            )
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            invalid_hours.append(
+                {
+                    "date": date,
+                    "hour": hour,
+                    "path": str(manifest_path),
+                    "reason": f"manifest_unreadable:{exc}",
+                }
+            )
+            continue
+        try:
+            hour_rows = int(manifest.get("row_count") or 0)
+        except (TypeError, ValueError):
+            hour_rows = 0
+        if hour_rows <= 0:
+            invalid_hours.append(
+                {
+                    "date": date,
+                    "hour": hour,
+                    "path": str(manifest_path),
+                    "reason": "row_count_empty",
+                }
+            )
+            continue
+        if manifest.get("full_fidelity") is not True:
+            full_fidelity = False
+            invalid_hours.append(
+                {
+                    "date": date,
+                    "hour": hour,
+                    "path": str(manifest_path),
+                    "reason": "not_full_fidelity",
+                }
+            )
+            continue
+        row_count += hour_rows
+        manifests.append(
+            {
+                "date": date,
+                "hour": hour,
+                "path": str(manifest_path),
+                "row_count": hour_rows,
+                "start_ts": manifest.get("start_ts", ""),
+                "end_ts": manifest.get("end_ts", ""),
+                "sha256": manifest.get("sha256", ""),
+            }
+        )
+
+    start = parse_utc_datetime(start_ts)
+    end = parse_utc_datetime(end_ts)
+    expected_buckets = max(0, int((end - start).total_seconds() // (bucket_minutes * 60)))
+    expected_hours = len(hour_keys)
+    present_hours = len(manifests)
+    status = "ok"
+    reasons: list[str] = []
+    if expected_hours == 0:
+        status = "critical"
+        reasons.append("archive audit window has no expected hours")
+    if missing_hours:
+        status = "critical"
+        reasons.append(f"missing archive hours {len(missing_hours)}/{expected_hours}")
+    if invalid_hours:
+        status = "critical"
+        reasons.append(f"invalid archive hours {len(invalid_hours)}/{expected_hours}")
+    if not full_fidelity:
+        status = "critical"
+        reasons.append("archive contains non-full-fidelity manifests")
+    if row_count <= 0:
+        status = "critical"
+        reasons.append("archive row_count is empty")
+    if not reasons:
+        reasons.append("archive full-depth orderbook coverage available")
+
+    return {
+        "schema_version": "orderbook_snapshot_archive_coverage.v1",
+        "source_id": "polymarket_orderbooks",
+        "surface": "clob_orderbook_snapshots",
+        "source": "orderbook_snapshot_archive",
+        "archive_root": str(root),
+        "start_ts": start_ts,
+        "end_ts": end_ts,
+        "expected_hours": expected_hours,
+        "present_hours": present_hours,
+        "missing_hours": len(missing_hours),
+        "invalid_hours": len(invalid_hours),
+        "expected_buckets": expected_buckets,
+        "present_buckets": expected_buckets if status == "ok" else 0,
+        "coverage_pct": 100.0 if status == "ok" and expected_buckets > 0 else 0.0,
+        "row_count": row_count,
+        "full_fidelity": full_fidelity,
+        "status": status,
+        "reasons": reasons,
+        "missing_hour_examples": missing_hours[:8],
+        "invalid_hour_examples": invalid_hours[:8],
+        "manifests": manifests[:24],
+    }
+
+
+def apply_orderbook_archive_coverage(
+    row: dict[str, Any],
+    target: GapTarget,
+    *,
+    start_ts: str | None,
+    end_ts: str | None,
+    bucket_minutes: int,
+    orderbook_archive_root: str,
+) -> dict[str, Any]:
+    if (
+        target.source_id != "polymarket_orderbooks"
+        or not start_ts
+        or not end_ts
+        or not orderbook_archive_root
+    ):
+        return row
+    archive = audit_orderbook_archive_coverage(
+        archive_root=orderbook_archive_root,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        bucket_minutes=bucket_minutes,
+    )
+    row["archive_coverage"] = archive
+    row["hot_table_expected_buckets"] = row.get("expected_buckets")
+    row["hot_table_present_buckets"] = row.get("present_buckets")
+    row["hot_table_missing_buckets"] = row.get("missing_buckets")
+    row["hot_table_coverage_pct"] = row.get("coverage_pct")
+    if archive.get("status") != "ok":
+        return row
+    row["coverage_source"] = archive["source"]
+    row["expected_buckets"] = archive["expected_buckets"]
+    row["present_buckets"] = archive["present_buckets"]
+    row["missing_buckets"] = 0
+    row["coverage_pct"] = archive["coverage_pct"]
+    row["max_gap_buckets"] = 0
+    row["max_gap_minutes"] = 0
+    row["max_gap_start"] = None
+    row["max_gap_end"] = None
+    return row
 
 
 def target_predicate(target: GapTarget, alias: str = "t") -> str:
@@ -244,7 +435,11 @@ def classify_gap(row: dict[str, Any], target: GapTarget) -> tuple[str, list[str]
     if coverage_status != "ok":
         reasons.extend(coverage_reasons)
     if not reasons:
-        reasons.append("coverage within thresholds")
+        coverage_source = row.get("coverage_source")
+        if coverage_source:
+            reasons.append(f"coverage via {coverage_source}")
+        else:
+            reasons.append("coverage within thresholds")
     return status, reasons
 
 
@@ -348,6 +543,7 @@ def audit_gap_target(
     gate_mode: str,
     start_ts: Optional[str] = None,
     end_ts: Optional[str] = None,
+    orderbook_archive_root: str = "",
 ) -> dict[str, Any]:
     started = time.monotonic()
     historical_window = bool(start_ts and end_ts)
@@ -363,6 +559,14 @@ def audit_gap_target(
                 end_ts=end_ts,
             ),
             psql_timeout_seconds,
+        )
+        row = apply_orderbook_archive_coverage(
+            row,
+            target,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            bucket_minutes=bucket_minutes,
+            orderbook_archive_root=orderbook_archive_root,
         )
         (
             status,
@@ -824,6 +1028,14 @@ def main() -> int:
             "freshness enforces only latest-row staleness while still reporting coverage"
         ),
     )
+    parser.add_argument(
+        "--orderbook-archive-root",
+        default=os.environ.get("PLOY_ORDERBOOK_ARCHIVE_ROOT", "/opt/ploy/data/lake"),
+        help=(
+            "root that contains orderbook_snapshots/date=YYYY-MM-DD/hour=HH archives; "
+            "used for explicit historical polymarket_orderbooks coverage"
+        ),
+    )
     args = parser.parse_args()
 
     if args.lookback_hours <= 0:
@@ -863,6 +1075,7 @@ def main() -> int:
             gate_mode=args.gate_mode,
             start_ts=start_ts or None,
             end_ts=end_ts or None,
+            orderbook_archive_root=args.orderbook_archive_root,
         )
         for target in selected_gap_targets
     ]
@@ -897,6 +1110,7 @@ def main() -> int:
         "bucket_minutes": args.bucket_minutes,
         "recent_minutes": args.recent_minutes,
         "gate_mode": args.gate_mode,
+        "orderbook_archive_root": args.orderbook_archive_root,
         "symbols": symbols,
         "required_sources": source_requirements,
         "overall_status": overall_status(items),

--- a/scripts/ci/run_tango_research_snapshot_cloud_assist.py
+++ b/scripts/ci/run_tango_research_snapshot_cloud_assist.py
@@ -117,6 +117,7 @@ PLOY_DATABASE__URL="${{PLOY_DATABASE__URL}}" \\
     --bucket-minutes 5 \\
     --symbols {q(require_env("SNAPSHOT_SYMBOLS"))} \\
     --required-sources {q(require_env("REQUIRED_SOURCES"))} \\
+    --orderbook-archive-root {q(env("SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT", "/opt/ploy/data/lake"))} \\
     --statement-timeout-seconds 20 \\
     --psql-timeout-seconds 30 \\
     --format json \\
@@ -159,6 +160,7 @@ timeout 3600 "${{compiler}}" \\
   --stake-usd {q(require_env("SNAPSHOT_STAKE_USD"))} \\
   --lob-sample-secs {q(require_env("SNAPSHOT_LOB_SAMPLE_SECS"))} \\
   --pm-book-sample-secs {q(require_env("SNAPSHOT_PM_BOOK_SAMPLE_SECS"))} \\
+  --pm-book-archive-dir {q(env("SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT", "/opt/ploy/data/lake") + "/orderbook_snapshots")} \\
   --observation-sample-secs {q(require_env("SNAPSHOT_OBSERVATION_SAMPLE_SECS"))} \\
   --max-quote-age-secs {q(require_env("SNAPSHOT_MAX_QUOTE_AGE_SECS"))} \\
   --output-dir research-snapshot \\

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -204,6 +204,46 @@ This is not a dry-run or live promotion decision.
   hosted walk-forward YAML parse, `rtk cargo test --locked --test
   workflow_security`, and `rtk git diff --check`.
 
+## Current Session - Archive-Aware Snapshot Data Audit (2026-05-24)
+
+Evidence stage: `walk_forward` / `executable_replay` data-contract repair.
+This is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Reconfirm PM5D project semantics and Event ML / AutoFactor workflow gates.
+- [x] Identify the data-layer contradiction: historical data audit reads the
+      hot `clob_orderbook_snapshots` table, while full-depth execution proof
+      reads the archived `orderbook_snapshots` surface.
+- [x] Add an archive-aware `polymarket_orderbooks` audit contract for explicit
+      historical windows.
+- [x] Wire `research-snapshot.yml` and Cloud Assistant fallback to pass the
+      orderbook archive root.
+- [x] Add focused Python/static workflow validation.
+- [ ] Commit, push, open PR, wait for CI, merge, and rerun the snapshot-backed
+      walk-forward.
+
+### Review
+
+- 2026-05-24: Real runs show the raw archive can be healthy
+  (`full_depth_execution_surface.v1`, `24/24` hours, `2214371` rows) while a
+  retained snapshot data audit reports `polymarket_orderbooks` as `0/288`.
+  The old audit treats the hot table as the only historical source even after
+  orderbook retention has moved full-fidelity rows into the data lake.
+- 2026-05-24: Implemented archive-aware historical coverage for
+  `polymarket_orderbooks`: when `/opt/ploy/data/lake/orderbook_snapshots`
+  contains complete full-fidelity hourly manifests, the audit reports
+  `coverage_source=orderbook_snapshot_archive` while preserving
+  `hot_table_*` diagnostics. Missing, invalid, zero-row, or non-full-fidelity
+  archive hours remain critical. `research-snapshot.yml` and its Cloud
+  Assistant fallback now pass the same `orderbook_archive_root` to both the
+  audit script and `research-snapshot-compile --pm-book-archive-dir`.
+- 2026-05-24: Validation passed: `python3 -m unittest discover -s tests -p
+  'test_*.py'` (`274` tests), `python3 -m py_compile scripts/*.py
+  scripts/ci/*.py`, active workflow YAML parse for all workflows,
+  `rtk cargo test --locked --test workflow_security`, focused audit/workflow
+  tests (`20` tests), and `rtk git diff --check`.
+
 ## Current Session - Market Data Promotion Blocker Actions (2026-05-24)
 
 Evidence stage: architecture/data-plane cleanup and research workflow planning;

--- a/tests/test_audit_market_data_gaps.py
+++ b/tests/test_audit_market_data_gaps.py
@@ -1,5 +1,7 @@
 import importlib.util
+import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -14,6 +16,155 @@ SPEC.loader.exec_module(audit)
 
 
 class AuditMarketDataGapsTests(unittest.TestCase):
+    def write_archive_hour(
+        self,
+        root: Path,
+        date: str,
+        hour: str,
+        *,
+        row_count: int = 100,
+        full_fidelity: bool = True,
+    ) -> None:
+        hour_dir = root / "orderbook_snapshots" / f"date={date}" / f"hour={hour}"
+        hour_dir.mkdir(parents=True)
+        (hour_dir / "snapshots.parquet").write_text("placeholder", encoding="utf-8")
+        (hour_dir / "_SUCCESS").touch()
+        (hour_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "table": "clob_orderbook_snapshots",
+                    "row_count": row_count,
+                    "full_fidelity": full_fidelity,
+                    "start_ts": f"{date} {hour}:00:00+08",
+                    "end_ts": f"{date} {hour}:59:59+08",
+                    "sha256": "abc123",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_historical_pm_orderbooks_use_archive_coverage_when_hot_table_empty(self):
+        target = audit.GapTarget(
+            "polymarket_orderbooks",
+            "clob_orderbook_snapshots",
+            "received_at",
+            900,
+            ignore_max_gap=True,
+            ignore_missing_buckets=True,
+        )
+        row = {
+            "latest_at": None,
+            "latest_lag_seconds": None,
+            "expected_buckets": 24,
+            "present_buckets": 0,
+            "max_gap_minutes": 120,
+            "missing_buckets": 24,
+            "coverage_pct": 0.0,
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_archive_hour(root, "2026-05-17", "08")
+            self.write_archive_hour(root, "2026-05-17", "09")
+
+            updated = audit.apply_orderbook_archive_coverage(
+                row,
+                target,
+                start_ts="2026-05-17T00:00:00Z",
+                end_ts="2026-05-17T02:00:00Z",
+                bucket_minutes=5,
+                orderbook_archive_root=str(root),
+            )
+            status, reasons, freshness_status, _, coverage_status, _ = (
+                audit.classify_gap_for_gate(
+                    updated,
+                    target,
+                    "coverage",
+                    historical_window=True,
+                )
+            )
+
+        self.assertEqual(status, "ok")
+        self.assertEqual(freshness_status, "critical")
+        self.assertEqual(coverage_status, "ok")
+        self.assertEqual(updated["coverage_source"], "orderbook_snapshot_archive")
+        self.assertEqual(updated["present_buckets"], 24)
+        self.assertEqual(updated["missing_buckets"], 0)
+        self.assertEqual(updated["hot_table_present_buckets"], 0)
+        self.assertEqual(updated["archive_coverage"]["present_hours"], 2)
+        self.assertIn("freshness not enforced for historical window", "; ".join(reasons))
+
+    def test_historical_pm_orderbooks_fail_closed_when_archive_hour_missing(self):
+        target = audit.GapTarget(
+            "polymarket_orderbooks",
+            "clob_orderbook_snapshots",
+            "received_at",
+            900,
+            ignore_max_gap=True,
+            ignore_missing_buckets=True,
+        )
+        row = {
+            "latest_at": None,
+            "latest_lag_seconds": None,
+            "expected_buckets": 24,
+            "present_buckets": 0,
+            "max_gap_minutes": 120,
+            "missing_buckets": 24,
+            "coverage_pct": 0.0,
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            updated = audit.apply_orderbook_archive_coverage(
+                row,
+                target,
+                start_ts="2026-05-17T00:00:00Z",
+                end_ts="2026-05-17T02:00:00Z",
+                bucket_minutes=5,
+                orderbook_archive_root=tmp,
+            )
+            status, reasons, _, _, coverage_status, coverage_reasons = (
+                audit.classify_gap_for_gate(
+                    updated,
+                    target,
+                    "coverage",
+                    historical_window=True,
+                )
+            )
+
+        self.assertEqual(status, "critical")
+        self.assertEqual(coverage_status, "critical")
+        self.assertIn("no covered buckets in audited window: 0/24", reasons)
+        self.assertIn("no covered buckets in audited window: 0/24", coverage_reasons)
+        self.assertEqual(updated["archive_coverage"]["status"], "critical")
+        self.assertNotIn("coverage_source", updated)
+
+    def test_archive_hour_keys_use_shanghai_partition_hours(self):
+        self.assertEqual(
+            audit.archive_hour_keys(
+                "2026-05-17T00:00:00Z",
+                "2026-05-17T03:00:00Z",
+            ),
+            [("2026-05-17", "08"), ("2026-05-17", "09"), ("2026-05-17", "10")],
+        )
+
+    def test_orderbook_archive_coverage_blocks_non_full_fidelity_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_archive_hour(root, "2026-05-17", "08", full_fidelity=False)
+
+            result = audit.audit_orderbook_archive_coverage(
+                archive_root=str(root),
+                start_ts="2026-05-17T00:00:00Z",
+                end_ts="2026-05-17T01:00:00Z",
+                bucket_minutes=5,
+            )
+
+        self.assertEqual(result["status"], "critical")
+        self.assertFalse(result["full_fidelity"])
+        self.assertEqual(result["present_hours"], 0)
+        self.assertEqual(result["invalid_hours"], 1)
+        self.assertIn("archive contains non-full-fidelity manifests", result["reasons"])
+
     def test_freshness_gate_allows_historical_gap_but_reports_it(self):
         target = audit.GapTarget(
             "binance_price/BTCUSDT",

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -9,6 +9,9 @@ AUDIT_SCRIPT = ROOT / "scripts" / "audit_market_data_gaps.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "market-data-gap-audit.yml"
 RESEARCH_SNAPSHOT_WORKFLOW = ROOT / ".github" / "workflows" / "research-snapshot.yml"
 CLOUD_ASSIST_SCRIPT = ROOT / "scripts" / "ci" / "run_tango_market_data_audit_cloud_assist.py"
+RESEARCH_SNAPSHOT_CLOUD_ASSIST_SCRIPT = (
+    ROOT / "scripts" / "ci" / "run_tango_research_snapshot_cloud_assist.py"
+)
 
 
 def load_audit_module():
@@ -141,6 +144,9 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         self.assertIn('audit_end_ts="${SNAPSHOT_END_TS:-${{ github.event.inputs.end_date }}}"', workflow)
         self.assertIn('--start-ts "${audit_start_ts}"', workflow)
         self.assertIn('--end-ts "${audit_end_ts}"', workflow)
+        self.assertIn('"orderbook_archive_root": "/opt/ploy/data/lake"', workflow)
+        self.assertIn('--orderbook-archive-root "${orderbook_archive_root}"', workflow)
+        self.assertIn('--pm-book-archive-dir "${orderbook_archive_root}/orderbook_snapshots"', workflow)
         self.assertIn("Gate mode: `{payload.get('gate_mode', 'unknown')}`", workflow)
         self.assertIn("Audit window: `{payload.get('audit_window_start_ts') or '<lookback-start>'}", workflow)
         self.assertIn("remote snapshot data audit failed after ${attempt} attempts", workflow)
@@ -148,6 +154,10 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         self.assertIn("copying research snapshot tar failed after ${attempt} attempts", workflow)
         self.assertIn("Compile snapshot via Cloud Assistant fallback", workflow)
         self.assertIn("scripts/ci/run_tango_research_snapshot_cloud_assist.py", workflow)
+        cloud_assist = RESEARCH_SNAPSHOT_CLOUD_ASSIST_SCRIPT.read_text()
+        self.assertIn("--orderbook-archive-root", cloud_assist)
+        self.assertIn("--pm-book-archive-dir", cloud_assist)
+        self.assertIn('SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT", "/opt/ploy/data/lake"', cloud_assist)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make historical `polymarket_orderbooks` audits use full-fidelity orderbook archive coverage when the hot table has aged out.
- Preserve hot-table diagnostics while failing closed on missing, invalid, zero-row, or non-full-fidelity archive hours.
- Thread one `orderbook_archive_root` through research snapshot audit, compile, and Cloud Assistant fallback.

## Test Plan
- `python3 -m unittest discover -s tests -p 'test_*.py'`\n- `python3 -m py_compile scripts/*.py scripts/ci/*.py`\n- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |p| YAML.load_file(p) }; puts "ok"'`\n- `rtk cargo test --locked --test workflow_security`\n- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added orderbook archive root configuration option to the research snapshot workflow for enhanced data validation.
  * Enhanced market data gap auditing to validate historical orderbook snapshot coverage from archives, improving data completeness detection.

* **Tests**
  * Added comprehensive test coverage for archive-based data validation scenarios.

* **Chores**
  * Updated internal documentation with completed workflow reconciliation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->