### PR TITLE
Prioritize runtime replay for new mappable factors

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -542,6 +542,8 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         if as_float(run["feedback"].get("best_reward")) is not None
     ]
     prior_best_reward = max(prior_rewards) if prior_rewards else None
+    runtime_requests = runtime_replay_requests(current)
+    has_runtime_replay_candidate = bool(runtime_requests)
 
     if handoff.get("status") == "ready":
         action = "ready_handoff"
@@ -552,6 +554,9 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     elif runtime_unmapped_feedback:
         action = "revise_prior"
         reason = str(runtime_unmapped_feedback.get("reason") or "missing_runtime_strategy_mapping")
+    elif has_runtime_replay_candidate and blocker_action not in {"fix_data", "fix_workflow"}:
+        action = "fix_runtime"
+        reason = "runtime_mappable_candidate_needs_runtime_replay"
     elif blocker_action in {"fix_runtime", "fix_data", "fix_workflow", "revise_prior"}:
         action = blocker_action
         reason = f"promotion_blockers_require_{blocker_action}"
@@ -604,7 +609,7 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         and chain.get("should_dispatch") is True
     )
     best = best_run(runs)
-    runtime_requests = runtime_replay_requests(current) if action == "fix_runtime" else []
+    runtime_requests = runtime_requests if action == "fix_runtime" else []
     runtime_request = runtime_requests[0] if runtime_requests else None
     return {
         "schema_version": 1,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,36 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Runtime Replay Priority After Prior Revision (2026-05-24)
+
+Evidence stage: `walk_forward` / `runtime_parity` closed-loop routing repair.
+This is not a dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Run Research Manager executor from trace-plan `26363701280` after PR
+      `#676` merged.
+- [x] Verify executor run `26364706828` emitted Rust-consumed
+      `runtime_avoid_factors` / `mutations` and dispatched hosted
+      walk-forward `26364709800`.
+- [x] Inspect hosted walk-forward `26364709800` and identify the next blocker:
+      a new runtime-mappable factor needs a fresh exact-score
+      `runtime_market_update_replay`.
+- [x] Manually dispatch runtime-candidate replay `26364996955` for
+      `autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`.
+- [x] Fix closed-loop routing so a runtime-mappable candidate needing exact
+      replay takes priority over high rejected-candidate ratio.
+- [x] Run focused Python validation.
+- [ ] Commit, push, open PR, wait for CI, merge, then rerun the trace plan
+      after replay evidence is persisted.
+
+### Review
+
+- 2026-05-24: Validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent` (`31`
+  tests), `python3 -m py_compile
+  scripts/alpha_search_closed_loop_agent.py
+  tests/test_alpha_search_closed_loop_agent.py`, and `rtk git diff --check`.
+
 ## Current Session - Negative Runtime Economics Prior Repair (2026-05-24)
 
 Evidence stage: `walk_forward` / `executable_replay` closed-loop search repair.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -740,6 +740,81 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             )
             self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
 
+    def test_runtime_replay_request_takes_priority_over_high_reject_ratio(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stale_runtime_score = (
+                "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_capacity"
+            )
+            better_runtime_score = (
+                "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
+            )
+            path = artifact(
+                Path(tmp),
+                target="tradeable_full_depth_settlement_pnl",
+                feedback={
+                    "target": "tradeable_full_depth_settlement_pnl",
+                    "candidate_count": 1079,
+                    "rejected_count": 958,
+                    "passed_count": 31,
+                    "best_candidate": "mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted",
+                    "best_reward": 5.7282,
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "roi_too_low:-0.079091<0.000000",
+                                "candidate_strategy_replay_not_ready",
+                                f"candidate_strategy_replay_runtime_score_mismatch:{stale_runtime_score}!={better_runtime_score}",
+                                "candidate_strategy_replay_roi_too_low:-0.079091<0.000000",
+                            ],
+                            "factor": {
+                                "name": "mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+                                "target": "tradeable_full_depth_settlement_pnl",
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_n": 216,
+                                "top_bucket_avg_label": 16.533648,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.8333,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.125437,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": better_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "runtime_score": stale_runtime_score,
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, "tradeable_full_depth_settlement_pnl")]
+            )
+
+        request = decision["runtime_replay_request"]
+        self.assertEqual("fix_runtime", decision["decision"])
+        self.assertEqual(
+            "runtime_mappable_candidate_needs_runtime_replay",
+            decision["reason"],
+        )
+        self.assertEqual(
+            "mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+            request["source_factor"],
+        )
+        self.assertEqual(request["inputs"]["runtime_score"], better_runtime_score)
+        self.assertEqual(
+            json.loads(request["inputs"]["options_json"])["source_target"],
+            "tradeable_full_depth_settlement_pnl",
+        )
+
     def test_fix_runtime_includes_batch_runtime_replay_requests(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             scores = [


### PR DESCRIPTION
## Summary
- Make closed-loop alpha-search choose fix_runtime when a new runtime-mappable candidate needs exact runtime replay, even if the search also has a high rejected-candidate ratio.
- Keep fix_data/fix_workflow blockers ahead of replay dispatch.
- Add regression coverage for the 26364709800 failure mode: old replay score mismatched the newly selected runtime-mappable factor.

## Evidence stage
walk_forward / runtime_parity closed-loop routing repair. This is not a dry-run or live promotion decision.

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system logic to better identify and prioritize runtime replay candidates earlier in the decision flow
  * Optimized runtime request computation and allocation strategy

* **Tests**
  * Added comprehensive test coverage for runtime replay priority handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->