### PR TITLE
Priority 3 Stage B+C: LLM-driven alpha search mutation proposer

### DIFF
--- a/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
+++ b/.github/workflows/factor-walk-forward-v2-hosted-artifact.yml
@@ -34,7 +34,7 @@ on:
       options_json:
         description: "Advanced options JSON: walk windows, factor filters, event-complete gates, replay parity, promotion gate, durable trace persistence, optional issue/config handoff"
         required: false
-        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","full_depth_execution_surface_json":"","full_depth_execution_surface_run_id":"","full_depth_execution_surface_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_zoo_snapshot_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"persist_research_trace":true,"dispatch_runtime_replay_requests":true,"strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
+        default: '{"train_window_days":2,"train_window_hours":"","test_window_days":1,"test_window_hours":"","step_days":1,"step_hours":"","lob_sample_secs":"","pm_book_sample_secs":"","observation_sample_secs":"","max_quote_age_secs":"","top_n":20,"min_observations":20,"top_quantile":0.2,"factor_name_filter":"","data_quality_mode":"event_complete","min_event_complete_events":20,"min_event_complete_rows":40,"replay_parity_json":"","replay_parity_run_id":"","replay_parity_artifact_name":"","candidate_strategy_replay_json":"","candidate_strategy_replay_run_id":"","candidate_strategy_replay_artifact_name":"","full_depth_execution_surface_json":"","full_depth_execution_surface_run_id":"","full_depth_execution_surface_artifact_name":"","alpha_search_plan_json":"","alpha_search_plan_run_id":"","alpha_search_plan_artifact_name":"","alpha_search_plan_target":"full_depth_settlement_executable_pnl","alpha_search_llm_prior_json":"","alpha_search_state_json":"","alpha_zoo_snapshot_json":"","alpha_search_min_reward_improvement":0.0,"chain_next_run":false,"chain_remaining":0,"required_strategy_profile":"settlement_probability","allowed_target":"full_depth_settlement_executable_pnl","issue_number":"","create_handoff_issue":false,"create_config_pr":false,"persist_research_trace":true,"dispatch_runtime_replay_requests":true,"enable_llm_expansion":false,"llm_expansion_provider":"anthropic","llm_expansion_model":"","strategy_config":"config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml","fail_if_blocked":false}'
       sweep_json:
         description: "Optional JSON array of walk-forward option overrides to run in one job after one download/build"
         required: false
@@ -124,10 +124,13 @@ jobs:
               "create_config_pr": "false",
               "persist_research_trace": "true",
               "dispatch_runtime_replay_requests": "true",
+              "enable_llm_expansion": "false",
+              "llm_expansion_provider": "anthropic",
+              "llm_expansion_model": "",
               "strategy_config": "config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
               "fail_if_blocked": "false",
           }
-          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "persist_research_trace", "dispatch_runtime_replay_requests", "fail_if_blocked", "require_deribit"}
+          bool_keys = {"chain_next_run", "create_handoff_issue", "create_config_pr", "persist_research_trace", "dispatch_runtime_replay_requests", "fail_if_blocked", "require_deribit", "enable_llm_expansion"}
           choices = {
               "report_suite": {"core", "full"},
               "data_quality_mode": {"strict_continuous", "event_complete"},
@@ -1088,6 +1091,42 @@ jobs:
             --output-prior-json "${prior_path}"
           if [ -f "${prior_path}" ]; then
             echo "Generated closed-loop typed prior at ${prior_path}."
+          fi
+
+      - name: Propose LLM-driven alpha search mutations
+        if: always()
+        env:
+          PLOY_RESEARCH_LLM_API_KEY: ${{ secrets.PLOY_RESEARCH_LLM_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ "${WALK_ENABLE_LLM_EXPANSION}" != "true" ]; then
+            echo "enable_llm_expansion is false; skipping real LLM-driven mutation proposal."
+            exit 0
+          fi
+          if [ ! -d artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2 ]; then
+            echo "No factor-walk-forward-v2 artifact directory found; skipping LLM proposal."
+            exit 0
+          fi
+          if [ -z "${PLOY_RESEARCH_LLM_API_KEY}" ]; then
+            echo "enable_llm_expansion is true but PLOY_RESEARCH_LLM_API_KEY is not configured; keeping the deterministic closed-loop prior unchanged."
+            exit 0
+          fi
+          target="${WALK_ALPHA_SEARCH_PLAN_TARGET}"
+          prior_path="artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2/alpha-search/${target}/next-llm-prior.json"
+          zoo_args=()
+          zoo_path="artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2/alpha-search/${target}/alpha-zoo-snapshot.json"
+          if [ -f "${zoo_path}" ]; then
+            zoo_args+=(--alpha-zoo-snapshot-json "${zoo_path}")
+          fi
+          PLOY_RESEARCH_LLM_PROVIDER="${WALK_LLM_EXPANSION_PROVIDER}" \
+          PLOY_RESEARCH_LLM_MODEL="${WALK_LLM_EXPANSION_MODEL}" \
+          python3 scripts/alpha_search_llm_propose.py \
+            artifacts/factor-walk-forward-v2-upload/factor-walk-forward-v2 \
+            --target "${target}" \
+            --output-prior-json "${prior_path}" \
+            "${zoo_args[@]}"
+          if [ -f "${prior_path}" ]; then
+            echo "LLM-proposed typed prior written to ${prior_path} (overrides the deterministic closed-loop prior when the model call succeeds)."
           fi
 
       - name: Summarize alpha search chain evidence

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -506,8 +506,35 @@ top-bucket diagnostics but cannot survive the executable runtime decision path.
 This is the current closed-loop boundary: a failed or stagnant search now
 produces a machine-readable next action and, when appropriate, a bounded typed
 prior draft using only the existing allowed mutation types. It still cannot
-guarantee profitability, does not call an external LLM, and cannot bypass
-walk-forward, promotion, replay parity, dry-run, or live approval gates.
+guarantee profitability and cannot bypass walk-forward, promotion, replay
+parity, dry-run, or live approval gates.
+
+## Real LLM Expansion
+
+The hosted artifact workflow can optionally replace the deterministic
+closed-loop prior with a real model-proposed typed prior. This is off by
+default. Enable it only on an explicit `workflow_dispatch` run by setting:
+
+```json
+{
+  "enable_llm_expansion": true,
+  "llm_expansion_provider": "anthropic",
+  "llm_expansion_model": ""
+}
+```
+
+The workflow also requires the repository secret
+`PLOY_RESEARCH_LLM_API_KEY`. If the flag is false, the secret is missing, the
+model call fails, optional artifact JSON is corrupt, or the model returns no
+mutations, the step exits successfully and leaves the deterministic
+`next-llm-prior.json` unchanged. A successful model response is still only a
+typed prior draft: Rust must compile it through the existing allowed
+`LlmMutationSpec` mutation types before any candidate is evaluated.
+
+When the provider returns usage data, the script writes
+`llm-expansion-usage.json` next to `next-llm-prior.json` in the alpha-search
+artifact directory. Treat that as per-run token accounting, not promotion
+evidence.
 
 ## FactorEvolve Research Manager V0
 
@@ -682,9 +709,10 @@ Current implementation status:
   `factor_registry` rows by root gene; `persist_research_trace
   --export-alpha-zoo-snapshot` produces it, and `factor_walk_forward_v2
   --alpha-zoo-snapshot-json <path>` consumes it. Omitting the flag is a no-op.
-- Not yet implemented: direct live LLM API invocation inside CI. The intended
-  boundary is still external LLM proposal -> reviewed typed JSON -> Rust DSL
-  compiler -> CI evaluation.
+- Implemented but opt-in: direct LLM API proposal inside hosted CI through
+  `scripts/alpha_search_llm_propose.py` and
+  `options_json.enable_llm_expansion=true`. It writes only a typed prior draft
+  and fails soft back to the deterministic closed-loop prior.
 
 The current system is enough to start systematizing alpha discovery in CI: every
 walk-forward run can now expand interpretable bounded multi-depth mutations,

--- a/scripts/alpha_search_llm_propose.py
+++ b/scripts/alpha_search_llm_propose.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Propose the next typed LLM-prior mutation batch via a real model call.
+
+This is the Priority 3 "genuine LLM-driven Expansion" script referenced in
+tasks/todo.md. It is deliberately separate from
+alpha_search_closed_loop_agent.py, which stays model-free and owns
+chain/promotion decisions (single responsibility per script).
+
+Stage B built prompt construction, response schema validation, and retry
+logic against an injectable `LlmClient` protocol, with zero real network
+calls in tests. Stage C (this file, current state) adds real provider
+implementations (`AnthropicLlmClient`, `OpenAiLlmClient`) that call the
+provider's HTTP API directly — never the Codex/Claude Code CLI, which is
+built for interactive, locally-authenticated sessions and would be fragile
+to wire into unattended CI. `client_from_env()` returns
+`UnconfiguredLlmClient` (which fails soft, matching how the search path
+already degrades when `--alpha-search-llm-prior-json` is omitted) unless
+`PLOY_RESEARCH_LLM_API_KEY` is set in the environment — so this script is a
+no-op everywhere until that secret is explicitly configured.
+
+The model is asked to produce entries shaped exactly like
+`LlmMutationSpec` (crates/ploy-research/src/autofactor.rs:238-255) inside a
+`next-llm-prior.json` file compatible with the existing
+`--alpha-search-llm-prior-json` flag, so no downstream Rust code needs to
+change: `compile_llm_mutation` already validates and compiles whatever
+lands there today. The proposal is never trusted blindly — it goes through
+the same JSON-schema-shaped validation as a hand-written prior file before
+being written out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Protocol
+
+try:
+    from alpha_search_closed_loop_agent import (
+        ALLOWED_MUTATIONS,
+        DIMENSION_TO_MUTATION,
+        DEFAULT_TARGET,
+        load_artifact,
+        selected_nodes,
+    )
+except ModuleNotFoundError:
+    from scripts.alpha_search_closed_loop_agent import (
+        ALLOWED_MUTATIONS,
+        DIMENSION_TO_MUTATION,
+        DEFAULT_TARGET,
+        load_artifact,
+        selected_nodes,
+    )
+
+
+# Fields accepted by LlmMutationSpec (crates/ploy-research/src/autofactor.rs:238-255).
+# Kept in sync by hand with that struct; a mismatch here fails validation loudly
+# rather than letting an unknown field silently pass through to the Rust compiler.
+REQUIRED_MUTATION_FIELDS = {"base_factor", "mutation_type"}
+OPTIONAL_MUTATION_FIELDS = {
+    "name",
+    "feature",
+    "denominator_feature",
+    "constant",
+    "lo",
+    "hi",
+    "window",
+}
+ALL_MUTATION_FIELDS = REQUIRED_MUTATION_FIELDS | OPTIONAL_MUTATION_FIELDS
+
+MAX_SCHEMA_RETRIES = 2
+
+
+class LlmClient(Protocol):
+    """Minimal seam between prompt construction and a real model call.
+
+    A production implementation calls the model provider's API directly
+    (not the Codex/Claude Code CLI — see tasks/todo.md Priority 3's
+    architecture-decision note on why CI should use a plain API key rather
+    than CLI auth). Tests inject a fake that returns canned responses so
+    prompt construction, schema validation, and retry logic can be verified
+    with zero network calls.
+    """
+
+    def propose(self, prompt: str) -> dict[str, Any]:
+        """Return a parsed JSON object matching the requested response schema."""
+        ...
+
+
+class UnconfiguredLlmClient:
+    """Default client: fails loudly instead of silently doing nothing.
+
+    Used whenever no provider API key is configured in the environment.
+    main() catches the resulting error and fails soft (see module docstring
+    on the fail-soft contract) rather than treating this as fatal.
+    """
+
+    def propose(self, prompt: str) -> dict[str, Any]:
+        raise RuntimeError(
+            "alpha_search_llm_propose has no LlmClient configured for a real "
+            "model call. Set PLOY_RESEARCH_LLM_API_KEY (and optionally "
+            "PLOY_RESEARCH_LLM_PROVIDER=anthropic|openai) to enable a real "
+            "provider call."
+        )
+
+
+# Response schema shared by both providers' structured-output / tool-calling
+# request, generated from the same field sets used by validate_response() so
+# the model is asked for exactly what will be accepted — not a hand-copied
+# third description of the same shape.
+def _mutation_json_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "mutations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "base_factor": {"type": "string"},
+                        "mutation_type": {
+                            "type": "string",
+                            "enum": sorted(ALLOWED_MUTATIONS),
+                        },
+                        "name": {"type": "string"},
+                        "feature": {"type": "string"},
+                        "denominator_feature": {"type": "string"},
+                        "constant": {"type": "number"},
+                        "lo": {"type": "number"},
+                        "hi": {"type": "number"},
+                        "window": {"type": "integer"},
+                    },
+                    "required": sorted(REQUIRED_MUTATION_FIELDS),
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["mutations"],
+        "additionalProperties": False,
+    }
+
+
+class AnthropicLlmClient:
+    """Real LlmClient backed by a direct Anthropic Messages API call.
+
+    Deliberately calls the HTTP API directly rather than the Claude Code
+    CLI: the CLI is built for interactive, locally-authenticated sessions,
+    and wiring its auth into unattended CI would be fragile and opaque
+    compared to a plain API key in a GitHub secret (see tasks/todo.md
+    Priority 3's architecture-decision note).
+
+    Uses tool-calling to force a structured response matching
+    _mutation_json_schema() — the model cannot return free text that would
+    need fragile parsing; the SDK/API either returns a well-formed tool
+    call or the request fails outright.
+    """
+
+    API_URL = "https://api.anthropic.com/v1/messages"
+    API_VERSION = "2023-06-01"
+    TOOL_NAME = "propose_mutations"
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "claude-sonnet-5",
+        timeout_secs: float = 60.0,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._timeout_secs = timeout_secs
+
+    def propose(self, prompt: str) -> dict[str, Any]:
+        import requests
+
+        response = requests.post(
+            self.API_URL,
+            headers={
+                "x-api-key": self._api_key,
+                "anthropic-version": self.API_VERSION,
+                "content-type": "application/json",
+            },
+            json={
+                "model": self._model,
+                "max_tokens": 2048,
+                "tools": [
+                    {
+                        "name": self.TOOL_NAME,
+                        "description": (
+                            "Propose bounded factor-formula mutations for the "
+                            "alpha search loop."
+                        ),
+                        "input_schema": _mutation_json_schema(),
+                    }
+                ],
+                "tool_choice": {"type": "tool", "name": self.TOOL_NAME},
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            timeout=self._timeout_secs,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        for block in payload.get("content", []):
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_input = block.get("input")
+                if isinstance(tool_input, dict):
+                    return tool_input
+        raise RuntimeError(
+            "Anthropic response contained no tool_use block with the "
+            f"expected tool name {self.TOOL_NAME!r}"
+        )
+
+
+class OpenAiLlmClient:
+    """Real LlmClient backed by a direct OpenAI Responses API call.
+
+    Same rationale as AnthropicLlmClient for calling the HTTP API directly
+    instead of the Codex CLI. Uses a JSON-schema-constrained structured
+    output request (`response_format`) rather than free-text parsing.
+    """
+
+    API_URL = "https://api.openai.com/v1/responses"
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gpt-5.5",
+        timeout_secs: float = 60.0,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._timeout_secs = timeout_secs
+
+    def propose(self, prompt: str) -> dict[str, Any]:
+        import requests
+
+        response = requests.post(
+            self.API_URL,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "content-type": "application/json",
+            },
+            json={
+                "model": self._model,
+                "input": prompt,
+                "text": {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "propose_mutations",
+                        "schema": _mutation_json_schema(),
+                        "strict": True,
+                    }
+                },
+            },
+            timeout=self._timeout_secs,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        output_text = _extract_openai_output_text(payload)
+        if output_text is None:
+            raise RuntimeError(
+                "OpenAI Responses API payload contained no output_text content"
+            )
+        parsed = json.loads(output_text)
+        if not isinstance(parsed, dict):
+            raise RuntimeError("OpenAI structured output did not decode to a JSON object")
+        return parsed
+
+
+def _extract_openai_output_text(payload: dict[str, Any]) -> str | None:
+    output = payload.get("output")
+    if not isinstance(output, list):
+        return None
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        for content in item.get("content", []):
+            if isinstance(content, dict) and content.get("type") == "output_text":
+                text = content.get("text")
+                if isinstance(text, str):
+                    return text
+    return None
+
+
+def client_from_env(env: dict[str, str]) -> LlmClient:
+    """Build a real client from environment variables, or fail soft.
+
+    Returns UnconfiguredLlmClient (which raises on use, caught by main()'s
+    fail-soft handling) when no API key is configured — this must never be
+    treated as fatal by a caller, matching how the search path already
+    degrades when --alpha-search-llm-prior-json is simply omitted.
+    """
+    api_key = env.get("PLOY_RESEARCH_LLM_API_KEY", "").strip()
+    if not api_key:
+        return UnconfiguredLlmClient()
+    provider = env.get("PLOY_RESEARCH_LLM_PROVIDER", "anthropic").strip().lower()
+    model = env.get("PLOY_RESEARCH_LLM_MODEL", "").strip()
+    if provider == "anthropic":
+        return AnthropicLlmClient(api_key, model=model or "claude-sonnet-5")
+    if provider == "openai":
+        return OpenAiLlmClient(api_key, model=model or "gpt-5.5")
+    raise RuntimeError(
+        f"PLOY_RESEARCH_LLM_PROVIDER={provider!r} is not supported; use "
+        "'anthropic' or 'openai'"
+    )
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a model response does not match the mutation schema."""
+
+
+def allowed_mutations_description() -> str:
+    """Render the allowed mutation-type list for the prompt.
+
+    Generated from the same ALLOWED_MUTATIONS set used for validation in
+    alpha_search_closed_loop_agent.py (which mirrors compile_llm_mutation's
+    match arms in autofactor.rs) rather than a hand-duplicated third copy,
+    so the prompt cannot silently drift out of sync with what the Rust
+    compiler actually accepts.
+    """
+    return ", ".join(sorted(ALLOWED_MUTATIONS))
+
+
+def weak_dimensions_summary(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Summarize weak search dimensions from mcts-expansion-plan.json.
+
+    Mirrors the same `selected_dimension` / `proposed_mutation` fields
+    alpha_search_closed_loop_agent.py's mutation_from_node() reads, so the
+    LLM sees the same weak-dimension signal the deterministic path already
+    uses to pick a default mutation type.
+    """
+    out = []
+    for node in selected_nodes(plan):
+        out.append(
+            {
+                "factor_name": node.get("factor_name"),
+                "selected_dimension": node.get("selected_dimension"),
+                "proposed_mutation": node.get("proposed_mutation"),
+                "reward": node.get("reward"),
+            }
+        )
+    return out
+
+
+def crowded_signatures_summary(avoided_subtrees: Any) -> list[dict[str, Any]]:
+    """Summarize batch-local Frequent-Subtree-Avoidance crowding, if present.
+
+    `avoided-subtrees.json` may not exist (older artifacts, or PR #728's
+    structural_signature() not yet merged) — treat absence as "no known
+    crowded shapes" rather than an error.
+    """
+    if not isinstance(avoided_subtrees, list):
+        return []
+    out = []
+    for item in avoided_subtrees:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("action") or "") != "penalize":
+            continue
+        out.append(
+            {
+                "root_gene": item.get("root_gene"),
+                "count": item.get("count"),
+                "reason": item.get("reason"),
+            }
+        )
+    return out
+
+
+def alpha_zoo_summary(alpha_zoo_snapshot: Any) -> list[dict[str, Any]]:
+    """Summarize an Alpha Zoo snapshot, if present.
+
+    The snapshot is optional input (--alpha-zoo-snapshot-json); when absent,
+    the LLM simply has no cross-run historical-crowding signal to avoid.
+    """
+    if not isinstance(alpha_zoo_snapshot, dict):
+        return []
+    entries = alpha_zoo_snapshot.get("entries")
+    if not isinstance(entries, list):
+        return []
+    out = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            out.append({"root_gene": entry.get("root_gene"), "count": entry.get("count")})
+    return out
+
+
+def build_prompt(
+    run: dict[str, Any],
+    alpha_zoo_snapshot: Any = None,
+    avoided_subtrees: Any = None,
+    mutation_limit: int = 6,
+) -> str:
+    """Build the prompt describing weak dimensions and known-crowded shapes.
+
+    Inputs are the run's own historical artifacts, not external user data,
+    so prompt-injection risk is low but not assumed zero: factor names and
+    human-written `notes` strings do flow through here. This function only
+    embeds structured, already-validated JSON artifact fields (never raw
+    free-text notes), which keeps the untrusted-content surface small.
+    """
+    payload = {
+        "task": (
+            "Propose up to "
+            f"{mutation_limit} bounded factor-formula mutations for the alpha "
+            "search loop. Each proposal must pick exactly one mutation_type "
+            "from the allowed list and reference an existing base_factor."
+        ),
+        "target": run.get("target"),
+        "allowed_mutation_types": allowed_mutations_description(),
+        "weak_dimensions": weak_dimensions_summary(run.get("plan") or {}),
+        "crowded_structural_shapes_within_batch": crowded_signatures_summary(
+            avoided_subtrees
+        ),
+        "crowded_root_genes_across_all_history": alpha_zoo_summary(alpha_zoo_snapshot),
+        "response_schema": {
+            "mutations": [
+                {
+                    "base_factor": "string, required, must match an existing factor name",
+                    "mutation_type": "string, required, one of allowed_mutation_types",
+                    "name": "string, optional",
+                    "feature": "string, optional",
+                    "denominator_feature": "string, optional",
+                    "constant": "number, optional",
+                    "lo": "number, optional",
+                    "hi": "number, optional",
+                    "window": "integer, optional",
+                }
+            ]
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def validate_response(response: Any) -> list[dict[str, Any]]:
+    """Validate a model response against the mutation schema.
+
+    Raises SchemaValidationError with a specific reason on any violation.
+    This is the fail-closed boundary: a response that doesn't match is
+    never partially accepted.
+    """
+    if not isinstance(response, dict):
+        raise SchemaValidationError("response must be a JSON object")
+    mutations = response.get("mutations")
+    if not isinstance(mutations, list):
+        raise SchemaValidationError("response.mutations must be a list")
+
+    validated: list[dict[str, Any]] = []
+    for index, item in enumerate(mutations):
+        if not isinstance(item, dict):
+            raise SchemaValidationError(f"mutations[{index}] must be an object")
+        unknown = sorted(set(item) - ALL_MUTATION_FIELDS)
+        if unknown:
+            raise SchemaValidationError(
+                f"mutations[{index}] has unknown fields: {', '.join(unknown)}"
+            )
+        missing = sorted(REQUIRED_MUTATION_FIELDS - set(item))
+        if missing:
+            raise SchemaValidationError(
+                f"mutations[{index}] missing required fields: {', '.join(missing)}"
+            )
+        base_factor = item.get("base_factor")
+        if not isinstance(base_factor, str) or not base_factor.strip():
+            raise SchemaValidationError(
+                f"mutations[{index}].base_factor must be a non-empty string"
+            )
+        mutation_type = item.get("mutation_type")
+        if mutation_type not in ALLOWED_MUTATIONS:
+            raise SchemaValidationError(
+                f"mutations[{index}].mutation_type {mutation_type!r} is not in "
+                f"the allowed set: {', '.join(sorted(ALLOWED_MUTATIONS))}"
+            )
+        for numeric_field in ("constant", "lo", "hi"):
+            if numeric_field in item and not isinstance(item[numeric_field], (int, float)):
+                raise SchemaValidationError(
+                    f"mutations[{index}].{numeric_field} must be numeric"
+                )
+        if "window" in item and not isinstance(item["window"], int):
+            raise SchemaValidationError(f"mutations[{index}].window must be an integer")
+        for string_field in ("name", "feature", "denominator_feature"):
+            if string_field in item and not isinstance(item[string_field], str):
+                raise SchemaValidationError(
+                    f"mutations[{index}].{string_field} must be a string"
+                )
+        validated.append(item)
+    return validated
+
+
+def propose_mutations(
+    client: LlmClient,
+    run: dict[str, Any],
+    alpha_zoo_snapshot: Any = None,
+    avoided_subtrees: Any = None,
+    mutation_limit: int = 6,
+    max_retries: int = MAX_SCHEMA_RETRIES,
+) -> list[dict[str, Any]]:
+    """Call the client and validate its response, retrying on schema failure.
+
+    Fails soft by design at the caller level (see main()): if every retry is
+    exhausted, this raises, and main() must catch that and proceed without a
+    fresh LLM prior — identical to today's behavior when
+    --alpha-search-llm-prior-json is simply omitted. LLM availability must
+    never become a hard gate on the deterministic search path.
+    """
+    prompt = build_prompt(
+        run,
+        alpha_zoo_snapshot=alpha_zoo_snapshot,
+        avoided_subtrees=avoided_subtrees,
+        mutation_limit=mutation_limit,
+    )
+    last_error: SchemaValidationError | None = None
+    for attempt in range(max_retries + 1):
+        response = client.propose(prompt)
+        try:
+            return validate_response(response)[:mutation_limit]
+        except SchemaValidationError as err:
+            last_error = err
+            if attempt < max_retries:
+                prompt = (
+                    f"{prompt}\n\nYour previous response was rejected: {err}. "
+                    "Return a corrected JSON object matching response_schema exactly."
+                )
+    assert last_error is not None
+    raise last_error
+
+
+def build_prior_from_mutations(
+    target: str, mutations: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Build a next-llm-prior.json payload shaped like build_prior()'s output.
+
+    Deliberately matches the schema alpha_search_closed_loop_agent.py's
+    build_prior() already produces (schema_version/kind/source/target/
+    mutations) so factor_walk_forward_v2.rs's read_llm_prior() and the
+    hosted workflow's prior-forwarding logic need no changes to accept
+    LLM-sourced mutations alongside deterministic ones.
+    """
+    return {
+        "schema_version": 1,
+        "kind": "typed_llm_prior_draft",
+        "source": "alpha_search_llm_propose",
+        "target": target,
+        "mutations": mutations,
+        "runtime_avoid_factors": [],
+    }
+
+
+def main(env: dict[str, str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact_dir", help="Downloaded alpha-search artifact directory")
+    parser.add_argument("--target", default=DEFAULT_TARGET)
+    parser.add_argument("--output-prior-json", required=True)
+    parser.add_argument("--mutation-limit", type=int, default=6)
+    parser.add_argument("--alpha-zoo-snapshot-json")
+    args = parser.parse_args()
+
+    run = load_artifact(Path(args.artifact_dir), args.target)
+    alpha_zoo_snapshot = None
+    if args.alpha_zoo_snapshot_json:
+        zoo_path = Path(args.alpha_zoo_snapshot_json)
+        if zoo_path.exists():
+            alpha_zoo_snapshot = json.loads(zoo_path.read_text(encoding="utf-8"))
+
+    alpha_root = run["root"] / "alpha-search" / args.target
+    avoided_subtrees_path = alpha_root / "avoided-subtrees.json"
+    avoided_subtrees = None
+    if avoided_subtrees_path.exists():
+        avoided_subtrees = json.loads(avoided_subtrees_path.read_text(encoding="utf-8"))
+
+    output_path = Path(args.output_prior_json)
+    client = client_from_env(env if env is not None else dict(os.environ))
+    try:
+        mutations = propose_mutations(
+            client,
+            run,
+            alpha_zoo_snapshot=alpha_zoo_snapshot,
+            avoided_subtrees=avoided_subtrees,
+            mutation_limit=max(1, args.mutation_limit),
+        )
+    except Exception as err:  # noqa: BLE001 - fail soft, never block the search path
+        print(f"alpha_search_llm_propose: no LLM prior produced ({err})")
+        return
+
+    prior = build_prior_from_mutations(args.target, mutations)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(prior, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"alpha_search_llm_propose: wrote {len(mutations)} mutation(s) to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/alpha_search_llm_propose.py
+++ b/scripts/alpha_search_llm_propose.py
@@ -169,6 +169,7 @@ class AnthropicLlmClient:
         self._api_key = api_key
         self._model = model
         self._timeout_secs = timeout_secs
+        self.last_usage: Any = None
 
     def propose(self, prompt: str) -> dict[str, Any]:
         import requests
@@ -200,6 +201,7 @@ class AnthropicLlmClient:
         )
         response.raise_for_status()
         payload = response.json()
+        self.last_usage = payload.get("usage")
         for block in payload.get("content", []):
             if isinstance(block, dict) and block.get("type") == "tool_use":
                 tool_input = block.get("input")
@@ -230,6 +232,7 @@ class OpenAiLlmClient:
         self._api_key = api_key
         self._model = model
         self._timeout_secs = timeout_secs
+        self.last_usage: Any = None
 
     def propose(self, prompt: str) -> dict[str, Any]:
         import requests
@@ -256,6 +259,7 @@ class OpenAiLlmClient:
         )
         response.raise_for_status()
         payload = response.json()
+        self.last_usage = payload.get("usage")
         output_text = _extract_openai_output_text(payload)
         if output_text is None:
             raise RuntimeError(
@@ -545,6 +549,26 @@ def build_prior_from_mutations(
     }
 
 
+def write_usage_artifact(
+    client: LlmClient, output_prior_path: Path, mutation_count: int
+) -> None:
+    usage = getattr(client, "last_usage", None)
+    if usage is None:
+        return
+    payload = {
+        "source": "alpha_search_llm_propose",
+        "client": client.__class__.__name__,
+        "model": getattr(client, "_model", None),
+        "mutation_count": mutation_count,
+        "usage": usage,
+    }
+    usage_path = output_prior_path.with_name("llm-expansion-usage.json")
+    usage_path.parent.mkdir(parents=True, exist_ok=True)
+    usage_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
 def main(env: dict[str, str] | None = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("artifact_dir", help="Downloaded alpha-search artifact directory")
@@ -554,22 +578,24 @@ def main(env: dict[str, str] | None = None) -> None:
     parser.add_argument("--alpha-zoo-snapshot-json")
     args = parser.parse_args()
 
-    run = load_artifact(Path(args.artifact_dir), args.target)
-    alpha_zoo_snapshot = None
-    if args.alpha_zoo_snapshot_json:
-        zoo_path = Path(args.alpha_zoo_snapshot_json)
-        if zoo_path.exists():
-            alpha_zoo_snapshot = json.loads(zoo_path.read_text(encoding="utf-8"))
-
-    alpha_root = run["root"] / "alpha-search" / args.target
-    avoided_subtrees_path = alpha_root / "avoided-subtrees.json"
-    avoided_subtrees = None
-    if avoided_subtrees_path.exists():
-        avoided_subtrees = json.loads(avoided_subtrees_path.read_text(encoding="utf-8"))
-
     output_path = Path(args.output_prior_json)
-    client = client_from_env(env if env is not None else dict(os.environ))
     try:
+        run = load_artifact(Path(args.artifact_dir), args.target)
+        alpha_zoo_snapshot = None
+        if args.alpha_zoo_snapshot_json:
+            zoo_path = Path(args.alpha_zoo_snapshot_json)
+            if zoo_path.exists():
+                alpha_zoo_snapshot = json.loads(zoo_path.read_text(encoding="utf-8"))
+
+        alpha_root = run["root"] / "alpha-search" / args.target
+        avoided_subtrees_path = alpha_root / "avoided-subtrees.json"
+        avoided_subtrees = None
+        if avoided_subtrees_path.exists():
+            avoided_subtrees = json.loads(
+                avoided_subtrees_path.read_text(encoding="utf-8")
+            )
+
+        client = client_from_env(env if env is not None else dict(os.environ))
         mutations = propose_mutations(
             client,
             run,
@@ -579,6 +605,12 @@ def main(env: dict[str, str] | None = None) -> None:
         )
     except Exception as err:  # noqa: BLE001 - fail soft, never block the search path
         print(f"alpha_search_llm_propose: no LLM prior produced ({err})")
+        return
+
+    write_usage_artifact(client, output_path, len(mutations))
+
+    if not mutations:
+        print("alpha_search_llm_propose: no LLM prior produced (empty mutation set)")
         return
 
     prior = build_prior_from_mutations(args.target, mutations)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22152,7 +22152,10 @@ further action is needed beyond noting the decision in
       `PLOY_RESEARCH_LLM_API_KEY` requires manual action by a repo admin, and
       a real dispatch has real model-API cost; both are deferred to an
       explicit follow-up decision rather than done silently here.
-- [ ] Stage D: docs + cost-accounting artifact.
+- [x] Stage D: docs + cost-accounting artifact. Documented opt-in hosted CI
+      usage in `docs/ALPHA_FACTOR_SEARCH_CICD.md` and writes
+      `llm-expansion-usage.json` next to `next-llm-prior.json` when the real
+      provider returns token usage.
 
 ## Review
 
@@ -22232,6 +22235,14 @@ further action is needed beyond noting the decision in
   check via `python3 -c "import yaml; yaml.safe_load(...)"`, `actionlint`
   (clean, zero findings) against the full workflow file, and `git diff
   --check`.
+- 2026-07-06: Closed the remaining PR review gaps after rebasing onto
+  `origin/main` post-#732. `alpha_search_llm_propose.py` now keeps artifact
+  loading inside the fail-soft boundary, leaves any deterministic prior
+  untouched when the model returns an empty mutation set, and records provider
+  usage in `llm-expansion-usage.json` when available. Added CLI happy-path,
+  empty-mutation, corrupt optional snapshot, and provider-usage tests.
+  Updated `docs/ALPHA_FACTOR_SEARCH_CICD.md` with the opt-in workflow usage
+  and current implemented status.
 - 2026-07-05: Priority 2 Stage A/B implemented. AutoFactor candidates and
   reports now carry explicit `parent_name` lineage, `tree-trace.json` records
   that parent, and `mcts-state.json` persists `parent_name` with

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21665,41 +21665,39 @@ Evidence stage: `factor_attribution` with `runtime_parity` gates.
   `rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs`,
   and `rtk git diff --check`.
 
-# Alpha Jungle Framework Gap Audit: Alpha Zoo, Tree Search, LLM Expansion (2026-07-04)
+# Formula-Factor Diversity: Structural Frequent-Subtree Avoidance (2026-07-04)
 
 ## Goal
 
-`crates/ploy-research/src/alpha_search.rs` implements a deterministic
-seed-search loop loosely modeled on "Navigating the Alpha Jungle", but three
-pieces of that paper's design are still missing or only partially wired:
+Upgrade the alpha-search diversity mechanism from a coarse, disconnected
+diagnostic into a real Frequent-Subtree-Avoidance (FSA) control that actually
+influences search behavior, matching the pattern in `Navigating the Alpha
+Jungle`. Current gap confirmed by reading `reward()`
+(`crates/ploy-research/src/alpha_search.rs:1204-1222`): it never references
+`avoided_subtrees()` or `root_gene` crowding, so `avoided-subtrees.json`'s
+`action: "penalize"` is currently write-only and has no effect on MCTS
+selection. `NodeMetric.diversity` (`alpha_search.rs:1058`) is also mislabeled:
+it is `1.0 / complexity` (simplicity), not structural novelty.
 
-- Alpha Zoo: a durable, cross-run repository of previously-accepted factors
-  that new candidates should be compared against for novelty (currently
-  missing; the existing `avoided_subtrees` / Frequent-Subtree Avoidance path
-  is batch-local only and does not persist across independent runs).
-- Full tree search (MCTS selection/expansion/backpropagation beyond the
-  current single-depth UCB ranking).
-- Deeper LLM-guided expansion beyond the current bounded typed-mutation prior.
-
-This audit tracks the gap by priority so each can be picked up as an
-independent, reviewable slice.
-
-Evidence stage: `factor_attribution` only. No promotion, dry-run, or live
-gates are touched by any of these priorities.
+Evidence stage: `factor_attribution` (search-layer change only; does not touch
+promotion gates, settlement, or runtime-parity contracts).
 
 ## Files / Ownership
 
 - `crates/ploy-research/src/alpha_search.rs`
-  - Owner: Alpha Zoo types, novelty penalty/score, reward and node-metric
-    wiring.
-- `crates/ploy-research/examples/persist_research_trace.rs`
-  - Owner: durable `factor_registry` export of the Alpha Zoo snapshot.
-- `crates/ploy-research/examples/factor_walk_forward_v2.rs`
-  - Owner: `--alpha-zoo-snapshot-json` CLI flag.
-- `crates/ploy-research/src/lib.rs`
-  - Owner: public exports for the new Alpha Zoo types.
+  - Owner: canonical structural fingerprint, persisted crowding state, real
+    reward wiring, renamed/split diversity vs simplicity metrics.
+- `crates/ploy-research/src/autofactor.rs`
+  - Owner: `FactorExpr` traversal helpers if canonicalization needs shared DSL
+    utilities.
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: surfacing persisted crowded/forbidden structural signatures into
+    the next `llm-priors.json` generation.
 - `docs/ALPHA_FACTOR_SEARCH_CICD.md`
-  - Owner: Alpha Zoo section and implementation-status bullet.
+  - Owner: correct the "penalize crowded or invalid subtrees" search-loop
+    description to match actually-wired behavior.
+- `tests/test_alpha_search_closed_loop_agent.py`
+  - Owner: Python-side coverage for forbidden-structure prior injection.
 - `tasks/todo.md`
   - Owner: current session tracking.
 
@@ -21735,30 +21733,504 @@ gates are touched by any of these priorities.
 
 ## Review
 
-- 2026-07-04: Priority 1 (Alpha Zoo wiring) implemented. `alpha_search.rs`
-  gained `AlphaZooSnapshot`/`AlphaZooEntry`, `alpha_zoo_novelty_penalty`
-  (threshold `5`, higher than Frequent-Subtree Avoidance's batch-local
-  threshold of `2`, since the zoo spans all historical runs), and
-  `alpha_zoo_novelty_score`, reusing the existing coarse `root_gene()`
-  fingerprint rather than the still-unmerged `structural_signature()` from PR
-  #728. `reward()` now subtracts the penalty at its real (non-test) call
-  sites in `write_alpha_search_artifacts_with_state_and_runtime_feedback` and
-  `node_metric()`; `write_alpha_search_artifacts_with_state` stays a thin
-  wrapper that passes `None`. `persist_research_trace.rs` gained a pure
-  `group_factor_registry_rows_into_alpha_zoo_snapshot` function (unit tested
-  with a synthetic `Vec<FactorRegistryRow>`, no sqlx/PgPool involved) plus a
-  thin `fetch_factor_registry_rows` sqlx wrapper and
-  `--export-alpha-zoo-snapshot` / `--export-alpha-zoo-target` flags.
-  `factor_walk_forward_v2.rs` gained `--alpha-zoo-snapshot-json`, following the
-  existing `--alpha-search-llm-prior-json` load-and-pass-`Some(&...)` pattern.
-  `root_gene` was made `pub` and re-exported from `lib.rs` so the export path
-  reuses the same fingerprint instead of duplicating it. Priorities 2 and 3
-  are out of scope for this slice and remain unchecked above.
-- 2026-07-04: Validation passed: `cargo test -p ploy-research alpha_search
-  --lib` (15 passed), `cargo test -p ploy-research --features db --example
-  persist_research_trace` (11 passed, including the new grouping test),
-  `cargo check -p ploy-research --features db --example factor_walk_forward_v2`,
-  `rustfmt --edition 2024 --check` on every touched Rust file, and `git diff
+(pending execution)
+
+# Alpha Jungle Framework Gap Audit: Alpha Zoo, Tree Search, LLM Expansion (2026-07-04)
+
+## Goal
+
+Audited the current alpha-search implementation against the five components
+of the `Navigating the Alpha Jungle` paper framework (Selection, Expansion,
+Multi-Dimensional Evaluation, Backpropagation, Alpha Zoo). FSA (this session's
+other tracked work, PR #728, still `OPEN`/unmerged at audit time) covers
+diversity scoring within a batch, but does not address these four remaining
+gaps. Evidence stage: `factor_attribution` design/architecture only; no code
+changed in this audit.
+
+Audit findings (see full detail in chat history 2026-07-04):
+
+- **Selection**: partial. `mcts_expansion_plan()`
+  (`crates/ploy-research/src/alpha_search.rs:1142-1187`) computes a
+  mathematically correct UCB1 score, but ranks a flat batch of candidates from
+  one run, not nodes in an explored tree. No `parent_id` exists on
+  `NodeMetric` or `MctsSelectedNode`.
+- **Expansion**: missing. No real LLM API call exists anywhere in the repo
+  (`crates/`, `scripts/`). All "mutation" generation, including the
+  `llm_prior` path, resolves to the same nine hardcoded transform types in
+  `deterministic_mutation_layer()` (`crates/ploy-research/src/autofactor.rs:1909`
+  onward). `docs/ALPHA_FACTOR_SEARCH_CICD.md:631-633` self-documents this as
+  "Not yet implemented: direct live LLM API invocation inside CI."
+- **Multi-Dimensional Evaluation**: mostly solid (`reward()`,
+  `crates/ploy-research/src/alpha_search.rs:1204-1222`, combines
+  effectiveness/stability/execution-cost/event-uniqueness/overfit-risk). Only
+  defect: pre-#728 `NodeMetric.diversity` duplicates `overfit_risk`
+  (`1.0/complexity`) instead of measuring structural novelty; resolved by
+  PR #728 Stage 3.
+- **Backpropagation**: missing. No parent/child edges are ever populated;
+  `TreeTraceNode.parent` is hardcoded `None` at its only write site
+  (`alpha_search.rs:506-515`). `mcts_search_state()`
+  (`alpha_search.rs:1093-1140`) only accumulates visits/reward per
+  `factor_name` string across CI runs — a multi-armed-bandit-style counter,
+  not tree backpropagation.
+- **Alpha Zoo**: missing entirely, the largest gap. The `factor_registry`
+  Postgres table (`crates/ploy-research/examples/persist_research_trace.rs:949-1017`)
+  is the closest analog — durably deduplicated by `(dsl_hash, target,
+  horizon)` — but no code path reads it back to score new candidates'
+  novelty against historical accepted factors. It is a record/audit mirror,
+  not a component the search loop queries. The closest active novelty signal,
+  `avoided_subtrees()`, only compares within a single run's batch and (pre-
+  #728) is not even wired into `reward()`.
+
+## Files / Ownership (future implementation, not yet started)
+
+- `crates/ploy-research/src/alpha_search.rs`
+  - Owner: tree-structured node state (parent/child edges), real
+    backpropagation, Alpha Zoo novelty scoring hook.
+- `crates/ploy-research/examples/persist_research_trace.rs`
+  - Owner: expose a read path from `factor_registry` for cross-run novelty
+    lookups (structural signature comparison against all historically
+    accepted factors, not just the current batch).
+- `crates/ploy-research/examples/factor_walk_forward_v2.rs`
+  - Owner: main search loop changes if expansion becomes tree-driven instead
+    of single-depth batch generation.
+- `scripts/alpha_search_closed_loop_agent.py`
+  - Owner: closed-loop decision/prior generation changes if a real LLM
+    expansion call is introduced.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: keep the "Implemented" / "Not yet implemented" status list honest
+    as each gap is closed; currently missing an explicit Alpha Zoo section.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks (priority order; each should land as its own atomic PR)
+
+- [x] Priority 1 — Alpha Zoo wiring: landed and merged in PR #729
+      (`feat/alpha-zoo-wiring`, merge commit `067dd916`). Added
+      `AlphaZooSnapshot`/`AlphaZooEntry`, `alpha_zoo_novelty_penalty()`/
+      `alpha_zoo_novelty_score()` wired into `reward()`/`node_metric()`, a
+      DB-independent `group_factor_registry_rows_into_alpha_zoo_snapshot()`
+      export in `persist_research_trace.rs`, and `--alpha-zoo-snapshot-json`
+      threaded through both `factor_walk_forward_v2.rs` and the hosted sweep
+      path (`scripts/run_factor_walk_forward_sweep.py` +
+      `factor-walk-forward-v2-hosted-artifact.yml`). Two Codex-review-caught
+      defects were fixed before merge: cross-target contamination (a
+      snapshot exported for one target penalized unrelated targets sharing a
+      root gene) and the missing hosted-sweep forwarding path. Still uses
+      the coarse `root_gene()` fingerprint pending PR #728's
+      `structural_signature()`.
+- [ ] Priority 2 — Tree-structured search state with real backpropagation.
+      Full design below.
+- [ ] Priority 3 — Genuine LLM-driven Expansion. Full design below;
+      requires an explicit architecture decision before implementation
+      starts (see "Architecture decision required").
+- [ ] Update `docs/ALPHA_FACTOR_SEARCH_CICD.md`: add an explicit Alpha Zoo
+      section (done in #729); correct the Selection/Backpropagation
+      completion-criteria language once Priority 2 lands so it doesn't
+      overstate what exists before that.
+- [ ] Re-run this gap audit against PR #728 once merged, to confirm the
+      Multi-Dimensional Evaluation `diversity` field fix and the FSA reward
+      wiring hold up together with the merged Alpha Zoo change.
+
+## Review
+
+- 2026-07-05: Priority 1 (Alpha Zoo) implemented via a background workflow
+  (implementer agent + independent adversarial reviewer agent), further
+  reviewed with `codex exec review --base origin/main`, which caught two real
+  defects (cross-target contamination, missing hosted-sweep flag forwarding)
+  before merge. Both fixed in follow-up commits, CI green (including
+  `Dependency audit`, which separately needed a `quinn-proto` bump to clear
+  RUSTSEC-2026-0185 — main's `Cargo.lock` doesn't yet have the fix from the
+  still-unmerged PR #728). Merged as PR #729. Priority 2 and 3 are
+  implementation plans only in this entry; no code written yet for either.
+
+---
+
+# Priority 2 Implementation Plan: Tree-Structured MCTS Backpropagation (2026-07-05)
+
+## Goal
+
+Replace the current flat, name-keyed candidate pool with genuine
+parent/child tree identity and real backpropagation, so `reward()` from
+evaluating a child candidate actually updates the cumulative statistics of
+its ancestors — not just its own counter. Today `mcts_search_state()`
+(`alpha_search.rs:1093-1140`) accumulates `visits`/`total_reward` per
+`factor_name` string across CI runs, which behaves like a multi-armed
+bandit over a fixed, flat set of arms — not a tree. `TreeTraceNode.parent`
+(`alpha_search.rs:163-181`) exists as a field but is hardcoded to `None` at
+its only write site. Evidence stage: `factor_attribution` only; no
+promotion/dry-run/live gates touched.
+
+## Key finding that simplifies this plan
+
+Candidate identity is *already* effectively stable and deterministic:
+`factor_name` is built deterministically from a base seed name plus a
+mutation suffix (`push_mutation` in `autofactor.rs:2054-2072` uses
+`mut_{seed.name}_{suffix}` / `mut2_{seed.name}_{suffix}`; the MCTS-guided
+branch in `domain_candidates_for_target_with_guidance`,
+`autofactor.rs:1686-1705`, renames to `mcts_`; `llm_prior_mutation_candidates`,
+`autofactor.rs:1713-1747`, uses `llm_{base.name}_{suffix}`). So this plan
+does **not** need to invent a new node-id scheme — `factor_name` already is
+one. What's missing is simply: nothing records *which* factor_name a given
+candidate was derived from. That's a much smaller gap than "build a tree
+identity system from scratch."
+
+## Design
+
+### Stage A — Capture parent lineage (plumbing only, no behavior change)
+
+- Add `parent_name: Option<String>` to `NamedFactorExpr`
+  (`crates/ploy-research/src/autofactor.rs:209-214`).
+- Set it at every site that derives a candidate from a `seed`/`base`:
+  `push_mutation` (`autofactor.rs:2054`), `compile_llm_mutation` call sites
+  inside `llm_prior_mutation_candidates` (`autofactor.rs:1713-1747`), and the
+  MCTS-guided expansion branch (`autofactor.rs:1686-1705`, which already has
+  `selected` candidates in scope to rename — thread the pre-rename name
+  through as `parent_name` before the `mcts_`/`mut_`/`mut2_` rename).
+  `domain_seed_candidates()` roots keep `parent_name: None`.
+- Thread `parent_name` through into `AutoFactorReport` (add the field; it
+  currently carries no lineage) so `alpha_search.rs`'s scoring code has
+  access to it by the time it builds `NodeMetric`.
+- Wire `TreeTraceNode.parent` (`alpha_search.rs:506-515`) to the new field
+  instead of hardcoding `None`.
+- Tests: for each derivation site (`push_mutation`, LLM-prior mutation,
+  MCTS-guided branch), assert the produced `NamedFactorExpr.parent_name`
+  matches the expected seed name. No reward/scoring behavior changes in this
+  stage — pure plumbing, safe to land alone.
+
+### Stage B — Real backpropagation
+
+- Add `parent_name: Option<String>` to `MctsSearchStateNode`
+  (`alpha_search.rs:63-71`) with `#[serde(default)]` so old `mcts-state.json`
+  artifacts without the field deserialize cleanly (missing parent = treated
+  as a root, which is the safe default — no silent backprop into an unknown
+  ancestor).
+- New function `fn backpropagate(nodes: &mut BTreeMap<String, MctsSearchStateNode>, leaf_name: &str, reward: f64)`:
+  walk `leaf_name`'s `parent_name` chain through the *already-merged* map
+  (which spans `prior_state` nodes + current batch, per the existing merge
+  logic at `alpha_search.rs:1128-1137`), adding `reward` to each ancestor's
+  `total_reward` and incrementing `visits`. Bound the walk (e.g. max depth
+  32, or track visited node names and stop on a repeat) as a defensive
+  measure against any future cycle, even though the derivation functions
+  should never produce one.
+- Call `backpropagate` for every leaf's evaluated `reward` inside
+  `mcts_search_state()`'s existing per-metric loop
+  (`alpha_search.rs:1139-1158`), after the leaf's own node is updated.
+- Tests: build a 3-generation synthetic chain (root -> `mut_root_x` ->
+  `mut2_root_x_y`), evaluate only the leaf with a known reward, assert the
+  root's `total_reward` increased by that amount and the middle node's did
+  too, while an unrelated sibling root's `total_reward` is unchanged.
+
+### Reconciling with `chain_next_run`/`chain_remaining`
+
+This is simpler than originally scoped: `chain_next_run`/`chain_remaining`
+operate purely at the CI-dispatch level (deciding whether to trigger another
+`workflow_dispatch`, tracked in `factor-walk-forward-v2-hosted-artifact.yml:960-1067`)
+and never inspect `mcts-state.json`'s internal node shape — they only check
+`search-feedback.json`'s `best_reward` field for stagnation. Since
+backpropagation is computed purely as a function of (current batch reports +
+the `prior_state` map already threaded through `--alpha-search-state-json`),
+it fits inside the existing single-artifact cross-run transport with no
+changes needed to the chain-decision logic itself. No redesign of the
+chaining mechanism is required — confirmed lower risk than originally
+flagged.
+
+### Stage C (optional refinement, separate PR)
+
+- Feed ancestor average reward into `mcts_expansion_plan()`'s UCB ranking
+  (`alpha_search.rs:1172-1187`) as a tie-breaker or eligibility filter — e.g.
+  don't select a node for expansion if its parent chain's average reward is
+  deeply negative, to avoid sinking search budget into a provably bad
+  lineage. This is additive and can be deferred without blocking Stage A/B.
+
+### Risks to verify during implementation
+
+- Depth-prefix parsing (`mut`/`mut2`) is currently used to label mutation
+  depth in `push_mutation` (`autofactor.rs:2062`), but the MCTS-guided branch
+  calls `deterministic_mutation_layer(..., depth=3)`
+  (`autofactor.rs:1693`) while still only distinguishing `mut`/`mut2` by
+  prefix — once `parent_name` exists as the source of truth for lineage,
+  confirm depth-based naming logic doesn't need to change in lockstep, or
+  decide to keep name-prefix depth labeling as purely cosmetic/legacy since
+  the real depth is now derivable by walking `parent_name`.
+- Name collisions across independent seeds producing the same mutated name
+  are an existing risk (since `factor_name` was already the sole dedup key
+  pre-this-change) — not newly introduced, but worth a regression test once
+  parent-chain walking exists, since a collision would now also corrupt
+  backpropagation (reward flowing to the wrong ancestor).
+
+## Files / Ownership
+
+- `crates/ploy-research/src/autofactor.rs` — `NamedFactorExpr.parent_name`,
+  lineage capture at all derivation sites, `AutoFactorReport.parent_name`.
+- `crates/ploy-research/src/alpha_search.rs` — `MctsSearchStateNode.parent_name`,
+  `backpropagate()`, wiring `TreeTraceNode.parent`, tests.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md` — update the MCTS search-loop pseudocode
+  and completion-criteria language once Stage B lands.
+- `tasks/todo.md` — current session tracking.
+
+## Tasks
+
+- [ ] Stage A: add `parent_name` plumbing (`NamedFactorExpr`,
+      `AutoFactorReport`, wire `TreeTraceNode.parent`), with derivation-site
+      tests. No behavior change; land as its own PR.
+- [ ] Stage B: add `MctsSearchStateNode.parent_name` (`#[serde(default)]`),
+      implement and wire `backpropagate()`, add 3-generation chain test plus
+      a name-collision regression test. Land as its own PR.
+- [ ] Stage C (optional, separate PR): ancestor-average-reward-aware UCB
+      eligibility filter in `mcts_expansion_plan()`.
+- [ ] Update `docs/ALPHA_FACTOR_SEARCH_CICD.md` MCTS section to match.
+- [ ] Run focused validation per stage: `cargo test -p ploy-research
+      alpha_search --lib`, `cargo test -p ploy-research autofactor --lib`,
+      `rustfmt --edition 2024 --check`, `git diff --check`.
+
+## Review
+
+(pending implementation — plan only, no code written)
+
+---
+
+# Priority 3 Implementation Plan: Genuine LLM-Driven Expansion (2026-07-05)
+
+## Goal
+
+Replace the current stand-in — where `LlmMutationSpec` JSON is either
+hand-written or produced by a local, model-free Python script
+(`scripts/alpha_search_closed_loop_agent.py`, which its own file header
+states "does not call an LLM") — with a real model API call that proposes
+bounded mutations, validated through the exact same fail-closed Rust
+compiler (`compile_llm_mutation`, `autofactor.rs:1749-1861`) as today. No
+code in this plan should be written until the architecture decision below
+is confirmed with the user.
+
+Evidence stage: `factor_attribution` only. Does not touch promotion,
+dry-run, or live trading gates — the LLM only ever *proposes* which bounded
+transform to try; the existing allowlisted `mutation_type` match arms in
+`compile_llm_mutation` remain the sole source of truth for what can actually
+be compiled into a `FactorExpr`.
+
+## Architecture decision required (stop-and-ask point)
+
+Two options, not a false choice — either is defensible:
+
+1. **Real API call from CI**, direct HTTP to the model provider (Anthropic
+   or OpenAI Responses API), *not* the Codex/Claude Code CLI. The CLIs are
+   built for interactive, locally-authenticated sessions; wiring their auth
+   into unattended CI is fragile and opaque compared to a plain API key in
+   a GitHub secret. This preserves the existing safety boundary
+   (`docs/ALPHA_FACTOR_SEARCH_CICD.md`'s stated principle: "no free-form
+   code generation in the search loop") because the model still only ever
+   emits typed JSON matching `LlmMutationSpec`, validated by the same
+   allowlist as a hand-written prior file today — nothing about the trust
+   boundary changes, only who/what authors the JSON.
+2. **Keep the current bounded-template architecture permanently** and treat
+   this as explicitly out of scope. This is a legitimate outcome, not a
+   failure to implement — the team already chose determinism/auditability
+   over generative breadth once; re-confirming that choice is cheaper than
+   building and then not using this.
+
+This plan assumes option 1 is chosen; if option 2 is chosen instead, no
+further action is needed beyond noting the decision in
+`docs/ALPHA_FACTOR_SEARCH_CICD.md`.
+
+## Design (if option 1 is approved)
+
+### Secrets and CI plumbing
+
+- New repository secret (e.g. `PLOY_RESEARCH_LLM_API_KEY`), scoped to
+  `factor-walk-forward-v2-hosted-artifact.yml` only — confirmed via grep
+  that no workflow in this repo currently references any LLM provider
+  secret, so this is a new secret category, not an extension of an
+  existing one.
+- New workflow input `enable_llm_expansion` (default `false`), so existing
+  and in-flight chained runs are entirely unaffected unless explicitly
+  opted into on a given `workflow_dispatch`.
+- New script `scripts/alpha_search_llm_propose.py` (kept separate from
+  `alpha_search_closed_loop_agent.py`, which stays model-free and handles
+  chain/promotion decisions — single responsibility per script):
+  - Reads the current run's `search-feedback.json`, `avoided-subtrees.json`
+    (once PR #728 merges), and/or the Alpha Zoo snapshot, plus the weak
+    dimension signal already computed by `selected_dimension()`
+    (`alpha_search.rs:1293-1323`).
+  - Builds a prompt describing weak dimensions and known-crowded structural
+    shapes to avoid.
+  - Calls the model with a JSON-schema-constrained response (tool-calling /
+    structured output, matching `LlmMutationSpec`'s exact fields) so the
+    model cannot return free text that needs fragile parsing.
+  - Bounded retries (e.g. 2) on schema-validation failure.
+  - Writes to the same `next-llm-prior.json` location the existing
+    `--alpha-search-llm-prior-json` flag already reads
+    (`factor_walk_forward_v2.rs`), so no downstream Rust code changes are
+    needed — `compile_llm_mutation` already validates and compiles whatever
+    lands there today.
+
+### Cost / failure handling
+
+- Fail soft: if the API call errors (timeout, rate limit, invalid key), log
+  a warning and proceed without a fresh LLM prior — identical to today's
+  behavior when `--alpha-search-llm-prior-json` is simply omitted. This
+  must never become a `fail_if_blocked`-style hard gate; LLM availability
+  should not be able to stall the deterministic search path.
+- Add a small `llm-expansion-usage.json` artifact recording token
+  count/cost per run — this is the first place in the alpha-search pipeline
+  with a real per-run dollar cost (mutation templates are free), so it
+  should be visible, not implicit.
+
+### Keeping the prompt's allowed-mutation list in sync
+
+- Generate the "allowed mutation types" description in the prompt
+  programmatically from the same source list already used for validation
+  (`ALLOWED_MUTATIONS` in `scripts/alpha_search_closed_loop_agent.py:29-39`,
+  which already mirrors `compile_llm_mutation`'s match arms) rather than
+  hand-duplicating the list a third time. If a new `mutation_type` is ever
+  added to `compile_llm_mutation`, the prompt should not silently drift out
+  of sync with what the Rust compiler actually accepts.
+
+### Stages
+
+- Stage A: confirm option 1 vs 2 with the user (this document is the input
+  to that conversation, not a decision already made).
+- Stage B: build `scripts/alpha_search_llm_propose.py` against a mocked API
+  client; unit-test prompt construction, schema validation, and retry logic
+  entirely offline — no real API call in CI or in tests at this stage.
+- Stage C: wire the real API call behind `enable_llm_expansion` + the new
+  secret; validate on one manual `workflow_dispatch` run with the flag on;
+  confirm the produced `next-llm-prior.json` compiles cleanly through the
+  existing, unchanged Rust pipeline.
+- Stage D: docs update (`docs/ALPHA_FACTOR_SEARCH_CICD.md`'s "Not yet
+  implemented: direct live LLM API invocation inside CI" line moves to
+  "Implemented"), cost-accounting artifact.
+
+## Risks
+
+- Prompt injection: inputs are the run's own historical artifacts (not
+  external user data), so risk is low but not zero — factor names and
+  human-written `notes` strings do flow into the prompt; sanitize/escape
+  before inclusion.
+- Schema drift between the Python prompt description and the Rust
+  compiler's actual accepted `mutation_type` values — mitigated by
+  generating the prompt's allowed-list from the same source list used for
+  validation (see above), not by hand-copying.
+- Recurring real cost: default `enable_llm_expansion` to `false` and only
+  enable it on manually dispatched runs — confirmed the workflow's only
+  trigger is `workflow_dispatch` (no scheduled/cron trigger exists in this
+  repo), so there is no risk of this silently running unattended on a
+  schedule once enabled.
+
+## Files / Ownership
+
+- `scripts/alpha_search_llm_propose.py` (new) — prompt construction, API
+  call, schema validation, retry logic.
+- `.github/workflows/factor-walk-forward-v2-hosted-artifact.yml` —
+  `enable_llm_expansion` input, secret wiring, invocation step.
+- `scripts/alpha_search_closed_loop_agent.py` — no logic changes expected;
+  stays model-free per its existing stated design.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md` — status list update once Stage C
+  lands.
+- `tasks/todo.md` — current session tracking.
+
+## Tasks
+
+- [x] Stage A: user confirmed option 1 (build genuine LLM-driven Expansion)
+      over option 2 (keep bounded-template architecture permanently).
+- [x] Stage B: built and unit-tested `scripts/alpha_search_llm_propose.py`
+      against a mocked `LlmClient`. No real network call exists yet — the
+      default `UnconfiguredLlmClient` raises, and `main()` catches that and
+      fails soft (prints a message, writes no output file), matching how
+      the search path already degrades when
+      `--alpha-search-llm-prior-json` is simply omitted.
+- [x] Stage C: wired real provider calls (`AnthropicLlmClient`,
+      `OpenAiLlmClient` in `scripts/alpha_search_llm_propose.py`) behind
+      `client_from_env()`, which returns `UnconfiguredLlmClient` (fail-soft)
+      unless `PLOY_RESEARCH_LLM_API_KEY` is set. Added `enable_llm_expansion`
+      (default `false`) / `llm_expansion_provider` / `llm_expansion_model` to
+      `factor-walk-forward-v2-hosted-artifact.yml`'s `options_json` schema and
+      a new "Propose LLM-driven alpha search mutations" step that calls the
+      script only when the flag is on and the secret resolves to a non-empty
+      value; otherwise it exits 0 and leaves the deterministic closed-loop
+      prior untouched. No GitHub secret was created and no real
+      `workflow_dispatch` was triggered in this pass — creating
+      `PLOY_RESEARCH_LLM_API_KEY` requires manual action by a repo admin, and
+      a real dispatch has real model-API cost; both are deferred to an
+      explicit follow-up decision rather than done silently here.
+- [ ] Stage D: docs + cost-accounting artifact.
+
+## Review
+
+- 2026-07-05: Stage B implemented. `scripts/alpha_search_llm_propose.py`
+  reuses `load_artifact()`, `ALLOWED_MUTATIONS`, and `DIMENSION_TO_MUTATION`
+  from `alpha_search_closed_loop_agent.py` rather than duplicating artifact-
+  loading or mutation-type logic. Prompt construction embeds only
+  structured, already-validated JSON fields (weak dimensions from
+  `mcts-expansion-plan.json`, batch-local crowding from
+  `avoided-subtrees.json` when present, cross-run crowding from an Alpha
+  Zoo snapshot when present) — never raw free-text `notes` strings, to keep
+  the prompt-injection surface small. `validate_response()` fail-closes on
+  unknown fields, missing required fields, non-allowlisted
+  `mutation_type`, and wrong value types; `propose_mutations()` retries up
+  to `MAX_SCHEMA_RETRIES` (2) with the rejection reason appended to the
+  prompt before giving up. `build_prior_from_mutations()` emits the same
+  `schema_version`/`kind`/`source`/`target`/`mutations` shape
+  `build_prior()` already produces, so `factor_walk_forward_v2.rs`'s
+  `read_llm_prior()` and the hosted workflow's existing prior-forwarding
+  path need no changes to accept LLM-sourced mutations. Added
+  `tests/test_alpha_search_llm_propose.py` (20 tests: prompt construction,
+  schema validation edge cases, retry/exhaustion behavior, mutation-limit
+  truncation, and a `main()` integration test proving the unconfigured
+  default fails soft without writing a partial file). Validation passed:
+  `python3 -m py_compile scripts/alpha_search_llm_propose.py
+  tests/test_alpha_search_llm_propose.py`,
+  `python3 -m unittest tests.test_alpha_search_closed_loop_agent
+  tests.test_factor_walk_forward_sweep tests.test_alpha_search_llm_propose`
+  (72 tests, all pass), and `git diff --check`. No CI workflow, secret, or
+  `docs/ALPHA_FACTOR_SEARCH_CICD.md` changes in this stage — Stage C is the
+  first stage that touches CI plumbing.
+- 2026-07-05: Stage C implemented in a fresh worktree/branch
+  (`feat/llm-expansion-stage-c`, based on `origin/main` post-#729) because the
+  main checkout's working tree was stale relative to `origin/main` (missing
+  PR #729's `alpha_zoo_snapshot_json` field) and carried unrelated
+  in-progress user changes that should not be touched. Added
+  `AnthropicLlmClient` (direct Messages API call with a forced `tool_use`
+  matching a JSON schema generated from the same `ALLOWED_MUTATIONS`/
+  `REQUIRED_MUTATION_FIELDS` sets used by `validate_response()`, never a
+  hand-duplicated third copy) and `OpenAiLlmClient` (direct Responses API
+  call with `text.format.type: "json_schema"` + `strict: true`) to
+  `scripts/alpha_search_llm_propose.py`. Both call the provider's HTTP API
+  directly — never the Codex/Claude Code CLI, which is built for
+  interactive, locally-authenticated sessions and would be fragile to wire
+  into unattended CI. `client_from_env()` selects a client from
+  `PLOY_RESEARCH_LLM_API_KEY`/`PLOY_RESEARCH_LLM_PROVIDER`/
+  `PLOY_RESEARCH_LLM_MODEL` and returns `UnconfiguredLlmClient` (fail-soft)
+  when no key is set, so `main()`'s existing fail-soft handling covers the
+  unconfigured case without new logic. Structured-output enforcement is a
+  correctness aid, not a substitute for validation — `validate_response()`
+  still runs on whatever the provider returns, since schema-shape validity
+  doesn't guarantee semantic validity (e.g. a syntactically valid
+  `base_factor` that doesn't reference a real factor). Added 11 new tests
+  (`AnthropicLlmClientTests`, `OpenAiLlmClientTests`, `ClientFromEnvTests`),
+  all mocking `requests.post` — zero real network calls. Wired
+  `enable_llm_expansion` (default `false`) / `llm_expansion_provider` /
+  `llm_expansion_model` into `factor-walk-forward-v2-hosted-artifact.yml`'s
+  `options_json` defaults dict and `bool_keys` set (the existing generic
+  `WALK_{key.upper()}` env-var-emission loop picked up the three new keys
+  with no further code changes needed), and added a new "Propose LLM-driven
+  alpha search mutations" step placed after the existing deterministic
+  "Classify alpha search closed-loop action" step: it only overwrites
+  `next-llm-prior.json` when `enable_llm_expansion=true` and
+  `PLOY_RESEARCH_LLM_API_KEY` resolves to a non-empty secret; any other case
+  exits 0 and leaves the deterministic prior from the closed-loop agent
+  untouched, so LLM unavailability can never block the search path.
+  Deliberately not done in this pass: creating the actual
+  `PLOY_RESEARCH_LLM_API_KEY` GitHub secret (requires a repo admin, and the
+  value must never be chosen or seen by an agent) and triggering a real
+  `workflow_dispatch` with the flag on (real model-API cost) — both are
+  follow-up actions for a human to take deliberately, not something to do
+  silently while implementing the code path. Validation passed:
+  `python3 -m py_compile scripts/alpha_search_llm_propose.py
+  tests/test_alpha_search_llm_propose.py`, `python3 -m unittest
+  tests.test_alpha_search_llm_propose tests.test_alpha_search_closed_loop_agent
+  tests.test_factor_walk_forward_sweep` (85 tests, all pass), YAML syntax
+  check via `python3 -c "import yaml; yaml.safe_load(...)"`, `actionlint`
+  (clean, zero findings) against the full workflow file, and `git diff
   --check`.
 - 2026-07-05: Priority 2 Stage A/B implemented. AutoFactor candidates and
   reports now carry explicit `parent_name` lineage, `tree-trace.json` records

--- a/tests/test_alpha_search_llm_propose.py
+++ b/tests/test_alpha_search_llm_propose.py
@@ -1,0 +1,503 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import alpha_search_llm_propose as propose
+from scripts.alpha_search_closed_loop_agent import ALLOWED_MUTATIONS
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def artifact(
+    root: Path,
+    *,
+    target: str = "full_depth_settlement_executable_pnl",
+    selected_nodes: list[dict] | None = None,
+    avoided_subtrees: list[dict] | None = None,
+) -> Path:
+    factor_root = root / "factor-walk-forward-v2"
+    alpha_root = factor_root / "alpha-search" / target
+    write_json(
+        alpha_root / "search-feedback.json",
+        {
+            "target": target,
+            "candidate_count": 4,
+            "best_candidate": "auto_settlement_full_depth_settlement_edge",
+            "best_reward": 1.25,
+        },
+    )
+    write_json(
+        alpha_root / "mcts-expansion-plan.json",
+        {
+            "target": target,
+            "selected_nodes": selected_nodes
+            if selected_nodes is not None
+            else [
+                {
+                    "factor_name": "auto_settlement_full_depth_settlement_edge",
+                    "selected_dimension": "execution_quality",
+                    "proposed_mutation": "add_capacity_gate",
+                    "reward": 0.8,
+                }
+            ],
+        },
+    )
+    write_json(
+        alpha_root / "search-space.json",
+        {
+            "target": target,
+            "feature_pool": ["entry_capacity_score", "side_spread"],
+        },
+    )
+    write_json(
+        factor_root / "autofactor-strategy-handoff.json",
+        {"status": "blocked", "recommended_action": "do_not_promote"},
+    )
+    write_json(
+        factor_root / "autofactor-strategy-promotion.json",
+        {"decision": "blocked", "evaluated_factors": []},
+    )
+    if avoided_subtrees is not None:
+        write_json(alpha_root / "avoided-subtrees.json", avoided_subtrees)
+    write_json(
+        root / "alpha-search-chain" / "chain-decision.json",
+        {"current_run_id": "1000000001"},
+    )
+    return root
+
+
+class FakeClient:
+    """Returns a queued sequence of canned responses, one per call."""
+
+    def __init__(self, responses: list[dict]) -> None:
+        self._responses = list(responses)
+        self.calls: list[str] = []
+
+    def propose(self, prompt: str) -> dict:
+        self.calls.append(prompt)
+        return self._responses.pop(0)
+
+
+class BuildPromptTests(unittest.TestCase):
+    def test_prompt_lists_allowed_mutations_from_shared_constant(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+            run = load_artifact(path, DEFAULT_TARGET)
+            prompt = propose.build_prompt(run)
+
+        payload = json.loads(prompt)
+        listed = set(payload["allowed_mutation_types"].split(", "))
+        self.assertEqual(listed, ALLOWED_MUTATIONS)
+
+    def test_prompt_includes_weak_dimensions_from_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                selected_nodes=[
+                    {
+                        "factor_name": "auto_settlement_x",
+                        "selected_dimension": "overfit_risk",
+                        "proposed_mutation": "remove_component",
+                        "reward": -0.2,
+                    }
+                ],
+            )
+            from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+            run = load_artifact(path, DEFAULT_TARGET)
+            prompt = propose.build_prompt(run)
+
+        payload = json.loads(prompt)
+        self.assertEqual(len(payload["weak_dimensions"]), 1)
+        self.assertEqual(payload["weak_dimensions"][0]["factor_name"], "auto_settlement_x")
+        self.assertEqual(payload["weak_dimensions"][0]["selected_dimension"], "overfit_risk")
+
+    def test_prompt_includes_crowded_structural_shapes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+            run = load_artifact(path, DEFAULT_TARGET)
+            avoided = [
+                {"root_gene": "SafeDiv", "count": 4, "action": "penalize", "reason": "x"},
+                {"root_gene": "Add", "count": 1, "action": "keep", "reason": "y"},
+            ]
+            prompt = propose.build_prompt(run, avoided_subtrees=avoided)
+
+        payload = json.loads(prompt)
+        shapes = payload["crowded_structural_shapes_within_batch"]
+        self.assertEqual(len(shapes), 1)
+        self.assertEqual(shapes[0]["root_gene"], "SafeDiv")
+
+    def test_prompt_includes_alpha_zoo_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+            run = load_artifact(path, DEFAULT_TARGET)
+            zoo = {
+                "version": "alpha_zoo_v1",
+                "target": "full_depth_settlement_executable_pnl",
+                "entries": [{"root_gene": "Mul", "count": 12}],
+            }
+            prompt = propose.build_prompt(run, alpha_zoo_snapshot=zoo)
+
+        payload = json.loads(prompt)
+        entries = payload["crowded_root_genes_across_all_history"]
+        self.assertEqual(entries, [{"root_gene": "Mul", "count": 12}])
+
+    def test_prompt_omits_alpha_zoo_summary_when_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+            run = load_artifact(path, DEFAULT_TARGET)
+            prompt = propose.build_prompt(run)
+
+        payload = json.loads(prompt)
+        self.assertEqual(payload["crowded_root_genes_across_all_history"], [])
+
+
+class ValidateResponseTests(unittest.TestCase):
+    def test_accepts_a_well_formed_response(self) -> None:
+        response = {
+            "mutations": [
+                {
+                    "base_factor": "auto_settlement_x",
+                    "mutation_type": "add_capacity_gate",
+                    "feature": "entry_capacity_score",
+                }
+            ]
+        }
+        validated = propose.validate_response(response)
+        self.assertEqual(len(validated), 1)
+        self.assertEqual(validated[0]["base_factor"], "auto_settlement_x")
+
+    def test_rejects_non_dict_response(self) -> None:
+        with self.assertRaises(propose.SchemaValidationError):
+            propose.validate_response(["not", "a", "dict"])
+
+    def test_rejects_missing_mutations_list(self) -> None:
+        with self.assertRaises(propose.SchemaValidationError):
+            propose.validate_response({})
+
+    def test_rejects_unknown_mutation_type(self) -> None:
+        response = {
+            "mutations": [
+                {"base_factor": "auto_settlement_x", "mutation_type": "delete_everything"}
+            ]
+        }
+        with self.assertRaises(propose.SchemaValidationError) as ctx:
+            propose.validate_response(response)
+        self.assertIn("not in the allowed set", str(ctx.exception))
+
+    def test_rejects_missing_required_field(self) -> None:
+        response = {"mutations": [{"mutation_type": "add_capacity_gate"}]}
+        with self.assertRaises(propose.SchemaValidationError) as ctx:
+            propose.validate_response(response)
+        self.assertIn("missing required fields", str(ctx.exception))
+
+    def test_rejects_unknown_field(self) -> None:
+        response = {
+            "mutations": [
+                {
+                    "base_factor": "auto_settlement_x",
+                    "mutation_type": "add_capacity_gate",
+                    "unexpected_field": "value",
+                }
+            ]
+        }
+        with self.assertRaises(propose.SchemaValidationError) as ctx:
+            propose.validate_response(response)
+        self.assertIn("unknown fields", str(ctx.exception))
+
+    def test_rejects_non_numeric_constant(self) -> None:
+        response = {
+            "mutations": [
+                {
+                    "base_factor": "auto_settlement_x",
+                    "mutation_type": "add_spread_penalty",
+                    "constant": "not-a-number",
+                }
+            ]
+        }
+        with self.assertRaises(propose.SchemaValidationError):
+            propose.validate_response(response)
+
+    def test_rejects_non_integer_window(self) -> None:
+        response = {
+            "mutations": [
+                {
+                    "base_factor": "auto_settlement_x",
+                    "mutation_type": "change_time_window",
+                    "window": 30.5,
+                }
+            ]
+        }
+        with self.assertRaises(propose.SchemaValidationError):
+            propose.validate_response(response)
+
+
+class ProposeMutationsTests(unittest.TestCase):
+    def _run(self, tmp: str):
+        from scripts.alpha_search_closed_loop_agent import DEFAULT_TARGET, load_artifact
+
+        path = artifact(Path(tmp))
+        return load_artifact(path, DEFAULT_TARGET)
+
+    def test_returns_validated_mutations_on_first_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self._run(tmp)
+            client = FakeClient(
+                [
+                    {
+                        "mutations": [
+                            {
+                                "base_factor": "auto_settlement_full_depth_settlement_edge",
+                                "mutation_type": "add_capacity_gate",
+                                "feature": "entry_capacity_score",
+                            }
+                        ]
+                    }
+                ]
+            )
+            mutations = propose.propose_mutations(client, run)
+
+        self.assertEqual(len(mutations), 1)
+        self.assertEqual(len(client.calls), 1)
+
+    def test_retries_on_schema_failure_then_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self._run(tmp)
+            client = FakeClient(
+                [
+                    {"mutations": [{"mutation_type": "add_capacity_gate"}]},  # missing base_factor
+                    {
+                        "mutations": [
+                            {
+                                "base_factor": "auto_settlement_full_depth_settlement_edge",
+                                "mutation_type": "add_capacity_gate",
+                            }
+                        ]
+                    },
+                ]
+            )
+            mutations = propose.propose_mutations(client, run, max_retries=2)
+
+        self.assertEqual(len(mutations), 1)
+        self.assertEqual(len(client.calls), 2)
+        # The retry prompt must mention the rejection reason so the model can self-correct.
+        self.assertIn("was rejected", client.calls[1])
+
+    def test_raises_after_exhausting_retries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self._run(tmp)
+            client = FakeClient(
+                [
+                    {"mutations": "not-a-list"},
+                    {"mutations": "still-not-a-list"},
+                    {"mutations": "nope"},
+                ]
+            )
+            with self.assertRaises(propose.SchemaValidationError):
+                propose.propose_mutations(client, run, max_retries=2)
+        self.assertEqual(len(client.calls), 3)
+
+    def test_mutation_limit_truncates_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run = self._run(tmp)
+            many_mutations = [
+                {
+                    "base_factor": "auto_settlement_full_depth_settlement_edge",
+                    "mutation_type": "add_capacity_gate",
+                }
+                for _ in range(5)
+            ]
+            client = FakeClient([{"mutations": many_mutations}])
+            mutations = propose.propose_mutations(client, run, mutation_limit=2)
+
+        self.assertEqual(len(mutations), 2)
+
+
+class UnconfiguredLlmClientTests(unittest.TestCase):
+    def test_raises_runtime_error(self) -> None:
+        with self.assertRaises(RuntimeError):
+            propose.UnconfiguredLlmClient().propose("any prompt")
+
+
+def _fake_response(json_payload: dict, status_ok: bool = True) -> mock.Mock:
+    response = mock.Mock()
+    response.json.return_value = json_payload
+    if status_ok:
+        response.raise_for_status.return_value = None
+    else:
+        response.raise_for_status.side_effect = RuntimeError("HTTP error")
+    return response
+
+
+class AnthropicLlmClientTests(unittest.TestCase):
+    def test_propose_extracts_tool_use_input(self) -> None:
+        client = propose.AnthropicLlmClient("test-key")
+        tool_input = {
+            "mutations": [
+                {"base_factor": "auto_settlement_x", "mutation_type": "add_capacity_gate"}
+            ]
+        }
+        fake_response = _fake_response(
+            {"content": [{"type": "tool_use", "name": "propose_mutations", "input": tool_input}]}
+        )
+        with mock.patch("requests.post", return_value=fake_response) as post:
+            result = client.propose("a prompt")
+
+        self.assertEqual(result, tool_input)
+        # Confirm the call is a tool-forced request, not free-text parsing.
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["json"]["tool_choice"], {"type": "tool", "name": "propose_mutations"})
+        self.assertEqual(kwargs["headers"]["x-api-key"], "test-key")
+
+    def test_propose_raises_when_no_tool_use_block(self) -> None:
+        client = propose.AnthropicLlmClient("test-key")
+        fake_response = _fake_response({"content": [{"type": "text", "text": "not a tool call"}]})
+        with mock.patch("requests.post", return_value=fake_response):
+            with self.assertRaises(RuntimeError):
+                client.propose("a prompt")
+
+    def test_propose_propagates_http_errors(self) -> None:
+        client = propose.AnthropicLlmClient("test-key")
+        fake_response = _fake_response({}, status_ok=False)
+        with mock.patch("requests.post", return_value=fake_response):
+            with self.assertRaises(RuntimeError):
+                client.propose("a prompt")
+
+
+class OpenAiLlmClientTests(unittest.TestCase):
+    def test_propose_extracts_output_text_and_parses_json(self) -> None:
+        client = propose.OpenAiLlmClient("test-key")
+        mutations_payload = {
+            "mutations": [
+                {"base_factor": "auto_settlement_x", "mutation_type": "add_capacity_gate"}
+            ]
+        }
+        fake_response = _fake_response(
+            {
+                "output": [
+                    {
+                        "content": [
+                            {"type": "output_text", "text": json.dumps(mutations_payload)}
+                        ]
+                    }
+                ]
+            }
+        )
+        with mock.patch("requests.post", return_value=fake_response) as post:
+            result = client.propose("a prompt")
+
+        self.assertEqual(result, mutations_payload)
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["json"]["text"]["format"]["type"], "json_schema")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+
+    def test_propose_raises_when_output_text_missing(self) -> None:
+        client = propose.OpenAiLlmClient("test-key")
+        fake_response = _fake_response({"output": []})
+        with mock.patch("requests.post", return_value=fake_response):
+            with self.assertRaises(RuntimeError):
+                client.propose("a prompt")
+
+    def test_propose_raises_on_non_object_json(self) -> None:
+        client = propose.OpenAiLlmClient("test-key")
+        fake_response = _fake_response(
+            {"output": [{"content": [{"type": "output_text", "text": "[1, 2, 3]"}]}]}
+        )
+        with mock.patch("requests.post", return_value=fake_response):
+            with self.assertRaises(RuntimeError):
+                client.propose("a prompt")
+
+
+class ClientFromEnvTests(unittest.TestCase):
+    def test_returns_unconfigured_when_no_api_key(self) -> None:
+        client = propose.client_from_env({})
+        self.assertIsInstance(client, propose.UnconfiguredLlmClient)
+
+    def test_defaults_to_anthropic_provider(self) -> None:
+        client = propose.client_from_env({"PLOY_RESEARCH_LLM_API_KEY": "key"})
+        self.assertIsInstance(client, propose.AnthropicLlmClient)
+
+    def test_selects_openai_provider(self) -> None:
+        client = propose.client_from_env(
+            {
+                "PLOY_RESEARCH_LLM_API_KEY": "key",
+                "PLOY_RESEARCH_LLM_PROVIDER": "openai",
+            }
+        )
+        self.assertIsInstance(client, propose.OpenAiLlmClient)
+
+    def test_rejects_unknown_provider(self) -> None:
+        with self.assertRaises(RuntimeError):
+            propose.client_from_env(
+                {
+                    "PLOY_RESEARCH_LLM_API_KEY": "key",
+                    "PLOY_RESEARCH_LLM_PROVIDER": "not-a-real-provider",
+                }
+            )
+
+    def test_honors_model_override(self) -> None:
+        client = propose.client_from_env(
+            {
+                "PLOY_RESEARCH_LLM_API_KEY": "key",
+                "PLOY_RESEARCH_LLM_PROVIDER": "openai",
+                "PLOY_RESEARCH_LLM_MODEL": "gpt-5.5-mini",
+            }
+        )
+        self.assertEqual(client._model, "gpt-5.5-mini")
+
+
+class BuildPriorFromMutationsTests(unittest.TestCase):
+    def test_matches_closed_loop_agent_prior_shape(self) -> None:
+        mutations = [
+            {"base_factor": "auto_settlement_x", "mutation_type": "add_capacity_gate"}
+        ]
+        prior = propose.build_prior_from_mutations("full_depth_settlement_executable_pnl", mutations)
+
+        self.assertEqual(prior["schema_version"], 1)
+        self.assertEqual(prior["kind"], "typed_llm_prior_draft")
+        self.assertEqual(prior["source"], "alpha_search_llm_propose")
+        self.assertEqual(prior["target"], "full_depth_settlement_executable_pnl")
+        self.assertEqual(prior["mutations"], mutations)
+        self.assertEqual(prior["runtime_avoid_factors"], [])
+
+
+class MainIntegrationTests(unittest.TestCase):
+    def test_main_fails_soft_when_no_client_is_configured(self) -> None:
+        # main() uses UnconfiguredLlmClient by default (Stage B has no real
+        # provider wired in yet), so it must print a message and exit
+        # cleanly rather than raising or writing a partial prior file.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            output_path = Path(tmp) / "next-llm-prior.json"
+            import sys
+
+            argv = sys.argv
+            sys.argv = [
+                "alpha_search_llm_propose.py",
+                str(path),
+                "--output-prior-json",
+                str(output_path),
+            ]
+            try:
+                propose.main()
+            finally:
+                sys.argv = argv
+
+        self.assertFalse(output_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_alpha_search_llm_propose.py
+++ b/tests/test_alpha_search_llm_propose.py
@@ -351,7 +351,12 @@ class AnthropicLlmClientTests(unittest.TestCase):
             ]
         }
         fake_response = _fake_response(
-            {"content": [{"type": "tool_use", "name": "propose_mutations", "input": tool_input}]}
+            {
+                "content": [
+                    {"type": "tool_use", "name": "propose_mutations", "input": tool_input}
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
         )
         with mock.patch("requests.post", return_value=fake_response) as post:
             result = client.propose("a prompt")
@@ -361,6 +366,7 @@ class AnthropicLlmClientTests(unittest.TestCase):
         _, kwargs = post.call_args
         self.assertEqual(kwargs["json"]["tool_choice"], {"type": "tool", "name": "propose_mutations"})
         self.assertEqual(kwargs["headers"]["x-api-key"], "test-key")
+        self.assertEqual(client.last_usage, {"input_tokens": 10, "output_tokens": 5})
 
     def test_propose_raises_when_no_tool_use_block(self) -> None:
         client = propose.AnthropicLlmClient("test-key")
@@ -393,7 +399,8 @@ class OpenAiLlmClientTests(unittest.TestCase):
                             {"type": "output_text", "text": json.dumps(mutations_payload)}
                         ]
                     }
-                ]
+                ],
+                "usage": {"input_tokens": 12, "output_tokens": 6},
             }
         )
         with mock.patch("requests.post", return_value=fake_response) as post:
@@ -403,6 +410,7 @@ class OpenAiLlmClientTests(unittest.TestCase):
         _, kwargs = post.call_args
         self.assertEqual(kwargs["json"]["text"]["format"]["type"], "json_schema")
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(client.last_usage, {"input_tokens": 12, "output_tokens": 6})
 
     def test_propose_raises_when_output_text_missing(self) -> None:
         client = propose.OpenAiLlmClient("test-key")
@@ -475,10 +483,106 @@ class BuildPriorFromMutationsTests(unittest.TestCase):
 
 
 class MainIntegrationTests(unittest.TestCase):
+    def test_main_writes_prior_on_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            output_path = Path(tmp) / "next-llm-prior.json"
+            client = FakeClient(
+                [
+                    {
+                        "mutations": [
+                            {
+                                "base_factor": "auto_settlement_full_depth_settlement_edge",
+                                "mutation_type": "add_capacity_gate",
+                                "feature": "entry_capacity_score",
+                            }
+                        ]
+                    }
+                ]
+            )
+            client.last_usage = {"input_tokens": 20, "output_tokens": 8}
+            import sys
+
+            argv = sys.argv
+            sys.argv = [
+                "alpha_search_llm_propose.py",
+                str(path),
+                "--output-prior-json",
+                str(output_path),
+            ]
+            try:
+                with mock.patch.object(
+                    propose, "client_from_env", return_value=client
+                ), mock.patch.object(
+                    propose, "propose_mutations", wraps=propose.propose_mutations
+                ) as propose_mutations:
+                    propose.main()
+            finally:
+                sys.argv = argv
+
+            self.assertTrue(output_path.exists())
+            prior = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(prior["source"], "alpha_search_llm_propose")
+            self.assertEqual(len(prior["mutations"]), 1)
+            self.assertEqual(propose_mutations.call_count, 1)
+            usage_path = output_path.with_name("llm-expansion-usage.json")
+            usage = json.loads(usage_path.read_text(encoding="utf-8"))
+            self.assertEqual(usage["source"], "alpha_search_llm_propose")
+            self.assertEqual(usage["mutation_count"], 1)
+            self.assertEqual(usage["usage"], {"input_tokens": 20, "output_tokens": 8})
+
+    def test_main_does_not_overwrite_prior_for_empty_mutations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            output_path = Path(tmp) / "next-llm-prior.json"
+            output_path.write_text("existing deterministic prior", encoding="utf-8")
+            client = FakeClient([{"mutations": []}])
+            import sys
+
+            argv = sys.argv
+            sys.argv = [
+                "alpha_search_llm_propose.py",
+                str(path),
+                "--output-prior-json",
+                str(output_path),
+            ]
+            try:
+                with mock.patch.object(propose, "client_from_env", return_value=client):
+                    propose.main()
+            finally:
+                sys.argv = argv
+
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"), "existing deterministic prior"
+            )
+
+    def test_main_fails_soft_on_corrupt_optional_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(Path(tmp))
+            output_path = Path(tmp) / "next-llm-prior.json"
+            zoo_path = Path(tmp) / "alpha-zoo-snapshot.json"
+            zoo_path.write_text("{not json", encoding="utf-8")
+            import sys
+
+            argv = sys.argv
+            sys.argv = [
+                "alpha_search_llm_propose.py",
+                str(path),
+                "--output-prior-json",
+                str(output_path),
+                "--alpha-zoo-snapshot-json",
+                str(zoo_path),
+            ]
+            try:
+                propose.main(env={"PLOY_RESEARCH_LLM_API_KEY": ""})
+            finally:
+                sys.argv = argv
+
+            self.assertFalse(output_path.exists())
+
     def test_main_fails_soft_when_no_client_is_configured(self) -> None:
-        # main() uses UnconfiguredLlmClient by default (Stage B has no real
-        # provider wired in yet), so it must print a message and exit
-        # cleanly rather than raising or writing a partial prior file.
+        # main() uses UnconfiguredLlmClient when no API key is set, so it must
+        # exit cleanly rather than raising or writing a partial prior file.
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(Path(tmp))
             output_path = Path(tmp) / "next-llm-prior.json"


### PR DESCRIPTION
## Summary
- Add `scripts/alpha_search_llm_propose.py` (Priority 3 in `tasks/todo.md`), separate from the model-free `alpha_search_closed_loop_agent.py`: builds prompts from existing artifact fields (weak dimensions, batch-local FSA crowding, Alpha Zoo snapshot when present), validates provider responses against the `LlmMutationSpec` schema with bounded retries, and writes output compatible with the existing `--alpha-search-llm-prior-json` flag so no downstream Rust changes are needed.
- Add real `AnthropicLlmClient`/`OpenAiLlmClient` implementations that call each provider's HTTP API directly with forced structured output (never the Codex/Claude Code CLI, which is built for interactive sessions). `client_from_env()` falls back to a fail-soft `UnconfiguredLlmClient` when no API key is configured.
- Wire an opt-in `enable_llm_expansion` toggle (default `false`) into `factor-walk-forward-v2-hosted-artifact.yml`'s `options_json` schema, plus a new step that only overwrites `next-llm-prior.json` when the flag is on and `PLOY_RESEARCH_LLM_API_KEY` resolves to a non-empty secret. Any other case exits 0 and leaves the deterministic closed-loop prior untouched — LLM unavailability can never block the search path.

## Deliberately not done here
- Creating the `PLOY_RESEARCH_LLM_API_KEY` GitHub secret — requires a repo admin; the value must never be chosen or seen by an agent.
- Triggering a real `workflow_dispatch` with the flag on — real model-API cost, needs an explicit human decision.

## Evidence stage
`factor_attribution` only; no promotion, dry-run, live trading, or runtime-parity gates changed.

## Validation
- `python3 -m unittest tests.test_alpha_search_llm_propose tests.test_alpha_search_closed_loop_agent tests.test_factor_walk_forward_sweep` (85 tests, all pass)
- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow file
- `actionlint` (clean, zero findings) against the full workflow file
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional hosted “LLM expansion” to propose additional typed prior mutations during alpha search, configurable via enablement and provider/model settings.
  * Records per-run LLM usage when an expansion is performed.
* **Bug Fixes**
  * Added strict validation and retry behavior for LLM-proposed outputs.
  * Fails softly: if LLM prerequisites or outputs are missing/invalid, the workflow leaves existing priors unchanged.
* **Documentation**
  * Updated CI documentation to reflect the opt-in “Real LLM Expansion” behavior and completion criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->