### PR TITLE
fix: pin runtime replay recording provenance

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -249,6 +249,36 @@ jobs:
           test -r "${config_path}"
           test -r "${recording_path}"
 
+          recording_provenance="${remote_dir}/recording-provenance.json"
+          recording_sha256="$(sha256sum "${recording_path}" | awk '{print $1}')"
+          recording_size_bytes="$(stat -c '%s' "${recording_path}")"
+          recording_mtime_epoch="$(stat -c '%Y' "${recording_path}")"
+          python3 - "${recording_path}" "${recording_sha256}" "${recording_size_bytes}" "${recording_mtime_epoch}" "${recording_provenance}" <<'PY'
+          import datetime as dt
+          import json
+          import sys
+          from pathlib import Path
+
+          path, sha256, size_bytes, mtime_epoch, output = sys.argv[1:]
+          mtime = dt.datetime.fromtimestamp(int(mtime_epoch), tz=dt.timezone.utc)
+          Path(output).write_text(
+              json.dumps(
+                  {
+                      "schema_version": "recording_provenance.v1",
+                      "recording_path": path,
+                      "recording_sha256": sha256,
+                      "recording_size_bytes": int(size_bytes),
+                      "recording_mtime_epoch": int(mtime_epoch),
+                      "recording_mtime_utc": mtime.isoformat().replace("+00:00", "Z"),
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
           set -a
           . /opt/ploy/.env
           set +a
@@ -388,13 +418,14 @@ jobs:
             --settlements-json "${settlements_json}" \
             --report-json "${remote_dir}/runtime-evidence-enrichment.json"
 
-          ls -lh "${remote_dir}/runtime-evaluation.json" "${official_settlement_report}" "${remote_dir}/recording-enrichment.json" "${remote_dir}/runtime-evidence-enrichment.json"
+          ls -lh "${remote_dir}/runtime-evaluation.json" "${official_settlement_report}" "${remote_dir}/recording-enrichment.json" "${remote_dir}/runtime-evidence-enrichment.json" "${recording_provenance}"
           EOF
 
           scp tango-1-1:"${REMOTE_DIR}/runtime-evaluation.json" artifacts/runtime-replay/runtime-evaluation.json
           scp tango-1-1:"${REMOTE_DIR}/official-settlement-report.json" artifacts/runtime-replay/official-settlement-report.json
           scp tango-1-1:"${REMOTE_DIR}/recording-enrichment.json" artifacts/runtime-replay/recording-enrichment.json
           scp tango-1-1:"${REMOTE_DIR}/runtime-evidence-enrichment.json" artifacts/runtime-replay/runtime-evidence-enrichment.json
+          scp tango-1-1:"${REMOTE_DIR}/recording-provenance.json" artifacts/runtime-replay/recording-provenance.json
 
       - name: Build candidate strategy replay artifact
         env:
@@ -409,6 +440,21 @@ jobs:
           SOURCE_HORIZON: ${{ env.REPLAY_SOURCE_HORIZON }}
         run: |
           set -euo pipefail
+          recording_sha256="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("artifacts/runtime-replay/recording-provenance.json")
+          if not path.is_file():
+              raise SystemExit("recording-provenance.json missing")
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          print(payload.get("recording_sha256") or "")
+          PY
+          )"
+          if [ -z "${recording_sha256}" ]; then
+            echo "recording sha256 missing from recording-provenance.json" >&2
+            exit 1
+          fi
           args=(
             --runtime-evaluation-json artifacts/runtime-replay/runtime-evaluation.json
             --runtime-score "${RUNTIME_SCORE}"
@@ -418,6 +464,7 @@ jobs:
             --workflow-run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             --artifact-name "runtime-candidate-replay-${GITHUB_RUN_ID}"
             --recording-path "${{ github.event.inputs.recording_path }}"
+            --recording-sha256 "${recording_sha256}"
             --config-path "${{ github.event.inputs.config_path }}"
             --runner-source "${GITHUB_WORKFLOW}:${GITHUB_REF_NAME}"
             --runner-git-sha "${GITHUB_SHA}"
@@ -445,6 +492,9 @@ jobs:
             echo "- Deployment: \`${{ github.event.inputs.deployment_id }}\`"
             echo "- Config: \`${{ github.event.inputs.config_path }}\`"
             echo "- Recording: \`${{ github.event.inputs.recording_path }}\`"
+            if [ -f artifacts/runtime-replay/recording-provenance.json ]; then
+              echo "- Recording SHA256: \`$(python3 -c 'import json; print(json.load(open("artifacts/runtime-replay/recording-provenance.json")).get("recording_sha256", ""))')\`"
+            fi
             echo "- Runtime score: \`${{ github.event.inputs.runtime_score }}\`"
             echo "- Artifact: \`runtime-candidate-replay-${{ github.run_id }}\`"
             if [ -f artifacts/runtime-replay/candidate-strategy-replay.json ]; then

--- a/scripts/build_runtime_candidate_strategy_replay.py
+++ b/scripts/build_runtime_candidate_strategy_replay.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 from collections import Counter
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -24,6 +25,7 @@ from autofactor_accounting_catalog import (
 
 
 RUNTIME_REPLAY_BASIS = "runtime_market_update_replay"
+ARCHIVED_RECORDING_SUFFIX_RE = re.compile(r"\.\d{8}T\d{6}Z?$")
 COUNTERFACTUAL_THRESHOLDS = (
     ("0.05", "005"),
     ("0.10", "010"),
@@ -62,6 +64,17 @@ def sha256_file_if_present(raw_path: str) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             hasher.update(chunk)
     return hasher.hexdigest()
+
+
+def looks_like_mutable_recording_path(raw_path: str) -> bool:
+    """Detect the active recording path, as opposed to timestamped archives."""
+    if not raw_path:
+        return False
+    name = Path(raw_path).name
+    if not name.endswith(".ndjson"):
+        return False
+    stem = name.removesuffix(".ndjson")
+    return ARCHIVED_RECORDING_SUFFIX_RE.search(stem) is None
 
 
 def canonical_sha256(payload: dict[str, Any]) -> str:
@@ -343,6 +356,12 @@ def build_artifact(
         blocking_flags.append(f"roi_too_low:{roi:.6f}<{min_roi:.6f}")
     if not entry_orders and not entry_fills:
         blocking_flags.append("zero_runtime_orders_and_fills")
+    if not recording_path:
+        blocking_flags.append("recording_path_missing")
+    if not recording_sha256:
+        blocking_flags.append("recording_sha256_missing")
+        if looks_like_mutable_recording_path(recording_path):
+            blocking_flags.append("mutable_recording_without_sha256")
 
     diagnostics = runtime_eval.get("strategy_diagnostics") or result.get("strategy_diagnostics") or {}
     counterfactual = score_counterfactual(diagnostics, configured_entry_threshold)
@@ -438,6 +457,8 @@ def render_markdown(artifact: dict[str, Any]) -> str:
         f"- Basis: `{artifact.get('basis')}`",
         f"- Runtime score: `{artifact.get('runtime_score')}`",
         f"- Strategy profile: `{artifact.get('strategy_profile')}`",
+        f"- Recording: `{artifact.get('recording_path')}`",
+        f"- Recording SHA256: `{artifact.get('recording_sha256')}`",
         f"- Updates processed: `{metrics.get('updates_processed')}`",
         f"- Intents submitted: `{metrics.get('intents_submitted')}`",
         f"- Trades: `{metrics.get('trade_count')}`",

--- a/scripts/evaluate_autofactor_strategy_promotion.py
+++ b/scripts/evaluate_autofactor_strategy_promotion.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,7 @@ DEFAULT_ALLOWED_TARGETS = (
     "full_depth_settlement_executable_pnl",
     "tradeable_full_depth_settlement_pnl",
 )
+ARCHIVED_RECORDING_SUFFIX_RE = re.compile(r"\.\d{8}T\d{6}Z?$")
 
 
 @dataclass
@@ -308,6 +310,15 @@ def candidate_strategy_replay_blockers(
             "candidate_strategy_replay_identity_basis_mismatch:"
             f"{replay.identity.get('basis') or '<missing>'}!=runtime_market_update_replay"
         )
+    if replay.identity:
+        recording_path = str(replay.identity.get("recording_path") or "")
+        recording_sha256 = str(replay.identity.get("recording_sha256") or "")
+        if not recording_path:
+            blockers.append("candidate_strategy_replay_missing_recording_path")
+        if not recording_sha256:
+            blockers.append("candidate_strategy_replay_missing_recording_sha256")
+            if looks_like_mutable_recording_path(recording_path):
+                blockers.append("candidate_strategy_replay_mutable_recording_without_sha256")
     provenance_fields = {
         "source_workflow": replay.source_workflow,
         "workflow_run_id": replay.workflow_run_id,
@@ -490,6 +501,15 @@ def is_autofactor_formula(mapping: dict[str, str] | None) -> bool:
     if not mapping:
         return False
     return mapping.get("runtime_score", "").startswith("autofactor_formula:")
+
+
+def looks_like_mutable_recording_path(raw_path: str) -> bool:
+    if not raw_path:
+        return False
+    name = Path(raw_path).name
+    if not name.endswith(".ndjson"):
+        return False
+    return ARCHIVED_RECORDING_SUFFIX_RE.search(name.removesuffix(".ndjson")) is None
 
 
 def global_gate_blockers(

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -14,6 +15,16 @@ from typing import Any
 
 EXECUTE_ACK = "execute-research-manager-plan"
 SCHEMA_VERSION = "research_manager_executor.v1"
+ARCHIVED_RECORDING_SUFFIX_RE = re.compile(r"\.\d{8}T\d{6}Z?$")
+
+
+def _looks_like_mutable_recording_path(raw_path: str) -> bool:
+    if not raw_path:
+        return False
+    name = Path(raw_path).name
+    if not name.endswith(".ndjson"):
+        return False
+    return ARCHIVED_RECORDING_SUFFIX_RE.search(name.removesuffix(".ndjson")) is None
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -464,6 +475,15 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
         contract = replay.get("decision_contract")
         if not isinstance(contract, dict):
             contract = {}
+        identity = replay.get("identity")
+        if not isinstance(identity, dict):
+            identity = {}
+        recording_path = str(replay.get("recording_path") or identity.get("recording_path") or "")
+        recording_sha256 = str(
+            replay.get("recording_sha256") or identity.get("recording_sha256") or ""
+        )
+        if _looks_like_mutable_recording_path(recording_path) and not recording_sha256:
+            continue
         source_factor = replay.get("source_factor")
         if not isinstance(source_factor, dict):
             source_factor = {}
@@ -480,6 +500,8 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
             "strategy_profile": str(replay.get("strategy_profile") or ""),
             "workflow_run_id": str(replay.get("workflow_run_id") or ""),
             "source_workflow": str(replay.get("source_workflow") or ""),
+            "recording_path": recording_path,
+            "recording_sha256": recording_sha256,
             "source_factor_name": str(
                 source_factor.get("name") or source_factor.get("factor_name") or ""
             ),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,48 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Runtime Replay Recording Provenance (2026-05-24)
+
+Evidence stage: `executable_replay` / replay provenance repair. This is not a
+dry-run or live promotion decision.
+
+### Tasks
+
+- [x] Approve Research Manager dispatched snapshot audit `26366091443` and
+      settlement repair `26366091933`.
+- [x] Verify snapshot audit failed on Binance LOB hot DB coverage, while
+      Polymarket full-depth orderbook archive was present and full-fidelity.
+- [x] Verify settlement repair succeeded but did not change rows, so the
+      previous official-settlement blocker was not a simple backfill gap.
+- [x] Rerun runtime candidate replay against the mutable active recording
+      `26366530448` and identify the non-reproducible tape problem.
+- [x] Rerun runtime candidate replay against the archived recording
+      `26366688853` and confirm the candidate passes replay gates on the
+      immutable tape.
+- [x] Fix runtime replay artifacts to carry recording provenance and make
+      mutable recording paths without SHA256 fail closed.
+- [ ] Commit, push, open PR, wait for CI, merge, then rerun the archived
+      recording replay from the fixed workflow so the passing replay carries a
+      recording SHA256.
+
+### Review
+
+- 2026-05-24: Research Snapshot `26366091443` failed because
+  `binance_lob/BTCUSDT`, `ETHUSDT`, and `SOLUSDT` had 33.333% hot DB coverage
+  and max gaps of 960 minutes in the 2026-05-17T00:00:00Z ->
+  2026-05-18T00:00:00Z window. The same artifact showed Polymarket
+  full-depth orderbook archive coverage was 24/24 hours with 2,214,371 rows and
+  `full_fidelity=true`.
+- 2026-05-24: Settlement repair `26366091933` ran in execute mode over 1,097
+  candidate markets and reported `settled_count=0`, `error_count=0`.
+- 2026-05-24: Runtime replay `26366530448` used the mutable active recording
+  and produced only 9 trades with ROI `-0.238054`; archived recording replay
+  `26366688853` used
+  `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson`
+  and produced 50 trades, 50 official settlements, fill rate `1.0`, ROI
+  `0.116538`, and `promotion_ready=true`. The passing run still lacks
+  `recording_sha256` because it used the pre-fix workflow, so it must be rerun
+  after this provenance fix lands.
+
 ## Current Session - Runtime Replay Priority After Prior Revision (2026-05-24)
 
 Evidence stage: `walk_forward` / `runtime_parity` closed-loop routing repair.

--- a/tests/test_autofactor_strategy_promotion.py
+++ b/tests/test_autofactor_strategy_promotion.py
@@ -180,6 +180,8 @@ DEFAULT_REPLAY_PAYLOAD = {
         "runtime_score": "autofactor_formula:auto_settlement_conservative_settlement_edge",
         "strategy_profile": "settlement_probability",
         "workflow_run_id": "26306734877",
+        "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson",
+        "recording_sha256": "a" * 64,
     },
     "evidence_stage": "executable_replay",
     "basis": "runtime_market_update_replay",
@@ -1187,6 +1189,27 @@ rank,name,target,decision,reason,n,spearman_ic,pearson_ic,window_count,icir,posi
         self.assertIn("candidate_strategy_replay_missing_workflow_run_url", first["blockers"])
         self.assertIn("candidate_strategy_replay_missing_artifact_name", first["blockers"])
         self.assertIn("Candidate strategy replay id: ``", handoff_md)
+
+    def test_blocks_mutable_runtime_replay_without_recording_hash(self):
+        replay = {
+            **DEFAULT_REPLAY_PAYLOAD,
+            "identity": {
+                **DEFAULT_REPLAY_PAYLOAD["identity"],
+                "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+                "recording_sha256": "",
+            },
+        }
+
+        _, payload, _, handoff, _ = self.run_script(
+            READY_GATE + AUTOFACTOR_SETTLEMENT_AUTO_REPORT,
+            replay_payload=replay,
+        )
+
+        self.assertEqual(payload["decision"], "blocked")
+        self.assertEqual(handoff["status"], "blocked")
+        blockers = payload["evaluated_factors"][0]["blockers"]
+        self.assertIn("candidate_strategy_replay_missing_recording_sha256", blockers)
+        self.assertIn("candidate_strategy_replay_mutable_recording_without_sha256", blockers)
 
     def test_blocks_replay_without_executable_strategy_contract(self):
         replay = {

--- a/tests/test_build_runtime_candidate_strategy_replay.py
+++ b/tests/test_build_runtime_candidate_strategy_replay.py
@@ -114,6 +114,10 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
                     str(runtime_json),
                     "--runtime-score",
                     "autofactor_formula:auto_settlement_conservative_settlement_edge",
+                    "--recording-path",
+                    "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson",
+                    "--recording-sha256",
+                    "a" * 64,
                     "--output-json",
                     str(output_json),
                     "--output-md",
@@ -150,6 +154,7 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(payload["source_workflow"], "runtime-candidate-replay.yml")
         self.assertEqual(payload["identity"]["runtime_score"], payload["runtime_score"])
         self.assertEqual(payload["identity"]["basis"], "runtime_market_update_replay")
+        self.assertEqual(payload["identity"]["recording_sha256"], "a" * 64)
         self.assertEqual(payload["source_factor"]["target"], "full_depth_settlement_executable_pnl")
         self.assertEqual(payload["source_factor"]["horizon"], "5m")
         self.assertEqual(payload["decision_contract"]["target"], "full_depth_settlement_executable_pnl")
@@ -172,6 +177,22 @@ class BuildRuntimeCandidateStrategyReplayTests(unittest.TestCase):
         self.assertEqual(payload["blocking_risk_flags"], [])
         self.assertIn("Promotion ready: `true`", markdown)
         self.assertIn("## Acceptance Criteria", markdown)
+
+    def test_blocks_mutable_recording_without_sha256(self):
+        payload, _ = self.run_script(
+            runtime_eval_payload(),
+            "--full-depth-entry",
+            "--min-trade-count",
+            "2",
+            "--recording-path",
+            "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+            "--recording-sha256",
+            "",
+        )
+
+        self.assertFalse(payload["promotion_ready"])
+        self.assertIn("recording_sha256_missing", payload["blocking_risk_flags"])
+        self.assertIn("mutable_recording_without_sha256", payload["blocking_risk_flags"])
 
     def test_resolves_source_horizon_from_shared_catalog(self):
         payload, _ = self.run_script(

--- a/tests/test_factor_walk_forward_sweep.py
+++ b/tests/test_factor_walk_forward_sweep.py
@@ -110,6 +110,8 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                     "candidate_replay_id": "candidate_replay:fedcba98765432100123456789abcdef",
                     "identity": {
                         "basis": "runtime_market_update_replay",
+                        "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson",
+                        "recording_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
                         "runtime_score": runtime_score,
                         "strategy_profile": "settlement_probability",
                         "workflow_run_id": "26306734877",
@@ -120,6 +122,8 @@ class FactorWalkForwardSweepTests(unittest.TestCase):
                     "runtime_score": runtime_score,
                     "promotion_ready": True,
                     "promotion_decision": "promote_to_runtime",
+                    "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson",
+                    "recording_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
                     "source_workflow": "runtime-candidate-replay.yml",
                     "workflow_run_id": "26306734877",
                     "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26306734877",

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -295,6 +295,51 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         )
         self.assertEqual("tradeable_full_depth_settlement_pnl", options["allowed_target"])
 
+    def test_revise_prior_ignores_mutable_replay_without_recording_hash(self) -> None:
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+        )
+        plan["input"]["latest_runs"] = {
+            "runs": [
+                {
+                    "run_id": "26362501135",
+                    "artifacts": [
+                        {
+                            "output_json": {
+                                "candidate_strategy_replay": {
+                                    "basis": "runtime_market_update_replay",
+                                    "runtime_score": "autofactor_formula:stale_candidate",
+                                    "source_workflow": "runtime-candidate-replay.yml",
+                                    "workflow_run_id": "26355035577",
+                                    "strategy_profile": "settlement_probability",
+                                    "recording_path": "/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson",
+                                    "recording_sha256": "",
+                                    "decision_contract": {
+                                        "target": "tradeable_full_depth_settlement_pnl",
+                                        "horizon": "5m",
+                                    },
+                                }
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+
+        payload = build_executor_payload(
+            base_args(
+                mode="execute",
+                execute_ack=EXECUTE_ACK,
+                snapshot_run_id="26354463118",
+            ),
+            plan,
+        )
+
+        options = json.loads(payload["dispatches"][0]["fields"]["options_json"])
+        self.assertNotIn("candidate_strategy_replay_run_id", options)
+        self.assertNotIn("candidate_strategy_replay_artifact_name", options)
+
     def test_fix_runtime_plan_maps_to_candidate_replay_and_parity(self) -> None:
         payload = build_executor_payload(
             Namespace(


### PR DESCRIPTION
## Summary
- capture remote runtime replay recording SHA256/size/mtime in `runtime-candidate-replay.yml`
- pass recording SHA into the candidate replay builder and upload `recording-provenance.json`
- fail closed when mutable recording paths are missing immutable SHA provenance
- prevent promotion and Research Manager inference from reusing mutable active recordings without SHA

## Evidence Stage
`executable_replay` / replay provenance repair. This is not a dry-run or live promotion decision.

## Validation
- YAML parse: `.github/workflows/runtime-candidate-replay.yml`
- Python compile: touched scripts and tests
- `python3 -m unittest tests.test_build_runtime_candidate_strategy_replay tests.test_autofactor_strategy_promotion tests.test_research_manager_execute_plan` (64 tests)
- `rtk git diff --check`
- `rtk cargo test --locked --test workflow_security runtime_candidate -- --nocapture`

## Follow-up After Merge
Rerun `runtime-candidate-replay.yml` from `main` against `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.20260524T155939.ndjson` so the previously passing archived replay carries nonempty `recording_sha256`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording provenance validation now captures and validates recording SHA256 hashes for replay artifacts.

* **Improvements**
  * Enhanced error reporting with new blocking risk flags for missing recording metadata.
  * Mutable recordings without SHA256 verification are now blocked from processing.

* **Tests**
  * Added validation test coverage for recording provenance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->