### PR TITLE
Prefer recent negative replay in Research Manager executor

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -598,9 +598,11 @@ def _latest_run(plan_payload: dict[str, Any]) -> dict[str, Any]:
 
 def _latest_candidate_replay_contract(plan_payload: dict[str, Any]) -> dict[str, Any]:
     summary = ((plan_payload.get("input") or {}).get("factor_registry_summary") or {})
-    ready_replays = summary.get("ready_candidate_replays")
-    if isinstance(ready_replays, list):
-        for item in ready_replays:
+    for replay_key in ("recent_candidate_replays", "ready_candidate_replays"):
+        replays = summary.get(replay_key)
+        if not isinstance(replays, list):
+            continue
+        for item in replays:
             if not isinstance(item, dict):
                 continue
             artifact = item.get("artifact_json")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,57 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Executor Negative Replay Selection (2026-05-27)
+
+Evidence stage: `runtime_parity` feedback repair. This keeps live and dry-run
+deployment state untouched and fixes the Research Manager executor so
+`revise_prior` follow-up plans use the latest negative runtime replay frontier
+instead of stale ready replay artifacts.
+
+### Files / Ownership
+
+- `scripts/research_manager_execute_plan.py`
+  - Owner: select recent runtime replay evidence before older ready replay
+    evidence when building typed prior and bounded walk-forward dispatches.
+- `tests/test_research_manager_execute_plan.py`
+  - Owner: regression for stale ready replay not overriding newer negative
+    runtime replay.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Confirm deployed trace-plan run `26531806982` now returns
+      `theme=revise_prior` with
+      `strategy_economics -> mutate_or_reject_negative_runtime_edge`.
+- [x] Reproduce executor dry-run issue: run `26531876702` generated no
+      executable dispatch because of missing `snapshot_run_id`, and its typed
+      prior still used stale ready replay `26367311478` instead of latest
+      negative replay `26528933436`.
+- [x] Make executor prefer `recent_candidate_replays` over
+      `ready_candidate_replays` when selecting the runtime replay contract.
+- [x] Run focused validation.
+- [x] Land through PR.
+- [x] Re-run executor dry-run against plan `26531806982` and verify the typed
+      prior points at replay `26528933436`.
+
+### Review
+
+- 2026-05-27: Trace-plan frontier handling was fixed by PR #715 and deployed
+  via tango deploy run `26531358971`, but the executor still selected the
+  stale ready replay list first. The next correction is executor-only: latest
+  `recent_candidate_replays` must be the replay evidence source for
+  `revise_prior` feedback so old handoff evidence cannot leak into the new
+  typed prior.
+- 2026-05-27: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py`, and `rtk git diff --check`.
+  A local replay of plan `26531806982` with source snapshot run `26516561409`
+  now creates one ready bounded walk-forward dispatch using candidate replay
+  `26528933436`, ROI `-0.013906620311657932`, and
+  `runtime_avoid_factors` for
+  `auto_settlement_model_full_depth_settlement_edge`.
+
 ## Current Session - Research Manager Negative Runtime Replay Frontier (2026-05-27)
 
 Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -240,6 +240,113 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             prior["mutations"][0]["base_factor"],
         )
 
+    def test_revise_prior_prefers_recent_negative_replay_over_stale_ready_replay(self) -> None:
+        stale_ready_replay = {
+            "artifact_json": {
+                "basis": "runtime_market_update_replay",
+                "runtime_score": "autofactor_formula:stale_ready",
+                "source_workflow": "runtime-candidate-replay.yml",
+                "workflow_run_id": "26367311478",
+                "strategy_profile": "settlement_probability",
+                "metrics": {
+                    "trade_count": 50,
+                    "unique_event_count": 50,
+                    "entry_fill_rate": 1.0,
+                    "roi": 0.116538,
+                    "total_pnl": 87.4035,
+                },
+                "decision_contract": {
+                    "target": "tradeable_full_depth_settlement_pnl",
+                    "horizon": "5m",
+                },
+                "recording_path": "/opt/ploy/data/recordings/archived.20260524T155939.ndjson",
+                "recording_sha256": "abc123",
+            },
+            "metrics": {"roi": 0.116538},
+        }
+        recent_negative_replay = {
+            "artifact_json": {
+                "basis": "runtime_market_update_replay",
+                "runtime_score": "autofactor_formula:latest_negative",
+                "source_workflow": "runtime-candidate-replay.yml",
+                "workflow_run_id": "26528933436",
+                "strategy_profile": "settlement_probability",
+                "metrics": {
+                    "trade_count": 145,
+                    "unique_event_count": 145,
+                    "entry_fill_rate": 1.0,
+                    "roi": -0.013906620311657932,
+                    "total_pnl": -30.246899177856,
+                },
+                "blocking_risk_flags": [
+                    "official_settlement_missing:142<145",
+                    "roi_too_low:-0.013907<0.000000",
+                ],
+                "decision_contract": {
+                    "target": "full_depth_settlement_executable_pnl",
+                    "horizon": "5m",
+                },
+                "recording_path": "/opt/ploy/data/recordings/live.ndjson",
+                "recording_sha256": "def456",
+            },
+            "metrics": {"roi": -0.013906620311657932},
+        }
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+            {
+                "ready_candidate_replays": [stale_ready_replay],
+                "recent_candidate_replays": [recent_negative_replay, stale_ready_replay],
+            },
+        )
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest replay or walk-forward evidence failed economic/OOS gates.",
+            }
+        ]
+
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK, snapshot_run_id="26516561409"),
+            plan,
+        )
+
+        dispatch = payload["dispatches"][0]
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertEqual("26528933436", options["candidate_strategy_replay_run_id"])
+        self.assertEqual(
+            "runtime-candidate-replay-26528933436",
+            options["candidate_strategy_replay_artifact_name"],
+        )
+        self.assertEqual(
+            "full_depth_settlement_executable_pnl",
+            options["alpha_search_plan_target"],
+        )
+        prior = json.loads(options["alpha_search_llm_prior_json"])
+        self.assertEqual(
+            [
+                {
+                    "base_factor": "latest_negative",
+                    "factor_family": "latest_negative",
+                    "runtime_score": "autofactor_formula:latest_negative",
+                    "reason": "negative_runtime_edge",
+                    "metrics": {
+                        "trade_count": 145,
+                        "unique_event_count": 145,
+                        "entry_fill_rate": 1.0,
+                        "roi": -0.013906620311657932,
+                        "total_pnl": -30.246899177856,
+                        "blocking_risk_flags": [
+                            "official_settlement_missing:142<145",
+                            "roi_too_low:-0.013907<0.000000",
+                        ],
+                    },
+                }
+            ],
+            prior["runtime_avoid_factors"],
+        )
+
     def test_negative_runtime_prior_normalizes_selector_threshold_family(self) -> None:
         plan = plan_payload(
             "revise_prior",


### PR DESCRIPTION
## Summary
- make the Research Manager executor select `recent_candidate_replays` before stale `ready_candidate_replays`
- keep typed prior and bounded walk-forward dispatches tied to the latest negative runtime replay evidence
- add regression coverage for stale ready replay being overridden by a newer negative replay

## Validation
- `python3 -m unittest tests.test_research_manager_execute_plan`
- `python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py`
- `rtk git diff --check`
- local executor replay of trace-plan run `26531806982` with snapshot run `26516561409` produced candidate replay `26528933436` and ROI `-0.013906620311657932` in `runtime_avoid_factors`

Live/dry-run configuration is untouched.