### PR TITLE
Fix Research Manager snapshot provenance continuations

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -8,6 +8,8 @@ import json
 import os
 import re
 import subprocess
+import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -33,6 +35,49 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _source_snapshot_run_id_from_text(raw: str) -> str:
+    for line in raw.splitlines():
+        key, sep, value = line.partition("=")
+        if sep and key.strip() == "source_snapshot_run_id":
+            return value.strip()
+    return ""
+
+
+def _source_snapshot_run_id_from_alpha_artifact(run_id: str, artifact_name: str) -> str:
+    if not run_id or not artifact_name:
+        return ""
+    if not (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")):
+        return ""
+    if not os.environ.get("GITHUB_REPOSITORY"):
+        return ""
+
+    downloader = Path(__file__).resolve().with_name("download_github_artifact.py")
+    with tempfile.TemporaryDirectory(prefix="ploy-alpha-provenance-") as tmp:
+        out = Path(tmp)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(downloader),
+                "--run-id",
+                run_id,
+                "--name",
+                artifact_name,
+                "--output-dir",
+                str(out),
+                "--require",
+                "snapshot-provenance/source.txt",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if completed.returncode != 0:
+            return ""
+        source = out / "snapshot-provenance" / "source.txt"
+        if not source.is_file():
+            return ""
+        return _source_snapshot_run_id_from_text(source.read_text(encoding="utf-8"))
 
 
 def _date_from_ts(raw: str | None) -> str:
@@ -257,12 +302,16 @@ def _walk_forward_dispatch(
     candidate_strategy_replay_artifact_name: str = "",
     full_depth_execution_surface_run_id: str = "",
     full_depth_execution_surface_artifact_name: str = "",
+    extra_blockers: list[str] | None = None,
+    snapshot_resolution: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     blockers: list[str] = []
     if not snapshot_run_id:
         blockers.append("missing_snapshot_run_id")
     if not _parse_symbols(symbols):
         blockers.append("missing_symbols")
+    if extra_blockers:
+        blockers.extend(extra_blockers)
     options = {
         "chain_next_run": chain_remaining > 0,
         "chain_remaining": max(chain_remaining - 1, 0),
@@ -302,13 +351,16 @@ def _walk_forward_dispatch(
         "stake_usd": stake_usd,
         "options_json": json.dumps(options, separators=(",", ":"), sort_keys=True),
     }
-    return {
+    dispatch = {
         "workflow": "factor-walk-forward-v2-hosted-artifact.yml",
         "reason": "bounded hosted walk-forward continuation from Research Manager plan",
         "ready": not blockers,
         "blockers": blockers,
         "fields": fields,
     }
+    if snapshot_resolution:
+        dispatch["snapshot_resolution"] = snapshot_resolution
+    return dispatch
 
 
 def _runtime_candidate_replay_dispatch(
@@ -980,6 +1032,47 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     alpha_search_plan_run_id = ""
     if plan.get("theme") == "revise_prior":
         alpha_search_plan_run_id = str(latest_replay_contract.get("source_run_id") or "")
+    alpha_search_plan_artifact_name = (
+        f"factor-walk-forward-v2-{alpha_search_plan_run_id}"
+        if alpha_search_plan_run_id
+        else ""
+    )
+    walk_forward_snapshot_run_id = args.snapshot_run_id
+    walk_forward_extra_blockers: list[str] = []
+    walk_forward_snapshot_resolution: dict[str, str] = {}
+    if alpha_search_plan_run_id and getattr(args, "resolve_snapshot_provenance", False):
+        resolved_source_snapshot_run_id = _source_snapshot_run_id_from_alpha_artifact(
+            alpha_search_plan_run_id,
+            alpha_search_plan_artifact_name,
+        )
+        if resolved_source_snapshot_run_id:
+            walk_forward_snapshot_resolution = {
+                "source": "alpha_search_plan_artifact_snapshot_provenance",
+                "alpha_search_plan_run_id": alpha_search_plan_run_id,
+                "alpha_search_plan_artifact_name": alpha_search_plan_artifact_name,
+                "source_snapshot_run_id": resolved_source_snapshot_run_id,
+            }
+            if (
+                not walk_forward_snapshot_run_id
+                or walk_forward_snapshot_run_id == alpha_search_plan_run_id
+            ):
+                walk_forward_snapshot_run_id = resolved_source_snapshot_run_id
+                walk_forward_snapshot_resolution["status"] = "applied"
+            else:
+                walk_forward_snapshot_resolution["status"] = "provided_snapshot_run_id_kept"
+                walk_forward_snapshot_resolution["provided_snapshot_run_id"] = (
+                    walk_forward_snapshot_run_id
+                )
+        elif walk_forward_snapshot_run_id == alpha_search_plan_run_id:
+            walk_forward_extra_blockers.append(
+                "snapshot_run_id_points_to_alpha_search_plan_without_source_snapshot_provenance"
+            )
+            walk_forward_snapshot_resolution = {
+                "source": "alpha_search_plan_artifact_snapshot_provenance",
+                "alpha_search_plan_run_id": alpha_search_plan_run_id,
+                "alpha_search_plan_artifact_name": alpha_search_plan_artifact_name,
+                "status": "unresolved",
+            }
     negative_economics_prior = _negative_economics_prior_payload(
         blocker_actions,
         latest_replay_contract,
@@ -1045,18 +1138,14 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
         dispatches.append(
             _walk_forward_dispatch(
                 git_ref=args.git_ref,
-                snapshot_run_id=args.snapshot_run_id,
+                snapshot_run_id=walk_forward_snapshot_run_id,
                 symbols=args.symbols,
                 stake_usd=args.stake_usd,
                 chain_remaining=args.chain_remaining,
                 alpha_search_plan_target=walk_forward_target,
                 allowed_target=walk_forward_target,
                 alpha_search_plan_run_id=alpha_search_plan_run_id,
-                alpha_search_plan_artifact_name=(
-                    f"factor-walk-forward-v2-{alpha_search_plan_run_id}"
-                    if alpha_search_plan_run_id
-                    else ""
-                ),
+                alpha_search_plan_artifact_name=alpha_search_plan_artifact_name,
                 alpha_search_llm_prior=typed_prior,
                 candidate_strategy_replay_run_id=getattr(
                     args,
@@ -1088,6 +1177,8 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
                     "",
                 )
                 or latest_full_depth_surface_artifact.get("artifact_name", ""),
+                extra_blockers=walk_forward_extra_blockers,
+                snapshot_resolution=walk_forward_snapshot_resolution,
             )
         )
 
@@ -1253,6 +1344,15 @@ def main() -> None:
     parser.add_argument("--runtime-min-roi", default="0")
     parser.add_argument("--runtime-source-target", default="full_depth_settlement_executable_pnl")
     parser.add_argument("--runtime-source-horizon", default="5m")
+    parser.add_argument(
+        "--resolve-snapshot-provenance",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Resolve hosted walk-forward continuations back to the source research "
+            "snapshot run id recorded in the prior alpha-search artifact."
+        ),
+    )
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,56 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Snapshot Provenance Continuation (2026-05-28)
+
+Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps
+dry-run/live deployment state untouched and fixes the Research Manager executor
+so a continued hosted walk-forward reuses the source research snapshot run id
+from the previous alpha-search artifact provenance instead of accidentally
+passing the previous walk-forward run id as `snapshot_run_id`.
+
+### Files / Ownership
+
+- `scripts/research_manager_execute_plan.py`
+  - Owner: resolve `snapshot-provenance/source.txt` from the prior
+    factor-walk-forward artifact and use `source_snapshot_run_id` for the next
+    hosted walk-forward.
+- `tests/test_research_manager_execute_plan.py`
+  - Owner: regression for the `snapshot_run_id == alpha_search_plan_run_id`
+    failure shape seen in run `26544076700`.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Reproduce failed follow-up run `26544076700`: hosted walk-forward tried
+      to download `research-snapshot-26542589633`, then failed because the
+      embedded factor artifact has only `snapshot-provenance/`, not
+      `research-snapshot/`.
+- [x] Confirm prior walk-forward artifact `26542589633` records
+      `source_snapshot_run_id=26516561409` in
+      `snapshot-provenance/source.txt`.
+- [x] Implement executor provenance resolution and fail closed when a
+      walk-forward run id is passed as `snapshot_run_id` but provenance cannot
+      be resolved.
+- [x] Run focused validation.
+- [ ] Land through PR, deploy main to tango, and rerun the Research Manager
+      executor against plan `26543982839`.
+- [ ] Verify the new follow-up walk-forward dispatch uses
+      `snapshot_run_id=26516561409` and
+      `alpha_search_plan_run_id=26542589633`.
+
+### Review
+
+- 2026-05-28: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py`, and `rtk git diff --check`.
+  A local dry-run of plan `26543982839` with the previously wrong
+  `--snapshot-run-id 26542589633` now resolves provenance from
+  `factor-walk-forward-v2-26542589633` and emits
+  `snapshot_run_id=26516561409` while keeping
+  `alpha_search_plan_run_id=26542589633`.
+
 ## Current Session - Research Manager Data Blocker Routing (2026-05-28)
 
 Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -57,6 +57,7 @@ def base_args(**overrides):
         "runtime_min_roi": "0",
         "runtime_source_target": "full_depth_settlement_executable_pnl",
         "runtime_source_horizon": "5m",
+        "resolve_snapshot_provenance": False,
     }
     values.update(overrides)
     return Namespace(**values)
@@ -401,6 +402,119 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
         self.assertEqual(
             "research_manager_typed_prior.v1",
             payload["typed_prior"]["schema_version"],
+        )
+
+    def test_revise_prior_resolves_source_snapshot_from_alpha_artifact_provenance(self) -> None:
+        recent_negative_replay = {
+            "run_id": "26542589633",
+            "artifact_json": {
+                "basis": "runtime_market_update_replay",
+                "runtime_score": "autofactor_formula:latest_negative",
+                "source_workflow": "runtime-candidate-replay.yml",
+                "workflow_run_id": "26528933436",
+                "strategy_profile": "settlement_probability",
+                "metrics": {
+                    "trade_count": 145,
+                    "unique_event_count": 145,
+                    "entry_fill_rate": 1.0,
+                    "roi": -0.013906620311657932,
+                    "total_pnl": -30.246899177856,
+                },
+                "blocking_risk_flags": ["roi_too_low:-0.013907<0.000000"],
+                "decision_contract": {
+                    "target": "full_depth_settlement_executable_pnl",
+                    "horizon": "5m",
+                },
+                "recording_path": "/opt/ploy/data/recordings/live.ndjson",
+                "recording_sha256": "def456",
+            },
+        }
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+            {"recent_candidate_replays": [recent_negative_replay]},
+        )
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest replay or walk-forward evidence failed economic/OOS gates.",
+            }
+        ]
+
+        with patch(
+            "scripts.research_manager_execute_plan._source_snapshot_run_id_from_alpha_artifact",
+            return_value="26516561409",
+        ) as resolver:
+            payload = build_executor_payload(
+                base_args(
+                    mode="execute",
+                    execute_ack=EXECUTE_ACK,
+                    snapshot_run_id="26542589633",
+                    resolve_snapshot_provenance=True,
+                ),
+                plan,
+            )
+
+        resolver.assert_called_once_with("26542589633", "factor-walk-forward-v2-26542589633")
+        dispatch = payload["dispatches"][0]
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertTrue(dispatch["ready"])
+        self.assertEqual("26516561409", dispatch["fields"]["snapshot_run_id"])
+        self.assertEqual("26542589633", options["alpha_search_plan_run_id"])
+        self.assertEqual(
+            "factor-walk-forward-v2-26542589633",
+            options["alpha_search_plan_artifact_name"],
+        )
+        self.assertEqual(
+            {
+                "source": "alpha_search_plan_artifact_snapshot_provenance",
+                "alpha_search_plan_run_id": "26542589633",
+                "alpha_search_plan_artifact_name": "factor-walk-forward-v2-26542589633",
+                "source_snapshot_run_id": "26516561409",
+                "status": "applied",
+            },
+            dispatch["snapshot_resolution"],
+        )
+
+    def test_revise_prior_blocks_alpha_run_id_snapshot_when_provenance_unresolved(self) -> None:
+        recent_negative_replay = {
+            "run_id": "26542589633",
+            "artifact_json": {
+                "basis": "runtime_market_update_replay",
+                "runtime_score": "autofactor_formula:latest_negative",
+                "source_workflow": "runtime-candidate-replay.yml",
+                "workflow_run_id": "26528933436",
+                "strategy_profile": "settlement_probability",
+                "recording_path": "/opt/ploy/data/recordings/live.ndjson",
+                "recording_sha256": "def456",
+            },
+        }
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+            {"recent_candidate_replays": [recent_negative_replay]},
+        )
+
+        with patch(
+            "scripts.research_manager_execute_plan._source_snapshot_run_id_from_alpha_artifact",
+            return_value="",
+        ):
+            payload = build_executor_payload(
+                base_args(
+                    mode="execute",
+                    execute_ack=EXECUTE_ACK,
+                    snapshot_run_id="26542589633",
+                    resolve_snapshot_provenance=True,
+                ),
+                plan,
+            )
+
+        dispatch = payload["dispatches"][0]
+        self.assertFalse(dispatch["ready"])
+        self.assertIn(
+            "snapshot_run_id_points_to_alpha_search_plan_without_source_snapshot_provenance",
+            dispatch["blockers"],
         )
 
     def test_negative_runtime_prior_normalizes_selector_threshold_family(self) -> None:


### PR DESCRIPTION
## Summary
- resolve source research snapshot run id from prior factor-walk-forward artifact provenance
- fail closed when a walk-forward run id is passed as snapshot_run_id and provenance cannot be resolved
- add executor regressions for the 26544076700 failure shape

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- rtk git diff --check
- local executor dry-run against plan 26543982839 with wrong --snapshot-run-id 26542589633 now emits snapshot_run_id=26516561409 and alpha_search_plan_run_id=26542589633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot provenance resolution to track the origin of research continuations from source artifacts.
  * New `--resolve-snapshot-provenance` CLI flag (enabled by default) to automatically resolve and validate artifact sources.
  * Improved validation with protective blockers when snapshot provenance cannot be resolved.

* **Tests**
  * Added test coverage for snapshot provenance resolution and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->