### PR TITLE
Fix Research Manager runtime replay prior routing

### DIFF
--- a/scripts/research_manager_execute_plan.py
+++ b/scripts/research_manager_execute_plan.py
@@ -767,6 +767,16 @@ def _candidate_replay_contract(
     }
 
 
+def _alpha_search_plan_run_id_from_replay_contract(replay_contract: dict[str, Any]) -> str:
+    source_run_id = str(replay_contract.get("source_run_id") or "")
+    workflow_run_id = str(replay_contract.get("workflow_run_id") or "")
+    if not source_run_id:
+        return ""
+    if workflow_run_id and source_run_id == workflow_run_id:
+        return ""
+    return source_run_id
+
+
 def _latest_valid_full_depth_surface_artifact(plan_payload: dict[str, Any]) -> dict[str, str]:
     latest_run = _latest_run(plan_payload)
     latest_run_id = str(latest_run.get("run_id") or latest_run.get("workflow_run_id") or "")
@@ -1031,7 +1041,9 @@ def build_executor_payload(args: argparse.Namespace, plan_payload: dict[str, Any
     )
     alpha_search_plan_run_id = ""
     if plan.get("theme") == "revise_prior":
-        alpha_search_plan_run_id = str(latest_replay_contract.get("source_run_id") or "")
+        alpha_search_plan_run_id = _alpha_search_plan_run_id_from_replay_contract(
+            latest_replay_contract
+        )
     alpha_search_plan_artifact_name = (
         f"factor-walk-forward-v2-{alpha_search_plan_run_id}"
         if alpha_search_plan_run_id

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,46 @@
 # Research Trace Plan Manager Workflow (2026-05-23)
 
+## Current Session - Research Manager Runtime Replay Prior Routing (2026-05-28)
+
+Evidence stage: `walk_forward` feedback repair. This keeps dry-run/live
+deployment state untouched and fixes the Research Manager executor so a
+standalone runtime replay run is not mistaken for a
+`factor-walk-forward-v2-*` alpha-search prior artifact.
+
+### Files / Ownership
+
+- `scripts/research_manager_execute_plan.py`
+  - Owner: distinguish runtime replay workflow run ids from source alpha-search
+    plan run ids when building `revise_prior` follow-up dispatches.
+- `tests/test_research_manager_execute_plan.py`
+  - Owner: regression for standalone runtime replay feedback with embedded
+    typed prior JSON.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+### Tasks
+
+- [x] Confirm Trace Plan run `26554391164` correctly returns
+      `theme=revise_prior` after replay `26554215670`.
+- [x] Reproduce executor dry-run blocker: it incorrectly emits
+      `alpha_search_plan_run_id=26554215670` /
+      `factor-walk-forward-v2-26554215670`.
+- [x] Add regression for standalone runtime replay feedback.
+- [x] Implement executor routing fix.
+- [x] Run focused validation.
+- [ ] Land through PR, then rerun executor against plan `26554391164` with
+      snapshot `26553958344`.
+
+### Review
+
+- 2026-05-28: Updated executor prior routing so standalone runtime replay
+  feedback embeds `research_manager_typed_prior.v1` directly instead of
+  pretending the replay run id is a `factor-walk-forward-v2` artifact. Focused
+  validation passed: `python3 -m unittest tests.test_research_manager_execute_plan`,
+  `python3 -m py_compile scripts/research_manager_execute_plan.py
+  tests/test_research_manager_execute_plan.py`, `rtk git diff --check`, and a
+  local dry-run of plan `26554391164` with `snapshot_run_id=26553958344`.
+
 ## Current Session - Research Manager Runtime Contract Frontier Cleanup (2026-05-28)
 
 Evidence stage: `executable_replay` / `walk_forward` feedback repair. This keeps
@@ -28,7 +69,7 @@ runtime-contract or top-bucket replay blockers from unselected factors.
       polluting a newer blocked runtime replay frontier.
 - [x] Implement Research Manager blocker derivation fix.
 - [x] Run focused validation.
-- [ ] Land through PR, deploy main to tango, rerun Research Trace Plan, and
+- [x] Land through PR, deploy main to tango, rerun Research Trace Plan, and
       verify the plan no longer includes stale runtime-contract blocker actions.
 
 ### Review
@@ -41,6 +82,10 @@ runtime-contract or top-bucket replay blockers from unselected factors.
   `rtk cargo test -p ploy-research research_os::manager --lib`,
   `rtk cargo check -p ploy-research --features db --example research_trace_plan`,
   and `rtk git diff --check`.
+- 2026-05-28: PR #724 merged as `cc2c937ce51fbd2cd3e1f41201584988f3e7c051`;
+  deploy run `26553428379` succeeded. Trace Plan run `26553835347` returned
+  `theme=fix_data` with only `data_settlement` and `search_power` blockers,
+  confirming stale `runtime_contract` blocker actions were removed.
 
 ## Current Session - Research Manager Blocked Replay Frontier (2026-05-28)
 

--- a/tests/test_research_manager_execute_plan.py
+++ b/tests/test_research_manager_execute_plan.py
@@ -404,6 +404,70 @@ class ResearchManagerExecutePlanTest(unittest.TestCase):
             payload["typed_prior"]["schema_version"],
         )
 
+    def test_revise_prior_embeds_typed_prior_for_standalone_runtime_replay(self) -> None:
+        recent_negative_replay = {
+            "run_id": "26554215670",
+            "workflow_run_id": "26554215670",
+            "artifact_json": {
+                "basis": "runtime_market_update_replay",
+                "runtime_score": "autofactor_formula:latest_negative",
+                "source_workflow": "runtime-candidate-replay.yml",
+                "workflow_run_id": "26554215670",
+                "strategy_profile": "settlement_probability",
+                "metrics": {
+                    "trade_count": 1,
+                    "unique_event_count": 1,
+                    "entry_fill_rate": 1.0,
+                    "roi": -1.0038087836330667,
+                    "total_pnl": -15.057131754496,
+                },
+                "blocking_risk_flags": [
+                    "trade_count_too_small:1<50",
+                    "roi_too_low:-1.003809<0.000000",
+                ],
+                "decision_contract": {
+                    "target": "full_depth_settlement_executable_pnl",
+                    "horizon": "5m",
+                },
+                "recording_path": "/opt/ploy/data/recordings/live.ndjson",
+                "recording_sha256": "replay-hash",
+            },
+        }
+        plan = plan_payload(
+            "revise_prior",
+            ["generate_typed_llm_prior_json", "rerun_alpha_search_with_bounded_mutations"],
+            {"recent_candidate_replays": [recent_negative_replay]},
+        )
+        plan["plan"]["blocker_actions"] = [
+            {
+                "blocker_family": "strategy_economics",
+                "action": "mutate_or_reject_negative_runtime_edge",
+                "reason": "Latest replay or walk-forward evidence failed economic/OOS gates.",
+            }
+        ]
+
+        payload = build_executor_payload(
+            base_args(mode="execute", execute_ack=EXECUTE_ACK, snapshot_run_id="26553958344"),
+            plan,
+        )
+
+        dispatch = payload["dispatches"][0]
+        self.assertTrue(dispatch["ready"])
+        options = json.loads(dispatch["fields"]["options_json"])
+        self.assertNotIn("alpha_search_plan_run_id", options)
+        self.assertNotIn("alpha_search_plan_artifact_name", options)
+        self.assertEqual("26554215670", options["candidate_strategy_replay_run_id"])
+        self.assertEqual(
+            "runtime-candidate-replay-26554215670",
+            options["candidate_strategy_replay_artifact_name"],
+        )
+        prior = json.loads(options["alpha_search_llm_prior_json"])
+        self.assertEqual("research_manager_typed_prior.v1", prior["schema_version"])
+        self.assertEqual(
+            "autofactor_formula:latest_negative",
+            prior["runtime_avoid_factors"][0]["runtime_score"],
+        )
+
     def test_revise_prior_resolves_source_snapshot_from_alpha_artifact_provenance(self) -> None:
         recent_negative_replay = {
             "run_id": "26542589633",


### PR DESCRIPTION
## Summary
- Do not treat standalone runtime replay workflow run IDs as factor-walk-forward prior artifacts
- Embed Research Manager typed prior JSON when source_run_id equals workflow_run_id
- Add regression coverage for replay 26554215670-style frontier feedback

## Validation
- python3 -m unittest tests.test_research_manager_execute_plan
- python3 -m py_compile scripts/research_manager_execute_plan.py tests/test_research_manager_execute_plan.py
- rtk git diff --check
- local dry-run of plan 26554391164 with snapshot_run_id=26553958344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of prior revisions when using runtime replay, ensuring correct dispatch routing and payload construction.

* **Tests**
  * Added test coverage validating prior revision behavior with standalone runtime replay scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proerror77/ploy/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->