### PR TITLE
Fix dry-run feedback prior family matching

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -1481,6 +1481,15 @@ fn runtime_feedback_penalty(feedback: &AlphaSearchRuntimeFeedback) -> f64 {
 fn normalized_factor_family(raw: &str) -> String {
     let mut value = normalized_factor_key(raw);
     let suffixes = [
+        "_select_entry_price_quality_ge_075",
+        "_select_entry_price_quality_ge_050",
+        "_select_entry_price_quality_ge_025",
+        "_select_full_depth_entry_ge_075",
+        "_select_full_depth_entry_ge_050",
+        "_select_full_depth_entry_ge_025",
+        "_select_near_strike_ge_075",
+        "_select_near_strike_ge_050",
+        "_select_near_strike_ge_025",
         "_runtime_pass_through_add_spread_penalty",
         "_runtime_pass_through_add_capacity_gate",
         "_add_spread_penalty",
@@ -2157,5 +2166,33 @@ mod tests {
             "auto_settlement_model_full_depth_settlement_edge_x_external_pressure"
         );
         assert!(matching_runtime_avoidance(&dangling_interaction, &composed_avoidances).is_some());
+
+        let selected_gate_variant = sample_report(
+            "mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_select_near_strike_ge_025",
+        );
+        assert_eq!(
+            normalized_factor_family(&selected_gate_variant.name),
+            "auto_settlement_model_full_depth_settlement_edge"
+        );
+        let selected_gate_prior = LlmPriorSpec {
+            mutations: Vec::new(),
+            runtime_avoid_factors: vec![crate::autofactor::RuntimeAvoidFactorSpec {
+                base_factor:
+                    "mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
+                        .to_string(),
+                factor_family: Some("auto_settlement_model_full_depth_settlement_edge".to_string()),
+                runtime_score: Some(
+                    "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
+                        .to_string(),
+                ),
+                reason: Some("negative_runtime_edge".to_string()),
+                metrics: serde_json::Value::Null,
+            }],
+        };
+        assert!(matching_runtime_avoidance(
+            &selected_gate_variant,
+            &runtime_avoidances(None, Some(&selected_gate_prior))
+        )
+        .is_some());
     }
 }

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -313,6 +313,15 @@ def normalized_factor_key(raw: str) -> str:
 def factor_family(raw: str) -> str:
     value = normalized_factor_key(raw)
     suffixes = (
+        "_select_entry_price_quality_ge_075",
+        "_select_entry_price_quality_ge_050",
+        "_select_entry_price_quality_ge_025",
+        "_select_full_depth_entry_ge_075",
+        "_select_full_depth_entry_ge_050",
+        "_select_full_depth_entry_ge_025",
+        "_select_near_strike_ge_075",
+        "_select_near_strike_ge_050",
+        "_select_near_strike_ge_025",
         "_runtime_pass_through_add_spread_penalty",
         "_runtime_pass_through_add_capacity_gate",
         "_add_spread_penalty",

--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -832,6 +832,15 @@ def _normalized_factor_key(raw: str) -> str:
 def _normalized_factor_family(raw: str) -> str:
     value = _normalized_factor_key(raw)
     suffixes = (
+        "_select_entry_price_quality_ge_075",
+        "_select_entry_price_quality_ge_050",
+        "_select_entry_price_quality_ge_025",
+        "_select_full_depth_entry_ge_075",
+        "_select_full_depth_entry_ge_050",
+        "_select_full_depth_entry_ge_025",
+        "_select_near_strike_ge_075",
+        "_select_near_strike_ge_050",
+        "_select_near_strike_ge_025",
         "_runtime_pass_through_add_spread_penalty",
         "_runtime_pass_through_add_capacity_gate",
         "_add_spread_penalty",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -143,6 +143,21 @@
   - Do not move a DB/private-endpoint workflow to GitHub-hosted runners by changing only `runs-on`; first replace the data source with a portable artifact or a hosted-safe export path.
   - When a complete sampled snapshot artifact exists, do not block strategy promotion on `ploy-ci-1` availability.
 
+- Pattern: Runtime feedback priors can look consumed while still failing to
+  affect AutoFactor selection if factor-family normalization misses generated
+  selector suffixes like `_select_near_strike_ge_025` or
+  `_select_entry_price_quality_ge_075`.
+- Rule: When a dry-run feedback prior is supposed to avoid or penalize a losing
+  runtime family, verify the artifact's `search-feedback.json`,
+  `node-metrics.json`, and selected MCTS nodes show the family penalty on every
+  generated selector/gate variant before concluding the search "retried"
+  correctly.
+- Guardrail:
+  - Add normalization regressions for any new deterministic or LLM mutation
+    suffix before relying on `runtime_avoid_factors`.
+  - If a retry still selects a same-family variant of the losing dry-run score,
+    inspect normalization first, not runtime contract plumbing.
+
 ## 2026-03-06
 
 - Pattern: Managed strategy bootstrap can silently drift from the checked-in live strategy template and override production sizing without touching host config files.

--- a/tasks/research_evidence/pm5d_settlement_probability_dryrun_feedback_prior_20260527.json
+++ b/tasks/research_evidence/pm5d_settlement_probability_dryrun_feedback_prior_20260527.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "research_manager_typed_prior.v1",
+  "source": "dry_run_runtime_feedback",
+  "evidence_stage": "dry_run_candidate",
+  "theme": "revise_prior",
+  "actions": [
+    "rerun_alpha_search_with_bounded_mutations"
+  ],
+  "blocker_actions": [
+    {
+      "blocker_family": "strategy_economics",
+      "action": "mutate_or_reject_negative_runtime_edge",
+      "reason": "Post-reset settlement-probability dry-run is execution-healthy but loses money after fees and settlement accounting."
+    }
+  ],
+  "constraints": [
+    "do not promote the current runtime score without a new runtime_market_update_replay artifact",
+    "penalize losing runtime-observed factor families and require positive executable PnL before handoff",
+    "treat symbol/side bucket splits as diagnostic until they survive walk-forward and runtime replay",
+    "preserve one-event-one-decision accounting and full-depth executable entry pricing"
+  ],
+  "runtime_avoid_factors": [
+    {
+      "base_factor": "mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+      "factor_family": "auto_settlement_model_full_depth_settlement_edge",
+      "runtime_score": "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+      "reason": "negative_dry_run_runtime_edge",
+      "metrics": {
+        "closed_trades": 137,
+        "realized_pnl": -207.4342,
+        "profit_factor": 0.781,
+        "sharpe": -1.0667,
+        "avg_trade": -1.5141,
+        "max_drawdown": -220.2696,
+        "buy_fill_rate_pct": 99.31,
+        "rejected_buy_orders": 0,
+        "post_reset_closed_trades": 74,
+        "post_reset_net_pnl": -74.5452,
+        "post_reset_profit_factor": 0.8498,
+        "worst_symbol_side_bucket": "BTCUSDT UP",
+        "worst_symbol_side_bucket_net_pnl": -105.6478,
+        "worst_symbol_side_bucket_profit_factor": 0.5316,
+        "second_worst_symbol_side_bucket": "ETHUSDT DOWN",
+        "second_worst_symbol_side_bucket_net_pnl": -28.4443,
+        "second_worst_symbol_side_bucket_profit_factor": 0.3699
+      }
+    }
+  ],
+  "mutations": [
+    {
+      "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_model_full_depth_edge_near_strike_gate_after_negative_dryrun",
+      "feature": "near_strike_score"
+    },
+    {
+      "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+      "mutation_type": "add_feature_gate",
+      "name": "llm_model_full_depth_edge_full_depth_gate_after_negative_dryrun",
+      "feature": "full_depth_entry_fillable_gate"
+    },
+    {
+      "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+      "mutation_type": "add_spread_penalty",
+      "name": "llm_model_full_depth_edge_spread_penalty_after_negative_dryrun",
+      "feature": "side_spread",
+      "constant": 0.02
+    },
+    {
+      "base_factor": "auto_settlement_conservative_settlement_edge",
+      "mutation_type": "invert_or_contrarian",
+      "name": "llm_conservative_settlement_edge_contrarian_after_negative_dryrun"
+    }
+  ]
+}

--- a/tasks/research_evidence/pm5d_settlement_probability_dryrun_revision_20260527.md
+++ b/tasks/research_evidence/pm5d_settlement_probability_dryrun_revision_20260527.md
@@ -1,0 +1,166 @@
+# Research Evidence: PM5D settlement-probability dry-run revision - 2026-05-27
+
+## Decision
+
+Status: `revise`
+
+One-line decision: The dry-run runtime and fill path are healthy, but the
+current settlement-probability AutoFactor score is losing money after costs and
+must be revised before any live-candidate discussion.
+
+## Semantic Context
+
+- Strategy lane: `settlement_probability`
+- Evidence stage: `dry_run_candidate`
+- Lifecycle segment tested: `signal -> intent -> order -> fill -> position -> pnl`
+- Promotion target, if any: `none`
+
+## Hypothesis
+
+- Claim: `autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted`
+  should produce positive small-stake dry-run PnL when run with full-depth
+  executable entry pricing and official settlement exits.
+- Expected edge mechanism: settlement probability should exceed executable
+  entry cost after capacity and spread adjustment.
+- Failure criteria: negative net PnL, profit factor below `1.0`, unstable
+  symbol/side buckets, or execution evidence showing rejected or unfillable
+  entries.
+- Next decision this evidence should unlock: feed runtime dry-run feedback back
+  into Research Manager / AutoFactor typed priors and search for a revised
+  runtime candidate; do not promote or scale this candidate.
+
+## Inputs
+
+- Git ref: `main@d4718d9e5a40af1233f83ec3a5b7e4560b2527a9`
+- Workflow run: dry-run deploy evidence from deploy run `26498545236`; live
+  remote verification performed on `2026-05-27 21:39-21:41 CST`.
+- Snapshot or artifact: deployed Tango dry-run runtime evidence and public
+  dry-run report.
+- Dataset/window: target deployment rows from `2026-05-27 09:27:02 +08` through
+  `2026-05-27 21:41:42 +08`; clean post-reset review window starts at
+  `2026-05-27 16:08:40 +08`.
+- Symbols/events: `BTCUSDT`, `ETHUSDT`; runtime event-track records for
+  `pm5d.threelayer.settlement-probability-btc-eth.dryrun`.
+- Config: `config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml`
+  with `stake_usd=15`, `max_positions=4`, and `max_daily_trades=0`
+  (unlimited dry-run evidence collection).
+- Local/remote artifact paths:
+  - Public report: `http://8.221.143.151/api/reports/dry-run`
+  - Deployment state: `http://8.221.143.151/api/deployments`
+  - Runtime recording:
+    `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`
+
+## Data Surface Audit
+
+- Binance spot/trade ticks: `present`
+- Binance L2/LOB: `present in runtime recording path; not separately promoted by this evidence`
+- Polymarket quote ticks: `present`
+- Polymarket full CLOB depth: `present`
+- Official settlement: `present`
+- Runtime/dry-run fills: `present`
+- Data audit status: sufficient to judge current dry-run execution quality and
+  runtime PnL; not sufficient to promote to live.
+- Missing surfaces and impact: recorded replay parity against this dry-run
+  window is still pending and blocks any live-candidate promotion.
+
+## Accounting Semantics
+
+- Event accounting: `one-event-one-trade`
+- Entry price model: runtime BUY orders use `runtime_price_basis=full_depth_sweep`
+  with `full_depth_runtime_parity=true`.
+- Exit or settlement label: official settlement exits; confirmed closed rows
+  are used for PnL.
+- Fillability assumption: dry-run paper fills against runtime full-depth sweep
+  accounting.
+- Fees/slippage/latency assumption: runtime order/fill rows include fees and
+  slippage; average BUY slippage was about `-0.003144`.
+- Capacity or stake assumption: `15 USDT` requested stake per entry,
+  `4` max positions, no daily trade cap.
+
+## Results
+
+- Headline metrics from the public report at
+  `2026-05-27T13:39:57.928887+00:00`:
+  - `total_trades=139`
+  - `closed_trades=137`
+  - `wins=74`, `losses=63`, `win_rate_pct=54.0`
+  - `realized_pnl=-207.43`
+  - `total_fees=16.43`
+  - `profit_factor=0.781`
+  - `sharpe=-1.0667`
+  - `avg_trade=-1.5141`
+  - `max_drawdown=-220.2696`
+  - `open_positions=2`, `open_exposure=29.47`
+- Post-reset DB window from `2026-05-27 16:08:40 +08`:
+  - `closed_trades=74`
+  - `wins=41`, `losses=33`, `win_rate_pct=55.41`
+  - `net_pnl=-74.5452`
+  - `avg_pnl=-1.0074`
+  - `gross_profit=421.6964`
+  - `gross_loss=496.2416`
+  - `profit_factor=0.8498`
+- Last two hours:
+  - `closed_trades=30`
+  - `wins=19`, `losses=11`, `win_rate_pct=63.33`
+  - `net_pnl=-25.8234`
+  - `profit_factor=0.8439`
+- Symbol/side post-reset bucket behavior:
+  - `BTCUSDT UP`: `22` trades, `7` wins, `15` losses,
+    `net_pnl=-105.6478`, `avg_pnl=-4.8022`, `profit_factor=0.5316`
+  - `ETHUSDT DOWN`: `12` trades, `9` wins, `3` losses,
+    `net_pnl=-28.4443`, `avg_pnl=-2.3704`, `profit_factor=0.3699`
+  - `ETHUSDT UP`: `7` trades, `5` wins, `2` losses,
+    `net_pnl=11.8338`, `avg_pnl=1.6905`, `profit_factor=1.3932`
+  - `BTCUSDT DOWN`: `33` trades, `20` wins, `13` losses,
+    `net_pnl=47.7131`, `avg_pnl=1.4459`, `profit_factor=1.2441`
+- Fill rate/capacity:
+  - BUY: `139 FILLED` orders, `2085.0000` requested notional,
+    `2070.5931` filled notional, `99.31%` filled notional rate.
+  - SELL: `134 FILLED` orders, `1769.9054` requested and filled notional,
+    `100.00%` filled notional rate.
+  - Rejected BUY orders in public report: `0`.
+- Runtime health:
+  - `pm5d.threelayer.live`: `desired_state=paused`,
+    `observed_state=paused`.
+  - `pm5d.threelayer.settlement-probability-btc-eth.dryrun`:
+    `desired_state=running`, `observed_state=running`.
+  - `ployd.service`: `ActiveState=active`, `SubState=running`,
+    `Restart=always`, `NRestarts=0`, `OOMPolicy=kill`,
+    `MemoryHigh=1342177280`, `MemoryMax=1610612736`.
+  - Recording file was actively growing with mtime
+    `2026-05-27 21:40:57 +08`.
+
+## Promotion Gate Check
+
+- Hypothesis explicit: `pass`
+- Data provenance recorded: `pass`
+- Executable pricing conservative: `pass`
+- Settlement/exit label matches lane: `pass`
+- Walk-forward or leakage guard: `n/a` for this dry-run observation; prior
+  research gates remain separate.
+- Replay/runtime parity: `fail` for live promotion because recorded replay
+  parity for this dry-run window is still pending.
+- Runtime scorer/config mapping: `pass`
+- Risk/stake/kill switch stated: `pass`
+
+## Caveats
+
+- This is a same-day dry-run window, so it is enough to reject or revise a poor
+  runtime candidate but not enough to prove a replacement candidate.
+- Public report aggregation can lag the latest DB settlement/order rows by a
+  few minutes; DB rows were used for bucket-level diagnosis.
+- Positive `BTCUSDT DOWN` and `ETHUSDT UP` buckets are not promoted by this
+  note because the combined score is still negative after costs and the bucket
+  split is a post-hoc diagnostic.
+- This evidence does not change live deployment state; live remains paused.
+
+## Follow-Up
+
+- Encode this runtime feedback into a Research Manager / AutoFactor typed prior
+  so the next hosted search penalizes or avoids the current losing runtime score
+  shape, especially `BTCUSDT UP` and `ETHUSDT DOWN` buckets.
+- Require the next candidate to pass runtime candidate replay before any dry-run
+  handoff or config PR.
+- Do not run recorded replay parity as a promotion step for this exact score
+  unless the goal is forensic parity diagnosis; the strategy quality decision is
+  already `revise`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,67 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Settlement Probability Dry-Run Runtime Feedback (2026-05-27)
+
+Evidence stage: `dry_run_candidate` / `execution_quality` runtime evidence.
+This session keeps `pm5d.threelayer.live` paused and treats the current
+settlement-probability dry-run candidate as a strategy-quality review, not as a
+live-promotion path.
+
+### Tasks
+
+- [x] Refresh the current public report, deployment state, service health,
+      recording freshness, runtime orders/fills, and event-track DB evidence.
+- [x] Decide whether the observed losses are execution/fill failures,
+      settlement/accounting failures, or signal/filter failures.
+- [x] Persist the dry-run quality decision in
+      `tasks/research_evidence/pm5d_settlement_probability_dryrun_revision_20260527.md`.
+- [x] Connect the negative runtime feedback to Research Manager / AutoFactor
+      typed priors so the next search revises the candidate instead of
+      repairing unrelated runtime-contract blockers.
+- [ ] Trigger or prepare the next research-loop action from `main` without
+      changing live deployment state.
+
+### Review
+
+- 2026-05-27 21:39-21:41 +0800: Remote verification showed live stayed
+  `paused/paused`, the target settlement-probability dry-run stayed
+  `running/running`, `ployd.service` stayed active with `Restart=always`,
+  `NRestarts=0`, `OOMPolicy=kill`, and no host Rust build was running. The
+  recording file remained fresh at
+  `/opt/ploy/data/recordings/pm5d-threelayer-settlement-probability-btc-eth.ndjson`.
+- 2026-05-27: The current dry-run is not blocked by the fill path. BUY orders
+  were `139 FILLED`, requested notional was `2085.0000`, filled notional was
+  `2070.5931` (`99.31%`), rejected BUY orders were `0`, and BUY order context
+  reported `runtime_price_basis=full_depth_sweep` with
+  `full_depth_runtime_parity=true`.
+- 2026-05-27: Strategy quality is not acceptable. The public report at
+  `2026-05-27T13:39:57.928887+00:00` showed `closed_trades=137`,
+  `realized_pnl=-207.43`, `profit_factor=0.781`, `sharpe=-1.0667`, and
+  `max_drawdown=-220.2696`. The clean post-reset window since
+  `2026-05-27 16:08:40 +0800` had `closed_trades=74`,
+  `net_pnl=-74.5452`, and `profit_factor=0.8498`.
+- 2026-05-27: The losing shape is concentrated enough to feed back into search:
+  post-reset `BTCUSDT UP` had `22` closed trades with `net_pnl=-105.6478` and
+  `profit_factor=0.5316`; `ETHUSDT DOWN` had `12` closed trades with
+  `net_pnl=-28.4443` and `profit_factor=0.3699`. `BTCUSDT DOWN` and
+  `ETHUSDT UP` were positive, but this is post-hoc bucket evidence and does not
+  make the combined runtime score promotable.
+- 2026-05-27: Added a typed prior draft at
+  `tasks/research_evidence/pm5d_settlement_probability_dryrun_feedback_prior_20260527.json`
+  with `mutate_or_reject_negative_runtime_edge`, a runtime avoid entry for the
+  current losing runtime score, and bounded mutations that can be passed through
+  `options_json.alpha_search_llm_prior_json` on the next hosted walk-forward
+  search.
+- 2026-05-27 22:24-22:29 +0800: Hosted walk-forward retry run
+  `26517302695` completed successfully from fresh snapshot run `26516561409`,
+  loaded the dry-run feedback typed prior, and generated
+  `after_negative_dryrun` candidates, but handoff stayed `blocked` with
+  `qualified_strategy_count=0`. The blocker was not a fresh runtime failure:
+  runtime-avoid family normalization did not strip selector-threshold suffixes
+  such as `_select_near_strike_ge_025`, so same-family variants of the losing
+  dry-run score could escape the intended penalty. Added focused regressions
+  and a normalization fix before retrying the hosted search again from `main`.
+
 ## Current Session - Settlement Probability Dry-Run Daily Cap (2026-05-27)
 
 Evidence stage: `dry_run_candidate` / `execution_quality` runtime evidence.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -1195,6 +1195,12 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 ),
                 "auto_settlement_model_full_depth_settlement_edge_x_external_pressure",
             )
+            self.assertEqual(
+                agent.factor_family(
+                    "mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_select_near_strike_ge_025"
+                ),
+                "auto_settlement_model_full_depth_settlement_edge",
+            )
 
     def test_zero_direct_signal_collapse_wins_over_unmapped_same_family(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -240,6 +240,58 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             prior["mutations"][0]["base_factor"],
         )
 
+    def test_negative_runtime_prior_normalizes_selector_threshold_family(self) -> None:
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+        )
+        runtime_score = (
+            "autofactor_formula:"
+            "mut_auto_settlement_model_full_depth_settlement_edge_spread_adjusted_select_near_strike_ge_025"
+        )
+        plan["input"]["latest_runs"] = {
+            "runs": [
+                {
+                    "artifacts": [
+                        {
+                            "output_json": {
+                                "candidate_strategy_replay": {
+                                    "basis": "runtime_market_update_replay",
+                                    "runtime_score": runtime_score,
+                                    "strategy_profile": "settlement_probability",
+                                    "metrics": {"roi": -0.05},
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest runtime evidence failed economic gates.",
+            }
+        ]
+
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK, snapshot_run_id="26516561409"),
+            plan,
+        )
+
+        dispatch = payload["dispatches"][0]
+        options = json.loads(dispatch["fields"]["options_json"])
+        prior = json.loads(options["alpha_search_llm_prior_json"])
+        self.assertEqual(
+            "auto_settlement_model_full_depth_settlement_edge",
+            prior["runtime_avoid_factors"][0]["factor_family"],
+        )
+        self.assertNotIn(
+            "auto_settlement_model_full_depth_settlement_edge",
+            {item["base_factor"] for item in prior["mutations"]},
+        )
+
     def test_revise_prior_infers_latest_replay_and_full_depth_artifacts(self) -> None:
         plan = plan_payload(
             "revise_prior",


### PR DESCRIPTION
## Summary
- record the negative settlement-probability dry-run decision and typed feedback prior
- normalize AutoFactor selector-threshold suffixes so runtime_avoid_factors match generated gate variants
- add Research Manager / alpha-search regressions for selector-threshold factor families

## Verification
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_research_manager_execute_plan
- rtk cargo test --locked -p ploy-research typed_prior_runtime_avoid_list_filters_failed_family_variants --lib
- rtk git diff --check

Live trading remains paused; this PR only fixes research-loop feedback handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved factor family matching consistency by expanding variant pattern recognition in runtime feedback systems.

* **Tests**
  * Added test coverage validating correct normalization and matching of factor family variants.

* **Documentation**
  * Added guidance on validating runtime feedback behavior and factor family normalization verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->