### PR TITLE
Handle AutoFactor promotion PR policy blocks

### DIFF
--- a/.github/workflows/autofactor-strategy-promotion.yml
+++ b/.github/workflows/autofactor-strategy-promotion.yml
@@ -334,8 +334,30 @@ jobs:
             echo ""
             echo "This PR is generated from a ready handoff artifact. It does not deploy and does not enable live trading."
           } > artifacts/autofactor-config-handoff/pr-body.md
-          gh pr create \
+          pr_url_file="artifacts/autofactor-config-handoff/pr-create-result.txt"
+          if gh pr create \
             --base "${BASE_REF}" \
             --head "${branch}" \
             --title "${title}" \
-            --body-file artifacts/autofactor-config-handoff/pr-body.md
+            --body-file artifacts/autofactor-config-handoff/pr-body.md \
+            | tee "${pr_url_file}"; then
+            echo "Created config PR from ready AutoFactor handoff."
+          else
+            status=$?
+            manual_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/new/${branch}"
+            {
+              echo "Config branch was pushed, but automatic PR creation failed with exit code ${status}."
+              echo "Manual PR URL: ${manual_url}"
+              echo "This commonly happens when repository policy blocks pull requests created by GitHub Actions tokens."
+            } | tee "${pr_url_file}"
+            {
+              echo "### AutoFactor config PR creation"
+              echo ""
+              echo "Config branch was pushed: \`${branch}\`"
+              echo ""
+              echo "Automatic PR creation failed with exit code \`${status}\`."
+              echo "Manual PR URL: ${manual_url}"
+              echo ""
+              echo "The workflow result remains successful because the research artifact and reviewable branch were produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,6 +26,32 @@ enable live trading.
   tests/test_research_manager_execute_plan.py`, real-plan dry-run rendering
   against trace-plan `26368346028`, and `rtk git diff --check`.
 
+## Current Session - AutoFactor Promotion PR Fallback (2026-05-24)
+
+Evidence stage: `dry_run_candidate` handoff execution hardening. This keeps
+reviewable dry-run config branches from failing the workflow when repository
+policy blocks GitHub Actions from creating pull requests.
+
+### Tasks
+
+- [x] Dispatch Research Manager executor run `26368780915` from merged
+      `main`; verify it successfully dispatched `autofactor-strategy-promotion.yml`.
+- [x] Inspect promotion run `26368784765` and confirm handoff validation,
+      config update, and branch push succeeded, while `gh pr create` failed on
+      repository policy.
+- [x] Align standalone AutoFactor promotion with the hosted walk-forward
+      fallback: keep the pushed config branch as successful reviewable output
+      and write a manual PR URL when automatic PR creation is blocked.
+
+### Review
+
+- 2026-05-24: Promotion run `26368784765` pushed
+  `autofactor/handoff-26368784765` with runtime score
+  `autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`,
+  but failed with `GitHub Actions is not permitted to create or approve pull
+  requests`. The fallback patch changes this from a workflow failure into a
+  reviewable branch/manual-PR output.
+
 ## Current Session - Runtime Replay Recording Provenance (2026-05-24)
 
 Evidence stage: `executable_replay` / replay provenance repair. This is not a

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -220,6 +220,9 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "direct_db_debug=true|canonical_result=no|registry=runner-local|runner=self-hosted|runner=ploy-ci-1",
             "create_handoff_issue requires successful durable Research OS trace persistence.",
             "create_config_pr requires successful durable Research OS trace persistence.",
+            "Config branch was pushed, but automatic PR creation failed",
+            "Manual PR URL:",
+            "The workflow result remains successful because the research artifact and reviewable branch were produced.",
         ]
         for snippet in required_snippets:
             self.assertIn(snippet, workflow)


### PR DESCRIPTION
## Summary
- make standalone AutoFactor promotion match hosted walk-forward config PR fallback behavior
- keep pushed dry-run config branches as successful reviewable output when repository policy blocks GitHub Actions PR creation
- add contract coverage for the fallback summary/manual PR URL

## Evidence stage
- dry_run_candidate handoff execution hardening only; no deploy and no live trading path

## Tests
- python3 -m unittest tests.test_persist_research_trace_contract
- ruby -e "require \"yaml\"; YAML.load_file(".github/workflows/autofactor-strategy-promotion.yml"); puts "yaml ok""
- rtk git diff --check