### PR TITLE
Ensure harness events log is initialized

### DIFF
--- a/ploy-sidecar/src/runtime/harness-memory.ts
+++ b/ploy-sidecar/src/runtime/harness-memory.ts
@@ -35,6 +35,7 @@ This file is maintained by the sidecar from completed agent runs.
 `;
 
 export async function readHarnessContext(maxChars = 6000): Promise<string> {
+  await ensureHarnessEventsLog();
   const path = await harnessContextPath();
   try {
     const body = await readFile(path, "utf8");
@@ -44,6 +45,10 @@ export async function readHarnessContext(maxChars = 6000): Promise<string> {
     await writeFile(path, DEFAULT_CONTEXT, "utf8");
     return DEFAULT_CONTEXT;
   }
+}
+
+async function ensureHarnessEventsLog(): Promise<void> {
+  await appendFile(await harnessEventsPath(), "", "utf8");
 }
 
 export function deriveHarnessLearning(record: AgentRunRecord): HarnessLearning | null {
@@ -193,6 +198,8 @@ async function selfTest() {
     process.env.PLOY_AGENT_RUNS_FILE = join(dir, "agent-runs.jsonl");
     process.env.PLOY_HARNESS_CONTEXT_FILE = join(dir, "harness-context.md");
     process.env.PLOY_HARNESS_EVENTS_FILE = join(dir, "harness-events.jsonl");
+    assert.equal(await readHarnessContext(), DEFAULT_CONTEXT);
+    assert.equal(await readFile(await harnessEventsPath(), "utf8"), "");
 
     const record = {
       run_id: "agent-test",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Current Session - Harness Events Initialization (2026-07-09)
+
+Evidence stage: `diagnostic` end-to-end smoke closeout. The main-branch Grok
+smoke succeeded, but a fully successful run does not naturally create a
+learning event. The harness should still expose an empty append-only event log
+so the memory API/UI and smoke checks have a stable file contract.
+
+## Files / Ownership
+
+- `ploy-sidecar/src/runtime/harness-memory.ts`
+  - Owner: meta-context and append-only harness event log initialization.
+- `tasks/todo.md`
+  - Owner: session tracking and verification notes.
+
+## Tasks
+
+- [x] Ensure `harness-events.jsonl` exists when meta-context is initialized.
+- [ ] Push PR, merge to main, and rerun Strategy Builder Grok smoke on main.
+
+## Review
+
+- 2026-07-09: Added empty event-log initialization to `readHarnessContext()`.
+  This preserves learning semantics: successful runs do not create fake events,
+  but the append-only `harness-events.jsonl` file now exists for API/UI and E2E
+  smoke verification.
+
 # Current Session - Grok Sidecar Engine Smoke Path (2026-07-09)
 
 Evidence stage: `diagnostic` end-to-end smoke unblocker. This adds an explicit


### PR DESCRIPTION
## Summary
- initialize an empty harness-events.jsonl when harness meta-context is read
- keep learning semantics unchanged: successful runs do not create fake events
- record the E2E smoke closeout gap in tasks/todo.md

## Validation
- cd ploy-sidecar && npx tsx src/runtime/harness-memory.ts
- cd ploy-sidecar && npx tsx src/runtime/run-recorder.ts
- cd ploy-sidecar && npm run build
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured session harness data is initialized consistently before use, preventing missing event logs and improving stability for related workflows.
  * Added a verification that the harness event log starts empty when a new session context is loaded.

* **Chores**
  * Updated internal task tracking with the latest session initialization follow-up items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->