### PR TITLE
Fix Research Manager runtime replay blocker frontier

### DIFF
--- a/crates/ploy-research/src/research_os/manager.rs
+++ b/crates/ploy-research/src/research_os/manager.rs
@@ -318,7 +318,7 @@ fn derive_blocker_actions(input: &ResearchManagerInput) -> Vec<ResearchBlockerAc
     let runtime_or_promotion_blockers = if runtime_replay.is_empty() {
         latest.clone()
     } else {
-        format!("{latest}\n{runtime_replay}")
+        runtime_replay.clone()
     };
     let data_blocker_text = if negative_runtime_replay {
         latest.as_str()
@@ -1184,7 +1184,18 @@ mod tests {
                     "artifacts": [{
                         "event_type": "autofactor_promotion",
                         "output_json": {
-                            "decision": "blocked"
+                            "decision": "blocked",
+                            "blockers": [
+                                "missing_runtime_contract",
+                                "runtime_contract_unmapped_factor"
+                            ],
+                            "candidate_strategy_replay": {
+                                "basis": "factor_walk_forward_top_bucket_aggregate",
+                                "blockers": [
+                                    "candidate_strategy_replay_not_runtime_replay",
+                                    "candidate_strategy_replay_identity_basis_mismatch"
+                                ]
+                            }
                         }
                     }]
                 }],
@@ -1271,6 +1282,14 @@ mod tests {
         assert!(!plan.blocker_actions.iter().any(|item| {
             item.blocker_family == "strategy_economics"
                 || item.action == "mutate_or_reject_negative_runtime_edge"
+        }));
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "runtime_contract"
+                && item.action == "repair_runtime_contract_mapping"
+        }));
+        assert!(!plan.blocker_actions.iter().any(|item| {
+            item.blocker_family == "runtime_replay"
+                && item.action == "build_runtime_market_update_replay"
         }));
     }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,47 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Runtime Contract Frontier Cleanup (2026-05-28)
+
+Evidence stage: `executable_replay` / `walk_forward` feedback repair. This keeps
+dry-run/live deployment state untouched and fixes Research Manager so a latest
+runtime MarketUpdate replay frontier is not polluted by stale walk-forward
+runtime-contract or top-bucket replay blockers from unselected factors.
+
+### Files / Ownership
+
+- `crates/ploy-research/src/research_os/manager.rs`
+  - Owner: derive blocker actions from the latest runtime replay frontier when
+    it exists, preserving replay data/search blockers while suppressing stale
+    runtime-contract repair actions.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Confirm deployed Trace Plan run `26552975041` now routes away from stale
+      `ready_handoff` but still carries stale
+      `runtime_contract -> repair_runtime_contract_mapping`.
+- [x] Confirm latest runtime replay frontier is run `26550036258`, with
+      blockers `trade_count_too_small:20<50` and
+      `official_settlement_missing:19<20`.
+- [x] Add regression for stale runtime-contract/top-bucket blockers not
+      polluting a newer blocked runtime replay frontier.
+- [x] Implement Research Manager blocker derivation fix.
+- [x] Run focused validation.
+- [ ] Land through PR, deploy main to tango, rerun Research Trace Plan, and
+      verify the plan no longer includes stale runtime-contract blocker actions.
+
+### Review
+
+- 2026-05-28: Updated blocker derivation so, once a latest
+  `runtime_market_update_replay` frontier exists, stale walk-forward
+  runtime-contract and top-bucket replay blockers no longer pollute the active
+  blocker actions. Focused validation passed:
+  `rtk cargo test -p ploy-research planner_routes_newer_blocked_runtime_replay_ahead_of_stale_ready_handoff --lib`,
+  `rtk cargo test -p ploy-research research_os::manager --lib`,
+  `rtk cargo check -p ploy-research --features db --example research_trace_plan`,
+  and `rtk git diff --check`.
+
 ## Current Session - Research Manager Blocked Replay Frontier (2026-05-28)
 
 Evidence stage: `executable_replay` / `walk_forward` feedback repair. This keeps
@@ -25,7 +67,7 @@ handoff state until replay blockers are resolved.
       overriding stale ready handoff.
 - [x] Implement Research Manager frontier gating fix.
 - [x] Run focused validation.
-- [ ] Land through PR, deploy main to tango, rerun Research Trace Plan, and
+- [x] Land through PR, deploy main to tango, rerun Research Trace Plan, and
       verify the plan no longer returns `ready_handoff` for replay `26550036258`.
 
 ### Review
@@ -41,6 +83,9 @@ handoff state until replay blockers are resolved.
   crates/ploy-research/src/research_os/manager.rs` still reports pre-existing
   assertion formatting drift in the same file; this slice leaves that unrelated
   formatting unchanged.
+- 2026-05-28: PR #723 merged as `ba0fadaa660f4bff0bb78db918ed056387ed675b`,
+  deploy run `26552637547` succeeded, and Trace Plan run `26552975041` returned
+  `theme=fix_data` instead of stale `ready_handoff`.
 
 ## Current Session - Runtime Candidate Replay Frontier Persistence (2026-05-28)
 


### PR DESCRIPTION
## Summary
- Treat latest runtime MarketUpdate replay as the active blocker frontier when present
- Stop stale walk-forward runtime-contract/top-bucket blockers from polluting blocked replay plans
- Record the regression and current evidence in tasks/todo.md

## Validation
- rtk cargo test -p ploy-research planner_routes_newer_blocked_runtime_replay_ahead_of_stale_ready_handoff --lib
- rtk cargo test -p ploy-research research_os::manager --lib
- rtk cargo check -p ploy-research --features db --example research_trace_plan
- rtk git diff --check