### PR TITLE
Route Research Manager runtime replay blocker actions

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -1182,7 +1182,14 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
             )
         )
 
-    if "compare_runtime_scorer_contract" in actions or "build_runtime_candidate_replay" in actions:
+    runtime_replay_actions = {
+        "compare_runtime_scorer_contract",
+        "build_runtime_candidate_replay",
+        "build_runtime_market_update_replay",
+    }
+    if any(action in runtime_replay_actions for action in actions) or (
+        action_names & runtime_replay_actions
+    ):
         replay_args = _runtime_replay_args(args, plan_payload)
         dispatches.append(
             _runtime_candidate_replay_dispatch(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,37 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Runtime Replay Blocker Action (2026-05-28)
+
+Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps
+dry-run/live deployment state untouched and fixes Research Manager executor
+routing so `build_runtime_market_update_replay` blocker actions dispatch
+`runtime-candidate-replay.yml` instead of only continuing alpha search.
+
+### Files / Ownership
+
+- `scripts/research_manager_execute_plan.py`
+  - Owner: route runtime replay blocker actions to candidate replay dispatch.
+- `tests/test_research_manager_execute_plan.py`
+  - Owner: regression for `build_runtime_market_update_replay` blocker action.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Confirm run `26546643694` stayed `blocked` and exposed
+      `build_runtime_market_update_replay` as a blocker action.
+- [x] Implement executor routing for `build_runtime_market_update_replay`.
+- [x] Add regression coverage.
+- [x] Run focused validation.
+- [ ] Land through PR and rerun executor against the latest trace plan.
+
+### Review
+
+- 2026-05-28: Focused validation passed:
+  `python3 -m unittest tests.test_research_manager_execute_plan`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py`, and `rtk git diff --check`.
+
 ## Current Session - Research Manager Snapshot Provenance Continuation (2026-05-28)
 
 Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -817,6 +817,53 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             dispatch["fields"]["runtime_score"],
         )
 
+    def test_runtime_replay_blocker_action_dispatches_candidate_replay(self) -> None:
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+            {
+                "runtime_ready_candidates": [
+                    {
+                        "factor_name": "runtime_ready_factor",
+                        "status": "candidate",
+                        "target": "full_depth_settlement_executable_pnl",
+                        "horizon": "5m",
+                        "blockers": [],
+                        "runtime_contract": {
+                            "version": "autofactor_runtime_contract_v1",
+                            "runtime_score": "autofactor_formula:runtime_ready_factor",
+                            "strategy_profile": "settlement_probability",
+                            "target": "full_depth_settlement_executable_pnl",
+                            "horizon": "5m",
+                            "blockers": [],
+                        },
+                    }
+                ]
+            },
+        )
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "runtime_replay",
+                "action": "build_runtime_market_update_replay",
+                "reason": "Top-bucket aggregate evidence must be replaced by runtime replay.",
+            }
+        ]
+
+        payload = build_executor_payload(base_args(snapshot_run_id="26516561409"), plan)
+
+        self.assertEqual(2, payload["executable_dispatch_count"])
+        replay_dispatch = next(
+            item
+            for item in payload["dispatches"]
+            if item["workflow"] == "runtime-candidate-replay.yml"
+        )
+        self.assertTrue(replay_dispatch["ready"])
+        self.assertEqual("runtime_ready_factor", replay_dispatch["selected_factor_name"])
+        self.assertEqual(
+            "autofactor_formula:runtime_ready_factor",
+            replay_dispatch["fields"]["runtime_score"],
+        )
+
     def test_fix_runtime_prefers_frontier_runtime_ready_candidates(self) -> None:
         payload = build_executor_payload(
             base_args(),


### PR DESCRIPTION
## Summary
- route build_runtime_market_update_replay blocker actions to runtime-candidate-replay dispatches
- keep existing bounded walk-forward continuation behavior
- add regression coverage and session notes

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- rtk git diff --check
- local executor replay against plan 26546457240 produced ready factor-walk-forward and runtime-candidate-replay dispatches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Extended runtime replay action handling to support additional action types in execution workflows.

* **Tests**
  * Added test coverage for runtime replay blocker action dispatch behavior.

* **Documentation**
  * Updated documentation with research manager runtime replay task details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->