### PR TITLE
ci: attest Aliyun SSH host keys

### DIFF
--- a/.github/workflows/bootstrap-aliyun-host-keys.yml
+++ b/.github/workflows/bootstrap-aliyun-host-keys.yml
@@ -1,0 +1,197 @@
+name: Bootstrap Aliyun Host Keys
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Host alias to attest"
+        required: true
+        type: choice
+        options:
+          - ploy-trade-1
+      regions_csv:
+        description: "Aliyun regions to search"
+        required: true
+        default: "ap-northeast-1,cn-hongkong,cn-hangzhou,ap-southeast-1"
+
+permissions:
+  contents: read
+
+env:
+  ALIYUN_CLI_VERSION: "3.3.18"
+  ALIYUN_CLI_LINUX_AMD64_SHA256: "0823286604dbd8beb8d65dd0694d23c913e7c5d5a02b20a3593a4f8a6517f1d4"
+
+jobs:
+  attest:
+    name: Attest ECS SSH host keys
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Validate main provenance
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF_NAME}" == "main" ]] || {
+            echo "Host-key attestation must be dispatched from main" >&2
+            exit 1
+          }
+
+      - name: Install Aliyun CLI
+        run: |
+          set -euo pipefail
+          asset="aliyun-cli-linux-${ALIYUN_CLI_VERSION}-amd64.tgz"
+          curl -fsSL \
+            "https://github.com/aliyun/aliyun-cli/releases/download/v${ALIYUN_CLI_VERSION}/${asset}" \
+            -o aliyun-cli.tgz
+          printf '%s  %s\n' "${ALIYUN_CLI_LINUX_AMD64_SHA256}" aliyun-cli.tgz \
+            | sha256sum -c -
+          tar -xzf aliyun-cli.tgz
+          sudo install -m 0755 aliyun /usr/local/bin/aliyun
+          aliyun version | grep -F "${ALIYUN_CLI_VERSION}"
+
+      - name: Configure Aliyun CLI
+        env:
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ECS_ACCESS_KEY_ID }}
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ECS_ACCESS_KEY_SECRET }}
+        run: |
+          set -euo pipefail
+          [[ -n "${ALIYUN_ACCESS_KEY_ID}" && -n "${ALIYUN_ACCESS_KEY_SECRET}" ]]
+          aliyun configure set \
+            --profile default \
+            --mode AK \
+            --region ap-northeast-1 \
+            --access-key-id "${ALIYUN_ACCESS_KEY_ID}" \
+            --access-key-secret "${ALIYUN_ACCESS_KEY_SECRET}"
+
+      - name: Resolve target ECS instance
+        id: instance
+        env:
+          TARGET_ALIAS: ${{ inputs.target }}
+          TARGET_HOST: ${{ secrets.PLOY_TRADE_1_HOST }}
+          REGIONS_CSV: ${{ inputs.regions_csv }}
+        run: |
+          set -euo pipefail
+          [[ "${TARGET_ALIAS}" == "ploy-trade-1" ]]
+          [[ -n "${TARGET_HOST}" ]]
+          target_ips="$(getent ahostsv4 "${TARGET_HOST}" | awk '{print $1}' | sort -u | paste -sd, -)"
+          [[ -n "${target_ips}" ]] || {
+            echo "could not resolve ${TARGET_ALIAS} host" >&2
+            exit 1
+          }
+
+          : > matches.tsv
+          IFS=',' read -ra regions <<< "${REGIONS_CSV}"
+          for raw_region in "${regions[@]}"; do
+            region="$(printf '%s' "${raw_region}" | xargs)"
+            [[ -n "${region}" ]] || continue
+            aliyun ecs DescribeInstances \
+              --RegionId "${region}" \
+              --PageSize 100 > "instances-${region}.json"
+            python3 - "${region}" "${target_ips}" "instances-${region}.json" >> matches.tsv <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          region, raw_target_ips, source = sys.argv[1:]
+          target_ips = set(raw_target_ips.split(","))
+          payload = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+          for instance in payload.get("Instances", {}).get("Instance", []):
+              addresses = set(instance.get("PublicIpAddress", {}).get("IpAddress", []))
+              addresses.update(instance.get("InnerIpAddress", {}).get("IpAddress", []))
+              addresses.update(instance.get("VpcAttributes", {}).get("PrivateIpAddress", {}).get("IpAddress", []))
+              eip = instance.get("EipAddress", {}).get("IpAddress")
+              if eip:
+                  addresses.add(eip)
+              if addresses & target_ips:
+                  print(region, instance["InstanceId"], instance.get("InstanceName", ""), sep="\t")
+          PY
+          done
+
+          [[ "$(wc -l < matches.tsv)" -eq 1 ]] || {
+            echo "expected exactly one ECS match for ${TARGET_ALIAS}; found:" >&2
+            sed -n '1,20p' matches.tsv >&2
+            exit 1
+          }
+          IFS=$'\t' read -r region instance_id instance_name < matches.tsv
+          echo "region=${region}" >> "${GITHUB_OUTPUT}"
+          echo "instance_id=${instance_id}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved ${TARGET_ALIAS} to ${instance_name} (${instance_id}) in ${region}"
+
+      - name: Read host keys through Cloud Assistant
+        id: attest
+        env:
+          TARGET_ALIAS: ${{ inputs.target }}
+          REGION: ${{ steps.instance.outputs.region }}
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+          # Expanded by the remote shell after Cloud Assistant starts the command.
+          # shellcheck disable=SC2016
+          command_content='set -euo pipefail
+          for key in /etc/ssh/ssh_host_ed25519_key.pub /etc/ssh/ssh_host_ecdsa_key.pub /etc/ssh/ssh_host_rsa_key.pub; do
+            [ -f "${key}" ] || continue
+            read -r key_type key_material _ < "${key}"
+            printf "%s %s %s\n" "ploy-trade-1" "${key_type}" "${key_material}"
+          done'
+          invoke_id="$(aliyun ecs RunCommand \
+            --RegionId "${REGION}" \
+            --Type RunShellScript \
+            --Name "ploy-attest-host-keys-${GITHUB_RUN_ID}" \
+            --Timeout 120 \
+            --CommandContent "${command_content}" \
+            --InstanceId.1 "${INSTANCE_ID}" | jq -r '.InvokeId')"
+          [[ -n "${invoke_id}" && "${invoke_id}" != "null" ]]
+
+          for _ in $(seq 1 60); do
+            aliyun ecs DescribeInvocationResults \
+              --RegionId "${REGION}" \
+              --InvokeId "${invoke_id}" > invocation.json
+            status="$(jq -r '.Invocation.InvocationResults.InvocationResult[0].InvocationStatus // empty' invocation.json)"
+            case "${status}" in
+              Pending|Running|"") sleep 2 ;;
+              Success) break ;;
+              *) jq . invocation.json >&2; exit 1 ;;
+            esac
+          done
+          [[ "${status}" == "Success" ]]
+          jq -r '.Invocation.InvocationResults.InvocationResult[0].Output' invocation.json \
+            | base64 --decode > attested-known-hosts.txt
+          awk 'NF == 3 && $1 == "ploy-trade-1" && $2 ~ /^ssh-|^ecdsa-/ {print}' \
+            attested-known-hosts.txt | sort -u > validated-known-hosts.txt
+          mv validated-known-hosts.txt attested-known-hosts.txt
+          [[ -s attested-known-hosts.txt ]]
+          while read -r _ key_type key_material; do
+            printf '%s %s\n' "${key_type}" "${key_material}" | ssh-keygen -lf -
+          done < attested-known-hosts.txt
+
+      - name: Compare public network host identity
+        env:
+          TARGET_HOST: ${{ secrets.PLOY_TRADE_1_HOST }}
+        run: |
+          set -euo pipefail
+          ssh-keyscan -T 15 "${TARGET_HOST}" 2>/dev/null \
+            | awk 'NF >= 3 {print "ploy-trade-1", $2, $3}' \
+            | sort -u > network-known-hosts.txt
+          [[ -s network-known-hosts.txt ]]
+          if comm -23 network-known-hosts.txt attested-known-hosts.txt | grep -q .; then
+            echo "network SSH keys do not match Cloud Assistant attestation" >&2
+            comm -23 network-known-hosts.txt attested-known-hosts.txt >&2
+            exit 1
+          fi
+
+      - name: Upload attested known_hosts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.target }}-known-hosts
+          path: attested-known-hosts.txt
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Summary
+        run: |
+          {
+            echo "## Aliyun SSH host-key attestation"
+            echo "- Target: \`${{ inputs.target }}\`"
+            echo "- Trust root: Aliyun ECS Cloud Assistant"
+            echo "- Public network identity: matched"
+            echo "- Artifact: \`${{ inputs.target }}-known-hosts\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/runbooks/platform-deploy.md
+++ b/docs/runbooks/platform-deploy.md
@@ -16,6 +16,28 @@ Aliyun host mutation is split by role:
 checksums the portable platform bundle but has no remote host credentials or
 deployment job, so it cannot become a third production path.
 
+## Host Identity Bootstrap
+
+Both SSH deploy paths require alias-keyed pinned host material:
+`TANGO_1_1_KNOWN_HOSTS` for `tango-1-1` and
+`PLOY_TRADE_1_KNOWN_HOSTS` for `ploy-trade-1`. Never create these secrets from
+an unauthenticated `ssh-keyscan` result alone.
+
+When the trade-host secret is missing or the ECS host keys rotate, dispatch
+`.github/workflows/bootstrap-aliyun-host-keys.yml` from `main`. The workflow
+resolves the host to exactly one ECS instance, reads `/etc/ssh/ssh_host_*_key.pub`
+through authenticated Aliyun Cloud Assistant, and requires the public network
+keys to match that attestation. Download the resulting
+`ploy-trade-1-known-hosts` artifact, inspect its fingerprints in the workflow
+log, then set the repository secret:
+
+```bash
+gh secret set PLOY_TRADE_1_KNOWN_HOSTS < attested-known-hosts.txt
+```
+
+The bootstrap workflow only emits public host keys. It does not deploy, alter
+the instance, weaken `StrictHostKeyChecking`, or expose SSH private keys.
+
 The trade path deploys three binaries:
 
 - `/opt/ploy/bin/ployd`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,51 @@
+# Current Session - Aliyun Research Runtime And Paused Trade Deploy (2026-07-11)
+
+Evidence stage: `deployment/runtime safety plumbing`, followed by fresh
+`diagnostic` / `factor_attribution` / `executable_replay` evidence. Existing
+negative replay evidence blocks `dry_run_candidate` and `live_candidate`.
+
+## Files / Ownership
+
+- `.github/workflows/bootstrap-aliyun-host-keys.yml`
+  - Owner: authenticated ECS host-key attestation artifact; no deployment.
+- `.github/workflows/deploy-tango-1-1.yml`, research/audit workflows
+  - Owner: Cloud Assistant reachability when pinned SSH material is absent;
+    SSH remains strict and is never TOFU.
+- `docs/runbooks/`, `tests/`
+  - Owner: operator procedure and workflow contracts.
+- `tasks/todo.md`, `tasks/lessons.md`
+  - Owner: plan, runtime evidence, blockers, and reusable fixture lessons.
+
+## Tasks
+
+- [x] Add an authenticated Aliyun Cloud Assistant host-key attestation workflow.
+- [ ] Verify both ECS identities, set pinned GitHub known-host secrets, and
+      prove strict SSH or authenticated Cloud Assistant reachability.
+- [ ] Merge the bootstrap/reachability slice through PR and green CI.
+- [ ] Deploy latest main to Tango; verify collectors, data freshness, research
+      binaries, dry-run isolation, no live authority, and no on-host Rust build.
+- [ ] Run fresh snapshot, factor attribution, walk-forward, executable replay,
+      backtest/drawdown, and recorded parity as allowed by evidence gates.
+- [ ] Deploy latest main to `ploy-trade-1` paused; verify immutable SHA,
+      systemd guardrails, control plane, venue health, and approval receipt path.
+- [ ] Keep live paused unless fresh evidence passes and the user approves the
+      protected `ploy-trade-live` environment risk gate.
+
+## Review
+
+- PR #742 merged as `5e54364b`; all required CI passed after two worker tests
+  were corrected to use explicit fixture synchronization.
+- Repository secrets currently contain both host addresses and SSH keys but
+  lack `TANGO_1_1_KNOWN_HOSTS` and `PLOY_TRADE_1_KNOWN_HOSTS`. Local Aliyun CLI
+  credentials belong to a different/empty account, so host identity must be
+  attested inside GitHub Actions using repository-scoped Aliyun credentials.
+- Independent review found and closed one supply-chain blocker: the attestation
+  workflow now downloads the versioned official Aliyun CLI v3.3.18 asset and
+  verifies its published SHA256 before extraction or access-key configuration.
+  Final review found no remaining P0/P1; actionlint and six contract tests pass.
+
+---
+
 # Current Session - Live Admission And Account Guards (2026-07-11)
 
 Evidence stage: `implementation hardening`. Implement Slice 1 from the approved

--- a/tests/test_aliyun_host_key_bootstrap.py
+++ b/tests/test_aliyun_host_key_bootstrap.py
@@ -1,0 +1,37 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class AliyunHostKeyBootstrapContracts(unittest.TestCase):
+    def test_host_key_attestation_uses_cloud_assistant_as_trust_root(self):
+        workflow = (
+            ROOT / ".github" / "workflows" / "bootstrap-aliyun-host-keys.yml"
+        ).read_text()
+
+        for required in (
+            "Host-key attestation must be dispatched from main",
+            "ALIYUN_ECS_ACCESS_KEY_ID",
+            'ALIYUN_CLI_VERSION: "3.3.18"',
+            "0823286604dbd8beb8d65dd0694d23c913e7c5d5a02b20a3593a4f8a6517f1d4",
+            "sha256sum -c -",
+            "DescribeInstances",
+            "RunCommand",
+            "/etc/ssh/ssh_host_ed25519_key.pub",
+            "DescribeInvocationResults",
+            "base64 --decode",
+            "ssh-keyscan -T 15",
+            "comm -23 network-known-hosts.txt attested-known-hosts.txt",
+            "actions/upload-artifact@v7",
+        ):
+            self.assertIn(required, workflow)
+
+        self.assertNotIn("StrictHostKeyChecking=no", workflow)
+        self.assertNotIn("UserKnownHostsFile=/dev/null", workflow)
+        self.assertNotIn("aliyun-cli-linux-latest", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- attest ploy-trade-1 SSH host keys through authenticated Aliyun Cloud Assistant
- require public network keys to match the authenticated ECS result
- pin and verify the official Aliyun CLI before exposing repository credentials
- document the host identity bootstrap and secret installation path

## Verification
- actionlint
- 6 workflow contract tests
- git diff --check
- independent review: no remaining P0/P1

This workflow is read-only and emits public host keys only; it does not deploy or alter live state.