### PR TITLE
Fix walk-forward comments reading closed-loop artifacts

### DIFF
--- a/.github/scripts/autofactor-walk-forward-evidence.js
+++ b/.github/scripts/autofactor-walk-forward-evidence.js
@@ -73,7 +73,21 @@ function closedLoopOutcome(closedLoop) {
 }
 
 function readClosedLoopDecision(artifactDir) {
-  return readJson(path.join(artifactDir, "..", "alpha-search-chain", "closed-loop-decision.json"));
+  const candidates = [
+    path.join(artifactDir, "..", "alpha-search-chain", "closed-loop-decision.json"),
+    path.join(
+      artifactDir,
+      "..",
+      "factor-walk-forward-v2-upload",
+      "alpha-search-chain",
+      "closed-loop-decision.json",
+    ),
+  ];
+  for (const candidate of candidates) {
+    const payload = readJson(candidate);
+    if (payload) return payload;
+  }
+  return null;
 }
 
 function decisionFromArtifacts({ promotion, handoff, closedLoop }) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -61,6 +61,14 @@ live-promotion path.
   such as `_select_near_strike_ge_025`, so same-family variants of the losing
   dry-run score could escape the intended penalty. Added focused regressions
   and a normalization fix before retrying the hosted search again from `main`.
+- 2026-05-27 23:23-23:28 +0800: PR `#709` merged as `main@0d92698e` and
+  retry run `26520742421` completed successfully from snapshot `26516561409`.
+  The artifact's closed-loop decision is `fix_data` with reason
+  `promotion_blockers_require_fix_data`, but the issue comment still reported
+  `fix-runtime` because the comment builder read
+  `artifacts/factor-walk-forward-v2` while the generated closed-loop artifact
+  lived under `artifacts/factor-walk-forward-v2-upload/alpha-search-chain`.
+  Added a follow-up regression for the live workflow staged-upload layout.
 
 ## Current Session - Settlement Probability Dry-Run Daily Cap (2026-05-27)
 

--- a/tests/test_autofactor_walk_forward_evidence_js.py
+++ b/tests/test_autofactor_walk_forward_evidence_js.py
@@ -232,6 +232,64 @@ class AutoFactorWalkForwardEvidenceJsTest(unittest.TestCase):
         self.assertIn("- Next action: missing_runtime_strategy_mapping", result["body"])
         self.assertIn("- Actionable blockers: `missing_runtime_strategy_mapping`", result["body"])
 
+    def test_reads_closed_loop_from_workflow_staged_upload_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifacts = root / "artifacts"
+            artifact_dir = artifacts / "factor-walk-forward-v2"
+            artifact_dir.mkdir(parents=True)
+            staged_alpha = (
+                artifacts
+                / "factor-walk-forward-v2-upload"
+                / "alpha-search-chain"
+            )
+            staged_alpha.mkdir(parents=True)
+            (staged_alpha / "closed-loop-decision.json").write_text(
+                json.dumps(
+                    {
+                        "action": "fix_data",
+                        "reason": "promotion_blockers_require_fix_data",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-handoff.json").write_text(
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "incomplete_runtime_contract_mapping:factor",
+                                "runtime_contract_unmapped_factor",
+                            ],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifact_dir / "autofactor-strategy-promotion.json").write_text(
+                json.dumps(
+                    {
+                        "decision": "blocked",
+                        "promotion_gate": {
+                            "ready": False,
+                            "blocked_gates": [
+                                "incomplete_runtime_contract_mapping:factor",
+                                "runtime_contract_unmapped_factor",
+                            ],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_builder(artifact_dir)
+
+        self.assertEqual(result["decision"], "fix-data")
+        self.assertIn("- Decision: fix-data", result["body"])
+        self.assertIn("- Next action: promotion_blockers_require_fix_data", result["body"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- read closed-loop decisions from the workflow staged upload artifact layout
- add regression coverage for live workflow comment generation
- record the retry evidence in tasks/todo.md

## Tests
- python3 -m unittest tests.test_autofactor_walk_forward_evidence_js
- node require sanity for .github/scripts/autofactor-walk-forward-evidence.js
- rtk git diff --check