### PR TITLE
Route ready Research Manager handoffs

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -391,6 +391,115 @@ def _recorded_replay_parity_dispatch(
     }
 
 
+def _ready_handoff_from_plan(plan_payload: dict[str, Any]) -> dict[str, str]:
+    latest_runs = ((plan_payload.get("input") or {}).get("latest_runs") or {})
+    runs = latest_runs.get("runs")
+    if not isinstance(runs, list):
+        return {}
+
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        run_id = str(run.get("run_id") or run.get("workflow_run_id") or "")
+        if not run_id:
+            continue
+        artifacts = run.get("artifacts")
+        if not isinstance(artifacts, list):
+            continue
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            output = artifact.get("output_json")
+            if not isinstance(output, dict):
+                continue
+            if output.get("kind") != "autofactor_strategy_handoff":
+                continue
+            if output.get("status") != "ready":
+                continue
+            if output.get("recommended_action") != "create_dry_run_handoff":
+                continue
+            strategies = output.get("strategies")
+            strategy = strategies[0] if isinstance(strategies, list) and strategies else {}
+            if not isinstance(strategy, dict):
+                strategy = {}
+            replay = output.get("candidate_strategy_replay")
+            if not isinstance(replay, dict):
+                replay = {}
+            contract = replay.get("decision_contract")
+            if not isinstance(contract, dict):
+                contract = {}
+
+            return {
+                "factor_walk_forward_run_id": run_id,
+                "artifact_name": f"factor-walk-forward-v2-{run_id}",
+                "required_strategy_profile": str(
+                    strategy.get("strategy_profile")
+                    or replay.get("strategy_profile")
+                    or "settlement_probability"
+                ),
+                "allowed_target": str(
+                    strategy.get("target")
+                    or contract.get("target")
+                    or "full_depth_settlement_executable_pnl"
+                ),
+                "runtime_score": str(
+                    strategy.get("runtime_score") or replay.get("runtime_score") or ""
+                ),
+                "strategy_config": (
+                    "config/strategies/"
+                    "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+                ),
+            }
+    return {}
+
+
+def _autofactor_promotion_handoff_dispatch(
+    *,
+    plan_payload: dict[str, Any],
+    git_ref: str,
+    create_handoff_issue: bool,
+    create_config_pr: bool,
+    issue_number: str,
+) -> dict[str, Any]:
+    ready_handoff = _ready_handoff_from_plan(plan_payload)
+    blockers: list[str] = []
+    if not ready_handoff:
+        blockers.append("missing_ready_autofactor_handoff")
+    if not create_handoff_issue and not create_config_pr:
+        blockers.append("missing_ready_handoff_side_effect")
+
+    fields = {
+        "git_ref": git_ref,
+        "factor_walk_forward_run_id": ready_handoff.get("factor_walk_forward_run_id", ""),
+        "artifact_name": ready_handoff.get("artifact_name", ""),
+        "required_strategy_profile": ready_handoff.get(
+            "required_strategy_profile",
+            "settlement_probability",
+        ),
+        "allowed_target": ready_handoff.get(
+            "allowed_target",
+            "full_depth_settlement_executable_pnl",
+        ),
+        "issue_number": issue_number,
+        "create_handoff_issue": "true" if create_handoff_issue else "false",
+        "create_config_pr": "true" if create_config_pr else "false",
+        "strategy_config": ready_handoff.get(
+            "strategy_config",
+            "config/strategies/"
+            "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+        ),
+        "fail_if_blocked": "true",
+    }
+    return {
+        "workflow": "autofactor-strategy-promotion.yml",
+        "reason": "execute ready AutoFactor handoff through durable trace-gated promotion workflow",
+        "ready": not blockers,
+        "blockers": blockers,
+        "fields": fields,
+        "runtime_score": ready_handoff.get("runtime_score", ""),
+    }
+
+
 def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -910,6 +1019,20 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                 deployment_id=args.runtime_deployment_id,
                 config_path=args.runtime_config_path,
                 recording_path=args.runtime_recording_path,
+                issue_number=args.runtime_issue_number,
+            )
+        )
+
+    if plan.get("theme") == "ready_handoff" or any(
+        action in {"create_dry_run_handoff_issue", "open_config_pr_from_ready_handoff"}
+        for action in actions
+    ):
+        dispatches.append(
+            _autofactor_promotion_handoff_dispatch(
+                plan_payload=plan_payload,
+                git_ref=args.git_ref,
+                create_handoff_issue="create_dry_run_handoff_issue" in actions,
+                create_config_pr="open_config_pr_from_ready_handoff" in actions,
                 issue_number=args.runtime_issue_number,
             )
         )

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,31 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Ready Handoff Executor Dispatch (2026-05-24)
+
+Evidence stage: `dry_run_candidate` handoff execution planning. This creates
+reviewable dry-run handoff issue/config PR work only; it does not deploy or
+enable live trading.
+
+### Tasks
+
+- [x] Verify post-deploy Research Trace Plan `26368346028` emits
+      `theme=ready_handoff` with actions `create_dry_run_handoff_issue` and
+      `open_config_pr_from_ready_handoff`.
+- [x] Confirm Research Manager executor did not previously map those actions
+      to a workflow dispatch.
+- [x] Add executor support that routes ready handoff actions through the
+      existing durable trace-gated `autofactor-strategy-promotion.yml` workflow.
+- [x] Validate the real plan artifact produces a ready dry-run handoff dispatch
+      for walk-forward run `26367562792`.
+
+### Review
+
+- 2026-05-24: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py`, real-plan dry-run rendering
+  against trace-plan `26368346028`, and `rtk git diff --check`.
+
 ## Current Session - Runtime Replay Recording Provenance (2026-05-24)
 
 Evidence stage: `executable_replay` / replay provenance repair. This is not a

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -477,6 +477,99 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             dispatch["fields"]["runtime_score"],
         )
 
+    def test_ready_handoff_maps_to_autofactor_promotion_side_effects(self) -> None:
+        plan = plan_payload(
+            "ready_handoff",
+            ["create_dry_run_handoff_issue", "open_config_pr_from_ready_handoff"],
+        )
+        plan["input"]["latest_runs"] = {
+            "runs": [
+                {
+                    "run_id": "26367562792",
+                    "artifacts": [
+                        {
+                            "output_json": {
+                                "kind": "autofactor_strategy_handoff",
+                                "status": "ready",
+                                "recommended_action": "create_dry_run_handoff",
+                                "strategies": [
+                                    {
+                                        "runtime_score": (
+                                            "autofactor_formula:"
+                                            "mut_auto_settlement_model_full_depth_"
+                                            "settlement_edge_x_capacity_spread_adjusted"
+                                        ),
+                                        "strategy_profile": "settlement_probability",
+                                        "target": "tradeable_full_depth_settlement_pnl",
+                                    }
+                                ],
+                                "candidate_strategy_replay": {
+                                    "basis": "runtime_market_update_replay",
+                                    "runtime_score": (
+                                        "autofactor_formula:"
+                                        "mut_auto_settlement_model_full_depth_"
+                                        "settlement_edge_x_capacity_spread_adjusted"
+                                    ),
+                                    "strategy_profile": "settlement_probability",
+                                    "decision_contract": {
+                                        "target": "tradeable_full_depth_settlement_pnl",
+                                        "horizon": "5m",
+                                    },
+                                },
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK),
+            plan,
+        )
+
+        self.assertEqual("execute", payload["mode"])
+        self.assertEqual(1, payload["executable_dispatch_count"])
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("autofactor-strategy-promotion.yml", dispatch["workflow"])
+        self.assertEqual("26367562792", dispatch["fields"]["factor_walk_forward_run_id"])
+        self.assertEqual(
+            "factor-walk-forward-v2-26367562792",
+            dispatch["fields"]["artifact_name"],
+        )
+        self.assertEqual(
+            "tradeable_full_depth_settlement_pnl",
+            dispatch["fields"]["allowed_target"],
+        )
+        self.assertEqual(
+            "settlement_probability",
+            dispatch["fields"]["required_strategy_profile"],
+        )
+        self.assertEqual("true", dispatch["fields"]["create_handoff_issue"])
+        self.assertEqual("true", dispatch["fields"]["create_config_pr"])
+        self.assertEqual("true", dispatch["fields"]["fail_if_blocked"])
+        self.assertEqual(
+            "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+            dispatch["fields"]["strategy_config"],
+        )
+
+    def test_ready_handoff_blocks_without_ready_source_artifact(self) -> None:
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK),
+            plan_payload(
+                "ready_handoff",
+                ["create_dry_run_handoff_issue", "open_config_pr_from_ready_handoff"],
+            ),
+        )
+
+        self.assertEqual(0, payload["executable_dispatch_count"])
+        self.assertEqual("autofactor-strategy-promotion.yml", payload["dispatches"][0]["workflow"])
+        self.assertIn(
+            "missing_ready_autofactor_handoff",
+            payload["blocked_dispatches"][0]["blockers"],
+        )
+
     def test_cli_writes_executor_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- teach Research Manager executor to turn ready_handoff plans into autofactor-strategy-promotion.yml dispatches
- preserve inferred walk-forward run, artifact, strategy profile, allowed target, and dry-run config path
- add regression coverage for ready handoff dispatch and fail-closed missing-source behavior

## Evidence stage
- dry_run_candidate handoff planning only; no deploy and no live trading path

## Tests
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- python3 scripts/research_manager_execute_plan.py --plan-json /tmp/ploy-trace-plan-26368346028/research-trace-plan-26368346028/research-trace-plan.json --output-dir /tmp/ploy-ready-handoff-executor --mode dry_run --git-ref main --snapshot-run-id 26354463118
- rtk git diff --check
- ruby -e "require \"yaml\"; YAML.load_file(".github/workflows/research-manager-execute-plan.yml"); YAML.load_file(".github/workflows/autofactor-strategy-promotion.yml"); puts "workflow yaml ok""

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AutoFactor strategy promotion through a ready handoff workflow, enabling automated dispatch triggering based on strategy readiness status.

* **Tests**
  * Added test coverage for ready handoff execution flow, validating workflow dispatch behavior and blocker handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->