### PR TITLE
Wire structural FSA into alpha search

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -175,6 +175,7 @@ struct CandidateExpression {
     source: &'static str,
     complexity: usize,
     root_gene: String,
+    structural_signature: String,
     expr: FactorExpr,
 }
 
@@ -183,6 +184,7 @@ struct RejectedExpression {
     name: String,
     target: Option<String>,
     root_gene: String,
+    structural_signature: String,
     reason: String,
     complexity: usize,
 }
@@ -245,6 +247,8 @@ struct NodeMetric {
 #[derive(Debug, Serialize)]
 struct AvoidedSubtree {
     root_gene: String,
+    structural_signature: String,
+    depth: usize,
     count: usize,
     action: &'static str,
     reason: &'static str,
@@ -490,6 +494,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
             source: candidate_source(&report.name),
             complexity: report.complexity,
             root_gene: root_gene(&report.expr),
+            structural_signature: structural_signature(&report.expr),
             expr: report.expr.clone(),
         })
         .collect::<Vec<_>>();
@@ -502,6 +507,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
             name: report.name.clone(),
             target: report.target.clone(),
             root_gene: root_gene(&report.expr),
+            structural_signature: structural_signature(&report.expr),
             reason: report.reason.clone(),
             complexity: report.complexity,
         })
@@ -1430,20 +1436,159 @@ fn selected_dimension(
 }
 
 fn avoided_subtrees(reports: &[AutoFactorReport]) -> Vec<AvoidedSubtree> {
-    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut counts: BTreeMap<String, StructuralSubtreeCount> = BTreeMap::new();
     for report in reports {
-        *counts.entry(root_gene(&report.expr)).or_default() += 1;
+        record_subtree_count(&mut counts, &report.expr);
+        for subtree in inner_structural_subtrees(&report.expr) {
+            record_subtree_count(&mut counts, subtree);
+        }
     }
     counts
         .into_iter()
-        .filter(|(_, count)| *count > 2)
-        .map(|(root_gene, count)| AvoidedSubtree {
-            root_gene,
-            count,
+        .filter(|(_, item)| item.count > 2)
+        .map(|(structural_signature, item)| AvoidedSubtree {
+            root_gene: item.root_gene,
+            structural_signature,
+            depth: item.depth,
+            count: item.count,
             action: "penalize",
-            reason: "root_gene_crowding",
+            reason: "structural_signature_crowding",
         })
         .collect()
+}
+
+#[derive(Debug, Default)]
+struct StructuralSubtreeCount {
+    root_gene: String,
+    depth: usize,
+    count: usize,
+}
+
+fn record_subtree_count(counts: &mut BTreeMap<String, StructuralSubtreeCount>, expr: &FactorExpr) {
+    let signature = structural_signature(expr);
+    let entry = counts
+        .entry(signature)
+        .or_insert_with(|| StructuralSubtreeCount {
+            root_gene: root_gene(expr),
+            depth: structural_depth(expr),
+            count: 0,
+        });
+    entry.count = entry.count.saturating_add(1);
+}
+
+fn structural_signature(expr: &FactorExpr) -> String {
+    match expr {
+        FactorExpr::Input(name) => format!("Input({name})"),
+        FactorExpr::Const(_) => "Const(_)".to_string(),
+        FactorExpr::Add(lhs, rhs) => commutative_signature("Add", lhs, rhs),
+        FactorExpr::Sub(lhs, rhs) => {
+            format!(
+                "Sub({},{})",
+                structural_signature(lhs),
+                structural_signature(rhs)
+            )
+        }
+        FactorExpr::Mul(lhs, rhs) => commutative_signature("Mul", lhs, rhs),
+        FactorExpr::SafeDiv(lhs, rhs) => {
+            format!(
+                "SafeDiv({},{})",
+                structural_signature(lhs),
+                structural_signature(rhs)
+            )
+        }
+        FactorExpr::Max(lhs, rhs) => commutative_signature("Max", lhs, rhs),
+        FactorExpr::Min(lhs, rhs) => commutative_signature("Min", lhs, rhs),
+        FactorExpr::Tanh(inner) => format!("Tanh({})", structural_signature(inner)),
+        FactorExpr::Log1pAbs(inner) => format!("Log1pAbs({})", structural_signature(inner)),
+        FactorExpr::SqrtAbs(inner) => format!("SqrtAbs({})", structural_signature(inner)),
+        FactorExpr::Clip { expr, .. } => format!("Clip(_,_,{})", structural_signature(expr)),
+        FactorExpr::Delta { expr, .. } => format!("Delta(_,{})", structural_signature(expr)),
+        FactorExpr::RollingMean { expr, .. } => {
+            format!("RollingMean(_,{})", structural_signature(expr))
+        }
+        FactorExpr::RollingStd { expr, .. } => {
+            format!("RollingStd(_,{})", structural_signature(expr))
+        }
+        FactorExpr::ZScore { expr, .. } => format!("ZScore(_,{})", structural_signature(expr)),
+        FactorExpr::Gate { expr, gate, .. } => {
+            format!(
+                "Gate(_,{},{})",
+                structural_signature(expr),
+                structural_signature(gate)
+            )
+        }
+    }
+}
+
+fn commutative_signature(op: &str, lhs: &FactorExpr, rhs: &FactorExpr) -> String {
+    let mut children = [structural_signature(lhs), structural_signature(rhs)];
+    children.sort();
+    format!("{op}({},{})", children[0], children[1])
+}
+
+fn inner_structural_subtrees(expr: &FactorExpr) -> Vec<&FactorExpr> {
+    let mut out = Vec::new();
+    collect_inner_structural_subtrees(expr, false, &mut out);
+    out
+}
+
+fn collect_inner_structural_subtrees<'a>(
+    expr: &'a FactorExpr,
+    include_current: bool,
+    out: &mut Vec<&'a FactorExpr>,
+) {
+    if include_current && structural_depth(expr) >= 2 {
+        out.push(expr);
+    }
+    match expr {
+        FactorExpr::Input(_) | FactorExpr::Const(_) => {}
+        FactorExpr::Add(lhs, rhs)
+        | FactorExpr::Sub(lhs, rhs)
+        | FactorExpr::Mul(lhs, rhs)
+        | FactorExpr::SafeDiv(lhs, rhs)
+        | FactorExpr::Max(lhs, rhs)
+        | FactorExpr::Min(lhs, rhs) => {
+            collect_inner_structural_subtrees(lhs, true, out);
+            collect_inner_structural_subtrees(rhs, true, out);
+        }
+        FactorExpr::Tanh(inner)
+        | FactorExpr::Log1pAbs(inner)
+        | FactorExpr::SqrtAbs(inner)
+        | FactorExpr::Clip { expr: inner, .. }
+        | FactorExpr::Delta { expr: inner, .. }
+        | FactorExpr::RollingMean { expr: inner, .. }
+        | FactorExpr::RollingStd { expr: inner, .. }
+        | FactorExpr::ZScore { expr: inner, .. } => {
+            collect_inner_structural_subtrees(inner, true, out);
+        }
+        FactorExpr::Gate { expr, gate, .. } => {
+            collect_inner_structural_subtrees(expr, true, out);
+            collect_inner_structural_subtrees(gate, true, out);
+        }
+    }
+}
+
+fn structural_depth(expr: &FactorExpr) -> usize {
+    match expr {
+        FactorExpr::Input(_) | FactorExpr::Const(_) => 1,
+        FactorExpr::Add(lhs, rhs)
+        | FactorExpr::Sub(lhs, rhs)
+        | FactorExpr::Mul(lhs, rhs)
+        | FactorExpr::SafeDiv(lhs, rhs)
+        | FactorExpr::Max(lhs, rhs)
+        | FactorExpr::Min(lhs, rhs) => 1 + structural_depth(lhs).max(structural_depth(rhs)),
+        FactorExpr::Tanh(inner)
+        | FactorExpr::Log1pAbs(inner)
+        | FactorExpr::SqrtAbs(inner)
+        | FactorExpr::Clip { expr: inner, .. }
+        | FactorExpr::Delta { expr: inner, .. }
+        | FactorExpr::RollingMean { expr: inner, .. }
+        | FactorExpr::RollingStd { expr: inner, .. }
+        | FactorExpr::ZScore { expr: inner, .. } => 1 + structural_depth(inner),
+        FactorExpr::Gate { expr, gate, .. } => {
+            1 + structural_depth(expr).max(structural_depth(gate))
+        }
+    }
 }
 
 /// Coarse root-operator-only structural fingerprint, shared by both the
@@ -1770,6 +1915,88 @@ mod tests {
             reason: "passed".to_string(),
             parent_name: None,
         }
+    }
+
+    #[test]
+    fn structural_signature_normalizes_commutative_operands() {
+        let lhs = FactorExpr::Add(
+            Box::new(FactorExpr::Input("near_strike_score".to_string())),
+            Box::new(FactorExpr::Mul(
+                Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+                Box::new(FactorExpr::Const(0.25)),
+            )),
+        );
+        let rhs = FactorExpr::Add(
+            Box::new(FactorExpr::Mul(
+                Box::new(FactorExpr::Const(0.25)),
+                Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+            )),
+            Box::new(FactorExpr::Input("near_strike_score".to_string())),
+        );
+
+        assert_eq!(structural_signature(&lhs), structural_signature(&rhs));
+    }
+
+    #[test]
+    fn structural_signature_abstracts_numeric_constants() {
+        let first = FactorExpr::SafeDiv(
+            Box::new(FactorExpr::Input(
+                "external_move_since_poly_update".to_string(),
+            )),
+            Box::new(FactorExpr::Const(0.01)),
+        );
+        let second = FactorExpr::SafeDiv(
+            Box::new(FactorExpr::Input(
+                "external_move_since_poly_update".to_string(),
+            )),
+            Box::new(FactorExpr::Const(0.05)),
+        );
+
+        assert_eq!(structural_signature(&first), structural_signature(&second));
+    }
+
+    #[test]
+    fn avoided_subtrees_counts_repeated_inner_structures() {
+        let inner = FactorExpr::SafeDiv(
+            Box::new(FactorExpr::Input(
+                "external_move_since_poly_update".to_string(),
+            )),
+            Box::new(FactorExpr::Add(
+                Box::new(FactorExpr::Input("pm_spread".to_string())),
+                Box::new(FactorExpr::Const(0.01)),
+            )),
+        );
+        let reports = vec![
+            AutoFactorReport {
+                name: "wrapped_tanh".to_string(),
+                expr: FactorExpr::Tanh(Box::new(inner.clone())),
+                complexity: 5,
+                ..sample_report("wrapped_tanh")
+            },
+            AutoFactorReport {
+                name: "wrapped_log".to_string(),
+                expr: FactorExpr::Log1pAbs(Box::new(inner.clone())),
+                complexity: 5,
+                ..sample_report("wrapped_log")
+            },
+            AutoFactorReport {
+                name: "wrapped_sqrt".to_string(),
+                expr: FactorExpr::SqrtAbs(Box::new(inner.clone())),
+                complexity: 5,
+                ..sample_report("wrapped_sqrt")
+            },
+        ];
+
+        let avoided = avoided_subtrees(&reports);
+        let inner_signature = structural_signature(&inner);
+        let subtree = avoided
+            .iter()
+            .find(|item| item.structural_signature == inner_signature)
+            .expect("shared inner subtree is crowded");
+
+        assert_eq!(subtree.root_gene, "SafeDiv");
+        assert_eq!(subtree.count, 3);
+        assert_eq!(subtree.reason, "structural_signature_crowding");
     }
 
     #[test]

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -2066,6 +2066,26 @@ mod tests {
     }
 
     #[test]
+    fn structural_signature_normalizes_commutative_comparators() {
+        let lhs = FactorExpr::Max(
+            Box::new(FactorExpr::Input("near_strike_score".to_string())),
+            Box::new(FactorExpr::Min(
+                Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+                Box::new(FactorExpr::Const(0.25)),
+            )),
+        );
+        let rhs = FactorExpr::Max(
+            Box::new(FactorExpr::Min(
+                Box::new(FactorExpr::Const(0.25)),
+                Box::new(FactorExpr::Input("entry_capacity_score".to_string())),
+            )),
+            Box::new(FactorExpr::Input("near_strike_score".to_string())),
+        );
+
+        assert_eq!(structural_signature(&lhs), structural_signature(&rhs));
+    }
+
+    #[test]
     fn structural_signature_abstracts_numeric_constants() {
         let first = FactorExpr::SafeDiv(
             Box::new(FactorExpr::Input(

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -2169,6 +2169,7 @@ mod tests {
             mode: "cumulative_ucb_state".to_string(),
             target: "full_depth_settlement_executable_pnl".to_string(),
             total_visits: 0,
+            backpropagation_truncated_count: 0,
             nodes: Vec::new(),
             subtree_frequencies: vec![SubtreeFrequencyState {
                 root_gene: "SafeDiv".to_string(),
@@ -2219,8 +2220,8 @@ mod tests {
             "crowded expression should be penalized"
         );
         assert!(
-            reward(&crowded, &runtime_avoidances, &frequencies)
-                < reward(&novel, &runtime_avoidances, &frequencies),
+            reward(&crowded, &runtime_avoidances, None, &frequencies)
+                < reward(&novel, &runtime_avoidances, None, &frequencies),
             "same-quality crowded expression should rank below novel expression"
         );
     }
@@ -2602,13 +2603,18 @@ mod tests {
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None, &Vec::new()))
             .collect::<Vec<_>>();
         let reward_by_name = metrics
             .iter()
             .map(|metric| (metric.factor_name.as_str(), metric.reward))
             .collect::<BTreeMap<_, _>>();
-        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            None,
+            Vec::new(),
+        );
         let nodes = state
             .nodes
             .iter()
@@ -2656,10 +2662,15 @@ mod tests {
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None, &Vec::new()))
             .collect::<Vec<_>>();
         let expected_root_total = metrics.iter().map(|metric| metric.reward).sum::<f64>();
-        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            None,
+            Vec::new(),
+        );
         let root = state
             .nodes
             .iter()
@@ -2676,7 +2687,13 @@ mod tests {
         let runtime_avoidances = Vec::new();
         let mut report = sample_report("cycle_a");
         report.parent_name = Some("cycle_b".to_string());
-        let metrics = [node_metric(0, &report, &runtime_avoidances, None)];
+        let metrics = [node_metric(
+            0,
+            &report,
+            &runtime_avoidances,
+            None,
+            &Vec::new(),
+        )];
         let prior = MctsSearchStateArtifact {
             version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),
             mode: "cumulative_ucb_state".to_string(),
@@ -2693,12 +2710,14 @@ mod tests {
                 selected_dimension: "exploit".to_string(),
                 last_decision: "candidate".to_string(),
             }],
+            subtree_frequencies: Vec::new(),
         };
 
         let state = mcts_search_state(
             "full_depth_settlement_executable_pnl",
             &metrics,
             Some(&prior),
+            Vec::new(),
         );
 
         assert_eq!(state.backpropagation_truncated_count, 1);
@@ -2818,7 +2837,12 @@ mod tests {
         );
         assert!(
             reward(&collapsed, &runtime_avoidances, None, &subtree_frequencies)
-                < reward(&alternative, &runtime_avoidances, None, &subtree_frequencies),
+                < reward(
+                    &alternative,
+                    &runtime_avoidances,
+                    None,
+                    &subtree_frequencies
+                ),
             "runtime pass-through collapse should dominate top-bucket reward"
         );
     }
@@ -2996,7 +3020,7 @@ mod tests {
     fn alpha_zoo_crowded_root_gene_lowers_reward() {
         let report = sample_report("auto_settlement_alpha_zoo_crowded_candidate");
         let runtime_avoidances = Vec::new();
-        let baseline_reward = reward(&report, &runtime_avoidances, None);
+        let baseline_reward = reward(&report, &runtime_avoidances, None, &Vec::new());
 
         let zoo = AlphaZooSnapshot {
             version: "alpha_zoo_v1".to_string(),
@@ -3006,7 +3030,7 @@ mod tests {
                 count: 50,
             }],
         };
-        let penalized_reward = reward(&report, &runtime_avoidances, Some(&zoo));
+        let penalized_reward = reward(&report, &runtime_avoidances, Some(&zoo), &Vec::new());
 
         assert!(
             penalized_reward < baseline_reward,
@@ -3022,7 +3046,7 @@ mod tests {
     fn alpha_zoo_snapshot_for_a_different_target_is_a_no_op() {
         let report = sample_report("auto_settlement_alpha_zoo_cross_target_candidate");
         let runtime_avoidances = Vec::new();
-        let baseline_reward = reward(&report, &runtime_avoidances, None);
+        let baseline_reward = reward(&report, &runtime_avoidances, None, &Vec::new());
 
         // The snapshot's root gene matches, but its `target` does not match
         // this report's target. A snapshot exported for one search target
@@ -3036,7 +3060,8 @@ mod tests {
                 count: 50,
             }],
         };
-        let reward_with_mismatched_zoo = reward(&report, &runtime_avoidances, Some(&zoo));
+        let reward_with_mismatched_zoo =
+            reward(&report, &runtime_avoidances, Some(&zoo), &Vec::new());
 
         assert_eq!(
             baseline_reward, reward_with_mismatched_zoo,
@@ -3057,7 +3082,7 @@ mod tests {
         let report = sample_report("auto_settlement_alpha_zoo_no_op_candidate");
         let runtime_avoidances = Vec::new();
 
-        let reward_without_zoo = reward(&report, &runtime_avoidances, None);
+        let reward_without_zoo = reward(&report, &runtime_avoidances, None, &Vec::new());
 
         // An empty snapshot, and no snapshot at all, must be equivalent: absence
         // of Alpha Zoo evidence should never change search behavior.
@@ -3066,7 +3091,8 @@ mod tests {
             target: "full_depth_settlement_executable_pnl".to_string(),
             entries: Vec::new(),
         };
-        let reward_with_empty_zoo = reward(&report, &runtime_avoidances, Some(&empty_zoo));
+        let reward_with_empty_zoo =
+            reward(&report, &runtime_avoidances, Some(&empty_zoo), &Vec::new());
 
         assert_eq!(
             reward_without_zoo, reward_with_empty_zoo,

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -59,6 +59,8 @@ pub struct MctsSearchStateArtifact {
     #[serde(default)]
     pub backpropagation_truncated_count: usize,
     pub nodes: Vec<MctsSearchStateNode>,
+    #[serde(default)]
+    pub subtree_frequencies: Vec<SubtreeFrequencyState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,6 +96,14 @@ pub struct AlphaZooSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AlphaZooEntry {
     pub root_gene: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubtreeFrequencyState {
+    pub root_gene: String,
+    pub structural_signature: String,
+    pub depth: usize,
     pub count: usize,
 }
 
@@ -222,6 +232,9 @@ struct NodeMetric {
     stability: f64,
     diversity: f64,
     alpha_zoo_novelty: f64,
+    simplicity: f64,
+    structural_novelty: f64,
+    diversity_penalty: f64,
     execution_cost: f64,
     event_uniqueness: f64,
     overfit_risk: f64,
@@ -515,17 +528,26 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
     write_json(&output_dir.join("rejected-expressions.json"), &rejected)?;
 
     let runtime_avoidances = runtime_avoidances(runtime_feedback, llm_prior);
+    let subtree_frequencies = subtree_frequency_state(target, reports, prior_state, llm_prior);
     let node_metrics = reports
         .iter()
         .enumerate()
-        .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, alpha_zoo))
+        .map(|(idx, report)| {
+            node_metric(
+                idx,
+                report,
+                &runtime_avoidances,
+                alpha_zoo,
+                &subtree_frequencies,
+            )
+        })
         .collect::<Vec<_>>();
     write_json(&output_dir.join("node-metrics.json"), &node_metrics)?;
     write_json(
         &output_dir.join("factor-registry-preview.json"),
         &factor_registry_preview_artifact(target, reports, &node_metrics)?,
     )?;
-    let mcts_state = mcts_search_state(target, &node_metrics, prior_state);
+    let mcts_state = mcts_search_state(target, &node_metrics, prior_state, subtree_frequencies);
     let prior_truncated_count = prior_state
         .filter(|state| state.target == target)
         .map(|state| state.backpropagation_truncated_count)
@@ -560,7 +582,12 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
                     factor_name: report.name.clone(),
                     mutation: "seed",
                     selected_dimension: selected_dimension(report, &runtime_avoidances),
-                    reward: reward(report, &runtime_avoidances, alpha_zoo),
+                    reward: reward(
+                        report,
+                        &runtime_avoidances,
+                        alpha_zoo,
+                        &mcts_state.subtree_frequencies,
+                    ),
                     visits: 1,
                     decision: report.decision.as_str().to_string(),
                 })
@@ -570,7 +597,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
 
     write_json(
         &output_dir.join("avoided-subtrees.json"),
-        &avoided_subtrees(reports),
+        &avoided_subtrees(&mcts_state.subtree_frequencies),
     )?;
 
     let best = node_metrics
@@ -1096,8 +1123,12 @@ fn node_metric(
     report: &AutoFactorReport,
     runtime_avoidances: &[RuntimeAvoidance],
     alpha_zoo: Option<&AlphaZooSnapshot>,
+    subtree_frequencies: &[SubtreeFrequencyState],
 ) -> NodeMetric {
     let matching_avoidance = matching_runtime_avoidance(report, runtime_avoidances);
+    let simplicity = 1.0 / report.complexity.max(1) as f64;
+    let structural_novelty = structural_novelty_score(&report.expr, subtree_frequencies);
+    let diversity_penalty = structural_diversity_penalty(&report.expr, subtree_frequencies);
     NodeMetric {
         id: format!("node-{idx}"),
         factor_name: report.name.clone(),
@@ -1108,15 +1139,18 @@ fn node_metric(
         selected_dimension: selected_dimension(report, runtime_avoidances),
         effectiveness: normalized_positive(report.top_bucket_avg_label),
         stability: report.positive_window_ratio.clamp(0.0, 1.0),
-        diversity: 1.0 / report.complexity.max(1) as f64,
+        diversity: structural_novelty,
         alpha_zoo_novelty: alpha_zoo_novelty_score(
             &report.expr,
             report.target.as_deref(),
             alpha_zoo,
         ),
+        simplicity,
+        structural_novelty,
+        diversity_penalty,
         execution_cost: execution_score(report),
         event_uniqueness: event_uniqueness_score(report),
-        overfit_risk: 1.0 / report.complexity.max(1) as f64,
+        overfit_risk: simplicity,
         runtime_readiness: if report.name.starts_with("auto_settlement_")
             || report.name == "amplitude_weighted_momentum_30s_sigma"
         {
@@ -1124,7 +1158,7 @@ fn node_metric(
         } else {
             0.5
         },
-        reward: reward(report, runtime_avoidances, alpha_zoo),
+        reward: reward(report, runtime_avoidances, alpha_zoo, subtree_frequencies),
         spearman_ic: finite_or_zero(report.spearman_ic),
         icir: finite_or_zero(report.icir),
         positive_window_ratio: finite_or_zero(report.positive_window_ratio),
@@ -1157,6 +1191,7 @@ fn mcts_search_state(
     target: &str,
     metrics: &[NodeMetric],
     prior_state: Option<&MctsSearchStateArtifact>,
+    subtree_frequencies: Vec<SubtreeFrequencyState>,
 ) -> MctsSearchStateArtifact {
     let mut nodes = prior_state
         .filter(|state| state.target == target)
@@ -1215,6 +1250,7 @@ fn mcts_search_state(
         total_visits,
         backpropagation_truncated_count,
         nodes,
+        subtree_frequencies,
     }
 }
 
@@ -1313,6 +1349,7 @@ fn reward(
     report: &AutoFactorReport,
     runtime_avoidances: &[RuntimeAvoidance],
     alpha_zoo: Option<&AlphaZooSnapshot>,
+    subtree_frequencies: &[SubtreeFrequencyState],
 ) -> f64 {
     let decision_bonus = match report.decision {
         AutoFactorDecision::Candidate => 1.0,
@@ -1331,6 +1368,7 @@ fn reward(
         - execution_penalty(report)
         - runtime_pass_through_penalty(report, runtime_avoidances)
         - alpha_zoo_novelty_penalty(&report.expr, report.target.as_deref(), alpha_zoo)
+        - structural_diversity_penalty(&report.expr, subtree_frequencies)
         - (report.complexity as f64 / 32.0)
 }
 
@@ -1435,20 +1473,78 @@ fn selected_dimension(
     .to_string()
 }
 
-fn avoided_subtrees(reports: &[AutoFactorReport]) -> Vec<AvoidedSubtree> {
-    let mut counts: BTreeMap<String, StructuralSubtreeCount> = BTreeMap::new();
+fn subtree_frequency_state(
+    target: &str,
+    reports: &[AutoFactorReport],
+    prior_state: Option<&MctsSearchStateArtifact>,
+    llm_prior: Option<&LlmPriorSpec>,
+) -> Vec<SubtreeFrequencyState> {
+    let mut counts: BTreeMap<String, StructuralSubtreeCount> = prior_state
+        .filter(|state| state.target == target)
+        .map(|state| {
+            state
+                .subtree_frequencies
+                .iter()
+                .map(|item| {
+                    (
+                        item.structural_signature.clone(),
+                        StructuralSubtreeCount {
+                            root_gene: item.root_gene.clone(),
+                            depth: item.depth,
+                            count: item.count,
+                        },
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     for report in reports {
         record_subtree_count(&mut counts, &report.expr);
         for subtree in inner_structural_subtrees(&report.expr) {
             record_subtree_count(&mut counts, subtree);
         }
     }
+
+    if let Some(prior) = llm_prior {
+        for item in &prior.structural_avoid_signatures {
+            let signature = item.structural_signature.trim();
+            if signature.is_empty() {
+                continue;
+            }
+            let entry =
+                counts
+                    .entry(signature.to_string())
+                    .or_insert_with(|| StructuralSubtreeCount {
+                        root_gene: item.root_gene.clone().unwrap_or_default(),
+                        depth: 0,
+                        count: 0,
+                    });
+            if entry.root_gene.is_empty() {
+                entry.root_gene = item.root_gene.clone().unwrap_or_default();
+            }
+            entry.count = entry.count.max(item.count.max(3));
+        }
+    }
+
     counts
         .into_iter()
-        .filter(|(_, item)| item.count > 2)
-        .map(|(structural_signature, item)| AvoidedSubtree {
+        .map(|(structural_signature, item)| SubtreeFrequencyState {
             root_gene: item.root_gene,
             structural_signature,
+            depth: item.depth,
+            count: item.count,
+        })
+        .collect()
+}
+
+fn avoided_subtrees(frequencies: &[SubtreeFrequencyState]) -> Vec<AvoidedSubtree> {
+    frequencies
+        .iter()
+        .filter(|item| item.count > 2)
+        .map(|item| AvoidedSubtree {
+            root_gene: item.root_gene.clone(),
+            structural_signature: item.structural_signature.clone(),
             depth: item.depth,
             count: item.count,
             action: "penalize",
@@ -1474,6 +1570,38 @@ fn record_subtree_count(counts: &mut BTreeMap<String, StructuralSubtreeCount>, e
             count: 0,
         });
     entry.count = entry.count.saturating_add(1);
+}
+
+fn structural_diversity_penalty(expr: &FactorExpr, frequencies: &[SubtreeFrequencyState]) -> f64 {
+    let max_count = max_structural_frequency(expr, frequencies);
+    if max_count <= 2 {
+        0.0
+    } else {
+        ((max_count - 2) as f64 * 0.35).min(2.0)
+    }
+}
+
+fn structural_novelty_score(expr: &FactorExpr, frequencies: &[SubtreeFrequencyState]) -> f64 {
+    1.0 / max_structural_frequency(expr, frequencies).max(1) as f64
+}
+
+fn max_structural_frequency(expr: &FactorExpr, frequencies: &[SubtreeFrequencyState]) -> usize {
+    let signatures = structural_signatures(expr);
+    frequencies
+        .iter()
+        .filter(|item| signatures.contains(&item.structural_signature))
+        .map(|item| item.count)
+        .max()
+        .unwrap_or(1)
+}
+
+fn structural_signatures(expr: &FactorExpr) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    out.insert(structural_signature(expr));
+    for subtree in inner_structural_subtrees(expr) {
+        out.insert(structural_signature(subtree));
+    }
+    out
 }
 
 fn structural_signature(expr: &FactorExpr) -> String {
@@ -1987,7 +2115,9 @@ mod tests {
             },
         ];
 
-        let avoided = avoided_subtrees(&reports);
+        let frequencies =
+            subtree_frequency_state("full_depth_settlement_executable_pnl", &reports, None, None);
+        let avoided = avoided_subtrees(&frequencies);
         let inner_signature = structural_signature(&inner);
         let subtree = avoided
             .iter()
@@ -1997,6 +2127,82 @@ mod tests {
         assert_eq!(subtree.root_gene, "SafeDiv");
         assert_eq!(subtree.count, 3);
         assert_eq!(subtree.reason, "structural_signature_crowding");
+    }
+
+    #[test]
+    fn subtree_frequencies_merge_prior_state_counts() {
+        let expr = FactorExpr::SafeDiv(
+            Box::new(FactorExpr::Input(
+                "external_move_since_poly_update".to_string(),
+            )),
+            Box::new(FactorExpr::Const(0.01)),
+        );
+        let report = AutoFactorReport {
+            name: "current_safe_div".to_string(),
+            expr: expr.clone(),
+            complexity: 3,
+            ..sample_report("current_safe_div")
+        };
+        let signature = structural_signature(&expr);
+        let prior = MctsSearchStateArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),
+            mode: "cumulative_ucb_state".to_string(),
+            target: "full_depth_settlement_executable_pnl".to_string(),
+            total_visits: 0,
+            nodes: Vec::new(),
+            subtree_frequencies: vec![SubtreeFrequencyState {
+                root_gene: "SafeDiv".to_string(),
+                structural_signature: signature.clone(),
+                depth: structural_depth(&expr),
+                count: 2,
+            }],
+        };
+
+        let frequencies = subtree_frequency_state(
+            "full_depth_settlement_executable_pnl",
+            &[report],
+            Some(&prior),
+            None,
+        );
+        let item = frequencies
+            .iter()
+            .find(|item| item.structural_signature == signature)
+            .expect("merged signature");
+
+        assert_eq!(item.count, 3);
+    }
+
+    #[test]
+    fn crowded_signature_receives_reward_penalty() {
+        let expr = FactorExpr::SafeDiv(
+            Box::new(FactorExpr::Input(
+                "external_move_since_poly_update".to_string(),
+            )),
+            Box::new(FactorExpr::Const(0.01)),
+        );
+        let mut crowded = sample_report("crowded_safe_div");
+        crowded.expr = expr.clone();
+        crowded.complexity = 3;
+        let mut novel = sample_report("novel_tanh");
+        novel.expr = FactorExpr::Tanh(Box::new(FactorExpr::Input("near_strike_score".to_string())));
+        novel.complexity = 3;
+        let frequencies = vec![SubtreeFrequencyState {
+            root_gene: "SafeDiv".to_string(),
+            structural_signature: structural_signature(&expr),
+            depth: structural_depth(&expr),
+            count: 5,
+        }];
+        let runtime_avoidances = Vec::new();
+
+        assert!(
+            structural_diversity_penalty(&crowded.expr, &frequencies) > 0.0,
+            "crowded expression should be penalized"
+        );
+        assert!(
+            reward(&crowded, &runtime_avoidances, &frequencies)
+                < reward(&novel, &runtime_avoidances, &frequencies),
+            "same-quality crowded expression should rank below novel expression"
+        );
     }
 
     #[test]
@@ -2332,6 +2538,7 @@ mod tests {
                 selected_dimension: "exploit".to_string(),
                 last_decision: "candidate".to_string(),
             }],
+            subtree_frequencies: Vec::new(),
         };
 
         write_alpha_search_artifacts_with_state(
@@ -2497,12 +2704,20 @@ mod tests {
 
         let reports = vec![repeated, one_event];
         let runtime_avoidances = Vec::new();
+        let subtree_frequencies = Vec::new();
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .map(|(idx, report)| {
+                node_metric(idx, report, &runtime_avoidances, None, &subtree_frequencies)
+            })
             .collect::<Vec<_>>();
-        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            None,
+            subtree_frequencies.clone(),
+        );
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
         assert_eq!(
@@ -2512,8 +2727,8 @@ mod tests {
             Some("auto_settlement_lower_raw_score_one_event")
         );
         assert!(
-            reward(&reports[0], &runtime_avoidances, None)
-                < reward(&reports[1], &runtime_avoidances, None),
+            reward(&reports[0], &runtime_avoidances, None, &subtree_frequencies)
+                < reward(&reports[1], &runtime_avoidances, None, &subtree_frequencies),
             "repeated-event penalty should dominate raw IC/top-bucket strength"
         );
     }
@@ -2575,14 +2790,15 @@ mod tests {
             executable_edge_pass_min_edge: 5,
         };
         let runtime_avoidances = runtime_avoidances(Some(&feedback), None);
+        let subtree_frequencies = Vec::new();
 
         assert_eq!(
             selected_dimension(&collapsed, &runtime_avoidances),
             "runtime_executable_entry"
         );
         assert!(
-            reward(&collapsed, &runtime_avoidances, None)
-                < reward(&alternative, &runtime_avoidances, None),
+            reward(&collapsed, &runtime_avoidances, None, &subtree_frequencies)
+                < reward(&alternative, &runtime_avoidances, None, &subtree_frequencies),
             "runtime pass-through collapse should dominate top-bucket reward"
         );
     }
@@ -2607,12 +2823,20 @@ mod tests {
         };
         let runtime_avoidances = runtime_avoidances(Some(&feedback), None);
         let reports = vec![collapsed, alternative];
+        let subtree_frequencies = Vec::new();
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .map(|(idx, report)| {
+                node_metric(idx, report, &runtime_avoidances, None, &subtree_frequencies)
+            })
             .collect::<Vec<_>>();
-        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            None,
+            subtree_frequencies,
+        );
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
         assert!(
@@ -2646,6 +2870,7 @@ mod tests {
         let alternative = sample_report("auto_settlement_full_depth_settlement_edge_x_capacity");
         let prior = LlmPriorSpec {
             mutations: Vec::new(),
+            structural_avoid_signatures: Vec::new(),
             runtime_avoid_factors: vec![crate::autofactor::RuntimeAvoidFactorSpec {
                 base_factor: "mut_spread_adjusted_external_move_squashed".to_string(),
                 factor_family: Some("spread_adjusted_external_move".to_string()),
@@ -2658,12 +2883,20 @@ mod tests {
         };
         let prior_avoidances = runtime_avoidances(None, Some(&prior));
         let reports = vec![squashed, spread_adjusted, alternative];
+        let subtree_frequencies = Vec::new();
         let metrics = reports
             .iter()
             .enumerate()
-            .map(|(idx, report)| node_metric(idx, report, &prior_avoidances, None))
+            .map(|(idx, report)| {
+                node_metric(idx, report, &prior_avoidances, None, &subtree_frequencies)
+            })
             .collect::<Vec<_>>();
-        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            None,
+            subtree_frequencies,
+        );
         let plan = mcts_expansion_plan("full_depth_settlement_executable_pnl", &metrics, &state);
 
         assert!(
@@ -2683,6 +2916,7 @@ mod tests {
         );
         let composed_prior = LlmPriorSpec {
             mutations: Vec::new(),
+            structural_avoid_signatures: Vec::new(),
             runtime_avoid_factors: vec![crate::autofactor::RuntimeAvoidFactorSpec {
                 base_factor:
                     "mut_auto_settlement_model_full_depth_settlement_edge_x_external_pressure_spread_adjusted"
@@ -2715,6 +2949,7 @@ mod tests {
         );
         let selected_gate_prior = LlmPriorSpec {
             mutations: Vec::new(),
+            structural_avoid_signatures: Vec::new(),
             runtime_avoid_factors: vec![crate::autofactor::RuntimeAvoidFactorSpec {
                 base_factor:
                     "mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -3839,6 +3839,7 @@ mod tests {
         };
         let prior = LlmPriorSpec {
             runtime_avoid_factors: Vec::new(),
+            structural_avoid_signatures: Vec::new(),
             mutations: vec![LlmMutationSpec {
                 base_factor:
                     "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -226,6 +226,8 @@ pub struct LlmPriorSpec {
     pub mutations: Vec<LlmMutationSpec>,
     #[serde(default)]
     pub runtime_avoid_factors: Vec<RuntimeAvoidFactorSpec>,
+    #[serde(default)]
+    pub structural_avoid_signatures: Vec<StructuralAvoidSignatureSpec>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -239,6 +241,17 @@ pub struct RuntimeAvoidFactorSpec {
     pub reason: Option<String>,
     #[serde(default)]
     pub metrics: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructuralAvoidSignatureSpec {
+    pub structural_signature: String,
+    #[serde(default)]
+    pub root_gene: Option<String>,
+    #[serde(default)]
+    pub count: usize,
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3777,6 +3790,7 @@ mod tests {
         };
         let prior = LlmPriorSpec {
             runtime_avoid_factors: Vec::new(),
+            structural_avoid_signatures: Vec::new(),
             mutations: vec![LlmMutationSpec {
                 base_factor: "auto_settlement_model_full_depth_settlement_edge".to_string(),
                 mutation_type: "add_feature_gate".to_string(),

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -153,6 +153,7 @@ select node
   -> expand with allowed mutation
   -> evaluate candidate
   -> backpropagate multi-dimensional reward
+  -> persist structural subtree frequencies
   -> penalize crowded or invalid subtrees
 ```
 
@@ -328,9 +329,19 @@ advice until it is parsed into typed mutations.
 
 ## Frequent-Subtree Avoidance
 
-The search layer must track repeated expression structures. A subtree can be
-penalized or blocked when it repeats a crowded root gene without improving the
-selected weak dimension.
+The search layer tracks repeated expression structures with canonical structural
+signatures, not only top-level operator names. The signature normalizes
+commutative `Add`/`Mul` operands and abstracts numeric constants, so formulas
+that only reorder operands or tune an epsilon are treated as the same shape.
+The search records both whole-expression signatures and repeated inner subtrees
+with structural depth >= 2.
+
+Crowded signatures are persisted in `mcts-state.json` under
+`subtree_frequencies`, then surfaced in `avoided-subtrees.json` when their
+count crosses the penalty threshold. Node metrics split the old overloaded
+`diversity` meaning into `simplicity`, `structural_novelty`, and
+`diversity_penalty`; reward subtracts the diversity penalty so repeated
+structures affect MCTS ranking instead of remaining write-only diagnostics.
 
 Examples:
 
@@ -340,7 +351,10 @@ Examples:
 
 Avoidance is not a hard ban forever. It is a diversity control: a crowded
 subtree can be revisited only when the candidate improves a declared weak
-dimension such as capacity, stability, or overfit risk.
+dimension such as capacity, stability, or overfit risk. The closed-loop agent
+also carries crowded `structural_avoid_signatures` into the next
+`llm-priors.json` draft, so the next prior-generation step can avoid repeating
+known-crowded formula shapes before Rust scoring penalizes them.
 
 ## Alpha Zoo
 
@@ -642,8 +656,9 @@ Current implementation status:
 - Implemented: MCTS control artifacts, `mcts-state.json` and
   `mcts-expansion-plan.json`. The state artifact stores explicit factor
   parent lineage, accumulates leaf visits, backpropagates leaf rewards through
-  ancestor nodes across runs, and the expansion plan ranks non-rejected
-  current-run nodes with a UCB-style priority using that cumulative state.
+  ancestor nodes across runs, and persists structural subtree frequencies
+  across runs. The expansion plan ranks non-rejected current-run nodes with a
+  UCB-style priority using that cumulative state.
   `mcts-state.json.backpropagation_truncated_count > 0` means reward
   propagation hit a defensive stop before reaching a root node. Inspect
   `parent_name` lineage for cycles first; if there is no cycle, check whether
@@ -657,7 +672,8 @@ Current implementation status:
 - Implemented: `factor_walk_forward_v2 --alpha-search-state-json <path>` can
   consume a prior `mcts-state.json`; when a prior alpha-search artifact is
   downloaded via `options_json.alpha_search_plan_run_id`, the workflows pass
-  its `mcts-state.json` automatically when present.
+  its `mcts-state.json` automatically when present. This carries both MCTS node
+  rewards and structural subtree frequency counts into the next run.
 - Implemented: `factor_walk_forward_v2 --alpha-search-llm-prior-json <path>`
   accepts a typed LLM-prior JSON file with bounded mutation requests. The Rust
   layer compiles those requests into existing `FactorExpr` candidates only when
@@ -694,6 +710,10 @@ Current implementation status:
 - Implemented: alpha-search node metrics and MCTS reward now include
   event-level uniqueness and execution-capacity penalties, so repeated-event or
   high-slippage candidates are de-prioritized before the promotion gate.
+- Implemented: alpha-search node metrics and MCTS reward now include
+  structural novelty and diversity penalties from persisted subtree crowding, so
+  `avoided-subtrees.json` reflects a reward input rather than a write-only
+  diagnostic.
 - Implemented: settlement AutoFactor targets score one candidate decision per
   event before bucket and promotion metrics, while repricing targets preserve
   row-level diagnostics.
@@ -704,6 +724,9 @@ Current implementation status:
   boundary. `remove_component` can now ablate a named existing input from a
   candidate AST, or unwrap a top-level robustness/gate component, while still
   compiling only into existing `FactorExpr` nodes.
+- Implemented: closed-loop prior drafts carry `structural_avoid_signatures`
+  from crowded subtree artifacts, giving the next prior-generation step an
+  explicit list of formula shapes to avoid.
 - Implemented: a durable, cross-run Alpha Zoo novelty penalty. `reward()` and
   `node_metric()` accept an optional `AlphaZooSnapshot` grouped from historical
   `factor_registry` rows by root gene; `persist_research_trace

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -124,6 +124,7 @@ def load_artifact(path: Path, target: str) -> dict[str, Any]:
         "feedback": optional_json(alpha_root / "search-feedback.json") or {},
         "plan": optional_json(alpha_root / "mcts-expansion-plan.json") or {},
         "state": optional_json(alpha_root / "mcts-state.json") or {},
+        "avoided_subtrees": optional_json(alpha_root / "avoided-subtrees.json") or [],
         "handoff": optional_json(root / "autofactor-strategy-handoff.json") or {},
         "promotion": optional_json(root / "autofactor-strategy-promotion.json") or {},
         "registry_preview": optional_json(alpha_root / "factor-registry-preview.json") or {},
@@ -1284,6 +1285,47 @@ def collect_runtime_avoid_factors(
     return [by_family[key] for key in sorted(by_family)]
 
 
+def collect_structural_avoid_signatures(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_signature: dict[str, dict[str, Any]] = {}
+
+    def add_item(item: dict[str, Any]) -> None:
+        signature = str(item.get("structural_signature") or "").strip()
+        if not signature:
+            return
+        count = item.get("count")
+        try:
+            count_value = int(count)
+        except (TypeError, ValueError):
+            count_value = 0
+        payload = {
+            "structural_signature": signature,
+            "root_gene": str(item.get("root_gene") or ""),
+            "count": max(count_value, 3),
+            "reason": str(item.get("reason") or "structural_signature_crowding"),
+        }
+        existing = by_signature.get(signature)
+        if existing is None or int(existing.get("count") or 0) < payload["count"]:
+            by_signature[signature] = payload
+
+    for run in runs:
+        prior = run.get("input_prior") if isinstance(run, dict) else {}
+        prior_existing = (
+            prior.get("structural_avoid_signatures") if isinstance(prior, dict) else None
+        )
+        if isinstance(prior_existing, list):
+            for item in prior_existing:
+                if isinstance(item, dict):
+                    add_item(item)
+
+        avoided = run.get("avoided_subtrees") if isinstance(run, dict) else None
+        if isinstance(avoided, list):
+            for item in avoided:
+                if isinstance(item, dict) and str(item.get("action") or "") == "penalize":
+                    add_item(item)
+
+    return [by_signature[key] for key in sorted(by_signature)]
+
+
 def runtime_feedback_has_direct_signal(runtime_feedback: dict[str, Any]) -> bool:
     metrics = runtime_feedback.get("metrics")
     if not isinstance(metrics, dict):
@@ -1301,6 +1343,7 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
     current = latest_run(runs)
     mutations = []
     runtime_avoid_factors = collect_runtime_avoid_factors(runs, decision)
+    structural_avoid_signatures = collect_structural_avoid_signatures(runs)
     runtime_avoid_families = {
         str(item.get("factor_family") or "").strip()
         for item in runtime_avoid_factors
@@ -1383,6 +1426,7 @@ def build_prior(runs: list[dict[str, Any]], decision: dict[str, Any], limit: int
         "target": current["target"],
         "decision_reason": decision["reason"],
         "runtime_avoid_factors": runtime_avoid_factors,
+        "structural_avoid_signatures": structural_avoid_signatures,
         "mutations": mutations,
     }
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -28,6 +28,7 @@ def artifact(
     promotion: dict | None = None,
     registry_preview: dict | None = None,
     candidate_strategy_replay: dict | None = None,
+    avoided_subtrees: list[dict] | None = None,
     write_feedback: bool = True,
 ) -> Path:
     factor_root = root / "factor-walk-forward-v2"
@@ -87,6 +88,8 @@ def artifact(
     )
     if registry_preview is not None:
         write_json(alpha_root / "factor-registry-preview.json", registry_preview)
+    if avoided_subtrees is not None:
+        write_json(alpha_root / "avoided-subtrees.json", avoided_subtrees)
     write_json(
         root / "alpha-search-chain" / "chain-decision.json",
         {
@@ -1859,6 +1862,71 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
                 prior["mutations"][0]["base_factor"],
                 "mut_spread_adjusted_external_move_squashed",
             )
+
+    def test_structural_avoid_signatures_enter_next_prior(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            crowded_signature = "SafeDiv(Input(external_move_since_poly_update),Add(Const(_),Input(side_spread)))"
+            path = artifact(
+                Path(tmp),
+                chain_reason="reward_stagnation",
+                avoided_subtrees=[
+                    {
+                        "root_gene": "SafeDiv",
+                        "structural_signature": crowded_signature,
+                        "depth": 3,
+                        "count": 4,
+                        "action": "penalize",
+                        "reason": "structural_signature_crowding",
+                    }
+                ],
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(decision["decision"], "revise_prior")
+            self.assertEqual(
+                prior["structural_avoid_signatures"],
+                [
+                    {
+                        "structural_signature": crowded_signature,
+                        "root_gene": "SafeDiv",
+                        "count": 4,
+                        "reason": "structural_signature_crowding",
+                    }
+                ],
+            )
+
+    def test_prior_structural_avoid_signatures_carry_forward(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp), chain_reason="reward_stagnation")
+            write_json(
+                path
+                / "alpha-search-chain"
+                / "input-alpha-search-plan"
+                / "next-llm-prior.json",
+                {
+                    "structural_avoid_signatures": [
+                        {
+                            "structural_signature": "Mul(Input(a),Input(b))",
+                            "root_gene": "Mul",
+                            "count": 5,
+                            "reason": "structural_signature_crowding",
+                        }
+                    ]
+                },
+            )
+
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 3)
+
+            self.assertEqual(
+                prior["structural_avoid_signatures"][0]["structural_signature"],
+                "Mul(Input(a),Input(b))",
+            )
+            self.assertEqual(prior["structural_avoid_signatures"][0]["count"], 5)
 
     def test_cli_markdown_includes_runtime_replay_request(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add canonical structural signatures for alpha-search formula artifacts while preserving `root_gene` compatibility
- persist cumulative subtree frequencies in `mcts-state.json` and derive `avoided-subtrees.json` from structural crowding
- wire structural crowding into `reward()` via a diversity penalty and split node metrics into `simplicity`, `structural_novelty`, and `diversity_penalty`
- carry crowded `structural_avoid_signatures` into the closed-loop typed prior draft for the next LLM generation round
- update the alpha-search CI/CD docs and focused Rust/Python regressions
- update `quinn-proto` to clear the new cargo-audit advisory

## Evidence stage
`factor_attribution` only; no promotion, dry-run, live trading, or runtime-parity gates changed.

## Validation
- `rtk cargo test -p ploy-research alpha_search --lib`
- `python3 -m unittest tests.test_alpha_search_closed_loop_agent`
- `python3 -m py_compile scripts/alpha_search_closed_loop_agent.py tests/test_alpha_search_closed_loop_agent.py`
- `rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs`
- `rtk git diff --check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104 --ignore RUSTSEC-2025-0021`

## CI
- Test: pass
- Legacy Python Tools: pass
- Auto Review / CodeRabbit: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking structural patterns in search results and carrying them forward into future runs.
  * Enhanced prior-generation flow to include structural avoidance signals from past searches.

* **Bug Fixes**
  * Improved handling of repeated structures so common inner patterns are recognized more consistently.
  * Updated scoring to account for structural crowding, helping reduce repetitive outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->