### PR TITLE
Persist full-depth execution surfaces

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -55,6 +55,7 @@ env:
     044_candidate_replay_tapes.sql
     045_candidate_replay_basis_stage_constraint.sql
     046_factor_registry_blockers.sql
+    047_full_depth_execution_surfaces.sql
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -603,6 +603,10 @@ jobs:
           if [ -z "${candidate_strategy_replay_json}" ]; then
             candidate_strategy_replay_json="$(find artifacts/factor-walk-forward-v2 -name 'candidate-strategy-replay.json' -print -quit 2>/dev/null || true)"
           fi
+          full_depth_execution_surface_json="${WALK_FULL_DEPTH_EXECUTION_SURFACE_JSON:-}"
+          if [ -z "${full_depth_execution_surface_json}" ] && [ -f artifacts/full-depth-execution-surface/full-depth-execution-surface.json ]; then
+            full_depth_execution_surface_json="artifacts/full-depth-execution-surface/full-depth-execution-surface.json"
+          fi
           if [ -d artifacts/factor-walk-forward-v2/alpha-search ]; then
             trace_args+=(--alpha-search-dir artifacts/factor-walk-forward-v2/alpha-search)
           fi
@@ -617,6 +621,9 @@ jobs:
           fi
           if [ -n "${candidate_strategy_replay_json}" ] && [ -f "${candidate_strategy_replay_json}" ]; then
             trace_args+=(--candidate-replay-json "${candidate_strategy_replay_json}")
+          fi
+          if [ -n "${full_depth_execution_surface_json}" ] && [ -f "${full_depth_execution_surface_json}" ]; then
+            trace_args+=(--full-depth-execution-surface-json "${full_depth_execution_surface_json}")
           fi
 
           case "${db_host}" in
@@ -673,6 +680,11 @@ jobs:
                 cp "${candidate_strategy_replay_json}" \
                   /tmp/research-trace-input/candidate-strategy-replay/candidate-strategy-replay.json
               fi
+              if [ -n "${full_depth_execution_surface_json}" ] && [ -f "${full_depth_execution_surface_json}" ]; then
+                mkdir -p /tmp/research-trace-input/full-depth-execution-surface
+                cp "${full_depth_execution_surface_json}" \
+                  /tmp/research-trace-input/full-depth-execution-surface/full-depth-execution-surface.json
+              fi
               tar -C /tmp/research-trace-input -cf /tmp/research-trace-input.tar .
               # shellcheck disable=SC2029
               ssh tango-1-1 "rm -rf '${remote_dir}' && mkdir -p '${remote_dir}'"
@@ -705,6 +717,9 @@ jobs:
           fi
           if [ -f "${remote_dir}/candidate-strategy-replay/candidate-strategy-replay.json" ]; then
             trace_args+=(--candidate-replay-json "${remote_dir}/candidate-strategy-replay/candidate-strategy-replay.json")
+          fi
+          if [ -f "${remote_dir}/full-depth-execution-surface/full-depth-execution-surface.json" ]; then
+            trace_args+=(--full-depth-execution-surface-json "${remote_dir}/full-depth-execution-surface/full-depth-execution-surface.json")
           fi
           DATABASE_URL="${db_url}" "${persist_bin}" "${trace_args[@]}"
           EOF

--- a/crates/ploy-research/examples/persist_research_trace.rs
+++ b/crates/ploy-research/examples/persist_research_trace.rs
@@ -34,6 +34,7 @@ struct TracePlan {
     promotion_json: Option<PathBuf>,
     handoff_json: Option<PathBuf>,
     candidate_replay_jsons: Vec<PathBuf>,
+    full_depth_execution_surface_jsons: Vec<PathBuf>,
     dry_run: bool,
 }
 
@@ -115,6 +116,33 @@ struct CandidateReplayTapeRow {
 }
 
 #[derive(Debug, Clone)]
+struct FullDepthExecutionSurfaceRow {
+    full_depth_execution_surface_id: String,
+    run_id: String,
+    source_workflow: String,
+    workflow_run_id: Option<String>,
+    workflow_run_url: Option<String>,
+    artifact_name: Option<String>,
+    artifact_sha256: String,
+    artifact_json: Value,
+    schema_version: String,
+    surface: String,
+    source: String,
+    data_snapshot_id: String,
+    window_start_ts: DateTime<Utc>,
+    window_end_ts: DateTime<Utc>,
+    checked_hours: i64,
+    existing_hours: i64,
+    exported_hours: i64,
+    row_count: i64,
+    full_fidelity: bool,
+    incomplete: bool,
+    valid: bool,
+    blockers_json: Value,
+    artifact_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
 struct ArtifactTrace {
     event_type: String,
     artifact_path: PathBuf,
@@ -160,7 +188,7 @@ fn flag_present(args: &[String], flag: &str) -> bool {
 }
 
 fn usage() -> &'static str {
-    "usage: persist_research_trace --run-id <id> --snapshot-dir <dir> [--db-url <url>|DATABASE_URL] [--alpha-search-dir <dir>] [--registry-json <path>] [--promotion-json <path>] [--handoff-json <path>] [--candidate-replay-json <path>...] [--dry-run]"
+    "usage: persist_research_trace --run-id <id> --snapshot-dir <dir> [--db-url <url>|DATABASE_URL] [--alpha-search-dir <dir>] [--registry-json <path>] [--promotion-json <path>] [--handoff-json <path>] [--candidate-replay-json <path>...] [--full-depth-execution-surface-json <path>...] [--dry-run]"
 }
 
 fn parse_args(args: &[String]) -> Result<TracePlan> {
@@ -178,6 +206,13 @@ fn parse_args(args: &[String]) -> Result<TracePlan> {
             .into_iter()
             .map(PathBuf::from)
             .collect(),
+        full_depth_execution_surface_jsons: flag_values(
+            args,
+            "--full-depth-execution-surface-json",
+        )
+        .into_iter()
+        .map(PathBuf::from)
+        .collect(),
         dry_run: flag_present(args, "--dry-run"),
     })
 }
@@ -191,14 +226,16 @@ async fn main() -> Result<()> {
     let traces = collect_artifact_traces(&plan)?;
     let factor_rows = collect_factor_preview_rows(&plan)?;
     let candidate_replay_rows = collect_candidate_replay_rows(&plan, &dataset)?;
+    let full_depth_surface_rows = collect_full_depth_execution_surface_rows(&plan, &dataset)?;
 
     eprintln!(
-        "persist_research_trace: run_id={} snapshot={} factors={} candidate_replays={} traces={} dry_run={}",
+        "persist_research_trace: run_id={} snapshot={} factors={} candidate_replays={} full_depth_surfaces={} traces={} dry_run={}",
         plan.run_id,
         dataset.data_snapshot_id,
         factor_rows.len(),
         candidate_replay_rows.len(),
-        traces.len() + candidate_replay_rows.len() + 1,
+        full_depth_surface_rows.len(),
+        traces.len() + candidate_replay_rows.len() + full_depth_surface_rows.len() + 1,
         plan.dry_run
     );
 
@@ -224,11 +261,15 @@ async fn main() -> Result<()> {
         upsert_candidate_replay_tape(&pool, replay).await?;
         upsert_candidate_replay_evaluation(&pool, replay).await?;
     }
+    for surface in &full_depth_surface_rows {
+        upsert_full_depth_execution_surface(&pool, surface).await?;
+    }
 
     append_experiment_trace(
         &pool,
         &plan.run_id,
         Some(&dataset.data_snapshot_id),
+        None,
         None,
         None,
         "research_snapshot_manifest",
@@ -244,6 +285,7 @@ async fn main() -> Result<()> {
             &pool,
             &plan.run_id,
             Some(&dataset.data_snapshot_id),
+            None,
             None,
             None,
             &trace.event_type,
@@ -262,12 +304,34 @@ async fn main() -> Result<()> {
             Some(&dataset.data_snapshot_id),
             replay.dsl_hash.as_deref(),
             Some(&replay.candidate_replay_id),
+            None,
             "candidate_replay_tape",
             "candidate_replay_tape",
             &replay.evidence_stage,
             Some(&replay.promotion_decision),
             &replay.artifact_path,
             &replay.artifact_json,
+        )
+        .await?;
+    }
+    for surface in &full_depth_surface_rows {
+        append_experiment_trace(
+            &pool,
+            &plan.run_id,
+            Some(&dataset.data_snapshot_id),
+            None,
+            None,
+            Some(&surface.full_depth_execution_surface_id),
+            "full_depth_execution_surface",
+            "full_depth_execution_surface",
+            "executable_replay",
+            if surface.valid {
+                Some("continue")
+            } else {
+                Some("blocked")
+            },
+            &surface.artifact_path,
+            &surface.artifact_json,
         )
         .await?;
     }
@@ -522,6 +586,124 @@ fn candidate_replay_row(
     })
 }
 
+fn collect_full_depth_execution_surface_rows(
+    plan: &TracePlan,
+    dataset: &DatasetSnapshotRow,
+) -> Result<Vec<FullDepthExecutionSurfaceRow>> {
+    let mut rows = Vec::new();
+    for path in &plan.full_depth_execution_surface_jsons {
+        rows.push(full_depth_execution_surface_row(plan, dataset, path)?);
+    }
+    rows.sort_by(|left, right| {
+        left.full_depth_execution_surface_id
+            .cmp(&right.full_depth_execution_surface_id)
+    });
+    Ok(rows)
+}
+
+fn full_depth_execution_surface_row(
+    plan: &TracePlan,
+    dataset: &DatasetSnapshotRow,
+    path: &Path,
+) -> Result<FullDepthExecutionSurfaceRow> {
+    let artifact_json: Value = read_json(path)?;
+    let artifact_sha256 = file_sha256(path)?;
+    let schema_version =
+        string_field(&artifact_json, "schema_version").unwrap_or_else(|| "".to_string());
+    let surface = string_field(&artifact_json, "surface").unwrap_or_default();
+    let source = string_field(&artifact_json, "source").unwrap_or_else(|| "unknown".to_string());
+    let window_start_ts = timestamp_field(&artifact_json, "start_ts")
+        .or_else(|| timestamp_field(&artifact_json, "start"))
+        .with_context(|| format!("{} missing start_ts", path.display()))?;
+    let window_end_ts = timestamp_field(&artifact_json, "end_ts")
+        .or_else(|| timestamp_field(&artifact_json, "end"))
+        .with_context(|| format!("{} missing end_ts", path.display()))?;
+    let checked_hours = integer_field(&artifact_json, "checked_hours").unwrap_or(0);
+    let existing_hours = integer_field(&artifact_json, "existing_hours").unwrap_or(0);
+    let exported_hours = integer_field(&artifact_json, "exported_hours").unwrap_or(0);
+    let row_count = integer_field(&artifact_json, "row_count").unwrap_or(0);
+    let full_fidelity = artifact_json
+        .get("full_fidelity")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let incomplete = artifact_json
+        .get("incomplete")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let mut blockers = Vec::new();
+    if schema_version != "full_depth_execution_surface.v1" {
+        blockers.push("unsupported_schema_version".to_string());
+    }
+    if surface.is_empty() {
+        blockers.push("missing_surface".to_string());
+    }
+    if !full_fidelity {
+        blockers.push("not_full_fidelity".to_string());
+    }
+    if incomplete {
+        blockers.push("incomplete".to_string());
+    }
+    if checked_hours <= 0 {
+        blockers.push("checked_hours_empty".to_string());
+    }
+    if existing_hours < checked_hours {
+        blockers.push(format!("missing_hours:{existing_hours}<{checked_hours}"));
+    }
+    if row_count <= 0 {
+        blockers.push("row_count_empty".to_string());
+    }
+    if window_start_ts >= window_end_ts {
+        blockers.push("invalid_window".to_string());
+    }
+    if window_start_ts > dataset.dataset_start_ts || window_end_ts < dataset.dataset_end_ts {
+        blockers.push(format!(
+            "window_not_covered:{}->{}!covers{}->{}",
+            window_start_ts.to_rfc3339(),
+            window_end_ts.to_rfc3339(),
+            dataset.dataset_start_ts.to_rfc3339(),
+            dataset.dataset_end_ts.to_rfc3339()
+        ));
+    }
+    blockers.sort();
+    blockers.dedup();
+    let valid = full_depth_surface_valid(&blockers);
+
+    Ok(FullDepthExecutionSurfaceRow {
+        full_depth_execution_surface_id: string_field(
+            &artifact_json,
+            "full_depth_execution_surface_id",
+        )
+        .unwrap_or_else(|| format!("full_depth_execution_surface:{}", &artifact_sha256[..32])),
+        run_id: plan.run_id.clone(),
+        source_workflow: string_field(&artifact_json, "source_workflow")
+            .unwrap_or_else(|| "collect-full-depth-execution-surface.yml".to_string()),
+        workflow_run_id: string_field(&artifact_json, "workflow_run_id"),
+        workflow_run_url: string_field(&artifact_json, "workflow_run_url"),
+        artifact_name: string_field(&artifact_json, "artifact_name"),
+        artifact_sha256,
+        artifact_json: artifact_json.clone(),
+        schema_version,
+        surface,
+        source,
+        data_snapshot_id: dataset.data_snapshot_id.clone(),
+        window_start_ts,
+        window_end_ts,
+        checked_hours,
+        existing_hours,
+        exported_hours,
+        row_count,
+        full_fidelity,
+        incomplete,
+        valid,
+        blockers_json: Value::Array(blockers.into_iter().map(Value::String).collect()),
+        artifact_path: path.to_path_buf(),
+    })
+}
+
+fn full_depth_surface_valid(blockers: &[String]) -> bool {
+    blockers.is_empty()
+}
+
 fn canonical_candidate_replay_evidence_stage(
     basis: &str,
     explicit_evidence_stage: Option<&str>,
@@ -610,6 +792,22 @@ fn string_field(value: &Value, key: &str) -> Option<String> {
         .and_then(Value::as_str)
         .filter(|raw| !raw.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn integer_field(value: &Value, key: &str) -> Option<i64> {
+    value.get(key).and_then(|raw| {
+        raw.as_i64()
+            .or_else(|| raw.as_u64().and_then(|item| i64::try_from(item).ok()))
+            .or_else(|| raw.as_str().and_then(|item| item.parse::<i64>().ok()))
+    })
+}
+
+fn timestamp_field(value: &Value, key: &str) -> Option<DateTime<Utc>> {
+    value.get(key).and_then(Value::as_str).and_then(|raw| {
+        DateTime::parse_from_rfc3339(raw)
+            .ok()
+            .map(|parsed| parsed.with_timezone(&Utc))
+    })
 }
 
 fn merged_blockers(factor: &Value, runtime_contract: &Value) -> Value {
@@ -1235,12 +1433,98 @@ fn candidate_replay_promotion_status(row: &CandidateReplayTapeRow) -> &'static s
     }
 }
 
+async fn upsert_full_depth_execution_surface(
+    pool: &PgPool,
+    row: &FullDepthExecutionSurfaceRow,
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO full_depth_execution_surfaces (
+            full_depth_execution_surface_id,
+            run_id,
+            source_workflow,
+            workflow_run_id,
+            workflow_run_url,
+            artifact_name,
+            artifact_sha256,
+            artifact_json,
+            schema_version,
+            surface,
+            source,
+            data_snapshot_id,
+            window_start_ts,
+            window_end_ts,
+            checked_hours,
+            existing_hours,
+            exported_hours,
+            row_count,
+            full_fidelity,
+            incomplete,
+            valid,
+            blockers_json
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14,
+            $15, $16, $17, $18, $19, $20, $21, $22::jsonb
+        )
+        ON CONFLICT (full_depth_execution_surface_id) DO UPDATE SET
+            run_id = EXCLUDED.run_id,
+            source_workflow = EXCLUDED.source_workflow,
+            workflow_run_id = EXCLUDED.workflow_run_id,
+            workflow_run_url = EXCLUDED.workflow_run_url,
+            artifact_name = EXCLUDED.artifact_name,
+            artifact_sha256 = EXCLUDED.artifact_sha256,
+            artifact_json = EXCLUDED.artifact_json,
+            schema_version = EXCLUDED.schema_version,
+            surface = EXCLUDED.surface,
+            source = EXCLUDED.source,
+            data_snapshot_id = EXCLUDED.data_snapshot_id,
+            window_start_ts = EXCLUDED.window_start_ts,
+            window_end_ts = EXCLUDED.window_end_ts,
+            checked_hours = EXCLUDED.checked_hours,
+            existing_hours = EXCLUDED.existing_hours,
+            exported_hours = EXCLUDED.exported_hours,
+            row_count = EXCLUDED.row_count,
+            full_fidelity = EXCLUDED.full_fidelity,
+            incomplete = EXCLUDED.incomplete,
+            valid = EXCLUDED.valid,
+            blockers_json = EXCLUDED.blockers_json
+        "#,
+    )
+    .bind(&row.full_depth_execution_surface_id)
+    .bind(&row.run_id)
+    .bind(&row.source_workflow)
+    .bind(&row.workflow_run_id)
+    .bind(&row.workflow_run_url)
+    .bind(&row.artifact_name)
+    .bind(&row.artifact_sha256)
+    .bind(row.artifact_json.to_string())
+    .bind(&row.schema_version)
+    .bind(&row.surface)
+    .bind(&row.source)
+    .bind(&row.data_snapshot_id)
+    .bind(row.window_start_ts)
+    .bind(row.window_end_ts)
+    .bind(row.checked_hours)
+    .bind(row.existing_hours)
+    .bind(row.exported_hours)
+    .bind(row.row_count)
+    .bind(row.full_fidelity)
+    .bind(row.incomplete)
+    .bind(row.valid)
+    .bind(row.blockers_json.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 async fn append_experiment_trace(
     pool: &PgPool,
     run_id: &str,
     data_snapshot_id: Option<&str>,
     dsl_hash: Option<&str>,
     candidate_replay_id: Option<&str>,
+    full_depth_execution_surface_id: Option<&str>,
     event_type: &str,
     artifact_kind: &str,
     evidence_stage: &str,
@@ -1285,6 +1569,7 @@ async fn append_experiment_trace(
             data_snapshot_id,
             dsl_hash,
             candidate_replay_id,
+            full_depth_execution_surface_id,
             artifact_kind,
             evidence_stage,
             promotion_decision,
@@ -1294,7 +1579,7 @@ async fn append_experiment_trace(
             hash_prev,
             hash_current
         )
-        VALUES ($1::uuid, $2, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15)
+        VALUES ($1::uuid, $2, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15, $16)
         "#,
     )
     .bind(Uuid::new_v4().to_string())
@@ -1304,6 +1589,7 @@ async fn append_experiment_trace(
     .bind(data_snapshot_id)
     .bind(dsl_hash)
     .bind(candidate_replay_id)
+    .bind(full_depth_execution_surface_id)
     .bind(artifact_kind)
     .bind(evidence_stage)
     .bind(promotion_decision)
@@ -1408,6 +1694,7 @@ mod tests {
             promotion_json: None,
             handoff_json: None,
             candidate_replay_jsons: Vec::new(),
+            full_depth_execution_surface_jsons: Vec::new(),
             dry_run: true,
         }
     }

--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -211,7 +211,9 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
 
     Ok(match row {
         Some(row) => {
-            let surface_blockers = source_surface_blockers(&row.3);
+            let execution_surfaces =
+                latest_full_depth_execution_surfaces(pool, row.1, row.2).await?;
+            let surface_blockers = source_surface_blockers(&row.3, &execution_surfaces);
             let data_repair_blockers = blockers_by_type(&surface_blockers, "data_repair");
             let promotion_blockers = blockers_by_type(&surface_blockers, "promotion");
             let has_surface_blockers = !surface_blockers.is_empty();
@@ -223,6 +225,7 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
                 "dataset_end_ts": row.2,
                 "source_surfaces": row.3,
                 "row_counts": row.4,
+                "execution_surfaces": execution_surfaces,
                 "surface_blockers": surface_blockers,
                 "data_repair_blockers": data_repair_blockers,
                 "promotion_blockers": promotion_blockers,
@@ -238,6 +241,72 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
     })
 }
 
+async fn latest_full_depth_execution_surfaces(
+    pool: &PgPool,
+    dataset_start_ts: DateTime<Utc>,
+    dataset_end_ts: DateTime<Utc>,
+) -> Result<Value> {
+    let rows: Vec<(
+        String,
+        String,
+        String,
+        DateTime<Utc>,
+        DateTime<Utc>,
+        i32,
+        i32,
+        i64,
+        bool,
+        bool,
+        Value,
+    )> = sqlx::query_as(
+        r#"
+            SELECT
+                full_depth_execution_surface_id,
+                surface,
+                source,
+                window_start_ts,
+                window_end_ts,
+                checked_hours,
+                existing_hours,
+                row_count,
+                full_fidelity,
+                incomplete,
+                blockers_json
+            FROM full_depth_execution_surfaces
+            WHERE valid = true
+              AND window_start_ts <= $1
+              AND window_end_ts >= $2
+            ORDER BY created_at DESC
+            LIMIT 50
+            "#,
+    )
+    .bind(dataset_start_ts)
+    .bind(dataset_end_ts)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(json!({
+        "source": "full_depth_execution_surfaces",
+        "dataset_start_ts": dataset_start_ts,
+        "dataset_end_ts": dataset_end_ts,
+        "surfaces": rows.into_iter().map(|row| {
+            json!({
+                "full_depth_execution_surface_id": row.0,
+                "surface": row.1,
+                "source": row.2,
+                "window_start_ts": row.3,
+                "window_end_ts": row.4,
+                "checked_hours": row.5,
+                "existing_hours": row.6,
+                "row_count": row.7,
+                "full_fidelity": row.8,
+                "incomplete": row.9,
+                "blockers": row.10,
+            })
+        }).collect::<Vec<_>>()
+    }))
+}
+
 fn blockers_by_type(blockers: &[Value], blocker_type: &str) -> Vec<Value> {
     blockers
         .iter()
@@ -251,7 +320,7 @@ fn blockers_by_type(blockers: &[Value], blocker_type: &str) -> Vec<Value> {
         .collect()
 }
 
-fn source_surface_blockers(source_surfaces: &Value) -> Vec<Value> {
+fn source_surface_blockers(source_surfaces: &Value, execution_surfaces: &Value) -> Vec<Value> {
     let Some(items) = source_surfaces.as_array() else {
         return vec![json!({
             "surface": "<invalid>",
@@ -276,18 +345,21 @@ fn source_surface_blockers(source_surfaces: &Value) -> Vec<Value> {
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
             let requires_execution = gate_category == "required_for_execution";
+            let full_depth_covered = execution_surface_covered(execution_surfaces, name);
 
             let blocker = if gate_category == "missing_blocks_promotion" {
                 Some(("surface_declared_missing_blocks_promotion", "promotion"))
             } else if requires_execution && row_count == Some(0) {
                 Some(("required_execution_surface_empty", "data_repair"))
-            } else if requires_execution && row_count.is_none() {
-                Some(("required_execution_surface_not_materialized", "promotion"))
+            } else if requires_execution && snapshot_sampled && full_depth_covered {
+                None
             } else if requires_execution && snapshot_sampled {
                 Some((
                     "required_execution_surface_is_sampled_snapshot",
                     "promotion",
                 ))
+            } else if requires_execution && row_count.is_none() {
+                Some(("required_execution_surface_not_materialized", "promotion"))
             } else {
                 None
             };
@@ -302,4 +374,23 @@ fn source_surface_blockers(source_surfaces: &Value) -> Vec<Value> {
             })
         })
         .collect()
+}
+
+fn execution_surface_covered(execution_surfaces: &Value, surface_name: &str) -> bool {
+    execution_surfaces
+        .get("surfaces")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.iter().any(|item| {
+                item.get("surface").and_then(Value::as_str) == Some(surface_name)
+                    && item
+                        .get("full_fidelity")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                    && !item
+                        .get("incomplete")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(true)
+            })
+        })
 }

--- a/crates/ploy-research/src/research_os/registry.rs
+++ b/crates/ploy-research/src/research_os/registry.rs
@@ -107,6 +107,34 @@ pub struct CandidateReplayTapeRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FullDepthExecutionSurfaceRecord {
+    pub full_depth_execution_surface_id: String,
+    pub run_id: String,
+    pub source_workflow: String,
+    pub workflow_run_id: Option<String>,
+    pub workflow_run_url: Option<String>,
+    pub artifact_name: Option<String>,
+    pub artifact_sha256: String,
+    pub artifact_json: serde_json::Value,
+    pub schema_version: String,
+    pub surface: String,
+    pub source: String,
+    pub data_snapshot_id: Option<String>,
+    pub window_start_ts: DateTime<Utc>,
+    pub window_end_ts: DateTime<Utc>,
+    pub checked_hours: i32,
+    pub existing_hours: i32,
+    pub exported_hours: i32,
+    pub row_count: i64,
+    pub full_fidelity: bool,
+    pub incomplete: bool,
+    pub valid: bool,
+    #[serde(default = "default_json_array")]
+    pub blockers_json: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentTraceRecord {
     pub trace_id: String,
     pub run_id: String,
@@ -115,6 +143,7 @@ pub struct ExperimentTraceRecord {
     pub data_snapshot_id: Option<String>,
     pub dsl_hash: Option<String>,
     pub candidate_replay_id: Option<String>,
+    pub full_depth_execution_surface_id: Option<String>,
     pub artifact_kind: String,
     pub evidence_stage: String,
     pub promotion_decision: Option<String>,

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -96,9 +96,10 @@ Research data products are intentionally split into four layers:
 3. Candidate replay tapes: exact `MarketUpdate` sequences and runtime scorer
    inputs used to test one candidate/event lifecycle.
 4. Durable research trace: `research_dataset_snapshots`, `factor_registry`,
-   `factor_evaluations`, and append-only `experiment_trace` rows tying
-   `dsl_hash`, `ast_json`, `runtime_contract`, run id, dataset window, blockers,
-   and promotion decision together.
+   `factor_evaluations`, `candidate_replay_tapes`,
+   `full_depth_execution_surfaces`, and append-only `experiment_trace` rows
+   tying `dsl_hash`, `ast_json`, `runtime_contract`, run id, dataset window,
+   execution-surface proof, blockers, and promotion decision together.
 
 Do not call a sampled research snapshot "full data". It can be a complete
 retained research artifact for a chosen cadence and window, but full-resolution
@@ -115,6 +116,7 @@ rtk cargo run -p ploy-research --example persist_research_trace --features db --
   --alpha-search-dir <alpha-search-artifact-dir> \
   --registry-json <optional-promotion-registry.json> \
   --handoff-json <optional-strategy-handoff.json> \
+  --full-depth-execution-surface-json <optional-full-depth-execution-surface.json> \
   --db-url "$DATABASE_URL"
 ```
 
@@ -128,7 +130,10 @@ or live promotion evidence; candidate factors remain `continue` / `candidate`
 until executable replay, runtime scorer parity, and dry-run evidence are
 attached through the later gates. Candidate replay tapes must use their own
 `candidate_replay_id` instead of being collapsed into the sampled research
-snapshot identity.
+snapshot identity. Full-depth CLOB execution proof must use a
+`full_depth_execution_surface_id` and be queryable through
+`full_depth_execution_surfaces`; Research Manager must not infer
+execution-surface coverage only by reverse-reading promotion JSON.
 
 As of current mainline evidence, this chain has been proven through a durable
 trace-backed plan, but not through automatic strategy discovery. Hosted

--- a/migrations/047_full_depth_execution_surfaces.sql
+++ b/migrations/047_full_depth_execution_surfaces.sql
@@ -1,0 +1,68 @@
+-- Migration 047: Make full-depth execution-surface proofs queryable by Research OS.
+
+CREATE TABLE IF NOT EXISTS full_depth_execution_surfaces (
+    full_depth_execution_surface_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    source_workflow TEXT NOT NULL,
+    workflow_run_id TEXT,
+    workflow_run_url TEXT,
+    artifact_name TEXT,
+    artifact_sha256 TEXT NOT NULL,
+    artifact_json JSONB NOT NULL,
+    schema_version TEXT NOT NULL DEFAULT 'full_depth_execution_surface.v1',
+    surface TEXT NOT NULL,
+    source TEXT NOT NULL,
+    data_snapshot_id TEXT REFERENCES research_dataset_snapshots(data_snapshot_id),
+    window_start_ts TIMESTAMPTZ NOT NULL,
+    window_end_ts TIMESTAMPTZ NOT NULL,
+    checked_hours INTEGER NOT NULL,
+    existing_hours INTEGER NOT NULL,
+    exported_hours INTEGER NOT NULL DEFAULT 0,
+    row_count BIGINT NOT NULL,
+    full_fidelity BOOLEAN NOT NULL DEFAULT false,
+    incomplete BOOLEAN NOT NULL DEFAULT true,
+    valid BOOLEAN NOT NULL DEFAULT false,
+    blockers_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_full_depth_execution_surfaces_artifact_sha256 UNIQUE (artifact_sha256),
+    CONSTRAINT chk_full_depth_execution_surfaces_schema
+        CHECK (schema_version = 'full_depth_execution_surface.v1'),
+    CONSTRAINT chk_full_depth_execution_surfaces_window
+        CHECK (window_start_ts < window_end_ts),
+    CONSTRAINT chk_full_depth_execution_surfaces_hours
+        CHECK (checked_hours >= 0 AND existing_hours >= 0 AND exported_hours >= 0),
+    CONSTRAINT chk_full_depth_execution_surfaces_rows
+        CHECK (row_count >= 0),
+    CONSTRAINT chk_full_depth_execution_surfaces_blockers_array
+        CHECK (jsonb_typeof(blockers_json) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS idx_full_depth_execution_surfaces_surface_window
+    ON full_depth_execution_surfaces(surface, window_start_ts, window_end_ts);
+CREATE INDEX IF NOT EXISTS idx_full_depth_execution_surfaces_valid
+    ON full_depth_execution_surfaces(valid, surface, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_full_depth_execution_surfaces_run
+    ON full_depth_execution_surfaces(run_id);
+
+ALTER TABLE experiment_trace
+    ADD COLUMN IF NOT EXISTS full_depth_execution_surface_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_experiment_trace_full_depth_execution_surface
+    ON experiment_trace(full_depth_execution_surface_id, created_at DESC)
+    WHERE full_depth_execution_surface_id IS NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_experiment_trace_full_depth_execution_surface'
+          AND conrelid = 'experiment_trace'::regclass
+    ) THEN
+        ALTER TABLE experiment_trace
+            ADD CONSTRAINT fk_experiment_trace_full_depth_execution_surface
+            FOREIGN KEY (full_depth_execution_surface_id)
+            REFERENCES full_depth_execution_surfaces(full_depth_execution_surface_id)
+            NOT VALID;
+    END IF;
+END $$;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,50 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Full-Depth Execution Surface Trace (2026-05-25)
+
+Evidence stage: `diagnostic` / `execution_quality` trace repair. This makes
+full-depth CLOB execution-surface proofs queryable by Research Manager; it is
+not dry-run or live-promotion evidence.
+
+### Tasks
+
+- [x] Add a durable Research OS table for full-depth execution-surface proofs.
+- [x] Teach `persist_research_trace` to persist
+      `full_depth_execution_surface.v1` artifacts and append trace rows.
+- [x] Pass hosted walk-forward full-depth proof artifacts into durable trace
+      persistence.
+- [x] Teach Research Trace Plan to use valid full-depth proof coverage when
+      classifying sampled execution-surface blockers.
+- [x] Run focused migration, writer, workflow, and planner tests.
+- [ ] Land through PR after CI.
+
+### Review
+
+- 2026-05-25: Added `full_depth_execution_surfaces` as a first-class Research
+  OS table and linked `experiment_trace.full_depth_execution_surface_id` to it.
+  `persist_research_trace` now accepts `--full-depth-execution-surface-json`,
+  validates `full_depth_execution_surface.v1` fail-closed, persists blockers,
+  and appends an `executable_replay` trace row. Hosted walk-forward now passes
+  downloaded full-depth proof artifacts into trace persistence on both local DB
+  and remote Tango DB paths. Research Trace Plan reads valid proof coverage from
+  the durable table before classifying sampled execution surfaces as promotion
+  blockers.
+- 2026-05-25: Focused validation passed:
+  `python3 -m unittest tests.test_factor_research_os_registry
+  tests.test_persist_research_trace_contract
+  tests.test_factor_walk_forward_sweep tests.test_research_manager_execute_plan`
+  (`59` tests), `CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research
+  --example persist_research_trace --features db` (`10` tests),
+  `CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research
+  --example research_trace_plan --features db` (`0` tests),
+  `CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research
+  research_os --lib` (`20` tests), workflow security (`29` tests), Ruby YAML
+  parse for hosted walk-forward and Tango deploy workflows, and
+  `rtk git diff --check`.
+
 ## Current Session - Factor Router Workflow Removal (2026-05-25)
 
 Evidence stage: `diagnostic` / workflow architecture cleanup. This removes

--- a/tests/test_factor_research_os_registry.py
+++ b/tests/test_factor_research_os_registry.py
@@ -7,6 +7,7 @@ MIGRATION_042 = ROOT / "migrations" / "042_factor_research_os_registry.sql"
 MIGRATION_043 = ROOT / "migrations" / "043_research_os_trace_constraints.sql"
 MIGRATION_044 = ROOT / "migrations" / "044_candidate_replay_tapes.sql"
 MIGRATION_046 = ROOT / "migrations" / "046_factor_registry_blockers.sql"
+MIGRATION_047 = ROOT / "migrations" / "047_full_depth_execution_surfaces.sql"
 
 
 def research_os_sql() -> str:
@@ -16,6 +17,7 @@ def research_os_sql() -> str:
             MIGRATION_043.read_text(encoding="utf-8"),
             MIGRATION_044.read_text(encoding="utf-8"),
             MIGRATION_046.read_text(encoding="utf-8"),
+            MIGRATION_047.read_text(encoding="utf-8"),
         ]
     )
 
@@ -29,6 +31,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
             "factor_evaluations",
             "experiment_trace",
             "candidate_replay_tapes",
+            "full_depth_execution_surfaces",
         ]:
             self.assertIn(f"CREATE TABLE IF NOT EXISTS {table}", sql)
         self.assertRegex(
@@ -85,6 +88,33 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         for snippet in required_snippets:
             self.assertIn(snippet, sql)
 
+    def test_full_depth_execution_surface_schema_and_links_exist(self) -> None:
+        sql = research_os_sql()
+        required_snippets = [
+            "full_depth_execution_surface_id TEXT PRIMARY KEY",
+            "schema_version TEXT NOT NULL DEFAULT 'full_depth_execution_surface.v1'",
+            "artifact_sha256 TEXT NOT NULL",
+            "CONSTRAINT uq_full_depth_execution_surfaces_artifact_sha256 UNIQUE (artifact_sha256)",
+            "surface TEXT NOT NULL",
+            "source TEXT NOT NULL",
+            "window_start_ts TIMESTAMPTZ NOT NULL",
+            "window_end_ts TIMESTAMPTZ NOT NULL",
+            "checked_hours INTEGER NOT NULL",
+            "existing_hours INTEGER NOT NULL",
+            "row_count BIGINT NOT NULL",
+            "full_fidelity BOOLEAN NOT NULL DEFAULT false",
+            "incomplete BOOLEAN NOT NULL DEFAULT true",
+            "valid BOOLEAN NOT NULL DEFAULT false",
+            "blockers_json JSONB NOT NULL DEFAULT '[]'::jsonb",
+            "idx_full_depth_execution_surfaces_surface_window",
+            "idx_full_depth_execution_surfaces_valid",
+            "ADD COLUMN IF NOT EXISTS full_depth_execution_surface_id TEXT",
+            "fk_experiment_trace_full_depth_execution_surface",
+            "REFERENCES full_depth_execution_surfaces(full_depth_execution_surface_id)",
+        ]
+        for snippet in required_snippets:
+            self.assertIn(snippet, sql)
+
     def test_experiment_trace_is_append_only_by_trigger(self) -> None:
         sql = research_os_sql()
         self.assertIn("prevent_experiment_trace_update", sql)
@@ -119,6 +149,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         self.assertIn("043_research_os_trace_constraints.sql", workflow)
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
         self.assertIn("046_factor_registry_blockers.sql", workflow)
+        self.assertIn("047_full_depth_execution_surfaces.sql", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -34,6 +34,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "factor_evaluations",
             "experiment_trace",
             "candidate_replay_tapes",
+            "full_depth_execution_surfaces",
         ]:
             self.assertIn(table, source)
         self.assertIn("ON CONFLICT (data_snapshot_id) DO UPDATE", source)
@@ -43,10 +44,15 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("SELECT eval_id::text", source)
         self.assertIn("trace_hash(", source)
         self.assertIn("--candidate-replay-json", source)
+        self.assertIn("--full-depth-execution-surface-json", source)
         self.assertIn("candidate_replay_tape", source)
+        self.assertIn("full_depth_execution_surface", source)
         self.assertIn("evaluation_kind = 'candidate_replay'", source)
         self.assertIn("candidate_replay_id = $3", source)
         self.assertIn("ON CONFLICT (candidate_replay_id) DO UPDATE", source)
+        self.assertIn("ON CONFLICT (full_depth_execution_surface_id) DO UPDATE", source)
+        self.assertIn("full_depth_execution_surface.v1", source)
+        self.assertIn("full_depth_surface_valid", source)
         self.assertIn("canonical_candidate_replay_evidence_stage", source)
         self.assertIn("contradicts basis", source)
         self.assertIn('"promotion_registry" | "autofactor_promotion" | "strategy_handoff" => "walk_forward"', source)
@@ -195,7 +201,9 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "--promotion-json artifacts/factor-walk-forward-v2/autofactor-strategy-promotion.json",
             "--handoff-json artifacts/factor-walk-forward-v2/autofactor-strategy-handoff.json",
             "--candidate-replay-json",
+            "--full-depth-execution-surface-json",
             "candidate-strategy-replay/candidate-strategy-replay.json",
+            "full-depth-execution-surface/full-depth-execution-surface.json",
             "--snapshot-manifest-json artifacts/research-snapshot/manifest.json",
             "validate_autofactor_handoff_replay_gate.py",
             "factor walk-forward report is required for durable trace persistence.",
@@ -238,6 +246,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("--example research_trace_plan", workflow)
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
         self.assertIn("045_candidate_replay_basis_stage_constraint.sql", workflow)
+        self.assertIn("047_full_depth_execution_surfaces.sql", workflow)
 
     def test_research_trace_plan_reads_durable_tables(self) -> None:
         source = TRACE_PLAN.read_text(encoding="utf-8")
@@ -246,12 +255,16 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "factor_registry",
             "factor_evaluations",
             "research_dataset_snapshots",
+            "full_depth_execution_surfaces",
         ]:
             self.assertIn(table, source)
         self.assertIn("plan_next_research", source)
         self.assertIn('"research_trace_plan.v1"', source)
         self.assertIn("GROUP BY run_id", source)
         self.assertIn("source_surface_blockers", source)
+        self.assertIn("latest_full_depth_execution_surfaces", source)
+        self.assertIn("valid = true", source)
+        self.assertIn("execution_surfaces", source)
         self.assertIn("missing_blocks_promotion", source)
 
     def test_trace_plan_workflow_accepts_candidate_runtime_replay_theme(self) -> None:


### PR DESCRIPTION
## Summary
- add a durable `full_depth_execution_surfaces` Research OS table and experiment-trace linkage
- persist `full_depth_execution_surface.v1` artifacts from hosted walk-forward into Research OS trace
- let Research Trace Plan use valid full-depth proof coverage instead of reverse-reading promotion JSON

## Validation
- python3 -m unittest tests.test_factor_research_os_registry tests.test_persist_research_trace_contract tests.test_factor_walk_forward_sweep tests.test_research_manager_execute_plan
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --example persist_research_trace --features db
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --example research_trace_plan --features db
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_os --lib
- CARGO_TARGET_DIR=/tmp/ploy-full-depth-trace-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/factor-walk-forward-v2-hosted-artifact.yml"); YAML.load_file(".github/workflows/deploy-tango-1-1.yml"); puts "ok"'\n- rtk git diff --check