### PR TITLE
Add self-mod deployment dispatch gate

### DIFF
--- a/ploy-sidecar/src/index.ts
+++ b/ploy-sidecar/src/index.ts
@@ -574,7 +574,11 @@ async function runQueuedStrategyRequest(queued: QueuedAgentRunRequest): Promise<
     process.env.SIDECAR_ALLOW_SELF_MODIFICATION === "true" &&
     queued.request.run_contract.includes("requires_harness_self_modification = true")
   ) {
-    queuedAllowedTools.push("mcp__agent-runtime__apply_self_modification");
+    queuedAllowedTools.push(
+      "mcp__agent-runtime__apply_self_modification",
+      "mcp__agent-runtime__dispatch_self_modification_deployment",
+      "mcp__agent-runtime__dispatch_self_modification_rollback"
+    );
   }
 
   console.log(`\n[${startedAt}] Starting queued strategy run ${queued.run_id}`);

--- a/ploy-sidecar/src/runtime/self-modification.ts
+++ b/ploy-sidecar/src/runtime/self-modification.ts
@@ -25,6 +25,33 @@ export type SelfModificationProposal = {
   pull_request_url?: string;
 };
 
+type WorkflowInputs = Record<string, string | number | boolean>;
+
+export type SelfModificationDeploymentDispatch = {
+  kind: "self_modification_deployment_dispatch";
+  deployment_id: string;
+  workflow: string;
+  workflow_ref: string;
+  inputs: WorkflowInputs;
+  rollback_workflow: string;
+  rollback_workflow_ref: string;
+  rollback_inputs: WorkflowInputs;
+  status: "dispatched";
+  run_url?: string;
+  created_at: string;
+};
+
+export type SelfModificationRollbackDispatch = {
+  kind: "self_modification_rollback_dispatch";
+  deployment_id: string;
+  workflow: string;
+  workflow_ref: string;
+  inputs: WorkflowInputs;
+  status: "dispatched";
+  run_url?: string;
+  created_at: string;
+};
+
 export async function proposeSelfModification(params: {
   title: string;
   patch: string;
@@ -45,6 +72,81 @@ export async function proposeSelfModification(params: {
   return proposal;
 }
 
+export async function dispatchApprovedSelfModificationDeployment(params: {
+  approval_token: string;
+  workflow: string;
+  workflow_ref?: string;
+  inputs?: WorkflowInputs;
+  rollback_workflow: string;
+  rollback_workflow_ref?: string;
+  rollback_inputs?: WorkflowInputs;
+}): Promise<SelfModificationDeploymentDispatch> {
+  verifySelfModificationApproval(params.approval_token);
+  if (process.env.PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY !== "true") {
+    throw new Error("self-modification deployment dispatch is not enabled");
+  }
+  const workflowRef = params.workflow_ref || "main";
+  const rollbackWorkflowRef = params.rollback_workflow_ref || "main";
+  const inputs = params.inputs || {};
+  const rollbackInputs = params.rollback_inputs || {};
+  validateWorkflowAllowed(params.workflow);
+  validateWorkflowAllowed(params.rollback_workflow);
+  validateWorkflowRef(workflowRef, inputs);
+  validateWorkflowRef(rollbackWorkflowRef, rollbackInputs);
+  validateWorkflowInputs(inputs);
+  validateWorkflowInputs(rollbackInputs);
+
+  const repoRoot = await findRepoRoot();
+  const runUrl = await dispatchWorkflow(repoRoot, params.workflow, workflowRef, inputs);
+  const record: SelfModificationDeploymentDispatch = {
+    kind: "self_modification_deployment_dispatch",
+    deployment_id: `selfdeploy-${randomUUID()}`,
+    workflow: params.workflow,
+    workflow_ref: workflowRef,
+    inputs,
+    rollback_workflow: params.rollback_workflow,
+    rollback_workflow_ref: rollbackWorkflowRef,
+    rollback_inputs: rollbackInputs,
+    status: "dispatched",
+    run_url: runUrl,
+    created_at: new Date().toISOString(),
+  };
+  await appendFile(await harnessSelfModificationsPath(), `${JSON.stringify(record)}\n`, "utf8");
+  return record;
+}
+
+export async function dispatchApprovedSelfModificationRollback(params: {
+  approval_token: string;
+  workflow: string;
+  workflow_ref?: string;
+  inputs?: WorkflowInputs;
+}): Promise<SelfModificationRollbackDispatch> {
+  verifySelfModificationApproval(params.approval_token);
+  if (process.env.PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY !== "true") {
+    throw new Error("self-modification rollback dispatch is not enabled");
+  }
+  const workflowRef = params.workflow_ref || "main";
+  const inputs = params.inputs || {};
+  validateWorkflowAllowed(params.workflow);
+  validateWorkflowRef(workflowRef, inputs);
+  validateWorkflowInputs(inputs);
+
+  const repoRoot = await findRepoRoot();
+  const runUrl = await dispatchWorkflow(repoRoot, params.workflow, workflowRef, inputs);
+  const record: SelfModificationRollbackDispatch = {
+    kind: "self_modification_rollback_dispatch",
+    deployment_id: `selfrollback-${randomUUID()}`,
+    workflow: params.workflow,
+    workflow_ref: workflowRef,
+    inputs,
+    status: "dispatched",
+    run_url: runUrl,
+    created_at: new Date().toISOString(),
+  };
+  await appendFile(await harnessSelfModificationsPath(), `${JSON.stringify(record)}\n`, "utf8");
+  return record;
+}
+
 export async function applyApprovedSelfModification(params: {
   proposal_id: string;
   approval_token: string;
@@ -55,14 +157,7 @@ export async function applyApprovedSelfModification(params: {
   pull_request_body?: string;
   base_branch?: string;
 }): Promise<SelfModificationProposal> {
-  const expectedToken = process.env.PLOY_HARNESS_SELF_MOD_APPROVAL_TOKEN;
-  if (!expectedToken) {
-    throw new Error("self-modification apply is not configured");
-  }
-  if (params.approval_token !== expectedToken) {
-    throw new Error("invalid self-modification approval token");
-  }
-
+  verifySelfModificationApproval(params.approval_token);
   const proposal = await readProposal(params.proposal_id);
   const repoRoot = await findRepoRoot();
   await ensureCleanWorktree(repoRoot);
@@ -150,6 +245,81 @@ export async function applyApprovedSelfModification(params: {
   }
 
   return recordApplied(proposal, {});
+}
+
+function verifySelfModificationApproval(approvalToken: string): void {
+  const expectedToken = process.env.PLOY_HARNESS_SELF_MOD_APPROVAL_TOKEN;
+  if (!expectedToken) {
+    throw new Error("self-modification approval is not configured");
+  }
+  if (approvalToken !== expectedToken) {
+    throw new Error("invalid self-modification approval token");
+  }
+}
+
+function validateWorkflowAllowed(workflow: string): void {
+  if (!/^[A-Za-z0-9._-]+\.ya?ml$/.test(workflow)) {
+    throw new Error(`invalid workflow name: ${workflow}`);
+  }
+  const allowed = new Set(
+    (process.env.PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS || "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean)
+  );
+  if (!allowed.has(workflow)) {
+    throw new Error(`self-modification deployment workflow is not allowlisted: ${workflow}`);
+  }
+}
+
+function validateWorkflowInputs(inputs: WorkflowInputs): void {
+  for (const [key, value] of Object.entries(inputs)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]{0,63}$/.test(key)) {
+      throw new Error(`invalid workflow input name: ${key}`);
+    }
+    if (!["string", "number", "boolean"].includes(typeof value)) {
+      throw new Error(`invalid workflow input value for ${key}`);
+    }
+  }
+}
+
+function validateWorkflowRef(workflowRef: string, inputs: WorkflowInputs): void {
+  if (process.env.PLOY_HARNESS_SELF_MOD_ALLOW_NON_MAIN_DEPLOY_REF === "true") return;
+  if (workflowRef !== "main") {
+    throw new Error("self-modification deployment dispatch requires workflow_ref=main");
+  }
+  const gitRef = inputs.git_ref;
+  if (gitRef !== undefined && String(gitRef) !== "main") {
+    throw new Error("self-modification deployment dispatch requires git_ref=main");
+  }
+}
+
+async function dispatchWorkflow(
+  cwd: string,
+  workflow: string,
+  workflowRef: string,
+  inputs: WorkflowInputs
+): Promise<string | undefined> {
+  const args = ["workflow", "run", workflow, "--ref", workflowRef];
+  for (const [key, value] of Object.entries(inputs)) {
+    args.push("-f", `${key}=${String(value)}`);
+  }
+  await run(cwd, "gh", args);
+  const runUrl = (
+    await runOutput(cwd, "gh", [
+      "run",
+      "list",
+      "--workflow",
+      workflow,
+      "--limit",
+      "1",
+      "--json",
+      "url",
+      "--jq",
+      ".[0].url",
+    ]).catch(() => "")
+  ).trim();
+  return runUrl || undefined;
 }
 
 async function recordApplied(
@@ -253,6 +423,8 @@ async function selfTest() {
   const originalRoot = process.env.PLOY_SELF_MOD_REPO_ROOT;
   const originalToken = process.env.PLOY_HARNESS_SELF_MOD_APPROVAL_TOKEN;
   const originalAllowPr = process.env.PLOY_HARNESS_SELF_MOD_ALLOW_PR;
+  const originalAllowDeploy = process.env.PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY;
+  const originalDeployWorkflows = process.env.PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS;
   const originalPathValue = process.env.PATH;
   const dir = await mkdtemp(join(tmpdir(), "ploy-self-mod-"));
   const logDir = await mkdtemp(join(tmpdir(), "ploy-self-mod-log-"));
@@ -265,10 +437,21 @@ async function selfTest() {
     process.env.PLOY_SELF_MOD_REPO_ROOT = dir;
     process.env.PLOY_HARNESS_SELF_MOD_APPROVAL_TOKEN = "approve";
     process.env.PLOY_HARNESS_SELF_MOD_ALLOW_PR = "true";
+    process.env.PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY = "true";
+    process.env.PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS = "deploy-test.yml,rollback-test.yml";
     process.env.PATH = `${binDir}${delimiter}${process.env.PATH || ""}`;
     await writeFile(
       join(binDir, "gh"),
-      "#!/bin/sh\nprintf '%s\\n' 'https://github.example/ploy/pull/1'\n",
+      [
+        "#!/bin/sh",
+        "case \"$1 $2\" in",
+        "  \"pr create\") printf '%s\\n' 'https://github.example/ploy/pull/1' ;;",
+        "  \"workflow run\") exit 0 ;;",
+        "  \"run list\") printf '%s\\n' 'https://github.example/ploy/actions/runs/42' ;;",
+        "  *) exit 1 ;;",
+        "esac",
+        "",
+      ].join("\n"),
       "utf8"
     );
     await chmod(join(binDir, "gh"), 0o755);
@@ -319,11 +502,42 @@ async function selfTest() {
     );
     assert.equal((await runOutput(dir, "git", ["branch", "--show-current"])).trim(), "selfmod/test");
     assert.equal((await runOutput(dir, "git", ["branch", "--list", "selfmod/fail"])).trim(), "");
+
+    const deployment = await dispatchApprovedSelfModificationDeployment({
+      approval_token: "approve",
+      workflow: "deploy-test.yml",
+      inputs: { git_ref: "main", deploy: true },
+      rollback_workflow: "rollback-test.yml",
+      rollback_inputs: { git_ref: "main", deploy: true },
+    });
+    assert.equal(deployment.workflow, "deploy-test.yml");
+    assert.equal(deployment.rollback_workflow, "rollback-test.yml");
+    assert.equal(deployment.run_url, "https://github.example/ploy/actions/runs/42");
+    await assert.rejects(
+      dispatchApprovedSelfModificationDeployment({
+        approval_token: "approve",
+        workflow: "not-allowed.yml",
+        inputs: { git_ref: "main" },
+        rollback_workflow: "rollback-test.yml",
+      })
+    );
+
+    const rollback = await dispatchApprovedSelfModificationRollback({
+      approval_token: "approve",
+      workflow: "rollback-test.yml",
+      inputs: { git_ref: "main", deploy: true },
+    });
+    assert.equal(rollback.workflow, "rollback-test.yml");
+    assert.equal(rollback.run_url, "https://github.example/ploy/actions/runs/42");
+    assert.match(await readFile(logPath, "utf8"), /self_modification_deployment_dispatch/);
+    assert.match(await readFile(logPath, "utf8"), /self_modification_rollback_dispatch/);
   } finally {
     restoreEnv("PLOY_HARNESS_SELF_MODIFICATIONS_FILE", originalPath);
     restoreEnv("PLOY_SELF_MOD_REPO_ROOT", originalRoot);
     restoreEnv("PLOY_HARNESS_SELF_MOD_APPROVAL_TOKEN", originalToken);
     restoreEnv("PLOY_HARNESS_SELF_MOD_ALLOW_PR", originalAllowPr);
+    restoreEnv("PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY", originalAllowDeploy);
+    restoreEnv("PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS", originalDeployWorkflows);
     restoreEnv("PATH", originalPathValue);
     await rm(dir, { recursive: true, force: true });
     await rm(logDir, { recursive: true, force: true });

--- a/ploy-sidecar/src/tools/agent-runtime.ts
+++ b/ploy-sidecar/src/tools/agent-runtime.ts
@@ -3,8 +3,12 @@ import { z } from "zod";
 import { appendHarnessProposal } from "../runtime/harness-memory.js";
 import {
   applyApprovedSelfModification,
+  dispatchApprovedSelfModificationDeployment,
+  dispatchApprovedSelfModificationRollback,
   proposeSelfModification,
 } from "../runtime/self-modification.js";
+
+const workflowInputSchema = z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]));
 
 export const agentRuntimeServer = createSdkMcpServer({
   name: "agent-runtime",
@@ -139,6 +143,72 @@ export const agentRuntimeServer = createSdkMcpServer({
           pull_request_title,
           pull_request_body,
           base_branch,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      }
+    ),
+    tool(
+      "dispatch_self_modification_deployment",
+      "Dispatch an allowlisted GitHub Actions deployment workflow after approval, with a required rollback workflow gate.",
+      {
+        approval_token: z.string(),
+        workflow: z.string().describe("Allowlisted workflow file, for example deploy-tango-1-1.yml"),
+        workflow_ref: z.string().default("main"),
+        inputs: workflowInputSchema.default({}),
+        rollback_workflow: z.string().describe("Allowlisted workflow file to use for rollback"),
+        rollback_workflow_ref: z.string().default("main"),
+        rollback_inputs: workflowInputSchema.default({}),
+      },
+      async ({
+        approval_token,
+        workflow,
+        workflow_ref,
+        inputs,
+        rollback_workflow,
+        rollback_workflow_ref,
+        rollback_inputs,
+      }) => {
+        const result = await dispatchApprovedSelfModificationDeployment({
+          approval_token,
+          workflow,
+          workflow_ref,
+          inputs,
+          rollback_workflow,
+          rollback_workflow_ref,
+          rollback_inputs,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      }
+    ),
+    tool(
+      "dispatch_self_modification_rollback",
+      "Dispatch an allowlisted GitHub Actions rollback workflow after approval.",
+      {
+        approval_token: z.string(),
+        workflow: z.string(),
+        workflow_ref: z.string().default("main"),
+        inputs: workflowInputSchema.default({}),
+      },
+      async ({ approval_token, workflow, workflow_ref, inputs }) => {
+        const result = await dispatchApprovedSelfModificationRollback({
+          approval_token,
+          workflow,
+          workflow_ref,
+          inputs,
         });
         return {
           content: [

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Current Session - Self-Mod Deploy Dispatch Gate (2026-07-09)
+
+Evidence stage: `diagnostic` self-modification deployment gate. This adds an
+approval-gated GitHub Actions dispatch path for self-mod deployments without
+duplicating deploy logic or bypassing protected environments.
+
+## Files / Ownership
+
+- `ploy-sidecar/src/runtime/self-modification.ts`
+  - Owner: allowlisted deployment and rollback workflow dispatch records.
+- `ploy-sidecar/src/tools/agent-runtime.ts`
+  - Owner: MCP schema for deployment and rollback dispatch.
+- `ploy-sidecar/src/index.ts`
+  - Owner: expose dispatch tools only for approved queued self-mod runs.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+## Tasks
+
+- [x] Add approval-token and env-gated deployment workflow dispatch.
+- [x] Require allowlisted deploy and rollback workflow names.
+- [x] Keep default dispatch refs on `main`; block non-main deploy refs unless
+      explicitly enabled.
+- [x] Add rollback dispatch tool and self-test coverage with fake `gh`.
+- [ ] Push PR and verify CI.
+
+## Review
+
+- 2026-07-09: Added self-mod deployment dispatch using existing GitHub Actions
+  workflows via `gh workflow run`. Dispatch requires
+  `PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY=true`, an allowlist in
+  `PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS`, an approval token, and a rollback
+  workflow. The queued sidecar only exposes these tools when
+  `SIDECAR_ALLOW_SELF_MODIFICATION=true` and the run contract requires harness
+  self-modification. Validation passed:
+  `npx tsx src/runtime/self-modification.ts` and `npm run build` in
+  `ploy-sidecar`.
+
 # Current Session - Self-Mod PR Gate Continuation (2026-07-09)
 
 Evidence stage: `diagnostic` self-modification gate hardening. This extends


### PR DESCRIPTION
## Summary
- add approval-gated self-mod deployment workflow dispatch via existing GitHub Actions
- require PLOY_HARNESS_SELF_MOD_ALLOW_DEPLOY=true and an explicit PLOY_HARNESS_SELF_MOD_DEPLOY_WORKFLOWS allowlist
- require a rollback workflow gate and expose a separate rollback dispatch tool
- only expose deploy/rollback tools to queued self-mod runs when SIDECAR_ALLOW_SELF_MODIFICATION=true and the run contract requires it

## Validation
- cd ploy-sidecar && npx tsx src/runtime/self-modification.ts
- cd ploy-sidecar && npm run build