### PR TITLE
Share AutoFactor runtime contract catalog

### DIFF
--- a/config/autofactor_runtime_contract_catalog.json
+++ b/config/autofactor_runtime_contract_catalog.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "autofactor_runtime_contract_catalog.v1",
+  "research_input_mappings": {
+    "conservative_settlement_edge": {
+      "runtime_input_names": ["settlement_edge"],
+      "projection": "settlement_edge_projection"
+    },
+    "full_depth_settlement_edge": {
+      "runtime_input_names": ["settlement_edge"],
+      "projection": "settlement_edge_projection"
+    },
+    "model_conservative_settlement_edge": {
+      "runtime_input_names": ["settlement_edge"],
+      "projection": "settlement_edge_projection"
+    },
+    "model_full_depth_settlement_edge": {
+      "runtime_input_names": ["settlement_edge"],
+      "projection": "settlement_edge_projection"
+    },
+    "settlement_edge": {
+      "runtime_input_names": ["settlement_edge"],
+      "projection": "settlement_edge_projection"
+    },
+    "near_strike_score": {
+      "runtime_input_names": ["direction_sign", "distance_over_sigma"],
+      "projection": "runtime_near_strike_score"
+    },
+    "entry_capacity_score": {
+      "runtime_input_names": ["entry_capacity_ratio"],
+      "projection": "runtime_entry_capacity_score"
+    },
+    "full_depth_entry_fillable_gate": {
+      "runtime_input_names": ["entry_capacity_ratio"],
+      "projection": "runtime_full_depth_entry_gate"
+    },
+    "entry_price_quality_score": {
+      "runtime_input_names": ["entry_price"],
+      "projection": "runtime_entry_price_quality_score"
+    },
+    "external_move_since_poly_update": {
+      "runtime_input_names": ["direction_sign", "drift_30s"],
+      "projection": "runtime_side_drift_30s"
+    },
+    "cex_return_30s_side": {
+      "runtime_input_names": ["direction_sign", "drift_30s"],
+      "projection": "runtime_side_drift_30s"
+    },
+    "sigma_horizon_pos": {
+      "runtime_input_names": ["sigma_horizon"],
+      "projection": "runtime_sigma_horizon"
+    },
+    "poly_quote_age": {
+      "runtime_input_names": ["pm_lag_secs"],
+      "projection": "runtime_quote_age"
+    },
+    "side_spread": {
+      "runtime_input_names": ["side_spread"],
+      "projection": "runtime_native_input"
+    },
+    "entry_price": {
+      "runtime_input_names": ["entry_price"],
+      "projection": "runtime_native_input"
+    },
+    "distance_over_sigma": {
+      "runtime_input_names": ["distance_over_sigma"],
+      "projection": "runtime_native_input"
+    },
+    "direction_sign": {
+      "runtime_input_names": ["direction_sign"],
+      "projection": "runtime_native_input"
+    },
+    "drift_30s": {
+      "runtime_input_names": ["drift_30s"],
+      "projection": "runtime_native_input"
+    },
+    "sigma_horizon": {
+      "runtime_input_names": ["sigma_horizon"],
+      "projection": "runtime_native_input"
+    },
+    "entry_capacity_ratio": {
+      "runtime_input_names": ["entry_capacity_ratio"],
+      "projection": "runtime_native_input"
+    },
+    "pm_lag_secs": {
+      "runtime_input_names": ["pm_lag_secs"],
+      "projection": "runtime_native_input"
+    },
+    "external_pressure": {
+      "blocker": "runtime_input_semantics_mismatch:external_pressure"
+    },
+    "iv_change_1m": {
+      "blocker": "runtime_input_not_supplied:iv_change_1m"
+    }
+  },
+  "formula_blockers": [
+    {
+      "match": "prefix",
+      "value": "auto_settlement_bayes_",
+      "blocker": "runtime_contract_unmapped_bayes_formula"
+    },
+    {
+      "match": "prefix",
+      "value": "poly_lag_pressure",
+      "blocker": "runtime_input_semantics_mismatch:external_pressure"
+    },
+    {
+      "match": "contains",
+      "value": "external_pressure",
+      "blocker": "runtime_input_semantics_mismatch:external_pressure"
+    },
+    {
+      "match": "contains",
+      "value": "iv_change",
+      "blocker": "runtime_input_not_supplied:iv_change_1m"
+    }
+  ]
+}

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::autofactor::{
     AutoFactorDecision, AutoFactorOptions, AutoFactorReport, FactorExpr, LlmPriorSpec,
-    autofactor_target_horizon, factor_expr_hash,
+    autofactor_runtime_contract_catalog, autofactor_target_horizon, factor_expr_hash,
 };
 
 const ALPHA_SEARCH_ARTIFACT_VERSION: &str = "alpha_search_artifacts_v1";
@@ -293,7 +293,7 @@ struct FactorRegistryPreviewArtifact {
 struct RuntimeInputMapping {
     ast_input_name: String,
     runtime_input_names: Vec<String>,
-    projection: &'static str,
+    projection: String,
 }
 
 #[derive(Debug)]
@@ -756,72 +756,40 @@ fn runtime_input_projection(ast_input_names: &[String]) -> RuntimeInputProjectio
     }
 }
 
-fn runtime_input_mapping(input: &str) -> Result<(Vec<String>, &'static str), String> {
-    let runtime_inputs = match input {
-        "conservative_settlement_edge"
-        | "full_depth_settlement_edge"
-        | "model_conservative_settlement_edge"
-        | "model_full_depth_settlement_edge"
-        | "settlement_edge" => (
-            vec!["settlement_edge".to_string()],
-            "settlement_edge_projection",
-        ),
-        "near_strike_score" => (
-            vec![
-                "direction_sign".to_string(),
-                "distance_over_sigma".to_string(),
-            ],
-            "runtime_near_strike_score",
-        ),
-        "entry_capacity_score" => (
-            vec!["entry_capacity_ratio".to_string()],
-            "runtime_entry_capacity_score",
-        ),
-        "full_depth_entry_fillable_gate" => (
-            vec!["entry_capacity_ratio".to_string()],
-            "runtime_full_depth_entry_gate",
-        ),
-        "entry_price_quality_score" => (
-            vec!["entry_price".to_string()],
-            "runtime_entry_price_quality_score",
-        ),
-        "external_move_since_poly_update" | "cex_return_30s_side" => (
-            vec!["direction_sign".to_string(), "drift_30s".to_string()],
-            "runtime_side_drift_30s",
-        ),
-        "sigma_horizon_pos" => (vec!["sigma_horizon".to_string()], "runtime_sigma_horizon"),
-        "poly_quote_age" => (vec!["pm_lag_secs".to_string()], "runtime_quote_age"),
-        "side_spread"
-        | "entry_price"
-        | "distance_over_sigma"
-        | "direction_sign"
-        | "drift_30s"
-        | "sigma_horizon"
-        | "entry_capacity_ratio"
-        | "pm_lag_secs" => (vec![input.to_string()], "runtime_native_input"),
-        "external_pressure" => {
-            return Err("runtime_input_semantics_mismatch:external_pressure".to_string());
-        }
-        "iv_change_1m" => return Err("runtime_input_not_supplied:iv_change_1m".to_string()),
-        other => return Err(format!("runtime_input_unsupported:{other}")),
+fn runtime_input_mapping(input: &str) -> Result<(Vec<String>, String), String> {
+    let Some(contract) = autofactor_runtime_contract_catalog()
+        .research_input_mappings
+        .get(input)
+    else {
+        return Err(format!("runtime_input_unsupported:{input}"));
     };
-    Ok(runtime_inputs)
+    if let Some(blocker) = contract.blocker.as_deref() {
+        return Err(blocker.to_string());
+    }
+    if contract.runtime_input_names.is_empty() {
+        return Err(format!("runtime_input_unsupported:{input}"));
+    }
+    Ok((
+        contract.runtime_input_names.clone(),
+        contract
+            .projection
+            .clone()
+            .unwrap_or_else(|| "runtime_native_input".to_string()),
+    ))
 }
 
 fn runtime_formula_blockers(name: &str) -> Vec<String> {
     let normalized = normalized_factor_key(name);
     let mut blockers = Vec::new();
-    if normalized.starts_with("auto_settlement_bayes_") {
-        blockers.push("runtime_contract_unmapped_bayes_formula".to_string());
-    }
-    if normalized.starts_with("poly_lag_pressure") {
-        blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string());
-    }
-    if normalized.contains("external_pressure") {
-        blockers.push("runtime_input_semantics_mismatch:external_pressure".to_string());
-    }
-    if normalized.contains("iv_change") {
-        blockers.push("runtime_input_not_supplied:iv_change_1m".to_string());
+    for rule in &autofactor_runtime_contract_catalog().formula_blockers {
+        let matches = match rule.match_kind.as_str() {
+            "prefix" => normalized.starts_with(&rule.value),
+            "contains" => normalized.contains(&rule.value),
+            _ => false,
+        };
+        if matches {
+            blockers.push(rule.blocker.clone());
+        }
     }
     if is_predictive_formula_base(&normalized) && !is_predictive_settlement_formula(&normalized) {
         blockers.push("runtime_contract_unsupported_predictive_suffix".to_string());

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -23,8 +23,12 @@ const SELECTOR_GATE_FEATURES: [&str; 4] = [
 const ACCOUNTING_CATALOG_JSON: &str =
     include_str!("../../../config/autofactor_accounting_catalog.json");
 const ACCOUNTING_CATALOG_SCHEMA_VERSION: &str = "autofactor_accounting_catalog.v1";
+const RUNTIME_CONTRACT_CATALOG_JSON: &str =
+    include_str!("../../../config/autofactor_runtime_contract_catalog.json");
+const RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION: &str = "autofactor_runtime_contract_catalog.v1";
 
 static ACCOUNTING_CATALOG: OnceLock<AutoFactorAccountingCatalog> = OnceLock::new();
+static RUNTIME_CONTRACT_CATALOG: OnceLock<AutoFactorRuntimeContractCatalog> = OnceLock::new();
 
 #[derive(Debug, Clone, Deserialize)]
 struct AutoFactorAccountingCatalog {
@@ -43,6 +47,29 @@ pub struct AutoFactorTargetContract {
     pub full_depth_entry_required: bool,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoFactorRuntimeContractCatalog {
+    schema_version: String,
+    pub research_input_mappings: BTreeMap<String, AutoFactorRuntimeInputContract>,
+    pub formula_blockers: Vec<AutoFactorRuntimeFormulaBlocker>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoFactorRuntimeInputContract {
+    #[serde(default)]
+    pub runtime_input_names: Vec<String>,
+    pub projection: Option<String>,
+    pub blocker: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AutoFactorRuntimeFormulaBlocker {
+    #[serde(rename = "match")]
+    pub match_kind: String,
+    pub value: String,
+    pub blocker: String,
+}
+
 fn autofactor_accounting_catalog() -> &'static AutoFactorAccountingCatalog {
     ACCOUNTING_CATALOG.get_or_init(|| {
         let catalog: AutoFactorAccountingCatalog = serde_json::from_str(ACCOUNTING_CATALOG_JSON)
@@ -57,6 +84,19 @@ fn autofactor_accounting_catalog() -> &'static AutoFactorAccountingCatalog {
 
 pub fn autofactor_target_contract(target: &str) -> Option<&'static AutoFactorTargetContract> {
     autofactor_accounting_catalog().targets.get(target)
+}
+
+pub fn autofactor_runtime_contract_catalog() -> &'static AutoFactorRuntimeContractCatalog {
+    RUNTIME_CONTRACT_CATALOG.get_or_init(|| {
+        let catalog: AutoFactorRuntimeContractCatalog =
+            serde_json::from_str(RUNTIME_CONTRACT_CATALOG_JSON)
+                .expect("AutoFactor runtime contract catalog JSON must parse");
+        assert_eq!(
+            catalog.schema_version, RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION,
+            "unsupported AutoFactor runtime contract catalog schema"
+        );
+        catalog
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -3678,5 +3718,39 @@ mod tests {
         assert!(contract.full_depth_entry_required);
         assert_eq!(autofactor_target_horizon("experimental_target"), "unknown");
         assert!(autofactor_target_contract("experimental_target").is_none());
+    }
+
+    #[test]
+    fn autofactor_runtime_contract_catalog_covers_research_inputs_and_blockers() {
+        let catalog = autofactor_runtime_contract_catalog();
+        assert_eq!(
+            catalog.schema_version,
+            RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION
+        );
+        let near_strike = catalog
+            .research_input_mappings
+            .get("near_strike_score")
+            .expect("near strike mapping");
+        assert_eq!(
+            near_strike.runtime_input_names,
+            vec!["direction_sign", "distance_over_sigma"]
+        );
+        assert_eq!(
+            near_strike.projection.as_deref(),
+            Some("runtime_near_strike_score")
+        );
+        let external_pressure = catalog
+            .research_input_mappings
+            .get("external_pressure")
+            .expect("external pressure blocker");
+        assert_eq!(
+            external_pressure.blocker.as_deref(),
+            Some("runtime_input_semantics_mismatch:external_pressure")
+        );
+        assert!(catalog.formula_blockers.iter().any(|rule| {
+            rule.match_kind == "contains"
+                && rule.value == "iv_change"
+                && rule.blocker == "runtime_input_not_supplied:iv_change_1m"
+        }));
     }
 }

--- a/crates/ploy-research/src/lib.rs
+++ b/crates/ploy-research/src/lib.rs
@@ -92,12 +92,13 @@ pub use alpha_search::{
 };
 pub use attribution::{factor_pnl, regime_pnl, AttributionReport, RegimePnl};
 pub use autofactor::{
-    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_target_contract,
-    autofactor_target_horizon, autofactor_windows_from_v2, domain_seed_candidates,
-    evaluate_named_factor, format_autofactor_reports, mine_autofactors,
+    autofactor_labels_from_v2, autofactor_matrix_from_v2, autofactor_runtime_contract_catalog,
+    autofactor_target_contract, autofactor_target_horizon, autofactor_windows_from_v2,
+    domain_seed_candidates, evaluate_named_factor, format_autofactor_reports, mine_autofactors,
     mine_domain_autofactors_from_v2, mine_domain_autofactors_from_v2_with_guidance,
     mine_domain_autofactors_from_v2_with_mcts_plan, AutoFactorDecision, AutoFactorError,
-    AutoFactorMatrix, AutoFactorOptions, AutoFactorReport, AutoFactorTargetContract,
+    AutoFactorMatrix, AutoFactorOptions, AutoFactorReport, AutoFactorRuntimeContractCatalog,
+    AutoFactorRuntimeFormulaBlocker, AutoFactorRuntimeInputContract, AutoFactorTargetContract,
     AutoFactorV2Target, FactorExpr, LlmMutationSpec, LlmPriorSpec, NamedFactorExpr,
 };
 pub use backtest::{run_binary_backtest, BacktestMetrics, SimulatedFill};

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -145,6 +145,10 @@ When that preview is present, missing runtime contracts, contract blockers,
 unsupported inputs, semantic input mismatches, or placeholder runtime fields
 block promotion/replay handoff instead of falling back to factor-name
 inference.
+The cross-language runtime input mapping and formula-blocker rules live in
+`config/autofactor_runtime_contract_catalog.json`. Rust alpha-search and Python
+promotion/replay tooling must consume that catalog instead of maintaining
+separate runtime input allow/block lists.
 
 AutoFactor promotion and candidate replay must also consume the source
 snapshot manifest. If a `required_for_execution` surface is marked

--- a/scripts/autofactor_runtime_contract.py
+++ b/scripts/autofactor_runtime_contract.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,10 @@ SETTLEMENT_RUNTIME_MAPPING = {
     "strategy_profile": "settlement_probability",
     "strategy_family": "settlement_probability",
 }
+RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION = "autofactor_runtime_contract_catalog.v1"
+RUNTIME_CONTRACT_CATALOG_PATH = (
+    Path(__file__).resolve().parents[1] / "config" / "autofactor_runtime_contract_catalog.json"
+)
 
 PREDICTIVE_FORMULA_BASES = (
     "amplitude_weighted_momentum_30s_sigma",
@@ -85,29 +90,38 @@ for _base in SETTLEMENT_FORMULA_BASES:
         }
 
 
-SUPPORTED_RUNTIME_INPUT_NAMES = {
-    "conservative_settlement_edge",
-    "full_depth_settlement_edge",
-    "model_conservative_settlement_edge",
-    "model_full_depth_settlement_edge",
-    "settlement_edge",
-    "entry_price",
-    "distance_over_sigma",
-    "direction_sign",
-    "drift_30s",
-    "sigma_horizon",
-    "entry_capacity_ratio",
-    "side_spread",
-    "pm_lag_secs",
-}
+@lru_cache(maxsize=1)
+def load_runtime_contract_catalog() -> dict[str, Any]:
+    payload = json.loads(RUNTIME_CONTRACT_CATALOG_PATH.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported AutoFactor runtime contract catalog schema: "
+            f"{payload.get('schema_version')!r}"
+        )
+    mappings = payload.get("research_input_mappings")
+    if not isinstance(mappings, dict):
+        raise ValueError("AutoFactor runtime contract catalog missing research_input_mappings")
+    return payload
 
-# These fields exist in the Rust scoring struct, but the current runtime fills
-# them from non-equivalent or placeholder values. Treat them as blocked until
-# research and runtime share the same source definition.
-BLOCKED_RUNTIME_INPUT_NAMES = {
-    "external_pressure": "runtime_input_semantics_mismatch:external_pressure",
-    "iv_change_1m": "runtime_input_not_supplied:iv_change_1m",
-}
+
+def runtime_input_contract(input_name: str) -> dict[str, Any] | None:
+    contract = load_runtime_contract_catalog()["research_input_mappings"].get(input_name)
+    if not isinstance(contract, dict):
+        return None
+    return dict(contract)
+
+
+def runtime_contract_supported_runtime_inputs() -> set[str]:
+    supported: set[str] = set()
+    for raw_contract in load_runtime_contract_catalog()["research_input_mappings"].values():
+        if not isinstance(raw_contract, dict):
+            continue
+        if raw_contract.get("blocker"):
+            continue
+        runtime_names = raw_contract.get("runtime_input_names")
+        if isinstance(runtime_names, list):
+            supported.update(str(item) for item in runtime_names if str(item))
+    return supported
 
 
 def normalize_formula_name(name: str) -> str:
@@ -191,9 +205,16 @@ def inferred_runtime_mapping(name: str) -> dict[str, str] | None:
 def runtime_input_blockers(input_names: list[str]) -> list[str]:
     blockers: list[str] = []
     for name in sorted({str(item) for item in input_names if str(item)}):
-        if name in BLOCKED_RUNTIME_INPUT_NAMES:
-            blockers.append(BLOCKED_RUNTIME_INPUT_NAMES[name])
-        elif name not in SUPPORTED_RUNTIME_INPUT_NAMES:
+        contract = runtime_input_contract(name)
+        if contract is None:
+            blockers.append(f"runtime_input_unsupported:{name}")
+            continue
+        blocker = contract.get("blocker")
+        if blocker:
+            blockers.append(str(blocker))
+            continue
+        runtime_names = contract.get("runtime_input_names")
+        if not isinstance(runtime_names, list) or not runtime_names:
             blockers.append(f"runtime_input_unsupported:{name}")
     return blockers
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,6 +33,12 @@ does not claim strategy profitability or dry-run readiness.
   and `rtk git diff --check`. Whole-file `rustfmt --check` on
   `crates/ploy-research/src/autofactor.rs` still reports pre-existing formatting
   drift outside this patch, so it was not used as a completion gate.
+- 2026-05-25: PR CI exposed a separate mainline test drift after the dry-run
+  config was promoted to
+  `autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`.
+  Updated `tests/test_strategy_config_contracts.py` to assert the current
+  reviewed runtime score. Full legacy Python validation passed:
+  `python3 -m unittest discover -s tests -p 'test_*.py'` (`284` tests).
 
 ## Current Session - Ready Handoff Executor Dispatch (2026-05-24)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,39 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - AutoFactor Runtime Contract Catalog (2026-05-25)
+
+Evidence stage: `factor_attribution` / `runtime_parity` contract repair. This
+does not claim strategy profitability or dry-run readiness.
+
+### Tasks
+
+- [x] Verify current `main` already has durable `candidate_replay_tapes` and
+      Research Manager handoff execution, so this slice should not duplicate
+      that work.
+- [x] Add a shared AutoFactor runtime contract catalog for research input ->
+      runtime input projection and runtime blocker rules.
+- [x] Make Python promotion/replay helpers and Rust alpha-search consume the
+      shared catalog instead of mirrored input allow/block lists.
+- [x] Document the catalog as the source of truth for runtime input
+      canonicalization.
+- [x] Run focused Python/Rust validation.
+- [ ] Land through PR.
+
+### Review
+
+- 2026-05-25: Added `config/autofactor_runtime_contract_catalog.json` and made
+  Rust alpha-search plus Python promotion/replay validation consume it for
+  research-input projection and runtime-input blocker rules. Focused validation
+  passed:
+  `python3 -m unittest tests.test_autofactor_accounting_catalog tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay`,
+  `python3 -m unittest tests.test_persist_research_trace_contract tests.test_factor_research_os_registry`,
+  `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runtime-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research runtime_contract --lib`,
+  `CARGO_TARGET_DIR=/tmp/ploy-autofactor-runtime-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor_target_horizon_covers_repricing_and_settlement_catalog --lib`,
+  `rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs`,
+  and `rtk git diff --check`. Whole-file `rustfmt --check` on
+  `crates/ploy-research/src/autofactor.rs` still reports pre-existing formatting
+  drift outside this patch, so it was not used as a completion gate.
+
 ## Current Session - Ready Handoff Executor Dispatch (2026-05-24)
 
 Evidence stage: `dry_run_candidate` handoff execution planning. This creates

--- a/tests/test_autofactor_accounting_catalog.py
+++ b/tests/test_autofactor_accounting_catalog.py
@@ -8,10 +8,18 @@ from scripts.autofactor_accounting_catalog import (
     autofactor_target_horizon,
     validate_autofactor_source_contract,
 )
+from scripts.autofactor_runtime_contract import (
+    RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION,
+    load_runtime_contract_catalog,
+    runtime_contract_supported_runtime_inputs,
+    runtime_input_blockers,
+    runtime_input_contract,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 CATALOG = ROOT / "config" / "autofactor_accounting_catalog.json"
+RUNTIME_CONTRACT_CATALOG = ROOT / "config" / "autofactor_runtime_contract_catalog.json"
 
 
 class AutoFactorAccountingCatalogTest(unittest.TestCase):
@@ -50,6 +58,31 @@ class AutoFactorAccountingCatalogTest(unittest.TestCase):
         self.assertEqual(
             validate_autofactor_source_contract(target="experimental", horizon="5m"),
             ["unknown_source_target:experimental"],
+        )
+
+    def test_runtime_contract_catalog_is_shared_input_mapping_source(self) -> None:
+        payload = json.loads(RUNTIME_CONTRACT_CATALOG.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], RUNTIME_CONTRACT_CATALOG_SCHEMA_VERSION)
+        self.assertEqual(payload, load_runtime_contract_catalog())
+        self.assertEqual(
+            runtime_input_contract("near_strike_score"),
+            {
+                "runtime_input_names": ["direction_sign", "distance_over_sigma"],
+                "projection": "runtime_near_strike_score",
+            },
+        )
+        self.assertEqual(
+            runtime_input_contract("external_pressure"),
+            {"blocker": "runtime_input_semantics_mismatch:external_pressure"},
+        )
+        self.assertIn("settlement_edge", runtime_contract_supported_runtime_inputs())
+        self.assertIn("entry_capacity_ratio", runtime_contract_supported_runtime_inputs())
+        self.assertEqual(
+            runtime_input_blockers(["near_strike_score", "external_pressure", "iv_change_1m"]),
+            [
+                "runtime_input_semantics_mismatch:external_pressure",
+                "runtime_input_not_supplied:iv_change_1m",
+            ],
         )
 
 

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -82,7 +82,7 @@ class StrategyConfigContractTests(unittest.TestCase):
         self.assertEqual(strategy["three_layer_strategy_profile"], "settlement_probability")
         self.assertEqual(
             strategy["three_layer_autofactor_runtime_score"],
-            "autofactor_formula:mcts_mcts_spread_adjusted_external_move_select_entry_price_quality_ge_025_select_entry_capacity_ge_025",
+            "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
         )
         self.assertEqual(Decimal(str(strategy["three_layer_min_entry_score"])), Decimal("0.10"))
 


### PR DESCRIPTION
## Summary
- add a shared AutoFactor runtime contract catalog for research-input projection and runtime blocker rules
- make Rust alpha-search and Python promotion/replay validation consume the shared catalog
- document the catalog as the cross-language runtime input source of truth

## Evidence stage
factor_attribution / runtime_parity contract repair. This does not claim dry-run or live readiness.

## Tests
- python3 -m unittest tests.test_autofactor_accounting_catalog tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay
- python3 -m unittest tests.test_persist_research_trace_contract tests.test_factor_research_os_registry
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-runtime-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research runtime_contract --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-runtime-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research autofactor_target_horizon_covers_repricing_and_settlement_catalog --lib
- rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs
- rtk git diff --check

Note: whole-file rustfmt checks on ploy-research currently report pre-existing formatting drift outside this patch, so this PR avoids broad formatting churn.