### PR TITLE
Fix DB Polymarket settlement expiry retry

### DIFF
--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -33,6 +33,7 @@ use crate::reference_prices::{
 const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
 const POLYMARKET_CLOB_HTTP_ENDPOINT: &str = "https://clob.polymarket.com";
 const NEAR_DEPTH_PCT_RANGE: f64 = 0.001;
+const DB_POLYMARKET_SETTLEMENT_RETRY_LOOKBACK_SECS: i64 = 30 * 60;
 
 fn rtds_market_data_ws_config() -> PolymarketWsConfig {
     let mut config = PolymarketWsConfig::default();
@@ -525,7 +526,7 @@ pub fn spawn_db_polymarket_feed(
                     price_to_beat
                 FROM pm_market_metadata
                 WHERE symbol = ANY($1)
-                  AND end_time > NOW() - INTERVAL '120 seconds'
+                  AND end_time > NOW() - ($2::BIGINT * INTERVAL '1 second')
                   AND COALESCE(start_time, end_time - INTERVAL '300 seconds')
                         < NOW() + INTERVAL '6 minutes'
                   AND raw_market->'markets'->0->'clobTokenIds' IS NOT NULL
@@ -533,6 +534,7 @@ pub fn spawn_db_polymarket_feed(
                 "#,
             )
             .bind(&symbols_upper)
+            .bind(DB_POLYMARKET_SETTLEMENT_RETRY_LOOKBACK_SECS)
             .fetch_all(&pool)
             .await
             {
@@ -580,10 +582,21 @@ pub fn spawn_db_polymarket_feed(
                 }
 
                 if end_time <= now {
-                    if expired_events.insert(event_id.clone()) {
+                    if !expired_events.contains(&event_id) {
                         let resolved_up_won =
                             resolve_db_event_outcome(&pool, &event_id, &up_token, &down_token)
                                 .await;
+                        if !mark_db_event_expired_if_resolved(
+                            &mut expired_events,
+                            &event_id,
+                            resolved_up_won,
+                        ) {
+                            debug!(
+                                event_id = %event_id,
+                                "DB Polymarket event settlement pending; retrying until official outcome is available",
+                            );
+                            continue;
+                        }
                         let _ = tx.send(MarketUpdate::EventExpired {
                             event_id: Arc::from(event_id.as_str()),
                             end_time,
@@ -712,6 +725,17 @@ pub fn spawn_db_polymarket_feed(
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
     })
+}
+
+fn mark_db_event_expired_if_resolved(
+    expired_events: &mut HashSet<String>,
+    event_id: &str,
+    resolved_up_won: Option<bool>,
+) -> bool {
+    if resolved_up_won.is_none() {
+        return false;
+    }
+    expired_events.insert(event_id.to_string())
 }
 
 async fn resolve_db_event_outcome(
@@ -1445,14 +1469,15 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 #[cfg(test)]
 mod tests {
     use super::{
-        book_quote_from_rest, l2_updates_from_book, parse_agg_trade_msg,
-        rtds_market_data_ws_config, RestBook,
+        book_quote_from_rest, l2_updates_from_book, mark_db_event_expired_if_resolved,
+        parse_agg_trade_msg, rtds_market_data_ws_config, RestBook,
     };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;
     use rust_decimal::prelude::ToPrimitive;
     use rust_decimal_macros::dec;
     use serde_json::json;
+    use std::collections::HashSet;
     use std::time::Duration;
 
     #[test]
@@ -1538,6 +1563,33 @@ mod tests {
         assert_eq!(quote.bid_size, None);
         assert_eq!(quote.ask, None);
         assert_eq!(quote.ask_size, None);
+    }
+
+    #[test]
+    fn db_polymarket_expiry_waits_for_official_settlement_before_marking_done() {
+        let mut expired_events = HashSet::new();
+
+        assert!(!mark_db_event_expired_if_resolved(
+            &mut expired_events,
+            "event-1",
+            None
+        ));
+        assert!(
+            !expired_events.contains("event-1"),
+            "missing settlement must stay retryable"
+        );
+
+        assert!(mark_db_event_expired_if_resolved(
+            &mut expired_events,
+            "event-1",
+            Some(true)
+        ));
+        assert!(expired_events.contains("event-1"));
+        assert!(!mark_db_event_expired_if_resolved(
+            &mut expired_events,
+            "event-1",
+            Some(true)
+        ));
     }
 
     #[test]

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -94,6 +94,47 @@
   - After boot, use Cloud Assistant if needed to run `systemctl enable --now actions.runner.proerror77-ploy.ploy-ci-1.service`.
   - Confirm queued workflow runs move to `in_progress` before assuming ploy-ci work has actually started.
 
+- Pattern: A dry-run data stall on `tango-1-1` can look like a strategy,
+  replay, collector, or fill-simulation bug when the real failure is public
+  egress. In the 2026-05-26 incident, TCP handshakes worked but public payload
+  packets from the instance were not ACKed, while Cloud Assistant/internal
+  traffic still worked; Aliyun then reported `AccountInArrears` and refused
+  public-IP/EIP recovery operations.
+- Rule: Before changing PM5D strategy code or waiting for more dry-run records,
+  verify market-data freshness and public payload flow from `tango-1-1`. If
+  Cloud Assistant works but GitHub/Binance/Deribit/Polymarket HTTPS payloads
+  time out, check Aliyun billing/account state and public IP/EIP status before
+  debugging collectors.
+- Recovery rule: After an Aliyun arrears/public-egress incident is fixed, prove
+  recovery with both public payload curl probes and fresh data-plane rows/logs.
+  Start a new clean dry-run evidence window after recovery; do not blend records
+  collected during the outage into replay parity or promotion evidence.
+- Traffic rule: Use ECS monitor counters and host logs before blaming the public
+  dashboard for bandwidth consumption. In the 2026-05-27 check, nginx served
+  only about `0.20MB` over 24h while ECS monitor showed hundreds of MB to GB per
+  day of `InternetRX`, matching market-data collector ingress rather than page
+  serving.
+- Evidence checklist:
+  - `curl` from `tango-1-1` to `https://api.github.com/zen`,
+    Binance, Deribit, and Polymarket with timing fields.
+  - `tcpdump` proving whether payload packets are ACKed, not only whether TCP
+    connect succeeds.
+  - `antiddos-public describe-instance-ip-address` for blackhole/defense state.
+  - A paid-account/public-egress check before allocating or converting EIPs.
+
+- Pattern: A PM5D dry-run can look profitable in the report while the active
+  runner is still stuck at `max_positions`. The report may close rows by joining
+  official settlement labels, but the runner's in-memory `PositionLedger` only
+  frees capacity after a SELL/settlement fill.
+- Rule: When dry-run stops entering after an initial batch, compare report
+  closure against runtime BUY/SELL fills and strategy diagnostics. If
+  `skip_max_positions` rises and runtime fills have no SELL exits, debug event
+  expiry and settlement emission before changing factor logic.
+- Feed rule: Local-DB PM event feeds must not mark an event expired-done when
+  `resolved_up_won` is still missing. Keep the event retryable until official
+  `pm_token_settlements` arrives, because observed settlement lag can exceed the
+  old 120-second DB feed lookback.
+
 - Pattern: AutoFactor / settlement-probability PRD downstream evidence does not need a live self-hosted runner once a complete sampled research snapshot artifact exists.
 - Rule: Prefer GitHub-hosted `ubuntu-latest` artifact workflows for AutoFactor mining, promotion, and dry-run handoff gates. Treat `ploy-ci-1` as a legacy DB-adjacent fallback only for fresh snapshot/export work that still requires Tango private-network database access.
 - Migration guardrail:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,8 +16,80 @@ verification. This keeps `pm5d.threelayer.live` paused and does not claim
 - [x] Let Tango deploy/recovery restart downstream data services before final
       market-discovery gates fail the deploy.
 - [x] Run focused workflow/script validation.
-- [ ] Merge, redeploy from `main`, and verify fresh recording / DB rows before
-      treating any new dry-run rows as usable evidence.
+- [x] Merge, redeploy from `main`, and verify whether fresh recording / DB rows
+      recover before treating any new dry-run rows as usable evidence.
+
+### Review
+
+- 2026-05-26: PR `#701` landed as `main@575cdc88` and deploy recovery reached
+  downstream service restarts, but final freshness still failed. Cloud
+  Assistant diagnostics showed DNS, route, local firewall, proxy env, services,
+  DB, and collectors were not the primary blocker: TCP handshakes to GitHub,
+  Binance, Deribit, Polymarket, and inbound HTTP succeeded, but payload packets
+  from `tango-1-1` over the public path were not ACKed. Reboot, stop/start, NIC
+  offload toggles, Aegis/CloudMonitor stop probe, and a temporary equivalent
+  security group did not restore public payload flow.
+- 2026-05-26: The decisive cloud-side blocker is account state. Attempts to
+  allocate a low-bandwidth test EIP failed with `PAY.INSUFFICIENT_BALANCE`, and
+  converting the existing NAT public IP to an EIP failed with
+  `AccountInArrears`. Until the Aliyun account is brought current or the host is
+  moved behind a working paid public egress path, collectors cannot fetch fresh
+  Binance/Deribit/Polymarket data and the current dry-run recording is not
+  usable new evidence.
+- 2026-05-27: After the Aliyun account was brought current, public payload flow
+  recovered. Cloud Assistant curl probes from `tango-1-1` returned HTTP 200 for
+  GitHub, Binance, Deribit, and Polymarket; local public `/health` returned 200.
+  The settlement-probability recording advanced to sequence `1597876` at
+  `2026-05-27 00:08:27 +0800`, and current DB/log probes showed fresh Binance,
+  CLOB quote/orderbook, Deribit, market-discovery, and PM trade activity. This
+  restores data collection but does not make the strategy `live_candidate`.
+- 2026-05-27: Target deployment
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun` had `8` orders,
+  `8` fills, `0` rejects, requested notional about `120.00`, filled notional
+  about `119.18`, and last order at `2026-05-26 18:42:10 +0800`. Treat the
+  post-recovery dry-run evidence window as newly starting after market data
+  freshness recovered; do not mix the outage window into replay/parity gates.
+- 2026-05-27 08:08 +0800: Follow-up dry-run check showed the target deployment
+  still `desired=Running observed=Running` while `pm5d.threelayer.live` remained
+  paused. The recording grew from `1267674049` to `1267827073` bytes in eight
+  seconds (`sequence` `3458686 -> 3459079`), confirming fresh market updates.
+  Closed-trade report for the target deployment showed `8` closed trades,
+  `7` wins, `1` loss, `net_pnl=108.8669`, and `notional=119.1819`; runtime
+  tables still showed `8` fills, `0` rejects, and no orders/fills since
+  `2026-05-27 00:00 +0800`. This is positive early dry-run evidence but still
+  below the minimum sample needed for promotion.
+- 2026-05-27 follow-up hypothesis: The dry-run runner may be evaluating fresh
+  updates but failing to re-enter its next trade loop after an earlier trigger.
+  Investigate the runtime lifecycle boundary before changing strategy logic:
+  compare strategy diagnostics (`skip_max_positions`, `skip_existing_position`),
+  runtime orders/fills, closed-trade report rows, and event-expiry/position
+  release behavior for the target deployment.
+- 2026-05-27 loop root cause: The target dry-run was not merely idle. Runner
+  diagnostics kept processing fresh updates while `skip_max_positions` rose, and
+  DB evidence showed all `8` target runtime fills were BUY fills with `0`
+  SELL/settlement/TP/SL exit orders. The public dry-run report counted those
+  events as closed by joining official `pm_token_settlements`, but the active
+  runtime position ledger never received settlement exits. The local DB
+  Polymarket feed emitted `EventExpired` with `resolved_up_won=None` at event
+  expiry, marked the event done, and only queried events for `120 seconds` after
+  expiry; official settlement rows for the observed events arrived around
+  `6-12` minutes later. Added a focused fix so missing settlement remains
+  retryable and the DB feed keeps recently expired events visible for `30`
+  minutes, plus a regression proving an unresolved expiry does not burn the
+  retry state.
+
+### Follow-up Tasks
+
+- [x] Prove whether the target runner is truly stuck after a trigger or simply
+      rejecting new opportunities by design.
+- [x] Trace the state boundary that should release a filled event/position for
+      the next candidate.
+- [x] If a lifecycle bug is confirmed, patch it with a focused regression and
+      deploy through CI-built artifacts only.
+- [ ] Land the DB-feed settlement retry fix through PR/CI and deploy from
+      `main`; do not build Rust on `tango-1-1`.
+- [ ] After deploy, start a clean dry-run evidence window before replay/parity
+      or promotion review.
 
 ## Current Session - Research Manager Frontier Ready State (2026-05-25)
 


### PR DESCRIPTION
## Summary
- keep local-DB Polymarket expired events retryable until official settlement is available
- extend the DB event lookback from 120 seconds to 30 minutes so delayed settlement rows can trigger settlement exits
- document the dry-run max-position/settlement lifecycle diagnosis

## Evidence
- remote DB showed 8 target dry-run BUY fills and 0 SELL/settlement/TP/SL exit orders for pm5d.threelayer.settlement-probability-btc-eth.dryrun
- target pm_token_settlements rows existed, but recording had event_expired rows with resolved_up_won=null before settlement arrived
- cargo test --locked -p ploy-market-data --features live --lib
- rustfmt --edition 2021 --check crates/ploy-market-data/src/feeds.rs
- rtk git diff --check

Evidence stage: dry_run_candidate lifecycle fix only; this does not claim live_candidate readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced market event settlement handling with improved retry logic to prevent marking events as expired before official settlement confirmation

* **Documentation**
  * Added comprehensive PM5D troubleshooting and operational guidance including diagnostics, recovery steps, and feed management rules

* **Chores**
  * Updated internal task tracking with deployment results and follow-up work items

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->