### PR TITLE
fix(deploy): enforce Aliyun dual-host boundary

### DIFF
--- a/.github/workflows/approve-live-trade.yml
+++ b/.github/workflows/approve-live-trade.yml
@@ -1,0 +1,338 @@
+name: Approve Live Trade
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_sha:
+        description: "Exact 40-character main SHA already deployed to ploy-trade-1"
+        required: true
+      runtime_replay_run_id:
+        description: "Successful Runtime Candidate Replay run ID for deploy_sha"
+        required: true
+      parity_run_id:
+        description: "Successful Recorded Replay Dry-run Parity run ID for deploy_sha"
+        required: true
+      min_replay_trades:
+        description: "Minimum independent executable-replay event trades"
+        required: true
+        default: "20"
+      min_dryrun_closed_trades:
+        description: "Minimum closed dry-run trades"
+        required: true
+        default: "30"
+      max_drawdown_usd:
+        description: "Maximum accepted absolute dry-run drawdown in USD"
+        required: true
+        default: "25"
+      risk_confirmation:
+        description: "Type exactly: I APPROVE LIVE RISK AT 5 USD MAX EXPOSURE"
+        required: true
+
+concurrency:
+  group: ploy-trade-host
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate-evidence:
+    name: Validate exact-SHA replay, drawdown, and parity evidence
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_sha: ${{ steps.validate.outputs.deploy_sha }}
+
+    steps:
+      - name: Checkout approved SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Validate main provenance and explicit risk acknowledgement
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          RISK_CONFIRMATION: ${{ inputs.risk_confirmation }}
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF_NAME}" == "main" ]] || {
+            echo "live approval must be dispatched from main" >&2
+            exit 1
+          }
+          [[ "${DEPLOY_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "deploy_sha must be 40 lowercase hex characters" >&2
+            exit 1
+          }
+          git fetch --no-tags --depth=1 origin main
+          [[ "$(git rev-parse HEAD)" == "${DEPLOY_SHA}" ]] || exit 1
+          [[ "$(git rev-parse origin/main)" == "${DEPLOY_SHA}" ]] || {
+            echo "deploy_sha is not the current origin/main SHA" >&2
+            exit 1
+          }
+          [[ "${RISK_CONFIRMATION}" == "I APPROVE LIVE RISK AT 5 USD MAX EXPOSURE" ]] || {
+            echo "risk confirmation does not match the required acknowledgement" >&2
+            exit 1
+          }
+          python3 - <<'PY'
+          import json
+          import tomllib
+          from decimal import Decimal
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("config/deployments/pm5d.threelayer.live.json").read_text(encoding="utf-8")
+          )
+          strategy = tomllib.loads(
+              Path("config/strategies/02-pm5d-threelayer.live.toml").read_text(encoding="utf-8")
+          )
+          cap = Decimal(str(manifest["max_gross_exposure"]))
+          stake = Decimal(str(strategy["strategy"]["stake_usd"]))
+          if manifest.get("desired_state") != "paused" or manifest.get("runtime_mode") != "live":
+              raise SystemExit("live manifest must remain runtime_mode=live desired_state=paused")
+          if cap <= 0 or cap > Decimal("5") or stake <= 0 or stake > cap:
+              raise SystemExit(f"bounded live risk invalid: stake={stake} cap={cap}")
+          PY
+
+      - name: Validate source workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          REPLAY_RUN_ID: ${{ inputs.runtime_replay_run_id }}
+          PARITY_RUN_ID: ${{ inputs.parity_run_id }}
+        run: |
+          set -euo pipefail
+          validate_run() {
+            local run_id="$1" expected_path="$2"
+            local payload
+            payload="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+            [[ "$(jq -r .conclusion <<<"${payload}")" == "success" ]] || {
+              echo "run ${run_id} did not conclude success" >&2
+              exit 1
+            }
+            [[ "$(jq -r .head_sha <<<"${payload}")" == "${DEPLOY_SHA}" ]] || {
+              echo "run ${run_id} head SHA does not match deploy_sha" >&2
+              exit 1
+            }
+            [[ "$(jq -r .path <<<"${payload}")" == "${expected_path}" ]] || {
+              echo "run ${run_id} is not from ${expected_path}" >&2
+              exit 1
+            }
+          }
+          validate_run "${REPLAY_RUN_ID}" ".github/workflows/runtime-candidate-replay.yml"
+          validate_run "${PARITY_RUN_ID}" ".github/workflows/recorded-replay-parity.yml"
+
+      - name: Download immutable evidence artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPLAY_RUN_ID: ${{ inputs.runtime_replay_run_id }}
+          PARITY_RUN_ID: ${{ inputs.parity_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p evidence/replay evidence/parity evidence/inputs
+          gh run download "${REPLAY_RUN_ID}" \
+            --name "runtime-candidate-replay-${REPLAY_RUN_ID}" --dir evidence/replay
+          gh run download "${PARITY_RUN_ID}" \
+            --name "recorded-replay-parity-${PARITY_RUN_ID}" --dir evidence/parity
+          gh run download "${PARITY_RUN_ID}" \
+            --name "recorded-replay-inputs-${PARITY_RUN_ID}" --dir evidence/inputs
+
+      - name: Validate promotion evidence and bounded risk
+        id: validate
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          MIN_REPLAY_TRADES: ${{ inputs.min_replay_trades }}
+          MIN_DRYRUN_CLOSED_TRADES: ${{ inputs.min_dryrun_closed_trades }}
+          MAX_DRAWDOWN_USD: ${{ inputs.max_drawdown_usd }}
+          REPLAY_RUN_ID: ${{ inputs.runtime_replay_run_id }}
+          PARITY_RUN_ID: ${{ inputs.parity_run_id }}
+        run: |
+          set -euo pipefail
+          replay="$(find evidence/replay -name candidate-strategy-replay.json -type f -print -quit)"
+          parity="$(find evidence/parity -name parity-evaluation.json -type f -print -quit)"
+          parity_provenance="$(find evidence/parity -name approval-provenance.json -type f -print -quit)"
+          dryrun="$(find evidence/inputs -name dryrun.json -type f -print -quit)"
+          [[ -n "${replay}" && -n "${parity}" && -n "${parity_provenance}" && -n "${dryrun}" ]]
+          source_config=config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+          live_config=config/strategies/02-pm5d-threelayer.live.toml
+          source_config_sha256="$(sha256sum "${source_config}" | cut -d ' ' -f1)"
+          live_config_sha256="$(sha256sum "${live_config}" | cut -d ' ' -f1)"
+          runtime_score="$(python3 -c 'import sys,tomllib; print(tomllib.load(open(sys.argv[1], "rb"))["strategy"]["three_layer_autofactor_runtime_score"])' "${source_config}")"
+          python3 scripts/validate_live_promotion_evidence.py \
+            --replay "${replay}" \
+            --parity "${parity}" \
+            --parity-provenance "${parity_provenance}" \
+            --dryrun "${dryrun}" \
+            --git-sha "${DEPLOY_SHA}" \
+            --min-replay-trades "${MIN_REPLAY_TRADES}" \
+            --min-dryrun-closed-trades "${MIN_DRYRUN_CLOSED_TRADES}" \
+            --max-drawdown-usd "${MAX_DRAWDOWN_USD}" \
+            --expected-deployment-id "pm5d.threelayer.settlement-probability-btc-eth.dryrun" \
+            --expected-strategy-profile "settlement_probability" \
+            --expected-runtime-score "${runtime_score}" \
+            --expected-config-sha256 "${source_config_sha256}" \
+            --output evidence/live-promotion-validation.json
+          LIVE_CONFIG_SHA256="${live_config_sha256}" SOURCE_CONFIG_SHA256="${source_config_sha256}" \
+            python3 - "${replay}" "${parity}" "${parity_provenance}" "${dryrun}" <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          import sys
+
+          def sha256(path):
+              return hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+
+          receipt = {
+              "schema_version": 1,
+              "deploy_sha": os.environ["DEPLOY_SHA"],
+              "approval_workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "runtime_replay_run_id": os.environ["REPLAY_RUN_ID"],
+              "parity_run_id": os.environ["PARITY_RUN_ID"],
+              "min_replay_trades": int(os.environ["MIN_REPLAY_TRADES"]),
+              "min_dryrun_closed_trades": int(os.environ["MIN_DRYRUN_CLOSED_TRADES"]),
+              "max_drawdown_usd": float(os.environ["MAX_DRAWDOWN_USD"]),
+              "deployment_id": "pm5d.threelayer.live",
+              "source_deployment_id": "pm5d.threelayer.settlement-probability-btc-eth.dryrun",
+              "source_config_sha256": os.environ["SOURCE_CONFIG_SHA256"],
+              "live_config_sha256": os.environ["LIVE_CONFIG_SHA256"],
+              "max_gross_exposure": "5",
+              "ready_for_human_live_approval": True,
+              "evidence_sha256": {
+                  "runtime_replay": sha256(sys.argv[1]),
+                  "parity": sha256(sys.argv[2]),
+                  "parity_provenance": sha256(sys.argv[3]),
+                  "dryrun": sha256(sys.argv[4]),
+              },
+          }
+          pathlib.Path("evidence/live-approval-receipt.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+          echo "deploy_sha=${DEPLOY_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload live-approval evidence package
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-approval-evidence-${{ github.run_id }}
+          path: evidence/
+          retention-days: 90
+
+  human-approved-live:
+    name: Human-approved bounded live resume
+    needs: validate-evidence
+    runs-on: ubuntu-latest
+    environment: ploy-trade-live
+
+    steps:
+      - name: Download validated approval package
+        uses: actions/download-artifact@v8
+        with:
+          name: live-approval-evidence-${{ github.run_id }}
+          path: evidence
+
+      - name: Configure pinned SSH
+        env:
+          PLOY_TRADE_1_KNOWN_HOSTS: ${{ secrets.PLOY_TRADE_1_KNOWN_HOSTS }}
+          PLOY_TRADE_1_SSH_KEY: ${{ secrets.PLOY_TRADE_1_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          [[ -n "${PLOY_TRADE_1_KNOWN_HOSTS}" && -n "${PLOY_TRADE_1_SSH_KEY}" ]]
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${PLOY_TRADE_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          printf '%s\n' "${PLOY_TRADE_1_SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/known_hosts ~/.ssh/deploy_key
+          cat > ~/.ssh/config <<EOF
+          Host ploy-trade-1
+            HostName ${{ secrets.PLOY_TRADE_1_HOST }}
+            User root
+            IdentityFile ~/.ssh/deploy_key
+            HostKeyAlias ploy-trade-1
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            ConnectTimeout 30
+          EOF
+
+      - name: Persist approval receipt and resume live
+        env:
+          DEPLOY_SHA: ${{ needs.validate-evidence.outputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          ssh ploy-trade-1 "install -d -m 0750 -o root -g ploy /opt/ploy/data/live-approvals"
+          scp evidence/live-approval-receipt.json \
+            "ploy-trade-1:/opt/ploy/data/live-approvals/${GITHUB_RUN_ID}.json"
+          # shellcheck disable=SC2087
+          ssh ploy-trade-1 /bin/bash -s -- "${DEPLOY_SHA}" <<'REMOTE'
+          set -euo pipefail
+          deploy_sha="$1"
+          postflight=/opt/ploy/current/scripts/verify_trade_host_postflight.sh
+          ployctl=/opt/ploy/current/bin/ployctl
+          gate=/opt/ploy/current/scripts/drills/pm5d_threelayer_live_gate.sh
+          approval_archive="/opt/ploy/data/live-approvals/${GITHUB_RUN_ID}.json"
+          pending_approval=/opt/ploy/data/live-approvals/pending.json
+
+          chmod 0640 "${approval_archive}"
+          chown root:ploy "${approval_archive}"
+          set -a
+          # shellcheck disable=SC1091
+          . /opt/ploy/.env
+          set +a
+          principal="$("${ployctl}" trading principal)"
+          python3 - "${approval_archive}" "${pending_approval}" "${principal}" <<'PY'
+          import datetime
+          import json
+          import pathlib
+          import sys
+
+          source, destination, principal = sys.argv[1:]
+          payload = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+          payload["account_id"] = principal
+          payload["expires_at"] = (
+              datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=15)
+          ).isoformat()
+          target = pathlib.Path(destination)
+          temporary = target.with_suffix(".tmp")
+          temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          temporary.replace(target)
+          PY
+          chmod 0640 "${pending_approval}"
+          chown root:ploy "${pending_approval}"
+          cleanup_failed_approval() {
+            "${ployctl}" deployments pause pm5d.threelayer.live >/dev/null 2>&1 || true
+            rm -f "${pending_approval}"
+          }
+          trap cleanup_failed_approval ERR
+
+          gate_output="$("${gate}" --skip-dry-run-drill 2>&1)"
+          printf '%s\n' "${gate_output}"
+          if [[ "${gate_output}" == *"STAGED-WITH-WARNINGS"* ]]; then
+            echo "live readiness warnings remain active" >&2
+            exit 1
+          fi
+          "${postflight}" "${deploy_sha}" paused
+          "${ployctl}" deployments resume pm5d.threelayer.live
+          ready=0
+          for _ in $(seq 1 30); do
+            if "${postflight}" "${deploy_sha}" running; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [[ "${ready}" -ne 1 ]]; then
+            echo "live postflight failed; deployment was paused" >&2
+            exit 1
+          fi
+          trap - ERR
+          rm -f "${pending_approval}"
+          REMOTE
+
+      - name: Live approval summary
+        run: |
+          {
+            echo "## Human-approved live resume"
+            echo "- Deploy SHA: \`${{ needs.validate-evidence.outputs.deploy_sha }}\`"
+            echo "- Runtime replay: \`${{ inputs.runtime_replay_run_id }}\`"
+            echo "- Recorded parity: \`${{ inputs.parity_run_id }}\`"
+            echo "- Exposure cap: \`5 USD\`"
+            echo "- Rollback: automatic pause on failed observed-running or venue-health postflight"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -173,16 +173,25 @@ jobs:
           cp "target/${PLATFORM_TARGET}/release/examples/persist_research_trace" dist/bin/persist-research-trace
           cp "target/${PLATFORM_TARGET}/release/examples/research_trace_plan" dist/bin/research-trace-plan
           cp config/strategies/02-pm5d.unified.toml dist/config/strategies/02-pm5d.unified.toml
-          cp config/strategies/02-pm5d.live.toml dist/config/strategies/02-pm5d.live.toml
           cp config/strategies/02-pm5d-threelayer.unified.toml dist/config/strategies/02-pm5d-threelayer.unified.toml
-          cp config/strategies/02-pm5d-threelayer.live.toml dist/config/strategies/02-pm5d-threelayer.live.toml
           cp config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml dist/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml dist/config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.champion-dryrun.toml dist/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml dist/config/strategies/02-pm5d-threelayer.continuation-soft-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml dist/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
           cp config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml dist/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
-          cp config/deployments/*.json dist/config/deployments/
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import shutil
+
+          destination = pathlib.Path("dist/config/deployments")
+          for source in pathlib.Path("config/deployments").glob("*.json"):
+              payload = json.loads(source.read_text(encoding="utf-8"))
+              if payload.get("runtime_mode") == "live":
+                  continue
+              shutil.copy2(source, destination / source.name)
+          PY
           cp scripts/binance_aggtrade_collector.py dist/scripts/binance_aggtrade_collector.py
           cp scripts/binance_price_collector.py dist/scripts/binance_price_collector.py
           cp scripts/binance_lob_collector.py dist/scripts/binance_lob_collector.py
@@ -200,7 +209,9 @@ jobs:
           cp scripts/fix_deribit_partitions.sql dist/scripts/fix_deribit_partitions.sql
           cp scripts/fix_clob_trade_partitions.sql dist/scripts/fix_clob_trade_partitions.sql
           cp scripts/repair_strategy_track_record_official_settlement.sql dist/scripts/repair_strategy_track_record_official_settlement.sql
-          cp scripts/drills/*.sh dist/scripts/drills/
+          find scripts/drills -maxdepth 1 -type f -name '*.sh' \
+            ! -name 'pm5d_threelayer_live_gate.sh' \
+            -exec cp {} dist/scripts/drills/ \;
           for migration in ${DEPLOY_MIGRATIONS}; do
             migration="$(printf '%s' "${migration}" | xargs)"
             [ -n "${migration}" ] || continue
@@ -227,22 +238,26 @@ jobs:
             -C dist -cf - . | gzip -n > "${DEPLOY_BUNDLE_NAME}"
           sha256sum "${DEPLOY_BUNDLE_NAME}" > "${DEPLOY_BUNDLE_NAME}.sha256"
 
-      - name: Verify live deployment remains paused in bundle
+      - name: Verify research bundle has no live authority
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import json
           from pathlib import Path
 
-          manifest = Path("dist/config/deployments/pm5d.threelayer.live.json")
-          data = json.loads(manifest.read_text(encoding="utf-8"))
-          if data.get("deployment_id") != "pm5d.threelayer.live":
-              raise SystemExit(f"unexpected live deployment manifest: {data.get('deployment_id')}")
-          if data.get("runtime_mode") != "live":
-              raise SystemExit("pm5d.threelayer.live manifest is not runtime_mode=live")
-          if data.get("desired_state") != "paused":
-              raise SystemExit("pm5d.threelayer.live must remain desired_state=paused")
-          print("pm5d.threelayer.live bundle manifest remains paused")
+          for manifest in Path("dist/config/deployments").glob("*.json"):
+              data = json.loads(manifest.read_text(encoding="utf-8"))
+              if data.get("runtime_mode") == "live":
+                  raise SystemExit(f"research host bundle contains a live deployment: {manifest}")
+          forbidden = [
+              Path("dist/config/strategies/02-pm5d.live.toml"),
+              Path("dist/config/strategies/02-pm5d-threelayer.live.toml"),
+              Path("dist/scripts/drills/pm5d_threelayer_live_gate.sh"),
+          ]
+          present = [str(path) for path in forbidden if path.exists()]
+          if present:
+              raise SystemExit(f"research host bundle contains live authority: {present}")
+          print("research host bundle contains data/research/dry-run surfaces only")
           PY
 
       - name: Validate OSS deploy secrets
@@ -434,19 +449,19 @@ jobs:
               fi
             }
 
-            require_pm5d_live_paused() {
-              local live_status
-              local live_line
-              live_status="\$(${DEPLOY_ROOT}/bin/ployctl deployments inspect pm5d.threelayer.live 2>&1)"
-              echo "\${live_status}"
-              live_line="\$(printf '%s\n' "\${live_status}" | awk '\$1 == "pm5d.threelayer.live" { print; exit }')"
-              case "\${live_line}" in
-                *"desired=Paused"*"observed=Paused"*) ;;
-                *)
-                  echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-                  exit 1
-                  ;;
-              esac
+            require_research_host_has_no_live() {
+              local deployments
+              if grep -Eq '^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=' ${DEPLOY_ROOT}/.env; then
+                echo "research host must not retain a live signing key" >&2
+                exit 1
+              fi
+              deployments="\$(${DEPLOY_ROOT}/bin/ployctl deployments list 2>&1)"
+              echo "\${deployments}"
+              if printf '%s\n' "\${deployments}" | awk \
+                '/mode=Live/ && !/lifecycle=Archived desired=Stopped observed=Stopped/ { found=1 } END { exit !found }'; then
+                echo "research host still has a non-archived live deployment" >&2
+                exit 1
+              fi
             }
 
             service_exists() {
@@ -487,6 +502,23 @@ jobs:
             sha256sum -c "${DEPLOY_BUNDLE_NAME}.sha256"
             tar -xzf "${DEPLOY_BUNDLE_NAME}"
 
+            # Revoke runtime authority before replacing any research-host files.
+            if [ -f ${DEPLOY_ROOT}/.env ]; then
+              set -a
+              # shellcheck disable=SC1091
+              . ${DEPLOY_ROOT}/.env
+              set +a
+            fi
+            if service_exists ployd.service; then
+              if [ -x ${DEPLOY_ROOT}/bin/ployctl ]; then
+                ${DEPLOY_ROOT}/bin/ployctl deployments pause pm5d.threelayer.live >/dev/null 2>&1 || true
+              fi
+              systemctl stop ployd.service
+            fi
+            if [ -f ${DEPLOY_ROOT}/data/state/deployments.json ]; then
+              python3 -c 'import json,pathlib,sys; path=pathlib.Path(sys.argv[1]); records=json.loads(path.read_text(encoding="utf-8")); [record.update(desired_state="paused", observed_state="paused") for record in records if record.get("runtime_mode") == "live"]; temporary=path.with_suffix(".tmp"); temporary.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8"); temporary.replace(path)' ${DEPLOY_ROOT}/data/state/deployments.json
+            fi
+
             # Install artifacts into the live runtime root used by systemd.
             install -m 0755 ./bin/ployd ${DEPLOY_ROOT}/bin/ployd
             install -m 0755 ./bin/ploy-runner ${DEPLOY_ROOT}/bin/ploy-runner
@@ -495,9 +527,7 @@ jobs:
             install -m 0755 ./bin/persist-research-trace ${DEPLOY_ROOT}/bin/persist-research-trace
             install -m 0755 ./bin/research-trace-plan ${DEPLOY_ROOT}/bin/research-trace-plan
             install -m 0644 ./config/strategies/02-pm5d.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.unified.toml
-            install -m 0644 ./config/strategies/02-pm5d.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d.live.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.unified.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml
-            install -m 0644 ./config/strategies/02-pm5d-threelayer.live.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.live.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.obi-soft-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.obi-hard-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.champion-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.champion-dryrun.toml
@@ -505,6 +535,12 @@ jobs:
             install -m 0644 ./config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.repricing-momentum-dryrun.toml
             install -m 0644 ./config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml ${DEPLOY_ROOT}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
             install -m 0644 ./config/deployments/*.json ${DEPLOY_ROOT}/config/deployments/
+            find ${DEPLOY_ROOT}/config/strategies -maxdepth 1 -type f -iname '*live*.toml' -delete
+            python3 -c 'import json,pathlib,sys; [path.unlink() for path in pathlib.Path(sys.argv[1]).glob("*.json") if json.loads(path.read_text()).get("runtime_mode") == "live"]' ${DEPLOY_ROOT}/config/deployments
+            rm -f ${DEPLOY_ROOT}/scripts/drills/pm5d_threelayer_live_gate.sh
+            if [ -f ${DEPLOY_ROOT}/.env ]; then
+              sed -i -E '/^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=/d' ${DEPLOY_ROOT}/.env
+            fi
             install -m 0755 ./scripts/binance_aggtrade_collector.py ${DEPLOY_ROOT}/scripts/binance_aggtrade_collector.py
             install -m 0755 ./scripts/binance_price_collector.py ${DEPLOY_ROOT}/scripts/binance_price_collector.py
             install -m 0755 ./scripts/binance_lob_collector.py ${DEPLOY_ROOT}/scripts/binance_lob_collector.py
@@ -601,6 +637,13 @@ jobs:
             systemctl restart ploy-pm-trade-collector.service
             if service_exists ployd.service; then
               systemctl restart ployd.service
+              existing_live_ids="\$(${DEPLOY_ROOT}/bin/ployctl deployments list 2>/dev/null \
+                | awk '/mode=Live/ && !/lifecycle=Archived/ {print \$1}' || true)"
+              while IFS= read -r live_id; do
+                [ -n "\${live_id}" ] || continue
+                ${DEPLOY_ROOT}/bin/ployctl deployments pause "\${live_id}"
+                ${DEPLOY_ROOT}/bin/ployctl deployments archive "\${live_id}"
+              done <<< "\${existing_live_ids}"
             fi
 
             DEPLOY_VERIFY_SINCE=\$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -628,7 +671,7 @@ jobs:
               curl -fsS http://127.0.0.1:8081/health
               curl -fsS http://127.0.0.1:8081/api/reports/dry-run | ${DEPLOY_ROOT}/scripts/check_dryrun_report_contract.py
               ${DEPLOY_ROOT}/bin/ployctl deployments list
-              require_pm5d_live_paused
+              require_research_host_has_no_live
             fi
 
             wait_for_recent_rows \

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: "Git ref to deploy (branch, tag, or SHA)"
+        description: "Git ref to build; deploy=true requires main"
         required: true
         default: "main"
       deploy:
-        description: "Copy the built runner to ploy-trade-1 and restart services"
+        description: "Install an immutable paused trade release on ploy-trade-1"
         type: boolean
         required: true
         default: false
 
 concurrency:
-  group: deploy-trade-1
+  group: ploy-trade-host
   cancel-in-progress: false
 
 permissions:
@@ -28,14 +28,15 @@ env:
   LC_ALL: C
   LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
-  DEPLOY_HOST: ploy-trade-1
+  DEPLOY_ROOT: /opt/ploy
+  DEPLOY_BUNDLE_NAME: ploy-trade-release.tar.gz
 
 jobs:
   build-and-deploy:
-    name: Build and deploy to ploy-trade-1
+    name: Build and deploy immutable trade control plane
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    environment: ploy-trade-1
+    environment: ${{ inputs.deploy && 'ploy-trade-1' || 'ploy-trade-1-build-only' }}
 
     steps:
       - name: Checkout code
@@ -49,22 +50,20 @@ jobs:
           INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
         run: |
           set -euo pipefail
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "Deployments to ploy-trade-1 must dispatch the workflow from main; got ${GITHUB_REF_NAME}" >&2
+          [[ "${GITHUB_REF_NAME}" == "main" ]] || {
+            echo "Deployments to ploy-trade-1 must dispatch the workflow from main" >&2
             exit 1
-          fi
-          if [ "${INPUT_GIT_REF}" != "main" ]; then
-            echo "Deployments to ploy-trade-1 must use git_ref=main; got ${INPUT_GIT_REF}" >&2
+          }
+          [[ "${INPUT_GIT_REF}" == "main" ]] || {
+            echo "Deployments to ploy-trade-1 must use git_ref=main" >&2
             exit 1
-          fi
+          }
           git fetch --no-tags --depth=1 origin main
-          checked_out_sha="$(git rev-parse HEAD)"
-          main_sha="$(git rev-parse origin/main)"
-          if [ "${checked_out_sha}" != "${main_sha}" ]; then
-            echo "Checked-out deploy SHA ${checked_out_sha} does not match origin/main ${main_sha}" >&2
+          [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || {
+            echo "checked-out deploy SHA does not match origin/main" >&2
             exit 1
-          fi
-          echo "Deploy provenance verified: git_ref=main sha=${checked_out_sha}"
+          }
+          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]
 
       - name: Set reproducible build environment
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
@@ -80,67 +79,86 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
           sudo apt-get install -y sccache || cargo install sccache --locked
-          sudo apt-get install -y mold || true
 
-      - name: Capture cache metadata
-        id: cache_meta
-        run: |
-          echo "rustc_version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
-          echo "sccache_version=$(sccache --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
-            ${{ runner.os }}-cargo-trade-${{ env.PLATFORM_TARGET }}-release-
-            ${{ runner.os }}-cargo-trade-
-
-      - name: Cache sccache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/sccache
-          key: ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-sccache-${{ steps.cache_meta.outputs.sccache_version }}-
-            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-rust-${{ steps.cache_meta.outputs.rustc_version }}-
-            ${{ runner.os }}-sccache-deploy-trade-${{ env.PLATFORM_TARGET }}-release-
-            ${{ runner.os }}-sccache-deploy-trade-
-            ${{ runner.os }}-sccache-
-
-      - name: Build new-ploy-runner
+      - name: Build trade control plane
         run: |
           cargo build --release --locked \
             --target "${PLATFORM_TARGET}" \
-            --features full \
+            --features new-ploy-runner/full \
+            -p new-ployd \
+            -p ployctl \
             -p new-ploy-runner
+          strip "target/${PLATFORM_TARGET}/release/new-ployd" || true
+          strip "target/${PLATFORM_TARGET}/release/ployctl" || true
           strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
-          (cd "target/${PLATFORM_TARGET}/release" && sha256sum new-ploy-runner > new-ploy-runner.sha256)
 
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats || true
+      - name: Build immutable trade bundle
+        run: |
+          set -euo pipefail
+          root=dist/trade-release
+          rm -rf dist
+          mkdir -p "${root}/bin" "${root}/config/strategies" \
+            "${root}/config/deployments" "${root}/deployment" \
+            "${root}/scripts/drills"
+          install -m 0755 "target/${PLATFORM_TARGET}/release/new-ployd" "${root}/bin/ployd"
+          install -m 0755 "target/${PLATFORM_TARGET}/release/ployctl" "${root}/bin/ployctl"
+          install -m 0755 "target/${PLATFORM_TARGET}/release/new-ploy-runner" "${root}/bin/ploy-runner"
+          install -m 0644 config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml \
+            "${root}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+          install -m 0644 config/strategies/02-pm5d-threelayer.live.toml \
+            "${root}/config/strategies/02-pm5d-threelayer.live.toml"
+          install -m 0644 config/deployments/pm5d.threelayer.live.json \
+            "${root}/config/deployments/pm5d.threelayer.live.json"
+          install -m 0644 deployment/ployd-trade.service "${root}/deployment/ployd.service"
+          install -m 0755 scripts/drills/pm5d_threelayer_live_gate.sh \
+            "${root}/scripts/drills/pm5d_threelayer_live_gate.sh"
+          install -m 0755 scripts/drills/live_dry_run.sh \
+            "${root}/scripts/drills/live_dry_run.sh"
+          install -m 0755 scripts/verify_trade_host_postflight.sh \
+            "${root}/scripts/verify_trade_host_postflight.sh"
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
 
-      - name: Configure SSH
+          manifest = Path("dist/trade-release/config/deployments/pm5d.threelayer.live.json")
+          payload = json.loads(manifest.read_text(encoding="utf-8"))
+          if payload.get("runtime_mode") != "live":
+              raise SystemExit("trade manifest must use runtime_mode=live")
+          if payload.get("desired_state") != "paused":
+              raise SystemExit("trade manifest desired_state must remain paused")
+          if payload.get("account_id") != "live-wallet-must-be-rendered":
+              raise SystemExit("repository trade manifest must retain its wallet sentinel")
+          PY
+          # FILES.sha256 is excluded from the input set before the manifest is written.
+          # shellcheck disable=SC2094
+          (cd "${root}" && find . -type f ! -name FILES.sha256 -print0 \
+            | sort -z | xargs -0 sha256sum > FILES.sha256)
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+            -C "${root}" -cf - . | gzip -n > "dist/${DEPLOY_BUNDLE_NAME}"
+          (cd dist && sha256sum "${DEPLOY_BUNDLE_NAME}" > "${DEPLOY_BUNDLE_NAME}.sha256")
+
+      - name: Upload auditable trade bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: ploy-trade-release-${{ github.sha }}
+          path: |
+            dist/${{ env.DEPLOY_BUNDLE_NAME }}
+            dist/${{ env.DEPLOY_BUNDLE_NAME }}.sha256
+          retention-days: 30
+
+      - name: Configure pinned SSH
         if: ${{ inputs.deploy }}
         env:
           PLOY_TRADE_1_KNOWN_HOSTS: ${{ secrets.PLOY_TRADE_1_KNOWN_HOSTS }}
+          PLOY_TRADE_1_SSH_KEY: ${{ secrets.PLOY_TRADE_1_SSH_KEY }}
         run: |
           set -euo pipefail
+          [[ -n "${PLOY_TRADE_1_KNOWN_HOSTS}" ]] || { echo "missing PLOY_TRADE_1_KNOWN_HOSTS" >&2; exit 1; }
+          [[ -n "${PLOY_TRADE_1_SSH_KEY}" ]] || { echo "missing PLOY_TRADE_1_SSH_KEY" >&2; exit 1; }
           install -m 700 -d ~/.ssh
-          if [ -z "${PLOY_TRADE_1_KNOWN_HOSTS}" ]; then
-            echo "PLOY_TRADE_1_KNOWN_HOSTS secret is required for pinned SSH host verification" >&2
-            exit 1
-          fi
           printf '%s\n' "${PLOY_TRADE_1_KNOWN_HOSTS}" > ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
-          printf '%s\n' '${{ secrets.PLOY_TRADE_1_SSH_KEY }}' > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${PLOY_TRADE_1_SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/known_hosts ~/.ssh/deploy_key
           cat > ~/.ssh/config <<EOF
           Host ploy-trade-1
             HostName ${{ secrets.PLOY_TRADE_1_HOST }}
@@ -154,71 +172,185 @@ jobs:
             ConnectTimeout 30
           EOF
 
-      - name: Deploy binary and configs
+      - name: Upload immutable release
         if: ${{ inputs.deploy }}
         run: |
-          RUNNER_SHA256="$(cut -d ' ' -f1 "target/${PLATFORM_TARGET}/release/new-ploy-runner.sha256")"
-          scp "target/${PLATFORM_TARGET}/release/new-ploy-runner" ploy-trade-1:/opt/ploy/bin/ploy-runner
-          scp config/strategies/02-pm5d.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
-          scp config/strategies/02-pm5d.live.toml ploy-trade-1:/opt/ploy/config/strategies/
-          scp config/strategies/02-pm5d-threelayer.unified.toml ploy-trade-1:/opt/ploy/config/strategies/
-          scp config/strategies/02-pm5d-threelayer.live.toml ploy-trade-1:/opt/ploy/config/strategies/
+          # The deploy path is intentionally derived from the checked-out client SHA.
+          # shellcheck disable=SC2029
+          ssh ploy-trade-1 "mkdir -p ${DEPLOY_ROOT}/tmp/deploy-${GITHUB_SHA}"
+          scp "dist/${DEPLOY_BUNDLE_NAME}" "dist/${DEPLOY_BUNDLE_NAME}.sha256" \
+            "ploy-trade-1:${DEPLOY_ROOT}/tmp/deploy-${GITHUB_SHA}/"
 
-          ssh ploy-trade-1 RUNNER_SHA256="${RUNNER_SHA256}" bash <<'REMOTE'
-            set -euo pipefail
-            printf '%s  /opt/ploy/bin/ploy-runner\n' "${RUNNER_SHA256}" | sha256sum -c -
-            chmod +x /opt/ploy/bin/ploy-runner
+      - name: Install paused trade control plane
+        if: ${{ inputs.deploy }}
+        run: |
+          # shellcheck disable=SC2087
+          ssh ploy-trade-1 /bin/bash -s -- "${GITHUB_SHA}" "${DEPLOY_BUNDLE_NAME}" <<'REMOTE'
+          set -euo pipefail
+          git_sha="$1"
+          bundle_name="$2"
+          root=/opt/ploy
+          workdir="${root}/tmp/deploy-${git_sha}"
+          release_dir="${root}/releases/${git_sha}"
+          staging="${root}/releases/.${git_sha}.staging"
+          bundle_sha="$(cut -d ' ' -f1 "${workdir}/${bundle_name}.sha256")"
 
-            systemctl daemon-reload
-
-            if systemctl is-active --quiet ployd.service; then
-              systemctl restart ployd.service
-            fi
-            if systemctl is-active --quiet ploy-strategy-dryrun.service; then
-              systemctl restart ploy-strategy-dryrun.service
-            fi
-
-            sleep 5
-
-            # Verify services came back up
-            if systemctl is-enabled --quiet ployd.service; then
-              systemctl is-active --quiet ployd.service
-              echo "ployd.service: active"
-            fi
-            if systemctl is-enabled --quiet ploy-strategy-dryrun.service; then
-              systemctl is-active --quiet ploy-strategy-dryrun.service
-              echo "ploy-strategy-dryrun.service: active"
-            fi
-            if pgrep -af '(^|/)cargo|(^|/)rustc' >/dev/null; then
-              echo "Unexpected Rust build process running on ploy-trade-1" >&2
-              pgrep -af '(^|/)cargo|(^|/)rustc' >&2
+          cd "${workdir}"
+          sha256sum -c "${bundle_name}.sha256"
+          if [[ -e "${release_dir}" ]]; then
+            existing_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("bundle_sha256", ""))' "${release_dir}/release.json")"
+            [[ "${existing_sha}" == "${bundle_sha}" ]] || {
+              echo "immutable release ${git_sha} already exists with a different bundle" >&2
               exit 1
+            }
+            (cd "${release_dir}" && sha256sum -c FILES.sha256)
+          else
+            rm -rf "${staging}"
+            mkdir -p "${staging}"
+            tar -xzf "${bundle_name}" -C "${staging}"
+            python3 - "${staging}/release.json" "${git_sha}" "${bundle_sha}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          pathlib.Path(sys.argv[1]).write_text(
+              json.dumps({"git_sha": sys.argv[2], "bundle_sha256": sys.argv[3]}, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+            mv "${staging}" "${release_dir}"
+          fi
+
+          id -u ploy >/dev/null 2>&1 || useradd --system --home "${root}" --shell /usr/sbin/nologin --no-create-home ploy
+          mkdir -p "${root}"/{bin,config/strategies,config/deployments,data/state,logs,run/platform,scripts/drills,releases}
+          install -d -m 0750 -o root -g ploy "${root}/data/live-approvals"
+          touch "${root}/.env"
+          chmod 600 "${root}/.env"
+
+          previous="$(readlink "${root}/current" 2>/dev/null || true)"
+          cp -a "${root}/.env" "${workdir}/env.backup"
+          if [[ -f /etc/systemd/system/ployd.service ]]; then
+            cp -a /etc/systemd/system/ployd.service "${workdir}/ployd.service.backup"
+          fi
+          rollback() {
+            "${root}/current/bin/ployctl" deployments pause pm5d.threelayer.live >/dev/null 2>&1 || true
+            if [[ -n "${previous}" ]]; then
+              ln -sfn "${previous}" "${root}/current.rollback"
+              mv -Tf "${root}/current.rollback" "${root}/current"
+            else
+              systemctl stop ployd.service || true
             fi
+            cp -a "${workdir}/env.backup" "${root}/.env"
+            if [[ -f "${workdir}/ployd.service.backup" ]]; then
+              cp -a "${workdir}/ployd.service.backup" /etc/systemd/system/ployd.service
+            fi
+            systemctl daemon-reload || true
+            if [[ -n "${previous}" ]]; then
+              systemctl restart ployd.service || true
+              "${root}/current/bin/ployctl" deployments pause pm5d.threelayer.live >/dev/null 2>&1 || true
+            else
+              systemctl stop ployd.service || true
+            fi
+          }
+          trap rollback ERR
+
+          if [[ -x "${root}/current/bin/ployctl" ]]; then
+            set -a
+            # shellcheck disable=SC1091
+            . "${root}/.env"
+            set +a
+            existing_live="$("${root}/current/bin/ployctl" deployments inspect pm5d.threelayer.live 2>/dev/null || true)"
+            if [[ -n "${existing_live}" && "${existing_live}" != *"desired=Paused"* ]]; then
+              "${root}/current/bin/ployctl" deployments pause pm5d.threelayer.live
+            fi
+          fi
+          systemctl stop ployd.service >/dev/null 2>&1 || true
+          python3 - "${root}/data/state/deployments.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          if path.exists():
+              records = json.loads(path.read_text(encoding="utf-8"))
+              for record in records:
+                  if record.get("runtime_mode") == "live":
+                      record["desired_state"] = "paused"
+                      record["observed_state"] = "paused"
+              temporary = path.with_suffix(".tmp")
+              temporary.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
+              temporary.replace(path)
+          PY
+
+          upsert_env() {
+            local key="$1" value="$2"
+            if grep -qE "^${key}=" "${root}/.env"; then
+              sed -i -E "s|^${key}=.*|${key}=${value}|" "${root}/.env"
+            else
+              printf '%s=%s\n' "${key}" "${value}" >> "${root}/.env"
+            fi
+          }
+          upsert_env PLOY_DEPLOYMENTS_FILE "${root}/data/state/deployments.json"
+          upsert_env PLOY_RUNTIME_ROOT "${root}/run/platform"
+          upsert_env PLOY_SYSTEM_STATUS_FILE "${root}/run/platform/system-status.json"
+          upsert_env PLOY_DEPLOYMENT_STATUS_FILE "${root}/run/platform/deployments.json"
+          upsert_env PLOY_TRADING_STATE_FILE "${root}/run/platform/trading-state.json"
+          upsert_env PLOY_RUNNER_BINARY "${root}/current/bin/ploy-runner"
+          upsert_env PLOY_STRATEGY_CONFIG_ROOT "${root}/current/config/strategies"
+          upsert_env PLOY_LISTEN_ADDR "127.0.0.1:8081"
+          upsert_env PLOY_RELEASE_SHA "${git_sha}"
+          upsert_env PLOY_LIVE_APPROVAL_FILE "${root}/data/live-approvals/pending.json"
+
+          grep -Eq '^(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=[^[:space:]]+' "${root}/.env" || {
+            echo "trade host signing key is missing" >&2
+            exit 1
+          }
+          grep -Eq '^PLOY_LIVE_ACCOUNT_ID=0[xX][0-9a-fA-F]{40}$' "${root}/.env" || {
+            echo "trade host PLOY_LIVE_ACCOUNT_ID is missing or invalid" >&2
+            exit 1
+          }
+
+          ln -sfn "releases/${git_sha}" "${root}/current.next"
+          mv -Tf "${root}/current.next" "${root}/current"
+          for binary in ployd ployctl ploy-runner; do
+            ln -sfn "../current/bin/${binary}" "${root}/bin/${binary}"
+          done
+          for config in 02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml 02-pm5d-threelayer.live.toml; do
+            ln -sfn "../../current/config/strategies/${config}" "${root}/config/strategies/${config}"
+          done
+          ln -sfn "../../current/config/deployments/pm5d.threelayer.live.json" \
+            "${root}/config/deployments/pm5d.threelayer.live.json"
+          ln -sfn "../../current/scripts/drills/live_dry_run.sh" "${root}/scripts/drills/live_dry_run.sh"
+          ln -sfn "../../current/scripts/drills/pm5d_threelayer_live_gate.sh" \
+            "${root}/scripts/drills/pm5d_threelayer_live_gate.sh"
+
+          install -m 0644 "${release_dir}/deployment/ployd.service" /etc/systemd/system/ployd.service
+          chown -R ploy:ploy "${root}/data/state" "${root}/run" "${root}/logs"
+          chown root:ploy "${root}/data/live-approvals"
+          chmod 0750 "${root}/data/live-approvals"
+          chown -R root:root "${release_dir}" "${root}/config" "${root}/bin" "${root}/scripts"
+          systemctl daemon-reload
+          systemctl enable ployd.service
+          systemctl restart ployd.service
+          sleep 3
+
+          "${release_dir}/scripts/drills/pm5d_threelayer_live_gate.sh" \
+            --manifest "${release_dir}/config/deployments/pm5d.threelayer.live.json" \
+            --dryrun-config "${release_dir}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml" \
+            --live-config "${release_dir}/config/strategies/02-pm5d-threelayer.live.toml" \
+            --skip-dry-run-drill
+          "${release_dir}/scripts/verify_trade_host_postflight.sh" "${git_sha}" paused
+          trap - ERR
+          rm -rf "${workdir}"
           REMOTE
-
-      - name: Verify deployment
-        if: ${{ inputs.deploy }}
-        run: |
-          ssh ploy-trade-1 bash <<'VERIFY'
-            echo "=== Binary ==="
-            ls -la /opt/ploy/bin/ploy-runner
-            /opt/ploy/bin/ploy-runner --version || true
-
-            echo "=== Strategy configs ==="
-            ls -la /opt/ploy/config/strategies/02-pm5d*.toml
-
-            echo "=== Services ==="
-            systemctl list-units 'ploy-*' --no-pager || true
-          VERIFY
 
       - name: Deployment summary
         if: ${{ inputs.deploy }}
         run: |
           {
-            echo "## Deployment to ploy-trade-1"
-            echo "- Binary: \`ploy-runner\`"
-            echo "- Target: \`ploy-trade-1\` (\`${{ secrets.PLOY_TRADE_1_HOST }}\`)"
-            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
-            echo "- Strategy configs: \`02-pm5d.unified.toml\`, \`02-pm5d.live.toml\`, \`02-pm5d-threelayer.unified.toml\`"
-            echo "- Services restarted: \`ployd\`, \`ploy-strategy-dryrun\` (if active)"
+            echo "## ploy-trade-1 immutable paused release"
+            echo "- Git SHA: \`${GITHUB_SHA}\`"
+            echo "- Release: \`/opt/ploy/releases/${GITHUB_SHA}\`"
+            echo "- State: \`pm5d.threelayer.live desired=Paused observed=Paused\`"
+            echo "- Live resume: blocked; use the protected live-approval workflow after evidence passes"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/recorded-replay-parity.yml
+++ b/.github/workflows/recorded-replay-parity.yml
@@ -38,15 +38,15 @@ on:
       skip_settlement_exits:
         description: "Skip settlement exits for entry-only dry-run parity; set false for executable settlement replay"
         required: false
-        default: "true"
+        default: "false"
         type: choice
         options:
           - "true"
           - "false"
       runner_source:
-        description: "Runner binary source: deployed for runtime parity, workflow_ref for branch regression"
+        description: "Runner source: workflow_ref for exact-SHA promotion, deployed for diagnostics"
         required: false
-        default: "deployed"
+        default: "workflow_ref"
         type: choice
         options:
           - "deployed"
@@ -180,7 +180,8 @@ jobs:
             "${SINCE}" \
             "${UNTIL}" \
             "${SKIP_SETTLEMENT_EXITS}" \
-            "${RUNNER_SOURCE}" <<'EOF'
+            "${RUNNER_SOURCE}" \
+            "${GITHUB_SHA}" <<'EOF'
           set -euo pipefail
           deployment_id="$1"
           config_path="$2"
@@ -190,6 +191,7 @@ jobs:
           until_ts="$6"
           skip_settlement_exits="$7"
           runner_source="$8"
+          runner_git_sha="$9"
           case "${skip_settlement_exits}" in
             true|false) ;;
             *) echo "skip_settlement_exits must be true or false" >&2; exit 1 ;;
@@ -215,6 +217,42 @@ jobs:
           test -r "${remote_dir}/extract_official_settlement_evidence.py"
           test -r "${remote_dir}/replay_dryrun_parity.py"
           test -r "${remote_dir}/resolve_recorded_replay_window.py"
+
+          python3 - \
+            "${remote_dir}/approval-provenance.json" \
+            "${deployment_id}" \
+            "${config_path}" \
+            "${recording_path}" \
+            "${runner_source}" \
+            "${runner_git_sha}" \
+            "${skip_settlement_exits}" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+
+          output, deployment_id, config_path, recording_path, runner_source, runner_git_sha, skip_settlement_exits = sys.argv[1:]
+          def sha256(path):
+              return hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+          pathlib.Path(output).write_text(
+              json.dumps(
+                  {
+                      "schema_version": 1,
+                      "deployment_id": deployment_id,
+                      "config_path": config_path,
+                      "config_sha256": sha256(config_path),
+                      "recording_path": recording_path,
+                      "recording_sha256": sha256(recording_path),
+                      "runner_source": runner_source,
+                      "runner_git_sha": runner_git_sha,
+                      "skip_settlement_exits": skip_settlement_exits == "true",
+                  },
+                  indent=2,
+                  sort_keys=True,
+              ) + "\n",
+              encoding="utf-8",
+          )
+          PY
 
           set -a
           . /opt/ploy/.env
@@ -392,6 +430,7 @@ jobs:
           scp tango-1-1:"${REMOTE_DIR}/dryrun-report.json" artifacts/dryrun/dryrun.json
           scp tango-1-1:"${REMOTE_DIR}/resolved-window.json" artifacts/parity/resolved-window.json
           scp tango-1-1:"${REMOTE_DIR}/resolved-window.env" artifacts/parity/resolved-window.env
+          scp tango-1-1:"${REMOTE_DIR}/approval-provenance.json" artifacts/parity/approval-provenance.json
 
       - name: Compare replay and dry-run evidence
         env:

--- a/.github/workflows/release-platform.yml
+++ b/.github/workflows/release-platform.yml
@@ -1,4 +1,4 @@
-name: Release Platform
+name: Build Platform Bundle
 
 on:
   workflow_dispatch:
@@ -7,11 +7,6 @@ on:
         description: "Git ref to release (branch, tag, or SHA)"
         required: true
         default: "main"
-      deploy:
-        description: "Deploy the built bundle after build verification"
-        type: boolean
-        required: true
-        default: true
 
 concurrency:
   group: release-platform-${{ github.ref }}
@@ -28,7 +23,6 @@ env:
   LC_ALL: C
   LANG: C
   PLATFORM_TARGET: x86_64-unknown-linux-gnu
-  DEPLOY_ROOT: ${{ vars.PLOY_DEPLOY_ROOT || '/opt/ploy' }}
 
 jobs:
   build:
@@ -41,29 +35,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.git_ref }}
-
-      - name: Validate deploy provenance
-        if: ${{ inputs.deploy }}
-        env:
-          INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
-        run: |
-          set -euo pipefail
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "deploy=true must dispatch the workflow from main; got ${GITHUB_REF_NAME}" >&2
-            exit 1
-          fi
-          if [ "${INPUT_GIT_REF}" != "main" ]; then
-            echo "deploy=true must use git_ref=main; got ${INPUT_GIT_REF}" >&2
-            exit 1
-          fi
-          git fetch --no-tags --depth=1 origin main
-          checked_out_sha="$(git rev-parse HEAD)"
-          main_sha="$(git rev-parse origin/main)"
-          if [ "${checked_out_sha}" != "${main_sha}" ]; then
-            echo "checked-out deploy SHA ${checked_out_sha} does not match origin/main ${main_sha}" >&2
-            exit 1
-          fi
-          echo "Deploy provenance verified: git_ref=main sha=${checked_out_sha}"
 
       - name: Set reproducible build environment
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
@@ -162,106 +133,3 @@ jobs:
             dist/ploy-platform.tar.gz
             dist/ploy-platform.tar.gz.sha256
           retention-days: 14
-
-  deploy:
-    name: Deploy platform bundle
-    needs: build
-    if: ${{ inputs.deploy }}
-    runs-on: ubuntu-latest
-    environment: production
-
-    steps:
-      - name: Download platform bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: ploy-platform-bundle
-          path: dist
-
-      - name: Verify platform bundle checksum
-        run: (cd dist && sha256sum -c ploy-platform.tar.gz.sha256)
-
-      - name: Upload platform bundle to host
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ vars.EC2_USER || 'ec2-user' }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          fingerprint: ${{ secrets.EC2_HOST_FINGERPRINT || secrets.AWS_EC2_HOST_FINGERPRINT }}
-          source: dist/ploy-platform.tar.gz,dist/ploy-platform.tar.gz.sha256
-          target: /tmp/
-          strip_components: 1
-
-      - name: Install platform bundle and restart ployd
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ vars.EC2_USER || 'ec2-user' }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          fingerprint: ${{ secrets.EC2_HOST_FINGERPRINT || secrets.AWS_EC2_HOST_FINGERPRINT }}
-          envs: DEPLOY_ROOT
-          script_stop: true
-          script: |
-            set -euo pipefail
-
-            WORKDIR="/tmp/ploy-platform"
-            rm -rf "${WORKDIR}"
-            mkdir -p "${WORKDIR}"
-            (cd /tmp && sha256sum -c ploy-platform.tar.gz.sha256)
-            tar xzf /tmp/ploy-platform.tar.gz -C "${WORKDIR}"
-
-            SUDO=""
-            if [ "$(id -u)" -ne 0 ]; then
-              SUDO="sudo"
-            fi
-
-            $SUDO mkdir -p "${DEPLOY_ROOT}/bin" "${DEPLOY_ROOT}/config/deployments" "${DEPLOY_ROOT}/deployment" "${DEPLOY_ROOT}/scripts" "${DEPLOY_ROOT}/scripts/drills" "${DEPLOY_ROOT}/data/state"
-            $SUDO install -m 755 "${WORKDIR}/bin/ployd" "${DEPLOY_ROOT}/bin/ployd"
-            $SUDO install -m 755 "${WORKDIR}/bin/ployctl" "${DEPLOY_ROOT}/bin/ployctl"
-            $SUDO install -m 755 "${WORKDIR}/bin/ploytui" "${DEPLOY_ROOT}/bin/ploytui"
-            $SUDO install -m 755 "${WORKDIR}/bin/ploy-runner" "${DEPLOY_ROOT}/bin/ploy-runner"
-            $SUDO install -m 644 "${WORKDIR}/deployment/ployd.service" "${DEPLOY_ROOT}/deployment/ployd.service"
-            $SUDO install -m 644 "${WORKDIR}/deployment/ploy-maintenance.service" "${DEPLOY_ROOT}/deployment/ploy-maintenance.service"
-            $SUDO install -m 644 "${WORKDIR}/deployment/ploy-maintenance.timer" "${DEPLOY_ROOT}/deployment/ploy-maintenance.timer"
-            $SUDO install -m 644 "${WORKDIR}/deployment/ploy-platform-watchdog.service" "${DEPLOY_ROOT}/deployment/ploy-platform-watchdog.service"
-            $SUDO install -m 644 "${WORKDIR}/deployment/ploy-platform-watchdog.timer" "${DEPLOY_ROOT}/deployment/ploy-platform-watchdog.timer"
-            $SUDO install -m 755 "${WORKDIR}/scripts/install-platform-service.sh" "${DEPLOY_ROOT}/scripts/install-platform-service.sh"
-            $SUDO install -m 755 "${WORKDIR}/scripts/ploy_maintenance.sh" "${DEPLOY_ROOT}/scripts/ploy_maintenance.sh"
-            $SUDO install -m 755 "${WORKDIR}/scripts/ploy_platform_watchdog.sh" "${DEPLOY_ROOT}/scripts/ploy_platform_watchdog.sh"
-            $SUDO install -m 755 "${WORKDIR}/scripts/drills/live_dry_run.sh" "${DEPLOY_ROOT}/scripts/drills/live_dry_run.sh"
-            $SUDO install -m 644 "${WORKDIR}/config/deployments/example.live.dry-run.json.sample" "${DEPLOY_ROOT}/config/deployments/example.live.dry-run.json.sample"
-            if [ ! -f "${DEPLOY_ROOT}/data/state/deployments.json" ]; then
-              $SUDO install -m 644 "${WORKDIR}/data/state/deployments.json.sample" "${DEPLOY_ROOT}/data/state/deployments.json"
-            fi
-
-            $SUDO bash "${DEPLOY_ROOT}/scripts/install-platform-service.sh"
-            $SUDO systemctl restart ployd || $SUDO systemctl start ployd
-            sleep 2
-            $SUDO systemctl status ployd --no-pager
-            $SUDO systemctl status ploy-platform-watchdog.timer --no-pager
-            $SUDO systemctl status ploy-maintenance.timer --no-pager
-            curl -fsS http://127.0.0.1:8081/health
-            set -a
-            . "${DEPLOY_ROOT}/.env"
-            set +a
-            api_token="${PLOY_ADMIN_TOKEN:-${PLOY_API_ADMIN_TOKEN:-${PLOY_API_KEY:-}}}"
-            test -n "${api_token}"
-            curl -N --max-time 2 -H "Authorization: Bearer ${api_token}" \
-              http://127.0.0.1:8081/api/events/stream || true
-            # Verify the deployed operator client path: ployctl system status
-            # Verify the deployed operator client path: ployctl system metrics
-            # Verify the deployed operator client path: ployctl system alerts
-            # Verify the deployed operator client path: ployctl trading status
-            "${DEPLOY_ROOT}/bin/ployctl" system status
-            "${DEPLOY_ROOT}/bin/ployctl" system metrics
-            "${DEPLOY_ROOT}/bin/ployctl" system alerts
-            "${DEPLOY_ROOT}/bin/ployctl" trading status
-            "${DEPLOY_ROOT}/bin/ploytui" || true
-
-      - name: Deployment summary
-        run: |
-          {
-            echo "## Platform Release"
-            echo "- Bundle: \`ployd + ployctl + ploytui\`"
-            echo "- Service: \`ployd.service\`"
-            echo "- Drill: \`/opt/ploy/scripts/drills/live_dry_run.sh\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/runtime-candidate-replay.yml
+++ b/.github/workflows/runtime-candidate-replay.yml
@@ -18,7 +18,7 @@ on:
       runtime_score:
         description: "Exact runtime score expected by promotion evaluator"
         required: true
-        default: "autofactor_formula:auto_settlement_full_depth_settlement_edge_x_near_strike"
+        default: "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
       strategy_profile:
         description: "Expected strategy profile"
         required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,9 +160,10 @@ ci/<short-description>        — CI/workflow changes
 
 ### Deployment
 - **Backtest**: trigger `backtest.yml` (workflow_dispatch) with `git_ref=main`
-- **Deploy dryrun/live**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
+- **Deploy research/dry-run**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
 - **Deploy trade**: trigger `deploy-trade.yml` (workflow_dispatch) with `git_ref=main`
-- **Release platform**: trigger `release-platform.yml` (workflow_dispatch) with `git_ref=main`
+- **Build portable platform bundle**: trigger `release-platform.yml` (workflow_dispatch); it is build-only
+- **Approve live**: trigger `approve-live-trade.yml` from `main`; exact-SHA evidence and protected human approval are required
 - **ACK deploy**: trigger `build-push-acr.yml` with `push_images=true` only from `git_ref=main`, then `deploy-ack.yml` with the immutable 40-character SHA image tag
 - Never deploy from a feature branch directly
 - Never build Rust on tango-1-1 — CI builds and ships artifacts only
@@ -186,8 +187,9 @@ ci/<short-description>        — CI/workflow changes
   Do not push or deploy mutable `latest` tags.
 - Keep deployment secrets in GitHub environments/repository secrets. Never place
   secrets in local files, commits, logs, pasted command output, or ad hoc scripts.
-- Prefer environment-scoped workflows (`tango-1-1`, `production`, `ploy-ci-1`,
-  `ack`) over direct SSH when an equivalent workflow exists.
+- Prefer environment-scoped workflows (`tango-1-1`, `ploy-trade-1`,
+  `ploy-trade-live`, `ploy-ci-1`, `ack`) over direct SSH when an equivalent
+  workflow exists.
 - Do not recover from failed CI/CD by hot-patching Rust binaries or compiling
   source on trading hosts. Fix the workflow or source and redeploy CI-built
   artifacts.
@@ -362,7 +364,10 @@ When using a skill:
 
 - For trading hosts (for example `tango-1-1`), do not build Rust source on-host.
 - Build in CI/GitHub Actions and deploy release artifacts only.
-- Preferred production path: `.github/workflows/release-aliyun.yml`.
+- Preferred Aliyun paths are `.github/workflows/deploy-tango-1-1.yml` for the
+  research/data host and `.github/workflows/deploy-trade.yml` for the paused
+  trade host. Live resume is restricted to
+  `.github/workflows/approve-live-trade.yml`.
 - Keep host Rust on latest stable via rustup, and ensure default `rustc`/`cargo` resolve to rustup-managed binaries.
 - Enforce systemd guardrails on live ploy services:
   - `Restart=always`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,9 +160,10 @@ ci/<short-description>        — CI/workflow changes
 
 ### Deployment
 - **Backtest**: trigger `backtest.yml` (workflow_dispatch) with `git_ref=main`
-- **Deploy dryrun/live**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
+- **Deploy research/dry-run**: trigger `deploy-tango-1-1.yml` (workflow_dispatch) with `git_ref=main`
 - **Deploy trade**: trigger `deploy-trade.yml` (workflow_dispatch) with `git_ref=main`
-- **Release platform**: trigger `release-platform.yml` (workflow_dispatch) with `git_ref=main`
+- **Build portable platform bundle**: trigger `release-platform.yml` (workflow_dispatch); it is build-only
+- **Approve live**: trigger `approve-live-trade.yml` from `main`; exact-SHA evidence and protected human approval are required
 - **ACK deploy**: trigger `build-push-acr.yml` with `push_images=true` only from `git_ref=main`, then `deploy-ack.yml` with the immutable 40-character SHA image tag
 - Never deploy from a feature branch directly
 - Never build Rust on tango-1-1 — CI builds and ships artifacts only
@@ -186,8 +187,9 @@ ci/<short-description>        — CI/workflow changes
   Do not push or deploy mutable `latest` tags.
 - Keep deployment secrets in GitHub environments/repository secrets. Never place
   secrets in local files, commits, logs, pasted command output, or ad hoc scripts.
-- Prefer environment-scoped workflows (`tango-1-1`, `production`, `ploy-ci-1`,
-  `ack`) over direct SSH when an equivalent workflow exists.
+- Prefer environment-scoped workflows (`tango-1-1`, `ploy-trade-1`,
+  `ploy-trade-live`, `ploy-ci-1`, `ack`) over direct SSH when an equivalent
+  workflow exists.
 - Do not recover from failed CI/CD by hot-patching Rust binaries or compiling
   source on trading hosts. Fix the workflow or source and redeploy CI-built
   artifacts.
@@ -372,7 +374,10 @@ Available gstack skills: /office-hours, /plan-ceo-review, /plan-eng-review, /pla
 
 - For trading hosts (for example `tango-1-1`), do not build Rust source on-host.
 - Build in CI/GitHub Actions and deploy release artifacts only.
-- Preferred production path: `.github/workflows/release-aliyun.yml`.
+- Preferred Aliyun paths are `.github/workflows/deploy-tango-1-1.yml` for the
+  research/data host and `.github/workflows/deploy-trade.yml` for the paused
+  trade host. Live resume is restricted to
+  `.github/workflows/approve-live-trade.yml`.
 - Keep host Rust on latest stable via rustup, and ensure default `rustc`/`cargo` resolve to rustup-managed binaries.
 - Enforce systemd guardrails on live ploy services:
   - `Restart=always`

--- a/apps/ployctl/src/deployments.rs
+++ b/apps/ployctl/src/deployments.rs
@@ -9,13 +9,14 @@ pub fn render_deployments(client: &ControlPlaneClient) -> Result<String, String>
         .into_iter()
         .map(|deployment| {
             format!(
-                "{} account={} max_gross_exposure={} lifecycle={:?} desired={:?} observed={:?}",
+                "{} account={} max_gross_exposure={} mode={:?} lifecycle={:?} desired={:?} observed={:?}",
                 deployment.deployment_id,
                 deployment.account_id,
                 deployment
                     .max_gross_exposure
                     .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
+                deployment.runtime_mode,
                 deployment.deployment_state,
                 deployment.desired_state,
                 deployment.observed_state
@@ -31,13 +32,14 @@ pub fn render_deployment(
 ) -> Result<String, String> {
     client.inspect_deployment(deployment_id).map(|deployment| {
         format!(
-            "{} account={} max_gross_exposure={} lifecycle={:?} desired={:?} observed={:?}",
+            "{} account={} max_gross_exposure={} mode={:?} lifecycle={:?} desired={:?} observed={:?}",
             deployment.deployment_id,
             deployment.account_id,
             deployment
                 .max_gross_exposure
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "-".to_string()),
+            deployment.runtime_mode,
             deployment.deployment_state,
             deployment.desired_state,
             deployment.observed_state
@@ -59,13 +61,14 @@ pub fn apply_deployment_file(
         serde_json::from_str(&body).map_err(|err| format!("parse deployment manifest: {err}"))?;
     let deployment = client.apply_deployment(&request)?;
     Ok(format!(
-        "{} account={} max_gross_exposure={} lifecycle={:?} desired={:?} observed={:?}",
+        "{} account={} max_gross_exposure={} mode={:?} lifecycle={:?} desired={:?} observed={:?}",
         deployment.deployment_id,
         deployment.account_id,
         deployment
             .max_gross_exposure
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string()),
+        deployment.runtime_mode,
         deployment.deployment_state,
         deployment.desired_state,
         deployment.observed_state
@@ -79,13 +82,14 @@ pub fn control_deployment(
 ) -> Result<String, String> {
     let deployment = client.set_desired_state(deployment_id, desired_state)?;
     Ok(format!(
-        "{} account={} max_gross_exposure={} lifecycle={:?} desired={:?} observed={:?}",
+        "{} account={} max_gross_exposure={} mode={:?} lifecycle={:?} desired={:?} observed={:?}",
         deployment.deployment_id,
         deployment.account_id,
         deployment
             .max_gross_exposure
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string()),
+        deployment.runtime_mode,
         deployment.deployment_state,
         deployment.desired_state,
         deployment.observed_state

--- a/apps/ploytui/src/lib.rs
+++ b/apps/ploytui/src/lib.rs
@@ -241,6 +241,7 @@ mod tests {
             }],
             deployments: vec![DeploymentSummary {
                 deployment_id: "example.paper".to_string(),
+                runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Paper,
                 account_id: "acct-paper".to_string(),
                 max_gross_exposure: None,
                 deployment_state: DeploymentState::Enabled,
@@ -274,6 +275,7 @@ mod tests {
                 OperatorEvent::DeploymentSnapshot(DeploymentSnapshotEvent {
                     deployments: vec![DeploymentSummary {
                         deployment_id: "example.paper".to_string(),
+                        runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Paper,
                         account_id: "acct-paper".to_string(),
                         max_gross_exposure: None,
                         deployment_state: DeploymentState::Enabled,

--- a/config/strategies/02-pm5d-threelayer.live.toml
+++ b/config/strategies/02-pm5d-threelayer.live.toml
@@ -1,9 +1,8 @@
-# Three-layer scoring strategy - live config
-# Mirrors 02-pm5d-threelayer.unified.toml; only [runtime].mode differs.
+# Three-layer settlement-probability live config
 #
-# Scoring model: direction(50%) + edge(35%) + confirmation bonus(15%)
-# Entry when total_score > min_entry_score
-# OBI uses 5s EWMA smoothing for 10 Hz LOB data
+# Model and execution semantics mirror
+# 02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml. Only runtime
+# recording fields are removed and live risk is reduced to the bounded policy.
 
 [runtime]
 strategy_variant = "three_layer"
@@ -11,40 +10,44 @@ mode = "live"
 throttle_hz = 10
 
 [strategy]
-symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "DOGEUSDT", "BNBUSDT"]
+symbols = ["BTCUSDT", "ETHUSDT"]
 
 vol_floor = 0.001
 min_probability = 0.51
 min_z_score = 0.20
 
 min_entry_price = 0.10
-max_entry_price = 0.85
+max_entry_price = 0.95
 no_trade_zone_min = 0.45
 no_trade_zone_max = 0.55
 
-min_edge = 0.0316
+min_edge = 0.0
 
-min_time_remaining_secs = 69
-max_time_remaining_secs = 99
-cooldown_secs = 35
+min_time_remaining_secs = 30
+max_time_remaining_secs = 180
+cooldown_secs = 30
 
 stake_usd = 5.0
-max_positions = 1000
-max_daily_trades = 1000
+max_positions = 1
+max_daily_trades = 10
 allowed_window_secs = [300]
 
-# Optimized parameters (TPE 200 trials, train Apr 10-13, val Apr 14-15)
-# Train: Sharpe=137.8, 239 trades, +$5,743
-# Val:   Sharpe=141.7, 1017 trades, +$25,689
-three_layer_min_entry_score = 0.25
-three_layer_min_direction_prob = 0.6297
-three_layer_min_distance_over_sigma = 0.4622
-three_layer_min_confirmation_score = 0.2472
-three_layer_min_drift_confirmation = 0.000546
-three_layer_min_edge = 0.0316
-three_layer_min_reward_risk = 1.2630
-three_layer_take_profit_ask = 0.8437
-three_layer_stop_distance_pct = 0.0152
+three_layer_strategy_profile = "settlement_probability"
+three_layer_autofactor_runtime_score = "autofactor_formula:mut_auto_settlement_model_full_depth_settlement_edge_x_capacity_spread_adjusted"
+three_layer_min_entry_score = 0.10
+three_layer_min_direction_prob = 0.56
+three_layer_min_distance_over_sigma = 0.30
+three_layer_min_confirmation_score = 0.0
+three_layer_require_confirmation = false
+three_layer_min_drift_confirmation = 0.0
+three_layer_min_edge = 0.02
+three_layer_min_reward_risk = 0.0
+three_layer_alpha_contrarian = false
+three_layer_cex_contrarian = false
+three_layer_probability_shrink = 1.0
+three_layer_probability_haircut = 0.0
+three_layer_take_profit_ask = 0.99
+three_layer_stop_distance_pct = 0.030
 three_layer_max_pm_lag_secs = 15
 
 [execution]
@@ -56,6 +59,9 @@ enable_market_impact = true
 impact_coefficient = 0.1
 default_depth_shares = 500
 require_lob_liquidity = true
+visible_depth_haircut = 0.5
+max_sweep_levels = 3
+max_sweep_price_delta = 0.003
 
 [reference_data]
 capture_sports_state = false

--- a/contracts/schemas/deployment-summary.schema.json
+++ b/contracts/schemas/deployment-summary.schema.json
@@ -36,9 +36,24 @@
     },
     "observed_state": {
       "$ref": "#/definitions/ObservedState"
+    },
+    "runtime_mode": {
+      "default": "paper",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeploymentRuntimeMode"
+        }
+      ]
     }
   },
   "definitions": {
+    "DeploymentRuntimeMode": {
+      "type": "string",
+      "enum": [
+        "paper",
+        "live"
+      ]
+    },
     "DeploymentState": {
       "type": "string",
       "enum": [

--- a/contracts/schemas/operator-event.schema.json
+++ b/contracts/schemas/operator-event.schema.json
@@ -345,6 +345,14 @@
         },
         "observed_state": {
           "$ref": "#/definitions/ObservedState"
+        },
+        "runtime_mode": {
+          "default": "paper",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeploymentRuntimeMode"
+            }
+          ]
         }
       }
     },

--- a/crates/ploy-control-client/src/lib.rs
+++ b/crates/ploy-control-client/src/lib.rs
@@ -603,6 +603,7 @@ mod tests {
             runtime_root.join("deployments.json"),
             serde_json::to_string(&vec![DeploymentSummary {
                 deployment_id: "example.paper".to_string(),
+                runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Paper,
                 account_id: "acct-paper".to_string(),
                 max_gross_exposure: Some(rust_decimal::Decimal::new(500, 2)),
                 deployment_state: DeploymentState::Enabled,
@@ -817,6 +818,7 @@ mod tests {
                 DeploymentSnapshotEvent {
                     deployments: vec![DeploymentSummary {
                         deployment_id: "example.paper".to_string(),
+                        runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Paper,
                         account_id: "acct-paper".to_string(),
                         max_gross_exposure: Some(rust_decimal::Decimal::new(500, 2)),
                         deployment_state: DeploymentState::Enabled,

--- a/crates/ploy-daemon-host/src/config.rs
+++ b/crates/ploy-daemon-host/src/config.rs
@@ -31,6 +31,8 @@ pub struct PlatformConfig {
     pub audit_log_file: PathBuf,
     pub agent_runs_file: PathBuf,
     pub proposals_file: PathBuf,
+    pub release_sha: Option<String>,
+    pub live_approval_file: Option<PathBuf>,
     pub tick_interval_ms: u64,
     pub request_rate_limit_per_minute: u32,
     pub live_reconcile_backoff_base_ms: u64,
@@ -60,6 +62,8 @@ impl Default for PlatformConfig {
             audit_log_file: runtime_root.join("audit-log.jsonl"),
             agent_runs_file: PathBuf::from("run/sidecar/agent-runs.jsonl"),
             proposals_file: runtime_root.join("proposals.json"),
+            release_sha: None,
+            live_approval_file: None,
             runtime_root,
             tick_interval_ms: 1_000,
             request_rate_limit_per_minute: 240,
@@ -181,6 +185,16 @@ impl PlatformConfig {
             config.proposals_file = PathBuf::from(value);
         } else {
             config.proposals_file = config.runtime_root.join("proposals.json");
+        }
+        if let Ok(value) = std::env::var("PLOY_RELEASE_SHA") {
+            if !value.trim().is_empty() {
+                config.release_sha = Some(value);
+            }
+        }
+        if let Ok(value) = std::env::var("PLOY_LIVE_APPROVAL_FILE") {
+            if !value.trim().is_empty() {
+                config.live_approval_file = Some(PathBuf::from(value));
+            }
         }
         if let Ok(value) = std::env::var("PLOY_TICK_INTERVAL_MS") {
             if let Ok(parsed) = value.parse() {

--- a/crates/ploy-daemon-host/src/runtime.rs
+++ b/crates/ploy-daemon-host/src/runtime.rs
@@ -33,6 +33,8 @@ use ploy_platform_runtime::{
 };
 use ploy_trading::{TradingIntent, TradingRuntime, TradingRuntimeSnapshot};
 use rust_decimal::Decimal;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
@@ -42,6 +44,17 @@ use std::thread;
 use std::time::Duration;
 
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Deserialize)]
+struct LiveApprovalReceipt {
+    deployment_id: String,
+    deploy_sha: String,
+    account_id: String,
+    max_gross_exposure: String,
+    live_config_sha256: String,
+    expires_at: DateTime<Utc>,
+    ready_for_human_live_approval: bool,
+}
 
 pub use ploy_platform_runtime::next_paper_intent_id;
 
@@ -253,6 +266,17 @@ impl PloyDaemon {
         &mut self,
         request: DeploymentApplyRequest,
     ) -> io::Result<DeploymentRecord> {
+        if request.runtime_mode == DeploymentRuntimeMode::Live
+            && request.desired_state == DesiredState::Running
+            && request.deployment_state != DeploymentState::Archived
+        {
+            self.ensure_live_record_resume_approved(
+                &request.deployment_id,
+                &request.account_id,
+                request.max_gross_exposure,
+                &request.bundle_id,
+            )?;
+        }
         let existing = self
             .control_plane
             .deployments
@@ -471,6 +495,9 @@ impl PloyDaemon {
         deployment_id: &str,
         request: DeploymentControlRequest,
     ) -> io::Result<Option<DeploymentRecord>> {
+        if request.desired_state == Some(DesiredState::Running) {
+            self.ensure_live_resume_approved(deployment_id)?;
+        }
         if request.deployment_state == Some(DeploymentState::Archived) {
             self.ensure_deployment_flat_for_archive(deployment_id)?;
         }
@@ -479,6 +506,98 @@ impl PloyDaemon {
         self.persist_registry()?;
         self.write_runtime_snapshots()?;
         Ok(record)
+    }
+
+    fn ensure_live_resume_approved(&self, deployment_id: &str) -> io::Result<()> {
+        let Some(record) = self.control_plane.deployments.get(deployment_id) else {
+            return Ok(());
+        };
+        if record.runtime_mode != DeploymentRuntimeMode::Live {
+            return Ok(());
+        }
+        self.ensure_live_record_resume_approved(
+            deployment_id,
+            &record.account_id,
+            record.max_gross_exposure,
+            &record.bundle_id,
+        )
+    }
+
+    fn ensure_live_record_resume_approved(
+        &self,
+        deployment_id: &str,
+        account_id: &str,
+        max_gross_exposure: Option<Decimal>,
+        bundle_id: &str,
+    ) -> io::Result<()> {
+        let Some(receipt_path) = self.config.live_approval_file.as_ref() else {
+            #[cfg(test)]
+            return Ok(());
+            #[cfg(not(test))]
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "live resume requires PLOY_LIVE_APPROVAL_FILE",
+            ));
+        };
+        let release_sha = self.config.release_sha.as_deref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "live resume requires PLOY_RELEASE_SHA when approval enforcement is configured",
+            )
+        })?;
+        let raw = fs::read(receipt_path).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("live resume approval receipt is unavailable: {error}"),
+            )
+        })?;
+        let receipt: LiveApprovalReceipt = serde_json::from_slice(&raw).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("live resume approval receipt is invalid: {error}"),
+            )
+        })?;
+        let mut config_path = self.config.strategy_config_root.join(bundle_id);
+        if config_path.extension().is_none() {
+            config_path.set_extension("toml");
+        }
+        let config_bytes = fs::read(&config_path).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("live strategy config cannot be hashed: {error}"),
+            )
+        })?;
+        let config_sha256 = format!("{:x}", Sha256::digest(&config_bytes));
+        let receipt_cap = receipt
+            .max_gross_exposure
+            .parse::<Decimal>()
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("live approval exposure cap is invalid: {error}"),
+                )
+            })?;
+        let expected_cap = max_gross_exposure.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "live deployment has no exposure cap",
+            )
+        })?;
+        let approved = receipt.ready_for_human_live_approval
+            && receipt.deployment_id == deployment_id
+            && receipt.deploy_sha == release_sha
+            && receipt.account_id == account_id
+            && receipt_cap == expected_cap
+            && receipt.live_config_sha256 == config_sha256
+            && receipt.expires_at > Utc::now()
+            && receipt.expires_at <= Utc::now() + chrono::Duration::minutes(20);
+        if !approved {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "live resume approval receipt does not match deployment, release, config, cap, or expiry",
+            ));
+        }
+        Ok(())
     }
 
     fn ensure_deployment_flat_for_archive(&self, deployment_id: &str) -> io::Result<()> {
@@ -1187,6 +1306,7 @@ mod tests {
         TradingIntent, TradingRuntime, TradingRuntimeSnapshot,
     };
     use rust_decimal_macros::dec;
+    use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
     use std::fs;
     use std::io::ErrorKind;
@@ -1230,6 +1350,97 @@ mod tests {
             deployment_state: DeploymentState::Enabled,
             desired_state: DesiredState::Paused,
         }
+    }
+
+    #[test]
+    fn configured_live_resume_requires_matching_unexpired_approval_receipt() {
+        let root = temp_dir("live-approval-receipt");
+        let runtime_root = root.join("run/platform");
+        let strategy_root = root.join("config/strategies");
+        let approval_file = root.join("data/live-approvals/pending.json");
+        fs::create_dir_all(&strategy_root).expect("strategy root");
+        fs::create_dir_all(approval_file.parent().expect("approval parent"))
+            .expect("approval root");
+        let live_config = strategy_root.join("example.toml");
+        fs::write(&live_config, "[runtime]\nmode = \"live\"\n").expect("live config");
+        let config_sha256 = format!(
+            "{:x}",
+            Sha256::digest(fs::read(&live_config).expect("config bytes"))
+        );
+        let config = PlatformConfig {
+            registry_file: root.join("data/state/deployments.json"),
+            strategy_config_root: strategy_root,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            release_sha: Some("a".repeat(40)),
+            live_approval_file: Some(approval_file.clone()),
+            ..PlatformConfig::default()
+        };
+        let mut daemon = PloyDaemon::boot(&config).expect("boot");
+        let mut running_apply = paused_live_request("example.live", LIVE_WALLET);
+        running_apply.desired_state = DesiredState::Running;
+        let error = daemon
+            .apply_deployment(running_apply)
+            .expect_err("live running apply without approval must fail");
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        daemon
+            .apply_deployment(paused_live_request("example.live", LIVE_WALLET))
+            .expect("apply paused live");
+
+        let resume = DeploymentControlRequest {
+            desired_state: Some(DesiredState::Running),
+            deployment_state: None,
+        };
+        let error = daemon
+            .control_deployment("example.live", resume.clone())
+            .expect_err("missing approval must fail");
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(
+            daemon
+                .inspect_deployment("example.live")
+                .expect("deployment")
+                .desired_state,
+            DesiredState::Paused
+        );
+
+        fs::write(
+            &approval_file,
+            serde_json::json!({
+                "deployment_id": "example.live",
+                "deploy_sha": "a".repeat(40),
+                "account_id": LIVE_WALLET,
+                "max_gross_exposure": "5",
+                "live_config_sha256": config_sha256,
+                "expires_at": chrono::Utc::now() + chrono::Duration::minutes(5),
+                "ready_for_human_live_approval": true
+            })
+            .to_string(),
+        )
+        .expect("approval receipt");
+        daemon
+            .control_deployment("example.live", resume.clone())
+            .expect("matching approval resumes");
+        daemon
+            .control_deployment(
+                "example.live",
+                DeploymentControlRequest {
+                    desired_state: Some(DesiredState::Paused),
+                    deployment_state: None,
+                },
+            )
+            .expect("pause");
+
+        fs::write(
+            &live_config,
+            "[runtime]\nmode = \"live\"\nthrottle_hz = 20\n",
+        )
+        .expect("mutate config");
+        let error = daemon
+            .control_deployment("example.live", resume)
+            .expect_err("config drift must fail");
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
     }
 
     fn order_runtime(deployment_id: &str, state: OrderState) -> TradingRuntime {

--- a/crates/ploy-operator-contracts/src/deployments.rs
+++ b/crates/ploy-operator-contracts/src/deployments.rs
@@ -61,6 +61,8 @@ pub enum ObservedState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct DeploymentSummary {
     pub deployment_id: String,
+    #[serde(default)]
+    pub runtime_mode: DeploymentRuntimeMode,
     #[serde(default = "default_account_id")]
     pub account_id: String,
     #[serde(default)]
@@ -124,6 +126,7 @@ mod tests {
     fn deployment_summary_uses_stable_wire_keys() {
         let summary = DeploymentSummary {
             deployment_id: "openclaw.default".to_string(),
+            runtime_mode: DeploymentRuntimeMode::Paper,
             account_id: "acct-main".to_string(),
             max_gross_exposure: Some(Decimal::new(250, 2)),
             deployment_state: DeploymentState::Enabled,
@@ -136,6 +139,7 @@ mod tests {
             value,
             json!({
                 "deployment_id": "openclaw.default",
+                "runtime_mode": "paper",
                 "account_id": "acct-main",
                 "max_gross_exposure": "2.50",
                 "deployment_state": "enabled",

--- a/crates/ploy-operator-contracts/src/events.rs
+++ b/crates/ploy-operator-contracts/src/events.rs
@@ -115,6 +115,7 @@ mod tests {
             serde_json::to_value(OperatorEvent::DeploymentSnapshot(DeploymentSnapshotEvent {
                 deployments: vec![DeploymentSummary {
                     deployment_id: "example.paper".to_string(),
+                    runtime_mode: crate::deployments::DeploymentRuntimeMode::Paper,
                     account_id: "acct-paper".to_string(),
                     max_gross_exposure: Some(Decimal::new(500, 2)),
                     deployment_state: DeploymentState::Enabled,
@@ -131,6 +132,7 @@ mod tests {
                 "data": {
                     "deployments": [{
                         "deployment_id": "example.paper",
+                        "runtime_mode": "paper",
                         "account_id": "acct-paper",
                         "max_gross_exposure": "5.00",
                         "deployment_state": "enabled",

--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -338,18 +338,29 @@ mod tests {
     fn missing_live_ledger_terminates_legacy_pidfile_worker() {
         let working_directory = test_working_directory();
         let pid_file = working_directory.join("run/platform/workers/missing-ledger.live.pid");
+        let ready_file = working_directory.join("legacy-worker.ready");
         fs::create_dir_all(pid_file.parent().expect("pid parent")).expect("pid parent");
         let mut legacy = std::process::Command::new("/bin/sh")
             .args([
                 "-c",
-                "sleep 30; :",
+                "touch \"$READY_FILE\"; sleep 30; :",
                 "worker",
                 "--deployment-id",
                 "missing-ledger.live",
             ])
+            .env("READY_FILE", &ready_file)
             .spawn()
             .expect("spawn legacy worker");
         let legacy_pid = legacy.id();
+        let ready = (0..100).any(|_| {
+            if ready_file.exists() {
+                true
+            } else {
+                thread::sleep(StdDuration::from_millis(10));
+                false
+            }
+        });
+        assert!(ready, "legacy worker did not finish exec setup");
         fs::write(&pid_file, format!("{legacy_pid}\n")).expect("pidfile");
         let config = WorkerTickConfig {
             listen_addr: "127.0.0.1:8081".to_string(),

--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -620,6 +620,18 @@ mod tests {
             observed_state: ObservedState::Starting,
         });
         tick_workers(&mut control_plane, &mut supervisor, &config);
+        let initial_launched = (0..1000).any(|_| {
+            if fs::read_to_string(&launch_log).is_ok_and(|launches| launches.lines().count() >= 1) {
+                true
+            } else {
+                thread::sleep(StdDuration::from_millis(10));
+                false
+            }
+        });
+        assert!(
+            initial_launched,
+            "initial stale-spec launch was not recorded"
+        );
         supervisor.pause("resume.current").expect("pause worker");
 
         control_plane.deployments.upsert(DeploymentRecord {
@@ -637,7 +649,7 @@ mod tests {
         let launches = (0..1000)
             .find_map(|_| {
                 if let Ok(launches) = fs::read_to_string(&launch_log) {
-                    if launches.lines().count() >= 1 {
+                    if launches.lines().count() >= 2 {
                         return Some(launches);
                     }
                 }

--- a/crates/ploy-platform/src/deployments.rs
+++ b/crates/ploy-platform/src/deployments.rs
@@ -30,6 +30,7 @@ impl DeploymentRecord {
     pub fn summary(&self) -> DeploymentSummary {
         DeploymentSummary {
             deployment_id: self.deployment_id.clone(),
+            runtime_mode: self.runtime_mode.clone(),
             account_id: self.account_id.clone(),
             max_gross_exposure: self.max_gross_exposure,
             deployment_state: self.deployment_state,

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -762,9 +762,10 @@ venue = "sportsbook"
     }
 
     #[test]
-    fn threelayer_live_config_matches_dryrun_except_runtime_mode() {
+    fn threelayer_live_config_matches_promoted_dryrun_with_bounded_risk_reductions() {
         let config_dir = strategy_config_dir();
-        let dryrun_path = config_dir.join("02-pm5d-threelayer.unified.toml");
+        let dryrun_path =
+            config_dir.join("02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml");
         let live_path = config_dir.join("02-pm5d-threelayer.live.toml");
 
         let dryrun_body = std::fs::read_to_string(&dryrun_path).unwrap();
@@ -786,11 +787,51 @@ venue = "sportsbook"
             Some("live")
         );
 
-        dryrun
+        let dryrun_runtime = dryrun
             .get_mut("runtime")
             .and_then(toml::Value::as_table_mut)
+            .unwrap();
+        dryrun_runtime.insert("mode".to_string(), toml::Value::String("live".to_string()));
+        for recording_key in [
+            "record_market_updates_to",
+            "record_market_updates_max_records",
+            "record_market_updates_max_bytes",
+        ] {
+            dryrun_runtime.remove(recording_key);
+        }
+
+        let live_strategy = live
+            .get("strategy")
+            .and_then(toml::Value::as_table)
+            .unwrap();
+        let dryrun_strategy = dryrun
+            .get_mut("strategy")
+            .and_then(toml::Value::as_table_mut)
+            .unwrap();
+        assert!(
+            dryrun_strategy["stake_usd"].as_float().unwrap()
+                >= live_strategy["stake_usd"].as_float().unwrap()
+        );
+        assert!(
+            dryrun_strategy["max_positions"].as_integer().unwrap()
+                >= live_strategy["max_positions"].as_integer().unwrap()
+        );
+        assert_eq!(dryrun_strategy["max_daily_trades"].as_integer(), Some(0));
+        assert!(live_strategy["max_daily_trades"].as_integer().unwrap() > 0);
+        let dryrun_windows = dryrun_strategy["allowed_window_secs"].as_array().unwrap();
+        assert!(live_strategy["allowed_window_secs"]
+            .as_array()
             .unwrap()
-            .insert("mode".to_string(), toml::Value::String("live".to_string()));
+            .iter()
+            .all(|window| dryrun_windows.contains(window)));
+        for risk_key in [
+            "stake_usd",
+            "max_positions",
+            "max_daily_trades",
+            "allowed_window_secs",
+        ] {
+            dryrun_strategy.insert(risk_key.to_string(), live_strategy[risk_key].clone());
+        }
         assert_eq!(dryrun, live);
     }
 

--- a/deployment/ployd-trade.service
+++ b/deployment/ployd-trade.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Ploy Trade Control Plane
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=ploy
+Group=ploy
+WorkingDirectory=/opt/ploy
+EnvironmentFile=/opt/ploy/.env
+ExecStart=/opt/ploy/current/bin/ployd
+Restart=always
+RestartSec=5
+MemoryHigh=1280M
+MemoryMax=1536M
+OOMPolicy=kill
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/ploy/run /opt/ploy/data /opt/ploy/logs /opt/ploy/config
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ployd-trade
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -99,13 +99,11 @@ A separate release/deploy path can still build release artifacts, but the defaul
 
 ### Deployment Pipelines
 
-The default platform deployment workflow is `.github/workflows/release-platform.yml`.
-Legacy single-binary workflows remain in `.github/workflows/`, but they are not
-the default release path for the workspace runtime.
-
-For build-only release verification without touching a remote host, dispatch
-`release-platform.yml` with `deploy=false`. The deploy workflows keep
-`deploy=true` as their default for the established operator path.
+Named host workflows own deployment: `deploy-tango-1-1.yml` for the
+research/data/dry-run host and `deploy-trade.yml` for the immutable paused trade
+control plane. `approve-live-trade.yml` is the only live resume path and uses a
+protected human environment. `release-platform.yml` is build-only portable
+artifact verification and cannot mutate a host.
 
 ## Running Tests
 

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -117,7 +117,10 @@ rules.
   required.
 - On trading hosts, do not build Rust source on-host. Build in CI and deploy
   release artifacts only.
-- Preferred production workflow: `.github/workflows/release-platform.yml`.
+- Use `.github/workflows/deploy-tango-1-1.yml` for the research/data host and
+  `.github/workflows/deploy-trade.yml` for the immutable paused trade host.
+  Live resume is restricted to `.github/workflows/approve-live-trade.yml`.
+  `.github/workflows/release-platform.yml` is build-only.
 - Live services should keep these systemd guardrails:
   - `Restart=always`
   - `RestartSec=5`

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -17,7 +17,8 @@ collection behavior.
 | `scripts/export_parquet.sh` | canonical export helper | data/export host | Keep as the explicit Parquet export entrypoint until replaced by Rust datactl. |
 | `.github/workflows/backtest.yml` | canonical CI backtest lane | CI/backtest host | Should remain separated from trade-host deploy assumptions. |
 | `.github/workflows/optimize.yml` | canonical snapshot optimization lane | CI/backtest host | Requires a retained complete sampled research snapshot artifact. |
-| `.github/workflows/deploy-trade.yml` | canonical trade-host deploy lane | trade host | Should own trading artifacts only. |
+| `.github/workflows/deploy-trade.yml` | canonical trade-host deploy lane | ploy-trade-1 | Owns the immutable `ployd`/`ployctl`/runner bundle and stages the live deployment paused. |
+| `.github/workflows/approve-live-trade.yml` | canonical live admission lane | protected human approval | The only workflow allowed to resume live after exact-SHA replay, dry-run drawdown, and strict parity evidence pass. |
 
 ## Compatibility Or Transitional Live Collection
 
@@ -27,7 +28,7 @@ collection behavior.
 | `scripts/binance_aggtrade_collector.py` | compatibility collector | data host | Deployed by `deploy-tango-1-1.yml`; retire only after Rust feed/persistence replacement. |
 | `scripts/binance_lob_collector.py` | compatibility collector | data host | Critical L2 source today; do not delete without live replacement and freshness evidence. |
 | `scripts/polymarket_quote_collector.py` | compatibility collector | data host | Prefer `collect-quotes`/market-data long term. |
-| `.github/workflows/deploy-tango-1-1.yml` | transitional combined data/runtime deploy | tango-1-1 | Still bundles data collectors plus research artifacts; split after host-role cleanup. |
+| `.github/workflows/deploy-tango-1-1.yml` | canonical research/data deploy | tango-1-1 | Bundles collectors, research tools, replay, and dry-run surfaces; removes live manifests, signing keys, and live gate authority. |
 
 ## One-Shot Backfill / Repair Jobs
 
@@ -60,7 +61,8 @@ collection behavior.
 
 | Surface | Status | Owner | Notes |
 | --- | --- | --- | --- |
-| `scripts/install-platform-service.sh` | canonical platform release installer | release-platform | Active `release-platform.yml` bundle/install/execute path; now also owns host-support maintenance/watchdog unit installation; guarded by `tests/platform_release_workflow.rs`; do not archive. |
+| `.github/workflows/release-platform.yml` | build-only portable bundle | CI | Produces a checksumed bootstrap artifact only. It cannot deploy; named Tango/trade workflows own host mutation. |
+| `scripts/install-platform-service.sh` | portable bootstrap installer | release-platform bundle | Kept for non-host-specific bootstrap artifacts; not an Aliyun deployment authority. |
 
 ## Removed Legacy Assets
 

--- a/docs/runbooks/live-deployment-checklist.md
+++ b/docs/runbooks/live-deployment-checklist.md
@@ -12,12 +12,10 @@ This checklist is the operator-facing go/no-go gate. It assumes:
 
 ## Before You Start
 
-- Confirm you are on the workspace-default release path:
-  - `.github/workflows/release-platform.yml`
-  - `deployment/ployd.service`
-  - `scripts/install-platform-service.sh`
-  - `deployment/ploy-maintenance.timer`
-  - `deployment/ploy-platform-watchdog.timer`
+- Confirm the trade host was installed from the named protected path:
+  - `.github/workflows/deploy-trade.yml`
+  - `deployment/ployd-trade.service`
+  - an immutable `/opt/ploy/releases/<main-sha>` receipt
 - Confirm the host has:
   - `/opt/ploy/bin/ployd`
   - `/opt/ploy/bin/ployctl`
@@ -105,15 +103,25 @@ This verifies `02-pm5d-threelayer.live.toml` against the dry-run config, applies
 `pm5d.threelayer.live` with `desired_state=paused`, and stops before any live
 orders can be placed.
 
-Only after explicit operator approval, run:
+The staging script cannot resume live. Real live enablement is available only
+through `.github/workflows/approve-live-trade.yml`, which requires successful
+exact-SHA runtime replay, recorded replay/dry-run strict parity, positive
+dry-run economics, bounded drawdown, no open dry-run positions, the protected
+`ploy-trade-live` environment approval, and the explicit 5 USD risk
+acknowledgement. A failed observed-running or fresh-venue postflight pauses the
+deployment automatically.
 
-```bash
-/opt/ploy/scripts/drills/pm5d_threelayer_live_gate.sh --go-live
-```
+The trade daemon also enforces this boundary: when
+`PLOY_LIVE_APPROVAL_FILE` is configured, both a live `apply` with
+`desired_state=running` and a later `resume` are rejected unless the protected
+workflow has installed a short-lived root-owned receipt matching the deployment
+wallet, 5 USD exposure cap, exact release SHA, and immutable live-config hash.
+The workflow removes the pending receipt after the transition, so a later
+pause requires a new evidence review and human approval.
 
 ## Not Covered By This Checklist
 
-This checklist does not:
+Manual execution of this checklist does not:
 
 - place live orders
 - cancel live venue orders

--- a/docs/runbooks/platform-deploy.md
+++ b/docs/runbooks/platform-deploy.md
@@ -1,26 +1,30 @@
 # Platform Deploy Runbook
 
-## Default Release Path
+## Deployment Paths
 
-The workspace-default deploy path is:
+Aliyun host mutation is split by role:
 
-- GitHub Actions workflow: `.github/workflows/release-platform.yml`
-- Long-running systemd unit: `deployment/ployd.service`
-- Host install helper: `scripts/install-platform-service.sh`
+- `.github/workflows/deploy-tango-1-1.yml`: data collection, research,
+  replay, and dry-run only. The bundle contains no live manifest, live config,
+  signing key, or live-resume gate.
+- `.github/workflows/deploy-trade.yml`: immutable exact-main-SHA trade control
+  plane, installed under `/opt/ploy/releases/<sha>` and staged paused.
+- `.github/workflows/approve-live-trade.yml`: the only live resume path, behind
+  artifact validation and the protected `ploy-trade-live` human environment.
 
-Use `deploy=false` when dispatching the workflow if you only want CI to build,
-package, checksum, and upload the platform bundle artifact without touching the
-remote host. The default `deploy=true` preserves the normal release path.
+`.github/workflows/release-platform.yml` is build-only. It packages and
+checksums the portable platform bundle but has no remote host credentials or
+deployment job, so it cannot become a third production path.
 
-This path deploys three binaries:
+The trade path deploys three binaries:
 
 - `/opt/ploy/bin/ployd`
 - `/opt/ploy/bin/ployctl`
-- `/opt/ploy/bin/ploytui`
+- `/opt/ploy/bin/ploy-runner`
 
-`ployd` is the only default long-running process. `ployctl` is an operator
-client used for post-deploy verification and remote inspection. `ploytui` is
-the thin terminal console built on the same daemon HTTP surface.
+`ployd` is the only systemd platform process. It supervises the runner;
+`ployctl` is the operator client used for post-deploy verification and remote
+inspection.
 
 Deployment resources are managed separately from the daemon process. Operators
 apply a deployment manifest and then use `ployctl` to inspect or change desired
@@ -49,32 +53,28 @@ The release bundle contains:
 - `scripts/ploy_platform_watchdog.sh`
 - `data/state/deployments.json.sample`
 
-## Host Installation Flow
+## Trade Host Installation Flow
 
-After the bundle lands on the host, the deploy workflow:
+After the bundle lands on `ploy-trade-1`, the deploy workflow:
 
-1. Installs `ployd`, `ployctl`, and `ploytui` into `/opt/ploy/bin`
-2. Installs `deployment/ployd.service` and host-support maintenance/watchdog
-   unit files into `/opt/ploy/deployment`
-3. Installs `scripts/install-platform-service.sh`,
-   `scripts/ploy_maintenance.sh`, and `scripts/ploy_platform_watchdog.sh` into
-   `/opt/ploy/scripts`
-4. Seeds `/opt/ploy/data/state/deployments.json` if missing
-5. Runs `install-platform-service.sh`, which installs `ployd.service` and the
-   maintenance/watchdog timers into systemd
-6. Restarts `ployd`
-7. Verifies:
-   - `systemctl status ployd`
-   - `systemctl status ploy-platform-watchdog.timer`
-   - `systemctl status ploy-maintenance.timer`
-   - `curl -fsS http://127.0.0.1:8081/health`
-   - `/opt/ploy/bin/ployctl system status`
-   - `/opt/ploy/bin/ployctl system metrics`
-   - `/opt/ploy/bin/ployctl system alerts`
-   - `/opt/ploy/bin/ployctl system audit`
-   - `/opt/ploy/bin/ployctl trading status`
-   - `/opt/ploy/bin/ploytui`
-   - `curl -N http://127.0.0.1:8081/api/events/stream`
+1. Verifies the CI bundle checksum and refuses to overwrite an existing SHA
+   release with different bytes.
+2. Installs the bundle under `/opt/ploy/releases/<sha>` and atomically switches
+   `/opt/ploy/current`, with rollback on failed postflight.
+3. Installs `deployment/ployd-trade.service` with exact restart, memory, and OOM
+   guardrails; no Rust build occurs on-host.
+4. Derives and verifies the execution principal, renders the wallet-bound live
+   manifest in memory, and applies it with `desired_state=paused`.
+5. Verifies the release receipt, health endpoint, operator surfaces, exact
+   systemd guardrails, absence of `cargo`/`rustc`, and
+   `desired=Paused observed=Paused`.
+
+Before changing a release, the trade workflow pauses the canonical live
+deployment, stops `ployd`, and rewrites every persisted live desired state to
+paused. Deploy and live approval share the `ploy-trade-host` concurrency group.
+Release files and stable config aliases remain root-owned; `ploy` receives write
+access only to state/run/log paths. Rollback restores the previous symlink,
+service unit, and environment while keeping live paused.
 
 ## Required Host Paths
 

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -70,7 +70,8 @@ when the mismatch is understood and tracked as a follow-up issue.
 | ACK deploy | `.github/workflows/deploy-ack.yml` | Deploy immutable SHA image tags through the protected `ack` environment |
 | Tango deploy | `.github/workflows/deploy-tango-1-1.yml` | Ship CI-built artifacts to `tango-1-1` and verify host health |
 | Trade deploy | `.github/workflows/deploy-trade.yml` | Deploy runner/configs to `ploy-trade-1` through a protected environment |
-| Platform release | `.github/workflows/release-platform.yml` | Build platform bundle and optionally deploy it |
+| Platform bundle | `.github/workflows/release-platform.yml` | Build a portable checksumed artifact only; named host workflows own deployment |
+| Live approval | `.github/workflows/approve-live-trade.yml` | Validate exact-SHA replay/dry-run/parity evidence, then require protected human approval before bounded live resume |
 
 `backtest.yml` emits `strategy_backtest_evaluation` as replay/backtest
 evidence, not as dry-run or live promotion evidence. Its `data_dir` path uses
@@ -247,13 +248,13 @@ closed dry-run rows when available, and falls back to current open rows when a
 fresh recording has not yet accumulated closed events. The workflow records the resolved window in the workflow summary, issue comment, and
 `resolved-window.json` artifact. Manual timestamps remain supported for
 reproducing a known incident window or an older research issue.
-The workflow is read-only evidence generation. `runner_source=deployed` is the
-default because runtime parity should compare the deployed dry-run report with
-the deployed `/opt/ploy/bin/ploy-runner` on the same host. Use
-`runner_source=workflow_ref` only as the branch-regression mode: it builds
-`new-ploy-runner` on the GitHub runner from the requested workflow ref, copies
-that temporary binary to the replay scratch directory on `tango-1-1`, and
-compares that branch binary against the deployed config/recording. Both modes
+The workflow is read-only evidence generation. `runner_source=workflow_ref` is
+the default so promotion evidence is bound to the exact reviewed Git SHA: it
+builds `new-ploy-runner` on the GitHub runner, copies that temporary binary to
+the replay scratch directory on `tango-1-1`, and compares it against the
+deployed config/recording. Use `runner_source=deployed` only as a diagnostic for
+the currently installed Tango binary; deployed-runner evidence cannot satisfy
+the protected live-approval gate. Both modes
 use a temporary replay config plus report/database reads. The workflow does not
 deploy artifacts, restart services, replace `/opt/ploy/bin/ploy-runner`, or
 enable live orders. Its `approval_environment` input therefore defaults to

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -9,15 +9,15 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
+export type DeploymentRuntimeMode = "paper" | "live";
+
 export type DeploymentState = "enabled" | "draining" | "disabled" | "archived";
 
 export type DesiredState = "running" | "paused" | "stopped";
 
 export type ObservedState = "starting" | "running" | "degraded" | "paused" | "stopped" | "failed";
 
-export interface DeploymentSummary { account_id?: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; observed_state: ObservedState; }
-
-export type DeploymentRuntimeMode = "paper" | "live";
+export interface DeploymentSummary { account_id?: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; observed_state: ObservedState; runtime_mode?: DeploymentRuntimeMode; }
 
 export interface DeploymentApplyRequest { account_id?: string; bundle_id: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; runtime_mode: DeploymentRuntimeMode; }
 

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -9,15 +9,15 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
+export type DeploymentRuntimeMode = "paper" | "live";
+
 export type DeploymentState = "enabled" | "draining" | "disabled" | "archived";
 
 export type DesiredState = "running" | "paused" | "stopped";
 
 export type ObservedState = "starting" | "running" | "degraded" | "paused" | "stopped" | "failed";
 
-export interface DeploymentSummary { account_id?: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; observed_state: ObservedState; }
-
-export type DeploymentRuntimeMode = "paper" | "live";
+export interface DeploymentSummary { account_id?: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; observed_state: ObservedState; runtime_mode?: DeploymentRuntimeMode; }
 
 export interface DeploymentApplyRequest { account_id?: string; bundle_id: string; deployment_id: string; deployment_state?: DeploymentState; desired_state: DesiredState; max_gross_exposure?: string | null; runtime_mode: DeploymentRuntimeMode; }
 

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -82,19 +82,19 @@ service_exists() {{
   systemctl cat "$1" >/dev/null 2>&1
 }}
 
-require_pm5d_live_paused() {{
-  local live_status
-  local live_line
-  live_status="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments inspect pm5d.threelayer.live 2>&1)"
-  echo "${{live_status}}"
-  live_line="$(printf '%s\n' "${{live_status}}" | awk '$1 == "pm5d.threelayer.live" {{ print; exit }}')"
-  case "${{live_line}}" in
-    *"desired=Paused"*"observed=Paused"*) ;;
-    *)
-      echo "pm5d.threelayer.live must remain desired=Paused observed=Paused after deploy" >&2
-      exit 1
-      ;;
-  esac
+require_research_host_has_no_live() {{
+  local deployments
+  if grep -Eq '^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=' "${{DEPLOY_ROOT}}/.env"; then
+    echo "research host must not retain a live signing key" >&2
+    exit 1
+  fi
+  deployments="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments list 2>&1)"
+  echo "${{deployments}}"
+  if printf '%s\n' "${{deployments}}" | awk \
+    '/mode=Live/ && !/lifecycle=Archived desired=Stopped observed=Stopped/ {{ found=1 }} END {{ exit !found }}'; then
+    echo "research host still has a non-archived live deployment" >&2
+    exit 1
+  fi
 }}
 
 require_service_guardrails() {{
@@ -203,6 +203,36 @@ for unit in \\
   fi
 done
 
+# Revoke runtime authority before replacing any research-host files.
+if [ -f "${{DEPLOY_ROOT}}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${{DEPLOY_ROOT}}/.env"
+  set +a
+fi
+if service_exists ployd.service; then
+  if [ -x "${{DEPLOY_ROOT}}/bin/ployctl" ]; then
+    "${{DEPLOY_ROOT}}/bin/ployctl" deployments pause pm5d.threelayer.live >/dev/null 2>&1 || true
+  fi
+  systemctl stop ployd.service
+fi
+python3 - "${{DEPLOY_ROOT}}/data/state/deployments.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if path.exists():
+    records = json.loads(path.read_text(encoding="utf-8"))
+    for record in records:
+        if record.get("runtime_mode") == "live":
+            record["desired_state"] = "paused"
+            record["observed_state"] = "paused"
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+PY
+
 install -m 0755 ./bin/ployd "${{DEPLOY_ROOT}}/bin/ployd"
 install -m 0755 ./bin/ploy-runner "${{DEPLOY_ROOT}}/bin/ploy-runner"
 rm -f "${{DEPLOY_ROOT}}/bin/factor-research"
@@ -211,6 +241,12 @@ install -m 0755 ./bin/persist-research-trace "${{DEPLOY_ROOT}}/bin/persist-resea
 install -m 0755 ./bin/research-trace-plan "${{DEPLOY_ROOT}}/bin/research-trace-plan"
 install -m 0644 ./config/strategies/*.toml "${{DEPLOY_ROOT}}/config/strategies/"
 install -m 0644 ./config/deployments/*.json "${{DEPLOY_ROOT}}/config/deployments/"
+find "${{DEPLOY_ROOT}}/config/strategies" -maxdepth 1 -type f -iname '*live*.toml' -delete
+python3 -c 'import json,pathlib,sys; [path.unlink() for path in pathlib.Path(sys.argv[1]).glob("*.json") if json.loads(path.read_text()).get("runtime_mode") == "live"]' "${{DEPLOY_ROOT}}/config/deployments"
+rm -f "${{DEPLOY_ROOT}}/scripts/drills/pm5d_threelayer_live_gate.sh"
+if [ -f "${{DEPLOY_ROOT}}/.env" ]; then
+  sed -i -E '/^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=/d' "${{DEPLOY_ROOT}}/.env"
+fi
 install -m 0755 ./scripts/*.py "${{DEPLOY_ROOT}}/scripts/"
 install -m 0755 ./scripts/*.sh "${{DEPLOY_ROOT}}/scripts/"
 install -m 0644 ./scripts/*.sql "${{DEPLOY_ROOT}}/scripts/"
@@ -290,6 +326,13 @@ systemctl enable --now ploy-pm-trade-collector.service
 systemctl restart ploy-pm-trade-collector.service
 if service_exists ployd.service; then
   systemctl restart ployd.service
+  existing_live_ids="$("${{DEPLOY_ROOT}}/bin/ployctl" deployments list 2>/dev/null \
+    | awk '/mode=Live/ && !/lifecycle=Archived/ {{print $1}}' || true)"
+  while IFS= read -r live_id; do
+    [ -n "${{live_id}}" ] || continue
+    "${{DEPLOY_ROOT}}/bin/ployctl" deployments pause "${{live_id}}"
+    "${{DEPLOY_ROOT}}/bin/ployctl" deployments archive "${{live_id}}"
+  done <<< "${{existing_live_ids}}"
 fi
 
 DEPLOY_VERIFY_SINCE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -317,7 +360,7 @@ if service_exists ployd.service; then
   curl -fsS http://127.0.0.1:8081/health
   curl -fsS http://127.0.0.1:8081/api/reports/dry-run | "${{DEPLOY_ROOT}}/scripts/check_dryrun_report_contract.py"
   "${{DEPLOY_ROOT}}/bin/ployctl" deployments list
-  require_pm5d_live_paused
+  require_research_host_has_no_live
 fi
 
 wait_for_recent_rows \\

--- a/scripts/drills/pm5d_threelayer_live_gate.sh
+++ b/scripts/drills/pm5d_threelayer_live_gate.sh
@@ -8,15 +8,14 @@ RENDERED_MANIFEST=""
 DRYRUN_CONFIG=""
 LIVE_CONFIG=""
 DEPLOYMENT_ID=""
-GO_LIVE=0
 RUN_DRY_RUN_DRILL=1
 WARNINGS=0
 
 usage() {
   cat <<'EOF'
-Usage: pm5d_threelayer_live_gate.sh [--go-live] [--host-root /opt/ploy] [--addr http://127.0.0.1:8081]
+Usage: pm5d_threelayer_live_gate.sh [--host-root /opt/ploy] [--addr http://127.0.0.1:8081]
 
-Prepares the PM5D ThreeLayer live deployment on a Tango host.
+Stages the PM5D ThreeLayer live deployment as paused on the trade host.
 
 Default behavior:
   - verify daemon, env, manifest, and live/dry-run config parity
@@ -24,12 +23,8 @@ Default behavior:
   - apply pm5d.threelayer.live with desired_state=paused
   - stop before placing any live orders
 
-With --go-live:
-  - perform the same checks
-  - apply the paused live manifest
-  - resume pm5d.threelayer.live
-
 The script never edits /opt/ploy/.env and never changes strategy parameters.
+Only the protected live-approval workflow may resume the deployment.
 EOF
 }
 
@@ -129,10 +124,6 @@ PY
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --go-live)
-      GO_LIVE=1
-      shift
-      ;;
     --host-root)
       HOST_ROOT="$2"
       shift 2
@@ -170,7 +161,7 @@ done
 PLOYCTL="${HOST_ROOT}/bin/ployctl"
 ENV_FILE="${HOST_ROOT}/.env"
 MANIFEST="${MANIFEST:-${HOST_ROOT}/config/deployments/pm5d.threelayer.live.json}"
-DRYRUN_CONFIG="${DRYRUN_CONFIG:-${HOST_ROOT}/config/strategies/02-pm5d-threelayer.unified.toml}"
+DRYRUN_CONFIG="${DRYRUN_CONFIG:-${HOST_ROOT}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml}"
 LIVE_CONFIG="${LIVE_CONFIG:-${HOST_ROOT}/config/strategies/02-pm5d-threelayer.live.toml}"
 
 require_command systemctl
@@ -251,16 +242,16 @@ case "$SIGNATURE_TYPE" in
 esac
 
 log_step "manifest and config parity"
-python3 - "$MANIFEST" "$DRYRUN_CONFIG" "$LIVE_CONFIG" "$GO_LIVE" <<'PY'
+python3 - "$MANIFEST" "$DRYRUN_CONFIG" "$LIVE_CONFIG" <<'PY'
 import json
 import pathlib
 import re
 import sys
+import tomllib
 
 manifest_path = pathlib.Path(sys.argv[1])
 dryrun_path = pathlib.Path(sys.argv[2])
 live_path = pathlib.Path(sys.argv[3])
-go_live = sys.argv[4] == "1"
 
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 if manifest.get("deployment_id") != "pm5d.threelayer.live":
@@ -270,32 +261,44 @@ if manifest.get("bundle_id") != "02-pm5d-threelayer.live":
 if manifest.get("runtime_mode") != "live":
     raise SystemExit("manifest runtime_mode must be live")
 if manifest.get("desired_state") != "paused":
-    raise SystemExit("manifest desired_state must stay paused; --go-live resumes explicitly")
+    raise SystemExit("manifest desired_state must stay paused")
 if manifest.get("account_id") != "live-wallet-must-be-rendered":
     raise SystemExit("repository live manifest must retain its unrendered wallet sentinel")
 
-dryrun = dryrun_path.read_text(encoding="utf-8")
-live = live_path.read_text(encoding="utf-8")
-if not re.search(r'(?m)^mode = "dryrun"$', dryrun):
-    raise SystemExit("dry-run config must contain mode = \"dryrun\"")
-if not re.search(r'(?m)^mode = "live"$', live):
-    raise SystemExit("live config must contain mode = \"live\"")
+dryrun = tomllib.loads(dryrun_path.read_text(encoding="utf-8"))
+live = tomllib.loads(live_path.read_text(encoding="utf-8"))
+if dryrun.get("runtime", {}).get("mode") != "dryrun":
+    raise SystemExit("source config must use runtime.mode=dryrun")
+if live.get("runtime", {}).get("mode") != "live":
+    raise SystemExit("live config must use runtime.mode=live")
 
-def material_config(text):
-    return "\n".join(
-        line.rstrip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    )
+dryrun["runtime"]["mode"] = "live"
+for key in (
+    "record_market_updates_to",
+    "record_market_updates_max_records",
+    "record_market_updates_max_bytes",
+):
+    dryrun["runtime"].pop(key, None)
 
-normalized = re.sub(r'(?m)^mode = "dryrun"$', 'mode = "live"', dryrun, count=1)
-if material_config(normalized) != material_config(live):
-    raise SystemExit("live config must match dry-run config exactly except [runtime].mode")
+dry_strategy = dryrun["strategy"]
+live_strategy = live["strategy"]
+if not (0 < float(live_strategy["stake_usd"]) <= float(manifest["max_gross_exposure"]) <= 5):
+    raise SystemExit("live stake/exposure must be positive and capped at 5 USD")
+if not (0 < int(live_strategy["max_positions"]) <= int(dry_strategy["max_positions"])):
+    raise SystemExit("live max_positions must be a positive dry-run risk reduction")
+if not (0 < int(live_strategy["max_daily_trades"]) <= 10):
+    raise SystemExit("live max_daily_trades must be bounded at 10")
+if not set(live_strategy["allowed_window_secs"]).issubset(dry_strategy["allowed_window_secs"]):
+    raise SystemExit("live windows must be a subset of replayed dry-run windows")
+if float(live_strategy["stake_usd"]) > float(dry_strategy["stake_usd"]):
+    raise SystemExit("live stake cannot exceed replayed dry-run stake")
 
-if go_live:
-    print("manifest/config gate: go-live requested")
-else:
-    print("manifest/config gate: paused apply only")
+for key in ("stake_usd", "max_positions", "max_daily_trades", "allowed_window_secs"):
+    dry_strategy[key] = live_strategy[key]
+if dryrun != live:
+    raise SystemExit("live model/execution config differs from promoted dry-run source")
+
+print("manifest/config gate: paused apply only")
 PY
 
 RENDERED_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/ploy-live-manifest.XXXXXX.json")"
@@ -328,38 +331,9 @@ case "$INSPECT_OUTPUT" in
   *) fail "live deployment was not applied as paused" ;;
 esac
 
-if [[ "$GO_LIVE" -ne 1 ]]; then
-  log_step "result"
-  if [[ "$WARNINGS" -gt 0 ]]; then
-    printf 'READY-WITH-WARNINGS: %s is staged paused; review warnings before --go-live.\n' "$DEPLOYMENT_ID"
-  else
-    printf 'READY: %s is staged paused. Run with --go-live only after manual live approval.\n' "$DEPLOYMENT_ID"
-  fi
-  exit 0
-fi
-
-[[ "$WARNINGS" -eq 0 ]] || fail "go-live is blocked while readiness warnings are active"
-
-log_step "resume live deployment"
-RESUME_OUTPUT="$(ployctl_capture deployments resume "$DEPLOYMENT_ID")"
-printf '%s\n' "$RESUME_OUTPUT"
-LIVE_READY=0
-for _ in {1..15}; do
-  FINAL_INSPECT="$(ployctl_capture deployments inspect "$DEPLOYMENT_ID")"
-  FINAL_METRICS="$(ployctl_capture system metrics)"
-  if [[ "$FINAL_INSPECT" == *"desired=Running"*"observed=Running"* ]] \
-    && [[ "$FINAL_METRICS" == *"venue:venue:polymarket:healthy"* ]]; then
-    LIVE_READY=1
-    break
-  fi
-  sleep 1
-done
-printf '%s\n' "$FINAL_INSPECT"
-printf '%s\n' "$FINAL_METRICS"
-if [[ "$LIVE_READY" -ne 1 ]]; then
-  ployctl_capture deployments pause "$DEPLOYMENT_ID" >&2 || true
-  fail "live deployment failed observed-running or fresh-venue postflight and was paused"
-fi
-
 log_step "result"
-printf 'LIVE: %s resume command accepted. Watch ployctl trading status and worker logs immediately.\n' "$DEPLOYMENT_ID"
+if [[ "$WARNINGS" -gt 0 ]]; then
+  printf 'STAGED-WITH-WARNINGS: %s remains paused; live approval is blocked until warnings are cleared.\n' "$DEPLOYMENT_ID"
+else
+  printf 'STAGED: %s remains paused. Only the protected live-approval workflow may resume it.\n' "$DEPLOYMENT_ID"
+fi

--- a/scripts/validate_live_promotion_evidence.py
+++ b/scripts/validate_live_promotion_evidence.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for the protected live-promotion workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def validate(
+    replay: dict[str, Any],
+    parity: dict[str, Any],
+    parity_provenance: dict[str, Any],
+    dryrun: dict[str, Any],
+    *,
+    git_sha: str,
+    min_replay_trades: int,
+    min_dryrun_closed_trades: int,
+    max_drawdown_usd: float,
+    expected_deployment_id: str,
+    expected_strategy_profile: str,
+    expected_runtime_score: str,
+    expected_config_sha256: str,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    replay_metrics = replay.get("metrics") or {}
+    replay_blockers = replay.get("blocking_risk_flags") or []
+    decision_contract = replay.get("decision_contract") or {}
+    runtime = parity.get("runtime_evidence_comparison") or {}
+    parity_blockers = parity.get("blocking_risk_flags") or parity.get("risk_flags") or []
+    matching_dryruns = [
+        item
+        for item in dryrun.get("strategies") or []
+        if isinstance(item, dict) and item.get("deployment_id") == expected_deployment_id
+    ]
+    require(len(matching_dryruns) == 1, "dryrun_deployment_slice_missing_or_ambiguous", failures)
+    dryrun_slice = matching_dryruns[0] if len(matching_dryruns) == 1 else {}
+    dryrun_summary = dryrun_slice.get("summary") or {}
+    dryrun_metrics = dryrun_slice.get("metrics") or {}
+
+    require(min_replay_trades >= 20, "min_replay_trades_below_policy_floor", failures)
+    require(
+        min_dryrun_closed_trades >= 30,
+        "min_dryrun_closed_trades_below_policy_floor",
+        failures,
+    )
+    require(0 < max_drawdown_usd <= 25, "max_drawdown_policy_limit_invalid", failures)
+
+    require(bool(re.fullmatch(r"[0-9a-f]{40}", git_sha)), "invalid_git_sha", failures)
+    require(replay.get("evidence_stage") == "executable_replay", "replay_stage_not_executable", failures)
+    require(replay.get("basis") == "runtime_market_update_replay", "replay_basis_not_runtime_market_update", failures)
+    require(replay.get("promotion_ready") is True, "replay_not_promotion_ready", failures)
+    require(not replay_blockers, f"replay_blockers:{replay_blockers}", failures)
+    require(replay.get("runner_git_sha") == git_sha, "replay_runner_sha_mismatch", failures)
+    require(replay.get("deployment_id") == expected_deployment_id, "replay_deployment_mismatch", failures)
+    require(replay.get("strategy_profile") == expected_strategy_profile, "replay_strategy_profile_mismatch", failures)
+    require(replay.get("runtime_score") == expected_runtime_score, "replay_runtime_score_mismatch", failures)
+    require(replay.get("config_sha256") == expected_config_sha256, "replay_config_sha_mismatch", failures)
+    require(bool(replay.get("recording_sha256")), "replay_recording_sha_missing", failures)
+    require(int(replay_metrics.get("trade_count") or 0) >= min_replay_trades, "replay_trade_count_too_small", failures)
+    require(replay_metrics.get("trade_count") == replay_metrics.get("unique_event_count"), "replay_not_one_trade_per_event", failures)
+    require(decision_contract.get("official_settlement") is True, "official_settlement_not_proven", failures)
+    require(decision_contract.get("full_depth_entry") is True, "full_depth_entry_not_proven", failures)
+    require(float(replay_metrics.get("roi") or 0) > 0, "replay_roi_not_positive", failures)
+
+    orders = runtime.get("orders") or {}
+    fills = runtime.get("fills") or {}
+    require(runtime.get("strict_parity_ready") is True, "strict_runtime_parity_not_ready", failures)
+    require(not parity_blockers, f"parity_blockers:{parity_blockers}", failures)
+    require(int(orders.get("shared_count") or 0) > 0, "parity_has_no_shared_orders", failures)
+    require(int(fills.get("shared_count") or 0) > 0, "parity_has_no_shared_fills", failures)
+    require(
+        (parity.get("filters") or {}).get("deployment_id") == expected_deployment_id,
+        "parity_deployment_mismatch",
+        failures,
+    )
+    require(parity_provenance.get("deployment_id") == expected_deployment_id, "parity_provenance_deployment_mismatch", failures)
+    require(parity_provenance.get("config_sha256") == expected_config_sha256, "parity_config_sha_mismatch", failures)
+    require(parity_provenance.get("runner_source") == "workflow_ref", "parity_runner_not_workflow_ref", failures)
+    require(parity_provenance.get("runner_git_sha") == git_sha, "parity_runner_sha_mismatch", failures)
+    require(parity_provenance.get("skip_settlement_exits") is False, "parity_skipped_settlement_exits", failures)
+    require(
+        parity_provenance.get("recording_sha256") == replay.get("recording_sha256"),
+        "parity_recording_sha_mismatch",
+        failures,
+    )
+
+    closed_trades = int(dryrun_summary.get("closed_trades") or 0)
+    drawdown = float(dryrun_metrics.get("max_drawdown") or 0)
+    require(closed_trades >= min_dryrun_closed_trades, "dryrun_closed_trade_count_too_small", failures)
+    require(float(dryrun_summary.get("realized_pnl") or 0) > 0, "dryrun_realized_pnl_not_positive", failures)
+    require(drawdown <= 0, "dryrun_drawdown_sign_invalid", failures)
+    require(abs(drawdown) <= max_drawdown_usd, "dryrun_drawdown_limit_exceeded", failures)
+    require(int(dryrun_summary.get("open_positions") or 0) == 0, "dryrun_has_open_positions", failures)
+
+    result = {
+        "schema_version": 1,
+        "git_sha": git_sha,
+        "ready_for_human_live_approval": not failures,
+        "failures": failures,
+        "replay_trade_count": replay_metrics.get("trade_count"),
+        "replay_roi": replay_metrics.get("roi"),
+        "dryrun_closed_trades": closed_trades,
+        "dryrun_realized_pnl": dryrun_summary.get("realized_pnl"),
+        "dryrun_max_drawdown": drawdown,
+        "strict_parity_ready": runtime.get("strict_parity_ready"),
+    }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--replay", type=Path, required=True)
+    parser.add_argument("--parity", type=Path, required=True)
+    parser.add_argument("--parity-provenance", type=Path, required=True)
+    parser.add_argument("--dryrun", type=Path, required=True)
+    parser.add_argument("--git-sha", required=True)
+    parser.add_argument("--min-replay-trades", type=int, required=True)
+    parser.add_argument("--min-dryrun-closed-trades", type=int, required=True)
+    parser.add_argument("--max-drawdown-usd", type=float, required=True)
+    parser.add_argument("--expected-deployment-id", required=True)
+    parser.add_argument("--expected-strategy-profile", required=True)
+    parser.add_argument("--expected-runtime-score", required=True)
+    parser.add_argument("--expected-config-sha256", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = validate(
+        load_object(args.replay),
+        load_object(args.parity),
+        load_object(args.parity_provenance),
+        load_object(args.dryrun),
+        git_sha=args.git_sha,
+        min_replay_trades=args.min_replay_trades,
+        min_dryrun_closed_trades=args.min_dryrun_closed_trades,
+        max_drawdown_usd=args.max_drawdown_usd,
+        expected_deployment_id=args.expected_deployment_id,
+        expected_strategy_profile=args.expected_strategy_profile,
+        expected_runtime_score=args.expected_runtime_score,
+        expected_config_sha256=args.expected_config_sha256,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["ready_for_human_live_approval"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_trade_host_postflight.sh
+++ b/scripts/verify_trade_host_postflight.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PLOY_ROOT_DIR:-/opt/ploy}"
+EXPECTED_SHA="${1:?usage: verify_trade_host_postflight.sh <40-char-sha> <paused|running>}"
+EXPECTED_STATE="${2:?usage: verify_trade_host_postflight.sh <40-char-sha> <paused|running>}"
+SYSTEMCTL="${SYSTEMCTL:-systemctl}"
+PLOYCTL="${PLOYCTL:-${ROOT_DIR}/current/bin/ployctl}"
+CURL="${CURL:-curl}"
+PGREP="${PGREP:-pgrep}"
+
+fail() {
+  printf 'trade-host postflight failed: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "expected release SHA must be 40 lowercase hex characters"
+case "$EXPECTED_STATE" in
+  paused|running) ;;
+  *) fail "expected state must be paused or running" ;;
+esac
+
+release_path="${ROOT_DIR}/releases/${EXPECTED_SHA}"
+[[ -d "$release_path" ]] || fail "immutable release directory is missing"
+release_dir="$(cd "$release_path" && pwd -P)"
+current_dir="$(readlink -f "${ROOT_DIR}/current")"
+[[ "$current_dir" == "$release_dir" ]] || fail "current release is ${current_dir}, expected ${release_dir}"
+[[ -x "${release_dir}/bin/ployd" ]] || fail "ployd missing from immutable release"
+[[ -x "${release_dir}/bin/ployctl" ]] || fail "ployctl missing from immutable release"
+[[ -x "${release_dir}/bin/ploy-runner" ]] || fail "ploy-runner missing from immutable release"
+(cd "$release_dir" && sha256sum -c FILES.sha256 >/dev/null) \
+  || fail "immutable release file checksum verification failed"
+grep -Fxq "PLOY_RELEASE_SHA=${EXPECTED_SHA}" "${ROOT_DIR}/.env" \
+  || fail "PLOY_RELEASE_SHA is not bound to the immutable release"
+grep -Fxq "PLOY_LIVE_APPROVAL_FILE=${ROOT_DIR}/data/live-approvals/pending.json" "${ROOT_DIR}/.env" \
+  || fail "runtime live-approval enforcement is not configured"
+
+python3 - "$release_dir/release.json" "$EXPECTED_SHA" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expected = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+if payload.get("git_sha") != expected:
+    raise SystemExit(f"release receipt SHA mismatch: {payload.get('git_sha')} != {expected}")
+if not payload.get("bundle_sha256"):
+    raise SystemExit("release receipt is missing bundle_sha256")
+PY
+
+"$SYSTEMCTL" is-active --quiet ployd.service || fail "ployd.service is not active"
+
+assert_property() {
+  local property="$1"
+  local expected="$2"
+  local actual
+  actual="$($SYSTEMCTL show -P "$property" ployd.service)"
+  [[ "$actual" == "$expected" ]] || fail "ployd.service ${property}=${actual}, expected ${expected}"
+}
+
+assert_property Restart always
+assert_property RestartUSec 5s
+assert_property MemoryHigh 1342177280
+assert_property MemoryMax 1610612736
+assert_property OOMPolicy kill
+
+if "$PGREP" -af '(^|/)cargo([[:space:]]|$)|(^|/)rustc([[:space:]]|$)' >/dev/null; then
+  "$PGREP" -af '(^|/)cargo([[:space:]]|$)|(^|/)rustc([[:space:]]|$)' >&2 || true
+  fail "Rust build process is running on the trade host"
+fi
+
+"$CURL" -fsS http://127.0.0.1:8081/health >/dev/null || fail "ployd health endpoint failed"
+"$PLOYCTL" system status
+"$PLOYCTL" system metrics
+"$PLOYCTL" system alerts
+"$PLOYCTL" trading status
+deployments="$($PLOYCTL deployments list 2>&1)"
+printf '%s\n' "$deployments"
+if printf '%s\n' "$deployments" | awk \
+  '$0 ~ /mode=Live/ && $1 != "pm5d.threelayer.live" && $0 !~ /lifecycle=Archived/ { found=1 } END { exit !found }'; then
+  fail "unexpected non-archived live deployment exists on trade host"
+fi
+
+inspect="$($PLOYCTL deployments inspect pm5d.threelayer.live 2>&1)"
+printf '%s\n' "$inspect"
+case "$EXPECTED_STATE" in
+  paused)
+    [[ "$inspect" == *"desired=Paused"*"observed=Paused"* ]] \
+      || fail "live deployment is not desired=Paused observed=Paused"
+    ;;
+  running)
+    [[ "$inspect" == *"desired=Running"*"observed=Running"* ]] \
+      || fail "live deployment is not desired=Running observed=Running"
+    metrics="$($PLOYCTL system metrics 2>&1)"
+    [[ "$metrics" == *"venue:venue:polymarket:healthy"* ]] \
+      || fail "Polymarket venue health is not fresh"
+    ;;
+esac
+
+printf 'trade-host postflight passed: sha=%s state=%s\n' "$EXPECTED_SHA" "$EXPECTED_STATE"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -366,3 +366,12 @@
   `allow_running=false`, `confirm=delete-strategy-runtime-evidence`, backup
   artifacts, and a passing post-reset clean-baseline gate before any fresh
   dry-run observation or strategy-quality claim.
+
+## 2026-07-11
+
+- Pattern: Process fixtures passed locally but failed on GitHub because they
+  inferred child readiness from `spawn()` or accepted the first log row while
+  asserting behavior from a later restart.
+- Rule: Synchronize worker-process fixtures on an explicit child-ready signal
+  and wait for the exact expected event count before assertions. Do not weaken
+  production PID identity checks or add arbitrary sleeps to mask fixture races.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22837,3 +22837,73 @@ gates are touched.
   to the root instead of silently stopping at 64 hops. Cycle/max-hop defensive
   stops increment `backpropagation_truncated_count`, and artifact generation
   emits a warning when the count is non-zero.
+
+# Aliyun Dual-Host Runtime Boundary (2026-07-11)
+
+## Goal
+
+Make the deployable host contract explicit and fail closed: `tango-1-1` owns
+data collection, research, replay, and dry-run evidence; `ploy-trade-1` owns the
+paused trading control plane and may enter live only through a separate,
+evidence-bound human approval gate.
+
+Current evidence stage: deployment/runtime safety plumbing. This slice does not
+claim `dry_run_candidate` or `live_candidate` research evidence and must not
+resume live trading.
+
+## Files / Ownership
+
+- `.github/workflows/deploy-tango-1-1.yml`
+  - Owner: research-host bundle boundary and postflight assertions.
+- `.github/workflows/deploy-trade.yml`
+  - Owner: immutable CI-built trade release, systemd guardrails, paused
+    postflight, and deployment receipt.
+- `.github/workflows/approve-live-trade.yml`
+  - Owner: exact-main-SHA, artifact/evidence, and protected human approval gate.
+- `scripts/ci/` and `tests/`
+  - Owner: static workflow contract tests for host separation and fail-closed
+    live admission.
+- `docs/runbooks/`
+  - Owner: operator-facing dual-host and rollback contract.
+
+## Tasks
+
+- [x] Remove live strategy/config surfaces from the Tango release bundle and
+      assert that the research host cannot start a live deployment.
+- [x] Replace the legacy trade config copy with a checksum-verified immutable
+      SHA release built in CI, atomically switched on `ploy-trade-1`.
+- [x] Install and verify systemd restart/memory/OOM guardrails and prove no
+      on-host Rust build is running.
+- [x] Keep the deployed live manifest paused and verify control-plane, venue,
+      reconcile, and release-receipt state after deploy.
+- [x] Add a separate protected live-approval workflow bound to exact `main`
+      SHA and auditable replay/dry-run/parity evidence.
+- [x] Add workflow-contract tests, actionlint, shell checks, focused repo tests,
+      and an independent review before PR.
+
+## Review
+
+- Tango artifacts now exclude live configs, manifests, gate scripts, and
+  signing keys. Both SSH and Cloud Assistant paths stop `ployd`, atomically
+  rewrite every persisted live record to paused before restart, remove all
+  generic live surfaces, and archive residual live records after restart.
+- The trade host installs a root-owned, checksum-verified immutable SHA release,
+  atomically switches `current`, preserves rollback state, and enforces the
+  required restart, memory, and OOM systemd guardrails. Deployment always ends
+  with the live record paused and a postflight readback.
+- Live apply-running and resume now require a short-lived root-owned approval
+  receipt bound to deployment, exact main/release SHA, account, exposure cap,
+  live config hash, and expiry. The protected approval workflow additionally
+  validates exact replay, dry-run, and strict recorded-parity evidence and
+  automatically pauses on any failure.
+- Local verification: 337 focused Rust tests and 31 workflow/platform tests
+  passed; the locked workspace check completed with 0 errors and 12 existing
+  warnings; 21 Python contract tests, actionlint, shell syntax/ShellCheck,
+  frontend/Sidecar generated-contract checks, and `git diff --check` passed.
+- Final independent review found no remaining P0/P1. Its last runtime-path
+  finding (a missing `tomllib` import inside the gate heredoc) is now covered by
+  a fixture test that extracts and executes the exact embedded Python program.
+- Current research evidence remains negative and is intentionally not promoted:
+  the latest replay had one losing trade and `promotion_ready=false`. This
+  slice therefore changes safety plumbing only and does not deploy or resume
+  live trading.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22903,6 +22903,10 @@ resume live trading.
 - Final independent review found no remaining P0/P1. Its last runtime-path
   finding (a missing `tomllib` import inside the gate heredoc) is now covered by
   a fixture test that extracts and executes the exact embedded Python program.
+- PR CI exposed a pre-existing legacy-worker test setup race: the pidfile could
+  be checked before `/bin/sh` had exec'd into the expected worker identity. The
+  fixture now waits for an explicit child-ready file before exercising the
+  missing-ledger termination path, preserving the PID-reuse safety check.
 - Current research evidence remains negative and is intentionally not promoted:
   the latest replay had one losing trade and `promotion_ready=false`. This
   slice therefore changes safety plumbing only and does not deploy or resume

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22907,6 +22907,10 @@ resume live trading.
   be checked before `/bin/sh` had exec'd into the expected worker identity. The
   fixture now waits for an explicit child-ready file before exercising the
   missing-ledger termination path, preserving the PID-reuse safety check.
+- A second CI run confirmed the failures were fixture synchronization, not
+  runtime behavior: the resume test accepted the first (stale-spec) launch
+  record before asserting on the second (current-spec) launch. It now waits for
+  both records before reading the resumed launch.
 - Current research evidence remains negative and is intentionally not promoted:
   the latest replay had one losing trade and `promotion_ready=false`. This
   slice therefore changes safety plumbing only and does not deploy or resume

--- a/tests/platform_release_workflow.rs
+++ b/tests/platform_release_workflow.rs
@@ -30,13 +30,6 @@ fn release_platform_workflow_builds_new_workspace_binaries() {
         "scripts/install-platform-service.sh",
         "scripts/ploy_maintenance.sh",
         "scripts/ploy_platform_watchdog.sh",
-        "systemctl status ploy-platform-watchdog.timer",
-        "systemctl status ploy-maintenance.timer",
-        "systemctl status ployd",
-        "curl -fsS http://127.0.0.1:8081/health",
-        "api/events/stream",
-        "ployctl system status",
-        "ployctl trading status",
         "ploytui",
     ] {
         if !content.contains(needle) {
@@ -49,6 +42,12 @@ fn release_platform_workflow_builds_new_workspace_binaries() {
     if content.contains("target/release/ploy") {
         offenders
             .push("release-platform.yml: still references legacy target/release/ploy".to_string());
+    }
+    if content.contains("uses: appleboy/") || content.contains("environment: production") {
+        offenders.push(
+            "release-platform.yml must remain build-only; named host workflows own deployment"
+                .to_string(),
+        );
     }
 
     assert!(

--- a/tests/test_aliyun_dual_host_workflows.py
+++ b/tests/test_aliyun_dual_host_workflows.py
@@ -1,0 +1,112 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class AliyunDualHostWorkflowContracts(unittest.TestCase):
+    def test_trade_service_has_exact_guardrails_and_immutable_entrypoint(self):
+        service = (ROOT / "deployment" / "ployd-trade.service").read_text()
+        for required in (
+            "ExecStart=/opt/ploy/current/bin/ployd",
+            "Restart=always",
+            "RestartSec=5",
+            "MemoryHigh=1280M",
+            "MemoryMax=1536M",
+            "OOMPolicy=kill",
+        ):
+            self.assertIn(required, service)
+
+    def test_postflight_checks_runtime_guardrails_and_paused_live_state(self):
+        script = (ROOT / "scripts" / "verify_trade_host_postflight.sh").read_text()
+        for required in (
+            "RestartUSec 5s",
+            "MemoryHigh 1342177280",
+            "MemoryMax 1610612736",
+            "OOMPolicy kill",
+            "Rust build process is running on the trade host",
+            "desired=Paused",
+            "observed=Paused",
+            "venue:venue:polymarket:healthy",
+            "release.json",
+        ):
+            self.assertIn(required, script)
+
+    def test_tango_bundle_has_no_live_authority(self):
+        workflow = (ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml").read_text()
+        self.assertNotIn("02-pm5d.live.toml dist/", workflow)
+        self.assertNotIn("02-pm5d-threelayer.live.toml dist/", workflow)
+        self.assertNotIn(
+            "cp scripts/drills/pm5d_threelayer_live_gate.sh dist/", workflow
+        )
+        self.assertIn("! -name 'pm5d_threelayer_live_gate.sh'", workflow)
+        self.assertIn("research host bundle contains a live deployment", workflow)
+
+    def test_trade_bundle_contains_full_control_plane_and_paused_gate(self):
+        workflow = (ROOT / ".github" / "workflows" / "deploy-trade.yml").read_text()
+        for required in (
+            "-p new-ployd",
+            "-p ployctl",
+            "-p new-ploy-runner",
+            "pm5d.threelayer.live.json",
+            "pm5d_threelayer_live_gate.sh",
+            "verify_trade_host_postflight.sh",
+            "releases/${GITHUB_SHA}",
+            "desired_state"):
+            self.assertIn(required, workflow)
+        self.assertIn('default: false', workflow)
+
+    def test_live_resume_is_separate_evidence_bound_human_approval(self):
+        workflow = (ROOT / ".github" / "workflows" / "approve-live-trade.yml").read_text()
+        for required in (
+            "environment: ploy-trade-live",
+            "runtime_replay_run_id",
+            "parity_run_id",
+            "validate_live_promotion_evidence.py",
+            "I APPROVE LIVE RISK AT 5 USD MAX EXPOSURE",
+            "actions/runs/${run_id}",
+            "head_sha",
+            "deployments resume pm5d.threelayer.live",
+            "deployments pause pm5d.threelayer.live",
+            "verify_trade_host_postflight.sh",
+            "--expected-config-sha256",
+            "approval-provenance.json",
+            "pending.json",
+        ):
+            self.assertIn(required, workflow)
+
+        tango = (ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml").read_text()
+        trade = (ROOT / ".github" / "workflows" / "deploy-trade.yml").read_text()
+        gate = (ROOT / "scripts" / "drills" / "pm5d_threelayer_live_gate.sh").read_text()
+        self.assertNotIn("deployments resume pm5d.threelayer.live", tango)
+        self.assertNotIn("deployments resume pm5d.threelayer.live", trade)
+        self.assertNotIn("deployments resume", gate)
+
+        daemon = (ROOT / "crates" / "ploy-daemon-host" / "src" / "runtime.rs").read_text()
+        self.assertIn("ensure_live_resume_approved", daemon)
+        self.assertIn("live_config_sha256", daemon)
+        self.assertIn("expires_at > Utc::now()", daemon)
+        self.assertIn("chrono::Duration::minutes(20)", daemon)
+        self.assertIn("io::ErrorKind::PermissionDenied", daemon)
+        self.assertIn("live resume requires PLOY_LIVE_APPROVAL_FILE", daemon)
+
+        self.assertIn('import re', gate)
+
+        self.assertIn(
+            'record.update(desired_state="paused", observed_state="paused")', tango
+        )
+        cloud_assist = (
+            ROOT / "scripts" / "ci" / "deploy_tango_cloud_assist.py"
+        ).read_text()
+        self.assertIn('record["desired_state"] = "paused"', cloud_assist)
+        self.assertIn('record["observed_state"] = "paused"', cloud_assist)
+        for research_deploy in (tango, cloud_assist):
+            self.assertIn("-iname '*live*.toml'", research_deploy)
+
+        self.assertIn("group: ploy-trade-host", workflow)
+        self.assertIn("group: ploy-trade-host", trade)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from decimal import Decimal
 import json
+import subprocess
 import tomllib
 import unittest
 
@@ -40,6 +41,9 @@ class StrategyConfigContractTests(unittest.TestCase):
         )["strategy"]
 
         self.assertEqual(strategy["allowed_window_secs"], [300])
+        self.assertEqual(strategy["three_layer_strategy_profile"], "settlement_probability")
+        self.assertEqual(strategy["max_positions"], 1)
+        self.assertEqual(strategy["max_daily_trades"], 10)
 
     def test_live_gate_requires_and_normalizes_wallet(self) -> None:
         script = (ROOT / "scripts" / "drills" / "pm5d_threelayer_live_gate.sh").read_text()
@@ -50,9 +54,35 @@ class StrategyConfigContractTests(unittest.TestCase):
         self.assertIn("does not match execution principal", script)
         self.assertIn("mktemp", script)
         self.assertIn('deployments apply "$RENDERED_MANIFEST"', script)
-        self.assertIn("go-live is blocked while readiness warnings are active", script)
-        self.assertIn("venue:venue:polymarket:healthy", script)
-        self.assertIn('deployments pause "$DEPLOYMENT_ID"', script)
+        self.assertIn("Only the protected live-approval workflow may resume", script)
+        self.assertNotIn("--go-live", script)
+        self.assertNotIn('deployments resume "$DEPLOYMENT_ID"', script)
+
+    def test_live_gate_manifest_config_parity_fixture_executes(self) -> None:
+        script = (ROOT / "scripts" / "drills" / "pm5d_threelayer_live_gate.sh").read_text()
+        start_marker = "python3 - \"$MANIFEST\" \"$DRYRUN_CONFIG\" \"$LIVE_CONFIG\" <<'PY'\n"
+        start = script.index(start_marker) + len(start_marker)
+        parity_program = script[start : script.index("\nPY\n", start)]
+
+        completed = subprocess.run(
+            [
+                "python3",
+                "-",
+                str(DEPLOYMENT_DIR / "pm5d.threelayer.live.json"),
+                str(
+                    STRATEGY_DIR
+                    / "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
+                ),
+                str(STRATEGY_DIR / "02-pm5d-threelayer.live.toml"),
+            ],
+            input=parity_program,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("manifest/config gate: paused apply only", completed.stdout)
 
     def test_paper_manifests_use_paper_namespace(self) -> None:
         manifests = [

--- a/tests/test_trade_host_postflight.py
+++ b/tests/test_trade_host_postflight.py
@@ -1,0 +1,124 @@
+import json
+import hashlib
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify_trade_host_postflight.sh"
+SHA = "a" * 40
+
+
+def executable(path: pathlib.Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class TradeHostPostflightTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        release = self.root / "releases" / SHA
+        (release / "bin").mkdir(parents=True)
+        for name in ("ployd", "ployctl", "ploy-runner"):
+            executable(release / "bin" / name, "#!/bin/sh\nexit 0\n")
+        (release / "FILES.sha256").write_text(
+            "".join(
+                f"{hashlib.sha256((release / 'bin' / name).read_bytes()).hexdigest()}  ./bin/{name}\n"
+                for name in ("ployd", "ployctl", "ploy-runner")
+            ),
+            encoding="utf-8",
+        )
+        (release / "release.json").write_text(
+            json.dumps({"git_sha": SHA, "bundle_sha256": "f" * 64}),
+            encoding="utf-8",
+        )
+        (self.root / "current").symlink_to(pathlib.Path("releases") / SHA)
+        (self.root / ".env").write_text(
+            f"PLOY_RELEASE_SHA={SHA}\n"
+            f"PLOY_LIVE_APPROVAL_FILE={self.root}/data/live-approvals/pending.json\n",
+            encoding="utf-8",
+        )
+
+        self.bin = self.root / "fake-bin"
+        self.bin.mkdir()
+        executable(
+            self.bin / "systemctl",
+            """#!/bin/sh
+if [ "$1" = is-active ]; then exit 0; fi
+if [ "$1" = show ]; then
+  case "$3" in
+    Restart) printf '%s\n' "${FAKE_RESTART:-always}" ;;
+    RestartUSec) printf '%s\n' "${FAKE_RESTART_USEC:-5s}" ;;
+    MemoryHigh) printf '%s\n' "${FAKE_MEMORY_HIGH:-1342177280}" ;;
+    MemoryMax) printf '%s\n' "${FAKE_MEMORY_MAX:-1610612736}" ;;
+    OOMPolicy) printf '%s\n' "${FAKE_OOM_POLICY:-kill}" ;;
+  esac
+  exit 0
+fi
+exit 1
+""",
+        )
+        executable(self.bin / "curl", "#!/bin/sh\nexit 0\n")
+        executable(self.bin / "pgrep", "#!/bin/sh\nexit ${FAKE_PGREP_EXIT:-1}\n")
+        executable(
+            self.bin / "ployctl",
+            """#!/bin/sh
+if [ "$1 $2" = "deployments inspect" ]; then
+  echo 'pm5d.threelayer.live mode=Live lifecycle=Enabled desired=Paused observed=Paused'
+elif [ "$1 $2" = "deployments list" ]; then
+  echo 'pm5d.threelayer.live mode=Live lifecycle=Enabled desired=Paused observed=Paused'
+else
+  echo ok
+fi
+""",
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_postflight(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "PLOY_ROOT_DIR": str(self.root),
+                "SYSTEMCTL": str(self.bin / "systemctl"),
+                "PLOYCTL": str(self.bin / "ployctl"),
+                "CURL": str(self.bin / "curl"),
+                "PGREP": str(self.bin / "pgrep"),
+                **overrides,
+            }
+        )
+        return subprocess.run(
+            [str(SCRIPT), SHA, "paused"],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_valid_trade_host_passes(self):
+        result = self.run_postflight()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_each_guardrail_and_host_build_check_fails_closed(self):
+        cases = {
+            "FAKE_RESTART": "on-failure",
+            "FAKE_RESTART_USEC": "1s",
+            "FAKE_MEMORY_HIGH": "1",
+            "FAKE_MEMORY_MAX": "2",
+            "FAKE_OOM_POLICY": "continue",
+            "FAKE_PGREP_EXIT": "0",
+        }
+        for key, value in cases.items():
+            with self.subTest(key=key):
+                result = self.run_postflight(**{key: value})
+                self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_live_promotion_evidence.py
+++ b/tests/test_validate_live_promotion_evidence.py
@@ -1,0 +1,153 @@
+import unittest
+
+from scripts.validate_live_promotion_evidence import validate
+
+
+SHA = "a" * 40
+DEPLOYMENT_ID = "pm5d.threelayer.settlement-probability-btc-eth.dryrun"
+CONFIG_SHA = "b" * 64
+RECORDING_SHA = "c" * 64
+RUNTIME_SCORE = "autofactor_formula:test"
+
+
+def ready_evidence():
+    replay = {
+        "evidence_stage": "executable_replay",
+        "basis": "runtime_market_update_replay",
+        "promotion_ready": True,
+        "blocking_risk_flags": [],
+        "runner_git_sha": SHA,
+        "deployment_id": DEPLOYMENT_ID,
+        "strategy_profile": "settlement_probability",
+        "runtime_score": RUNTIME_SCORE,
+        "config_sha256": CONFIG_SHA,
+        "recording_sha256": RECORDING_SHA,
+        "decision_contract": {"official_settlement": True, "full_depth_entry": True},
+        "metrics": {"trade_count": 20, "unique_event_count": 20, "roi": 0.1},
+    }
+    parity = {
+        "blocking_risk_flags": [],
+        "filters": {"deployment_id": DEPLOYMENT_ID},
+        "runtime_evidence_comparison": {
+            "strict_parity_ready": True,
+            "orders": {"shared_count": 20},
+            "fills": {"shared_count": 20},
+        },
+    }
+    parity_provenance = {
+        "deployment_id": DEPLOYMENT_ID,
+        "config_sha256": CONFIG_SHA,
+        "recording_sha256": RECORDING_SHA,
+        "runner_source": "workflow_ref",
+        "runner_git_sha": SHA,
+        "skip_settlement_exits": False,
+    }
+    dryrun = {
+        "strategies": [
+            {
+                "deployment_id": DEPLOYMENT_ID,
+                "summary": {
+                    "closed_trades": 30,
+                    "realized_pnl": 12.0,
+                    "open_positions": 0,
+                },
+                "metrics": {"max_drawdown": -10.0},
+            }
+        ]
+    }
+    return replay, parity, parity_provenance, dryrun
+
+
+class LivePromotionEvidenceTests(unittest.TestCase):
+    def test_ready_evidence_passes(self):
+        replay, parity, parity_provenance, dryrun = ready_evidence()
+        result = validate(
+            replay,
+            parity,
+            parity_provenance,
+            dryrun,
+            git_sha=SHA,
+            min_replay_trades=20,
+            min_dryrun_closed_trades=30,
+            max_drawdown_usd=25,
+            expected_deployment_id=DEPLOYMENT_ID,
+            expected_strategy_profile="settlement_probability",
+            expected_runtime_score=RUNTIME_SCORE,
+            expected_config_sha256=CONFIG_SHA,
+        )
+        self.assertTrue(result["ready_for_human_live_approval"])
+        self.assertEqual(result["failures"], [])
+
+    def test_each_safety_surface_fails_closed(self):
+        mutations = {
+            "sha": lambda r, p, d: r.update(runner_git_sha="b" * 40),
+            "replay": lambda r, p, d: r.update(promotion_ready=False),
+            "parity": lambda r, p, d: p["runtime_evidence_comparison"].update(strict_parity_ready=False),
+            "drawdown": lambda r, p, d: d["strategies"][0]["metrics"].update(max_drawdown=-26),
+            "open_positions": lambda r, p, d: d["strategies"][0]["summary"].update(open_positions=1),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                replay, parity, parity_provenance, dryrun = ready_evidence()
+                mutate(replay, parity, dryrun)
+                result = validate(
+                    replay,
+                    parity,
+                    parity_provenance,
+                    dryrun,
+                    git_sha=SHA,
+                    min_replay_trades=20,
+                    min_dryrun_closed_trades=30,
+                    max_drawdown_usd=25,
+                    expected_deployment_id=DEPLOYMENT_ID,
+                    expected_strategy_profile="settlement_probability",
+                    expected_runtime_score=RUNTIME_SCORE,
+                    expected_config_sha256=CONFIG_SHA,
+                )
+                self.assertFalse(result["ready_for_human_live_approval"])
+
+    def test_inputs_cannot_weaken_policy_floors(self):
+        replay, parity, parity_provenance, dryrun = ready_evidence()
+        result = validate(
+            replay,
+            parity,
+            parity_provenance,
+            dryrun,
+            git_sha=SHA,
+            min_replay_trades=1,
+            min_dryrun_closed_trades=1,
+            max_drawdown_usd=1000,
+            expected_deployment_id=DEPLOYMENT_ID,
+            expected_strategy_profile="settlement_probability",
+            expected_runtime_score=RUNTIME_SCORE,
+            expected_config_sha256=CONFIG_SHA,
+        )
+        self.assertFalse(result["ready_for_human_live_approval"])
+        self.assertIn("min_replay_trades_below_policy_floor", result["failures"])
+        self.assertIn("max_drawdown_policy_limit_invalid", result["failures"])
+
+    def test_parity_identity_must_match_replay_and_live_source(self):
+        replay, parity, parity_provenance, dryrun = ready_evidence()
+        parity_provenance["recording_sha256"] = "d" * 64
+        parity_provenance["config_sha256"] = "e" * 64
+        result = validate(
+            replay,
+            parity,
+            parity_provenance,
+            dryrun,
+            git_sha=SHA,
+            min_replay_trades=20,
+            min_dryrun_closed_trades=30,
+            max_drawdown_usd=25,
+            expected_deployment_id=DEPLOYMENT_ID,
+            expected_strategy_profile="settlement_probability",
+            expected_runtime_score=RUNTIME_SCORE,
+            expected_config_sha256=CONFIG_SHA,
+        )
+        self.assertFalse(result["ready_for_human_live_approval"])
+        self.assertIn("parity_config_sha_mismatch", result["failures"])
+        self.assertIn("parity_recording_sha_mismatch", result["failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/workflow_security.rs
+++ b/tests/workflow_security.rs
@@ -441,8 +441,8 @@ fn recorded_replay_parity_supports_auto_window() {
         "approval_environment:",
         "default: \"tango-1-1-build-only\"",
         "runner_source:",
-        "Runner binary source: deployed for runtime parity, workflow_ref for branch regression",
-        "default: \"deployed\"",
+        "Runner source: workflow_ref for exact-SHA promotion, deployed for diagnostics",
+        "default: \"workflow_ref\"",
         "- \"deployed\"",
         "- \"workflow_ref\"",
         "Build replay runner from workflow ref",
@@ -500,8 +500,8 @@ fn recorded_replay_parity_supports_auto_window() {
         }
     }
     for needle in [
-        "`runner_source=deployed` is the\ndefault",
-        "`runner_source=workflow_ref` only as the branch-regression mode",
+        "`runner_source=workflow_ref` is\nthe default",
+        "`runner_source=deployed` only as a diagnostic",
         "does not\ndeploy artifacts, restart services, replace `/opt/ploy/bin/ploy-runner`, or\nenable live orders",
     ] {
         if !runbook.contains(needle) {
@@ -843,21 +843,21 @@ fn runtime_candidate_replay_allows_empty_entry_score_override() {
 }
 
 #[test]
-fn tango_deploy_keeps_pm5d_live_paused() {
+fn tango_deploy_removes_live_authority() {
     let workflow = workflow_contents(".github/workflows/deploy-tango-1-1.yml");
     let cloud_assist = workflow_contents("scripts/ci/deploy_tango_cloud_assist.py");
     let mut offenders = Vec::new();
 
     for needle in [
         "environment: ${{ inputs.deploy && 'tango-1-1' || 'tango-1-1-build-only' }}",
-        "Verify live deployment remains paused in bundle",
-        "pm5d.threelayer.live.json",
-        "desired_state=paused",
-        "deployments inspect pm5d.threelayer.live",
-        "deployments inspect pm5d.threelayer.live 2>&1",
-        "awk '\\$1 == \"pm5d.threelayer.live\"",
-        "desired=Paused",
-        "observed=Paused",
+        "Verify research bundle has no live authority",
+        "research host bundle contains a live deployment",
+        "require_research_host_has_no_live",
+        "sed -i -E '/^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=/d'",
+        "mode=Live",
+        "systemctl stop ployd.service",
+        "deployments pause",
+        "deployments archive",
     ] {
         if !workflow.contains(needle) {
             offenders.push(format!("deploy-tango-1-1.yml: missing `{needle}`"));
@@ -865,12 +865,12 @@ fn tango_deploy_keeps_pm5d_live_paused() {
     }
 
     for needle in [
-        "require_pm5d_live_paused",
-        "deployments inspect pm5d.threelayer.live",
-        "deployments inspect pm5d.threelayer.live 2>&1",
-        "awk '$1 == \"pm5d.threelayer.live\"",
-        "desired=Paused",
-        "observed=Paused",
+        "require_research_host_has_no_live",
+        "sed -i -E '/^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=/d'",
+        "mode=Live",
+        "systemctl stop ployd.service",
+        "deployments pause",
+        "deployments archive",
     ] {
         if !cloud_assist.contains(needle) {
             offenders.push(format!("deploy_tango_cloud_assist.py: missing `{needle}`"));
@@ -879,7 +879,7 @@ fn tango_deploy_keeps_pm5d_live_paused() {
 
     assert!(
         offenders.is_empty(),
-        "tango deploy live-paused guard failed:\n{}",
+        "tango deploy live-authority removal guard failed:\n{}",
         offenders.join("\n")
     );
 }
@@ -1239,29 +1239,26 @@ fn test_matrix_owns_research_heavy_feature_contract() {
 }
 
 #[test]
-fn release_platform_workflow_pins_host_fingerprints() {
+fn release_platform_workflow_is_build_only() {
     let content = workflow_contents(".github/workflows/release-platform.yml");
     let mut offenders = Vec::new();
 
-    if content.matches("uses: appleboy/").count() != 2 {
-        offenders.push(
-            "release-platform.yml: expected exactly two appleboy steps (scp + ssh)".to_string(),
-        );
-    }
-
-    if content.matches("fingerprint:").count() != 2 {
-        offenders.push(
-            "release-platform.yml: expected fingerprint pinning on both appleboy steps".to_string(),
-        );
-    }
-
-    if !content.contains("EC2_HOST_FINGERPRINT || secrets.AWS_EC2_HOST_FINGERPRINT") {
-        offenders.push("release-platform.yml: missing EC2 fingerprint secret wiring".to_string());
+    for forbidden in [
+        "uses: appleboy/",
+        "environment: production",
+        "EC2_HOST",
+        "deploy:",
+    ] {
+        if content.contains(forbidden) {
+            offenders.push(format!(
+                "release-platform.yml: build-only workflow contains `{forbidden}`"
+            ));
+        }
     }
 
     assert!(
         offenders.is_empty(),
-        "release-platform.yml fingerprint pinning check failed:\n{}",
+        "release-platform.yml build-only check failed:\n{}",
         offenders.join("\n")
     );
 }
@@ -1282,7 +1279,7 @@ fn host_deploy_workflows_require_main_provenance_and_pinned_ssh() {
         (
             "deploy-trade.yml",
             &trade,
-            "environment: ploy-trade-1",
+            "'ploy-trade-1'",
             "PLOY_TRADE_1_KNOWN_HOSTS",
         ),
     ] {


### PR DESCRIPTION
## Summary
- make Tango research-only and remove live authority before daemon restart
- deploy immutable checksum-verified trade-host releases that remain paused
- require exact evidence, short-lived runtime receipt, and protected human approval before live resume

## Verification
- 337 focused Rust tests
- 31 workflow/platform Rust tests
- 21 Python contract/fixture tests
- cargo check --workspace (0 errors, 12 existing warnings)
- actionlint, bash -n, ShellCheck, generated contract checks, git diff --check
- independent review: no remaining P0/P1

## Safety
This PR does not deploy or resume live trading. Current research evidence remains promotion-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a protected live-trade approval process requiring validated replay, parity, dry-run evidence, exact release verification, and human risk acknowledgment.
  * Added immutable, checksum-verified trade releases with rollback and post-deployment health checks.
  * Added deployment runtime-mode visibility for paper and live environments.

* **Safety Improvements**
  * Research hosts no longer retain live deployment authority or signing keys.
  * Live deployments remain paused unless explicitly approved through the protected workflow.

* **Documentation**
  * Updated deployment guidance, runbooks, workflow ownership, and host responsibilities.

* **Bug Fixes**
  * Improved deployment state reporting and validation across operator interfaces and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->