### PR TITLE
Remove legacy PRD snapshot fallback

### DIFF
--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -39,8 +39,8 @@ exploration and CI evidence.
 The repo now has the core alpha-search factory, not only the downstream
 promotion half:
 
-- `factor-walk-forward-v2.yml`: self-hosted research path for fresh DB-adjacent
-  snapshot and walk-forward evidence.
+- `factor-walk-forward-v2.yml`: router-only compatibility entrypoint that
+  requires `snapshot_run_id` and forwards to the hosted artifact workflow.
 - `factor-walk-forward-v2-hosted-artifact.yml`: GitHub-hosted path that consumes
   a retained complete sampled research snapshot artifact, emits alpha-search artifacts, and
   can chain bounded follow-up search runs.
@@ -348,8 +348,9 @@ dimension such as capacity, stability, or overfit risk.
 
 - `factor-walk-forward-v2-hosted-artifact.yml` should be the default efficient
   search surface once a complete sampled snapshot artifact exists.
-- `factor-walk-forward-v2.yml` should be used when a fresh DB-adjacent snapshot
-  or data audit is required.
+- `factor-walk-forward-v2.yml` is retained only as a snapshot-backed router.
+  Build or select a retained `research-snapshot.yml` artifact first, then pass
+  `snapshot_run_id` so the hosted artifact workflow performs the search.
 - `pm5d-execution` settlement-probability searches should not require Deribit by
   default. Use `options_json.require_deribit=true` only when the hypothesis
   explicitly depends on the `pm5d-vol`/Deribit surface.

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -89,7 +89,9 @@ promotion-safe evidence path instead.
   Artifact-backed research starts with `research-snapshot.yml`, routes through
   hosted factor review/walk-forward workflows, persists Research OS trace, and
   lets `research-trace-plan.yml` produce the next bounded research action.
-- Treat `--allow-direct-db-debug` and `--allow-legacy-snapshot-build` as
-  audited manual exceptions. They may reproduce old evidence or debug a data
-  incident, but they must not feed promotion, handoff issues, config PRs, or
-  Research Manager "ready" decisions.
+- Treat `--allow-direct-db-debug` as an audited manual exception. It may
+  reproduce old evidence or debug a data incident, but it must not feed
+  promotion, handoff issues, config PRs, or Research Manager "ready" decisions.
+- The old `--allow-legacy-snapshot-build` PRD-gate exception has been removed.
+  Build or select retained `research-snapshot.yml` artifacts explicitly before
+  dispatching promotion or handoff gates.

--- a/docs/runbooks/event-ml-automl-workflow.md
+++ b/docs/runbooks/event-ml-automl-workflow.md
@@ -378,8 +378,8 @@ The gate requires `snapshot_run_id` by default and dispatches
 `factor-walk-forward-v2-hosted-artifact.yml` on `ubuntu-latest`. If
 `snapshot_run_id` is omitted, the orchestrator fails before dispatch instead of
 falling back to the legacy DB-adjacent `research-snapshot.yml` path. Direct CLI
-callers can still use `--allow-legacy-snapshot-build` as a manual exception
-while snapshot export is moved to a hosted-safe data source.
+callers must build or select a retained `research-snapshot.yml` artifact first;
+the PRD gate no longer has a legacy snapshot-build exception.
 When replay parity evidence uses a non-default artifact name, encode the input
 as `replay_parity_run_id=<run-id>:<artifact-name>` so the workflow stays within
 GitHub's 10-input dispatch limit.

--- a/scripts/run_settlement_probability_prd_gate.py
+++ b/scripts/run_settlement_probability_prd_gate.py
@@ -4,8 +4,7 @@
 The default gate is intentionally strict:
 
 1. Reuse a retained complete sampled research snapshot artifact supplied with
-   --snapshot-run-id. The legacy pm5d-vol snapshot build path is an explicit
-   manual exception, not the default PRD gate.
+   --snapshot-run-id.
 2. Feed that snapshot artifact into the GitHub-hosted Factor Walk-Forward V2
    artifact workflow.
 3. Optionally attach a replay/dry-run parity artifact to the promotion gate.
@@ -39,7 +38,6 @@ except ModuleNotFoundError:  # unittest imports this file as scripts.<module>.
     from scripts.validate_autofactor_handoff_replay_gate import validate_handoff_payload
 
 
-RESEARCH_SNAPSHOT_WORKFLOW = "research-snapshot.yml"
 HOSTED_WALK_FORWARD_WORKFLOW = "factor-walk-forward-v2-hosted-artifact.yml"
 
 
@@ -312,14 +310,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--allow-legacy-snapshot-build",
-        action="store_true",
-        help=(
-            "Manual exception only: build a legacy pm5d-vol snapshot when no "
-            "--snapshot-run-id is supplied."
-        ),
-    )
-    parser.add_argument(
         "--snapshot-artifact-name",
         default="",
         help="Optional snapshot artifact name; defaults to research-snapshot-<snapshot-run-id>",
@@ -337,22 +327,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--lob-sample-secs",
         default="",
-        help="Override LOB sampling seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+        help="Override LOB sampling seconds; empty inherits the existing snapshot manifest",
     )
     parser.add_argument(
         "--pm-book-sample-secs",
         default="",
-        help="Override PM full-book sampling seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+        help="Override PM full-book sampling seconds; empty inherits the existing snapshot manifest",
     )
     parser.add_argument(
         "--observation-sample-secs",
         default="",
-        help="Override observation sampling seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+        help="Override observation sampling seconds; empty inherits the existing snapshot manifest",
     )
     parser.add_argument(
         "--max-quote-age-secs",
         default="",
-        help="Override quote-age seconds; empty inherits an existing snapshot manifest or uses 30 for new snapshots",
+        help="Override quote-age seconds; empty inherits the existing snapshot manifest",
     )
     parser.add_argument("--train-window-days", default="2")
     parser.add_argument("--test-window-days", default="1")
@@ -362,10 +352,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--top-n", default="20")
     parser.add_argument("--replay-parity-run-id", default="")
     parser.add_argument("--replay-parity-artifact-name", default="")
-    parser.add_argument("--snapshot-timeout-minutes", type=int, default=180)
     parser.add_argument("--walk-timeout-minutes", type=int, default=120)
     parser.add_argument("--poll-seconds", type=int, default=30)
-    parser.add_argument("--no-wait", action="store_true", help="Dispatch the snapshot only and return")
+    parser.add_argument("--no-wait", action="store_true", help="Dispatch walk-forward and return")
     parser.add_argument("--dry-run", action="store_true", help="Print workflow dispatches without running them")
     return parser.parse_args()
 
@@ -374,7 +363,6 @@ def main() -> int:
     args = parse_args()
     git_ref = args.git_ref or git_branch()
     rust_data_quality_mode = args.data_quality_mode.replace("-", "_")
-    snapshot_data_gate = "critical" if args.data_quality_mode == "strict-continuous" else "never"
     replay_parity_run_id, replay_parity_artifact_name = split_replay_parity_input(
         args.replay_parity_run_id,
         args.replay_parity_artifact_name,
@@ -388,85 +376,18 @@ def main() -> int:
             flush=True,
         )
     else:
-        if not args.allow_legacy_snapshot_build:
-            message = "\n".join(
-                [
-                    "Settlement probability PRD gate blocked before dispatch:",
-                    "",
-                    "- Missing required `--snapshot-run-id` for a retained complete sampled research snapshot.",
-                    "- The legacy pm5d-vol snapshot build path is disabled by default.",
-                    "- Decision: dispatch or select a research-snapshot artifact first, then rerun the PRD gate.",
-                ]
-            )
-            print(message, flush=True)
-            issue_comment(args.issue_number, message, dry_run=args.dry_run)
-            return 2
-        snapshot_options = {
-            "lob_sample_secs": int(args.lob_sample_secs or "30"),
-            "pm_book_sample_secs": int(args.pm_book_sample_secs or "30"),
-            "observation_sample_secs": int(args.observation_sample_secs or "30"),
-            "max_quote_age_secs": int(args.max_quote_age_secs or "30"),
-            "optimizer_data_dir": "/tmp/ploy-parquet",
-            "data_profile": "pm5d-vol",
-            "custom_required_sources": "",
-            "audit_lookback_hours": int(args.audit_lookback_hours),
-            "data_gate": snapshot_data_gate,
-            "snapshot_registry_dir": "",
-            "upload_sampled_snapshot": True,
-        }
-        snapshot_fields = {
-            "git_ref": git_ref,
-            "start_date": args.start_date,
-            "end_date": args.end_date,
-            "symbols": args.symbols,
-            "stake_usd": args.stake_usd,
-            "options_json": compact_json(snapshot_options),
-        }
-
-        print(
-            "No snapshot_run_id supplied; dispatching legacy pm5d-vol research "
-            f"snapshot gate data_quality_mode={args.data_quality_mode} "
-            f"snapshot_data_gate={snapshot_data_gate}.",
-            flush=True,
+        message = "\n".join(
+            [
+                "Settlement probability PRD gate blocked before dispatch:",
+                "",
+                "- Missing required `--snapshot-run-id` for a retained complete sampled research snapshot.",
+                "- Legacy pm5d-vol snapshot build fallback has been removed from this gate.",
+                "- Decision: dispatch or select a research-snapshot artifact first, then rerun the PRD gate.",
+            ]
         )
-        snapshot_run = dispatch_workflow(
-            RESEARCH_SNAPSHOT_WORKFLOW,
-            snapshot_fields,
-            workflow_ref=git_ref,
-            dry_run=args.dry_run,
-        )
-        if args.dry_run:
-            return 0
-        if snapshot_run is None:
-            raise RuntimeError("snapshot dispatch did not return a run")
-        print(f"snapshot_run_id={snapshot_run.database_id} url={snapshot_run.url}", flush=True)
-        if args.no_wait:
-            return 0
-
-        snapshot_result = wait_for_run(
-            snapshot_run,
-            timeout_minutes=args.snapshot_timeout_minutes,
-            poll_seconds=args.poll_seconds,
-        )
-        if snapshot_result.conclusion != "success":
-            issue_comment(
-                args.issue_number,
-                "\n".join(
-                    [
-                        "Settlement probability PRD gate blocked at legacy snapshot build:",
-                        "",
-                        f"- Snapshot run: {snapshot_result.url}",
-                        f"- Conclusion: `{snapshot_result.conclusion}`",
-                        f"- Data profile: `pm5d-vol`",
-                        f"- Data quality mode: `{args.data_quality_mode}`",
-                        f"- Snapshot data gate: `{snapshot_data_gate}`",
-                        f"- Lookback: `{args.audit_lookback_hours}h`",
-                        "- Decision: provide an existing complete sampled snapshot artifact or inspect snapshot compilation/data coverage before promotion.",
-                    ]
-                ),
-                dry_run=False,
-            )
-            return 1
+        print(message, flush=True)
+        issue_comment(args.issue_number, message, dry_run=args.dry_run)
+        return 2
 
     walk_options = {
         "train_window_days": int(args.train_window_days),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17,7 +17,7 @@ does not claim strategy profitability or dry-run readiness.
 - [x] Document the catalog as the source of truth for runtime input
       canonicalization.
 - [x] Run focused Python/Rust validation.
-- [ ] Land through PR.
+- [x] Land through PR.
 
 ### Review
 
@@ -39,6 +39,56 @@ does not claim strategy profitability or dry-run readiness.
   Updated `tests/test_strategy_config_contracts.py` to assert the current
   reviewed runtime score. Full legacy Python validation passed:
   `python3 -m unittest discover -s tests -p 'test_*.py'` (`284` tests).
+- 2026-05-25: PR #685 merged to `main` as
+  `d2ed71b9 Share AutoFactor runtime contract catalog (#685)`. Main Test run
+  `26369527506` passed.
+
+## Current Session - Legacy Research Cleanup (2026-05-25)
+
+Evidence stage: `diagnostic` / architecture cleanup. This removes legacy
+control-plane fallback paths; it is not strategy profitability, dry-run, or
+live-promotion evidence.
+
+### Scope
+
+- `scripts/run_settlement_probability_prd_gate.py`
+  - Owner: settlement-probability PRD gate orchestration.
+- `tests/test_settlement_probability_prd_gate.py`
+  - Owner: fail-closed regression coverage for retained snapshot requirement.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`,
+  `docs/runbooks/event-ml-automl-workflow.md`,
+  `docs/operations/data-jobs-inventory.md`
+  - Owner: remove stale legacy snapshot-build guidance.
+- `tasks/todo.md`
+  - Owner: session tracking and review evidence.
+
+### Tasks
+
+- [x] Confirm project semantics and Event ML / AutoFactor gate ordering.
+- [x] Re-scan current `main` for legacy research cleanup candidates.
+- [x] Remove the settlement-probability PRD gate's legacy snapshot-build
+      exception.
+- [x] Update docs so retained snapshot artifacts are the only PRD gate input
+      path.
+- [x] Run focused regression validation.
+
+### Review
+
+- 2026-05-25: Removed `--allow-legacy-snapshot-build` from
+  `scripts/run_settlement_probability_prd_gate.py`. Missing `--snapshot-run-id`
+  now always fails before dispatch, and the gate no longer dispatches
+  `research-snapshot.yml` as a fallback. Focused validation passed:
+  `python3 -m unittest tests.test_settlement_probability_prd_gate` and
+  `python3 -m py_compile scripts/run_settlement_probability_prd_gate.py
+  tests/test_settlement_probability_prd_gate.py`.
+- 2026-05-25: Agent-team review found no issues in the cleanup diff. Additional
+  validation passed:
+  `python3 -m unittest tests.test_settlement_probability_prd_gate
+  tests.test_persist_research_trace_contract`, Ruby YAML parse for
+  `settlement-probability-prd-gate.yml`,
+  `CARGO_TARGET_DIR=/tmp/ploy-legacy-cleanup-target /opt/homebrew/bin/timeout
+  300 rtk cargo test --locked --test workflow_security`, and
+  `rtk git diff --check`.
 
 ## Current Session - Ready Handoff Executor Dispatch (2026-05-24)
 
@@ -1670,6 +1720,8 @@ evidence is supplied.
 - [x] Reproduce the hosted failure as a snapshot contract mismatch.
 - [x] Leave snapshot-bound sampling options empty for retained snapshot runs.
 - [x] Keep legacy snapshot builds on explicit 30-second sampling defaults.
+      Superseded on 2026-05-25: the PRD gate's legacy snapshot-build exception
+      was removed, so retained snapshots are now required.
 - [x] Run focused validation.
 - [x] Commit, push, merge, and rerun the PRD gate from `main`.
 
@@ -1681,8 +1733,8 @@ evidence is supplied.
   those fields, causing hosted factor walk-forward run `26305481049` to fail
   closed before strategy evaluation. The fix keeps those options blank when an
   existing snapshot is supplied so the hosted workflow can resolve them from
-  `artifacts/research-snapshot/manifest.json`; legacy snapshot creation still
-  materializes the historical 30-second defaults.
+  `artifacts/research-snapshot/manifest.json`. The old legacy snapshot-creation
+  exception was later removed from the PRD gate on 2026-05-25.
 - 2026-05-23: Focused validation passed:
   `python3 -m unittest discover -s tests -p 'test_settlement_probability_prd_gate.py'`,
   `python3 -m py_compile scripts/run_settlement_probability_prd_gate.py tests/test_settlement_probability_prd_gate.py`,
@@ -6387,7 +6439,7 @@ evidence comes from Polymarket full CLOB depth, not top book.
 - [x] Route legacy snapshot-backed Factor Review V2 / Factor Walk-Forward V2
   workflow dispatches to GitHub-hosted artifact workflows. Direct
   `snapshot_run_id` requests now skip `ploy-ci-1`; the self-hosted branch is
-  retained only for fresh DB/private-network snapshot export.
+  retained only for fail-closed router compatibility.
 
 ## Review
 

--- a/tests/test_settlement_probability_prd_gate.py
+++ b/tests/test_settlement_probability_prd_gate.py
@@ -127,15 +127,12 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
         self.assertEqual(status, 2)
         self.assertEqual(dispatches, [])
 
-    def test_explicit_legacy_snapshot_build_keeps_default_sampling_values(self):
-        dispatches = []
-
-        def capture_dispatch(workflow, fields, *, workflow_ref, dry_run):
-            dispatches.append((workflow, fields, workflow_ref, dry_run))
-            return None
-
-        status = self.run_main(
+    def test_legacy_snapshot_build_flag_is_removed(self):
+        with mock.patch.object(
+            sys,
+            "argv",
             [
+                "run_settlement_probability_prd_gate.py",
                 "--git-ref",
                 "main",
                 "--start-date",
@@ -145,20 +142,9 @@ class SettlementProbabilityPrdGateTests(unittest.TestCase):
                 "--allow-legacy-snapshot-build",
                 "--dry-run",
             ],
-            dispatch=capture_dispatch,
-        )
-
-        self.assertEqual(status, 0)
-        self.assertEqual(len(dispatches), 1)
-        workflow, fields, _, _ = dispatches[0]
-        self.assertEqual(workflow, gate.RESEARCH_SNAPSHOT_WORKFLOW)
-        options = json.loads(fields["options_json"])
-        self.assertEqual(options["lob_sample_secs"], 30)
-        self.assertEqual(options["pm_book_sample_secs"], 30)
-        self.assertEqual(options["observation_sample_secs"], 30)
-        self.assertEqual(options["max_quote_age_secs"], 30)
-        self.assertTrue(options["upload_sampled_snapshot"])
-        self.assertNotIn("upload_full_snapshot", options)
+        ):
+            with self.assertRaises(SystemExit):
+                gate.parse_args()
 
     def test_workflow_requires_snapshot_and_does_not_expose_legacy_build(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove the settlement-probability PRD gate's legacy snapshot-build fallback
- keep retained snapshot artifacts as the only PRD gate input path
- update tests and docs to match the fail-closed architecture

## Evidence stage
- diagnostic / architecture cleanup only; this is not strategy profitability, dry-run, or live-promotion evidence

## Validation
- python3 -m unittest tests.test_settlement_probability_prd_gate
- python3 -m unittest tests.test_settlement_probability_prd_gate tests.test_persist_research_trace_contract
- python3 -m py_compile scripts/run_settlement_probability_prd_gate.py tests/test_settlement_probability_prd_gate.py
- ruby -e 'require yaml; YAML.load_file(.github/workflows/settlement-probability-prd-gate.yml); puts ok'
- CARGO_TARGET_DIR=/tmp/ploy-legacy-cleanup-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security
- rtk git diff --check