### PR TITLE
Add MCTS lineage backpropagation

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -62,6 +62,8 @@ pub struct MctsSearchStateArtifact {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MctsSearchStateNode {
     pub factor_name: String,
+    #[serde(default)]
+    pub parent_name: Option<String>,
     pub visits: usize,
     pub total_reward: f64,
     pub best_reward: f64,
@@ -207,6 +209,7 @@ struct TreeTraceNode {
 struct NodeMetric {
     id: String,
     factor_name: String,
+    parent_name: Option<String>,
     target: Option<String>,
     decision: String,
     reason: String,
@@ -1077,6 +1080,7 @@ fn node_metric(
     NodeMetric {
         id: format!("node-{idx}"),
         factor_name: report.name.clone(),
+        parent_name: report.parent_name.clone(),
         target: report.target.clone(),
         decision: report.decision.as_str().to_string(),
         reason: report.reason.clone(),
@@ -1145,10 +1149,11 @@ fn mcts_search_state(
         .unwrap_or_default();
 
     for metric in metrics {
-        let mut node = nodes
-            .remove(&metric.factor_name)
-            .unwrap_or_else(|| MctsSearchStateNode {
+        let node = nodes
+            .entry(metric.factor_name.clone())
+            .or_insert_with(|| MctsSearchStateNode {
                 factor_name: metric.factor_name.clone(),
+                parent_name: metric.parent_name.clone(),
                 visits: 0,
                 total_reward: 0.0,
                 best_reward: f64::NEG_INFINITY,
@@ -1156,13 +1161,20 @@ fn mcts_search_state(
                 selected_dimension: metric.selected_dimension.clone(),
                 last_decision: metric.decision.clone(),
             });
+        node.parent_name = metric.parent_name.clone();
+    }
+
+    for metric in metrics {
+        let Some(node) = nodes.get_mut(&metric.factor_name) else {
+            continue;
+        };
         node.visits = node.visits.saturating_add(1);
         node.total_reward += metric.reward;
         node.best_reward = node.best_reward.max(metric.reward);
         node.last_reward = metric.reward;
         node.selected_dimension = metric.selected_dimension.clone();
         node.last_decision = metric.decision.clone();
-        nodes.insert(node.factor_name.clone(), node);
+        backpropagate(&mut nodes, &metric.factor_name, metric.reward);
     }
 
     let mut nodes = nodes.into_values().collect::<Vec<_>>();
@@ -1174,6 +1186,29 @@ fn mcts_search_state(
         target: target.to_string(),
         total_visits,
         nodes,
+    }
+}
+
+fn backpropagate(nodes: &mut BTreeMap<String, MctsSearchStateNode>, leaf_name: &str, reward: f64) {
+    let mut current = leaf_name.to_string();
+    let mut visited = BTreeSet::new();
+    for _ in 0..64 {
+        if !visited.insert(current.clone()) {
+            break;
+        }
+        let Some(parent_name) = nodes
+            .get(&current)
+            .and_then(|node| node.parent_name.clone())
+        else {
+            break;
+        };
+        let Some(parent) = nodes.get_mut(&parent_name) else {
+            break;
+        };
+        parent.visits = parent.visits.saturating_add(1);
+        parent.total_reward += reward;
+        parent.best_reward = parent.best_reward.max(reward);
+        current = parent_name;
     }
 }
 
@@ -1220,7 +1255,7 @@ fn mcts_expansion_plan(
         target: target.to_string(),
         exploration_weight,
         selected_nodes: selected,
-        note: "This is the first MCTS control artifact. It selects branches for the next search run from node metrics, but does not yet execute multi-run backpropagation.",
+        note: "MCTS state accumulates leaf visits and backpropagates leaf rewards through recorded parent lineage; this plan selects branches for the next bounded search run with UCB priority.",
     }
 }
 
@@ -2032,6 +2067,7 @@ mod tests {
             total_visits: 3,
             nodes: vec![MctsSearchStateNode {
                 factor_name: "auto_settlement_conservative_settlement_edge".to_string(),
+                parent_name: None,
                 visits: 3,
                 total_reward: 6.0,
                 best_reward: 2.0,
@@ -2063,6 +2099,61 @@ mod tests {
         assert_eq!(node.visits, 4);
         assert!(node.total_reward > 6.0);
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mcts_state_backpropagates_leaf_reward_to_ancestors() {
+        let runtime_avoidances = Vec::new();
+        let root = sample_report("root_factor");
+        let mut sibling = sample_report("sibling_factor");
+        sibling.top_bucket_avg_label = 0.15;
+        let mut child = sample_report("mut_root_factor_capacity");
+        child.parent_name = Some(root.name.clone());
+        child.top_bucket_avg_label = 0.30;
+        let mut grandchild = sample_report("mut2_root_factor_capacity_squashed");
+        grandchild.parent_name = Some(child.name.clone());
+        grandchild.top_bucket_avg_label = 0.40;
+
+        let reports = vec![root, sibling, child, grandchild];
+        let metrics = reports
+            .iter()
+            .enumerate()
+            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .collect::<Vec<_>>();
+        let reward_by_name = metrics
+            .iter()
+            .map(|metric| (metric.factor_name.as_str(), metric.reward))
+            .collect::<BTreeMap<_, _>>();
+        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let nodes = state
+            .nodes
+            .iter()
+            .map(|node| (node.factor_name.as_str(), node))
+            .collect::<BTreeMap<_, _>>();
+
+        let root_node = nodes.get("root_factor").expect("root node");
+        let child_node = nodes.get("mut_root_factor_capacity").expect("child node");
+        let grandchild_node = nodes
+            .get("mut2_root_factor_capacity_squashed")
+            .expect("grandchild node");
+        let sibling_node = nodes.get("sibling_factor").expect("sibling node");
+
+        assert_eq!(root_node.visits, 3);
+        assert_eq!(child_node.visits, 2);
+        assert_eq!(grandchild_node.visits, 1);
+        assert_eq!(sibling_node.visits, 1);
+        assert_eq!(
+            root_node.total_reward,
+            reward_by_name["root_factor"]
+                + reward_by_name["mut_root_factor_capacity"]
+                + reward_by_name["mut2_root_factor_capacity_squashed"]
+        );
+        assert_eq!(
+            child_node.total_reward,
+            reward_by_name["mut_root_factor_capacity"]
+                + reward_by_name["mut2_root_factor_capacity_squashed"]
+        );
+        assert_eq!(sibling_node.total_reward, reward_by_name["sibling_factor"]);
     }
 
     #[test]

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -532,7 +532,7 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
                 .enumerate()
                 .map(|(idx, report)| TreeTraceNode {
                     id: format!("node-{idx}"),
-                    parent: None,
+                    parent: report.parent_name.clone(),
                     factor_name: report.name.clone(),
                     mutation: "seed",
                     selected_dimension: selected_dimension(report, &runtime_avoidances),
@@ -1704,6 +1704,7 @@ mod tests {
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
             reason: "passed".to_string(),
+            parent_name: None,
         }
     }
 
@@ -1742,6 +1743,7 @@ mod tests {
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
             reason: "passed".to_string(),
+            parent_name: None,
         };
         let summary = write_alpha_search_artifacts(
             &tmp,
@@ -2021,6 +2023,7 @@ mod tests {
             complexity: 1,
             decision: AutoFactorDecision::Candidate,
             reason: "passed".to_string(),
+            parent_name: None,
         };
         let prior = MctsSearchStateArtifact {
             version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),

--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -2405,11 +2405,13 @@ mod tests {
                 metrics: serde_json::Value::Null,
             }],
         };
-        assert!(matching_runtime_avoidance(
-            &selected_gate_variant,
-            &runtime_avoidances(None, Some(&selected_gate_prior))
-        )
-        .is_some());
+        assert!(
+            matching_runtime_avoidance(
+                &selected_gate_variant,
+                &runtime_avoidances(None, Some(&selected_gate_prior))
+            )
+            .is_some()
+        );
     }
 
     #[test]

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -2329,7 +2329,8 @@ fn bayes_settlement_generated_candidates(input_names: &BTreeSet<String>) -> Vec<
         );
         push_generated(
             &mut out,
-            "auto_settlement_bayes_model_contrarian_full_depth_confidence_weighted_edge".to_string(),
+            "auto_settlement_bayes_model_contrarian_full_depth_confidence_weighted_edge"
+                .to_string(),
             negate(input("bayes_model_full_depth_confidence_weighted_edge")),
             "Contrarian full-depth model-calibrated Bayesian edge weighted by row-local quote and execution confidence.",
         );
@@ -3131,14 +3132,18 @@ mod tests {
         let matrix = autofactor_matrix_from_v2(&rows).expect("matrix");
 
         assert!(matrix.column("bayes_posterior_prob").expect("posterior")[0].is_finite());
-        assert!(matrix
-            .column("bayes_model_calibrated_prob")
-            .expect("model calibrated")[0]
-            .is_nan());
-        assert!(matrix
-            .column("bayes_model_calibrated_edge")
-            .expect("model edge")[0]
-            .is_nan());
+        assert!(
+            matrix
+                .column("bayes_model_calibrated_prob")
+                .expect("model calibrated")[0]
+                .is_nan()
+        );
+        assert!(
+            matrix
+                .column("bayes_model_calibrated_edge")
+                .expect("model edge")[0]
+                .is_nan()
+        );
     }
 
     #[test]
@@ -3146,12 +3151,16 @@ mod tests {
         let rows = (0..8).map(synthetic_v2_row).collect::<Vec<_>>();
         let matrix = autofactor_matrix_from_v2(&rows).expect("matrix");
         let seeds = domain_seed_candidates(&matrix.input_names());
-        assert!(seeds
-            .iter()
-            .any(|candidate| candidate.name == "bayes_contrarian_settlement_edge"));
-        assert!(seeds
-            .iter()
-            .any(|candidate| candidate.name == "bayes_model_market_reversal"));
+        assert!(
+            seeds
+                .iter()
+                .any(|candidate| candidate.name == "bayes_contrarian_settlement_edge")
+        );
+        assert!(
+            seeds
+                .iter()
+                .any(|candidate| candidate.name == "bayes_model_market_reversal")
+        );
 
         let generated = bayes_settlement_generated_candidates(&matrix.input_names());
         assert!(generated.iter().any(|candidate| {
@@ -3172,14 +3181,18 @@ mod tests {
 
         assert!(matrix.column("bayes_market_prior_prob").expect("prior")[0].is_nan());
         assert!(matrix.column("bayes_edge").expect("edge")[0].is_nan());
-        assert!(matrix
-            .column("bayes_full_depth_edge")
-            .expect("full depth edge")[0]
-            .is_nan());
-        assert!(matrix
-            .column("bayes_conservative_edge")
-            .expect("conservative edge")[0]
-            .is_nan());
+        assert!(
+            matrix
+                .column("bayes_full_depth_edge")
+                .expect("full depth edge")[0]
+                .is_nan()
+        );
+        assert!(
+            matrix
+                .column("bayes_conservative_edge")
+                .expect("conservative edge")[0]
+                .is_nan()
+        );
         assert!(matrix.column("bayes_external_prob").expect("external")[0].is_finite());
         assert!(matrix.column("bayes_posterior_prob").expect("posterior")[0].is_finite());
     }
@@ -3222,9 +3235,11 @@ mod tests {
     fn evaluates_domain_candidate_with_icir_gate() {
         let (matrix, labels, windows) = synthetic_matrix(24);
         let candidates = domain_seed_candidates(&matrix.input_names());
-        assert!(candidates
-            .iter()
-            .any(|item| item.name == "ofi_l5_depth_norm"));
+        assert!(
+            candidates
+                .iter()
+                .any(|item| item.name == "ofi_l5_depth_norm")
+        );
         let options = AutoFactorOptions {
             min_observations: 20,
             min_window_observations: 6,
@@ -3311,22 +3326,30 @@ mod tests {
             .expect("repricing gap report");
         assert_eq!(repricing_gap.decision, AutoFactorDecision::Candidate);
         assert!(repricing_gap.spearman_ic > 0.95);
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "poly_lag_pressure"));
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "amplitude_weighted_momentum_30s_sigma"));
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "amplitude_weighted_momentum_30s_vol_gap"));
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "mut_spread_adjusted_external_move_pm_lag_gate"));
-        assert!(reports
-            .iter()
-            .any(|report| report.name
-                == "mut2_mut_spread_adjusted_external_move_pm_lag_gate_squashed"));
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "poly_lag_pressure")
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "amplitude_weighted_momentum_30s_sigma")
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "amplitude_weighted_momentum_30s_vol_gap")
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "mut_spread_adjusted_external_move_pm_lag_gate")
+        );
+        assert!(
+            reports.iter().any(|report| report.name
+                == "mut2_mut_spread_adjusted_external_move_pm_lag_gate_squashed")
+        );
     }
 
     #[test]
@@ -3428,25 +3451,31 @@ mod tests {
             report.name
                 == "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity_x_entry_price_quality"
         }));
-        assert!(reports
-            .iter()
-            .any(|report| report.name
-                == "mut_auto_settlement_model_full_depth_settlement_edge_capacity"));
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "auto_settlement_bayes_full_depth_edge"));
+        assert!(
+            reports.iter().any(|report| report.name
+                == "mut_auto_settlement_model_full_depth_settlement_edge_capacity")
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "auto_settlement_bayes_full_depth_edge")
+        );
         assert!(reports.iter().any(
             |report| report.name == "auto_settlement_bayes_full_depth_confidence_weighted_edge"
         ));
-        assert!(reports
-            .iter()
-            .any(|report| report.name == "auto_settlement_bayes_model_full_depth_edge"));
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name == "auto_settlement_bayes_model_full_depth_edge")
+        );
         assert!(reports.iter().any(|report| {
             report.name == "auto_settlement_bayes_model_full_depth_confidence_weighted_edge"
         }));
-        assert!(reports
-            .iter()
-            .any(|report| report.name.starts_with("mut2_")));
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.name.starts_with("mut2_"))
+        );
     }
 
     #[test]
@@ -3759,9 +3788,11 @@ mod tests {
         )
         .expect("reports");
 
-        assert!(reports
-            .iter()
-            .all(|report| !report.name.starts_with("auto_settlement_")));
+        assert!(
+            reports
+                .iter()
+                .all(|report| !report.name.starts_with("auto_settlement_"))
+        );
     }
 
     #[test]
@@ -3779,9 +3810,11 @@ mod tests {
                 .expect("reports");
 
         assert!(!reports.is_empty());
-        assert!(reports
-            .iter()
-            .all(|report| report.target.as_deref() == Some("reprice_pnl_30s")));
+        assert!(
+            reports
+                .iter()
+                .all(|report| report.target.as_deref() == Some("reprice_pnl_30s"))
+        );
 
         let formatted = format_autofactor_reports(&reports, reports.len());
         assert!(formatted.contains("reprice_pnl_30s"));

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -211,6 +211,13 @@ pub struct NamedFactorExpr {
     pub expr: FactorExpr,
     pub target: Option<String>,
     pub notes: Vec<String>,
+    /// The `name` of the candidate this one was derived from, or `None` for
+    /// a root candidate (a domain seed or a settlement-native generated
+    /// formula). This is lineage plumbing only in this stage: it powers
+    /// `TreeTraceNode.parent` and Stage B's `backpropagate()`, but does not
+    /// itself change any reward/scoring behavior.
+    #[serde(default)]
+    pub parent_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -261,6 +268,7 @@ impl NamedFactorExpr {
             expr,
             target: None,
             notes: Vec::new(),
+            parent_name: None,
         }
     }
 }
@@ -393,6 +401,10 @@ pub struct AutoFactorReport {
     pub complexity: usize,
     pub decision: AutoFactorDecision,
     pub reason: String,
+    /// Carried over from `NamedFactorExpr.parent_name`: the candidate this
+    /// report's factor was derived from, or `None` for a root candidate.
+    #[serde(default)]
+    pub parent_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -645,6 +657,7 @@ pub fn evaluate_named_factor(
         complexity,
         decision,
         reason,
+        parent_name: factor.parent_name.clone(),
     })
 }
 
@@ -1408,6 +1421,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             expr: input("repricing_gap_side_10s"),
             target: Some("reprice_pnl_10s".to_string()),
             notes: vec!["Side-aligned fair-minus-entry gap proxy.".to_string()],
+            parent_name: None,
         });
     }
     if input_names.contains("side_fair_edge") {
@@ -1416,6 +1430,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             expr: input("side_fair_edge"),
             target: Some("settlement_executable_pnl".to_string()),
             notes: vec!["Settlement fair probability minus executable ask and fee.".to_string()],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_edge") {
@@ -1427,6 +1442,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Row-local Bayesian posterior probability minus executable ask and fee."
                     .to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_contrarian_settlement_edge".to_string(),
@@ -1436,6 +1452,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Contrarian Bayesian settlement edge for windows where raw posterior ranks backwards."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_confidence_weighted_edge") {
@@ -1447,6 +1464,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Bayesian settlement edge weighted by quote, capacity, agreement, and probability quality."
                     .to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_contrarian_confidence_weighted_edge".to_string(),
@@ -1456,6 +1474,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Contrarian confidence-weighted Bayesian edge for explicitly testing reversed calibration."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_model_calibrated_edge") {
@@ -1466,6 +1485,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             notes: vec![
                 "Bayesian settlement edge calibrated by decision-time side_model_prob.".to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_model_contrarian_calibrated_edge".to_string(),
@@ -1475,6 +1495,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Contrarian model-calibrated Bayesian edge for testing reversed posterior ranking."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_model_confidence_weighted_edge") {
@@ -1486,6 +1507,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Model-calibrated Bayesian settlement edge weighted by row-local quote and execution confidence."
                     .to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_model_contrarian_confidence_weighted_edge".to_string(),
@@ -1495,6 +1517,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Contrarian model-calibrated confidence-weighted edge for reversed-calibration diagnostics."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_disagreement") {
@@ -1505,6 +1528,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             notes: vec![
                 "Posterior settlement probability minus Polymarket midpoint prior.".to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_market_external_reversal".to_string(),
@@ -1514,6 +1538,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Contrarian posterior-minus-market disagreement for testing mean-reverting probability residuals."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if input_names.contains("bayes_model_disagreement") {
@@ -1524,6 +1549,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             notes: vec![
                 "Model-calibrated Bayesian posterior minus Polymarket midpoint prior.".to_string(),
             ],
+            parent_name: None,
         });
         out.push(NamedFactorExpr {
             name: "bayes_model_market_reversal".to_string(),
@@ -1532,6 +1558,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             notes: vec![
                 "Contrarian model-calibrated posterior-minus-market disagreement.".to_string(),
             ],
+            parent_name: None,
         });
     }
     if has_all(input_names, &["ofi_l5", "depth_top5"]) {
@@ -1540,6 +1567,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             expr: safe_div_expr(input("ofi_l5"), input("depth_top5")),
             target: Some("reprice_pnl_10s".to_string()),
             notes: vec!["External OFI scaled by local depth.".to_string()],
+            parent_name: None,
         });
     }
     if has_all(
@@ -1566,6 +1594,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             notes: vec![
                 "External move is more actionable when Polymarket quote is stale.".to_string(),
             ],
+            parent_name: None,
         });
     }
     if has_all(
@@ -1580,6 +1609,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             ),
             target: Some("tradable_move_10s".to_string()),
             notes: vec!["Vol shock matters most near strike and in thin LOB regimes.".to_string()],
+            parent_name: None,
         });
     }
     if has_all(
@@ -1611,6 +1641,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Depth-normalized OFI should matter more when the contract is near strike and PM is stale."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if has_all(
@@ -1628,6 +1659,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
             ),
             target: Some("reprice_pnl_10s".to_string()),
             notes: vec!["External move must clear the side spread to be tradable.".to_string()],
+            parent_name: None,
         });
     }
     if has_all(input_names, &["cex_return_30s_side", "sigma_horizon_pos"]) {
@@ -1642,6 +1674,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Side-aligned 30s CEX return weighted by current event volatility amplitude."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     if has_all(input_names, &["cex_return_30s_side", "vol_gap_pos"]) {
@@ -1656,6 +1689,7 @@ pub fn domain_seed_candidates(input_names: &BTreeSet<String>) -> Vec<NamedFactor
                 "Side-aligned 30s CEX return weighted by positive volatility shock versus implied baseline."
                     .to_string(),
             ],
+            parent_name: None,
         });
     }
     out
@@ -1741,6 +1775,7 @@ fn llm_prior_mutation_candidates(
                 "Typed LLM-prior mutation `{}` compiled from base factor `{}`.",
                 mutation.mutation_type, base.name
             )],
+            parent_name: Some(base.name.clone()),
         });
     }
     out
@@ -2069,6 +2104,7 @@ fn push_mutation(
             seed.name,
             note.into()
         )],
+        parent_name: Some(seed.name.clone()),
     });
 }
 
@@ -2315,6 +2351,7 @@ fn push_generated(
             "Auto-generated settlement-native formula. {}",
             note.into()
         )],
+        parent_name: None,
     });
 }
 
@@ -3461,6 +3498,7 @@ mod tests {
                 target: Some("tradeable_full_depth_settlement_pnl".to_string()),
                 expr: input("score"),
                 notes: vec![],
+                parent_name: None,
             }],
             &matrix,
             &labels,
@@ -3484,6 +3522,7 @@ mod tests {
             target: Some("tradeable_full_depth_settlement_pnl".to_string()),
             expr: input("external_move_since_poly_update"),
             notes: vec![],
+            parent_name: None,
         }];
 
         let mutations = deterministic_mutation_layer(
@@ -3513,6 +3552,7 @@ mod tests {
             target: Some("full_depth_settlement_executable_pnl".to_string()),
             expr: input("external_move_since_poly_update"),
             notes: vec![],
+            parent_name: None,
         }];
 
         let mutations = deterministic_mutation_layer(
@@ -3537,6 +3577,32 @@ mod tests {
             assert!(matches!(candidate.expr, FactorExpr::Gate { .. }));
             assert!(candidate.notes[0].contains("discovery-only selector"));
         }
+    }
+
+    #[test]
+    fn deterministic_mutations_record_parent_name() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let matrix = autofactor_matrix_from_v2(&rows).expect("matrix");
+        let seeds = vec![NamedFactorExpr {
+            name: "predictive_seed".to_string(),
+            target: Some("full_depth_settlement_executable_pnl".to_string()),
+            expr: input("external_move_since_poly_update"),
+            notes: vec![],
+            parent_name: None,
+        }];
+
+        let mutations = deterministic_mutation_layer(
+            &matrix.input_names(),
+            &seeds,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            1,
+        );
+        let mutation = mutations
+            .iter()
+            .find(|candidate| candidate.name.starts_with("mut_predictive_seed_"))
+            .expect("deterministic mutation");
+
+        assert_eq!(mutation.parent_name.as_deref(), Some("predictive_seed"));
     }
 
     #[test]
@@ -3581,6 +3647,43 @@ mod tests {
             Some("full_depth_settlement_executable_pnl")
         );
         assert!(matches!(report.expr, FactorExpr::Mul(_, _)));
+        assert_eq!(
+            report.parent_name.as_deref(),
+            Some("auto_settlement_model_full_depth_settlement_edge")
+        );
+    }
+
+    #[test]
+    fn mcts_guided_mutations_record_selected_parent_name() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+
+        let reports = mine_domain_autofactors_from_v2_with_guidance(
+            &rows,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            &options,
+            &["auto_settlement_model_full_depth_settlement_edge".to_string()],
+            None,
+        )
+        .expect("reports");
+        let report = reports
+            .iter()
+            .find(|report| {
+                report
+                    .name
+                    .starts_with("mcts_auto_settlement_model_full_depth_settlement_edge_")
+            })
+            .expect("MCTS-guided mutation");
+
+        assert_eq!(
+            report.parent_name.as_deref(),
+            Some("auto_settlement_model_full_depth_settlement_edge")
+        );
     }
 
     #[test]

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -1890,9 +1890,141 @@ fn compile_llm_mutation(
             "contrarian",
             mul(FactorExpr::Const(-1.0), base.expr.clone()),
         )),
-        "remove_component" => None,
+        "remove_component" => {
+            if let Some(feature) = mutation.feature.as_deref() {
+                let feature = existing_feature(input_names, Some(feature))?;
+                remove_feature_component(&base.expr, feature).map(|expr| ("remove_component", expr))
+            } else {
+                remove_top_level_component(&base.expr).map(|expr| ("remove_component", expr))
+            }
+        }
         _ => None,
     }
+}
+
+fn remove_top_level_component(expr: &FactorExpr) -> Option<FactorExpr> {
+    match expr {
+        FactorExpr::Tanh(expr)
+        | FactorExpr::Log1pAbs(expr)
+        | FactorExpr::SqrtAbs(expr)
+        | FactorExpr::Delta { expr, .. }
+        | FactorExpr::RollingMean { expr, .. }
+        | FactorExpr::RollingStd { expr, .. }
+        | FactorExpr::ZScore { expr, .. }
+        | FactorExpr::Clip { expr, .. } => Some((**expr).clone()),
+        FactorExpr::Gate { expr, .. } => Some((**expr).clone()),
+        _ => None,
+    }
+}
+
+fn remove_feature_component(expr: &FactorExpr, feature: &str) -> Option<FactorExpr> {
+    match expr {
+        FactorExpr::Input(_) | FactorExpr::Const(_) => None,
+        FactorExpr::Add(lhs, rhs) => {
+            remove_from_commutative_pair(lhs, rhs, feature, FactorExpr::Add)
+        }
+        FactorExpr::Mul(lhs, rhs) => {
+            remove_from_commutative_pair(lhs, rhs, feature, FactorExpr::Mul)
+        }
+        FactorExpr::Max(lhs, rhs) => {
+            remove_from_commutative_pair(lhs, rhs, feature, FactorExpr::Max)
+        }
+        FactorExpr::Min(lhs, rhs) => {
+            remove_from_commutative_pair(lhs, rhs, feature, FactorExpr::Min)
+        }
+        FactorExpr::Sub(lhs, rhs) => {
+            if is_input(lhs, feature) {
+                Some(negate((**rhs).clone()))
+            } else if is_input(rhs, feature) {
+                Some((**lhs).clone())
+            } else if let Some(new_lhs) = remove_feature_component(lhs, feature) {
+                Some(FactorExpr::Sub(Box::new(new_lhs), rhs.clone()))
+            } else {
+                remove_feature_component(rhs, feature)
+                    .map(|new_rhs| FactorExpr::Sub(lhs.clone(), Box::new(new_rhs)))
+            }
+        }
+        FactorExpr::SafeDiv(lhs, rhs) => remove_feature_component(lhs, feature)
+            .map(|new_lhs| FactorExpr::SafeDiv(Box::new(new_lhs), rhs.clone())),
+        FactorExpr::Tanh(inner) => {
+            remove_feature_component(inner, feature).map(|expr| FactorExpr::Tanh(Box::new(expr)))
+        }
+        FactorExpr::Log1pAbs(inner) => remove_feature_component(inner, feature)
+            .map(|expr| FactorExpr::Log1pAbs(Box::new(expr))),
+        FactorExpr::SqrtAbs(inner) => {
+            remove_feature_component(inner, feature).map(|expr| FactorExpr::SqrtAbs(Box::new(expr)))
+        }
+        FactorExpr::Clip { expr, lo, hi } => {
+            remove_feature_component(expr, feature).map(|expr| FactorExpr::Clip {
+                expr: Box::new(expr),
+                lo: *lo,
+                hi: *hi,
+            })
+        }
+        FactorExpr::Delta { expr, lag } => {
+            remove_feature_component(expr, feature).map(|expr| FactorExpr::Delta {
+                expr: Box::new(expr),
+                lag: *lag,
+            })
+        }
+        FactorExpr::RollingMean { expr, window } => {
+            remove_feature_component(expr, feature).map(|expr| FactorExpr::RollingMean {
+                expr: Box::new(expr),
+                window: *window,
+            })
+        }
+        FactorExpr::RollingStd { expr, window } => {
+            remove_feature_component(expr, feature).map(|expr| FactorExpr::RollingStd {
+                expr: Box::new(expr),
+                window: *window,
+            })
+        }
+        FactorExpr::ZScore { expr, window } => {
+            remove_feature_component(expr, feature).map(|expr| FactorExpr::ZScore {
+                expr: Box::new(expr),
+                window: *window,
+            })
+        }
+        FactorExpr::Gate { expr, gate, min } => {
+            if is_input(gate, feature) {
+                Some((**expr).clone())
+            } else if let Some(new_expr) = remove_feature_component(expr, feature) {
+                Some(FactorExpr::Gate {
+                    expr: Box::new(new_expr),
+                    gate: gate.clone(),
+                    min: *min,
+                })
+            } else {
+                remove_feature_component(gate, feature).map(|new_gate| FactorExpr::Gate {
+                    expr: expr.clone(),
+                    gate: Box::new(new_gate),
+                    min: *min,
+                })
+            }
+        }
+    }
+}
+
+fn remove_from_commutative_pair(
+    lhs: &FactorExpr,
+    rhs: &FactorExpr,
+    feature: &str,
+    rebuild: fn(Box<FactorExpr>, Box<FactorExpr>) -> FactorExpr,
+) -> Option<FactorExpr> {
+    if is_input(lhs, feature) {
+        Some(rhs.clone())
+    } else if is_input(rhs, feature) {
+        Some(lhs.clone())
+    } else if let Some(new_lhs) = remove_feature_component(lhs, feature) {
+        Some(rebuild(Box::new(new_lhs), Box::new(rhs.clone())))
+    } else {
+        remove_feature_component(rhs, feature)
+            .map(|new_rhs| rebuild(Box::new(lhs.clone()), Box::new(new_rhs)))
+    }
+}
+
+fn is_input(expr: &FactorExpr, feature: &str) -> bool {
+    matches!(expr, FactorExpr::Input(name) if name == feature)
 }
 
 fn existing_feature<'a>(
@@ -3679,6 +3811,58 @@ mod tests {
         assert_eq!(
             report.parent_name.as_deref(),
             Some("auto_settlement_model_full_depth_settlement_edge")
+        );
+    }
+
+    #[test]
+    fn typed_llm_prior_remove_component_ablates_named_feature() {
+        let rows = (0..80).map(synthetic_v2_row).collect::<Vec<_>>();
+        let options = AutoFactorOptions {
+            min_observations: 40,
+            min_window_observations: 10,
+            min_icir: 0.1,
+            ..Default::default()
+        };
+        let prior = LlmPriorSpec {
+            runtime_avoid_factors: Vec::new(),
+            mutations: vec![LlmMutationSpec {
+                base_factor:
+                    "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity"
+                        .to_string(),
+                mutation_type: "remove_component".to_string(),
+                name: Some("llm_full_depth_edge_without_near_strike".to_string()),
+                feature: Some("near_strike_score".to_string()),
+                denominator_feature: None,
+                constant: None,
+                lo: None,
+                hi: None,
+                window: None,
+            }],
+        };
+
+        let reports = mine_domain_autofactors_from_v2_with_guidance(
+            &rows,
+            AutoFactorV2Target::FullDepthSettlementExecutablePnl,
+            &options,
+            &[],
+            Some(&prior),
+        )
+        .expect("reports");
+
+        let report = reports
+            .iter()
+            .find(|report| report.name == "llm_full_depth_edge_without_near_strike")
+            .expect("remove_component prior mutation should compile");
+        assert_eq!(
+            report.expr,
+            mul(
+                input("model_full_depth_settlement_edge"),
+                input("entry_capacity_score")
+            )
+        );
+        assert_eq!(
+            report.parent_name.as_deref(),
+            Some("auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity")
         );
     }
 

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -667,6 +667,10 @@ Current implementation status:
 - Implemented as artifact and input contract: `llm-priors.json` records the
   typed prior schema, and an operator- or LLM-produced prior file can now enter
   CI through `--alpha-search-llm-prior-json` / `options_json.alpha_search_llm_prior_json`.
+- Implemented: deeper typed LLM-prior expansion at the existing safe compiler
+  boundary. `remove_component` can now ablate a named existing input from a
+  candidate AST, or unwrap a top-level robustness/gate component, while still
+  compiling only into existing `FactorExpr` nodes.
 - Implemented: a durable, cross-run Alpha Zoo novelty penalty. `reward()` and
   `node_metric()` accept an optional `AlphaZooSnapshot` grouped from historical
   `factor_registry` rows by root gene; `persist_research_trace

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -612,9 +612,10 @@ Current implementation status:
   a candidate cap to keep CI runs bounded.
 - Implemented: workflow upload path for the artifact bundle through both
   Factor Walk-Forward V2 workflows.
-- Implemented: first MCTS control artifacts, `mcts-state.json` and
-  `mcts-expansion-plan.json`. The state artifact accumulates visits and
-  rewards per factor across runs, and the expansion plan ranks non-rejected
+- Implemented: MCTS control artifacts, `mcts-state.json` and
+  `mcts-expansion-plan.json`. The state artifact stores explicit factor
+  parent lineage, accumulates leaf visits, backpropagates leaf rewards through
+  ancestor nodes across runs, and the expansion plan ranks non-rejected
   current-run nodes with a UCB-style priority using that cumulative state.
 - Implemented: `factor_walk_forward_v2 --alpha-search-plan-json <path>` can
   consume a prior `mcts-expansion-plan.json` and generate extra `mcts_*`

--- a/scripts/alpha_search_closed_loop_agent.py
+++ b/scripts/alpha_search_closed_loop_agent.py
@@ -54,6 +54,12 @@ PREFERRED_FEATURES = {
     "add_near_strike_interaction": ["near_strike_score"],
     "add_spread_penalty": ["side_spread"],
     "replace_denominator": ["side_spread", "entry_capacity_score"],
+    "remove_component": [
+        "near_strike_score",
+        "quote_freshness_score",
+        "pm_lag_score",
+        "side_spread",
+    ],
 }
 
 RUNTIME_CONTRACT_GAP_TOKENS = (

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21719,14 +21719,14 @@ gates are touched by any of these priorities.
       the snapshot flows from the durable `factor_registry` table into the
       search loop.
 
-### Priority 2 — Full tree search (in progress)
+### Priority 2 — Full tree search (implemented)
 
 - [x] Stage A: thread explicit factor lineage through `NamedFactorExpr`,
       `AutoFactorReport`, and `tree-trace.json` without changing reward or
       ranking behavior.
 - [x] Stage B: extend cumulative MCTS state with `parent_name` and
       backpropagate leaf rewards through ancestor nodes.
-- [ ] Add focused lineage/backpropagation tests and run local validation.
+- [x] Add focused lineage/backpropagation tests and run local validation.
 
 ### Priority 3 — Deeper LLM-guided expansion (not started)
 
@@ -21760,3 +21760,14 @@ gates are touched by any of these priorities.
   `cargo check -p ploy-research --features db --example factor_walk_forward_v2`,
   `rustfmt --edition 2024 --check` on every touched Rust file, and `git diff
   --check`.
+- 2026-07-05: Priority 2 Stage A/B implemented. AutoFactor candidates and
+  reports now carry explicit `parent_name` lineage, `tree-trace.json` records
+  that parent, and `mcts-state.json` persists `parent_name` with
+  `serde(default)` for old artifacts. `mcts_search_state()` now seeds the
+  current batch into the cumulative node map before updating leaves, then
+  backpropagates each leaf reward through ancestor nodes with cycle/depth
+  guards. Validation passed: `rtk cargo check -p ploy-research --lib --tests`,
+  `rtk cargo test -p ploy-research alpha_search --lib`, `rtk cargo test -p
+  ploy-research autofactor --lib`, `rustfmt --edition 2024 --check
+  crates/ploy-research/src/alpha_search.rs crates/ploy-research/src/autofactor.rs`,
+  and `rtk git diff --check`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21719,11 +21719,14 @@ gates are touched by any of these priorities.
       the snapshot flows from the durable `factor_registry` table into the
       search loop.
 
-### Priority 2 — Full tree search (not started)
+### Priority 2 — Full tree search (in progress)
 
-- [ ] Extend the current single-depth UCB ranking (`mcts_expansion_plan`) into
-      an actual multi-step selection/expansion/backpropagation loop instead of
-      a per-run ranking over cumulative state.
+- [x] Stage A: thread explicit factor lineage through `NamedFactorExpr`,
+      `AutoFactorReport`, and `tree-trace.json` without changing reward or
+      ranking behavior.
+- [ ] Stage B: extend cumulative MCTS state with `parent_name` and
+      backpropagate leaf rewards through ancestor nodes.
+- [ ] Add focused lineage/backpropagation tests and run local validation.
 
 ### Priority 3 — Deeper LLM-guided expansion (not started)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21728,9 +21728,9 @@ gates are touched by any of these priorities.
       backpropagate leaf rewards through ancestor nodes.
 - [x] Add focused lineage/backpropagation tests and run local validation.
 
-### Priority 3 — Deeper LLM-guided expansion (not started)
+### Priority 3 — Deeper LLM-guided expansion (implemented)
 
-- [ ] Explore LLM-proposed mutations beyond the current bounded typed-mutation
+- [x] Explore LLM-proposed mutations beyond the current bounded typed-mutation
       schema, still constrained to compile into existing `FactorExpr` nodes.
 
 ## Review
@@ -21771,3 +21771,10 @@ gates are touched by any of these priorities.
   ploy-research autofactor --lib`, `rustfmt --edition 2024 --check
   crates/ploy-research/src/alpha_search.rs crates/ploy-research/src/autofactor.rs`,
   and `rtk git diff --check`.
+- 2026-07-05: Priority 3 implemented at the existing typed-prior boundary.
+  `remove_component` now compiles into a bounded `FactorExpr` ablation when a
+  prior names an existing feature, or unwraps a top-level robustness/gate
+  component when no feature is supplied. The closed-loop agent now emits an
+  existing feature for `overfit_risk -> remove_component` drafts, so generated
+  prior JSON stays compileable instead of becoming inert advice. This still
+  intentionally excludes direct live LLM API invocation inside CI.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21724,7 +21724,7 @@ gates are touched by any of these priorities.
 - [x] Stage A: thread explicit factor lineage through `NamedFactorExpr`,
       `AutoFactorReport`, and `tree-trace.json` without changing reward or
       ranking behavior.
-- [ ] Stage B: extend cumulative MCTS state with `parent_name` and
+- [x] Stage B: extend cumulative MCTS state with `parent_name` and
       backpropagate leaf rewards through ancestor nodes.
 - [ ] Add focused lineage/backpropagation tests and run local validation.
 

--- a/tests/test_alpha_search_closed_loop_agent.py
+++ b/tests/test_alpha_search_closed_loop_agent.py
@@ -148,6 +148,26 @@ class AlphaSearchClosedLoopAgentTest(unittest.TestCase):
             self.assertFalse(decision["allow_dispatch"])
             self.assertTrue(decision["prior_revision_required"])
 
+    def test_overfit_prior_remove_component_names_existing_feature(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = artifact(
+                Path(tmp),
+                chain_reason="reward_stagnation",
+                selected_nodes=[
+                    {
+                        "factor_name": "auto_settlement_model_full_depth_settlement_edge_x_near_strike_x_capacity",
+                        "selected_dimension": "overfit_risk",
+                        "proposed_mutation": "remove_component",
+                    }
+                ],
+            )
+            runs = [agent.load_artifact(path, agent.DEFAULT_TARGET)]
+            decision = agent.closed_loop_decision(runs)
+            prior = agent.build_prior(runs, decision, 1)
+
+            self.assertEqual(prior["mutations"][0]["mutation_type"], "remove_component")
+            self.assertEqual(prior["mutations"][0]["feature"], "near_strike_score")
+
     def test_high_rejection_generates_prior_from_selected_nodes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = artifact(


### PR DESCRIPTION
## Summary
- thread explicit `parent_name` lineage through AutoFactor candidates, reports, and tree-trace artifacts
- persist `parent_name` in `mcts-state.json` with serde default compatibility for older state artifacts
- seed current-batch nodes before updating MCTS state, then backpropagate leaf rewards through ancestor nodes with cycle/depth guards
- update alpha-search docs and task tracking for Priority 2

## Evidence stage
`factor_attribution` only. No promotion, dry-run, live trading, or runtime-parity gates changed.

## Validation
- `rtk cargo check -p ploy-research --lib --tests`
- `rtk cargo test -p ploy-research alpha_search --lib`
- `rtk cargo test -p ploy-research autofactor --lib`
- `rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs crates/ploy-research/src/autofactor.rs`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and factor-generation results now retain parent lineage for clearer derivation tracking.
  * MCTS state now persists lineage across runs and backpropagates leaf rewards to ancestor nodes for more consistent ranking.
  * Typed-prior generation now supports `remove_component` mutations, including component ablation guidance from updated preferences.

* **Bug Fixes**
  * Improved visit and reward accumulation so parent outcomes reflect descendant results more accurately.

* **Documentation**
  * Updated workflow notes to clarify lineage tracking and cumulative MCTS behavior.

* **Chores**
  * Expanded validation coverage and added a test for `remove_component` selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->