### PR TITLE
Classify negative runtime replay as prior feedback

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -220,6 +220,17 @@ def classify_blockers(blockers: list[str]) -> str | None:
     if any(
         token in text
         for token in [
+            "roi_too_low",
+            "total_pnl_nonpositive",
+            "realized_pnl_nonpositive",
+            "negative_runtime_edge",
+            "negative_runtime_replay_edge",
+        ]
+    ):
+        return "revise_prior"
+    if any(
+        token in text
+        for token in [
             "data_audit_zero_coverage",
             "snapshot_contract_blocks_execution_claim",
             "sampled_snapshot_required_for_execution_surface",
@@ -403,6 +414,10 @@ def runtime_pass_through_feedback(run: dict[str, Any]) -> dict[str, Any]:
         or as_float(metrics.get("trade_count"))
         or 0
     )
+    roi = as_float(metrics.get("roi"))
+    total_pnl = as_float(metrics.get("total_pnl"))
+    unique_event_count = int(as_float(metrics.get("unique_event_count")) or 0)
+    entry_fill_rate = as_float(metrics.get("entry_fill_rate"))
     direct_passes = configured_direct_passes(counterfactual)
     if direct_passes is None:
         direct_passes = int(
@@ -410,32 +425,50 @@ def runtime_pass_through_feedback(run: dict[str, Any]) -> dict[str, Any]:
             or 0
         )
 
-    blockers: list[str] = []
+    pass_through_blockers: list[str] = []
     if direct_passes >= 50 and entry_signals < 50:
-        blockers.append(
+        pass_through_blockers.append(
             f"runtime_entry_pass_through_too_low:{entry_signals}/{direct_passes}<50"
         )
     if formula_evaluations >= 500 and executable_edge_pass < 50:
-        blockers.append(
+        pass_through_blockers.append(
             "runtime_executable_edge_pass_min_edge_too_low:"
             f"{executable_edge_pass}/{formula_evaluations}<50"
         )
     if depth_fillable >= 500 and entry_signals < 50:
-        blockers.append(
+        pass_through_blockers.append(
             f"runtime_depth_fillable_to_entry_signal_collapse:{entry_signals}/{depth_fillable}<50"
         )
+
+    economic_blockers: list[str] = []
+    if roi is not None and roi < 0.0:
+        economic_blockers.append(f"runtime_replay_roi_too_low:{roi:.6f}<0.000000")
+    elif roi is None and total_pnl is not None and total_pnl <= 0.0:
+        economic_blockers.append(f"runtime_replay_total_pnl_nonpositive:{total_pnl:.6f}")
+
+    blockers = pass_through_blockers + economic_blockers
     if not blockers:
         return {}
+    reason = (
+        "runtime_pass_through_collapse"
+        if pass_through_blockers
+        else "negative_runtime_replay_edge"
+    )
     return {
-        "reason": "runtime_pass_through_collapse",
+        "reason": reason,
         "runtime_score": runtime_score,
         "base_factor": runtime_score_base_factor(runtime_score),
         "metrics": {
             "entry_signals": entry_signals,
+            "unique_event_count": unique_event_count,
+            "entry_fill_rate": entry_fill_rate,
+            "roi": roi,
+            "total_pnl": total_pnl,
             "direct_passes_at_configured_threshold": direct_passes,
             "formula_evaluations": formula_evaluations,
             "depth_fillable": depth_fillable,
             "executable_edge_pass_min_edge": executable_edge_pass,
+            "score_counterfactual_diagnosis": counterfactual.get("diagnosis"),
             "skip_entry_score": diagnostics.get("skip_entry_score"),
             "skip_edge_score": diagnostics.get("skip_edge_score"),
             "skip_settlement_side_score": diagnostics.get("skip_settlement_side_score"),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,40 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Runtime Replay Negative Edge Feedback (2026-05-27)
+
+Evidence stage: `runtime_parity` / `walk_forward` feedback repair. This keeps
+live untouched and fixes the closed-loop classifier so completed runtime replay
+artifacts with real fills but negative executable ROI revise the AutoFactor
+prior instead of causing repeated runtime replay requests.
+
+### Tasks
+
+- [x] Inspect replay runs `26524390852`, `26524392527`, and `26524394212`.
+- [x] Confirm the state machine now reaches runtime replay evidence but the
+      candidate economics are not promotable.
+- [x] Teach the closed-loop agent to classify negative runtime replay ROI as
+      `revise_prior` feedback.
+- [x] Run focused validation.
+- [ ] Land through PR and rerun the hosted research
+      loop from `main`.
+
+### Review
+
+- 2026-05-27: Runtime replay evidence was generated successfully from
+  `main@9795a4a9`, but all candidates remained blocked. Two candidates had
+  enough runtime trades and `entry_fill_rate=1.0` but negative ROI; the third
+  emitted zero runtime trades. The next repair is classifier-level only: a
+  completed runtime replay with negative executable ROI should become typed
+  prior feedback, not another runtime-contract/data loop.
+- 2026-05-27: Added negative runtime replay feedback classification to
+  `scripts/alpha_search_closed_loop_agent.py`. Focused validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent`,
+  `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py
+  tests/test_alpha_search_closed_loop_agent.py`, `rtk git diff --check`, and a
+  simulation against runtime replay `26524392527`, which now produces
+  `action=revise_prior`, `reason=negative_runtime_replay_edge`, and no
+  repeated runtime replay request.
+
 ## Current Session - Registry Preview Runtime Replay Request (2026-05-28)
 
 Evidence stage: `walk_forward` / `runtime_parity` request repair. This keeps

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -1320,6 +1320,121 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 "auto_settlement_model_full_depth_settlement_edge",
             )
 
+    def test_negative_runtime_replay_roi_generates_prior_feedback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_score = (
+                "autofactor_formula:"
+                "mut_spread_adjusted_external_move_select_entry_price_quality_ge_075"
+            )
+            path = artifact(
+                Path(tmp),
+                chain_reason="continue",
+                should_dispatch=True,
+                candidate_strategy_replay={
+                    "basis": "runtime_market_update_replay",
+                    "promotion_ready": False,
+                    "runtime_score": runtime_score,
+                    "metrics": {
+                        "entry_fill_rate": 1.0,
+                        "trade_count": 53,
+                        "unique_event_count": 53,
+                        "roi": -0.07268639111313208,
+                        "total_pnl": -57.78568093494,
+                    },
+                    "score_counterfactual": {
+                        "configured_entry_threshold": "0.25",
+                        "depth_fillable": 903,
+                        "diagnosis": "reverse_direction_stronger_at_configured_threshold",
+                        "direct_pass_counts": {
+                            "0.05": 63,
+                            "0.10": 53,
+                            "0.15": 47,
+                            "0.25": 35,
+                        },
+                        "formula_evaluations": 185,
+                    },
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_ready",
+                                "candidate_strategy_replay_missing_contract:official_settlement",
+                                "candidate_strategy_replay_roi_too_low:-0.072686<0.000000",
+                            ],
+                            "factor": {
+                                "name": "mut_spread_adjusted_external_move_select_entry_price_quality_ge_075",
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                                "top_bucket_avg_label": 1.12,
+                                "positive_window_ratio": 1.0,
+                                "symbol_positive_ratio": 1.0,
+                                "spearman_ic": 0.13,
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": runtime_score,
+                                "strategy_profile": "settlement_probability",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "basis": "runtime_market_update_replay",
+                        "ready": False,
+                        "runtime_score": runtime_score,
+                        "metrics": {
+                            "trade_count": 53,
+                            "entry_fill_rate": 1.0,
+                            "roi": -0.07268639111313208,
+                        },
+                        "blockers": [
+                            "official_settlement_missing:52<53",
+                            "roi_too_low:-0.072686<0.000000",
+                        ],
+                    },
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(decision["reason"], "negative_runtime_replay_edge")
+            self.assertIn(
+                "runtime_replay_roi_too_low:-0.072686<0.000000",
+                decision["promotion_blockers"],
+            )
+            self.assertEqual(decision["runtime_replay_requests"], [])
+            self.assertEqual(
+                decision["runtime_pass_through_feedback"]["metrics"]["entry_signals"],
+                53,
+            )
+            self.assertEqual(
+                decision["runtime_pass_through_feedback"]["metrics"][
+                    "score_counterfactual_diagnosis"
+                ],
+                "reverse_direction_stronger_at_configured_threshold",
+            )
+            self.assertEqual(
+                prior["runtime_avoid_factors"][0]["reason"],
+                "negative_runtime_replay_edge",
+            )
+            self.assertEqual(prior["mutations"][0]["mutation_type"], "add_spread_penalty")
+
+    def test_roi_blockers_are_prior_feedback_even_with_missing_settlement(self) -> None:
+        self.assertEqual(
+            agent.classify_blockers(
+                [
+                    "candidate_strategy_replay_missing_contract:official_settlement",
+                    "candidate_strategy_replay_roi_too_low:-0.072686<0.000000",
+                ]
+            ),
+            "revise_prior",
+        )
+
     def test_zero_direct_signal_collapse_wins_over_unmapped_same_family(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             base_factor = (


### PR DESCRIPTION
## Summary
- classify runtime replay ROI/PnL blockers as `revise_prior` feedback
- emit `negative_runtime_replay_edge` feedback from completed runtime replay artifacts with real fills but negative ROI
- add regression coverage for a runtime replay with full fills, negative ROI, and partial official settlement coverage

## Validation
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `rtk git diff --check`
- simulated runtime replay `26524392527`: closed-loop now emits `action=revise_prior`, `reason=negative_runtime_replay_edge`, and no repeated runtime replay request

Evidence stage: `runtime_parity` / `walk_forward`. No live deployment changes.