### PR TITLE
Align walk-forward comment blockers with closed-loop decisions

### DIFF
--- a/.github/scripts/autofactor-walk-forward-evidence.js
+++ b/.github/scripts/autofactor-walk-forward-evidence.js
@@ -201,10 +201,14 @@ function buildWalkForwardEvidence({ title, metadata, artifactDir, runnerLabel })
   const promotion = readJson(`${artifactDir}/autofactor-strategy-promotion.json`);
   const handoff = readJson(`${artifactDir}/autofactor-strategy-handoff.json`);
   const closedLoop = readClosedLoopDecision(artifactDir);
+  const closedLoopDecision = closedLoopOutcome(closedLoop);
   const outcome = decisionFromArtifacts({ promotion, handoff, closedLoop });
   const gate = (handoff && handoff.promotion_gate) || (promotion && promotion.promotion_gate) || {};
   const strategies = topStrategies(handoff);
-  const blockers = outcome.decision === "revise" && closedLoop && closedLoop.reason
+  const blockers = closedLoopDecision
+    && closedLoopDecision.decision === outcome.decision
+    && closedLoop
+    && closedLoop.reason
     ? [closedLoop.reason]
     : actionableBlockers({ handoff, promotion });
 

--- a/tests/test_autofactor_walk_forward_evidence_js.py
+++ b/tests/test_autofactor_walk_forward_evidence_js.py
@@ -289,6 +289,8 @@ class AutoFactorWalkForwardEvidenceJsTest(unittest.TestCase):
         self.assertEqual(result["decision"], "fix-data")
         self.assertIn("- Decision: fix-data", result["body"])
         self.assertIn("- Next action: promotion_blockers_require_fix_data", result["body"])
+        self.assertIn("- Actionable blockers: `promotion_blockers_require_fix_data`", result["body"])
+        self.assertNotIn("runtime_contract_unmapped_factor", result["body"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- when a closed-loop decision determines the issue comment decision, use its reason as the displayed actionable blocker
- extend the staged-upload regression so runtime blocker noise does not appear when closed-loop says fix-data

## Tests
- python3 -m unittest tests.test_autofactor_walk_forward_evidence_js
- node -c .github/scripts/autofactor-walk-forward-evidence.js
- rtk git diff --check