### PR TITLE
test(ci): follow shared Tango deploy helper

### DIFF
--- a/crates/ploy-platform-runtime/src/worker_tick.rs
+++ b/crates/ploy-platform-runtime/src/worker_tick.rs
@@ -621,6 +621,7 @@ mod tests {
         });
         tick_workers(&mut control_plane, &mut supervisor, &config);
         let initial_launched = (0..1000).any(|_| {
+            tick_workers(&mut control_plane, &mut supervisor, &config);
             if fs::read_to_string(&launch_log).is_ok_and(|launches| launches.lines().count() >= 1) {
                 true
             } else {
@@ -648,6 +649,7 @@ mod tests {
 
         let launches = (0..1000)
             .find_map(|_| {
+                tick_workers(&mut control_plane, &mut supervisor, &config);
                 if let Ok(launches) = fs::read_to_string(&launch_log) {
                     if launches.lines().count() >= 2 {
                         return Some(launches);
@@ -661,5 +663,6 @@ mod tests {
         assert!(resumed.contains("config/strategies/new-paper.toml"));
         assert!(resumed.contains("--dry-run"));
         assert!(!resumed.contains("old-live"));
+        supervisor.stop("resume.current");
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -375,3 +375,6 @@
 - Rule: Synchronize worker-process fixtures on an explicit child-ready signal
   and wait for the exact expected event count before assertions. Do not weaken
   production PID identity checks or add arbitrary sleeps to mask fixture races.
+  Retry the runtime tick while waiting for a spawned fixture under CI load, and
+  explicitly stop the final child before the test returns so parallel suites do
+  not accumulate orphan workers and starve later spawns.

--- a/tests/test_persist_research_trace_contract.py
+++ b/tests/test_persist_research_trace_contract.py
@@ -355,9 +355,12 @@ class PersistResearchTraceContractTest(unittest.TestCase):
         cargo = CARGO.read_text(encoding="utf-8")
         self.assertNotIn('name = "factor_research"', cargo)
         deploy = TANGO_DEPLOY.read_text(encoding="utf-8")
+        deploy_helper = (
+            ROOT / "scripts" / "ci" / "deploy_tango_cloud_assist.py"
+        ).read_text(encoding="utf-8")
         self.assertNotIn("--example factor_research", deploy)
         self.assertNotIn("examples/factor_research", deploy)
-        self.assertIn("rm -f ${DEPLOY_ROOT}/bin/factor-research", deploy)
+        self.assertIn('rm -f "${{DEPLOY_ROOT}}/bin/factor-research"', deploy_helper)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -69,20 +69,18 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
         workflow_text = workflow.read_text()
         cloud_assist_text = (ROOT / "scripts" / "ci" / "deploy_tango_cloud_assist.py").read_text()
         self.assertIn("ploy-market-discovery.service", workflow_text)
+        self.assertIn("deploy_tango_cloud_assist.py --print-remote-script", workflow_text)
         self.assertLess(
-            workflow_text.index("systemctl restart ploy-market-discovery.service"),
-            workflow_text.index("systemctl restart ploy-quote-collector.service"),
+            cloud_assist_text.index("systemctl restart ploy-market-discovery.service"),
+            cloud_assist_text.index("systemctl restart ploy-quote-collector.service"),
             "market discovery must refresh catalog before quote collector subscribes",
         )
         self.assertLess(
-            workflow_text.index("systemctl restart ploy-market-discovery.service"),
-            workflow_text.index("systemctl restart ploy-pm-trade-collector.service"),
+            cloud_assist_text.index("systemctl restart ploy-market-discovery.service"),
+            cloud_assist_text.index("systemctl restart ploy-pm-trade-collector.service"),
             "market discovery must refresh catalog before trade collector polls",
         )
-        for text, name in (
-            (workflow_text, "deploy-tango-1-1.yml"),
-            (cloud_assist_text, "deploy_tango_cloud_assist.py"),
-        ):
+        for text, name in ((cloud_assist_text, "deploy_tango_cloud_assist.py"),):
             discovery_restart = text.index("systemctl restart ploy-market-discovery.service")
             catalog_wait = text.index(
                 "pm_market_catalog has no active crypto markets after market-discovery restart"
@@ -115,8 +113,11 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
     def test_pm_trade_deploy_health_uses_collector_poll_not_fresh_insert(self) -> None:
         workflow = ROOT / ".github" / "workflows" / "deploy-tango-1-1.yml"
         cloud_assist = ROOT / "scripts" / "ci" / "deploy_tango_cloud_assist.py"
+        self.assertIn(
+            "deploy_tango_cloud_assist.py --print-remote-script", workflow.read_text()
+        )
 
-        for path in (workflow, cloud_assist):
+        for path in (cloud_assist,):
             text = path.read_text()
             self.assertIn("wait_for_recent_log", text)
             self.assertIn("Polymarket trade collector poll complete", text)
@@ -124,22 +125,13 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
             self.assertIn("pm trade collector failed after deploy", text)
             self.assertIn("120", text)
             self.assertIn("5", text)
-            if path.name == "deploy-tango-1-1.yml":
-                self.assertIn('local since="\\${DEPLOY_STARTED_AT}"', text)
-                self.assertIn(
-                    '"pm trade collector did not complete a healthy poll after deploy" \\\n'
-                    "              120 \\\n"
-                    "              5",
-                    text,
-                )
-            else:
-                self.assertIn('local since="${{DEPLOY_STARTED_AT}}"', text)
-                self.assertIn(
-                    '"pm trade collector did not complete a healthy poll after deploy" \\\\\n'
-                    "  120 \\\\\n"
-                    "  5",
-                    text,
-                )
+            self.assertIn('local since="${{DEPLOY_STARTED_AT}}"', text)
+            self.assertIn(
+                '"pm trade collector did not complete a healthy poll after deploy" \\\\\n'
+                "  120 \\\\\n"
+                "  5",
+                text,
+            )
             self.assertNotIn(
                 "clob_trade_ticks WHERE received_at >= NOW() - INTERVAL '5 minutes'",
                 text,


### PR DESCRIPTION
## Summary
- update legacy Python workflow contracts to follow the shared Tango remote-script helper
- preserve workflow-to-helper invocation assertions and helper ordering/health/cleanup checks

## Verification
- full legacy Python unittest suite: 373 passed
- workflow security: 30 passed
- git diff --check

This is a fixture-only follow-up to merged PR #744.