### PR TITLE
Fix tango market-data recovery fallbacks

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -379,7 +379,7 @@ jobs:
               fi
             }
 
-            wait_for_recent_rows() {
+            check_recent_rows() {
               local sql="\$1"
               local message="\$2"
               local attempts="\${3:-20}"
@@ -395,7 +395,13 @@ jobs:
               done
 
               echo "\${message}" >&2
-              exit 1
+              return 1
+            }
+
+            wait_for_recent_rows() {
+              if ! check_recent_rows "\$@"; then
+                exit 1
+              fi
             }
 
             wait_for_recent_log() {
@@ -573,16 +579,20 @@ jobs:
             systemctl restart ploy-deribit-greeks-collector.service
             systemctl enable --now ploy-market-discovery.service
             systemctl restart ploy-market-discovery.service
-            wait_for_recent_rows \
+            if ! check_recent_rows \
               "SELECT EXISTS (SELECT 1 FROM pm_market_catalog WHERE market_family = 'crypto' AND strategy_symbol IS NOT NULL AND end_time >= NOW())" \
               "pm_market_catalog has no active crypto markets after market-discovery restart" \
               20 \
-              3
-            wait_for_recent_rows \
+              3; then
+              echo "Continuing downstream service restarts; final postflight will fail if pm_market_catalog remains empty" >&2
+            fi
+            if ! check_recent_rows \
               "SELECT EXISTS (SELECT 1 FROM pm_market_metadata WHERE symbol IS NOT NULL AND end_time >= NOW())" \
               "pm_market_metadata has no active crypto markets after market-discovery restart" \
               20 \
-              3
+              3; then
+              echo "Continuing downstream service restarts; final postflight will fail if pm_market_metadata remains empty" >&2
+            fi
             if service_exists ploy-quote-collector.service; then
               systemctl enable --now ploy-quote-collector.service
               systemctl restart ploy-quote-collector.service

--- a/.github/workflows/market-data-gap-audit.yml
+++ b/.github/workflows/market-data-gap-audit.yml
@@ -93,11 +93,13 @@ jobs:
             HostName ${DEPLOY_HOST}
             User root
             IdentityFile ~/.ssh/tango_1_1_key
+            BatchMode yes
+            ConnectionAttempts 1
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
-            ServerAliveInterval 30
-            ServerAliveCountMax 20
-            ConnectTimeout 30
+            ServerAliveInterval 10
+            ServerAliveCountMax 2
+            ConnectTimeout 10
           EOF
 
       - name: Resolve audit scope
@@ -161,6 +163,7 @@ jobs:
           BUCKET_MINUTES: ${{ steps.scope.outputs.bucket_minutes }}
           SYMBOLS: ${{ steps.scope.outputs.symbols }}
           GATE_MODE: ${{ steps.scope.outputs.gate_mode }}
+          SSH_ATTEMPT_TIMEOUT_SECONDS: "45"
         run: |
           set -euo pipefail
           mkdir -p artifacts/market-data-gap-audit
@@ -175,7 +178,7 @@ jobs:
 
             for attempt in 1 2 3; do
               # shellcheck disable=SC2029
-              if ssh tango-1-1 \
+              if timeout "${SSH_ATTEMPT_TIMEOUT_SECONDS}s" ssh tango-1-1 \
                 "DEPLOY_ROOT='${DEPLOY_ROOT}' AUDIT_KIND='${audit_kind}' LOOKBACK_HOURS='${lookback_hours}' BUCKET_MINUTES='${BUCKET_MINUTES}' SYMBOLS='${SYMBOLS}' REQUIRED_SOURCES='${REQUIRED_SOURCES}' GATE_MODE='${GATE_MODE}' REMOTE_FILE='${remote_file}' /bin/bash -s" <<'EOF'
           set -euo pipefail
           mkdir -p "$(dirname "${REMOTE_FILE}")"
@@ -205,7 +208,7 @@ jobs:
             done
 
             for attempt in 1 2 3; do
-              if scp "tango-1-1:${remote_file}" "${local_file}"; then
+              if timeout "${SSH_ATTEMPT_TIMEOUT_SECONDS}s" scp "tango-1-1:${remote_file}" "${local_file}"; then
                 break
               fi
               if [ "${attempt}" -eq 3 ]; then
@@ -341,6 +344,7 @@ jobs:
 
           lines.extend(["", f"Overall gate status: `{worst}`"])
           summary = "\n".join(lines) + "\n"
+          print(summary)
           with open("artifacts/market-data-gap-audit/summary.md", "w", encoding="utf-8") as fh:
               fh.write(summary)
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
@@ -349,7 +353,6 @@ jobs:
               fh.write(f"overall_status={worst}\n")
 
           if should_fail:
-              print(summary)
               raise SystemExit(f"market data audit gate failed: {worst}")
           PY
 

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -105,7 +105,7 @@ require_service_guardrails() {{
   test "$(systemctl show -P MemoryMax "${{unit}}")" != "[not set]"
 }}
 
-wait_for_recent_rows() {{
+check_recent_rows() {{
   local sql="$1"
   local message="$2"
   local attempts="${{3:-20}}"
@@ -119,7 +119,13 @@ wait_for_recent_rows() {{
     sleep "${{sleep_secs}}"
   done
   echo "${{message}}" >&2
-  exit 1
+  return 1
+}}
+
+wait_for_recent_rows() {{
+  if ! check_recent_rows "$@"; then
+    exit 1
+  fi
 }}
 
 wait_for_recent_log() {{
@@ -262,16 +268,20 @@ systemctl enable --now ploy-deribit-greeks-collector.service
 systemctl restart ploy-deribit-greeks-collector.service
 systemctl enable --now ploy-market-discovery.service
 systemctl restart ploy-market-discovery.service
-wait_for_recent_rows \\
+if ! check_recent_rows \\
   "SELECT EXISTS (SELECT 1 FROM pm_market_catalog WHERE market_family = 'crypto' AND strategy_symbol IS NOT NULL AND end_time >= NOW())" \\
   "pm_market_catalog has no active crypto markets after market-discovery restart" \\
   20 \\
-  3
-wait_for_recent_rows \\
+  3; then
+  echo "Continuing downstream service restarts; final postflight will fail if pm_market_catalog remains empty" >&2
+fi
+if ! check_recent_rows \\
   "SELECT EXISTS (SELECT 1 FROM pm_market_metadata WHERE symbol IS NOT NULL AND end_time >= NOW())" \\
   "pm_market_metadata has no active crypto markets after market-discovery restart" \\
   20 \\
-  3
+  3; then
+  echo "Continuing downstream service restarts; final postflight will fail if pm_market_metadata remains empty" >&2
+fi
 if service_exists ploy-quote-collector.service; then
   systemctl enable --now ploy-quote-collector.service
   systemctl restart ploy-quote-collector.service

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,24 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Tango Dry-Run Data Plane Recovery (2026-05-26)
+
+Evidence stage: `dry_run_candidate` data-plane recovery and freshness
+verification. This keeps `pm5d.threelayer.live` paused and does not claim
+`live_candidate` readiness.
+
+### Tasks
+
+- [x] Confirm current failure shape: direct SSH can hang before fallback, and
+      deploy Cloud Assistant exits before restarting quote / PM trade / ployd
+      when market discovery has no active crypto markets.
+- [x] Make market-data gap audit fail fast on SSH banner hangs so Cloud
+      Assistant read-only fallback can run.
+- [x] Let Tango deploy/recovery restart downstream data services before final
+      market-discovery gates fail the deploy.
+- [x] Run focused workflow/script validation.
+- [ ] Merge, redeploy from `main`, and verify fresh recording / DB rows before
+      treating any new dry-run rows as usable evidence.
+
 ## Current Session - Research Manager Frontier Ready State (2026-05-25)
 
 Evidence stage: `factor_attribution` / `runtime_parity` planner repair. This

--- a/tests/test_market_data_gap_audit_scope.py
+++ b/tests/test_market_data_gap_audit_scope.py
@@ -125,6 +125,10 @@ class MarketDataGapAuditScopeTests(unittest.TestCase):
         workflow = WORKFLOW.read_text()
         self.assertIn("REQUIRED_SOURCES: pm5d-vol", workflow)
         self.assertIn("--required-sources \"${REQUIRED_SOURCES}\"", workflow)
+        self.assertIn("SSH_ATTEMPT_TIMEOUT_SECONDS", workflow)
+        self.assertIn('timeout "${SSH_ATTEMPT_TIMEOUT_SECONDS}s" ssh tango-1-1', workflow)
+        self.assertIn('timeout "${SSH_ATTEMPT_TIMEOUT_SECONDS}s" scp', workflow)
+        self.assertIn("print(summary)", workflow)
         self.assertIn("remote ${audit_kind} audit failed after ${attempt} attempts", workflow)
         self.assertIn(
             "copying ${audit_kind} audit report failed after ${attempt} attempts",

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -829,8 +829,11 @@ fn tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows()
         for needle in [
             "systemctl is-active --quiet ploy-pm-trade-collector.service",
             "require_service_guardrails ploy-pm-trade-collector.service",
+            "check_recent_rows",
             "pm_market_catalog has no active crypto markets after market-discovery restart",
             "pm_market_metadata has no active crypto markets after market-discovery restart",
+            "Continuing downstream service restarts; final postflight will fail if pm_market_catalog remains empty",
+            "Continuing downstream service restarts; final postflight will fail if pm_market_metadata remains empty",
             "wait_for_recent_log",
             "journalctl -u",
             "Polymarket trade collector poll complete",
@@ -854,26 +857,44 @@ fn tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows()
         let metadata_wait = content
             .find("pm_market_metadata has no active crypto markets after market-discovery restart");
         let trade_restart = content.find("systemctl restart ploy-pm-trade-collector.service");
+        let final_catalog_wait =
+            content.rfind("pm_market_catalog has no active crypto markets after deploy");
+        let final_metadata_wait =
+            content.rfind("pm_market_metadata has no active crypto markets after deploy");
         match (
             discovery_restart,
             catalog_wait,
             metadata_wait,
             trade_restart,
+            final_catalog_wait,
+            final_metadata_wait,
         ) {
             (
                 Some(discovery_restart),
                 Some(catalog_wait),
                 Some(metadata_wait),
                 Some(trade_restart),
+                Some(final_catalog_wait),
+                Some(final_metadata_wait),
             ) => {
                 if !(discovery_restart < catalog_wait && catalog_wait < trade_restart) {
                     offenders.push(format!(
-                        "{name}: catalog readiness wait must run between market discovery and PM trade collector restart"
+                        "{name}: catalog readiness probe must run between market discovery and PM trade collector restart"
                     ));
                 }
                 if !(discovery_restart < metadata_wait && metadata_wait < trade_restart) {
                     offenders.push(format!(
-                        "{name}: metadata readiness wait must run between market discovery and PM trade collector restart"
+                        "{name}: metadata readiness probe must run between market discovery and PM trade collector restart"
+                    ));
+                }
+                if !(trade_restart < final_catalog_wait) {
+                    offenders.push(format!(
+                        "{name}: final catalog readiness gate must run after PM trade collector restart"
+                    ));
+                }
+                if !(trade_restart < final_metadata_wait) {
+                    offenders.push(format!(
+                        "{name}: final metadata readiness gate must run after PM trade collector restart"
                     ));
                 }
             }


### PR DESCRIPTION
## Summary
- Make market-data gap audit SSH attempts fail fast so the Cloud Assistant fallback can run instead of waiting on banner hangs.
- Keep Tango deploy postflight strict, but restart quote/PM trade/ployd before failing on empty market-discovery catalog/metadata.
- Print audit summaries in job logs and add regression coverage for the recovery ordering.

## Validation
- ruby YAML parse for deploy-tango-1-1.yml and market-data-gap-audit.yml
- python3 -m unittest tests.test_market_data_gap_audit_scope
- python3 -m py_compile scripts/ci/deploy_tango_cloud_assist.py scripts/ci/run_tango_market_data_audit_cloud_assist.py tests/test_market_data_gap_audit_scope.py
- rtk cargo test --locked --test workflow_security tango_deploy_pm_trade_postflight_uses_collector_health_not_fresh_trade_rows -- --exact
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment verification workflow: non-critical checks now emit warnings and continue instead of blocking, allowing faster service restarts with deferred final validation.
  * Enhanced SSH connection reliability with configurable timeout handling and adjusted keepalive settings for remote operations.
  * Updated deployment and workflow tests to validate improved verification behavior.
  * Updated task tracking documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->