### PR TITLE
Fix Research Manager frontier ready-state planning

### DIFF
--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -112,6 +112,7 @@ async fn latest_runs(pool: &PgPool, evidence_stage: &str, limit: usize) -> Resul
     .bind(limit as i64)
     .fetch_all(pool)
     .await?;
+    let ready_handoffs = ready_strategy_handoffs(pool, limit).await?;
 
     Ok(json!({
         "source": "experiment_trace",
@@ -122,8 +123,39 @@ async fn latest_runs(pool: &PgPool, evidence_stage: &str, limit: usize) -> Resul
                 "latest_created_at": row.1,
                 "artifacts": row.2,
             })
-        }).collect::<Vec<_>>()
+        }).collect::<Vec<_>>(),
+        "ready_handoffs": ready_handoffs,
     }))
+}
+
+async fn ready_strategy_handoffs(pool: &PgPool, limit: usize) -> Result<Value> {
+    let rows: Vec<(String, DateTime<Utc>, String, Value)> = sqlx::query_as(
+        r#"
+        SELECT run_id, created_at, event_type, output_json
+        FROM experiment_trace
+        WHERE event_type IN ('strategy_handoff', 'autofactor_strategy_handoff')
+          AND output_json->>'status' = 'ready'
+          AND output_json->>'recommended_action' = 'create_dry_run_handoff'
+        ORDER BY created_at DESC
+        LIMIT $1
+        "#,
+    )
+    .bind(limit as i64)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(Value::Array(
+        rows.into_iter()
+            .map(|row| {
+                json!({
+                    "run_id": row.0,
+                    "created_at": row.1,
+                    "event_type": row.2,
+                    "output_json": row.3,
+                })
+            })
+            .collect(),
+    ))
 }
 
 async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
@@ -148,6 +180,8 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
     .bind(limit as i64)
     .fetch_all(pool)
     .await?;
+    let runtime_ready_candidates = runtime_ready_factor_candidates(pool, limit).await?;
+    let ready_candidate_replays = ready_candidate_replays(pool, limit).await?;
 
     Ok(json!({
         "source": "factor_registry",
@@ -164,8 +198,144 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
                 "runtime_contract": row.5,
                 "blockers": row.6,
             })
-        }).collect::<Vec<_>>()
+        }).collect::<Vec<_>>(),
+        "runtime_ready_candidates": runtime_ready_candidates,
+        "ready_candidate_replays": ready_candidate_replays,
     }))
+}
+
+async fn runtime_ready_factor_candidates(pool: &PgPool, limit: usize) -> Result<Value> {
+    let rows: Vec<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        Value,
+        Value,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        r#"
+            SELECT
+                factor_name,
+                dsl_hash,
+                target,
+                horizon,
+                status,
+                runtime_contract,
+                blockers_json,
+                created_at
+            FROM factor_registry
+            WHERE status = 'candidate'
+              AND runtime_contract->>'version' = 'autofactor_runtime_contract_v1'
+              AND COALESCE(runtime_contract->>'runtime_score', '') <> ''
+              AND COALESCE(runtime_contract->>'strategy_profile', '') <> ''
+              AND jsonb_typeof(blockers_json) = 'array'
+              AND jsonb_array_length(blockers_json) = 0
+              AND jsonb_array_length(
+                    CASE
+                      WHEN jsonb_typeof(runtime_contract->'blockers') = 'array'
+                        THEN runtime_contract->'blockers'
+                      ELSE '[]'::jsonb
+                    END
+                  ) = 0
+            ORDER BY created_at DESC
+            LIMIT $1
+            "#,
+    )
+    .bind(limit as i64)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(Value::Array(
+        rows.into_iter()
+            .map(|row| {
+                json!({
+                    "factor_name": row.0,
+                    "dsl_hash": row.1,
+                    "target": row.2,
+                    "horizon": row.3,
+                    "status": row.4,
+                    "runtime_contract": row.5,
+                    "blockers": row.6,
+                    "created_at": row.7,
+                })
+            })
+            .collect(),
+    ))
+}
+
+async fn ready_candidate_replays(pool: &PgPool, limit: usize) -> Result<Value> {
+    let rows: Vec<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Value,
+        Value,
+        Value,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        r#"
+        SELECT
+            candidate_replay_id,
+            run_id,
+            workflow_run_id,
+            workflow_run_url,
+            basis,
+            promotion_decision,
+            strategy_profile,
+            runtime_score,
+            data_snapshot_id,
+            target,
+            horizon,
+            metrics_json,
+            blocking_risk_flags_json,
+            artifact_json,
+            created_at
+        FROM candidate_replay_tapes
+        WHERE promotion_ready = true
+          AND basis = 'runtime_market_update_replay'
+          AND jsonb_typeof(blocking_risk_flags_json) = 'array'
+          AND jsonb_array_length(blocking_risk_flags_json) = 0
+        ORDER BY created_at DESC
+        LIMIT $1
+        "#,
+    )
+    .bind(limit as i64)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(Value::Array(
+        rows.into_iter()
+            .map(|row| {
+                json!({
+                    "candidate_replay_id": row.0,
+                    "run_id": row.1,
+                    "workflow_run_id": row.2,
+                    "workflow_run_url": row.3,
+                    "basis": row.4,
+                    "promotion_decision": row.5,
+                    "strategy_profile": row.6,
+                    "runtime_score": row.7,
+                    "data_snapshot_id": row.8,
+                    "target": row.9,
+                    "horizon": row.10,
+                    "metrics": row.11,
+                    "blocking_risk_flags": row.12,
+                    "artifact_json": row.13,
+                    "created_at": row.14,
+                })
+            })
+            .collect(),
+    ))
 }
 
 async fn rejected_factor_patterns(pool: &PgPool, limit: usize) -> Result<Value> {

--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -90,7 +90,7 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
 
     let blocker_actions = derive_blocker_actions(input);
     let latest_decision = latest_run_decision_value(&input.latest_runs);
-    if has_ready_handoff(&latest_decision) {
+    if has_ready_handoff(&input.latest_runs) {
         return Ok(plan_with_blocker_actions(
             "ready_handoff",
             1,
@@ -472,7 +472,7 @@ fn strip_non_frontier_blocker_fields(value: &serde_json::Value) -> serde_json::V
             for (key, item) in map {
                 if matches!(
                     key.as_str(),
-                    "evaluated_factors" | "entries" | "recent_factors" | "patterns"
+                    "evaluated_factors" | "entries" | "factors" | "recent_factors" | "patterns"
                 ) {
                     continue;
                 }
@@ -882,6 +882,97 @@ mod tests {
             .actions
             .contains(&"open_config_pr_from_ready_handoff".to_string()));
         assert!(plan.blocker_actions.is_empty());
+    }
+
+    #[test]
+    fn planner_uses_durable_ready_handoff_frontier_summary() {
+        let plan = plan_next_research(&input(
+            "factor_attribution",
+            serde_json::json!({
+                "source": "experiment_trace",
+                "evidence_stage": "factor_attribution",
+                "runs": [{
+                    "run_id": "newest-factor-preview",
+                    "artifacts": [{
+                        "event_type": "factor_registry_preview",
+                        "output_json": {
+                            "factors": [{
+                                "factor_name": "blocked_unselected_factor",
+                                "blockers": ["missing_runtime_contract"]
+                            }]
+                        }
+                    }]
+                }],
+                "ready_handoffs": [{
+                    "run_id": "26377165132",
+                    "event_type": "strategy_handoff",
+                    "output_json": {
+                        "kind": "autofactor_strategy_handoff",
+                        "status": "ready",
+                        "recommended_action": "create_dry_run_handoff",
+                        "strategies": [{
+                            "runtime_score": "autofactor_formula:ready_factor"
+                        }],
+                        "candidate_strategy_replay": {
+                            "ready": true,
+                            "basis": "runtime_market_update_replay"
+                        }
+                    }
+                }]
+            }),
+            serde_json::json!({}),
+        ))
+        .expect("plan");
+
+        assert_eq!(plan.theme, "ready_handoff");
+        assert_eq!(plan.candidate_count, 1);
+        assert!(plan.blocker_actions.is_empty());
+    }
+
+    #[test]
+    fn planner_does_not_route_unselected_preview_factor_blockers_to_runtime_repair() {
+        let mut input = input(
+            "factor_attribution",
+            serde_json::json!({
+                "source": "experiment_trace",
+                "runs": [{
+                    "run_id": "newest-factor-preview",
+                    "artifacts": [{
+                        "event_type": "factor_registry_preview",
+                        "output_json": {
+                            "factors": [{
+                                "factor_name": "blocked_unselected_factor",
+                                "blockers": ["missing_runtime_contract"]
+                            }]
+                        }
+                    }]
+                }]
+            }),
+            serde_json::json!({}),
+        );
+        input.factor_registry_summary = serde_json::json!({
+            "runtime_ready_candidates": [{
+                "factor_name": "ready_factor",
+                "status": "candidate",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "blockers": [],
+                "runtime_contract": {
+                    "version": "autofactor_runtime_contract_v1",
+                    "runtime_score": "autofactor_formula:ready_factor",
+                    "strategy_profile": "settlement_probability",
+                    "blockers": []
+                }
+            }]
+        });
+
+        let plan = plan_next_research(&input).expect("plan");
+
+        assert_eq!(plan.theme, "candidate_to_runtime_replay");
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "runtime_contract"
+                && item.action == "repair_runtime_contract_mapping"
+        }));
     }
 
     #[test]

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -395,6 +395,21 @@ def _recorded_replay_parity_dispatch(
 
 def _ready_handoff_from_plan(plan_payload: dict[str, Any]) -> dict[str, str]:
     latest_runs = ((plan_payload.get("input") or {}).get("latest_runs") or {})
+    ready_handoffs = latest_runs.get("ready_handoffs")
+    if isinstance(ready_handoffs, list):
+        for item in ready_handoffs:
+            if not isinstance(item, dict):
+                continue
+            output = item.get("output_json")
+            if not isinstance(output, dict):
+                continue
+            ready_handoff = _ready_handoff_fields(
+                run_id=str(item.get("run_id") or item.get("workflow_run_id") or ""),
+                output=output,
+            )
+            if ready_handoff:
+                return ready_handoff
+
     runs = latest_runs.get("runs")
     if not isinstance(runs, list):
         return {}
@@ -414,45 +429,53 @@ def _ready_handoff_from_plan(plan_payload: dict[str, Any]) -> dict[str, str]:
             output = artifact.get("output_json")
             if not isinstance(output, dict):
                 continue
-            if output.get("kind") != "autofactor_strategy_handoff":
-                continue
-            if output.get("status") != "ready":
-                continue
-            if output.get("recommended_action") != "create_dry_run_handoff":
-                continue
-            strategies = output.get("strategies")
-            strategy = strategies[0] if isinstance(strategies, list) and strategies else {}
-            if not isinstance(strategy, dict):
-                strategy = {}
-            replay = output.get("candidate_strategy_replay")
-            if not isinstance(replay, dict):
-                replay = {}
-            contract = replay.get("decision_contract")
-            if not isinstance(contract, dict):
-                contract = {}
-
-            return {
-                "factor_walk_forward_run_id": run_id,
-                "artifact_name": f"factor-walk-forward-v2-{run_id}",
-                "required_strategy_profile": str(
-                    strategy.get("strategy_profile")
-                    or replay.get("strategy_profile")
-                    or "settlement_probability"
-                ),
-                "allowed_target": str(
-                    strategy.get("target")
-                    or contract.get("target")
-                    or "full_depth_settlement_executable_pnl"
-                ),
-                "runtime_score": str(
-                    strategy.get("runtime_score") or replay.get("runtime_score") or ""
-                ),
-                "strategy_config": (
-                    "config/strategies/"
-                    "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
-                ),
-            }
+            ready_handoff = _ready_handoff_fields(run_id=run_id, output=output)
+            if ready_handoff:
+                return ready_handoff
     return {}
+
+
+def _ready_handoff_fields(*, run_id: str, output: dict[str, Any]) -> dict[str, str]:
+    if output.get("kind") != "autofactor_strategy_handoff":
+        return {}
+    if output.get("status") != "ready":
+        return {}
+    if output.get("recommended_action") != "create_dry_run_handoff":
+        return {}
+    if not run_id:
+        return {}
+    strategies = output.get("strategies")
+    strategy = strategies[0] if isinstance(strategies, list) and strategies else {}
+    if not isinstance(strategy, dict):
+        strategy = {}
+    replay = output.get("candidate_strategy_replay")
+    if not isinstance(replay, dict):
+        replay = {}
+    contract = replay.get("decision_contract")
+    if not isinstance(contract, dict):
+        contract = {}
+
+    return {
+        "factor_walk_forward_run_id": run_id,
+        "artifact_name": f"factor-walk-forward-v2-{run_id}",
+        "required_strategy_profile": str(
+            strategy.get("strategy_profile")
+            or replay.get("strategy_profile")
+            or "settlement_probability"
+        ),
+        "allowed_target": str(
+            strategy.get("target")
+            or contract.get("target")
+            or "full_depth_settlement_executable_pnl"
+        ),
+        "runtime_score": str(
+            strategy.get("runtime_score") or replay.get("runtime_score") or ""
+        ),
+        "strategy_config": (
+            "config/strategies/"
+            "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+        ),
+    }
 
 
 def _autofactor_promotion_handoff_dispatch(
@@ -518,10 +541,16 @@ def _runtime_candidate_from_plan(
     """Select the newest typed, unblocked runtime contract from the trace plan."""
 
     summary = ((plan_payload.get("input") or {}).get("factor_registry_summary") or {})
+    candidates: list[Any] = []
+    runtime_ready = summary.get("runtime_ready_candidates")
+    if isinstance(runtime_ready, list):
+        candidates.extend(runtime_ready)
     recent = summary.get("recent_factors")
-    if not isinstance(recent, list):
+    if isinstance(recent, list):
+        candidates.extend(recent)
+    if not candidates:
         return None
-    for item in recent:
+    for item in candidates:
         if not isinstance(item, dict):
             continue
         status = str(item.get("status") or "")
@@ -568,6 +597,18 @@ def _latest_run(plan_payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, Any]:
+    summary = ((plan_payload.get("input") or {}).get("factor_registry_summary") or {})
+    ready_replays = summary.get("ready_candidate_replays")
+    if isinstance(ready_replays, list):
+        for item in ready_replays:
+            if not isinstance(item, dict):
+                continue
+            artifact = item.get("artifact_json")
+            replay = artifact if isinstance(artifact, dict) else item
+            contract = _candidate_replay_contract(replay, fallback=item)
+            if contract:
+                return contract
+
     latest_run = _latest_run(plan_payload)
     artifacts = latest_run.get("artifacts")
     if not isinstance(artifacts, list):
@@ -581,56 +622,86 @@ def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str,
         replay = output.get("candidate_strategy_replay")
         if not isinstance(replay, dict):
             continue
-        if replay.get("basis") != "runtime_market_update_replay":
-            continue
-        contract = replay.get("decision_contract")
-        if not isinstance(contract, dict):
-            contract = {}
-        identity = replay.get("identity")
-        if not isinstance(identity, dict):
-            identity = {}
-        recording_path = str(replay.get("recording_path") or identity.get("recording_path") or "")
-        recording_sha256 = str(
-            replay.get("recording_sha256") or identity.get("recording_sha256") or ""
-        )
-        if _looks_like_mutable_recording_path(recording_path) and not recording_sha256:
-            continue
-        source_factor = replay.get("source_factor")
-        if not isinstance(source_factor, dict):
-            source_factor = {}
-        metrics = replay.get("metrics") if isinstance(replay.get("metrics"), dict) else {}
-        blocking_flags = replay.get("blocking_risk_flags")
-        if not isinstance(blocking_flags, list):
-            blocking_flags = replay.get("blockers")
-        if not isinstance(blocking_flags, list):
-            blocking_flags = []
-        return {
-            "target": str(contract.get("target") or source_factor.get("target") or ""),
-            "horizon": str(contract.get("horizon") or source_factor.get("horizon") or ""),
-            "runtime_score": str(replay.get("runtime_score") or ""),
-            "strategy_profile": str(replay.get("strategy_profile") or ""),
-            "workflow_run_id": str(replay.get("workflow_run_id") or ""),
-            "source_workflow": str(replay.get("source_workflow") or ""),
-            "recording_path": recording_path,
-            "recording_sha256": recording_sha256,
-            "source_factor_name": str(
-                source_factor.get("name") or source_factor.get("factor_name") or ""
-            ),
-            "metrics": {
-                key: metrics[key]
-                for key in (
-                    "trade_count",
-                    "unique_event_count",
-                    "entry_fill_rate",
-                    "roi",
-                    "total_pnl",
-                    "avg_entry_price",
-                )
-                if key in metrics
-            },
-            "blocking_risk_flags": [str(item) for item in blocking_flags if str(item)],
-        }
+        contract = _candidate_replay_contract(replay, fallback={})
+        if contract:
+            return contract
     return {}
+
+
+def _candidate_replay_contract(
+    replay: dict[str, Any], *, fallback: dict[str, Any]
+) -> dict[str, Any]:
+    if replay.get("basis") != "runtime_market_update_replay":
+        return {}
+    contract = replay.get("decision_contract")
+    if not isinstance(contract, dict):
+        contract = {}
+    identity = replay.get("identity")
+    if not isinstance(identity, dict):
+        identity = {}
+    recording_path = str(replay.get("recording_path") or identity.get("recording_path") or "")
+    recording_sha256 = str(
+        replay.get("recording_sha256") or identity.get("recording_sha256") or ""
+    )
+    if _looks_like_mutable_recording_path(recording_path) and not recording_sha256:
+        return {}
+    source_factor = replay.get("source_factor")
+    if not isinstance(source_factor, dict):
+        source_factor = {}
+    metrics = replay.get("metrics") if isinstance(replay.get("metrics"), dict) else {}
+    if not metrics and isinstance(fallback.get("metrics"), dict):
+        metrics = fallback["metrics"]
+    blocking_flags = replay.get("blocking_risk_flags")
+    if not isinstance(blocking_flags, list):
+        blocking_flags = replay.get("blockers")
+    if not isinstance(blocking_flags, list):
+        blocking_flags = fallback.get("blocking_risk_flags")
+    if not isinstance(blocking_flags, list):
+        blocking_flags = []
+    return {
+        "target": str(
+            contract.get("target")
+            or source_factor.get("target")
+            or fallback.get("target")
+            or ""
+        ),
+        "horizon": str(
+            contract.get("horizon")
+            or source_factor.get("horizon")
+            or fallback.get("horizon")
+            or ""
+        ),
+        "runtime_score": str(
+            replay.get("runtime_score") or fallback.get("runtime_score") or ""
+        ),
+        "strategy_profile": str(
+            replay.get("strategy_profile") or fallback.get("strategy_profile") or ""
+        ),
+        "workflow_run_id": str(
+            replay.get("workflow_run_id") or fallback.get("workflow_run_id") or ""
+        ),
+        "source_workflow": str(
+            replay.get("source_workflow") or fallback.get("source_workflow") or ""
+        ),
+        "recording_path": recording_path,
+        "recording_sha256": recording_sha256,
+        "source_factor_name": str(
+            source_factor.get("name") or source_factor.get("factor_name") or ""
+        ),
+        "metrics": {
+            key: metrics[key]
+            for key in (
+                "trade_count",
+                "unique_event_count",
+                "entry_fill_rate",
+                "roi",
+                "total_pnl",
+                "avg_entry_price",
+            )
+            if key in metrics
+        },
+        "blocking_risk_flags": [str(item) for item in blocking_flags if str(item)],
+    }
 
 
 def _latest_valid_full_depth_surface_artifact(plan_payload: dict[str, Any]) -> dict[str, str]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,45 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Frontier Ready State (2026-05-25)
+
+Evidence stage: `factor_attribution` / `runtime_parity` planner repair. This
+fixes Research Manager frontier-state selection after a durable ready AutoFactor
+handoff or runtime-ready candidate exists; it does not claim live readiness.
+
+### Tasks
+
+- [x] Confirm current `main` is clean and latest hosted run has durable ready
+      AutoFactor evidence but Research Trace Plan still routes to
+      `runtime_contract`.
+- [x] Add durable frontier queries for runtime-ready candidates and ready
+      handoffs.
+- [x] Teach Research Manager and executor to consume the frontier summary
+      instead of only `recent_factors`.
+- [x] Run focused Rust/Python validation.
+- [ ] Land through PR and rerun Research Trace Plan from `main`.
+
+### Review
+
+- 2026-05-25: The remaining blocker is planner state selection, not missing
+  runtime contract extraction: ready handoff/replay artifacts can live under
+  `walk_forward` / `executable_replay`, while the default trace plan currently
+  asks for `factor_attribution` and the factor summary only reads newest
+  registry rows.
+- 2026-05-25: Added Research Trace Plan frontier summaries:
+  `ready_handoffs`, `runtime_ready_candidates`, and
+  `ready_candidate_replays`. Research Manager now treats a durable ready
+  handoff as the top-priority next action and ignores unselected preview
+  factor blocker noise from bulk `factors` arrays. The executor now consumes
+  the new frontier handoff/candidate fields instead of depending only on
+  `recent_factors`.
+- 2026-05-25: Focused validation passed:
+  `rtk cargo test --locked -p ploy-research research_os::manager --lib` (`17`
+  tests), `rtk cargo test --locked -p ploy-research --example
+  research_trace_plan --features db` (`2` tests), `python3 -m unittest
+  tests.test_research_manager_execute_plan
+  tests.test_persist_research_trace_contract` (`41` tests), targeted
+  `py_compile`, single-file `rustfmt --check`, and `rtk git diff --check`.
+
 ## Current Session - AutoFactor Selector Runtime Contract Repair (2026-05-25)
 
 Evidence stage: `factor_attribution` / runtime contract repair. This aligns

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -259,6 +259,7 @@ class PersistResearchTraceContractTest(unittest.TestCase):
             "experiment_trace",
             "factor_registry",
             "factor_evaluations",
+            "candidate_replay_tapes",
             "research_dataset_snapshots",
             "full_depth_execution_surfaces",
             "official_settlement_coverage_checks",
@@ -270,6 +271,11 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         self.assertIn("source_surface_blockers", source)
         self.assertIn("latest_full_depth_execution_surfaces", source)
         self.assertIn("latest_official_settlement_coverage_checks", source)
+        self.assertIn("ready_strategy_handoffs", source)
+        self.assertIn("runtime_ready_factor_candidates", source)
+        self.assertIn("ready_candidate_replays", source)
+        self.assertIn("runtime_ready_candidates", source)
+        self.assertIn("ready_handoffs", source)
         self.assertIn("valid = true", source)
         self.assertIn("execution_surfaces", source)
         self.assertIn("settlement_surfaces", source)

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -488,6 +488,56 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             dispatch["fields"]["runtime_score"],
         )
 
+    def test_fix_runtime_prefers_frontier_runtime_ready_candidates(self) -> None:
+        payload = build_executor_payload(
+            base_args(),
+            plan_payload(
+                "candidate_to_runtime_replay",
+                ["build_runtime_candidate_replay"],
+                {
+                    "runtime_ready_candidates": [
+                        {
+                            "factor_name": "ready_factor",
+                            "status": "candidate",
+                            "target": "full_depth_settlement_executable_pnl",
+                            "horizon": "5m",
+                            "blockers": [],
+                            "runtime_contract": {
+                                "version": "autofactor_runtime_contract_v1",
+                                "runtime_score": "autofactor_formula:ready_factor",
+                                "strategy_profile": "settlement_probability",
+                                "target": "full_depth_settlement_executable_pnl",
+                                "horizon": "5m",
+                                "blockers": [],
+                            },
+                        }
+                    ],
+                    "recent_factors": [
+                        {
+                            "factor_name": "blocked_recent_factor",
+                            "status": "candidate",
+                            "blockers": ["missing_runtime_contract"],
+                            "runtime_contract": {
+                                "version": "autofactor_runtime_contract_v1",
+                                "runtime_score": "autofactor_formula:blocked_recent_factor",
+                                "strategy_profile": "settlement_probability",
+                                "blockers": ["missing_runtime_contract"],
+                            },
+                        }
+                    ],
+                },
+            ),
+        )
+
+        self.assertEqual(1, payload["executable_dispatch_count"])
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("ready_factor", dispatch["selected_factor_name"])
+        self.assertEqual(
+            "autofactor_formula:ready_factor",
+            dispatch["fields"]["runtime_score"],
+        )
+
     def test_ready_handoff_maps_to_autofactor_promotion_side_effects(self) -> None:
         plan = plan_payload(
             "ready_handoff",
@@ -563,6 +613,57 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual(
             "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
             dispatch["fields"]["strategy_config"],
+        )
+
+    def test_ready_handoff_can_come_from_frontier_summary(self) -> None:
+        plan = plan_payload(
+            "ready_handoff",
+            ["create_dry_run_handoff_issue", "open_config_pr_from_ready_handoff"],
+        )
+        plan["input"]["latest_runs"] = {
+            "runs": [],
+            "ready_handoffs": [
+                {
+                    "run_id": "26377165132",
+                    "event_type": "strategy_handoff",
+                    "output_json": {
+                        "kind": "autofactor_strategy_handoff",
+                        "status": "ready",
+                        "recommended_action": "create_dry_run_handoff",
+                        "strategies": [
+                            {
+                                "runtime_score": "autofactor_formula:ready_factor",
+                                "strategy_profile": "settlement_probability",
+                                "target": "full_depth_settlement_executable_pnl",
+                            }
+                        ],
+                        "candidate_strategy_replay": {
+                            "basis": "runtime_market_update_replay",
+                            "runtime_score": "autofactor_formula:ready_factor",
+                            "strategy_profile": "settlement_probability",
+                        },
+                    },
+                }
+            ],
+        }
+
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK),
+            plan,
+        )
+
+        self.assertEqual(1, payload["executable_dispatch_count"])
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("autofactor-strategy-promotion.yml", dispatch["workflow"])
+        self.assertEqual("26377165132", dispatch["fields"]["factor_walk_forward_run_id"])
+        self.assertEqual(
+            "factor-walk-forward-v2-26377165132",
+            dispatch["fields"]["artifact_name"],
+        )
+        self.assertEqual(
+            "autofactor_formula:ready_factor",
+            dispatch["runtime_score"],
         )
 
     def test_ready_handoff_blocks_without_ready_source_artifact(self) -> None:


### PR DESCRIPTION
## Summary
- add Research Trace Plan frontier summaries for ready AutoFactor handoffs, runtime-ready candidates, and ready candidate replays
- teach Research Manager to prioritize durable ready handoffs and ignore unselected preview factor blocker noise
- update the executor to consume frontier handoff/candidate/replay fields instead of relying only on recent_factors

## Tests
- CARGO_TARGET_DIR=/tmp/ploy-research-manager-frontier /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research research_os::manager --lib
- CARGO_TARGET_DIR=/tmp/ploy-research-manager-frontier /opt/homebrew/bin/timeout 300 rtk cargo test --locked -p ploy-research --example research_trace_plan --features db
- python3 -m unittest tests.test_research_manager_execute_plan tests.test_persist_research_trace_contract
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py tests/test_persist_research_trace_contract.py
- rustfmt --edition 2021 --check crates/ploy-research/examples/research_trace_plan.rs crates/ploy-research/src/research_os/manager.rs
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ready-handoff routing in research planning to use durable frontier state instead of derived values, enhancing decision reliability.
  * Enhanced runtime candidate selection to prioritize runtime-ready factors and refactored replay contract validation.

* **Tests**
  * Added test coverage for frontier-style ready state handling in research manager execution and planning workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->