### PR TITLE
Carry Research Manager dispatch evidence

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -517,7 +517,33 @@ jobs:
             args+=(--alpha-search-state-json "${alpha_search_state_json}")
           fi
           if [ -n "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}" ]; then
-            args+=(--alpha-search-llm-prior-json "${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}")
+            alpha_search_llm_prior_json="${WALK_ALPHA_SEARCH_LLM_PRIOR_JSON}"
+            if python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ["WALK_ALPHA_SEARCH_LLM_PRIOR_JSON"].strip()
+          if not raw.startswith(("{", "[")):
+              raise SystemExit(1)
+          json.loads(raw)
+          PY
+            then
+              mkdir -p artifacts/alpha-search-plan
+              python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          raw = os.environ["WALK_ALPHA_SEARCH_LLM_PRIOR_JSON"]
+          prior = json.loads(raw)
+          Path("artifacts/alpha-search-plan/next-llm-prior.json").write_text(
+              json.dumps(prior, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+              alpha_search_llm_prior_json="artifacts/alpha-search-plan/next-llm-prior.json"
+            fi
+            args+=(--alpha-search-llm-prior-json "${alpha_search_llm_prior_json}")
           elif [ -f artifacts/alpha-search-plan/next-llm-prior.json ]; then
             args+=(--alpha-search-llm-prior-json artifacts/alpha-search-plan/next-llm-prior.json)
           fi

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -235,6 +235,11 @@ def _walk_forward_dispatch(
     symbols: str,
     stake_usd: str,
     chain_remaining: int,
+    alpha_search_llm_prior: dict[str, Any] | None = None,
+    candidate_strategy_replay_run_id: str = "",
+    candidate_strategy_replay_artifact_name: str = "",
+    full_depth_execution_surface_run_id: str = "",
+    full_depth_execution_surface_artifact_name: str = "",
 ) -> dict[str, Any]:
     blockers: list[str] = []
     if not snapshot_run_id:
@@ -249,6 +254,20 @@ def _walk_forward_dispatch(
         "fail_if_blocked": False,
         "persist_research_trace": True,
     }
+    if alpha_search_llm_prior:
+        options["alpha_search_llm_prior_json"] = json.dumps(
+            alpha_search_llm_prior,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    if candidate_strategy_replay_run_id:
+        options["candidate_strategy_replay_run_id"] = candidate_strategy_replay_run_id
+    if candidate_strategy_replay_artifact_name:
+        options["candidate_strategy_replay_artifact_name"] = candidate_strategy_replay_artifact_name
+    if full_depth_execution_surface_run_id:
+        options["full_depth_execution_surface_run_id"] = full_depth_execution_surface_run_id
+    if full_depth_execution_surface_artifact_name:
+        options["full_depth_execution_surface_artifact_name"] = full_depth_execution_surface_artifact_name
     fields = {
         "git_ref": git_ref,
         "snapshot_run_id": snapshot_run_id,
@@ -485,6 +504,21 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     action_names = {item["action"] for item in blocker_actions}
     snapshot_actions = {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
 
+    if (
+        plan.get("theme") == "revise_prior"
+        or "generate_typed_llm_prior_json" in actions
+        or blocker_actions
+    ):
+        typed_prior = {
+            "schema_version": "research_manager_typed_prior.v1",
+            "source": "research_trace_plan",
+            "evidence_stage": plan.get("evidence_stage", ""),
+            "theme": plan.get("theme", ""),
+            "actions": actions,
+            "blocker_actions": blocker_actions,
+            "constraints": _typed_prior_constraints(blocker_actions),
+        }
+
     if any(action in snapshot_actions for action in actions) or (
         plan.get("theme") == "fix_data" and not actions
     ):
@@ -532,6 +566,27 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                 symbols=args.symbols,
                 stake_usd=args.stake_usd,
                 chain_remaining=args.chain_remaining,
+                alpha_search_llm_prior=typed_prior,
+                candidate_strategy_replay_run_id=getattr(
+                    args,
+                    "candidate_strategy_replay_run_id",
+                    "",
+                ),
+                candidate_strategy_replay_artifact_name=getattr(
+                    args,
+                    "candidate_strategy_replay_artifact_name",
+                    "",
+                ),
+                full_depth_execution_surface_run_id=getattr(
+                    args,
+                    "full_depth_execution_surface_run_id",
+                    "",
+                ),
+                full_depth_execution_surface_artifact_name=getattr(
+                    args,
+                    "full_depth_execution_surface_artifact_name",
+                    "",
+                ),
             )
         )
 
@@ -568,21 +623,6 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                 issue_number=args.runtime_issue_number,
             )
         )
-
-    if (
-        plan.get("theme") == "revise_prior"
-        or "generate_typed_llm_prior_json" in actions
-        or blocker_actions
-    ):
-        typed_prior = {
-            "schema_version": "research_manager_typed_prior.v1",
-            "source": "research_trace_plan",
-            "evidence_stage": plan.get("evidence_stage", ""),
-            "theme": plan.get("theme", ""),
-            "actions": actions,
-            "blocker_actions": blocker_actions,
-            "constraints": _typed_prior_constraints(blocker_actions),
-        }
 
     executable_dispatches = [item for item in dispatches if item["ready"]]
     blocked_dispatches = [item for item in dispatches if not item["ready"]]
@@ -664,6 +704,10 @@ def main() -> None:
     parser.add_argument("--symbols", default="")
     parser.add_argument("--stake-usd", default="15")
     parser.add_argument("--chain-remaining", type=int, default=1)
+    parser.add_argument("--candidate-strategy-replay-run-id", default="")
+    parser.add_argument("--candidate-strategy-replay-artifact-name", default="")
+    parser.add_argument("--full-depth-execution-surface-run-id", default="")
+    parser.add_argument("--full-depth-execution-surface-artifact-name", default="")
     parser.add_argument("--max-snapshot-window-days", type=int, default=2)
     parser.add_argument("--max-full-depth-surface-hours", type=int, default=12)
     parser.add_argument(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -24,6 +24,12 @@ decision.
       factor registry entries do not drive the current plan.
 - [ ] Commit, push, open PR, wait for CI, merge, then redeploy/refresh the
       deployed `research-trace-plan` binary before rerunning the workflow.
+- [x] Run Research Manager executor in dry-run mode from corrected trace-plan
+      artifact.
+- [x] Run Research Manager executor in execute mode to dispatch a bounded
+      follow-up hosted walk-forward.
+- [x] Identify executor dispatch evidence propagation gap from the follow-up
+      walk-forward artifact.
 
 ### Review
 
@@ -64,6 +70,35 @@ decision.
   of run `26357108585` input through `factor_evolve_daily_plan`, which now
   returns `theme=revise_prior`, `candidate_count=8`, and only
   `strategy_economics -> mutate_or_reject_negative_runtime_edge`.
+- 2026-05-24: Corrected Research Trace Plan run `26361552258` from deployed
+  `main@d919a83c` now returns `theme=revise_prior`,
+  `candidate_count=8`, actions `generate_typed_llm_prior_json` and
+  `rerun_alpha_search_with_bounded_mutations`, and only blocker action
+  `strategy_economics -> mutate_or_reject_negative_runtime_edge`.
+  Research Manager executor dry-run `26361588811` emitted
+  `research_manager_typed_prior.v1` and one ready bounded
+  `factor-walk-forward-v2-hosted-artifact.yml` dispatch. Execute run
+  `26361615208` dispatched follow-up walk-forward `26361617883`.
+- 2026-05-24: Follow-up walk-forward `26361617883` succeeded and persisted
+  trace, but its artifact proved the executor dispatch did not yet pass the
+  typed prior or full-depth/runtime replay evidence into the child workflow.
+  The child run selected a positive aggregate candidate
+  `mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`
+  (`trade_count=216`, `entry_fill_rate=1.0`, aggregate ROI `1.1022432`) but
+  remained blocked because the replay basis was
+  `factor_walk_forward_top_bucket_aggregate` and the full-depth proof was not
+  carried into the dispatch.
+- 2026-05-24: Added executor/workflow wiring so bounded walk-forward dispatches
+  carry inline `research_manager_typed_prior.v1` as
+  `alpha_search_llm_prior_json`, and optional
+  `candidate_strategy_replay_*` / `full_depth_execution_surface_*` artifact
+  ids. Hosted walk-forward now materializes inline prior JSON to
+  `artifacts/alpha-search-plan/next-llm-prior.json` before invoking the sweep.
+  Validation passed: `python3 -m unittest
+  tests.test_research_manager_execute_plan` (`15` tests), `rtk cargo test
+  --locked --test workflow_security factor_walk_forward` (`5` tests), YAML
+  parse for the two touched workflows, a local dry-run executor replay of
+  trace-plan `26361552258`, and `rtk git diff --check`.
 
 ## Current Session - Runtime Replay Selector Repair (2026-05-24)
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -40,6 +40,10 @@ def base_args(**overrides):
         "symbols": "BTCUSDT",
         "stake_usd": "15",
         "chain_remaining": 1,
+        "candidate_strategy_replay_run_id": "",
+        "candidate_strategy_replay_artifact_name": "",
+        "full_depth_execution_surface_run_id": "",
+        "full_depth_execution_surface_artifact_name": "",
         "max_snapshot_window_days": 2,
         "max_full_depth_surface_hours": 12,
         "runtime_deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
@@ -123,6 +127,48 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         options = json.loads(dispatch["fields"]["options_json"])
         self.assertTrue(options["chain_next_run"])
         self.assertEqual(1, options["chain_remaining"])
+
+    def test_revise_prior_walk_forward_carries_typed_prior_and_evidence_artifacts(self) -> None:
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+        )
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest replay or walk-forward evidence failed economic/OOS gates.",
+            }
+        ]
+        payload = build_executor_payload(
+            base_args(
+                mode="execute",
+                execute_ack=EXECUTE_ACK,
+                snapshot_run_id="26354463118",
+                full_depth_execution_surface_run_id="26351573860",
+                full_depth_execution_surface_artifact_name="full-depth-execution-surface-26351573860",
+                candidate_strategy_replay_run_id="26355035577",
+                candidate_strategy_replay_artifact_name="runtime-candidate-replay-26355035577",
+            ),
+            plan,
+        )
+
+        dispatch = payload["dispatches"][0]
+        self.assertEqual("factor-walk-forward-v2-hosted-artifact.yml", dispatch["workflow"])
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertEqual(
+            "26351573860",
+            options["full_depth_execution_surface_run_id"],
+        )
+        self.assertEqual(
+            "full-depth-execution-surface-26351573860",
+            options["full_depth_execution_surface_artifact_name"],
+        )
+        self.assertEqual("26355035577", options["candidate_strategy_replay_run_id"])
+        prior = json.loads(options["alpha_search_llm_prior_json"])
+        self.assertEqual("research_manager_typed_prior.v1", prior["schema_version"])
+        self.assertEqual("revise_prior", prior["theme"])
+        self.assertEqual(plan["plan"]["blocker_actions"], prior["blocker_actions"])
 
     def test_fix_runtime_plan_maps_to_candidate_replay_and_parity(self) -> None:
         payload = build_executor_payload(


### PR DESCRIPTION
## Summary
- pass Research Manager typed priors into child hosted walk-forward dispatches
- add optional full-depth execution surface and candidate replay artifact pass-through inputs for executor-driven follow-up research
- materialize inline typed prior JSON inside hosted walk-forward before invoking the sweep

## Evidence
- Follow-up run 26361617883 proved the prior executor dispatch lost typed prior/full-depth evidence and fell back to aggregate replay/data blockers

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan
- rtk cargo test --locked --test workflow_security factor_walk_forward
- YAML parse for factor-walk-forward-v2-hosted-artifact.yml and research-manager-execute-plan.yml
- local dry-run executor replay of trace-plan 26361552258 with full-depth/replay artifact ids
- rtk git diff --check