### PR TITLE
Persist settlement coverage repair evidence

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -56,6 +56,7 @@ env:
     045_candidate_replay_basis_stage_constraint.sql
     046_factor_registry_blockers.sql
     047_full_depth_execution_surfaces.sql
+    048_official_settlement_coverage_checks.sql
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/repair-official-settlement-coverage.yml
+++ b/.github/workflows/repair-official-settlement-coverage.yml
@@ -164,7 +164,10 @@ jobs:
             "${SETTLEMENT_START_TS}" \
             "${SETTLEMENT_END_TS}" \
             "${SYMBOLS}" \
-            "${SETTLEMENT_MODE}" <<'EOF'
+            "${SETTLEMENT_MODE}" \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "official-settlement-repair-${GITHUB_RUN_ID}" <<'EOF'
           set -euo pipefail
           deploy_root="$1"
           remote_dir="$2"
@@ -172,6 +175,9 @@ jobs:
           end_ts="$4"
           symbols="$5"
           mode="$6"
+          workflow_run_id="$7"
+          workflow_run_url="$8"
+          artifact_name="$9"
           set -a
           . "${deploy_root}/.env"
           set +a
@@ -200,6 +206,14 @@ jobs:
           )
           if [ "${mode}" = "dry_run" ]; then
             args+=(--dry-run)
+          else
+            args+=(
+              --persist-coverage
+              --run-id "${workflow_run_id}"
+              --workflow-run-id "${workflow_run_id}"
+              --workflow-run-url "${workflow_run_url}"
+              --artifact-name "${artifact_name}"
+            )
           fi
           "${python_bin}" "${args[@]}"
           python3 - <<'PY' "${remote_dir}/official-settlement-repair.json" "${remote_dir}/official-settlement-repair.md"
@@ -217,6 +231,7 @@ jobs:
               f"- Candidate markets: `{payload.get('candidate_market_count')}`",
               f"- Would settle: `{payload.get('would_settle_count')}`",
               f"- Settled: `{payload.get('settled_count')}`",
+              f"- Settlement tokens covered: `{payload.get('settlement_token_count')}`",
               f"- Already matching: `{payload.get('unchanged_count')}`",
               f"- Active reset: `{payload.get('active_reset_count')}`",
               f"- Open markets: `{payload.get('open_market_count')}`",
@@ -225,6 +240,9 @@ jobs:
               f"- Token mismatches: `{payload.get('token_mismatch_count')}`",
               f"- Skipped: `{payload.get('skipped_count')}`",
               f"- Errors: `{payload.get('error_count')}`",
+              f"- Persisted coverage: `{payload.get('settlement_coverage_id', '')}`",
+              f"- Valid coverage: `{payload.get('valid')}`",
+              f"- Blockers: `{', '.join(payload.get('blockers') or [])}`",
           ]
           Path(sys.argv[2]).write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY

--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use ploy_research::research_os::manager::{
-    ResearchBudget, ResearchManagerInput, plan_next_research,
+    plan_next_research, ResearchBudget, ResearchManagerInput,
 };
-use serde_json::{Value, json};
-use sqlx::PgPool;
+use serde_json::{json, Value};
 use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2)
@@ -213,7 +213,10 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
         Some(row) => {
             let execution_surfaces =
                 latest_full_depth_execution_surfaces(pool, row.1, row.2).await?;
-            let surface_blockers = source_surface_blockers(&row.3, &execution_surfaces);
+            let settlement_surfaces =
+                latest_official_settlement_coverage_checks(pool, row.1, row.2).await?;
+            let surface_blockers =
+                source_surface_blockers(&row.3, &execution_surfaces, &settlement_surfaces);
             let data_repair_blockers = blockers_by_type(&surface_blockers, "data_repair");
             let promotion_blockers = blockers_by_type(&surface_blockers, "promotion");
             let has_surface_blockers = !surface_blockers.is_empty();
@@ -226,6 +229,7 @@ async fn latest_snapshot_health(pool: &PgPool) -> Result<Value> {
                 "source_surfaces": row.3,
                 "row_counts": row.4,
                 "execution_surfaces": execution_surfaces,
+                "settlement_surfaces": settlement_surfaces,
                 "surface_blockers": surface_blockers,
                 "data_repair_blockers": data_repair_blockers,
                 "promotion_blockers": promotion_blockers,
@@ -307,6 +311,75 @@ async fn latest_full_depth_execution_surfaces(
     }))
 }
 
+async fn latest_official_settlement_coverage_checks(
+    pool: &PgPool,
+    dataset_start_ts: DateTime<Utc>,
+    dataset_end_ts: DateTime<Utc>,
+) -> Result<Value> {
+    let rows: Vec<(
+        String,
+        String,
+        DateTime<Utc>,
+        DateTime<Utc>,
+        Value,
+        i32,
+        i32,
+        i32,
+        i32,
+        i32,
+        bool,
+        Value,
+    )> = sqlx::query_as(
+        r#"
+            SELECT
+                settlement_coverage_id,
+                surface,
+                window_start_ts,
+                window_end_ts,
+                symbols_json,
+                candidate_market_count,
+                settlement_token_count,
+                skipped_count,
+                error_count,
+                unchanged_count,
+                valid,
+                blockers_json
+            FROM official_settlement_coverage_checks
+            WHERE valid = true
+              AND window_start_ts <= $1
+              AND window_end_ts >= $2
+            ORDER BY created_at DESC
+            LIMIT 50
+            "#,
+    )
+    .bind(dataset_start_ts)
+    .bind(dataset_end_ts)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(json!({
+        "source": "official_settlement_coverage_checks",
+        "dataset_start_ts": dataset_start_ts,
+        "dataset_end_ts": dataset_end_ts,
+        "surfaces": rows.into_iter().map(|row| {
+            json!({
+                "settlement_coverage_id": row.0,
+                "surface": row.1,
+                "window_start_ts": row.2,
+                "window_end_ts": row.3,
+                "symbols": row.4,
+                "candidate_market_count": row.5,
+                "settlement_token_count": row.6,
+                "skipped_count": row.7,
+                "error_count": row.8,
+                "unchanged_count": row.9,
+                "valid": row.10,
+                "blockers": row.11,
+            })
+        }).collect::<Vec<_>>()
+    }))
+}
+
 fn blockers_by_type(blockers: &[Value], blocker_type: &str) -> Vec<Value> {
     blockers
         .iter()
@@ -320,7 +393,11 @@ fn blockers_by_type(blockers: &[Value], blocker_type: &str) -> Vec<Value> {
         .collect()
 }
 
-fn source_surface_blockers(source_surfaces: &Value, execution_surfaces: &Value) -> Vec<Value> {
+fn source_surface_blockers(
+    source_surfaces: &Value,
+    execution_surfaces: &Value,
+    settlement_surfaces: &Value,
+) -> Vec<Value> {
     let Some(items) = source_surfaces.as_array() else {
         return vec![json!({
             "surface": "<invalid>",
@@ -346,6 +423,7 @@ fn source_surface_blockers(source_surfaces: &Value, execution_surfaces: &Value) 
                 .unwrap_or(false);
             let requires_execution = gate_category == "required_for_execution";
             let full_depth_covered = execution_surface_covered(execution_surfaces, name);
+            let settlement_covered = official_settlement_covered(settlement_surfaces, name);
 
             let blocker = if gate_category == "missing_blocks_promotion" {
                 Some(("surface_declared_missing_blocks_promotion", "promotion"))
@@ -358,6 +436,8 @@ fn source_surface_blockers(source_surfaces: &Value, execution_surfaces: &Value) 
                     "required_execution_surface_is_sampled_snapshot",
                     "promotion",
                 ))
+            } else if requires_execution && row_count.is_none() && settlement_covered {
+                None
             } else if requires_execution && row_count.is_none() {
                 Some(("required_execution_surface_not_materialized", "promotion"))
             } else {
@@ -374,6 +454,28 @@ fn source_surface_blockers(source_surfaces: &Value, execution_surfaces: &Value) 
             })
         })
         .collect()
+}
+
+fn official_settlement_covered(settlement_surfaces: &Value, surface_name: &str) -> bool {
+    settlement_surfaces
+        .get("surfaces")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.iter().any(|item| {
+                item.get("surface").and_then(Value::as_str) == Some(surface_name)
+                    && item.get("valid").and_then(Value::as_bool).unwrap_or(false)
+                    && item
+                        .get("candidate_market_count")
+                        .and_then(Value::as_i64)
+                        .unwrap_or(0)
+                        > 0
+                    && item
+                        .get("settlement_token_count")
+                        .and_then(Value::as_i64)
+                        .unwrap_or(0)
+                        > 0
+            })
+        })
 }
 
 fn execution_surface_covered(execution_surfaces: &Value, surface_name: &str) -> bool {
@@ -393,4 +495,53 @@ fn execution_surface_covered(execution_surfaces: &Value, surface_name: &str) -> 
                         .unwrap_or(true)
             })
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settlement_coverage_clears_non_materialized_settlement_surface_blocker() {
+        let source_surfaces = json!([
+            {
+                "name": "pm_token_settlements",
+                "gate_category": "required_for_execution",
+                "row_count": null,
+                "snapshot_sampled": false
+            }
+        ]);
+        let settlement_surfaces = json!({
+            "surfaces": [{
+                "surface": "pm_token_settlements",
+                "valid": true,
+                "candidate_market_count": 1097,
+                "settlement_token_count": 2194
+            }]
+        });
+
+        let blockers = source_surface_blockers(&source_surfaces, &json!({}), &settlement_surfaces);
+
+        assert!(blockers.is_empty());
+    }
+
+    #[test]
+    fn missing_settlement_coverage_keeps_non_materialized_surface_blocker() {
+        let source_surfaces = json!([
+            {
+                "name": "pm_token_settlements",
+                "gate_category": "required_for_execution",
+                "row_count": null,
+                "snapshot_sampled": false
+            }
+        ]);
+
+        let blockers = source_surface_blockers(&source_surfaces, &json!({}), &json!({}));
+
+        assert_eq!(blockers.len(), 1);
+        assert_eq!(
+            blockers[0].get("reason").and_then(Value::as_str),
+            Some("required_execution_surface_not_materialized")
+        );
+    }
 }

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -97,9 +97,10 @@ Research data products are intentionally split into four layers:
    inputs used to test one candidate/event lifecycle.
 4. Durable research trace: `research_dataset_snapshots`, `factor_registry`,
    `factor_evaluations`, `candidate_replay_tapes`,
-   `full_depth_execution_surfaces`, and append-only `experiment_trace` rows
-   tying `dsl_hash`, `ast_json`, `runtime_contract`, run id, dataset window,
-   execution-surface proof, blockers, and promotion decision together.
+   `full_depth_execution_surfaces`, `official_settlement_coverage_checks`, and
+   append-only `experiment_trace` rows tying `dsl_hash`, `ast_json`,
+   `runtime_contract`, run id, dataset window, execution-surface proof,
+   settlement-coverage proof, blockers, and promotion decision together.
 
 Do not call a sampled research snapshot "full data". It can be a complete
 retained research artifact for a chosen cadence and window, but full-resolution
@@ -134,6 +135,11 @@ snapshot identity. Full-depth CLOB execution proof must use a
 `full_depth_execution_surface_id` and be queryable through
 `full_depth_execution_surfaces`; Research Manager must not infer
 execution-surface coverage only by reverse-reading promotion JSON.
+Official settlement coverage repair proof must use a valid
+`official_settlement_coverage_checks` row for the snapshot window; Research
+Manager must not keep treating `pm_token_settlements` as non-materialized when
+an executed repair/check proves all candidate market tokens are already
+settled and unchanged.
 
 As of current mainline evidence, this chain has been proven through a durable
 trace-backed plan, but not through automatic strategy discovery. Hosted

--- a/migrations/048_official_settlement_coverage_checks.sql
+++ b/migrations/048_official_settlement_coverage_checks.sql
@@ -1,0 +1,52 @@
+-- Migration 048: Make official settlement coverage repair evidence queryable by Research OS.
+
+CREATE TABLE IF NOT EXISTS official_settlement_coverage_checks (
+    settlement_coverage_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    source_workflow TEXT NOT NULL,
+    workflow_run_id TEXT,
+    workflow_run_url TEXT,
+    artifact_name TEXT,
+    artifact_sha256 TEXT NOT NULL,
+    artifact_json JSONB NOT NULL,
+    schema_version TEXT NOT NULL DEFAULT 'official_settlement_repair.v1',
+    surface TEXT NOT NULL DEFAULT 'pm_token_settlements',
+    data_snapshot_id TEXT REFERENCES research_dataset_snapshots(data_snapshot_id),
+    window_start_ts TIMESTAMPTZ NOT NULL,
+    window_end_ts TIMESTAMPTZ NOT NULL,
+    symbols_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    candidate_market_count INTEGER NOT NULL,
+    settlement_token_count INTEGER NOT NULL,
+    settled_count INTEGER NOT NULL DEFAULT 0,
+    unchanged_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,
+    error_count INTEGER NOT NULL DEFAULT 0,
+    valid BOOLEAN NOT NULL DEFAULT false,
+    blockers_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_official_settlement_coverage_artifact_sha256 UNIQUE (artifact_sha256),
+    CONSTRAINT chk_official_settlement_coverage_schema
+        CHECK (schema_version = 'official_settlement_repair.v1'),
+    CONSTRAINT chk_official_settlement_coverage_window
+        CHECK (window_start_ts < window_end_ts),
+    CONSTRAINT chk_official_settlement_coverage_symbols_array
+        CHECK (jsonb_typeof(symbols_json) = 'array'),
+    CONSTRAINT chk_official_settlement_coverage_counts
+        CHECK (
+            candidate_market_count >= 0
+            AND settlement_token_count >= 0
+            AND settled_count >= 0
+            AND unchanged_count >= 0
+            AND skipped_count >= 0
+            AND error_count >= 0
+        ),
+    CONSTRAINT chk_official_settlement_coverage_blockers_array
+        CHECK (jsonb_typeof(blockers_json) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS idx_official_settlement_coverage_surface_window
+    ON official_settlement_coverage_checks(surface, window_start_ts, window_end_ts);
+CREATE INDEX IF NOT EXISTS idx_official_settlement_coverage_valid
+    ON official_settlement_coverage_checks(valid, surface, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_official_settlement_coverage_run
+    ON official_settlement_coverage_checks(run_id);

--- a/scripts/backfill_settlements.py
+++ b/scripts/backfill_settlements.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,6 +40,12 @@ def parser() -> argparse.ArgumentParser:
     parsed.add_argument("--symbols", default=DEFAULT_SYMBOLS)
     parsed.add_argument("--dry-run", action="store_true")
     parsed.add_argument("--report-json", type=Path)
+    parsed.add_argument("--persist-coverage", action="store_true")
+    parsed.add_argument("--run-id", default="")
+    parsed.add_argument("--source-workflow", default="repair-official-settlement-coverage.yml")
+    parsed.add_argument("--workflow-run-id", default="")
+    parsed.add_argument("--workflow-run-url", default="")
+    parsed.add_argument("--artifact-name", default="")
     return parsed
 
 
@@ -161,6 +168,133 @@ async def upsert_settlement(
     return result != "INSERT 0 0"
 
 
+def report_sha256(report: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(report, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def coverage_blockers(report: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    candidate_count = int(report.get("candidate_market_count") or 0)
+    settled_count = int(report.get("settled_count") or 0)
+    unchanged_count = int(report.get("unchanged_count") or 0)
+    settlement_token_count = settled_count + unchanged_count
+    if report.get("dry_run"):
+        blockers.append("dry_run_not_durable_coverage")
+    if candidate_count <= 0:
+        blockers.append("candidate_market_count_empty")
+    expected_token_count = candidate_count * 2
+    if settlement_token_count != expected_token_count:
+        blockers.append(f"settlement_token_count:{settlement_token_count}!={expected_token_count}")
+    for key in [
+        "active_reset_count",
+        "open_market_count",
+        "malformed_payload_count",
+        "unresolved_price_count",
+        "token_mismatch_count",
+        "skipped_count",
+        "error_count",
+    ]:
+        value = int(report.get(key) or 0)
+        if value > 0:
+            blockers.append(f"{key}:{value}")
+    return sorted(set(blockers))
+
+
+async def persist_coverage_check(
+    conn: "asyncpg.Connection",
+    *,
+    report: dict[str, Any],
+    args: argparse.Namespace,
+) -> str:
+    blockers = coverage_blockers(report)
+    content_sha256 = report_sha256(report)
+    settlement_coverage_id = f"official_settlement_coverage:{content_sha256[:32]}"
+    settlement_token_count = int(report.get("settled_count") or 0) + int(
+        report.get("unchanged_count") or 0
+    )
+    valid = not blockers
+    report["settlement_coverage_id"] = settlement_coverage_id
+    report["settlement_token_count"] = settlement_token_count
+    report["valid"] = valid
+    report["blockers"] = blockers
+    artifact_sha256 = report_sha256(report)
+    await conn.execute(
+        """
+        INSERT INTO official_settlement_coverage_checks (
+            settlement_coverage_id,
+            run_id,
+            source_workflow,
+            workflow_run_id,
+            workflow_run_url,
+            artifact_name,
+            artifact_sha256,
+            artifact_json,
+            schema_version,
+            surface,
+            window_start_ts,
+            window_end_ts,
+            symbols_json,
+            candidate_market_count,
+            settlement_token_count,
+            settled_count,
+            unchanged_count,
+            skipped_count,
+            error_count,
+            valid,
+            blockers_json
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, 'pm_token_settlements',
+            $10, $11, $12::jsonb, $13, $14, $15, $16, $17, $18, $19, $20::jsonb
+        )
+        ON CONFLICT (settlement_coverage_id) DO UPDATE SET
+            run_id = EXCLUDED.run_id,
+            source_workflow = EXCLUDED.source_workflow,
+            workflow_run_id = EXCLUDED.workflow_run_id,
+            workflow_run_url = EXCLUDED.workflow_run_url,
+            artifact_name = EXCLUDED.artifact_name,
+            artifact_sha256 = EXCLUDED.artifact_sha256,
+            artifact_json = EXCLUDED.artifact_json,
+            schema_version = EXCLUDED.schema_version,
+            surface = EXCLUDED.surface,
+            window_start_ts = EXCLUDED.window_start_ts,
+            window_end_ts = EXCLUDED.window_end_ts,
+            symbols_json = EXCLUDED.symbols_json,
+            candidate_market_count = EXCLUDED.candidate_market_count,
+            settlement_token_count = EXCLUDED.settlement_token_count,
+            settled_count = EXCLUDED.settled_count,
+            unchanged_count = EXCLUDED.unchanged_count,
+            skipped_count = EXCLUDED.skipped_count,
+            error_count = EXCLUDED.error_count,
+            valid = EXCLUDED.valid,
+            blockers_json = EXCLUDED.blockers_json
+        """,
+        settlement_coverage_id,
+        args.run_id or args.workflow_run_id or "manual",
+        args.source_workflow,
+        args.workflow_run_id or None,
+        args.workflow_run_url or None,
+        args.artifact_name or None,
+        artifact_sha256,
+        json.dumps(report, sort_keys=True),
+        report["schema_version"],
+        parse_utc_ts(report["start_ts"]),
+        parse_utc_ts(report["end_ts"]),
+        json.dumps(report.get("symbols") or [], sort_keys=True),
+        int(report.get("candidate_market_count") or 0),
+        settlement_token_count,
+        int(report.get("settled_count") or 0),
+        int(report.get("unchanged_count") or 0),
+        int(report.get("skipped_count") or 0),
+        int(report.get("error_count") or 0),
+        valid,
+        json.dumps(blockers, sort_keys=True),
+    )
+    return settlement_coverage_id
+
+
 async def run(args: argparse.Namespace) -> dict[str, Any]:
     db_url = args.db_url or args.legacy_db_url
     if not db_url:
@@ -275,7 +409,7 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
 
                 await asyncio.sleep(0.2)
 
-        return {
+        report = {
             "schema_version": "official_settlement_repair.v1",
             "dry_run": args.dry_run,
             "start_ts": args.start_ts,
@@ -293,6 +427,12 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
             "skipped_count": skipped,
             "error_count": errors,
         }
+        report["settlement_token_count"] = settled + unchanged
+        report["blockers"] = coverage_blockers(report)
+        report["valid"] = not report["blockers"]
+        if args.persist_coverage:
+            await persist_coverage_check(conn, report=report, args=args)
+        return report
     finally:
         await conn.close()
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17,6 +17,10 @@ profitability, dry-run readiness, or live-promotion evidence.
       full-depth validation.
 - [x] Add official settlement repair reason counters so no-op / already
       matching settlement evidence is visible.
+- [x] Add durable `official_settlement_coverage_checks` rows for executed
+      settlement coverage repair evidence.
+- [x] Teach Research Trace Plan to clear `pm_token_settlements` materialization
+      blockers when a valid coverage proof spans the snapshot window.
 - [x] Run focused validation.
 - [ ] Land through PR and rerun trace-plan/manager follow-up evidence.
 
@@ -43,6 +47,16 @@ profitability, dry-run readiness, or live-promotion evidence.
   `rustfmt --edition 2021 --check
   crates/ploy-research/examples/persist_research_trace.rs`, and
   `rtk git diff --check`.
+- 2026-05-25: After deploy `26373626601`, full-depth execution-surface
+  collection `26373823385` persisted valid coverage for `2026-05-17T00:00:00Z`
+  through `2026-05-18T00:00:00Z`: 24/24 hours, 2,214,371 rows,
+  `dry_run=false`, `valid=true`, and no blockers. Settlement repair
+  `26373866980` proved 1,097 markets / 2,194 settlement tokens already matched
+  official settlement with no API, payload, unresolved-price, token-mismatch, or
+  error counters. Trace Plan `26374076688` still reported
+  `promotion_data_settlement` because the repair artifact was not yet persisted
+  as a queryable Research OS settlement-coverage surface. This slice adds that
+  missing durable coverage layer.
 
 ## Current Session - Legacy Factor Research Binary Removal (2026-05-25)
 

--- a/tests/test_backfill_settlements.py
+++ b/tests/test_backfill_settlements.py
@@ -2,7 +2,9 @@ import unittest
 from datetime import datetime, timezone
 
 from scripts.backfill_settlements import (
+    coverage_blockers,
     parse_utc_ts,
+    report_sha256,
     settlement_rows_from_gamma,
     settlement_rows_with_reason_from_gamma,
 )
@@ -73,6 +75,51 @@ class BackfillSettlementsTest(unittest.TestCase):
                 )
                 self.assertEqual([], rows)
                 self.assertEqual(reason, actual_reason)
+
+    def test_coverage_blockers_require_execute_complete_binary_settlement(self) -> None:
+        valid_report = {
+            "dry_run": False,
+            "candidate_market_count": 2,
+            "settled_count": 1,
+            "unchanged_count": 3,
+            "active_reset_count": 0,
+            "open_market_count": 0,
+            "malformed_payload_count": 0,
+            "unresolved_price_count": 0,
+            "token_mismatch_count": 0,
+            "skipped_count": 0,
+            "error_count": 0,
+        }
+        self.assertEqual([], coverage_blockers(valid_report))
+
+        blocked_report = {
+            **valid_report,
+            "dry_run": True,
+            "unchanged_count": 2,
+            "token_mismatch_count": 1,
+        }
+        self.assertEqual(
+            [
+                "dry_run_not_durable_coverage",
+                "settlement_token_count:3!=4",
+                "token_mismatch_count:1",
+            ],
+            coverage_blockers(blocked_report),
+        )
+        duplicate_count_report = {
+            **valid_report,
+            "unchanged_count": 4,
+        }
+        self.assertEqual(
+            ["settlement_token_count:5!=4"],
+            coverage_blockers(duplicate_count_report),
+        )
+
+    def test_report_sha256_is_canonical(self) -> None:
+        self.assertEqual(
+            report_sha256({"b": 2, "a": 1}),
+            report_sha256({"a": 1, "b": 2}),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_factor_research_os_registry.py
+++ b/tests/test_factor_research_os_registry.py
@@ -8,6 +8,7 @@ MIGRATION_043 = ROOT / "migrations" / "043_research_os_trace_constraints.sql"
 MIGRATION_044 = ROOT / "migrations" / "044_candidate_replay_tapes.sql"
 MIGRATION_046 = ROOT / "migrations" / "046_factor_registry_blockers.sql"
 MIGRATION_047 = ROOT / "migrations" / "047_full_depth_execution_surfaces.sql"
+MIGRATION_048 = ROOT / "migrations" / "048_official_settlement_coverage_checks.sql"
 
 
 def research_os_sql() -> str:
@@ -18,6 +19,7 @@ def research_os_sql() -> str:
             MIGRATION_044.read_text(encoding="utf-8"),
             MIGRATION_046.read_text(encoding="utf-8"),
             MIGRATION_047.read_text(encoding="utf-8"),
+            MIGRATION_048.read_text(encoding="utf-8"),
         ]
     )
 
@@ -32,6 +34,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
             "experiment_trace",
             "candidate_replay_tapes",
             "full_depth_execution_surfaces",
+            "official_settlement_coverage_checks",
         ]:
             self.assertIn(f"CREATE TABLE IF NOT EXISTS {table}", sql)
         self.assertRegex(
@@ -115,6 +118,24 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         for snippet in required_snippets:
             self.assertIn(snippet, sql)
 
+    def test_official_settlement_coverage_schema_exists(self) -> None:
+        sql = research_os_sql()
+        required_snippets = [
+            "settlement_coverage_id TEXT PRIMARY KEY",
+            "schema_version TEXT NOT NULL DEFAULT 'official_settlement_repair.v1'",
+            "surface TEXT NOT NULL DEFAULT 'pm_token_settlements'",
+            "symbols_json JSONB NOT NULL DEFAULT '[]'::jsonb",
+            "candidate_market_count INTEGER NOT NULL",
+            "settlement_token_count INTEGER NOT NULL",
+            "unchanged_count INTEGER NOT NULL DEFAULT 0",
+            "valid BOOLEAN NOT NULL DEFAULT false",
+            "CONSTRAINT uq_official_settlement_coverage_artifact_sha256 UNIQUE (artifact_sha256)",
+            "idx_official_settlement_coverage_surface_window",
+            "idx_official_settlement_coverage_valid",
+        ]
+        for snippet in required_snippets:
+            self.assertIn(snippet, sql)
+
     def test_experiment_trace_is_append_only_by_trigger(self) -> None:
         sql = research_os_sql()
         self.assertIn("prevent_experiment_trace_update", sql)
@@ -150,6 +171,7 @@ class FactorResearchOsRegistryMigrationTest(unittest.TestCase):
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
         self.assertIn("046_factor_registry_blockers.sql", workflow)
         self.assertIn("047_full_depth_execution_surfaces.sql", workflow)
+        self.assertIn("048_official_settlement_coverage_checks.sql", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -251,6 +251,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("044_candidate_replay_tapes.sql", workflow)
         self.assertIn("045_candidate_replay_basis_stage_constraint.sql", workflow)
         self.assertIn("047_full_depth_execution_surfaces.sql", workflow)
+        self.assertIn("048_official_settlement_coverage_checks.sql", workflow)
 
     def test_research_trace_plan_reads_durable_tables(self) -> None:
         source = TRACE_PLAN.read_text(encoding="utf-8")
@@ -260,6 +261,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "factor_evaluations",
             "research_dataset_snapshots",
             "full_depth_execution_surfaces",
+            "official_settlement_coverage_checks",
         ]:
             self.assertIn(table, source)
         self.assertIn("plan_next_research", source)
@@ -267,8 +269,10 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("GROUP BY run_id", source)
         self.assertIn("source_surface_blockers", source)
         self.assertIn("latest_full_depth_execution_surfaces", source)
+        self.assertIn("latest_official_settlement_coverage_checks", source)
         self.assertIn("valid = true", source)
         self.assertIn("execution_surfaces", source)
+        self.assertIn("settlement_surfaces", source)
         self.assertIn("missing_blocks_promotion", source)
 
     def test_trace_plan_workflow_accepts_candidate_runtime_replay_theme(self) -> None:


### PR DESCRIPTION
## Summary
- add Research OS table for official settlement coverage checks
- persist executed settlement repair coverage proofs from the repair workflow
- teach Research Trace Plan to clear pm_token_settlements materialization blockers when a valid coverage proof spans the snapshot window
- document the settlement coverage proof surface in the strategy research runbook

## Evidence stage
- diagnostic / factor_attribution repair-loop hardening only; this does not claim dry-run or live readiness

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py' (294 tests)
- CARGO_TARGET_DIR=/tmp/ploy-settlement-coverage-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked --test workflow_security (30 tests)
- CARGO_TARGET_DIR=/tmp/ploy-settlement-coverage-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --example research_trace_plan --features db (2 tests)
- workflow YAML parse for all .github/workflows/*.yml
- rustfmt --edition 2021 --check crates/ploy-research/examples/research_trace_plan.rs
- rtk git diff --check