### PR TITLE
Fix AutoFactor selector runtime contracts

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -822,17 +822,8 @@ fn is_predictive_settlement_formula(normalized: &str) -> bool {
 }
 
 fn predictive_formula_suffix_supported(suffix: &str) -> bool {
-    let suffix = suffix
-        .replace(
-            "_runtime_pass_through_add_spread_penalty",
-            "_spread_adjusted",
-        )
-        .replace(
-            "_runtime_pass_through_add_capacity_gate",
-            "_full_depth_entry_gate",
-        )
-        .replace("_add_capacity_gate", "_full_depth_entry_gate");
-    let Some(suffix) = strip_predictive_selector_gates(&suffix) else {
+    let suffix = normalize_runtime_formula_suffix(suffix);
+    let Some(suffix) = strip_runtime_selector_gates(&suffix) else {
         return false;
     };
     if suffix.is_empty() {
@@ -860,11 +851,24 @@ fn predictive_formula_suffix_supported(suffix: &str) -> bool {
     true
 }
 
-fn strip_predictive_selector_gates(suffix: &str) -> Option<String> {
+fn normalize_runtime_formula_suffix(suffix: &str) -> String {
+    suffix
+        .replace(
+            "_runtime_pass_through_add_spread_penalty",
+            "_spread_adjusted",
+        )
+        .replace(
+            "_runtime_pass_through_add_capacity_gate",
+            "_full_depth_entry_gate",
+        )
+        .replace("_add_capacity_gate", "_full_depth_entry_gate")
+}
+
+fn strip_runtime_selector_gates(suffix: &str) -> Option<String> {
     let mut remaining_suffix = suffix.to_string();
     while let Some((remaining, selector)) = remaining_suffix.split_once("_select_") {
-        let (_feature, raw_threshold, trailing_suffix) = parse_predictive_selector_gate(selector)?;
-        if parse_predictive_selector_threshold(raw_threshold).is_none() {
+        let (_feature, raw_threshold, trailing_suffix) = parse_runtime_selector_gate(selector)?;
+        if parse_runtime_selector_threshold(raw_threshold).is_none() {
             return None;
         }
         remaining_suffix = format!("{remaining}{trailing_suffix}");
@@ -872,7 +876,7 @@ fn strip_predictive_selector_gates(suffix: &str) -> Option<String> {
     Some(remaining_suffix)
 }
 
-fn parse_predictive_selector_gate(selector: &str) -> Option<(&'static str, &str, String)> {
+fn parse_runtime_selector_gate(selector: &str) -> Option<(&'static str, &str, String)> {
     for feature in [
         "entry_price_quality",
         "full_depth_entry",
@@ -892,7 +896,7 @@ fn parse_predictive_selector_gate(selector: &str) -> Option<(&'static str, &str,
     None
 }
 
-fn parse_predictive_selector_threshold(raw: &str) -> Option<f64> {
+fn parse_runtime_selector_threshold(raw: &str) -> Option<f64> {
     let threshold = if raw.contains('.') {
         raw.parse().ok()?
     } else {
@@ -918,6 +922,10 @@ fn is_settlement_formula(normalized: &str) -> bool {
 }
 
 fn settlement_formula_suffix_supported(suffix: &str) -> bool {
+    let suffix = normalize_runtime_formula_suffix(suffix);
+    let Some(suffix) = strip_runtime_selector_gates(&suffix) else {
+        return false;
+    };
     if suffix.is_empty() {
         return true;
     }
@@ -1714,6 +1722,70 @@ mod tests {
             ])
         );
         assert_eq!(contract["blockers"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn runtime_contract_maps_settlement_selector_threshold_formulas() {
+        let report = AutoFactorReport {
+            name: "auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_025"
+                .to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Gate {
+                expr: Box::new(FactorExpr::Mul(
+                    Box::new(FactorExpr::Input(
+                        "model_conservative_settlement_edge".to_string(),
+                    )),
+                    Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+                )),
+                gate: Box::new(FactorExpr::Input("entry_price_quality_score".to_string())),
+                min: 0.25,
+            },
+            ..sample_report(
+                "auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_025",
+            )
+        };
+        let contract =
+            runtime_contract_for_report(&report, "dsl-hash", &serde_json::json!({}), "5m");
+        assert_eq!(
+            contract["runtime_score"],
+            "autofactor_formula:auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_025"
+        );
+        assert_eq!(
+            contract["runtime_input_names"],
+            serde_json::json!(["entry_capacity_ratio", "entry_price", "settlement_edge"])
+        );
+        assert_eq!(contract["blockers"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn runtime_contract_rejects_malformed_settlement_selector_threshold() {
+        let report = AutoFactorReport {
+            name: "auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_bad"
+                .to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: FactorExpr::Gate {
+                expr: Box::new(FactorExpr::Mul(
+                    Box::new(FactorExpr::Input(
+                        "model_conservative_settlement_edge".to_string(),
+                    )),
+                    Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+                )),
+                gate: Box::new(FactorExpr::Input("entry_price_quality_score".to_string())),
+                min: 0.25,
+            },
+            ..sample_report(
+                "auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_bad",
+            )
+        };
+        let contract =
+            runtime_contract_for_report(&report, "dsl-hash", &serde_json::json!({}), "5m");
+        assert_eq!(contract["runtime_score"], "");
+        let blockers = contract["blockers"].as_array().expect("blockers");
+        assert!(
+            blockers
+                .iter()
+                .any(|item| item.as_str() == Some("runtime_contract_unmapped_factor"))
+        );
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer_model.rs
@@ -158,9 +158,11 @@ pub fn auto_settlement_formula_score(
         return None;
     }
     let mut score = inputs.settlement_edge;
-    let suffix = normalized_name.strip_prefix(settlement_prefix)?;
+    let suffix =
+        normalize_runtime_formula_suffix(normalized_name.strip_prefix(settlement_prefix)?);
+    let suffix = apply_selector_gate(&suffix, inputs)?;
 
-    match suffix {
+    match suffix.as_str() {
         "" => {}
         "_x_near_strike" => {
             score *=
@@ -203,7 +205,7 @@ pub fn auto_settlement_formula_score(
             }
             score *= inputs.iv_change_1m;
         }
-        _ => score = composed_settlement_formula_suffix_score(score, suffix, inputs)?,
+        _ => score = composed_settlement_formula_suffix_score(score, &suffix, inputs)?,
     }
     score.is_finite().then_some(score)
 }
@@ -309,7 +311,7 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     } else {
         return None;
     };
-    let suffix = normalize_predictive_llm_suffix(name.strip_prefix(base)?);
+    let suffix = normalize_runtime_formula_suffix(name.strip_prefix(base)?);
     let mut score = match base {
         "amplitude_weighted_momentum_30s_sigma" => {
             if !inputs.drift_30s.is_finite()
@@ -344,7 +346,7 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     if suffix.is_empty() {
         return Some(score);
     }
-    let suffix = apply_predictive_selector_gate(&suffix, inputs)?;
+    let suffix = apply_selector_gate(&suffix, inputs)?;
     if suffix.is_empty() {
         return Some(score);
     }
@@ -385,7 +387,7 @@ fn predictive_formula_score(name: &str, inputs: AutoSettlementFactorInputs) -> O
     Some(score)
 }
 
-fn normalize_predictive_llm_suffix(suffix: &str) -> String {
+fn normalize_runtime_formula_suffix(suffix: &str) -> String {
     suffix
         .replace(
             "_runtime_pass_through_add_spread_penalty",
@@ -398,10 +400,7 @@ fn normalize_predictive_llm_suffix(suffix: &str) -> String {
         .replace("_add_capacity_gate", "_full_depth_entry_gate")
 }
 
-fn apply_predictive_selector_gate(
-    suffix: &str,
-    inputs: AutoSettlementFactorInputs,
-) -> Option<String> {
+fn apply_selector_gate(suffix: &str, inputs: AutoSettlementFactorInputs) -> Option<String> {
     let mut remaining_suffix = suffix.to_string();
     while let Some((remaining, selector)) = remaining_suffix.split_once("_select_") {
         let remaining = remaining.to_string();
@@ -787,5 +786,55 @@ pub fn evaluate_entry_score(config: &ThreeLayerModelConfig, inputs: EntryScoreIn
                 + 0.10 * inputs.liquidity_score
         }
         ThreeLayerProfile::Mixed => unreachable!("mixed profile returned above"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_auto_settlement_inputs() -> AutoSettlementFactorInputs {
+        AutoSettlementFactorInputs {
+            settlement_edge: 0.12,
+            entry_price: 0.40,
+            distance_over_sigma: 0.20,
+            direction_sign: 1.0,
+            drift_30s: 0.004,
+            sigma_horizon: 2.0,
+            entry_capacity_ratio: 1.20,
+            side_spread: 0.02,
+            external_pressure: 0.0,
+            pm_lag_secs: 2.0,
+            iv_change_1m: 0.0,
+        }
+    }
+
+    #[test]
+    fn settlement_formula_supports_selector_threshold_gate() {
+        let score = auto_settlement_formula_score(
+            "autofactor_formula:auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_075",
+            sample_auto_settlement_inputs(),
+        )
+        .expect("selector should pass for high-quality entry price");
+
+        assert!((score - 0.048).abs() < 1e-12);
+
+        assert!(auto_settlement_formula_score(
+            "autofactor_formula:auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_075",
+            AutoSettlementFactorInputs {
+                entry_price: 0.10,
+                ..sample_auto_settlement_inputs()
+            },
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn settlement_formula_rejects_malformed_selector_threshold_gate() {
+        assert!(auto_settlement_formula_score(
+            "autofactor_formula:auto_settlement_model_conservative_settlement_edge_x_capacity_select_entry_price_quality_ge_bad",
+            sample_auto_settlement_inputs(),
+        )
+        .is_none());
     }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,49 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - AutoFactor Selector Runtime Contract Repair (2026-05-25)
+
+Evidence stage: `factor_attribution` / runtime contract repair. This aligns
+settlement selector formulas between factor-search registry contracts and the
+runtime AutoFactor scorer; it does not claim strategy profitability, dry-run
+readiness, or live-promotion evidence.
+
+### Tasks
+
+- [x] Confirm current `main` is clean and only the real `runtime_contract`
+      blocker remains in the latest Research Trace Plan summary.
+- [x] Add runtime scorer support for settlement selector threshold gates.
+- [x] Teach alpha-search runtime contract mapping to accept settlement selector
+      suffixes only when their runtime inputs are canonical.
+- [x] Keep `external_pressure`, `iv_change_1m`, Bayesian formulas, and unknown
+      inputs fail-closed.
+- [x] Run focused Rust/Python validation.
+- [ ] Land through PR and rerun Research Trace Plan from `main`.
+
+### Review
+
+- 2026-05-25: Latest verified trace-plan evidence after PR `#695/#696` has
+  durable full-depth and settlement surfaces clear; `blocker_actions` only
+  reports `runtime_contract -> repair_runtime_contract_mapping`. The current
+  repair is still pre-promotion `factor_attribution` evidence.
+- 2026-05-25: Added settlement selector threshold support to the shared
+  AutoFactor runtime scorer and reused the same selector grammar in
+  alpha-search contract mapping. Supported selector suffixes are
+  `select_near_strike_ge_*`, `select_entry_price_quality_ge_*`,
+  `select_entry_capacity_ge_*`, and `select_full_depth_entry_ge_*`; malformed
+  thresholds remain unmapped. Existing catalog blockers still fail-close
+  `external_pressure`, `iv_change_1m`, Bayesian formulas, and unknown inputs.
+- 2026-05-25: Focused validation passed:
+  `rtk cargo test --locked -p ploy-research runtime_contract --lib` (`7`
+  tests), `rtk cargo test --locked -p ploy-strategy-bundles
+  settlement_formula --lib` (`3` tests), wider `rtk cargo test --locked -p
+  ploy-research alpha_search --lib` (`13` tests), `rtk cargo test --locked -p
+  ploy-strategy-bundles three_layer --lib` (`79` tests),
+  `python3 -m unittest tests.test_autofactor_strategy_promotion
+  tests.test_build_autofactor_candidate_strategy_replay
+  tests.test_factor_walk_forward_sweep
+  tests.test_persist_research_trace_contract` (`88` tests), and
+  `rtk git diff --check`.
+
 ## Current Session - Research Manager Durable Repair Evidence (2026-05-25)
 
 Evidence stage: `diagnostic` / `factor_attribution` repair-loop hardening.


### PR DESCRIPTION
## Summary
- add settlement selector threshold support to the shared AutoFactor runtime scorer
- reuse the same selector grammar in alpha-search runtime contract mapping
- keep malformed selectors and noncanonical inputs fail-closed

## Evidence stage
factor_attribution / runtime contract repair only; this does not claim dry-run or live promotion readiness.

## Validation
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-selector-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research runtime_contract --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-selector-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles settlement_formula --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-selector-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research alpha_search --lib
- CARGO_TARGET_DIR=/tmp/ploy-autofactor-selector-contract /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-strategy-bundles three_layer --lib
- python3 -m unittest tests.test_autofactor_strategy_promotion tests.test_build_autofactor_candidate_strategy_replay tests.test_factor_walk_forward_sweep tests.test_persist_research_trace_contract
- rtk git diff --check