### PR TITLE
Classify unmapped runtime frontier as prior feedback

### DIFF
--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -56,6 +56,16 @@ PREFERRED_FEATURES = {
     "replace_denominator": ["side_spread", "entry_capacity_score"],
 }
 
+RUNTIME_CONTRACT_GAP_TOKENS = (
+    "runtime_contract_unmapped_bayes_formula",
+    "runtime_contract_unmapped_factor",
+    "runtime_input_unsupported",
+    "unsupported_runtime_input",
+    "unsupported_runtime_inputs",
+    "incomplete_runtime_contract_mapping",
+    "missing_runtime_contract",
+)
+
 
 def load_json(path: Path) -> Any:
     with path.open(encoding="utf-8") as handle:
@@ -477,13 +487,98 @@ def runtime_pass_through_feedback(run: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def runtime_mapping_gap_feedback(run: dict[str, Any]) -> dict[str, Any]:
+def runtime_gap_reason(
+    blockers: list[str],
+    *,
+    include_contract_gaps: bool,
+) -> str:
+    lowered = [str(item).lower() for item in blockers]
+    if any("missing_runtime_strategy_mapping" in item for item in lowered):
+        return "missing_runtime_strategy_mapping"
+    if not include_contract_gaps:
+        return ""
+    if any("runtime_input_unsupported" in item for item in lowered):
+        return "unsupported_runtime_input"
+    if any("unsupported_runtime_input" in item for item in lowered):
+        return "unsupported_runtime_input"
+    for token in RUNTIME_CONTRACT_GAP_TOKENS:
+        if any(token in item for item in lowered):
+            return token
+    return ""
+
+
+def registry_preview_runtime_gap_candidates(
+    run: dict[str, Any],
+    *,
+    include_contract_gaps: bool,
+) -> list[dict[str, Any]]:
+    preview = run.get("registry_preview")
+    if not isinstance(preview, dict):
+        return []
+    rows = preview.get("factors")
+    if not isinstance(rows, list):
+        return []
+    target = run.get("target") or DEFAULT_TARGET
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("target") not in {None, target}:
+            continue
+        if row.get("status") != "candidate":
+            continue
+        contract = row.get("runtime_contract")
+        if not isinstance(contract, dict):
+            contract = {}
+        metrics = row.get("metrics")
+        if not isinstance(metrics, dict):
+            metrics = {}
+        blockers: list[str] = []
+        for source in (row.get("blockers"), contract.get("blockers")):
+            if isinstance(source, list):
+                blockers.extend(str(item) for item in source if str(item))
+        blockers = sorted(set(blockers))
+        reason = runtime_gap_reason(
+            blockers,
+            include_contract_gaps=include_contract_gaps,
+        )
+        if not reason:
+            continue
+        name = str(row.get("factor_name") or "")
+        if not name:
+            continue
+        factor = {
+            "name": name,
+            "target": row.get("target"),
+            "decision": "candidate",
+            "reason": "passed",
+            "top_bucket_avg_label": metrics.get("top_bucket_avg_label"),
+            "positive_window_ratio": metrics.get("positive_window_ratio"),
+            "symbol_positive_ratio": metrics.get("symbol_positive_ratio"),
+            "spearman_ic": metrics.get("spearman_ic"),
+            "reward": metrics.get("reward"),
+        }
+        candidates.append(
+            {
+                "item": row,
+                "factor": factor,
+                "blockers": blockers,
+                "name": name,
+                "reason": reason,
+                "factor_family": str(
+                    contract.get("factor_family") or factor_family(name)
+                ),
+            }
+        )
+    return candidates
+
+
+def runtime_mapping_gap_feedback(
+    run: dict[str, Any],
+    *,
+    include_contract_gaps: bool = False,
+) -> dict[str, Any]:
     promotion = run.get("promotion")
-    if not isinstance(promotion, dict):
-        return {}
-    evaluated = promotion.get("evaluated_factors")
-    if not isinstance(evaluated, list):
-        return {}
     target = run.get("target") or DEFAULT_TARGET
     feedback = run.get("feedback") if isinstance(run.get("feedback"), dict) else {}
     best_candidate = str(feedback.get("best_candidate") or "")
@@ -491,23 +586,45 @@ def runtime_mapping_gap_feedback(run: dict[str, Any]) -> dict[str, Any]:
     top_selected = str(plan_nodes[0].get("factor_name") or "") if plan_nodes else ""
 
     candidates: list[dict[str, Any]] = []
-    for item in evaluated:
-        if not isinstance(item, dict):
-            continue
-        factor = item.get("factor")
-        if not isinstance(factor, dict):
-            continue
-        if factor.get("target") not in {None, target}:
-            continue
-        if factor.get("decision") != "candidate" or factor.get("reason") != "passed":
-            continue
-        blockers = blocker_strings(item)
-        if "missing_runtime_strategy_mapping" not in blockers:
-            continue
-        name = str(factor.get("name") or "")
-        if not name:
-            continue
-        candidates.append({"item": item, "factor": factor, "blockers": blockers, "name": name})
+    if isinstance(promotion, dict):
+        evaluated = promotion.get("evaluated_factors")
+        if isinstance(evaluated, list):
+            for item in evaluated:
+                if not isinstance(item, dict):
+                    continue
+                factor = item.get("factor")
+                if not isinstance(factor, dict):
+                    continue
+                if factor.get("target") not in {None, target}:
+                    continue
+                if factor.get("decision") != "candidate" or factor.get("reason") != "passed":
+                    continue
+                blockers = blocker_strings(item)
+                reason = runtime_gap_reason(
+                    blockers,
+                    include_contract_gaps=include_contract_gaps,
+                )
+                if not reason:
+                    continue
+                name = str(factor.get("name") or "")
+                if not name:
+                    continue
+                candidates.append(
+                    {
+                        "item": item,
+                        "factor": factor,
+                        "blockers": blockers,
+                        "name": name,
+                        "reason": reason,
+                        "factor_family": factor_family(name),
+                    }
+                )
+    candidates.extend(
+        registry_preview_runtime_gap_candidates(
+            run,
+            include_contract_gaps=include_contract_gaps,
+        )
+    )
     if not candidates:
         return {}
 
@@ -524,18 +641,50 @@ def runtime_mapping_gap_feedback(run: dict[str, Any]) -> dict[str, Any]:
     selected = max(candidates, key=score)
     factor = selected["factor"]
     base_factor = selected["name"]
+    selected_family = str(selected.get("factor_family") or factor_family(base_factor))
+    related: list[dict[str, Any]] = []
+    seen_families: set[str] = set()
+    for candidate in sorted(candidates, key=score, reverse=True):
+        name = str(candidate.get("name") or "")
+        family = str(candidate.get("factor_family") or factor_family(name)).strip()
+        if not name or not family or family in seen_families:
+            continue
+        seen_families.add(family)
+        candidate_factor = (
+            candidate.get("factor") if isinstance(candidate.get("factor"), dict) else {}
+        )
+        related.append(
+            {
+                "reason": candidate.get("reason") or "missing_runtime_strategy_mapping",
+                "base_factor": name,
+                "factor_family": family,
+                "runtime_score": "",
+                "metrics": {
+                    "top_bucket_avg_label": candidate_factor.get("top_bucket_avg_label"),
+                    "positive_window_ratio": candidate_factor.get("positive_window_ratio"),
+                    "symbol_positive_ratio": candidate_factor.get("symbol_positive_ratio"),
+                    "spearman_ic": candidate_factor.get("spearman_ic"),
+                    "reward": candidate_factor.get("reward"),
+                },
+                "blockers": candidate.get("blockers") or [],
+            }
+        )
+        if len(related) >= 8:
+            break
     return {
-        "reason": "missing_runtime_strategy_mapping",
+        "reason": selected.get("reason") or "missing_runtime_strategy_mapping",
         "base_factor": base_factor,
-        "factor_family": factor_family(base_factor),
+        "factor_family": selected_family,
         "runtime_score": "",
         "metrics": {
             "top_bucket_avg_label": factor.get("top_bucket_avg_label"),
             "positive_window_ratio": factor.get("positive_window_ratio"),
             "symbol_positive_ratio": factor.get("symbol_positive_ratio"),
             "spearman_ic": factor.get("spearman_ic"),
+            "reward": factor.get("reward"),
         },
         "blockers": selected["blockers"],
+        "related_factors": related,
     }
 
 
@@ -564,7 +713,12 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
     handoff_blockers = blocker_strings(handoff)
     runtime_feedback = runtime_pass_through_feedback(current)
     runtime_blockers = runtime_feedback.get("blockers") if runtime_feedback else []
-    runtime_unmapped_feedback = runtime_mapping_gap_feedback(current)
+    runtime_requests = runtime_replay_requests(current)
+    has_runtime_replay_candidate = bool(runtime_requests)
+    runtime_unmapped_feedback = runtime_mapping_gap_feedback(
+        current,
+        include_contract_gaps=not has_runtime_replay_candidate,
+    )
     runtime_unmapped_blockers = (
         runtime_unmapped_feedback.get("blockers") if runtime_unmapped_feedback else []
     )
@@ -585,8 +739,6 @@ def closed_loop_decision(runs: list[dict[str, Any]]) -> dict[str, Any]:
         if as_float(run["feedback"].get("best_reward")) is not None
     ]
     prior_best_reward = max(prior_rewards) if prior_rewards else None
-    runtime_requests = runtime_replay_requests(current)
-    has_runtime_replay_candidate = bool(runtime_requests)
 
     if handoff.get("status") == "ready":
         action = "ready_handoff"
@@ -1105,6 +1257,11 @@ def collect_runtime_avoid_factors(
             }
     runtime_unmapped_feedback = decision.get("runtime_unmapped_feedback")
     if isinstance(runtime_unmapped_feedback, dict) and runtime_unmapped_feedback:
+        related = runtime_unmapped_feedback.get("related_factors")
+        if isinstance(related, list):
+            for item in related:
+                if isinstance(item, dict):
+                    add_item(item)
         base_factor = str(runtime_unmapped_feedback.get("base_factor") or "").strip()
         family = str(
             runtime_unmapped_feedback.get("factor_family") or factor_family(base_factor)
@@ -1198,10 +1355,15 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
             item["window"] = 30
         mutations.append(item)
 
-    if not mutations and decision["action"] == "revise_prior":
+    fallback_base_factor = "auto_settlement_model_full_depth_settlement_edge"
+    if (
+        not mutations
+        and decision["action"] == "revise_prior"
+        and factor_family(fallback_base_factor) not in runtime_avoid_families
+    ):
         mutations.append(
             {
-                "base_factor": "auto_settlement_model_full_depth_settlement_edge",
+                "base_factor": fallback_base_factor,
                 "mutation_type": "add_capacity_gate",
                 "name": "llm_model_full_depth_edge_capacity_gate",
                 "feature": "entry_capacity_score",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,59 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Unmapped Runtime Contract Prior Feedback (2026-05-27)
+
+Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps
+live and dry-run deployment state untouched and fixes the closed-loop planner so
+a hosted walk-forward that has only unsupported or unmapped runtime-contract
+candidates does not stop at `fix_runtime` with no replay request.
+
+### Files / Ownership
+
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: classify unsupported runtime-contract frontier as typed prior
+    feedback when no executable replay request exists.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: regression coverage for the no-request runtime-contract gap state.
+- `tasks/todo.md`
+  - Owner: session tracking and evidence notes.
+
+### Tasks
+
+- [x] Reproduce hosted run `26526988422` locally and confirm it emits
+      `fix_runtime` with `runtime_replay_requests=[]`.
+- [x] Add regression coverage for unsupported/unmapped runtime-contract
+      candidates with no replayable runtime score.
+- [x] Route that state to `revise_prior` and emit runtime avoid feedback.
+- [x] Run focused validation and simulate against `26526988422`.
+- [ ] Land through PR and rerun the hosted research loop from `main`.
+
+### Review
+
+- 2026-05-27: Downloaded run `26526988422` artifacts from GitHub Actions and
+  reproduced the stale frontier locally. The run completed successfully from
+  `main@fe7e0dc1`, but closed-loop output remained
+  `action=fix_runtime`, `reason=promotion_blockers_require_fix_runtime`, and
+  `runtime_replay_requests=[]`. The current best and selected candidates are
+  unsupported/unmapped runtime-contract families such as
+  `auto_settlement_model_conservative_settlement_edge` and Bayes-derived
+  research-only inputs, while prior feedback already avoids the previously
+  failed runtime-ready families.
+- 2026-05-27: Added no-request runtime-contract gap feedback to
+  `scripts/alpha_search_closed_loop_agent.py`. A current-run registry preview
+  frontier with `runtime_contract_unmapped_factor` /
+  `runtime_input_unsupported:*` blockers now becomes
+  `action=revise_prior`, `reason=runtime_contract_unmapped_factor`, and emits
+  related runtime avoid families instead of an empty `fix_runtime` action.
+  Focused validation passed:
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent
+  tests.test_factor_walk_forward_sweep`, `python3 -m py_compile
+  scripts/alpha_search_closed_loop_agent.py
+  tests/test_alpha_search_closed_loop_agent.py`, and `rtk git diff --check`.
+  Replaying run `26526988422` with the patched script now produces
+  `runtime_replay_requests=[]`, no new prior mutations, and runtime avoid
+  families for the already failed replay families plus the unsupported
+  conservative-settlement and Bayes-derived runtime-contract families.
+
 ## Current Session - Runtime Replay Negative Edge Feedback (2026-05-27)
 
 Evidence stage: `runtime_parity` / `walk_forward` feedback repair. This keeps

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -933,6 +933,180 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
         )
         self.assertEqual(runtime_score, request["inputs"]["runtime_score"])
 
+    def test_unmapped_runtime_contract_without_replay_request_revises_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            blocked_factor = (
+                "mcts_mcts_auto_settlement_model_conservative_settlement_edge_"
+                "spread_adjusted_spread_adjusted_spread_adjusted"
+            )
+            blocked_family = "auto_settlement_model_conservative_settlement_edge"
+            bayes_factor = "mut_bayes_model_market_reversal_select_entry_price_quality_ge_025"
+            spread_runtime_score = (
+                "autofactor_formula:mut_spread_adjusted_external_move_entry_price_quality"
+            )
+            path = artifact(
+                Path(tmp),
+                chain_reason="chain_next_run_false",
+                selected_nodes=[
+                    {
+                        "factor_name": blocked_factor,
+                        "selected_dimension": "exploit",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
+                    {
+                        "factor_name": bayes_factor,
+                        "selected_dimension": "exploit",
+                        "proposed_mutation": "add_capacity_gate",
+                    },
+                ],
+                feedback={
+                    "target": agent.DEFAULT_TARGET,
+                    "candidate_count": 1289,
+                    "rejected_count": 875,
+                    "passed_count": 256,
+                    "best_candidate": blocked_factor,
+                    "best_reward": 6.3511,
+                    "runtime_avoid_factors": [
+                        {
+                            "base_factor": "mut_spread_adjusted_external_move_select_entry_price_quality_ge_075",
+                            "factor_family": "spread_adjusted_external_move",
+                            "runtime_score": (
+                                "autofactor_formula:"
+                                "mut_spread_adjusted_external_move_select_entry_price_quality_ge_075"
+                            ),
+                            "reason": "negative_runtime_replay_edge",
+                        }
+                    ],
+                },
+                promotion={
+                    "decision": "blocked",
+                    "required_strategy_profile": "settlement_probability",
+                    "evaluated_factors": [
+                        {
+                            "blockers": [
+                                "candidate_strategy_replay_not_runtime_replay:"
+                                "factor_walk_forward_top_bucket_aggregate!=runtime_market_update_replay",
+                                "runtime_contract_unmapped_factor",
+                                "empty_runtime_strategy_profile",
+                            ],
+                            "factor": {
+                                "name": blocked_factor,
+                                "target": agent.DEFAULT_TARGET,
+                                "decision": "candidate",
+                                "reason": "passed",
+                            },
+                            "runtime_mapping": {
+                                "runtime_score": "",
+                                "strategy_profile": "",
+                            },
+                        }
+                    ],
+                    "candidate_strategy_replay": {
+                        "basis": "factor_walk_forward_top_bucket_aggregate",
+                        "runtime_score": "",
+                        "strategy_profile": "settlement_probability",
+                    },
+                },
+                registry_preview={
+                    "version": "alpha_search_artifacts_v1",
+                    "target": agent.DEFAULT_TARGET,
+                    "horizon": "5m",
+                    "factors": [
+                        {
+                            "factor_name": blocked_factor,
+                            "target": agent.DEFAULT_TARGET,
+                            "status": "candidate",
+                            "runtime_contract": {
+                                "runtime_score": "",
+                                "strategy_profile": "",
+                                "strategy_family": "",
+                                "factor_family": blocked_family,
+                                "blockers": ["runtime_contract_unmapped_factor"],
+                            },
+                            "metrics": {
+                                "reward": 6.3511,
+                                "top_bucket_unique_event_count": 129,
+                                "top_bucket_avg_label": 8.8691,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.8888,
+                                "spearman_ic": 0.2316,
+                            },
+                            "blockers": ["runtime_contract_unmapped_factor"],
+                        },
+                        {
+                            "factor_name": bayes_factor,
+                            "target": agent.DEFAULT_TARGET,
+                            "status": "candidate",
+                            "runtime_contract": {
+                                "runtime_score": "",
+                                "strategy_profile": "",
+                                "strategy_family": "",
+                                "factor_family": "bayes_model_market_reversal",
+                                "blockers": [
+                                    "runtime_contract_unmapped_factor",
+                                    "runtime_input_unsupported:bayes_model_disagreement",
+                                ],
+                            },
+                            "metrics": {
+                                "reward": 6.15,
+                                "top_bucket_unique_event_count": 126,
+                                "top_bucket_avg_label": 7.1,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.7777,
+                                "spearman_ic": 0.18,
+                            },
+                            "blockers": [
+                                "runtime_contract_unmapped_factor",
+                                "runtime_input_unsupported:bayes_model_disagreement",
+                            ],
+                        },
+                        {
+                            "factor_name": "mut_spread_adjusted_external_move_entry_price_quality",
+                            "target": agent.DEFAULT_TARGET,
+                            "status": "candidate",
+                            "runtime_contract": {
+                                "runtime_score": spread_runtime_score,
+                                "strategy_profile": "settlement_probability",
+                                "strategy_family": "predictive_settlement_probability",
+                                "factor_family": "spread_adjusted_external_move",
+                                "blockers": [],
+                            },
+                            "metrics": {
+                                "reward": 6.02,
+                                "top_bucket_unique_event_count": 129,
+                                "top_bucket_avg_label": 8.4,
+                                "top_bucket_full_depth_entry_fill_rate": 1.0,
+                                "positive_window_ratio": 0.8888,
+                                "spearman_ic": 0.221,
+                            },
+                            "blockers": [],
+                        },
+                    ],
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 5)
+
+        self.assertEqual("revise_prior", decision["decision"])
+        self.assertEqual("runtime_contract_unmapped_factor", decision["reason"])
+        self.assertEqual([], decision["runtime_replay_requests"])
+        self.assertEqual(blocked_factor, decision["runtime_unmapped_feedback"]["base_factor"])
+        self.assertEqual(
+            blocked_family,
+            decision["runtime_unmapped_feedback"]["factor_family"],
+        )
+        avoid_families = {
+            item["factor_family"] for item in prior["runtime_avoid_factors"]
+        }
+        self.assertIn(blocked_family, avoid_families)
+        self.assertIn("bayes_model_market_reversal", avoid_families)
+        self.assertIn("spread_adjusted_external_move", avoid_families)
+        mutation_bases = {item["base_factor"] for item in prior["mutations"]}
+        self.assertNotIn(blocked_factor, mutation_bases)
+        self.assertNotIn(bayes_factor, mutation_bases)
+
     def test_fix_runtime_includes_batch_runtime_replay_requests(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             scores = [


### PR DESCRIPTION
## Summary
- classify unsupported/unmapped runtime-contract frontiers with no replay request as `revise_prior` instead of empty `fix_runtime`
- include registry-preview runtime contract gaps in closed-loop feedback and carry related families into `runtime_avoid_factors`
- add regression coverage for the `26526988422` failure shape

## Evidence stage
`walk_forward` / `runtime_parity` feedback repair. This does not touch live or dry-run deployment state.

## Validation
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent tests.test_factor_walk_forward_sweep`
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `rtk git diff --check`
- Replayed run `26526988422`: patched decision is `action=revise_prior`, `reason=runtime_contract_unmapped_factor`, `runtime_replay_requests=[]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved classification and handling of runtime contract issues when contracts cannot be executed
  * Enhanced decision-making logic with better identification of blocking factors and their relationships
  * More informative feedback that provides improved context for edge cases, including identification of related factors across different categories
  * Better reliability and robustness in handling complex scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->