### PR TITLE
Fix runtime replay request selection from registry preview

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -110,6 +110,7 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
         "state": optional_json(alpha_root / "mcts-state.json") or {},
         "handoff": optional_json(root / "autofactor-strategy-handoff.json") or {},
         "promotion": optional_json(root / "autofactor-strategy-promotion.json") or {},
+        "registry_preview": optional_json(alpha_root / "factor-registry-preview.json") or {},
         "chain": chain,
         "search_space": optional_json(alpha_root / "search-space.json") or {},
         "candidate_strategy_replay": candidate_strategy_replay or {},
@@ -763,15 +764,17 @@ def runtime_replay_candidates(
     limit: int = MAX_RUNTIME_REPLAY_REQUESTS,
 ) -> list[dict[str, Any]]:
     promotion = run.get("promotion")
-    if not isinstance(promotion, dict):
-        return []
-    evaluated = promotion.get("evaluated_factors")
-    if not isinstance(evaluated, list):
-        return []
     target = run.get("target") or DEFAULT_TARGET
-    required_profile = str(
-        promotion.get("required_strategy_profile") or "settlement_probability"
-    )
+    required_profile = "settlement_probability"
+    evaluated: list[Any] = []
+    if isinstance(promotion, dict):
+        required_profile = str(
+            promotion.get("required_strategy_profile") or required_profile
+        )
+        raw_evaluated = promotion.get("evaluated_factors")
+        if isinstance(raw_evaluated, list):
+            evaluated.extend(raw_evaluated)
+    evaluated.extend(registry_preview_runtime_candidates(run, required_profile))
     avoided_families = runtime_avoid_families(run)
     candidates: list[dict[str, Any]] = []
     for item in evaluated:
@@ -801,13 +804,14 @@ def runtime_replay_candidates(
 
     best_candidate_name = str((run.get("feedback") or {}).get("best_candidate") or "")
 
-    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float, float, float]:
+    def score(item: dict[str, Any]) -> tuple[float, float, float, float, float, float, float, float, float]:
         factor = item.get("factor") if isinstance(item.get("factor"), dict) else {}
         return (
             1.0 if best_candidate_name and factor.get("name") == best_candidate_name else 0.0,
             1.0
             if factor.get("decision") == "candidate" and factor.get("reason") == "passed"
             else 0.0,
+            as_float(factor.get("reward")) or 0.0,
             as_float(factor.get("top_bucket_n")) or 0.0,
             as_float(factor.get("top_bucket_avg_label")) or 0.0,
             as_float(factor.get("top_bucket_full_depth_entry_fill_rate")) or 0.0,
@@ -841,6 +845,71 @@ def runtime_replay_candidates(
         if len(requests) >= limit:
             break
     return requests
+
+
+def registry_preview_runtime_candidates(
+    run: dict[str, Any],
+    required_profile: str,
+) -> list[dict[str, Any]]:
+    preview = run.get("registry_preview")
+    if not isinstance(preview, dict):
+        return []
+    rows = preview.get("factors")
+    if not isinstance(rows, list):
+        return []
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        contract = row.get("runtime_contract")
+        if not isinstance(contract, dict):
+            continue
+        metrics = row.get("metrics")
+        if not isinstance(metrics, dict):
+            metrics = {}
+        runtime_score = str(contract.get("runtime_score") or "").strip()
+        strategy_profile = str(contract.get("strategy_profile") or "").strip()
+        if not runtime_score or strategy_profile != required_profile:
+            continue
+        blockers: list[str] = []
+        for source in (row.get("blockers"), contract.get("blockers")):
+            if isinstance(source, list):
+                blockers.extend(str(item) for item in source if str(item))
+        blockers = sorted(set(blockers))
+        factor_name = str(row.get("factor_name") or "")
+        status = str(row.get("status") or "")
+        candidates.append(
+            {
+                "blockers": blockers,
+                "factor": {
+                    "name": factor_name,
+                    "target": row.get("target"),
+                    "decision": "candidate" if status == "candidate" else status,
+                    "reason": "passed" if status == "candidate" else status,
+                    "reward": as_float(metrics.get("reward")) or 0.0,
+                    "top_bucket_n": as_float(metrics.get("top_bucket_n"))
+                    or as_float(metrics.get("top_bucket_unique_event_count"))
+                    or 0.0,
+                    "top_bucket_avg_label": as_float(metrics.get("top_bucket_avg_label"))
+                    or 0.0,
+                    "top_bucket_full_depth_entry_fill_rate": as_float(
+                        metrics.get("top_bucket_full_depth_entry_fill_rate")
+                    )
+                    or 0.0,
+                    "positive_window_ratio": as_float(metrics.get("positive_window_ratio"))
+                    or 0.0,
+                    "symbol_positive_ratio": as_float(metrics.get("symbol_positive_ratio"))
+                    or 0.0,
+                    "spearman_ic": as_float(metrics.get("spearman_ic")) or 0.0,
+                },
+                "runtime_mapping": {
+                    "runtime_score": runtime_score,
+                    "strategy_profile": strategy_profile,
+                    "strategy_family": str(contract.get("strategy_family") or ""),
+                },
+            }
+        )
+    return candidates
 
 
 def runtime_avoid_families(run: dict[str, Any]) -> set[str]:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,47 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Registry Preview Runtime Replay Request (2026-05-28)
+
+Evidence stage: `walk_forward` / `runtime_parity` request repair. This keeps
+`pm5d.threelayer.live` untouched and only repairs the closed-loop planner so a
+blocked hosted walk-forward can dispatch runtime replay evidence for a
+runtime-ready candidate already present in the alpha-search registry preview.
+
+### Tasks
+
+- [x] Inspect hosted walk-forward run `26522896093` and issue `#707`.
+- [x] Confirm full-depth execution-surface evidence is now present and the
+      remaining next action is `fix_runtime`.
+- [x] Make closed-loop runtime replay selection fall back to
+      `factor-registry-preview.json` when promotion top-N rows miss the
+      runtime-ready alpha-search candidate.
+- [ ] Run focused validation, land through PR, and rerun the research loop from
+      `main`.
+
+### Review
+
+- 2026-05-28: Run `26522896093` completed successfully and issue `#707`
+  advanced from `fix-data` to `fix-runtime`, but
+  `alpha-search-chain/closed-loop-decision.json` still had
+  `runtime_replay_requests=[]`. The alpha-search best candidate was
+  `mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted`,
+  whose registry contract remained blocked by duplicate spread adjustment. The
+  same registry preview also contained runtime-ready predictive settlement
+  candidates such as `mut_spread_adjusted_external_move_entry_price_quality`,
+  but the closed-loop selector only read promotion top-N rows and missed them.
+- 2026-05-28: Added registry-preview fallback candidate selection to
+  `scripts/alpha_search_closed_loop_agent.py`. Replaying run `26522896093` with
+  the patched script changes the next action to
+  `runtime_mappable_candidate_needs_runtime_replay` and emits three
+  runtime-candidate replay requests, led by
+  `autofactor_formula:mut_spread_adjusted_external_move_entry_price_quality`.
+  Focused validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent
+  tests.test_factor_walk_forward_sweep`, `python3 -m py_compile
+  scripts/alpha_search_closed_loop_agent.py
+  tests/test_alpha_search_closed_loop_agent.py tests/test_factor_walk_forward_sweep.py`,
+  and `rtk git diff --check`.
+
 ## Current Session - Settlement Probability Dry-Run Runtime Feedback (2026-05-27)
 
 Evidence stage: `dry_run_candidate` / `execution_quality` runtime evidence.

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -26,6 +26,7 @@ def artifact(
     selected_nodes: list[dict] | None = None,
     feedback: dict | None = None,
     promotion: dict | None = None,
+    registry_preview: dict | None = None,
     candidate_strategy_replay: dict | None = None,
     write_feedback: bool = True,
 ) -> Path:
@@ -84,6 +85,8 @@ def artifact(
         factor_root / "autofactor-strategy-promotion.json",
         promotion or {"decision": "blocked", "evaluated_factors": []},
     )
+    if registry_preview is not None:
+        write_json(alpha_root / "factor-registry-preview.json", registry_preview)
     write_json(
         root / "alpha-search-chain" / "chain-decision.json",
         {
@@ -814,6 +817,121 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             json.loads(request["inputs"]["options_json"])["source_target"],
             "tradeable_full_depth_settlement_pnl",
         )
+
+    def test_runtime_replay_request_can_use_registry_preview_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = (
+                "autofactor_formula:mut_spread_adjusted_external_move_entry_price_quality"
+            )
+            path = artifact(
+                Path(tmp),
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 1082,
+                    "rejected_count": 874,
+                    "passed_count": 96,
+                    "best_candidate": "mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted",
+                    "best_reward": 6.2416,
+                    "runtime_avoid_factors": [
+                        {
+                            "factor_family": "auto_settlement_model_full_depth_settlement_edge",
+                            "runtime_score": "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+                            "reason": "negative_dry_run_runtime_edge",
+                        }
+                    ],
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_runtime_replay:factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                                "incomplete_runtime_contract_mapping:mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted",
+                                "runtime_contract_unmapped_factor",
+                            ],
+                            "factor": {
+                                "name": "mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": "",
+                                "strategy_profile": "",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "basis": "factor_walk_forward_top_bucket_aggregate",
+                        "runtime_score": "",
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+                registry_preview={
+                    "version": "alpha_search_artifacts_v1",
+                    "target": agent.DEFAULT_TARGET,
+                    "horizon": "5m",
+                    "factors": [
+                        {
+                            "factor_name": "mut_auto_settlement_model_conservative_settlement_edge_spread_adjusted_spread_adjusted",
+                            "target": agent.DEFAULT_TARGET,
+                            "status": "candidate",
+                            "runtime_contract": {
+                                "runtime_score": "",
+                                "strategy_profile": "",
+                                "strategy_family": "",
+                                "blockers": ["runtime_contract_unmapped_factor"],
+                            },
+                            "metrics": {
+                                "reward": 6.2416,
+                                "top_bucket_unique_event_count": 129,
+                                "top_bucket_avg_label": 9.3898,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.8888,
+                                "spearman_ic": 0.1823,
+                            },
+                            "blockers": ["runtime_contract_unmapped_factor"],
+                        },
+                        {
+                            "factor_name": "mut_spread_adjusted_external_move_entry_price_quality",
+                            "target": agent.DEFAULT_TARGET,
+                            "status": "candidate",
+                            "runtime_contract": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                                "strategy_family": "predictive_settlement_probability",
+                                "blockers": [],
+                            },
+                            "metrics": {
+                                "reward": 6.0245,
+                                "top_bucket_unique_event_count": 129,
+                                "top_bucket_avg_label": 8.4060,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.8888,
+                                "spearman_ic": 0.221,
+                            },
+                            "blockers": [],
+                        },
+                    ],
+                },
+            )
+
+            decision = agent.closed_loop_decision(
+                [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            )
+
+        request = decision["runtime_replay_request"]
+        self.assertEqual("fix_runtime", decision["decision"])
+        self.assertEqual(
+            "runtime_mappable_candidate_needs_runtime_replay",
+            decision["reason"],
+        )
+        self.assertEqual(
+            "mut_spread_adjusted_external_move_entry_price_quality",
+            request["source_factor"],
+        )
+        self.assertEqual(runtime_score, request["inputs"]["runtime_score"])
 
     def test_fix_runtime_includes_batch_runtime_replay_requests(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- load alpha-search factor-registry-preview artifacts in the closed-loop agent
- fall back to registry-preview runtime-ready candidates when promotion top-N rows miss the replayable candidate
- add regression coverage for the 26522896093 shape where the best candidate is unmapped but a runtime-ready predictive candidate exists

## Validation
- python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_factor_walk_forward_sweep
- python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py tests/test_factor_walk_forward_sweep.py
- rtk git diff --check
- replayed /tmp/ploy-26522896093 through the patched closed-loop agent; runtime_replay_requests emitted 3 requests, led by autofactor_formula:mut_spread_adjusted_external_move_entry_price_quality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime replay candidate selection now incorporates registry preview data to expand the candidate pool for improved results
  * Added reward-based scoring to enhance candidate ranking during selection

* **Tests**
  * Added comprehensive test coverage for registry preview-based candidate selection in runtime replay requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->