### PR TITLE
Persist runtime candidate replay frontier

### DIFF
--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -40,9 +40,9 @@ on:
         required: false
         default: "0"
       options_json:
-        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits, three_layer_min_entry_score, source_target, source_horizon"
+        description: "Advanced options JSON: full_depth_entry, skip_settlement_exits, three_layer_min_entry_score, source_target, source_horizon, persist_research_trace"
         required: false
-        default: '{"full_depth_entry":true,"skip_settlement_exits":false,"source_target":"full_depth_settlement_executable_pnl","source_horizon":"5m"}'
+        default: '{"full_depth_entry":true,"skip_settlement_exits":false,"source_target":"full_depth_settlement_executable_pnl","source_horizon":"5m","persist_research_trace":true}'
 concurrency:
   group: runtime-candidate-replay-${{ github.event.inputs.deployment_id }}-${{ github.event.inputs.runtime_score }}
   cancel-in-progress: false
@@ -84,8 +84,9 @@ jobs:
               "three_layer_min_entry_score": "",
               "source_target": "full_depth_settlement_executable_pnl",
               "source_horizon": "5m",
+              "persist_research_trace": "true",
           }
-          bool_keys = {"full_depth_entry", "skip_settlement_exits"}
+          bool_keys = {"full_depth_entry", "skip_settlement_exits", "persist_research_trace"}
           threshold_keys = {"three_layer_min_entry_score"}
           string_keys = {"source_target", "source_horizon"}
           allowed_thresholds = {Decimal("0.05"), Decimal("0.10"), Decimal("0.15"), Decimal("0.25")}
@@ -126,6 +127,7 @@ jobs:
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as handle:
               handle.write(f"REPLAY_FULL_DEPTH_ENTRY={values['full_depth_entry']}\n")
               handle.write(f"REPLAY_SKIP_SETTLEMENT_EXITS={values['skip_settlement_exits']}\n")
+              handle.write(f"REPLAY_PERSIST_RESEARCH_TRACE={values['persist_research_trace']}\n")
               handle.write(f"REPLAY_SOURCE_TARGET={values['source_target']}\n")
               handle.write(f"REPLAY_SOURCE_HORIZON={values['source_horizon']}\n")
               handle.write(
@@ -482,6 +484,95 @@ jobs:
             args+=(--full-depth-entry)
           fi
           python3 scripts/build_runtime_candidate_strategy_replay.py "${args[@]}"
+
+      - name: Persist runtime replay frontier to Research OS
+        env:
+          REMOTE_DIR: /opt/ploy/tmp/runtime-candidate-replay-${{ github.run_id }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARTIFACT_NAME: runtime-candidate-replay-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          test -f artifacts/runtime-replay/candidate-strategy-replay.json
+          persist_research_trace="${REPLAY_PERSIST_RESEARCH_TRACE:-true}"
+          case "${persist_research_trace}" in
+            true|false) ;;
+            *) echo "REPLAY_PERSIST_RESEARCH_TRACE must be true or false" >&2; exit 2 ;;
+          esac
+
+          scp scripts/persist_candidate_replay_tape.py \
+            tango-1-1:"${REMOTE_DIR}/persist_candidate_replay_tape.py"
+          scp artifacts/runtime-replay/candidate-strategy-replay.json \
+            tango-1-1:"${REMOTE_DIR}/candidate-strategy-replay.json"
+
+          # shellcheck disable=SC2029
+          ssh tango-1-1 /bin/bash -s -- \
+            "${REMOTE_DIR}" \
+            "${GITHUB_RUN_ID}" \
+            "${WORKFLOW_RUN_URL}" \
+            "${ARTIFACT_NAME}" \
+            "${persist_research_trace}" <<'EOF'
+          set -euo pipefail
+          remote_dir="$1"
+          workflow_run_id="$2"
+          workflow_run_url="$3"
+          artifact_name="$4"
+          persist_research_trace="$5"
+          case "${persist_research_trace}" in
+            true|false) ;;
+            *) echo "persist_research_trace must be true or false" >&2; exit 2 ;;
+          esac
+
+          set -a
+          . /opt/ploy/.env
+          set +a
+          python_bin="python3"
+          if [ -x /opt/ploy/.venv/bin/python ]; then
+            python_bin="/opt/ploy/.venv/bin/python"
+          elif [ -x /opt/ploy/venv/bin/python ]; then
+            python_bin="/opt/ploy/venv/bin/python"
+          fi
+          persist_args=(
+            "${remote_dir}/persist_candidate_replay_tape.py"
+            --candidate-replay-json "${remote_dir}/candidate-strategy-replay.json"
+            --run-id "${workflow_run_id}"
+            --source-workflow "runtime-candidate-replay.yml"
+            --workflow-run-id "${workflow_run_id}"
+            --workflow-run-url "${workflow_run_url}"
+            --artifact-name "${artifact_name}"
+            --report-json "${remote_dir}/candidate-replay-persist.json"
+          )
+          if [ "${persist_research_trace}" = "true" ]; then
+            test -n "${PLOY_DATABASE__URL:-}"
+            "${python_bin}" - <<'PY'
+          import asyncpg
+          PY
+            "${python_bin}" "${persist_args[@]}" --db-url "${PLOY_DATABASE__URL}"
+          else
+            "${python_bin}" "${persist_args[@]}" --dry-run
+          fi
+          EOF
+
+          scp tango-1-1:"${REMOTE_DIR}/candidate-replay-persist.json" \
+            artifacts/runtime-replay/candidate-replay-persist.json
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          payload = json.loads(
+              Path("artifacts/runtime-replay/candidate-replay-persist.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print("")
+          print("## Durable Research OS replay frontier")
+          print("")
+          print(f"- Dry run: `{payload.get('dry_run')}`")
+          print(f"- Candidate replay id: `{payload.get('candidate_replay_id')}`")
+          print(f"- Runtime score: `{payload.get('runtime_score')}`")
+          print(f"- Promotion decision: `{payload.get('promotion_decision')}`")
+          blockers = payload.get("blocking_risk_flags") or []
+          print(f"- Blocking flags: `{', '.join(blockers) if blockers else '<none>'}`")
+          PY
 
       - name: Publish summary
         if: always()

--- a/scripts/persist_candidate_replay_tape.py
+++ b/scripts/persist_candidate_replay_tape.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Persist standalone runtime candidate replay evidence into Research OS."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+DEFAULT_SOURCE_WORKFLOW = "runtime-candidate-replay.yml"
+WRITER_AGENT = "persist_candidate_replay_tape"
+EVENT_TYPE = "candidate_replay_tape"
+ARTIFACT_KIND = "candidate_replay_tape"
+
+
+def file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def string_field(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    return str(value).strip() if value is not None else ""
+
+
+def optional_string(payload: dict[str, Any], key: str) -> str | None:
+    value = string_field(payload, key)
+    return value or None
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def trace_hash(
+    hash_prev: str | None,
+    run_id: str,
+    event_type: str,
+    agent_name: str,
+    input_json: dict[str, Any],
+    output_json: dict[str, Any],
+) -> str:
+    hasher = hashlib.sha256()
+    for item in [
+        hash_prev or "",
+        run_id,
+        event_type,
+        agent_name,
+        canonical_json(input_json),
+        canonical_json(output_json),
+    ]:
+        hasher.update(item.encode("utf-8"))
+        hasher.update(b"\n")
+    return hasher.hexdigest()
+
+
+def canonical_candidate_replay_evidence_stage(
+    basis: str,
+    explicit_evidence_stage: str | None,
+) -> str:
+    if basis == "runtime_market_update_replay":
+        canonical = "executable_replay"
+    elif basis == "factor_walk_forward_top_bucket_aggregate":
+        canonical = "diagnostic"
+    else:
+        raise SystemExit(f"unsupported candidate replay basis: {basis}")
+    if explicit_evidence_stage and explicit_evidence_stage != canonical:
+        raise SystemExit(
+            "candidate replay evidence_stage "
+            f"{explicit_evidence_stage} contradicts basis {basis}; expected {canonical}"
+        )
+    return canonical
+
+
+def factor_name_from_runtime_score(runtime_score: str) -> str | None:
+    prefix = "autofactor_formula:"
+    if runtime_score.startswith(prefix):
+        return runtime_score[len(prefix) :] or None
+    return None
+
+
+@dataclass(frozen=True)
+class CandidateReplayTapeRow:
+    candidate_replay_id: str
+    run_id: str
+    source_workflow: str
+    workflow_run_id: str
+    workflow_run_url: str
+    artifact_name: str
+    artifact_sha256: str
+    artifact_json: dict[str, Any]
+    basis: str
+    evidence_stage: str
+    deployment_id: str | None
+    strategy_profile: str
+    runtime_score: str
+    data_snapshot_id: str | None
+    dsl_hash: str | None
+    factor_name: str | None
+    target: str | None
+    horizon: str | None
+    recording_path: str | None
+    recording_sha256: str | None
+    config_path: str | None
+    config_sha256: str | None
+    runner_source: str | None
+    runner_git_sha: str | None
+    decision_contract: dict[str, Any]
+    acceptance_criteria: dict[str, Any]
+    metrics: dict[str, Any]
+    blocking_risk_flags: list[str]
+    promotion_ready: bool
+    promotion_decision: str
+    artifact_path: Path
+
+
+def build_row(
+    *,
+    candidate_replay_json: Path,
+    run_id: str,
+    source_workflow: str,
+    workflow_run_id: str,
+    workflow_run_url: str,
+    artifact_name: str,
+    data_snapshot_id: str | None,
+) -> CandidateReplayTapeRow:
+    payload = json.loads(candidate_replay_json.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("candidate replay JSON must be an object")
+
+    artifact_sha256 = file_sha256(candidate_replay_json)
+    basis = string_field(payload, "basis")
+    if not basis:
+        raise SystemExit(f"{candidate_replay_json} missing basis")
+    evidence_stage = canonical_candidate_replay_evidence_stage(
+        basis,
+        optional_string(payload, "evidence_stage"),
+    )
+    runtime_score = string_field(payload, "runtime_score")
+    source_factor = payload.get("source_factor")
+    if not isinstance(source_factor, dict):
+        source_factor = {}
+    factor_name = (
+        optional_string(source_factor, "name")
+        or factor_name_from_runtime_score(runtime_score)
+    )
+
+    blockers = payload.get("blocking_risk_flags", [])
+    if not isinstance(blockers, list):
+        raise SystemExit("blocking_risk_flags must be an array")
+    blockers = [str(item) for item in blockers]
+
+    return CandidateReplayTapeRow(
+        candidate_replay_id=string_field(payload, "candidate_replay_id")
+        or f"candidate_replay:{artifact_sha256[:32]}",
+        run_id=run_id,
+        source_workflow=source_workflow
+        or optional_string(payload, "source_workflow")
+        or DEFAULT_SOURCE_WORKFLOW,
+        workflow_run_id=workflow_run_id or string_field(payload, "workflow_run_id"),
+        workflow_run_url=workflow_run_url or string_field(payload, "workflow_run_url"),
+        artifact_name=artifact_name or string_field(payload, "artifact_name"),
+        artifact_sha256=artifact_sha256,
+        artifact_json=payload,
+        basis=basis,
+        evidence_stage=evidence_stage,
+        deployment_id=optional_string(payload, "deployment_id"),
+        strategy_profile=string_field(payload, "strategy_profile") or "unknown",
+        runtime_score=runtime_score,
+        data_snapshot_id=data_snapshot_id,
+        dsl_hash=optional_string(source_factor, "dsl_hash"),
+        factor_name=factor_name,
+        target=optional_string(source_factor, "target"),
+        horizon=optional_string(source_factor, "horizon") or "5m",
+        recording_path=optional_string(payload, "recording_path"),
+        recording_sha256=optional_string(payload, "recording_sha256"),
+        config_path=optional_string(payload, "config_path"),
+        config_sha256=optional_string(payload, "config_sha256"),
+        runner_source=optional_string(payload, "runner_source"),
+        runner_git_sha=optional_string(payload, "runner_git_sha"),
+        decision_contract=payload.get("decision_contract")
+        if isinstance(payload.get("decision_contract"), dict)
+        else {},
+        acceptance_criteria=payload.get("acceptance_criteria")
+        if isinstance(payload.get("acceptance_criteria"), dict)
+        else {},
+        metrics=payload.get("metrics") if isinstance(payload.get("metrics"), dict) else {},
+        blocking_risk_flags=blockers,
+        promotion_ready=bool(payload.get("promotion_ready", False)),
+        promotion_decision=string_field(payload, "promotion_decision") or "blocked",
+        artifact_path=candidate_replay_json,
+    )
+
+
+async def persist_row(db_url: str, row: CandidateReplayTapeRow) -> None:
+    import asyncpg
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO candidate_replay_tapes (
+                candidate_replay_id,
+                run_id,
+                source_workflow,
+                workflow_run_id,
+                workflow_run_url,
+                artifact_name,
+                artifact_sha256,
+                artifact_json,
+                basis,
+                evidence_stage,
+                deployment_id,
+                strategy_profile,
+                runtime_score,
+                data_snapshot_id,
+                dsl_hash,
+                target,
+                horizon,
+                recording_path,
+                recording_sha256,
+                config_path,
+                config_sha256,
+                runner_source,
+                runner_git_sha,
+                decision_contract_json,
+                acceptance_criteria_json,
+                metrics_json,
+                blocking_risk_flags_json,
+                promotion_ready,
+                promotion_decision
+            )
+            VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13,
+                $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24::jsonb,
+                $25::jsonb, $26::jsonb, $27::jsonb, $28, $29
+            )
+            ON CONFLICT (candidate_replay_id) DO UPDATE SET
+                run_id = EXCLUDED.run_id,
+                source_workflow = EXCLUDED.source_workflow,
+                workflow_run_id = EXCLUDED.workflow_run_id,
+                workflow_run_url = EXCLUDED.workflow_run_url,
+                artifact_name = EXCLUDED.artifact_name,
+                artifact_sha256 = EXCLUDED.artifact_sha256,
+                artifact_json = EXCLUDED.artifact_json,
+                basis = EXCLUDED.basis,
+                evidence_stage = EXCLUDED.evidence_stage,
+                deployment_id = EXCLUDED.deployment_id,
+                strategy_profile = EXCLUDED.strategy_profile,
+                runtime_score = EXCLUDED.runtime_score,
+                data_snapshot_id = EXCLUDED.data_snapshot_id,
+                dsl_hash = EXCLUDED.dsl_hash,
+                target = EXCLUDED.target,
+                horizon = EXCLUDED.horizon,
+                recording_path = EXCLUDED.recording_path,
+                recording_sha256 = EXCLUDED.recording_sha256,
+                config_path = EXCLUDED.config_path,
+                config_sha256 = EXCLUDED.config_sha256,
+                runner_source = EXCLUDED.runner_source,
+                runner_git_sha = EXCLUDED.runner_git_sha,
+                decision_contract_json = EXCLUDED.decision_contract_json,
+                acceptance_criteria_json = EXCLUDED.acceptance_criteria_json,
+                metrics_json = EXCLUDED.metrics_json,
+                blocking_risk_flags_json = EXCLUDED.blocking_risk_flags_json,
+                promotion_ready = EXCLUDED.promotion_ready,
+                promotion_decision = EXCLUDED.promotion_decision
+            """,
+            row.candidate_replay_id,
+            row.run_id,
+            row.source_workflow,
+            row.workflow_run_id or None,
+            row.workflow_run_url or None,
+            row.artifact_name or None,
+            row.artifact_sha256,
+            canonical_json(row.artifact_json),
+            row.basis,
+            row.evidence_stage,
+            row.deployment_id,
+            row.strategy_profile,
+            row.runtime_score,
+            row.data_snapshot_id,
+            row.dsl_hash,
+            row.target,
+            row.horizon,
+            row.recording_path,
+            row.recording_sha256,
+            row.config_path,
+            row.config_sha256,
+            row.runner_source,
+            row.runner_git_sha,
+            canonical_json(row.decision_contract),
+            canonical_json(row.acceptance_criteria),
+            canonical_json(row.metrics),
+            canonical_json(row.blocking_risk_flags),
+            row.promotion_ready,
+            row.promotion_decision,
+        )
+        await append_experiment_trace(conn, row)
+    finally:
+        await conn.close()
+
+
+async def append_experiment_trace(conn: Any, row: CandidateReplayTapeRow) -> None:
+    latest = await conn.fetchrow(
+        """
+        SELECT trace_id::text, hash_current
+        FROM experiment_trace
+        WHERE run_id = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        row.run_id,
+    )
+    parent_trace_id = latest["trace_id"] if latest else None
+    hash_prev = latest["hash_current"] if latest else None
+    input_json = {
+        "artifact_path": str(row.artifact_path),
+        "artifact_sha256": row.artifact_sha256,
+    }
+    hash_current = trace_hash(
+        hash_prev,
+        row.run_id,
+        EVENT_TYPE,
+        WRITER_AGENT,
+        input_json,
+        row.artifact_json,
+    )
+    await conn.execute(
+        """
+        INSERT INTO experiment_trace (
+            trace_id,
+            run_id,
+            parent_trace_id,
+            event_type,
+            data_snapshot_id,
+            dsl_hash,
+            candidate_replay_id,
+            artifact_kind,
+            evidence_stage,
+            promotion_decision,
+            agent_name,
+            input_json,
+            output_json,
+            hash_prev,
+            hash_current
+        )
+        VALUES (
+            $1::uuid, $2, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11,
+            $12::jsonb, $13::jsonb, $14, $15
+        )
+        """,
+        str(uuid4()),
+        row.run_id,
+        parent_trace_id,
+        EVENT_TYPE,
+        row.data_snapshot_id,
+        row.dsl_hash,
+        row.candidate_replay_id,
+        ARTIFACT_KIND,
+        row.evidence_stage,
+        row.promotion_decision,
+        WRITER_AGENT,
+        canonical_json(input_json),
+        canonical_json(row.artifact_json),
+        hash_prev,
+        hash_current,
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    parsed = argparse.ArgumentParser()
+    parsed.add_argument("--db-url", default=os.environ.get("DATABASE_URL", ""))
+    parsed.add_argument("--candidate-replay-json", required=True, type=Path)
+    parsed.add_argument("--run-id", default="")
+    parsed.add_argument("--source-workflow", default=DEFAULT_SOURCE_WORKFLOW)
+    parsed.add_argument("--workflow-run-id", default=os.environ.get("GITHUB_RUN_ID", ""))
+    parsed.add_argument("--workflow-run-url", default="")
+    parsed.add_argument("--artifact-name", default="")
+    parsed.add_argument("--data-snapshot-id", default="")
+    parsed.add_argument("--dry-run", action="store_true")
+    parsed.add_argument("--report-json", type=Path)
+    return parsed
+
+
+async def main_async() -> None:
+    args = parser().parse_args()
+    row = build_row(
+        candidate_replay_json=args.candidate_replay_json,
+        run_id=args.run_id or args.workflow_run_id or "manual-runtime-candidate-replay",
+        source_workflow=args.source_workflow,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_url=args.workflow_run_url,
+        artifact_name=args.artifact_name,
+        data_snapshot_id=args.data_snapshot_id or None,
+    )
+    report = {
+        "schema_version": "candidate_replay_tape_persist.v1",
+        "dry_run": args.dry_run,
+        "candidate_replay_id": row.candidate_replay_id,
+        "basis": row.basis,
+        "evidence_stage": row.evidence_stage,
+        "promotion_ready": row.promotion_ready,
+        "promotion_decision": row.promotion_decision,
+        "runtime_score": row.runtime_score,
+        "workflow_run_id": row.workflow_run_id,
+        "artifact_name": row.artifact_name,
+        "artifact_sha256": row.artifact_sha256,
+        "blocking_risk_flags": row.blocking_risk_flags,
+    }
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.report_json:
+        args.report_json.write_text(text, encoding="utf-8")
+    if not args.dry_run:
+        if not args.db_url:
+            raise SystemExit("--db-url or DATABASE_URL is required unless --dry-run is set")
+        await persist_row(args.db_url, row)
+    print(text, end="")
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,48 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Runtime Candidate Replay Frontier Persistence (2026-05-28)
+
+Evidence stage: `executable_replay` / `runtime_parity` feedback repair. This
+keeps dry-run/live deployment state untouched and fixes runtime candidate replay
+evidence so a standalone `runtime-candidate-replay.yml` run is durable Research
+OS frontier state instead of only an ephemeral GitHub artifact.
+
+### Files / Ownership
+
+- `.github/workflows/runtime-candidate-replay.yml`
+  - Owner: persist candidate replay frontier evidence to Research OS after the
+    replay artifact is built.
+- `scripts/persist_candidate_replay_tape.py`
+  - Owner: standalone candidate replay tape persistence without requiring a
+    research snapshot manifest.
+- `tests/test_persist_candidate_replay_tape.py`
+  - Owner: regression for standalone runtime replay persistence and workflow
+    default wiring.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Confirm Trace Plan run `26549182870` did not read standalone runtime replay
+      run `26548811702`; latest visible `recent_candidate_replays` still came
+      from walk-forward run `26548811085` and old replay `26528933436`.
+- [x] Add failing regression for standalone runtime replay persistence.
+- [x] Implement standalone candidate replay tape persistence and default
+      workflow wiring.
+- [x] Run focused validation.
+- [ ] Land through PR, deploy main to tango, rerun runtime replay, then rerun
+      Research Trace Plan and verify `26548811702`-style replay rows appear in
+      `recent_candidate_replays`.
+
+### Review
+
+- 2026-05-28: Focused validation passed:
+  `python3 -m unittest tests.test_persist_candidate_replay_tape
+  tests.test_persist_research_trace_contract`,
+  `python3 -m py_compile scripts/persist_candidate_replay_tape.py
+  tests/test_persist_candidate_replay_tape.py`, `rtk git diff --check`,
+  and a CLI dry-run of `scripts/persist_candidate_replay_tape.py`.
+
 ## Current Session - Research Manager Runtime Replay Blocker Action (2026-05-28)
 
 Evidence stage: `walk_forward` / `runtime_parity` feedback repair. This keeps

--- a/tests/test_persist_candidate_replay_tape.py
+++ b/tests/test_persist_candidate_replay_tape.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "persist_candidate_replay_tape.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "runtime-candidate-replay.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("persist_candidate_replay_tape", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PersistCandidateReplayTapeTest(unittest.TestCase):
+    def replay_payload(self) -> dict:
+        return {
+            "schema_version": 1,
+            "kind": "autofactor_candidate_strategy_replay",
+            "candidate_replay_id": "candidate_replay:0123456789abcdef0123456789abcdef",
+            "basis": "runtime_market_update_replay",
+            "evidence_stage": "executable_replay",
+            "source_workflow": "Runtime Candidate Replay:main",
+            "workflow_run_id": "26548811702",
+            "workflow_run_url": "https://github.com/proerror77/ploy/actions/runs/26548811702",
+            "artifact_name": "runtime-candidate-replay-26548811702",
+            "deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+            "strategy_profile": "settlement_probability",
+            "runtime_score": (
+                "autofactor_formula:"
+                "llm_mut_spread_adjusted_external_move_select_entry_price_quality_ge_075"
+            ),
+            "recording_path": "/opt/ploy/data/recordings/pm5d.ndjson",
+            "recording_sha256": "a" * 64,
+            "config_path": "/opt/ploy/config/strategies/pm5d.toml",
+            "runner_source": "Runtime Candidate Replay:main",
+            "runner_git_sha": "c32729542522f1e95735028177ffc7b527148da9",
+            "source_factor": {
+                "name": "",
+                "dsl_hash": "",
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+            },
+            "decision_contract": {
+                "event_level": True,
+                "full_depth_entry": True,
+                "one_decision_per_event": True,
+                "official_settlement": False,
+                "target": "full_depth_settlement_executable_pnl",
+                "horizon": "5m",
+            },
+            "acceptance_criteria": {"min_trade_count": 50},
+            "metrics": {
+                "trade_count": 16,
+                "unique_event_count": 16,
+                "entry_fill_rate": 1.0,
+                "roi": 0.3427,
+                "total_pnl": 82.25,
+            },
+            "blocking_risk_flags": [
+                "trade_count_too_small:16<50",
+                "official_settlement_missing:15<16",
+            ],
+            "promotion_ready": False,
+            "promotion_decision": "blocked",
+        }
+
+    def write_payload(self, payload: dict) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "candidate-strategy-replay.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_build_row_persists_standalone_runtime_replay_without_snapshot(self) -> None:
+        module = load_module()
+        payload = self.replay_payload()
+        path = self.write_payload(payload)
+
+        row = module.build_row(
+            candidate_replay_json=path,
+            run_id="26548811702",
+            source_workflow="runtime-candidate-replay.yml",
+            workflow_run_id="26548811702",
+            workflow_run_url="https://github.com/proerror77/ploy/actions/runs/26548811702",
+            artifact_name="runtime-candidate-replay-26548811702",
+            data_snapshot_id=None,
+        )
+
+        self.assertEqual("26548811702", row.run_id)
+        self.assertEqual("runtime-candidate-replay.yml", row.source_workflow)
+        self.assertEqual("26548811702", row.workflow_run_id)
+        self.assertEqual("runtime_market_update_replay", row.basis)
+        self.assertEqual("executable_replay", row.evidence_stage)
+        self.assertIsNone(row.data_snapshot_id)
+        self.assertEqual(
+            "llm_mut_spread_adjusted_external_move_select_entry_price_quality_ge_075",
+            row.factor_name,
+        )
+        self.assertEqual("full_depth_settlement_executable_pnl", row.target)
+        self.assertEqual("5m", row.horizon)
+        self.assertFalse(row.promotion_ready)
+        self.assertEqual(
+            ["trade_count_too_small:16<50", "official_settlement_missing:15<16"],
+            row.blocking_risk_flags,
+        )
+
+    def test_rejects_candidate_replay_stage_basis_mismatch(self) -> None:
+        module = load_module()
+        payload = self.replay_payload()
+        payload["evidence_stage"] = "walk_forward"
+        path = self.write_payload(payload)
+
+        with self.assertRaises(SystemExit) as raised:
+            module.build_row(
+                candidate_replay_json=path,
+                run_id="26548811702",
+                source_workflow="runtime-candidate-replay.yml",
+                workflow_run_id="26548811702",
+                workflow_run_url="",
+                artifact_name="",
+                data_snapshot_id=None,
+            )
+
+        self.assertIn("contradicts basis", str(raised.exception))
+
+    def test_runtime_candidate_replay_workflow_persists_frontier_by_default(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('"persist_research_trace":true', workflow)
+        self.assertIn("REPLAY_PERSIST_RESEARCH_TRACE", workflow)
+        self.assertIn("scripts/persist_candidate_replay_tape.py", workflow)
+        self.assertIn("Durable Research OS replay frontier", workflow)
+        self.assertIn("--candidate-replay-json", workflow)
+        self.assertIn("--db-url \"${PLOY_DATABASE__URL}\"", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add standalone candidate replay tape persistence for runtime-candidate-replay outputs
- wire runtime-candidate-replay.yml to persist the replay frontier to Research OS by default
- add regression coverage for standalone runtime replay persistence and workflow wiring

## Evidence
- python3 -m unittest tests.test_persist_candidate_replay_tape tests.test_persist_research_trace_contract
- python3 -m py_compile scripts/persist_candidate_replay_tape.py tests/test_persist_candidate_replay_tape.py
- rtk git diff --check
- CLI dry-run of scripts/persist_candidate_replay_tape.py

## Notes
This is research-only plumbing. It does not promote or deploy a strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistence of runtime candidate replay traces to a database backend, controlled by a new `persist_research_trace` advanced option in workflow dispatches.
  * Automated reporting and status tracking for persisted replay evidence.

* **Tests**
  * Added test coverage for candidate replay persistence functionality and workflow configuration validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->