### PR TITLE
Fix Research Manager settlement blocker derivation

### DIFF
--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -291,7 +291,7 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
     let mut actions = Vec::new();
     let latest_value = latest_run_decision_value(&input.latest_runs);
     let latest = latest_value.to_string().to_lowercase();
-    let market_data = input.market_data_health.to_string().to_lowercase();
+    let market_data = market_data_blocker_text(&input.market_data_health);
     let runtime_or_promotion_blockers = latest;
     let frontier_proves_full_depth = has_any_key_value(
         &latest_value,
@@ -500,6 +500,51 @@ fn blocker_action(blocker_family: &str, action: &str, reason: &str) -> ResearchB
 
 fn contains_any_text(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
+}
+
+fn market_data_blocker_text(value: &serde_json::Value) -> String {
+    let mut fragments = Vec::new();
+    collect_market_data_blocker_values(value, &mut fragments);
+    if fragments.is_empty()
+        && has_any_key_value(
+            value,
+            &["missing_blocks_promotion", "critical_missing"],
+            &[true.into(), "true".into(), "critical".into()],
+        )
+    {
+        fragments.push(value.clone());
+    }
+    fragments
+        .into_iter()
+        .map(|item| item.to_string().to_lowercase())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn collect_market_data_blocker_values(
+    value: &serde_json::Value,
+    fragments: &mut Vec<serde_json::Value>,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, item) in map {
+                if matches!(
+                    key.as_str(),
+                    "surface_blockers" | "promotion_blockers" | "data_repair_blockers"
+                ) {
+                    fragments.push(item.clone());
+                } else {
+                    collect_market_data_blocker_values(item, fragments);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_market_data_blocker_values(item, fragments);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn dedupe_blocker_actions(actions: Vec<ResearchBlockerAction>) -> Vec<ResearchBlockerAction> {
@@ -738,10 +783,9 @@ mod tests {
         ))
         .expect("plan");
         assert_eq!(plan.theme, "revise_prior");
-        assert!(
-            plan.actions
-                .contains(&"generate_typed_llm_prior_json".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
     }
 
     #[test]
@@ -775,10 +819,9 @@ mod tests {
 
         let plan = plan_next_research(&input).expect("plan");
         assert_eq!(plan.theme, "candidate_to_runtime_replay");
-        assert!(
-            plan.actions
-                .contains(&"build_runtime_candidate_replay".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"build_runtime_candidate_replay".to_string()));
     }
 
     #[test]
@@ -832,14 +875,12 @@ mod tests {
         assert_eq!(plan.theme, "ready_handoff");
         assert_eq!(plan.candidate_count, 1);
         assert_eq!(plan.search_depth, 0);
-        assert!(
-            plan.actions
-                .contains(&"create_dry_run_handoff_issue".to_string())
-        );
-        assert!(
-            plan.actions
-                .contains(&"open_config_pr_from_ready_handoff".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"create_dry_run_handoff_issue".to_string()));
+        assert!(plan
+            .actions
+            .contains(&"open_config_pr_from_ready_handoff".to_string()));
         assert!(plan.blocker_actions.is_empty());
     }
 
@@ -857,10 +898,9 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(
-            plan.actions
-                .contains(&"generate_typed_llm_prior_json".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "search_power"
                 && item.action == "increase_distinct_event_coverage_or_reduce_selectivity"
@@ -902,10 +942,9 @@ mod tests {
         let plan = plan_next_research(&input).expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(
-            plan.actions
-                .contains(&"generate_typed_llm_prior_json".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "strategy_economics"
                 && item.action == "mutate_or_reject_negative_runtime_edge"
@@ -988,10 +1027,9 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(
-            plan.actions
-                .contains(&"generate_typed_llm_prior_json".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"generate_typed_llm_prior_json".to_string()));
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "strategy_economics"
                 && item.action == "mutate_or_reject_negative_runtime_edge"
@@ -1020,14 +1058,12 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "fix_data");
-        assert!(
-            plan.actions
-                .contains(&"repair_official_settlement_coverage".to_string())
-        );
-        assert!(
-            plan.actions
-                .contains(&"collect_full_depth_execution_surface".to_string())
-        );
+        assert!(plan
+            .actions
+            .contains(&"repair_official_settlement_coverage".to_string()));
+        assert!(plan
+            .actions
+            .contains(&"collect_full_depth_execution_surface".to_string()));
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "data_settlement"
                 && item.action == "repair_official_settlement_coverage"
@@ -1121,6 +1157,53 @@ mod tests {
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "promotion_data_settlement"
                 && item.action == "repair_official_settlement_coverage"
+        }));
+    }
+
+    #[test]
+    fn planner_ignores_materialized_settlement_surface_metadata_without_blocker() {
+        let plan = plan_next_research(&input(
+            "factor_attribution",
+            serde_json::json!({
+                "candidate_strategy_replay": {
+                    "blocking_risk_flags": ["missing_runtime_contract"]
+                }
+            }),
+            serde_json::json!({
+                "missing_blocks_promotion": false,
+                "critical_missing": false,
+                "surface_blockers": [],
+                "promotion_blockers": [],
+                "data_repair_blockers": [],
+                "source_surfaces": [
+                    {
+                        "name": "pm_token_settlements",
+                        "row_count": null,
+                        "role": "settlement_labels"
+                    }
+                ],
+                "settlement_surfaces": {
+                    "source": "official_settlement_coverage_checks",
+                    "surfaces": [
+                        {
+                            "surface": "pm_token_settlements",
+                            "valid": true,
+                            "blockers": [],
+                            "settlement_token_count": 2194
+                        }
+                    ]
+                }
+            }),
+        ))
+        .expect("plan");
+
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "runtime_contract"
+                && item.action == "repair_runtime_contract_mapping"
+        }));
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "promotion_data_settlement"
+                || item.action == "repair_official_settlement_coverage"
         }));
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,7 +22,7 @@ profitability, dry-run readiness, or live-promotion evidence.
 - [x] Teach Research Trace Plan to clear `pm_token_settlements` materialization
       blockers when a valid coverage proof spans the snapshot window.
 - [x] Run focused validation.
-- [ ] Land through PR and rerun trace-plan/manager follow-up evidence.
+- [x] Land through PR and rerun trace-plan/manager follow-up evidence.
 
 ### Review
 
@@ -57,6 +57,48 @@ profitability, dry-run readiness, or live-promotion evidence.
   `promotion_data_settlement` because the repair artifact was not yet persisted
   as a queryable Research OS settlement-coverage surface. This slice adds that
   missing durable coverage layer.
+- 2026-05-25: PR `#694` landed as `main@6065667d` and deploy
+  `26374420569` succeeded. Execute-mode settlement repair `26375651179`
+  persisted `official_settlement_coverage:c9580ac9585c7b7715a8960e2e54de54`
+  for `2026-05-17T00:00:00Z` through `2026-05-18T00:00:00Z` with
+  `candidate_market_count=1097`, `settlement_token_count=2194`, `valid=true`,
+  and no blockers. Trace Plan `26375853818` consumed that surface and reported
+  `market_data_health.surface_blockers=[]`, but still emitted a
+  `promotion_data_settlement` blocker action because the planner searched the
+  whole market-data JSON and matched the healthy `pm_token_settlements` surface
+  name. The follow-up planner fix below makes blocker action derivation read
+  only structured blocker arrays.
+
+## Current Session - Research Manager Settlement Blocker Precision (2026-05-25)
+
+Evidence stage: `diagnostic` / Research Manager repair-loop hardening. This
+fixes false-positive blocker routing after durable settlement coverage is
+available; it does not claim strategy profitability, dry-run readiness, or
+live-promotion evidence.
+
+### Tasks
+
+- [x] Verify current durable settlement coverage evidence on `main@6065667d`.
+- [x] Reproduce the false-positive `promotion_data_settlement` blocker from
+      Research Trace Plan `26375853818`.
+- [x] Restrict market-data blocker-action derivation to structured blocker
+      fields instead of full JSON text matching.
+- [x] Add regression coverage for healthy materialized settlement-surface
+      metadata.
+- [ ] Land through PR and rerun Research Trace Plan to confirm only the real
+      runtime blocker remains.
+
+### Review
+
+- 2026-05-25: The data layer is no longer the settlement blocker for the latest
+  one-day snapshot: `settlement_surfaces.source=official_settlement_coverage_checks`,
+  `valid=true`, `blockers=[]`, and snapshot `promotion_blockers=[]`. The remaining
+  false blocker was planner logic, not missing data. Local validation passed:
+  `CARGO_TARGET_DIR=/tmp/ploy-research-manager-target /opt/homebrew/bin/timeout
+  300 rtk cargo test --locked -p ploy-research research_os::manager --lib`
+  (`15` tests) and `CARGO_TARGET_DIR=/tmp/ploy-research-manager-target
+  /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research
+  --example research_trace_plan --features db` (`2` tests).
 
 ## Current Session - Legacy Factor Research Binary Removal (2026-05-25)
 


### PR DESCRIPTION
## Summary
- derive Research Manager market-data blocker actions from structured blocker arrays instead of full market-data JSON text
- prevent healthy materialized pm_token_settlements metadata from re-triggering repair_official_settlement_coverage
- record the durable settlement coverage and trace-plan evidence in tasks/todo.md

## Evidence
- Deploy to tango-1-1 26374420569 succeeded for main@6065667d
- Repair Official Settlement Coverage 26375651179 persisted official_settlement_coverage:c9580ac9585c7b7715a8960e2e54de54 with valid=true and blockers=[]
- Research Trace Plan 26375853818 consumed settlement_surfaces but reproduced the false positive blocker action this PR fixes

## Tests
- CARGO_TARGET_DIR=/tmp/ploy-research-manager-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_os::manager --lib
- CARGO_TARGET_DIR=/tmp/ploy-research-manager-target /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --example research_trace_plan --features db
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined market data blocker detection logic to reduce false positives in settlement handling.

* **Tests**
  * Added test case validating settlement metadata blocker precision.
  * Updated test formatting for consistency.

* **Chores**
  * Updated development notes documenting blocker precision improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->