### PR TITLE
Block stale handoff on negative runtime replay

### DIFF
--- a/crates/ploy-research/examples/research_trace_plan.rs
+++ b/crates/ploy-research/examples/research_trace_plan.rs
@@ -6,11 +6,11 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use ploy_research::research_os::manager::{
-    plan_next_research, ResearchBudget, ResearchManagerInput,
+    ResearchBudget, ResearchManagerInput, plan_next_research,
 };
-use serde_json::{json, Value};
-use sqlx::postgres::PgPoolOptions;
+use serde_json::{Value, json};
 use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.windows(2)
@@ -182,6 +182,7 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
     .await?;
     let runtime_ready_candidates = runtime_ready_factor_candidates(pool, limit).await?;
     let ready_candidate_replays = ready_candidate_replays(pool, limit).await?;
+    let recent_candidate_replays = recent_candidate_replays(pool, limit).await?;
 
     Ok(json!({
         "source": "factor_registry",
@@ -201,6 +202,7 @@ async fn factor_registry_summary(pool: &PgPool, limit: usize) -> Result<Value> {
         }).collect::<Vec<_>>(),
         "runtime_ready_candidates": runtime_ready_candidates,
         "ready_candidate_replays": ready_candidate_replays,
+        "recent_candidate_replays": recent_candidate_replays,
     }))
 }
 
@@ -332,6 +334,79 @@ async fn ready_candidate_replays(pool: &PgPool, limit: usize) -> Result<Value> {
                     "blocking_risk_flags": row.12,
                     "artifact_json": row.13,
                     "created_at": row.14,
+                })
+            })
+            .collect(),
+    ))
+}
+
+async fn recent_candidate_replays(pool: &PgPool, limit: usize) -> Result<Value> {
+    let rows: Vec<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+        String,
+        bool,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Value,
+        Value,
+        Value,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        r#"
+        SELECT
+            candidate_replay_id,
+            run_id,
+            workflow_run_id,
+            workflow_run_url,
+            basis,
+            promotion_decision,
+            promotion_ready,
+            strategy_profile,
+            runtime_score,
+            data_snapshot_id,
+            target,
+            horizon,
+            metrics_json,
+            blocking_risk_flags_json,
+            artifact_json,
+            created_at
+        FROM candidate_replay_tapes
+        WHERE basis = 'runtime_market_update_replay'
+        ORDER BY created_at DESC
+        LIMIT $1
+        "#,
+    )
+    .bind(limit as i64)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(Value::Array(
+        rows.into_iter()
+            .map(|row| {
+                json!({
+                    "candidate_replay_id": row.0,
+                    "run_id": row.1,
+                    "workflow_run_id": row.2,
+                    "workflow_run_url": row.3,
+                    "basis": row.4,
+                    "promotion_decision": row.5,
+                    "promotion_ready": row.6,
+                    "strategy_profile": row.7,
+                    "runtime_score": row.8,
+                    "data_snapshot_id": row.9,
+                    "target": row.10,
+                    "horizon": row.11,
+                    "metrics": row.12,
+                    "blocking_risk_flags": row.13,
+                    "artifact_json": row.14,
+                    "created_at": row.15,
                 })
             })
             .collect(),

--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -90,7 +90,11 @@ pub fn plan_next_research(input: &ResearchManagerInput) -> Result<ResearchManage
 
     let blocker_actions = derive_blocker_actions(input);
     let latest_decision = latest_run_decision_value(&input.latest_runs);
-    if has_ready_handoff(&input.latest_runs) {
+    let has_negative_runtime_economics = blocker_actions.iter().any(|item| {
+        item.blocker_family == "strategy_economics"
+            && item.action == "mutate_or_reject_negative_runtime_edge"
+    });
+    if has_ready_handoff(&input.latest_runs) && !has_negative_runtime_economics {
         return Ok(plan_with_blocker_actions(
             "ready_handoff",
             1,
@@ -290,9 +294,30 @@ fn plan_with_blocker_actions(
 fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAction> {
     let mut actions = Vec::new();
     let latest_value = latest_run_decision_value(&input.latest_runs);
+    let latest_runtime_replay = latest_recent_runtime_replay(&input.factor_registry_summary);
     let latest = latest_value.to_string().to_lowercase();
+    let runtime_replay = latest_runtime_replay
+        .as_ref()
+        .map(|value| value.to_string().to_lowercase())
+        .unwrap_or_default();
     let market_data = market_data_blocker_text(&input.market_data_health);
-    let runtime_or_promotion_blockers = latest;
+    let frontier_runtime_replay_roi = latest_runtime_replay
+        .as_ref()
+        .and_then(runtime_market_update_replay_roi)
+        .or_else(|| runtime_market_update_replay_roi(&latest_value));
+    let negative_runtime_replay = frontier_runtime_replay_roi
+        .map(|roi| roi < 0.0)
+        .unwrap_or(false);
+    let runtime_or_promotion_blockers = if runtime_replay.is_empty() {
+        latest.clone()
+    } else {
+        format!("{latest}\n{runtime_replay}")
+    };
+    let data_blocker_text = if negative_runtime_replay {
+        latest.as_str()
+    } else {
+        runtime_or_promotion_blockers.as_str()
+    };
     let frontier_proves_full_depth = has_any_key_value(
         &latest_value,
         &[
@@ -307,10 +332,9 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
         &["official_settlement", "official_settlement_ready"],
         &[true.into(), "true".into()],
     );
-    let frontier_runtime_replay_roi = runtime_market_update_replay_roi(&latest_value);
 
     if contains_any_text(
-        &runtime_or_promotion_blockers,
+        data_blocker_text,
         &[
             "official_settlement_missing",
             "missing_official_settlement",
@@ -325,7 +349,7 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
         ));
     }
     if contains_any_text(
-        &runtime_or_promotion_blockers,
+        data_blocker_text,
         &[
             "sampled_snapshot_required_for_execution_surface",
             "required_execution_surface_is_sampled_snapshot",
@@ -381,7 +405,8 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
             "negative_runtime_edge",
         ][..]
     };
-    if contains_any_text(&runtime_or_promotion_blockers, economics_tokens)
+    if (contains_any_text(&runtime_or_promotion_blockers, economics_tokens)
+        || negative_runtime_replay)
         && !(positive_runtime_replay && has_data_action)
     {
         actions.push(blocker_action(
@@ -580,6 +605,21 @@ fn has_any_key_value(
             .any(|item| has_any_key_value(item, keys, expected_values)),
         _ => false,
     }
+}
+
+fn latest_recent_runtime_replay(value: &serde_json::Value) -> Option<serde_json::Value> {
+    value
+        .get("recent_candidate_replays")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| {
+                    item.get("basis").and_then(serde_json::Value::as_str)
+                        == Some("runtime_market_update_replay")
+                })
+                .cloned()
+        })
 }
 
 fn runtime_market_update_replay_roi(value: &serde_json::Value) -> Option<f64> {
@@ -783,9 +823,10 @@ mod tests {
         ))
         .expect("plan");
         assert_eq!(plan.theme, "revise_prior");
-        assert!(plan
-            .actions
-            .contains(&"generate_typed_llm_prior_json".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
     }
 
     #[test]
@@ -819,9 +860,10 @@ mod tests {
 
         let plan = plan_next_research(&input).expect("plan");
         assert_eq!(plan.theme, "candidate_to_runtime_replay");
-        assert!(plan
-            .actions
-            .contains(&"build_runtime_candidate_replay".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"build_runtime_candidate_replay".to_string())
+        );
     }
 
     #[test]
@@ -875,12 +917,14 @@ mod tests {
         assert_eq!(plan.theme, "ready_handoff");
         assert_eq!(plan.candidate_count, 1);
         assert_eq!(plan.search_depth, 0);
-        assert!(plan
-            .actions
-            .contains(&"create_dry_run_handoff_issue".to_string()));
-        assert!(plan
-            .actions
-            .contains(&"open_config_pr_from_ready_handoff".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"create_dry_run_handoff_issue".to_string())
+        );
+        assert!(
+            plan.actions
+                .contains(&"open_config_pr_from_ready_handoff".to_string())
+        );
         assert!(plan.blocker_actions.is_empty());
     }
 
@@ -927,6 +971,107 @@ mod tests {
         assert_eq!(plan.theme, "ready_handoff");
         assert_eq!(plan.candidate_count, 1);
         assert!(plan.blocker_actions.is_empty());
+    }
+
+    #[test]
+    fn planner_routes_newer_negative_runtime_replay_ahead_of_stale_ready_handoff() {
+        let mut input = input(
+            "walk_forward",
+            serde_json::json!({
+                "source": "experiment_trace",
+                "evidence_stage": "walk_forward",
+                "runs": [{
+                    "run_id": "26530018058",
+                    "artifacts": [{
+                        "event_type": "strategy_handoff",
+                        "output_json": {
+                            "status": "blocked",
+                            "recommended_action": "do_not_promote"
+                        }
+                    }]
+                }],
+                "ready_handoffs": [{
+                    "run_id": "26377165132",
+                    "created_at": "2026-05-24T17:16:29Z",
+                    "event_type": "strategy_handoff",
+                    "output_json": {
+                        "kind": "autofactor_strategy_handoff",
+                        "status": "ready",
+                        "recommended_action": "create_dry_run_handoff",
+                        "strategies": [{
+                            "runtime_score": "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
+                        }],
+                        "candidate_strategy_replay": {
+                            "ready": true,
+                            "basis": "runtime_market_update_replay"
+                        }
+                    }
+                }]
+            }),
+            serde_json::json!({}),
+        );
+        input.factor_registry_summary = serde_json::json!({
+            "recent_candidate_replays": [{
+                "candidate_replay_id": "candidate_replay:negative",
+                "run_id": "26530018058",
+                "workflow_run_id": "26528933436",
+                "basis": "runtime_market_update_replay",
+                "promotion_ready": false,
+                "promotion_decision": "blocked",
+                "strategy_profile": "settlement_probability",
+                "runtime_score": "autofactor_formula:auto_settlement_model_full_depth_settlement_edge_spread_adjusted",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+                "metrics": {
+                    "roi": -0.013906620311657932,
+                    "total_pnl": -30.246899177856,
+                    "trade_count": 145,
+                    "unique_event_count": 145,
+                    "entry_fill_rate": 1.0
+                },
+                "blocking_risk_flags": [
+                    "official_settlement_missing:142<145",
+                    "roi_too_low:-0.013907<0.000000"
+                ],
+                "created_at": "2026-05-27T18:17:00Z"
+            }],
+            "ready_candidate_replays": [{
+                "candidate_replay_id": "candidate_replay:old-ready",
+                "run_id": "26377165132",
+                "workflow_run_id": "26367311478",
+                "basis": "runtime_market_update_replay",
+                "promotion_ready": true,
+                "promotion_decision": "promote_to_runtime",
+                "runtime_score": "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted",
+                "metrics": {
+                    "roi": 0.11653800000105063,
+                    "trade_count": 50
+                },
+                "blocking_risk_flags": [],
+                "created_at": "2026-05-24T17:16:29Z"
+            }]
+        });
+
+        let plan = plan_next_research(&input).expect("plan");
+
+        assert_eq!(plan.theme, "revise_prior");
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
+        assert!(
+            !plan
+                .actions
+                .contains(&"create_dry_run_handoff_issue".to_string())
+        );
+        assert!(plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "strategy_economics"
+                && item.action == "mutate_or_reject_negative_runtime_edge"
+        }));
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "data_settlement"
+                && item.action == "repair_official_settlement_coverage"
+        }));
     }
 
     #[test]
@@ -989,9 +1134,10 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(plan
-            .actions
-            .contains(&"generate_typed_llm_prior_json".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "search_power"
                 && item.action == "increase_distinct_event_coverage_or_reduce_selectivity"
@@ -1033,9 +1179,10 @@ mod tests {
         let plan = plan_next_research(&input).expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(plan
-            .actions
-            .contains(&"generate_typed_llm_prior_json".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "strategy_economics"
                 && item.action == "mutate_or_reject_negative_runtime_edge"
@@ -1118,9 +1265,10 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "revise_prior");
-        assert!(plan
-            .actions
-            .contains(&"generate_typed_llm_prior_json".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"generate_typed_llm_prior_json".to_string())
+        );
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "strategy_economics"
                 && item.action == "mutate_or_reject_negative_runtime_edge"
@@ -1149,12 +1297,14 @@ mod tests {
         .expect("plan");
 
         assert_eq!(plan.theme, "fix_data");
-        assert!(plan
-            .actions
-            .contains(&"repair_official_settlement_coverage".to_string()));
-        assert!(plan
-            .actions
-            .contains(&"collect_full_depth_execution_surface".to_string()));
+        assert!(
+            plan.actions
+                .contains(&"repair_official_settlement_coverage".to_string())
+        );
+        assert!(
+            plan.actions
+                .contains(&"collect_full_depth_execution_surface".to_string())
+        );
         assert!(plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "data_settlement"
                 && item.action == "repair_official_settlement_coverage"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,53 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Negative Runtime Replay Frontier (2026-05-27)
+
+Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps
+live and dry-run deployment state untouched and fixes Research Trace Plan /
+Research Manager so a newer negative runtime replay blocks stale ready-handoff
+state.
+
+### Files / Ownership
+
+- `crates/ploy-research/examples/research_trace_plan.rs`
+  - Owner: expose recent runtime replay frontier evidence, including blocked
+    negative replay artifacts.
+- `crates/ploy-research/src/research_os/manager.rs`
+  - Owner: route latest negative runtime replay economics to `revise_prior`
+    before stale ready handoff.
+- `tasks/todo.md`
+  - Owner: session tracking and evidence notes.
+
+### Tasks
+
+- [x] Confirm hosted replay evidence: runs `26528932310`, `26528933436`,
+      `26528934580`, `26528935409`, and `26528936446` all completed but were
+      `promotion_ready=false`.
+- [x] Reproduce durable planner bug: direct `research-trace-plan` returned
+      `theme=ready_handoff` after negative replay run `26530018058`.
+- [x] Add recent candidate replay frontier summary to `research_trace_plan`.
+- [x] Add Research Manager regression for newer negative runtime replay
+      overriding stale ready handoff.
+- [x] Run focused local validation.
+- [ ] Rerun planner against durable trace and land through PR.
+
+### Review
+
+- 2026-05-27: Runtime replay evidence was real `runtime_market_update_replay`
+  evidence, not a top-bucket aggregate. The best replayed full-depth settlement
+  family candidate had `trade_count=145`, `entry_fill_rate=1.0`, and
+  `roi=-0.0139066`, so it is not promotable. Hosted feedback run
+  `26530018058` correctly emitted `action=revise_prior` and
+  `reason=negative_runtime_replay_edge`, but direct durable
+  `research-trace-plan` still returned `ready_handoff` because it only exposed
+  old ready candidate replays from `candidate_replay_tapes`.
+- 2026-05-27: Added `recent_candidate_replays` to the trace-plan frontier and
+  taught Research Manager to let the latest negative
+  `runtime_market_update_replay` economics override stale ready handoff state.
+  Focused validation passed:
+  `rtk cargo test -p ploy-research research_os::manager --lib` and
+  `rtk cargo check -p ploy-research --features db --example research_trace_plan`.
+
 ## Current Session - Unmapped Runtime Contract Prior Feedback (2026-05-27)
 
 Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps


### PR DESCRIPTION
## Summary
- expose recent runtime candidate replays in research trace planning, including blocked negative replay artifacts
- make Research Manager treat the latest negative runtime replay economics as revise-prior evidence before stale ready handoff state
- add regression coverage for a newer negative runtime replay overriding an older ready handoff

## Validation
- rtk cargo test -p ploy-research research_os::manager --lib
- rtk cargo check -p ploy-research --features db --example research_trace_plan
- rtk git diff --check

Live/dry-run deployment state was not changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened research planning system with enhanced evaluation of economic conditions before route selection decisions
  * Integrated runtime market replay data for improved blocker detection logic
  * Added validation to prevent unfavorable conditions from advancing

* **Tests**
  * Added test coverage for negative economic scenario handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->