### PR TITLE
Run snapshot audit from workflow checkout

### DIFF
--- a/.github/workflows/research-snapshot.yml
+++ b/.github/workflows/research-snapshot.yml
@@ -226,13 +226,25 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts/research-snapshot
           remote_audit="${REMOTE_DIR}/research-snapshot/data-gap-audit.json"
+          remote_audit_script="${REMOTE_DIR}/workflow-scripts/audit_market_data_gaps.py"
           audit_start_ts="${SNAPSHOT_START_TS:-${{ github.event.inputs.start_date }}}"
           audit_end_ts="${SNAPSHOT_END_TS:-${{ github.event.inputs.end_date }}}"
+
+          ssh tango-1-1 /bin/bash -s -- "${REMOTE_DIR}/workflow-scripts" <<'EOF'
+          set -euo pipefail
+          mkdir -p "$1"
+          EOF
+          scp scripts/audit_market_data_gaps.py "tango-1-1:${remote_audit_script}"
+          ssh tango-1-1 /bin/bash -s -- "${remote_audit_script}" <<'EOF'
+          set -euo pipefail
+          chmod 0755 "$1"
+          EOF
 
           for attempt in 1 2 3; do
             if ssh tango-1-1 /bin/bash -s -- \
               "${DEPLOY_ROOT}" \
               "${REMOTE_DIR}" \
+              "${remote_audit_script}" \
               "${remote_audit}" \
               "${SNAPSHOT_AUDIT_LOOKBACK_HOURS}" \
               "${audit_start_ts}" \
@@ -243,22 +255,23 @@ jobs:
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
-          remote_audit="$3"
-          audit_lookback_hours="$4"
-          audit_start_ts="$5"
-          audit_end_ts="$6"
-          symbols="$7"
-          required_sources="$8"
-          orderbook_archive_root="$9"
+          audit_script="$3"
+          remote_audit="$4"
+          audit_lookback_hours="$5"
+          audit_start_ts="$6"
+          audit_end_ts="$7"
+          symbols="$8"
+          required_sources="$9"
+          orderbook_archive_root="${10}"
 
           set -a
           . "${deploy_root}/.env"
           set +a
           : "${PLOY_DATABASE__URL:?PLOY_DATABASE__URL missing in ${deploy_root}/.env}"
           mkdir -p "${remote_dir}/research-snapshot"
-          test -x "${deploy_root}/scripts/audit_market_data_gaps.py"
+          test -x "${audit_script}"
           PLOY_DATABASE__URL="${PLOY_DATABASE__URL}" \
-            "${deploy_root}/scripts/audit_market_data_gaps.py" \
+            "${audit_script}" \
               --lookback-hours "${audit_lookback_hours}" \
               --start-ts "${audit_start_ts}" \
               --end-ts "${audit_end_ts}" \

--- a/scripts/ci/run_tango_research_snapshot_cloud_assist.py
+++ b/scripts/ci/run_tango_research_snapshot_cloud_assist.py
@@ -49,6 +49,9 @@ def remote_script() -> str:
     bucket = require_env("ALIYUN_OSS_BUCKET")
     region = require_env("DEPLOY_OSS_REGION")
     object_prefix = f"research-snapshot/{run_id}/{attempt}"
+    audit_script_b64 = base64.b64encode(
+        Path("scripts/audit_market_data_gaps.py").read_bytes()
+    ).decode("ascii")
 
     return f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -99,18 +102,28 @@ PY
 
 workdir={q(f"{deploy_root}/tmp/research-snapshot-cloud-assist-{run_id}-{attempt}")}
 rm -rf "${{workdir}}"
-mkdir -p "${{workdir}}/research-snapshot"
+mkdir -p "${{workdir}}/research-snapshot" "${{workdir}}/workflow-scripts"
 cd "${{workdir}}"
 ensure_ossutil
+
+python3 - <<'PY'
+import base64
+from pathlib import Path
+
+payload = {audit_script_b64!r}
+path = Path("workflow-scripts/audit_market_data_gaps.py")
+path.write_bytes(base64.b64decode(payload.encode("ascii")))
+path.chmod(0o755)
+PY
 
 set -a
 . {q(deploy_root)}/.env
 set +a
 : "${{PLOY_DATABASE__URL:?PLOY_DATABASE__URL missing in {deploy_root}/.env}}"
 
-test -x {q(deploy_root)}/scripts/audit_market_data_gaps.py
+test -x workflow-scripts/audit_market_data_gaps.py
 PLOY_DATABASE__URL="${{PLOY_DATABASE__URL}}" \\
-  {q(deploy_root)}/scripts/audit_market_data_gaps.py \\
+  ./workflow-scripts/audit_market_data_gaps.py \\
     --lookback-hours {q(env("SNAPSHOT_AUDIT_LOOKBACK_HOURS", "168"))} \\
     --start-ts {q(require_env("SNAPSHOT_START_TS"))} \\
     --end-ts {q(require_env("SNAPSHOT_END_TS"))} \\

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -243,6 +243,14 @@ This is not a dry-run or live promotion decision.
   scripts/ci/*.py`, active workflow YAML parse for all workflows,
   `rtk cargo test --locked --test workflow_security`, focused audit/workflow
   tests (`20` tests), and `rtk git diff --check`.
+- 2026-05-24: PR `#665` merged to `main` as
+  `3310b591a0acca9dc710e84f03702459a2ec7167`. The first real rerun
+  `26354172536` proved the next coupling bug: the workflow checkout had the new
+  audit script, but both SSH and Cloud Assistant paths executed
+  `/opt/ploy/scripts/audit_market_data_gaps.py` from the last deployed bundle.
+  Cloud Assistant failed with `unrecognized arguments:
+  --orderbook-archive-root`, so the snapshot workflow must carry the checked-out
+  audit script to the remote workspace instead of depending on a prior deploy.
 
 ## Current Session - Market Data Promotion Blocker Actions (2026-05-24)
 

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -145,6 +145,10 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         self.assertIn('--start-ts "${audit_start_ts}"', workflow)
         self.assertIn('--end-ts "${audit_end_ts}"', workflow)
         self.assertIn('"orderbook_archive_root": "/opt/ploy/data/lake"', workflow)
+        self.assertIn("remote_audit_script=", workflow)
+        self.assertIn('scp scripts/audit_market_data_gaps.py "tango-1-1:${remote_audit_script}"', workflow)
+        self.assertIn('"${audit_script}"', workflow)
+        self.assertNotIn('"${deploy_root}/scripts/audit_market_data_gaps.py" \\', workflow)
         self.assertIn('--orderbook-archive-root "${orderbook_archive_root}"', workflow)
         self.assertIn('--pm-book-archive-dir "${orderbook_archive_root}/orderbook_snapshots"', workflow)
         self.assertIn("Gate mode: `{payload.get('gate_mode', 'unknown')}`", workflow)
@@ -157,6 +161,9 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         cloud_assist = RESEARCH_SNAPSHOT_CLOUD_ASSIST_SCRIPT.read_text()
         self.assertIn("--orderbook-archive-root", cloud_assist)
         self.assertIn("--pm-book-archive-dir", cloud_assist)
+        self.assertIn('Path("scripts/audit_market_data_gaps.py").read_bytes()', cloud_assist)
+        self.assertIn("./workflow-scripts/audit_market_data_gaps.py", cloud_assist)
+        self.assertNotIn('/scripts/audit_market_data_gaps.py \\\\', cloud_assist)
         self.assertIn('SNAPSHOT_ORDERBOOK_ARCHIVE_ROOT", "/opt/ploy/data/lake"', cloud_assist)
 
 


### PR DESCRIPTION
## Summary
- Copy the checked-out `audit_market_data_gaps.py` into the remote snapshot workspace before SSH audit execution.
- Embed the checked-out audit script into the Cloud Assistant fallback command so fallback uses the same git ref.
- Record the real `26354172536` failure mode and lock the self-contained path with static workflow tests.

## Test Plan
- `python3 -m unittest discover -s tests -p 'test_*.py'`\n- `python3 -m py_compile scripts/*.py scripts/ci/*.py`\n- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |p| YAML.load_file(p) }; puts "ok"'`\n- `rtk cargo test --locked --test workflow_security`\n- `rtk git diff --check`