### PR TITLE
Promote AutoFactor handoff into dry-run config

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -39,7 +39,7 @@ max_daily_trades = 50
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"
-three_layer_autofactor_runtime_score = "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025"
+three_layer_autofactor_runtime_score = "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
 three_layer_min_entry_score = 0.10
 three_layer_min_direction_prob = 0.56
 three_layer_min_distance_over_sigma = 0.30


### PR DESCRIPTION
# AutoFactor Config Handoff

This PR applies the ready AutoFactor handoff produced from Research Manager ready_handoff execution. It updates only the dry-run strategy runtime score and does not deploy or enable live trading.

Source evidence:
- Research Manager executor run: https://github.com/proerror77/ploy/actions/runs/26368780915
- AutoFactor promotion run: https://github.com/proerror77/ploy/actions/runs/26368784765
- Source hosted walk-forward run: https://github.com/proerror77/ploy/actions/runs/26367562792
- Runtime candidate replay run: https://github.com/proerror77/ploy/actions/runs/26367311478

Selected runtime score:
`autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`

Evidence stage: `dry_run_candidate` handoff config review only. After merge, sync/deploy must use the protected dry-run config sync workflow from `main`.