### PR TITLE
Disable settlement dry-run daily trade cap

### DIFF
--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -35,7 +35,8 @@ cooldown_secs = 30
 
 stake_usd = 15.0
 max_positions = 4
-max_daily_trades = 1000
+# 0 disables the daily trade cap for dry-run evidence collection.
+max_daily_trades = 0
 allowed_window_secs = [300, 900]
 
 three_layer_strategy_profile = "settlement_probability"

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -1605,7 +1605,9 @@ impl ThreeLayerStrategy {
             debug!(symbol, "Balance exhausted pause active, skipping entry");
             return None;
         }
-        if self.daily_trade_count >= self.config.max_daily_trades {
+        if self.config.max_daily_trades > 0
+            && self.daily_trade_count >= self.config.max_daily_trades
+        {
             self.bump("skip_max_daily_trades");
             return None;
         }
@@ -2940,6 +2942,58 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(diagnostics.get("entry_evaluations"), Some(&1));
         assert_eq!(diagnostics.get("skip_no_candidate_events"), Some(&1));
+    }
+
+    #[test]
+    fn max_daily_trades_zero_disables_daily_cap() {
+        use chrono::TimeZone;
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let mut config = test_config();
+        config.max_daily_trades = 0;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        strategy.daily_trade_count = 10_000;
+        strategy.spot.insert(Arc::from("BTCUSDT"), dec!(100000));
+
+        let decision = strategy.try_entry(
+            "BTCUSDT",
+            now,
+            &PositionLedger::default(),
+            &OrderLedger::default(),
+        );
+
+        assert!(decision.is_none());
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("entry_evaluations"), Some(&1));
+        assert_eq!(diagnostics.get("skip_no_candidate_events"), Some(&1));
+        assert_eq!(diagnostics.get("skip_max_daily_trades"), None);
+    }
+
+    #[test]
+    fn positive_max_daily_trades_still_blocks_entries() {
+        use chrono::TimeZone;
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let mut config = test_config();
+        config.max_daily_trades = 1;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        strategy.daily_trade_count = 1;
+
+        let decision = strategy.try_entry(
+            "BTCUSDT",
+            now,
+            &PositionLedger::default(),
+            &OrderLedger::default(),
+        );
+
+        assert!(decision.is_none());
+        let diagnostics = strategy
+            .diagnostics()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(diagnostics.get("entry_evaluations"), Some(&1));
+        assert_eq!(diagnostics.get("skip_max_daily_trades"), Some(&1));
     }
 
     fn test_config() -> ThreeLayerConfig {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,8 +4,10 @@
 
 Evidence stage: `dry_run_candidate` / `execution_quality` runtime evidence.
 This keeps `pm5d.threelayer.live` paused and only adjusts the settlement
-probability dry-run candidate so it can continue accumulating clean evidence
-after the first 50 entries.
+probability dry-run candidate so it can continue accumulating clean evidence.
+The current operator requirement is no daily trade cap for this dry-run
+evidence window; `max_daily_trades = 0` must mean unlimited, not zero allowed
+entries.
 
 ### Tasks
 
@@ -15,6 +17,8 @@ after the first 50 entries.
       duplicate rows, or a runtime cap.
 - [x] Raise the settlement-probability dry-run daily cap and add a regression
       contract.
+- [x] Replace the finite cap with explicit unlimited semantics and regression
+      coverage.
 - [ ] Validate locally, land through PR, deploy from `main`, and verify new
       entries can resume without touching live.
 
@@ -35,6 +39,18 @@ after the first 50 entries.
   ploy-strategy-bundles
   settlement_probability_config_carries_autofactor_handoff_score --lib`, and
   `rtk git diff --check`.
+- 2026-05-27: Post-deploy remote evidence showed the strategy was not stuck:
+  the dry-run deployment was `running/running`, live stayed `paused/paused`,
+  the public report reached `total_trades=54`, latest open was
+  `2026-05-27T15:32:17.938+08:00`, and logs showed new entry signals after the
+  50-trade repair with no fresh `skip_max_daily_trades`. The config still used
+  finite `max_daily_trades = 1000`, so the follow-up is to make the dry-run
+  cap truly unlimited.
+- 2026-05-27: Implemented explicit unlimited semantics:
+  `max_daily_trades = 0` disables the daily cap, while positive values still
+  enforce `skip_max_daily_trades`. The regression test was red/green checked:
+  it fails under the old `daily_trade_count >= max_daily_trades` behavior and
+  passes with the new guard.
 
 ## Current Session - Tango Dry-Run Data Plane Recovery (2026-05-26)
 

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -86,7 +86,7 @@ class StrategyConfigContractTests(unittest.TestCase):
         )
         self.assertEqual(Decimal(str(strategy["three_layer_min_entry_score"])), Decimal("0.10"))
 
-    def test_settlement_probability_dryrun_daily_cap_allows_evidence_collection(self) -> None:
+    def test_settlement_probability_dryrun_disables_daily_trade_cap(self) -> None:
         strategy = tomllib.loads(
             (
                 STRATEGY_DIR
@@ -94,7 +94,7 @@ class StrategyConfigContractTests(unittest.TestCase):
             ).read_text()
         )["strategy"]
 
-        self.assertGreaterEqual(strategy["max_daily_trades"], 1000)
+        self.assertEqual(strategy["max_daily_trades"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make ThreeLayer max_daily_trades=0 mean unlimited instead of blocking all entries
- set the settlement-probability BTC/ETH dry-run config to max_daily_trades=0
- update config contract coverage and add Rust regressions for unlimited and positive cap behavior

## Evidence stage
- dry_run_candidate / execution_quality
- live deployment remains out of scope and should stay paused

## Verification
- python3 -m unittest tests.test_strategy_config_contracts
- python3 -m py_compile tests/test_strategy_config_contracts.py scripts/report_dryrun_summary.py
- rtk cargo test --locked -p ploy-strategy-bundles max_daily_trades --lib
- rtk cargo test --locked -p ploy-strategy-bundles settlement_probability_config_carries_autofactor_handoff_score --lib
- rustfmt --check crates/ploy-strategy-bundles/src/strategies/three_layer.rs
- rtk git diff --check

Note: repo-wide cargo fmt --check still reports pre-existing formatting drift in unrelated files; target file rustfmt passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Settlement-probability strategy's dry-run mode now supports unlimited daily trades for comprehensive evidence collection.

* **Improvements**
  * Daily trading limits can be disabled via configuration, enabling data-collection scenarios without trade constraints.

* **Tests**
  * Added regression tests verifying daily trading limits function correctly when enabled and disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->