### PR TITLE
Make negative runtime edge revise prior actionable

### DIFF
--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -3544,6 +3544,62 @@ mod tests {
     }
 
     #[test]
+    fn research_manager_typed_prior_metadata_deserializes_and_compiles_mutations() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+        let prior: LlmPriorSpec = serde_json::from_value(serde_json::json!({
+            "schema_version": "research_manager_typed_prior.v1",
+            "source": "research_trace_plan",
+            "theme": "revise_prior",
+            "blocker_actions": [{
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest replay or walk-forward evidence failed economic/OOS gates."
+            }],
+            "constraints": [
+                "penalize losing runtime-replayed factor families and require positive executable ROI before handoff"
+            ],
+            "runtime_avoid_factors": [{
+                "base_factor": "auto_settlement_conservative_settlement_edge",
+                "factor_family": "auto_settlement_conservative_settlement_edge",
+                "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                "reason": "negative_runtime_edge",
+                "metrics": {"roi": -0.079091}
+            }],
+            "mutations": [{
+                "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+                "mutation_type": "add_capacity_gate",
+                "name": "llm_model_full_depth_edge_full_depth_gate",
+                "feature": "full_depth_entry_fillable_gate"
+            }]
+        }))
+        .expect("Research Manager typed prior should be LlmPriorSpec-compatible");
+
+        assert_eq!(1, prior.runtime_avoid_factors.len());
+        assert_eq!(1, prior.mutations.len());
+
+        let reports = mine_domain_autofactors_from_v2_with_guidance(
+            &rows,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            &options,
+            &[],
+            Some(&prior),
+        )
+        .expect("reports");
+
+        let report = reports
+            .iter()
+            .find(|report| report.name == "llm_model_full_depth_edge_full_depth_gate")
+            .expect("Research Manager prior mutation should compile");
+        assert!(matches!(report.expr, FactorExpr::Gate { .. }));
+    }
+
+    #[test]
     fn keeps_settlement_native_generated_candidates_out_of_repricing_targets() {
         let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
         let options = AutoFactorOptions {

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -445,7 +445,7 @@ def _latest_run(plan_payload: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
-def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, str]:
+def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, Any]:
     latest_run = _latest_run(plan_payload)
     artifacts = latest_run.get("artifacts")
     if not isinstance(artifacts, list):
@@ -467,6 +467,12 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
         source_factor = replay.get("source_factor")
         if not isinstance(source_factor, dict):
             source_factor = {}
+        metrics = replay.get("metrics") if isinstance(replay.get("metrics"), dict) else {}
+        blocking_flags = replay.get("blocking_risk_flags")
+        if not isinstance(blocking_flags, list):
+            blocking_flags = replay.get("blockers")
+        if not isinstance(blocking_flags, list):
+            blocking_flags = []
         return {
             "target": str(contract.get("target") or source_factor.get("target") or ""),
             "horizon": str(contract.get("horizon") or source_factor.get("horizon") or ""),
@@ -474,6 +480,22 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
             "strategy_profile": str(replay.get("strategy_profile") or ""),
             "workflow_run_id": str(replay.get("workflow_run_id") or ""),
             "source_workflow": str(replay.get("source_workflow") or ""),
+            "source_factor_name": str(
+                source_factor.get("name") or source_factor.get("factor_name") or ""
+            ),
+            "metrics": {
+                key: metrics[key]
+                for key in (
+                    "trade_count",
+                    "unique_event_count",
+                    "entry_fill_rate",
+                    "roi",
+                    "total_pnl",
+                    "avg_entry_price",
+                )
+                if key in metrics
+            },
+            "blocking_risk_flags": [str(item) for item in blocking_flags if str(item)],
         }
     return {}
 
@@ -572,7 +594,144 @@ def _typed_prior_constraints(blocker_actions: list[dict[str, str]]) -> list[str]
         constraints.append("block promotion until official settlement coverage exists for all replay-traded events")
     if "repair_runtime_contract_mapping" in action_names:
         constraints.append("only select factors with typed unblocked runtime contracts")
+    if "mutate_or_reject_negative_runtime_edge" in action_names:
+        constraints.append(
+            "penalize losing runtime-replayed factor families and require positive executable ROI before handoff"
+        )
     return constraints
+
+
+def _runtime_score_base_factor(runtime_score: str) -> str:
+    prefix = "autofactor_formula:"
+    if runtime_score.startswith(prefix):
+        return runtime_score[len(prefix) :]
+    return runtime_score
+
+
+def _normalized_factor_key(raw: str) -> str:
+    value = _runtime_score_base_factor(str(raw or "").strip())
+    while True:
+        next_value = value
+        for prefix in ("mut2_", "llm_", "mcts_", "mut_"):
+            if next_value.startswith(prefix):
+                next_value = next_value[len(prefix) :]
+                break
+        if next_value == value:
+            break
+        value = next_value
+    marker = "_runtime_pass_through_"
+    if marker in value:
+        value = value.split(marker, 1)[0]
+    return value
+
+
+def _normalized_factor_family(raw: str) -> str:
+    value = _normalized_factor_key(raw)
+    suffixes = (
+        "_runtime_pass_through_add_spread_penalty",
+        "_runtime_pass_through_add_capacity_gate",
+        "_add_spread_penalty",
+        "_add_capacity_gate",
+        "_add_feature_gate",
+        "_entry_price_quality",
+        "_full_depth_entry_gate",
+        "_spread_adjusted",
+        "_near_strike",
+        "_capacity",
+        "_squashed",
+        "_pm_lag",
+        "_clip",
+    )
+    changed = True
+    while changed:
+        changed = False
+        for suffix in suffixes:
+            if value.endswith(suffix) and len(value) > len(suffix):
+                value = value[: -len(suffix)]
+                changed = True
+                break
+        if not changed and value.endswith("_x") and len(value) > 2:
+            value = value[:-2]
+            changed = True
+    return value
+
+
+def _negative_economics_prior_payload(
+    blocker_actions: list[dict[str, str]],
+    replay_contract: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    action_names = {item["action"] for item in blocker_actions}
+    if "mutate_or_reject_negative_runtime_edge" not in action_names:
+        return {"runtime_avoid_factors": [], "mutations": []}
+
+    runtime_score = str(replay_contract.get("runtime_score") or "")
+    base_factor = str(
+        replay_contract.get("source_factor_name") or ""
+    ) or _runtime_score_base_factor(runtime_score)
+    factor_family = _normalized_factor_family(base_factor)
+    metrics = (
+        replay_contract.get("metrics") if isinstance(replay_contract.get("metrics"), dict) else {}
+    )
+    flags = replay_contract.get("blocking_risk_flags")
+    if not isinstance(flags, list):
+        flags = []
+
+    runtime_avoid_factors: list[dict[str, Any]] = []
+    if base_factor and factor_family:
+        runtime_avoid_factors.append(
+            {
+                "base_factor": base_factor,
+                "factor_family": factor_family,
+                "runtime_score": runtime_score,
+                "reason": "negative_runtime_edge",
+                "metrics": {
+                    **metrics,
+                    "blocking_risk_flags": flags,
+                },
+            }
+        )
+
+    fallback_specs = [
+        {
+            "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+            "mutation_type": "add_capacity_gate",
+            "name": "llm_model_full_depth_edge_full_depth_gate",
+            "feature": "full_depth_entry_fillable_gate",
+        },
+        {
+            "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+            "mutation_type": "add_spread_penalty",
+            "name": "llm_model_full_depth_edge_spread_penalty",
+            "feature": "side_spread",
+            "constant": 0.01,
+        },
+        {
+            "base_factor": "auto_settlement_full_depth_settlement_edge",
+            "mutation_type": "add_near_strike_interaction",
+            "name": "llm_full_depth_edge_near_strike",
+        },
+        {
+            "base_factor": "auto_settlement_conservative_settlement_edge",
+            "mutation_type": "invert_or_contrarian",
+            "name": "llm_conservative_settlement_edge_contrarian",
+        },
+    ]
+    avoided_families = {item["factor_family"] for item in runtime_avoid_factors}
+    mutations = [
+        item
+        for item in fallback_specs
+        if _normalized_factor_family(item["base_factor"]) not in avoided_families
+    ]
+    if not mutations:
+        mutations = fallback_specs[:1]
+    for item in mutations:
+        item["feedback_reason"] = "negative_runtime_edge"
+        item["runtime_metrics"] = metrics
+
+    return {
+        "runtime_avoid_factors": runtime_avoid_factors,
+        "mutations": mutations,
+    }
 
 
 def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any]) -> dict[str, Any]:
@@ -594,6 +753,10 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
         "runtime_source_target",
         "full_depth_settlement_executable_pnl",
     )
+    negative_economics_prior = _negative_economics_prior_payload(
+        blocker_actions,
+        latest_replay_contract,
+    )
 
     if (
         plan.get("theme") == "revise_prior"
@@ -608,6 +771,8 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             "actions": actions,
             "blocker_actions": blocker_actions,
             "constraints": _typed_prior_constraints(blocker_actions),
+            "runtime_avoid_factors": negative_economics_prior["runtime_avoid_factors"],
+            "mutations": negative_economics_prior["mutations"],
         }
 
     if any(action in snapshot_actions for action in actions) or (

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,45 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Negative Runtime Economics Prior Repair (2026-05-24)
+
+Evidence stage: `walk_forward` / `executable_replay` closed-loop search repair.
+This is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Confirm latest restored chain blocker is `strategy_economics ->
+      mutate_or_reject_negative_runtime_edge`, not data/full-depth/runtime
+      plumbing.
+- [x] Identify that Research Manager typed prior carried audit constraints but
+      did not emit Rust-consumed `mutations` / `runtime_avoid_factors`.
+- [x] Make `scripts/research_manager_execute_plan.py` convert negative
+      runtime replay economics into LlmPriorSpec-compatible
+      `runtime_avoid_factors` and fallback settlement mutations.
+- [x] Add focused executor regression coverage for negative runtime economics
+      prior payloads.
+- [x] Run focused Python/static validation.
+- [ ] Commit, push, open PR, wait for CI, merge, then rerun Research Manager
+      executor from trace-plan `26363701280`.
+
+### Review
+
+- 2026-05-24: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan
+  tests.test_persist_research_trace_contract` (`33` tests),
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py
+  tests/test_persist_research_trace_contract.py`, `rtk git diff --check`,
+  `rtk cargo test --locked -p ploy-research typed_prior --lib` (`3` passed),
+  and a direct smoke assertion that
+  `mutate_or_reject_negative_runtime_edge` emits nonempty
+  `runtime_avoid_factors` plus LlmPriorSpec-shaped `mutations`.
+- 2026-05-24: Added a Rust boundary regression proving a complete
+  `research_manager_typed_prior.v1` with audit metadata still deserializes as
+  `LlmPriorSpec` and compiles a settlement mutation. A broad
+  `rustfmt --edition 2024 --check crates/ploy-research/src/autofactor.rs`
+  was not used as a completion gate because it reports pre-existing
+  whole-file formatting churn outside this patch.
+
 ## Current Session - Research Manager Evidence Inference (2026-05-24)
 
 Evidence stage: `walk_forward` / `executable_replay` closed-loop repair. This

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -143,6 +143,14 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
                                     "basis": "runtime_market_update_replay",
                                     "runtime_score": "autofactor_formula:prior_candidate",
                                     "strategy_profile": "settlement_probability",
+                                    "metrics": {
+                                        "trade_count": 53,
+                                        "unique_event_count": 53,
+                                        "entry_fill_rate": 1.0,
+                                        "roi": -0.079091,
+                                        "total_pnl": -62.8774,
+                                    },
+                                    "blocking_risk_flags": ["roi_too_low:-0.079091<0.000000"],
                                     "decision_contract": {
                                         "target": "tradeable_full_depth_settlement_pnl",
                                         "horizon": "5m",
@@ -195,6 +203,31 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual("research_manager_typed_prior.v1", prior["schema_version"])
         self.assertEqual("revise_prior", prior["theme"])
         self.assertEqual(plan["plan"]["blocker_actions"], prior["blocker_actions"])
+        self.assertEqual(
+            [
+                {
+                    "base_factor": "prior_candidate",
+                    "factor_family": "prior_candidate",
+                    "runtime_score": "autofactor_formula:prior_candidate",
+                    "reason": "negative_runtime_edge",
+                    "metrics": {
+                        "trade_count": 53,
+                        "unique_event_count": 53,
+                        "entry_fill_rate": 1.0,
+                        "roi": -0.079091,
+                        "total_pnl": -62.8774,
+                        "blocking_risk_flags": ["roi_too_low:-0.079091<0.000000"],
+                    },
+                }
+            ],
+            prior["runtime_avoid_factors"],
+        )
+        self.assertTrue(prior["mutations"])
+        self.assertEqual("add_capacity_gate", prior["mutations"][0]["mutation_type"])
+        self.assertEqual(
+            "auto_settlement_model_full_depth_settlement_edge",
+            prior["mutations"][0]["base_factor"],
+        )
 
     def test_revise_prior_infers_latest_replay_and_full_depth_artifacts(self) -> None:
         plan = plan_payload(


### PR DESCRIPTION
## Summary
- Convert Research Manager negative runtime economics blocker into Rust-consumed LlmPriorSpec fields.
- Emit runtime_avoid_factors for losing runtime-replayed factor families and fallback settlement mutations for the next bounded search.
- Add Python executor coverage and a Rust boundary regression for research_manager_typed_prior.v1 deserialization/compilation.

## Evidence stage
walk_forward / executable_replay closed-loop search repair. This is not a dry-run or live promotion decision.

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py tests/test_persist_research_trace_contract.py
- rtk cargo test --locked -p ploy-research typed_prior --lib
- rtk git diff --check