### PR TITLE
Fix walk-forward issue comments to use closed-loop decisions

### DIFF
--- a/.github/scripts/autofactor-walk-forward-evidence.js
+++ b/.github/scripts/autofactor-walk-forward-evidence.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 
 function readJson(path) {
   if (!fs.existsSync(path)) return null;
@@ -52,7 +53,30 @@ function blockerOutcome(blockers) {
   return null;
 }
 
-function decisionFromArtifacts({ promotion, handoff }) {
+function closedLoopOutcome(closedLoop) {
+  if (!closedLoop || typeof closedLoop !== "object") return null;
+  const action = String(closedLoop.action || closedLoop.decision || "");
+  const decisionByAction = {
+    continue_search: "continue-search",
+    fix_data: "fix-data",
+    fix_runtime: "fix-runtime",
+    fix_workflow: "fix-workflow-or-artifact",
+    ready_handoff: "promote-to-dry-run",
+    revise_prior: "revise",
+  };
+  const decision = decisionByAction[action];
+  if (!decision) return null;
+  return {
+    decision,
+    reason: String(closedLoop.reason || action),
+  };
+}
+
+function readClosedLoopDecision(artifactDir) {
+  return readJson(path.join(artifactDir, "..", "alpha-search-chain", "closed-loop-decision.json"));
+}
+
+function decisionFromArtifacts({ promotion, handoff, closedLoop }) {
   if (!promotion && !handoff) {
     return {
       decision: "fix-workflow-or-artifact",
@@ -66,6 +90,9 @@ function decisionFromArtifacts({ promotion, handoff }) {
       reason: "qualified AutoFactor strategy handoff is ready",
     };
   }
+
+  const closedLoopDecision = closedLoopOutcome(closedLoop);
+  if (closedLoopDecision) return closedLoopDecision;
 
   const blockerDecision = blockerOutcome(actionableBlockers({ handoff, promotion }));
   if (blockerDecision) return blockerDecision;
@@ -159,10 +186,13 @@ function actionableBlockers({ handoff, promotion }) {
 function buildWalkForwardEvidence({ title, metadata, artifactDir, runnerLabel }) {
   const promotion = readJson(`${artifactDir}/autofactor-strategy-promotion.json`);
   const handoff = readJson(`${artifactDir}/autofactor-strategy-handoff.json`);
-  const outcome = decisionFromArtifacts({ promotion, handoff });
+  const closedLoop = readClosedLoopDecision(artifactDir);
+  const outcome = decisionFromArtifacts({ promotion, handoff, closedLoop });
   const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
   const strategies = topStrategies(handoff);
-  const blockers = actionableBlockers({ handoff, promotion });
+  const blockers = outcome.decision === "revise" && closedLoop && closedLoop.reason
+    ? [closedLoop.reason]
+    : actionableBlockers({ handoff, promotion });
 
   const body = [
     `${title}:`,

--- a/tests/test_autofactor_walk_forward_evidence_js.py
+++ b/tests/test_autofactor_walk_forward_evidence_js.py
@@ -164,6 +164,74 @@ class AutoFactorWalkForwardEvidenceJsTest(unittest.TestCase):
         self.assertEqual(result["decision"], "fix-data")
         self.assertIn("data_quality", result["body"])
 
+    def test_closed_loop_revise_prior_overrides_runtime_mapping_noise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact_dir = root / "factor-walk-forward-v2"
+            artifact_dir.mkdir()
+            (root / "alpha-search-chain").mkdir()
+            (root / "alpha-search-chain" / "closed-loop-decision.json").write_text(
+                json.dumps(
+                    {
+                        "action": "revise_prior",
+                        "reason": "missing_runtime_strategy_mapping",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "walk_forward_oos: no non-naive model passed",
+                            ],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-promotion.json").write_text(
+                json.dumps(
+                    {
+                        "decision": "blocked",
+                        "minimums": {
+                            "top_bucket_full_depth_entry_fill_rate": 0.30,
+                        },
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "walk_forward_oos: no non-naive model passed",
+                            ],
+                        },
+                        "evaluated_factors": [
+                            {
+                                "qualified": False,
+                                "blockers": [
+                                    "runtime_contract_unmapped_factor",
+                                    "missing_runtime_strategy_mapping",
+                                ],
+                                "factor": {
+                                    "decision": "candidate",
+                                    "reason": "passed",
+                                    "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_builder(artifact_dir)
+
+        self.assertEqual(result["decision"], "revise")
+        self.assertIn("- Decision: revise", result["body"])
+        self.assertIn("- Next action: missing_runtime_strategy_mapping", result["body"])
+        self.assertIn("- Actionable blockers: `missing_runtime_strategy_mapping`", result["body"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- read alpha-search closed-loop decisions when building hosted walk-forward issue comments
- report revise_prior as Decision: revise instead of letting runtime/mapping blocker text force fix-runtime
- add regression coverage for blocked promotion artifacts with closed-loop revise_prior

## Verification
- python3 -m unittest tests.test_autofactor_walk_forward_evidence_js
- node -e "const m=require('./.github/scripts/autofactor-walk-forward-evidence.js'); console.log(Object.keys(m).sort().join(','))"
- rtk git diff --check