### PR TITLE
Fix settlement dry-run daily cap

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -35,7 +35,7 @@ cooldown_secs = 30
 
 stake_usd = 15.0
 max_positions = 4
-max_daily_trades = 50
+max_daily_trades = 1000
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,41 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Settlement Probability Dry-Run Daily Cap (2026-05-27)
+
+Evidence stage: `dry_run_candidate` / `execution_quality` runtime evidence.
+This keeps `pm5d.threelayer.live` paused and only adjusts the settlement
+probability dry-run candidate so it can continue accumulating clean evidence
+after the first 50 entries.
+
+### Tasks
+
+- [x] Reconcile trade-count semantics across dry-run report, runtime fills, and
+      event track records.
+- [x] Confirm whether the apparent count issue is stale data, report grouping,
+      duplicate rows, or a runtime cap.
+- [x] Raise the settlement-probability dry-run daily cap and add a regression
+      contract.
+- [ ] Validate locally, land through PR, deploy from `main`, and verify new
+      entries can resume without touching live.
+
+### Review
+
+- 2026-05-27: The public dry-run report's `total_trades=50` is lifecycle trade
+  count from `strategy_runtime_event_track_record`, not raw fill count. DB
+  evidence showed `50` BUY fills and `50` SELL fills, all paired into `50`
+  closed event/side rows. The runner was still active and recording was still
+  growing, but ployd logs showed `entry_signals=50` and
+  `skip_max_daily_trades=29` after the target config hit
+  `max_daily_trades = 50`. This cap explains why evidence stopped accumulating
+  after the 50th entry even though the data plane was healthy.
+- 2026-05-27: Local validation passed for the cap repair:
+  `python3 -m unittest tests.test_strategy_config_contracts`, `python3 -m
+  py_compile tests/test_strategy_config_contracts.py
+  scripts/report_dryrun_summary.py`, `rtk cargo test --locked -p
+  ploy-strategy-bundles
+  settlement_probability_config_carries_autofactor_handoff_score --lib`, and
+  `rtk git diff --check`.
+
 ## Current Session - Tango Dry-Run Data Plane Recovery (2026-05-26)
 
 Evidence stage: `dry_run_candidate` data-plane recovery and freshness

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -86,6 +86,16 @@ class StrategyConfigContractTests(unittest.TestCase):
         )
         self.assertEqual(Decimal(str(strategy["three_layer_min_entry_score"])), Decimal("0.10"))
 
+    def test_settlement_probability_dryrun_daily_cap_allows_evidence_collection(self) -> None:
+        strategy = tomllib.loads(
+            (
+                STRATEGY_DIR
+                / "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+            ).read_text()
+        )["strategy"]
+
+        self.assertGreaterEqual(strategy["max_daily_trades"], 1000)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- raise the settlement-probability dry-run daily trade cap from 50 to 1000 so clean runtime evidence can continue accumulating
- add a config contract test to prevent this candidate from regressing to a low evidence-collection cap
- record the count-semantics/root-cause evidence in tasks/todo.md

## Evidence
- dry-run report `total_trades=50` is lifecycle rows, while DB has 50 BUY fills + 50 SELL fills
- ployd diagnostic showed `entry_signals=50` and `skip_max_daily_trades=29`, proving the dry-run stopped on the config cap
- live remains paused; this PR only changes the dry-run candidate config

## Validation
- `python3 -m unittest tests.test_strategy_config_contracts`
- `python3 -m py_compile tests/test_strategy_config_contracts.py scripts/report_dryrun_summary.py`
- `rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased the daily trade execution limit for the BTC/ETH settlement probability strategy in dry-run mode, enabling improved evidence collection during testing.

* **Tests**
  * Added validation test to confirm the daily trade limit supports evidence collection requirements.

* **Documentation**
  * Updated session notes documenting the daily cap adjustment and validation results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->