### PR TITLE
Infer Research Manager evidence artifacts

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -404,11 +404,16 @@ jobs:
           if [ -z "${artifact_name}" ]; then
             artifact_name="full-depth-execution-surface-${WALK_FULL_DEPTH_EXECUTION_SURFACE_RUN_ID}"
           fi
-          python3 scripts/download_github_artifact.py \
-            --run-id "${WALK_FULL_DEPTH_EXECUTION_SURFACE_RUN_ID}" \
-            --name "${artifact_name}" \
-            --output-dir artifacts/full-depth-execution-surface \
+          download_args=(
+            --run-id "${WALK_FULL_DEPTH_EXECUTION_SURFACE_RUN_ID}"
+            --name "${artifact_name}"
+            --output-dir artifacts/full-depth-execution-surface
             --require full-depth-execution-surface.json
+          )
+          if [[ "${artifact_name}" == factor-walk-forward-v2-* ]]; then
+            download_args+=(--strip-prefix full-depth-execution-surface)
+          fi
+          python3 scripts/download_github_artifact.py "${download_args[@]}"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -437,12 +437,17 @@ def _runtime_candidate_from_plan(
     return None
 
 
-def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, str]:
+def _latest_run(plan_payload: dict[str, Any]) -> dict[str, Any]:
     latest_runs = ((plan_payload.get("input") or {}).get("latest_runs") or {})
     runs = latest_runs.get("runs")
-    if not isinstance(runs, list) or not runs:
-        return {}
-    artifacts = (runs[0] or {}).get("artifacts")
+    if isinstance(runs, list) and runs and isinstance(runs[0], dict):
+        return runs[0]
+    return {}
+
+
+def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, str]:
+    latest_run = _latest_run(plan_payload)
+    artifacts = latest_run.get("artifacts")
     if not isinstance(artifacts, list):
         return {}
     for artifact in artifacts:
@@ -467,7 +472,46 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
             "horizon": str(contract.get("horizon") or source_factor.get("horizon") or ""),
             "runtime_score": str(replay.get("runtime_score") or ""),
             "strategy_profile": str(replay.get("strategy_profile") or ""),
+            "workflow_run_id": str(replay.get("workflow_run_id") or ""),
+            "source_workflow": str(replay.get("source_workflow") or ""),
         }
+    return {}
+
+
+def _latest_valid_full_depth_surface_artifact(plan_payload: dict[str, Any]) -> dict[str, str]:
+    latest_run = _latest_run(plan_payload)
+    latest_run_id = str(latest_run.get("run_id") or latest_run.get("workflow_run_id") or "")
+    if not latest_run_id:
+        return {}
+    artifacts = latest_run.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        output = artifact.get("output_json")
+        if not isinstance(output, dict):
+            continue
+        snapshot_contract = output.get("source_snapshot_contract")
+        if not isinstance(snapshot_contract, dict):
+            continue
+        proofs = snapshot_contract.get("full_depth_execution_surface_proofs")
+        if not isinstance(proofs, list):
+            continue
+        for proof in proofs:
+            if not isinstance(proof, dict):
+                continue
+            if proof.get("valid") is not True:
+                continue
+            if proof.get("surface") != "clob_orderbook_snapshots":
+                continue
+            blockers = proof.get("blockers")
+            if isinstance(blockers, list) and blockers:
+                continue
+            return {
+                "run_id": latest_run_id,
+                "artifact_name": f"factor-walk-forward-v2-{latest_run_id}",
+            }
     return {}
 
 
@@ -544,6 +588,7 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     action_names = {item["action"] for item in blocker_actions}
     snapshot_actions = {"rerun_snapshot_data_audit", "repair_or_exclude_missing_data_surface"}
     latest_replay_contract = _latest_candidate_replay_contract(plan_payload)
+    latest_full_depth_surface_artifact = _latest_valid_full_depth_surface_artifact(plan_payload)
     walk_forward_target = latest_replay_contract.get("target") or getattr(
         args,
         "runtime_source_target",
@@ -619,22 +664,32 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                     args,
                     "candidate_strategy_replay_run_id",
                     "",
-                ),
+                )
+                or latest_replay_contract.get("workflow_run_id", ""),
                 candidate_strategy_replay_artifact_name=getattr(
                     args,
                     "candidate_strategy_replay_artifact_name",
                     "",
+                )
+                or (
+                    f"runtime-candidate-replay-{latest_replay_contract['workflow_run_id']}"
+                    if latest_replay_contract.get("workflow_run_id")
+                    and latest_replay_contract.get("source_workflow")
+                    == "runtime-candidate-replay.yml"
+                    else ""
                 ),
                 full_depth_execution_surface_run_id=getattr(
                     args,
                     "full_depth_execution_surface_run_id",
                     "",
-                ),
+                )
+                or latest_full_depth_surface_artifact.get("run_id", ""),
                 full_depth_execution_surface_artifact_name=getattr(
                     args,
                     "full_depth_execution_surface_artifact_name",
                     "",
-                ),
+                )
+                or latest_full_depth_surface_artifact.get("artifact_name", ""),
             )
         )
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,55 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Evidence Inference (2026-05-24)
+
+Evidence stage: `walk_forward` / `executable_replay` closed-loop repair. This
+is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Rerun Research Trace Plan after replay-fed hosted walk-forward
+      `26362501135` persisted trace.
+- [x] Verify the remaining Research Manager blocker is true strategy
+      economics, not stale data/full-depth/runtime plumbing.
+- [x] Reproduce the executor gap where hidden runtime replay/full-depth proof
+      artifact ids were only carried when supplied manually.
+- [x] Make Research Manager executor infer the latest
+      `runtime_market_update_replay` artifact from trace-plan evidence.
+- [x] Make Research Manager executor infer reusable full-depth proof from the
+      latest hosted walk-forward artifact when the trace carries a valid
+      full-depth execution-surface proof.
+- [x] Teach hosted walk-forward to download full-depth proof from a prior
+      `factor-walk-forward-v2-*` artifact by stripping the embedded
+      `full-depth-execution-surface` directory.
+- [x] Run focused Python, workflow static, YAML, and Rust workflow-security
+      validation.
+- [ ] Commit, push, open PR, wait for CI, merge, then run Research Manager
+      executor from trace-plan `26362759645` in execute mode.
+
+### Review
+
+- 2026-05-24: Research Trace Plan run `26362759645` from
+  `main@b7e75f5` returned `theme=revise_prior`, `candidate_count=8`, actions
+  `generate_typed_llm_prior_json` and
+  `rerun_alpha_search_with_bounded_mutations`, and only blocker action
+  `strategy_economics -> mutate_or_reject_negative_runtime_edge`. No stale
+  `fix_data`, full-depth, settlement, or runtime-replay blocker reappeared.
+- 2026-05-24: Local executor replay against the real trace-plan artifact now
+  emits one ready hosted walk-forward dispatch with:
+  `candidate_strategy_replay_run_id=26355035577`,
+  `candidate_strategy_replay_artifact_name=runtime-candidate-replay-26355035577`,
+  `full_depth_execution_surface_run_id=26362501135`,
+  `full_depth_execution_surface_artifact_name=factor-walk-forward-v2-26362501135`,
+  and target lane `tradeable_full_depth_settlement_pnl`.
+- 2026-05-24: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan
+  tests.test_factor_walk_forward_sweep` (`33` tests),
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py
+  tests/test_factor_walk_forward_sweep.py`, YAML parse for the touched
+  workflows, `rtk cargo test --locked --test workflow_security
+  factor_walk_forward` (`5` passed), and `rtk git diff --check`.
+
 ## Current Session - Research Manager Latest Blockers (2026-05-24)
 
 Evidence stage: Research Manager planning repair after `walk_forward` /
@@ -22,7 +72,7 @@ decision.
       blocker shape.
 - [x] Fix frontier-run blocker extraction so historical runs and unselected
       factor registry entries do not drive the current plan.
-- [ ] Commit, push, open PR, wait for CI, merge, then redeploy/refresh the
+- [x] Commit, push, open PR, wait for CI, merge, then redeploy/refresh the
       deployed `research-trace-plan` binary before rerunning the workflow.
 - [x] Run Research Manager executor in dry-run mode from corrected trace-plan
       artifact.

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -738,6 +738,8 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
         self.assertIn("--snapshot-data-audit-json artifacts/research-snapshot/data-gap-audit.json", workflow)
         self.assertIn("full_depth_execution_surface_run_id", workflow)
         self.assertIn("Download full-depth execution surface artifact", workflow)
+        self.assertIn('[[ "${artifact_name}" == factor-walk-forward-v2-* ]]', workflow)
+        self.assertIn("--strip-prefix full-depth-execution-surface", workflow)
         self.assertIn("--full-depth-execution-surface-json", workflow)
 
     def test_snapshot_manifest_passes_to_candidate_replay_and_promotion(self):

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -196,6 +196,72 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual("revise_prior", prior["theme"])
         self.assertEqual(plan["plan"]["blocker_actions"], prior["blocker_actions"])
 
+    def test_revise_prior_infers_latest_replay_and_full_depth_artifacts(self) -> None:
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+        )
+        plan["input"]["latest_runs"] = {
+            "runs": [
+                {
+                    "run_id": "26362501135",
+                    "artifacts": [
+                        {
+                            "output_json": {
+                                "candidate_strategy_replay": {
+                                    "basis": "runtime_market_update_replay",
+                                    "runtime_score": "autofactor_formula:prior_candidate",
+                                    "source_workflow": "runtime-candidate-replay.yml",
+                                    "workflow_run_id": "26355035577",
+                                    "strategy_profile": "settlement_probability",
+                                    "decision_contract": {
+                                        "target": "tradeable_full_depth_settlement_pnl",
+                                        "horizon": "5m",
+                                    },
+                                },
+                                "source_snapshot_contract": {
+                                    "full_depth_execution_surface_proofs": [
+                                        {
+                                            "valid": True,
+                                            "surface": "clob_orderbook_snapshots",
+                                            "path": "artifacts/full-depth-execution-surface/full-depth-execution-surface.json",
+                                        }
+                                    ],
+                                    "satisfied_execution_surfaces": ["clob_orderbook_snapshots"],
+                                },
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+
+        payload = build_executor_payload(
+            base_args(
+                mode="execute",
+                execute_ack=EXECUTE_ACK,
+                snapshot_run_id="26354463118",
+            ),
+            plan,
+        )
+
+        options = json.loads(payload["dispatches"][0]["fields"]["options_json"])
+        self.assertEqual("26355035577", options["candidate_strategy_replay_run_id"])
+        self.assertEqual(
+            "runtime-candidate-replay-26355035577",
+            options["candidate_strategy_replay_artifact_name"],
+        )
+        self.assertEqual("26362501135", options["full_depth_execution_surface_run_id"])
+        self.assertEqual(
+            "factor-walk-forward-v2-26362501135",
+            options["full_depth_execution_surface_artifact_name"],
+        )
+        self.assertEqual(
+            "tradeable_full_depth_settlement_pnl",
+            options["alpha_search_plan_target"],
+        )
+        self.assertEqual("tradeable_full_depth_settlement_pnl", options["allowed_target"])
+
     def test_fix_runtime_plan_maps_to_candidate_replay_and_parity(self) -> None:
         payload = build_executor_payload(
             Namespace(

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -636,7 +636,7 @@ fn hosted_factor_walk_forward_has_candidate_replay_feedback_input() {
     let candidate_section = hosted
         .split("- name: Download candidate strategy replay artifact")
         .nth(1)
-        .and_then(|tail| tail.split("- name: Cache cargo build").next())
+        .and_then(|tail| tail.split("- name: Download full-depth execution surface artifact").next())
         .unwrap_or("");
     if candidate_section.contains("--strip-prefix") {
         offenders.push(


### PR DESCRIPTION
## Summary
- infer latest runtime candidate replay artifact from Research Trace Plan evidence when dispatching bounded hosted walk-forward
- infer reusable full-depth execution-surface proof from the latest hosted walk-forward artifact
- let hosted walk-forward download embedded full-depth proof from prior factor-walk-forward artifacts

## Evidence stage
walk_forward / executable_replay closed-loop repair; no dry-run or live promotion.

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py tests/test_factor_walk_forward_sweep.py
- YAML parse for touched workflows
- rtk cargo test --locked --test workflow_security factor_walk_forward
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hosted artifact download workflow to conditionally handle prefix stripping based on artifact type.

* **Refactor**
  * Enhanced walk-forward execution continuation with improved automatic artifact inference.
  * Strengthened fallback logic for replay dispatch in the research manager executor.

* **Tests**
  * Added validation for workflow artifact handling and artifact inference during plan execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->