### PR TITLE
Fix MCTS backpropagation guardrails

### DIFF
--- a/crates/ploy-research/src/alpha_search.rs
+++ b/crates/ploy-research/src/alpha_search.rs
@@ -56,6 +56,8 @@ pub struct MctsSearchStateArtifact {
     pub mode: String,
     pub target: String,
     pub total_visits: usize,
+    #[serde(default)]
+    pub backpropagation_truncated_count: usize,
     pub nodes: Vec<MctsSearchStateNode>,
 }
 
@@ -518,6 +520,19 @@ pub fn write_alpha_search_artifacts_with_state_and_runtime_feedback(
         &factor_registry_preview_artifact(target, reports, &node_metrics)?,
     )?;
     let mcts_state = mcts_search_state(target, &node_metrics, prior_state);
+    let prior_truncated_count = prior_state
+        .filter(|state| state.target == target)
+        .map(|state| state.backpropagation_truncated_count)
+        .unwrap_or_default();
+    let new_truncated_count = mcts_state
+        .backpropagation_truncated_count
+        .saturating_sub(prior_truncated_count);
+    if new_truncated_count > 0 {
+        eprintln!(
+            "alpha-search warning: MCTS backpropagation truncated {} new time(s) for target `{}` ({} cumulative); inspect parent_name lineage for cycles or impossible depth.",
+            new_truncated_count, target, mcts_state.backpropagation_truncated_count
+        );
+    }
     write_json(&output_dir.join("mcts-state.json"), &mcts_state)?;
     write_json(
         &output_dir.join("mcts-expansion-plan.json"),
@@ -1164,6 +1179,11 @@ fn mcts_search_state(
         node.parent_name = metric.parent_name.clone();
     }
 
+    let mut backpropagation_truncated_count = prior_state
+        .filter(|state| state.target == target)
+        .map(|state| state.backpropagation_truncated_count)
+        .unwrap_or_default();
+
     for metric in metrics {
         let Some(node) = nodes.get_mut(&metric.factor_name) else {
             continue;
@@ -1174,7 +1194,9 @@ fn mcts_search_state(
         node.last_reward = metric.reward;
         node.selected_dimension = metric.selected_dimension.clone();
         node.last_decision = metric.decision.clone();
-        backpropagate(&mut nodes, &metric.factor_name, metric.reward);
+        if backpropagate(&mut nodes, &metric.factor_name, metric.reward) {
+            backpropagation_truncated_count = backpropagation_truncated_count.saturating_add(1);
+        }
     }
 
     let mut nodes = nodes.into_values().collect::<Vec<_>>();
@@ -1185,31 +1207,38 @@ fn mcts_search_state(
         mode: "cumulative_ucb_state".to_string(),
         target: target.to_string(),
         total_visits,
+        backpropagation_truncated_count,
         nodes,
     }
 }
 
-fn backpropagate(nodes: &mut BTreeMap<String, MctsSearchStateNode>, leaf_name: &str, reward: f64) {
+fn backpropagate(
+    nodes: &mut BTreeMap<String, MctsSearchStateNode>,
+    leaf_name: &str,
+    reward: f64,
+) -> bool {
     let mut current = leaf_name.to_string();
     let mut visited = BTreeSet::new();
-    for _ in 0..64 {
+    let max_hops = nodes.len().max(1);
+    for _ in 0..max_hops {
         if !visited.insert(current.clone()) {
-            break;
+            return true;
         }
         let Some(parent_name) = nodes
             .get(&current)
             .and_then(|node| node.parent_name.clone())
         else {
-            break;
+            return false;
         };
         let Some(parent) = nodes.get_mut(&parent_name) else {
-            break;
+            return false;
         };
         parent.visits = parent.visits.saturating_add(1);
         parent.total_reward += reward;
         parent.best_reward = parent.best_reward.max(reward);
         current = parent_name;
     }
+    true
 }
 
 fn mcts_expansion_plan(
@@ -2065,6 +2094,7 @@ mod tests {
             mode: "cumulative_ucb_state".to_string(),
             target: "full_depth_settlement_executable_pnl".to_string(),
             total_visits: 3,
+            backpropagation_truncated_count: 0,
             nodes: vec![MctsSearchStateNode {
                 factor_name: "auto_settlement_conservative_settlement_edge".to_string(),
                 parent_name: None,
@@ -2154,6 +2184,72 @@ mod tests {
                 + reward_by_name["mut2_root_factor_capacity_squashed"]
         );
         assert_eq!(sibling_node.total_reward, reward_by_name["sibling_factor"]);
+    }
+
+    #[test]
+    fn mcts_state_backpropagates_through_long_lineage() {
+        let runtime_avoidances = Vec::new();
+        let mut reports = Vec::new();
+        for idx in 0..100 {
+            let mut report = sample_report(&format!("factor_{idx:03}"));
+            if idx > 0 {
+                report.parent_name = Some(format!("factor_{:03}", idx - 1));
+            }
+            report.top_bucket_avg_label = 0.20 + (idx as f64 * 0.001);
+            reports.push(report);
+        }
+
+        let metrics = reports
+            .iter()
+            .enumerate()
+            .map(|(idx, report)| node_metric(idx, report, &runtime_avoidances, None))
+            .collect::<Vec<_>>();
+        let expected_root_total = metrics.iter().map(|metric| metric.reward).sum::<f64>();
+        let state = mcts_search_state("full_depth_settlement_executable_pnl", &metrics, None);
+        let root = state
+            .nodes
+            .iter()
+            .find(|node| node.factor_name == "factor_000")
+            .expect("root node");
+
+        assert_eq!(state.backpropagation_truncated_count, 0);
+        assert_eq!(root.visits, 100);
+        assert!((root.total_reward - expected_root_total).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mcts_state_counts_cycle_truncated_backpropagation() {
+        let runtime_avoidances = Vec::new();
+        let mut report = sample_report("cycle_a");
+        report.parent_name = Some("cycle_b".to_string());
+        let metrics = [node_metric(0, &report, &runtime_avoidances, None)];
+        let prior = MctsSearchStateArtifact {
+            version: ALPHA_SEARCH_ARTIFACT_VERSION.to_string(),
+            mode: "cumulative_ucb_state".to_string(),
+            target: "full_depth_settlement_executable_pnl".to_string(),
+            total_visits: 0,
+            backpropagation_truncated_count: 0,
+            nodes: vec![MctsSearchStateNode {
+                factor_name: "cycle_b".to_string(),
+                parent_name: Some("cycle_a".to_string()),
+                visits: 0,
+                total_reward: 0.0,
+                best_reward: f64::NEG_INFINITY,
+                last_reward: 0.0,
+                selected_dimension: "exploit".to_string(),
+                last_decision: "candidate".to_string(),
+            }],
+        };
+
+        let state = mcts_search_state(
+            "full_depth_settlement_executable_pnl",
+            &metrics,
+            Some(&prior),
+        );
+
+        assert_eq!(state.backpropagation_truncated_count, 1);
+        assert!(state.nodes.iter().any(|node| node.factor_name == "cycle_a"));
+        assert!(state.nodes.iter().any(|node| node.factor_name == "cycle_b"));
     }
 
     #[test]

--- a/docs/ALPHA_FACTOR_SEARCH_CICD.md
+++ b/docs/ALPHA_FACTOR_SEARCH_CICD.md
@@ -617,6 +617,12 @@ Current implementation status:
   parent lineage, accumulates leaf visits, backpropagates leaf rewards through
   ancestor nodes across runs, and the expansion plan ranks non-rejected
   current-run nodes with a UCB-style priority using that cumulative state.
+  `mcts-state.json.backpropagation_truncated_count > 0` means reward
+  propagation hit a defensive stop before reaching a root node. Inspect
+  `parent_name` lineage for cycles first; if there is no cycle, check whether
+  the search state graph has grown beyond the expected bounded chain size. CI
+  warnings report only newly observed truncations while including the
+  cumulative artifact count.
 - Implemented: `factor_walk_forward_v2 --alpha-search-plan-json <path>` can
   consume a prior `mcts-expansion-plan.json` and generate extra `mcts_*`
   guided mutations for selected branches. The Factor Walk-Forward workflows

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21778,3 +21778,40 @@ gates are touched by any of these priorities.
   existing feature for `overfit_risk -> remove_component` drafts, so generated
   prior JSON stays compileable instead of becoming inert advice. This still
   intentionally excludes direct live LLM API invocation inside CI.
+
+# MCTS Backpropagation Guardrails (2026-07-06)
+
+## Goal
+
+Remove the artificial fixed-depth cutoff from alpha-search MCTS reward
+backpropagation and make defensive truncation observable in `mcts-state.json`.
+
+Evidence stage: `factor_attribution` only. No promotion, dry-run, or live
+gates are touched.
+
+## Files / Ownership
+
+- `crates/ploy-research/src/alpha_search.rs`
+  - Owner: parent-chain backpropagation depth guard, truncation diagnostics, and
+    focused unit tests.
+- `docs/ALPHA_FACTOR_SEARCH_CICD.md`
+  - Owner: document the `backpropagation_truncated_count` artifact field.
+- `tasks/todo.md`
+  - Owner: current session tracking.
+
+## Tasks
+
+- [x] Replace the fixed `64` hop guard with a graph-size-bound guard using
+      `nodes.len().max(1)` while keeping cycle detection.
+- [x] Add `backpropagation_truncated_count` to `MctsSearchStateArtifact` with
+      `serde(default)` compatibility for old state artifacts.
+- [x] Warn in artifact generation when truncation count is non-zero.
+- [x] Add Rust coverage for a 100-node lineage and a synthetic cycle.
+- [x] Update docs and run focused validation.
+
+## Review
+
+- 2026-07-06: Implemented. Long acyclic lineage now backpropagates all the way
+  to the root instead of silently stopping at 64 hops. Cycle/max-hop defensive
+  stops increment `backpropagation_truncated_count`, and artifact generation
+  emits a warning when the count is non-zero.


### PR DESCRIPTION
## Summary
- replace the fixed 64-hop MCTS backpropagation guard with a graph-size-bound guard
- add backpropagation_truncated_count to mcts-state.json and warn when it is non-zero
- add long-lineage and synthetic-cycle coverage

## Evidence stage
factor_attribution only; no promotion, dry-run, or live trading path touched.

## Validation
- rtk cargo test -p ploy-research alpha_search --lib
- rtk cargo check -p ploy-research --lib --tests
- rustfmt --edition 2024 --check crates/ploy-research/src/alpha_search.rs
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCTS backpropagation guardrails to handle long or cyclic parent-chain structures more reliably.
  * Search state outputs now include a persistent truncation counter, including new behavior for cycle detection.
  * Artifact generation emits a warning when newly observed truncation occurs.
* **Documentation**
  * Updated guidance to interpret the truncation counter in `mcts-state.json` and troubleshoot lineage cycles or unexpected graph growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->