### PR TITLE
Fix Research Manager frontier blocker planning

### DIFF
--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -89,6 +89,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
     }
 
     let blocker_actions = derive_blocker_actions(input);
+    let latest_decision = latest_run_decision_value(&input.latest_runs);
     if blocker_actions
         .iter()
         .any(|item| item.blocker_family.starts_with("data_"))
@@ -118,7 +119,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
     }
 
     if contains_string(
-        &input.latest_runs,
+        &latest_decision,
         &[
             "replay_parity_missing",
             "runtime_parity_missing",
@@ -129,7 +130,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
             "missing_runtime_strategy_mapping",
         ],
     ) || has_any_key_value(
-        &input.latest_runs,
+        &latest_decision,
         &["replay_parity_ready", "runtime_parity_ready"],
         &[false.into(), "false".into()],
     ) {
@@ -183,7 +184,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
     }
 
     if contains_string(
-        &input.latest_runs,
+        &latest_decision,
         &[
             "reward_stagnation",
             "empty_search",
@@ -273,9 +274,24 @@ fn plan_with_blocker_actions(
 
 fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAction> {
     let mut actions = Vec::new();
-    let latest = input.latest_runs.to_string().to_lowercase();
+    let latest_value = latest_run_decision_value(&input.latest_runs);
+    let latest = latest_value.to_string().to_lowercase();
     let market_data = input.market_data_health.to_string().to_lowercase();
     let runtime_or_promotion_blockers = latest;
+    let frontier_proves_full_depth = has_any_key_value(
+        &latest_value,
+        &[
+            "full_depth_entry",
+            "full_depth_execution_surface",
+            "full_fidelity",
+        ],
+        &[true.into(), "true".into()],
+    );
+    let frontier_proves_official_settlement = has_any_key_value(
+        &latest_value,
+        &["official_settlement", "official_settlement_ready"],
+        &[true.into(), "true".into()],
+    );
 
     if contains_any_text(
         &runtime_or_promotion_blockers,
@@ -377,29 +393,33 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
         ));
     }
 
-    if contains_any_text(
-        &market_data,
-        &[
-            "required_execution_surface_is_sampled_snapshot",
-            "sampled_snapshot_required_for_execution_surface",
-            "full_depth_missing",
-            "full-depth missing",
-        ],
-    ) {
+    if !frontier_proves_full_depth
+        && contains_any_text(
+            &market_data,
+            &[
+                "required_execution_surface_is_sampled_snapshot",
+                "sampled_snapshot_required_for_execution_surface",
+                "full_depth_missing",
+                "full-depth missing",
+            ],
+        )
+    {
         actions.push(blocker_action(
             "promotion_data_execution_surface",
             "collect_full_depth_execution_surface",
             "Research snapshot data health reports sampled execution surface; promotion needs full-depth evidence.",
         ));
     }
-    if contains_any_text(
-        &market_data,
-        &[
-            "required_execution_surface_not_materialized",
-            "pm_token_settlements",
-            "official_settlement_missing",
-        ],
-    ) {
+    if !frontier_proves_official_settlement
+        && contains_any_text(
+            &market_data,
+            &[
+                "required_execution_surface_not_materialized",
+                "pm_token_settlements",
+                "official_settlement_missing",
+            ],
+        )
+    {
         actions.push(blocker_action(
             "promotion_data_settlement",
             "repair_official_settlement_coverage",
@@ -408,6 +428,40 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
     }
 
     dedupe_blocker_actions(actions)
+}
+
+fn latest_run_decision_value(latest_runs: &serde_json::Value) -> serde_json::Value {
+    let frontier = latest_runs
+        .get("runs")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|runs| runs.first())
+        .unwrap_or(latest_runs);
+    strip_non_frontier_blocker_fields(frontier)
+}
+
+fn strip_non_frontier_blocker_fields(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut stripped = serde_json::Map::new();
+            for (key, item) in map {
+                if matches!(
+                    key.as_str(),
+                    "evaluated_factors" | "entries" | "recent_factors" | "patterns"
+                ) {
+                    continue;
+                }
+                stripped.insert(key.clone(), strip_non_frontier_blocker_fields(item));
+            }
+            serde_json::Value::Object(stripped)
+        }
+        serde_json::Value::Array(items) => serde_json::Value::Array(
+            items
+                .iter()
+                .map(strip_non_frontier_blocker_fields)
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
 }
 
 fn blocker_action(blocker_family: &str, action: &str, reason: &str) -> ResearchBlockerAction {
@@ -714,6 +768,92 @@ mod tests {
             item.action == "repair_official_settlement_coverage"
                 || item.action == "collect_full_depth_execution_surface"
                 || item.action == "build_runtime_market_update_replay"
+        }));
+    }
+
+    #[test]
+    fn planner_uses_frontier_run_decision_not_historical_or_unselected_factor_blockers() {
+        let plan = plan_next_research(&input(
+            "walk_forward",
+            serde_json::json!({
+                "source": "experiment_trace",
+                "runs": [
+                    {
+                        "run_id": "newest",
+                        "artifacts": [{
+                            "event_type": "autofactor_promotion",
+                            "output_json": {
+                                "candidate_strategy_replay": {
+                                    "basis": "runtime_market_update_replay",
+                                    "blockers": [
+                                        "roi_too_low:-0.079091<0.000000"
+                                    ],
+                                    "decision_contract": {
+                                        "official_settlement": true,
+                                        "full_depth_entry": true,
+                                        "one_decision_per_event": true
+                                    }
+                                },
+                                "promotion_gate": {
+                                    "blocked_gates": ["walk_forward_oos"]
+                                },
+                                "evaluated_factors": [{
+                                    "blockers": [
+                                        "official_settlement_missing:48<51",
+                                        "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots",
+                                        "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                                        "missing_runtime_contract"
+                                    ]
+                                }]
+                            }
+                        }]
+                    },
+                    {
+                        "run_id": "older",
+                        "artifacts": [{
+                            "output_json": {
+                                "candidate_strategy_replay": {
+                                    "blockers": [
+                                        "official_settlement_missing:48<51",
+                                        "sampled_snapshot_required_for_execution_surface:clob_orderbook_snapshots",
+                                        "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay"
+                                    ]
+                                }
+                            }
+                        }]
+                    }
+                ]
+            }),
+            serde_json::json!({
+                "missing_blocks_promotion": true,
+                "critical_missing": false,
+                "promotion_blockers": [
+                    {
+                        "surface": "clob_orderbook_snapshots",
+                        "reason": "required_execution_surface_is_sampled_snapshot"
+                    },
+                    {
+                        "surface": "pm_token_settlements",
+                        "reason": "required_execution_surface_not_materialized"
+                    }
+                ]
+            }),
+        ))
+        .expect("plan");
+
+        assert_eq!(plan.theme, "revise_prior");
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "strategy_economics"
+                && item.action == "mutate_or_reject_negative_runtime_edge"
+        }));
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family.starts_with("data_")
+                || item.blocker_family == "runtime_replay"
+                || item.blocker_family == "runtime_contract"
         }));
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,6 +16,12 @@ decision.
 - [x] Route latest negative runtime economics / OOS blockers to
       `revise_prior`.
 - [x] Run focused Rust validation.
+- [x] Deploy `main@e1d48299` to refresh the Tango `research-trace-plan`
+      binary.
+- [x] Rerun Research Trace Plan from deployed binary and verify the remaining
+      blocker shape.
+- [x] Fix frontier-run blocker extraction so historical runs and unselected
+      factor registry entries do not drive the current plan.
 - [ ] Commit, push, open PR, wait for CI, merge, then redeploy/refresh the
       deployed `research-trace-plan` binary before rerunning the workflow.
 
@@ -39,6 +45,25 @@ decision.
   crates/ploy-research/src/research_os/manager.rs`, `rtk cargo test --locked -p
   ploy-research research_os::manager --lib` (`11` passed), and
   `rtk git diff --check`.
+- 2026-05-24: Deployed `main@e1d48299` to Tango with
+  `deploy-tango-1-1.yml` run `26356840758`; the SSH path completed and Cloud
+  Assistant fallback was not needed. Research Trace Plan run `26357108585`
+  then proved the source fix was still incomplete: the latest run had the real
+  `strategy_economics` blocker, but the plan still selected `theme=fix_data`
+  because planner text scans were reading older runs and unselected
+  `promotion_registry.entries`.
+- 2026-05-24: Tightened Research Manager blocker extraction to the current
+  frontier run's decision artifacts, stripping unselected factor lists such as
+  `evaluated_factors` and `promotion_registry.entries`. If the frontier replay
+  contract proves `full_depth_entry=true` and `official_settlement=true`,
+  stale snapshot-level promotion blockers no longer override the current
+  strategy-economics decision. Validation passed:
+  `rustfmt --edition 2024 --check
+  crates/ploy-research/src/research_os/manager.rs`, `rtk cargo test --locked -p
+  ploy-research research_os::manager --lib` (`12` passed), and a local replay
+  of run `26357108585` input through `factor_evolve_daily_plan`, which now
+  returns `theme=revise_prior`, `candidate_count=8`, and only
+  `strategy_economics -> mutate_or_reject_negative_runtime_edge`.
 
 ## Current Session - Runtime Replay Selector Repair (2026-05-24)
 


### PR DESCRIPTION
## Summary
- restrict Research Manager blocker/action routing to the current frontier run decision instead of scanning all recent runs
- strip unselected factor lists such as promotion registry entries before deriving current blocker actions
- suppress stale snapshot promotion blockers when the frontier runtime replay contract already proves full-depth entry and official settlement

## Validation
- rustfmt --edition 2024 --check crates/ploy-research/src/research_os/manager.rs
- rtk cargo test --locked -p ploy-research research_os::manager --lib
- rtk cargo run --locked -p ploy-research --example factor_evolve_daily_plan -- /tmp/ploy-research-manager-input-26357108585.json /tmp/ploy-research-manager-plan-local.json
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined runtime blocker detection to focus on current frontier runs only, preventing historical execution data from interfering with planning decisions.
  * Improved accuracy of promotion data blocker identification based on frontier execution verification.
  * Enhanced decision-making reliability through tightened blocker extraction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->