### PR TITLE
Keep matching runtime replay in hosted sweep

### DIFF
--- a/scripts/run_factor_walk_forward_sweep.py
+++ b/scripts/run_factor_walk_forward_sweep.py
@@ -352,6 +352,11 @@ def replay_identity_mismatch_blockers(promotion: dict[str, Any]) -> list[str]:
     if not selected_items:
         return []
 
+    for item in selected_items:
+        blockers = [str(blocker) for blocker in item.get("blockers") or []]
+        if not any(blocker.startswith(prefixes) for blocker in blockers):
+            return []
+
     def rank(item: dict[str, Any]) -> float:
         factor = item.get("factor") if isinstance(item.get("factor"), dict) else {}
         try:
@@ -609,6 +614,10 @@ def run_variant(
         promotion = json.loads(
             (variant_dir / "autofactor-strategy-promotion.json").read_text(encoding="utf-8")
         )
+    elif args.candidate_strategy_replay_json:
+        source_replay = Path(args.candidate_strategy_replay_json)
+        if source_replay.exists():
+            shutil.copy2(source_replay, variant_dir / "candidate-strategy-replay.json")
     item["decision"] = promotion.get("decision")
     item["qualified_count"] = len(promotion.get("qualified_strategies") or [])
     item["promotion_gate_ready"] = bool((promotion.get("promotion_gate") or {}).get("ready"))

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,56 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Runtime Replay Selector Repair (2026-05-24)
+
+Evidence stage: `walk_forward` / `executable_replay` promotion-chain repair.
+This is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Parse the five runtime candidate replay artifacts dispatched by hosted
+      walk-forward run `26354684867`.
+- [x] Feed runtime replay `26355035577` back into hosted walk-forward with
+      snapshot `26354463118` and full-depth execution surface `26351573860`.
+- [x] Diagnose why replay-fed run `26355312065` still chose `fix_runtime`.
+- [x] Fix sweep replay selection so an external runtime replay is kept when it
+      matches any current runtime-mappable candidate, not only the top-ranked
+      candidate.
+- [x] Add regression coverage for lower-ranked matching runtime replay
+      artifacts.
+- [x] Run focused validation.
+- [ ] Commit, push, open PR, wait for CI, merge, and rerun hosted
+      walk-forward from `main`.
+
+### Review
+
+- 2026-05-24: Runtime replay runs `26355035577`, `26355036231`,
+  `26355036901`, `26355037488`, and `26355038147` all completed as
+  `runtime_market_update_replay` evidence with `53` trades, `53` unique
+  events, one-decision event accounting, and `entry_fill_rate=1.0`. None are
+  promotion-ready: each has `roi=-0.07909107855471195`, total PnL
+  `-62.877407450996`, and blocker `roi_too_low:-0.079091<0.000000`.
+- 2026-05-24: Replay-fed hosted walk-forward run `26355312065` succeeded from
+  `main@bf55299770ab8ec0bb08d9464fabdda91e622f8c`, but the sweep runner
+  incorrectly ignored the downloaded runtime replay because it matched the
+  search-feedback best candidate
+  `mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity`
+  while another runtime-mappable factor ranked one row higher. Promotion then
+  consumed a regenerated `factor_walk_forward_top_bucket_aggregate` artifact
+  and incorrectly stayed in `fix_runtime`.
+- 2026-05-24: Local replay of the same artifacts through the promotion
+  evaluator with the downloaded runtime replay produces the expected blocker
+  shape: `basis=runtime_market_update_replay`, no data-audit blockers, full
+  depth execution proof satisfied, and economic blockers
+  `roi_too_low:-0.079091<0.000000` /
+  `candidate_strategy_replay_roi_too_low:-0.079091<0.000000`. Running the
+  closed-loop classifier on that corrected artifact selects `revise_prior`
+  instead of `fix_runtime`.
+- 2026-05-24: Focused validation passed: `python3 -m unittest
+  tests.test_factor_walk_forward_sweep tests.test_alpha_search_closed_loop_agent
+  tests.test_autofactor_strategy_promotion` (`82` tests),
+  `python3 -m py_compile` for the touched scripts/tests, and
+  `rtk git diff --check`.
+
 ## Current Session - PM5D Research Chain Recovery (2026-05-24)
 
 Evidence stage: `factor_attribution` / `walk_forward` recovery. This is not a

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -44,6 +44,23 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
 """)
 '''
 
+FAKE_TWO_RUNTIME_MAPPABLE_REPORT = r'''
+print("""=== Settlement Probability PRD Promotion Gate ===
+ready_for_dry_run_handoff=true stake_usd=15.00 min_entry_fill_rate=0.0500 max_ece=0.0500 min_positive_window_ratio=0.60 require_deribit=false include_deribit=false data_quality_mode=event_complete event_complete_events=2488 event_complete_rows=51989 replay_parity_ready=true
+gate,passed,evidence
+data_quality,true,mode=event_complete event_complete_events=2488 event_complete_rows=51989
+deribit_vol_surface,true,require_deribit=false include_deribit=false
+recorded_replay_parity,true,blocking_flags=<none>
+
+# AutoFactor target=full_depth_settlement_executable_pnl
+=== AutoFactor Seed Candidate Report ===
+target labels are side-aligned executable settlement PnL; reports are candidate discovery gates, not deploy decisions.
+rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,positive_window_ratio,symbol_count,symbol_positive_ratio,monotonicity,top_bucket_n,top_bucket_avg_label,top_bucket_positive_label_rate,top_bucket_full_depth_entry_fill_rate,top_bucket_unique_event_count,top_bucket_max_event_decisions,complexity
+1,mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted,full_depth_settlement_executable_pnl,candidate,passed,1079,0.125437,0.346161,12,1.334432,0.8333,3,1.0000,1.0000,216,16.533648,0.4722,1.0000,216,1,7
+2,mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity,full_depth_settlement_executable_pnl,candidate,passed,1079,0.125437,0.346161,12,1.334432,0.8333,3,1.0000,1.0000,216,16.533648,0.4722,1.0000,216,1,7
+""")
+'''
+
 FAKE_TRADEABLE_HARD_GATE_BY_FILTER = r'''
 import sys
 filter_value = ""
@@ -337,6 +354,50 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                 for blocker in blockers
             )
         )
+
+    def test_external_replay_matching_lower_rank_candidate_is_kept(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            (tmp / "snapshot").mkdir()
+            binary = self.fake_binary_with_report(tmp, FAKE_TWO_RUNTIME_MAPPABLE_REPORT)
+            replay_path = self.replay_file(
+                tmp,
+                "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity",
+            )
+            subprocess.run(
+                [
+                    *self.base_args(tmp, binary),
+                    "--candidate-strategy-replay-json",
+                    str(replay_path),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            summary = json.loads((tmp / "out" / "sweep-summary.json").read_text(encoding="utf-8"))
+            replay = json.loads(
+                (tmp / "out" / "candidate-strategy-replay.json").read_text(encoding="utf-8")
+            )
+            promotion = json.loads(
+                (tmp / "out" / "autofactor-strategy-promotion.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        variant = summary["variants"][0]
+        self.assertNotIn("ignored_candidate_strategy_replay_json", variant)
+        self.assertEqual(replay["basis"], "runtime_market_update_replay")
+        self.assertEqual(
+            replay["runtime_score"],
+            "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity",
+        )
+        self.assertEqual(
+            promotion["candidate_strategy_replay"]["basis"],
+            "runtime_market_update_replay",
+        )
+        self.assertEqual(variant["qualified_count"], 1)
 
     def test_builds_blocked_aggregate_candidate_replay_when_missing(self):
         with tempfile.TemporaryDirectory() as raw_tmp:


### PR DESCRIPTION
## Summary
- keep an external runtime candidate replay when it matches any current runtime-mappable AutoFactor candidate, instead of only the top-ranked candidate
- copy the retained external replay into the selected sweep artifact so downstream promotion/trace consumers see the same runtime evidence
- record the real run evidence from `26355312065` and add regression coverage for lower-ranked matching runtime replay artifacts

## Evidence
- `python3 -m unittest tests.test_factor_walk_forward_sweep tests.test_alpha_search_closed_loop_agent tests.test_autofactor_strategy_promotion` (`82` tests)
- `python3 -m py_compile scripts/run_factor_walk_forward_sweep.py scripts/alpha_search_closed_loop_agent.py scripts/evaluate_autofactor_strategy_promotion.py tests/test_factor_walk_forward_sweep.py`
- `rtk git diff --check`

## Context
Replay-fed hosted run `26355312065` downloaded runtime replay `26355035577`, but the sweep runner discarded it because another runtime-mappable candidate ranked slightly higher. Local artifact replay shows the downloaded runtime replay should be retained and changes the closed-loop class from `fix_runtime` to `revise_prior`, with ROI/economics as the real blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mismatch blocker detection in the walk-forward sweep to correctly identify candidate mismatches.
  * Enhanced JSON file handling to ensure candidate strategy replay files are properly copied to variant directories.

* **Tests**
  * Added test coverage for runtime-mappable candidate selection and ranking scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->