### PR TITLE
feat(account): add guarded Polymarket Redeem operations

### DIFF
--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -80,6 +80,13 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev libpq-dev clang lld openssh-client
           sudo apt-get install -y sccache || cargo install sccache --locked
 
+      - name: Install Node.js for account ops
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tools/polymarket-account-ops/package-lock.json
+
       - name: Build trade control plane
         run: |
           cargo build --release --locked \
@@ -92,6 +99,13 @@ jobs:
           strip "target/${PLATFORM_TARGET}/release/ployctl" || true
           strip "target/${PLATFORM_TARGET}/release/new-ploy-runner" || true
 
+      - name: Build and test Polymarket account ops
+        run: |
+          cd tools/polymarket-account-ops
+          npm ci --omit=dev
+          npm test
+          npm audit --omit=dev --audit-level=high
+
       - name: Build immutable trade bundle
         run: |
           set -euo pipefail
@@ -99,10 +113,11 @@ jobs:
           rm -rf dist
           mkdir -p "${root}/bin" "${root}/config/strategies" \
             "${root}/config/deployments" "${root}/deployment" \
-            "${root}/scripts/drills"
+            "${root}/scripts/drills" "${root}/tools/polymarket-account-ops"
           install -m 0755 "target/${PLATFORM_TARGET}/release/new-ployd" "${root}/bin/ployd"
           install -m 0755 "target/${PLATFORM_TARGET}/release/ployctl" "${root}/bin/ployctl"
           install -m 0755 "target/${PLATFORM_TARGET}/release/new-ploy-runner" "${root}/bin/ploy-runner"
+          install -m 0755 "$(command -v node)" "${root}/bin/node"
           install -m 0644 config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml \
             "${root}/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml"
           install -m 0644 config/strategies/02-pm5d-threelayer.live.toml \
@@ -116,6 +131,16 @@ jobs:
             "${root}/scripts/drills/live_dry_run.sh"
           install -m 0755 scripts/verify_trade_host_postflight.sh \
             "${root}/scripts/verify_trade_host_postflight.sh"
+          cp -R tools/polymarket-account-ops/node_modules \
+            "${root}/tools/polymarket-account-ops/node_modules"
+          install -m 0755 tools/polymarket-account-ops/cli.js \
+            "${root}/tools/polymarket-account-ops/cli.js"
+          install -m 0755 tools/polymarket-account-ops/ploy-account-ops \
+            "${root}/tools/polymarket-account-ops/ploy-account-ops"
+          install -m 0644 tools/polymarket-account-ops/account_ops.js \
+            tools/polymarket-account-ops/package.json \
+            tools/polymarket-account-ops/package-lock.json \
+            "${root}/tools/polymarket-account-ops/"
           python3 - <<'PY'
           import json
           from pathlib import Path
@@ -300,6 +325,9 @@ jobs:
           upsert_env PLOY_LISTEN_ADDR "127.0.0.1:8081"
           upsert_env PLOY_RELEASE_SHA "${git_sha}"
           upsert_env PLOY_LIVE_APPROVAL_FILE "${root}/data/live-approvals/pending.json"
+          upsert_env PLOY_ACCOUNT_OPS_WRITE_ENABLED "false"
+          upsert_env PLOY_REDEEM_LEDGER "${root}/data/account-ops/redeem-ledger.jsonl"
+          upsert_env PLOY_REDEEM_LOCK "${root}/data/account-ops/redeem-ledger.jsonl.lock"
 
           grep -Eq '^(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=[^[:space:]]+' "${root}/.env" || {
             echo "trade host signing key is missing" >&2
@@ -309,12 +337,19 @@ jobs:
             echo "trade host PLOY_LIVE_ACCOUNT_ID is missing or invalid" >&2
             exit 1
           }
+          for key in POLYMARKET_RELAYER_URL POLY_BUILDER_API_KEY POLY_BUILDER_SECRET POLY_BUILDER_PASSPHRASE POLYGON_RPC_URL POLY_WALLET_TYPE; do
+            grep -Eq "^${key}=[^[:space:]]+" "${root}/.env" || {
+              echo "trade host ${key} is missing" >&2
+              exit 1
+            }
+          done
 
           ln -sfn "releases/${git_sha}" "${root}/current.next"
           mv -Tf "${root}/current.next" "${root}/current"
           for binary in ployd ployctl ploy-runner; do
             ln -sfn "../current/bin/${binary}" "${root}/bin/${binary}"
           done
+          ln -sfn "../current/tools/polymarket-account-ops/ploy-account-ops" "${root}/bin/ploy-account-ops"
           for config in 02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml 02-pm5d-threelayer.live.toml; do
             ln -sfn "../../current/config/strategies/${config}" "${root}/config/strategies/${config}"
           done
@@ -326,6 +361,7 @@ jobs:
 
           install -m 0644 "${release_dir}/deployment/ployd.service" /etc/systemd/system/ployd.service
           chown -R ploy:ploy "${root}/data/state" "${root}/run" "${root}/logs"
+          install -d -m 0700 -o root -g root "${root}/data/account-ops"
           chown root:ploy "${root}/data/live-approvals"
           chmod 0750 "${root}/data/live-approvals"
           chown -R root:root "${release_dir}" "${root}/config" "${root}/bin" "${root}/scripts"

--- a/deployment/env.example
+++ b/deployment/env.example
@@ -9,8 +9,13 @@ POLYMARKET_PRIVATE_KEY=
 
 # Optional official Polymarket relayer credentials for gasless account operations.
 # Keep these in /opt/ploy/.env or a secrets manager; never commit real values.
-# RELAYER_API_KEY=
-# RELAYER_API_KEY_ADDRESS=0x...
+# POLYMARKET_RELAYER_URL=
+# POLY_BUILDER_API_KEY=
+# POLY_BUILDER_SECRET=
+# POLY_BUILDER_PASSPHRASE=
+# POLYGON_RPC_URL=
+# POLY_WALLET_TYPE=SAFE
+# PLOY_ACCOUNT_OPS_WRITE_ENABLED=false
 
 # Optional external APIs
 # THE_ODDS_API_KEY=

--- a/docs/operations/v2-claim-redeem-gate.md
+++ b/docs/operations/v2-claim-redeem-gate.md
@@ -1,34 +1,38 @@
 # V2 Claim/Redeem Gate For SDK And Claimer Cleanup
 
-Status: claimer retirement applied by operator decision.
+Status: retired claimer replaced by explicit, write-disabled account ops.
 
 This gate still controls Phase 9 SDK slimming. Phase 10 claimer retirement has
 been applied after the operator confirmed the account settlement flow has
 converted away from the self-claim path.
 
-Operational update on 2026-04-24: account-level Polymarket auto-claim is enabled
-outside Ploy. Runtime hosts should store only official relayer credentials
-(`RELAYER_API_KEY` and `RELAYER_API_KEY_ADDRESS`) for gasless account operations;
-do not restore `CLAIMER_*`, `POLY_BUILDER_*`, or the old in-process claimer
-daemon path.
+Operational update on 2026-07-12: Ploy uses the official V2 SDK for data/trading
+types and the official Builder Relayer client for manual account operations.
+`ploy-account-ops check` is read-only. `plan` emits a ten-minute plan bound to
+chain, account, wallet type, release SHA, contract manifest, and content hash.
+`execute` additionally requires that exact hash and
+`PLOY_ACCOUNT_OPS_WRITE_ENABLED=true`. Deployment always resets the write gate
+to `false`; no daemon invokes Redeem automatically. The immutable trade bundle
+includes the Node.js runtime used by the official relayer client, so account
+operations do not depend on a separately installed host runtime.
 
 ## Current Dependency Evidence
 
 Read-only checks from the local workspace show why the gate matters:
 
 ```sh
-cargo tree -p polymarket-client-sdk --no-default-features --features gamma -i alloy
-cargo tree -p polymarket-client-sdk --no-default-features --features data -i alloy
-cargo tree -p polymarket-client-sdk --no-default-features --features ctf -i alloy
+cargo tree -p ploy-market-data --features live -i polymarket_client_sdk_v2
+cargo tree -p ploy-connectivity -i polymarket_client_sdk_v2
+cargo tree -p ploy-market-data --features live -i alloy
 cargo metadata --format-version 1 --no-deps | grep '"name":"ploy-claimer"'
 ```
 
-Observed state before V2 evidence:
+Current state:
 
-- `polymarket-client-sdk` pulls `alloy` even for public `gamma` and `data`
-  feature checks because `alloy` is still an unconditional dependency in the
-  vendored SDK.
-- `ctf` correctly needs `alloy` for contract/provider paths.
+- Active crates use `polymarket_client_sdk_v2 = 0.6.0`; the archived vendored
+  V1 SDK is not in an active dependency path.
+- The SDK retains its base `alloy` types; only its `ctf` feature enables the
+  contract/provider subfeatures. Ploy's Redeem path remains outside a daemon.
 - Before retirement, `ploy-claimer` pulled both `alloy` and `ethers-core` /
   `ethers-signers`.
 - After retirement, `ploy-claimer` should not appear in workspace metadata or
@@ -36,7 +40,7 @@ Observed state before V2 evidence:
 
 ## Required Post-V2 Evidence
 
-Capture this evidence before changing code:
+Capture this evidence before enabling account-ops writes:
 
 1. Pick a resolved V2 market where the account held a winning position.
 2. Record the market id, condition id, token id, settlement timestamp, and
@@ -47,17 +51,19 @@ Capture this evidence before changing code:
    - whether the position disappears or becomes paid without a manual redeem
 4. Check wallet balance movement for settlement proceeds.
 5. If no auto-credit happens, test the gasless relayer path first.
-6. If relayer is unavailable or incomplete, test direct on-chain redeem on the
-   smallest safe position.
-7. Save tx hash, relayer id, API response, and before/after balances.
+6. Review the generated plan and exact SHA, then enable writes for one command.
+7. Save the relayer transaction id, tx hash, adapter route, JSONL ledger event,
+   and pUSD before/after balances.
+8. Confirm the Data API no longer reports the condition as redeemable. Any
+   submitted or ambiguous operation must be reconciled, never resubmitted.
 
 ## Decision Table
 
 | Evidence | Phase 9 action | Phase 10 action |
 | --- | --- | --- |
 | V2 auto-redeems or equivalent settlement credit is verified | Keep SDK signing features isolated | `ploy-claimer` retired |
-| V2 still requires manual redeem but relayer works | Keep CTF/on-chain capability; make SDK public DTO paths alloy-free if possible | Retain claimer, migrate legacy relayer flow from ethers to alloy |
-| V2 still requires manual redeem and relayer is unavailable | Keep CTF/on-chain capability | Retain claimer, delegate direct redeem to SDK CTF client, then remove duplicated `sol!` bindings |
+| V2 still requires manual redeem and relayer works | Keep account ops write-disabled by default | Use reviewed plan + official relayer |
+| V2 still requires manual redeem and relayer is unavailable | Block manual Redeem | Repair official relayer access; do not improvise a signer path |
 
 ## Retired Claimer Guardrails
 
@@ -65,6 +71,21 @@ Capture this evidence before changing code:
 - Do not reintroduce `ethers-core` or `ethers-signers`.
 - If manual redeem becomes necessary again, add a new account-ops capability
   instead of restoring the in-process live-runner daemon.
+- Route pUSD CTF actions through the current standard or NegRisk collateral
+  adapter manifest. Direct legacy USDC.e CTF calls are forbidden.
+
+## Operator Flow
+
+```sh
+ploy-account-ops check
+ploy-account-ops plan --out /root/redeem-plan.json
+# Review the plan, then use its printed SHA exactly once:
+PLOY_ACCOUNT_OPS_WRITE_ENABLED=true \
+  ploy-account-ops execute --plan /root/redeem-plan.json --sha256 <sha256>
+# If execute reports an ambiguous or still-redeemable transaction, keep writes
+# disabled and reconcile that exact relayer transaction before any new plan:
+ploy-account-ops reconcile --transaction-id <relayer-transaction-id>
+```
 
 ## Gate Verification Commands
 

--- a/docs/operations/v2-claim-redeem-gate.md
+++ b/docs/operations/v2-claim-redeem-gate.md
@@ -90,6 +90,8 @@ PLOY_ACCOUNT_OPS_WRITE_ENABLED=true \
 # If execute reports an ambiguous or still-redeemable transaction, keep writes
 # disabled and reconcile that exact relayer transaction before any new plan:
 ploy-account-ops reconcile --transaction-id <relayer-transaction-id>
+# If the submission response was lost before a transaction ID was returned:
+ploy-account-ops reconcile --operation-id <ledger-operation-id>
 ```
 
 ## Gate Verification Commands

--- a/docs/operations/v2-claim-redeem-gate.md
+++ b/docs/operations/v2-claim-redeem-gate.md
@@ -16,6 +16,11 @@ to `false`; no daemon invokes Redeem automatically. The immutable trade bundle
 includes the Node.js runtime used by the official relayer client, so account
 operations do not depend on a separately installed host runtime.
 
+The official JavaScript relayer SDK requires string credentials and cannot
+provide Rust-style `zeroize` guarantees. Account ops is therefore an isolated,
+one-shot process: it reads credentials only at execution/reconciliation time,
+never logs them, is not imported by a daemon, and exits after the command.
+
 ## Current Dependency Evidence
 
 Read-only checks from the local workspace show why the gate matters:

--- a/scripts/check_v2_claim_redeem_gate.sh
+++ b/scripts/check_v2_claim_redeem_gate.sh
@@ -12,9 +12,9 @@ run() {
   "$@"
 }
 
-run cargo tree -p polymarket-client-sdk --no-default-features --features gamma -i alloy
-run cargo tree -p polymarket-client-sdk --no-default-features --features data -i alloy
-run cargo tree -p polymarket-client-sdk --no-default-features --features ctf -i alloy
+run cargo tree -p ploy-market-data --features live -i polymarket_client_sdk_v2
+run cargo tree -p ploy-connectivity -i polymarket_client_sdk_v2
+run cargo tree -p ploy-market-data --features live -i alloy
 if cargo metadata --format-version 1 --no-deps | grep -q '"name":"ploy-claimer"'; then
   run cargo tree -p ploy-claimer -i ethers-core
   run cargo tree -p ploy-claimer -i ethers-signers
@@ -26,7 +26,8 @@ fi
 cat <<'MSG'
 
 Gate status:
-- Phase 9 SDK slimming remains blocked until V2 claim/redeem evidence exists.
+- Official V2 SDK dependency checks passed; live Redeem evidence is still required.
 - Phase 10 claimer retirement has been applied. Keep verifying no downstream
   crate reintroduces ploy-claimer or ethers.
+- Account ops stays write-disabled after every deploy and is never a daemon.
 MSG

--- a/scripts/verify_trade_host_postflight.sh
+++ b/scripts/verify_trade_host_postflight.sh
@@ -8,6 +8,7 @@ SYSTEMCTL="${SYSTEMCTL:-systemctl}"
 PLOYCTL="${PLOYCTL:-${ROOT_DIR}/current/bin/ployctl}"
 CURL="${CURL:-curl}"
 PGREP="${PGREP:-pgrep}"
+STAT="${STAT:-stat}"
 
 fail() {
   printf 'trade-host postflight failed: %s\n' "$*" >&2
@@ -28,12 +29,22 @@ current_dir="$(readlink -f "${ROOT_DIR}/current")"
 [[ -x "${release_dir}/bin/ployd" ]] || fail "ployd missing from immutable release"
 [[ -x "${release_dir}/bin/ployctl" ]] || fail "ployctl missing from immutable release"
 [[ -x "${release_dir}/bin/ploy-runner" ]] || fail "ploy-runner missing from immutable release"
+[[ -x "${release_dir}/bin/node" ]] || fail "bundled Node.js runtime missing from immutable release"
+[[ -x "${release_dir}/tools/polymarket-account-ops/cli.js" ]] || fail "account-ops CLI missing from immutable release"
+[[ -x "${release_dir}/tools/polymarket-account-ops/ploy-account-ops" ]] || fail "account-ops launcher missing from immutable release"
+[[ -L "${ROOT_DIR}/bin/ploy-account-ops" ]] || fail "account-ops CLI symlink is missing"
 (cd "$release_dir" && sha256sum -c FILES.sha256 >/dev/null) \
   || fail "immutable release file checksum verification failed"
 grep -Fxq "PLOY_RELEASE_SHA=${EXPECTED_SHA}" "${ROOT_DIR}/.env" \
   || fail "PLOY_RELEASE_SHA is not bound to the immutable release"
 grep -Fxq "PLOY_LIVE_APPROVAL_FILE=${ROOT_DIR}/data/live-approvals/pending.json" "${ROOT_DIR}/.env" \
   || fail "runtime live-approval enforcement is not configured"
+grep -Fxq "PLOY_ACCOUNT_OPS_WRITE_ENABLED=false" "${ROOT_DIR}/.env" \
+  || fail "account-ops must remain write-disabled after deploy"
+[[ "$($STAT -c '%U:%G:%a' "${ROOT_DIR}/data/account-ops")" == "root:root:700" ]] \
+  || fail "account-ops state directory must be root:root mode 700"
+"${release_dir}/bin/node" -e "require('${release_dir}/tools/polymarket-account-ops/account_ops.js')" \
+  || fail "account-ops runtime dependencies are not loadable"
 
 python3 - "$release_dir/release.json" "$EXPECTED_SHA" <<'PY'
 import json

--- a/tests/test_trade_host_postflight.py
+++ b/tests/test_trade_host_postflight.py
@@ -24,12 +24,26 @@ class TradeHostPostflightTests(unittest.TestCase):
         self.root = pathlib.Path(self.temp.name)
         release = self.root / "releases" / SHA
         (release / "bin").mkdir(parents=True)
-        for name in ("ployd", "ployctl", "ploy-runner"):
+        for name in ("ployd", "ployctl", "ploy-runner", "node"):
             executable(release / "bin" / name, "#!/bin/sh\nexit 0\n")
+        account_ops = release / "tools" / "polymarket-account-ops"
+        account_ops.mkdir(parents=True)
+        executable(account_ops / "cli.js", "#!/usr/bin/env node\n")
+        executable(account_ops / "ploy-account-ops", "#!/bin/sh\nexit 0\n")
+        (account_ops / "account_ops.js").write_text("module.exports = {};\n", encoding="utf-8")
+        (self.root / "bin").mkdir(parents=True)
+        (self.root / "bin" / "ploy-account-ops").symlink_to(
+            pathlib.Path("../current/tools/polymarket-account-ops/ploy-account-ops")
+        )
+        account_state = self.root / "data" / "account-ops"
+        account_state.mkdir(parents=True, mode=0o700)
+        account_state.chmod(0o700)
+        manifest_files = [release / "bin" / name for name in ("ployd", "ployctl", "ploy-runner", "node")]
+        manifest_files.extend([account_ops / "cli.js", account_ops / "account_ops.js", account_ops / "ploy-account-ops"])
         (release / "FILES.sha256").write_text(
             "".join(
-                f"{hashlib.sha256((release / 'bin' / name).read_bytes()).hexdigest()}  ./bin/{name}\n"
-                for name in ("ployd", "ployctl", "ploy-runner")
+                f"{hashlib.sha256(item.read_bytes()).hexdigest()}  ./{item.relative_to(release)}\n"
+                for item in manifest_files
             ),
             encoding="utf-8",
         )
@@ -40,7 +54,8 @@ class TradeHostPostflightTests(unittest.TestCase):
         (self.root / "current").symlink_to(pathlib.Path("releases") / SHA)
         (self.root / ".env").write_text(
             f"PLOY_RELEASE_SHA={SHA}\n"
-            f"PLOY_LIVE_APPROVAL_FILE={self.root}/data/live-approvals/pending.json\n",
+            f"PLOY_LIVE_APPROVAL_FILE={self.root}/data/live-approvals/pending.json\n"
+            "PLOY_ACCOUNT_OPS_WRITE_ENABLED=false\n",
             encoding="utf-8",
         )
 
@@ -65,6 +80,7 @@ exit 1
         )
         executable(self.bin / "curl", "#!/bin/sh\nexit 0\n")
         executable(self.bin / "pgrep", "#!/bin/sh\nexit ${FAKE_PGREP_EXIT:-1}\n")
+        executable(self.bin / "stat", "#!/bin/sh\necho root:root:700\n")
         executable(
             self.bin / "ployctl",
             """#!/bin/sh
@@ -90,6 +106,7 @@ fi
                 "PLOYCTL": str(self.bin / "ployctl"),
                 "CURL": str(self.bin / "curl"),
                 "PGREP": str(self.bin / "pgrep"),
+                "STAT": str(self.bin / "stat"),
                 **overrides,
             }
         )

--- a/tools/polymarket-account-ops/account_ops.js
+++ b/tools/polymarket-account-ops/account_ops.js
@@ -1,0 +1,410 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  RelayClient,
+  RelayerTxType,
+  deriveProxyWallet,
+  deriveSafe,
+} = require("@polymarket/builder-relayer-client");
+const { BuilderConfig } = require("@polymarket/builder-signing-sdk");
+const {
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  getAddress,
+  http,
+  zeroHash,
+} = require("viem");
+const { privateKeyToAccount } = require("viem/accounts");
+const { polygon } = require("viem/chains");
+
+const CHAIN_ID = 137;
+const CONTRACTS = Object.freeze({
+  pusd: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
+  conditionalTokens: "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
+  standardAdapter: "0xAdA100Db00Ca00073811820692005400218FcE1f",
+  negRiskAdapter: "0xadA2005600Dec949baf300f4C6120000bDB6eAab",
+  safeFactory: "0xaacFeEa03eb1561C4e67d661e40682Bd20E3541b",
+  proxyFactory: "0xaB45c5A4B0c941a2F231C04C3f49182e1A254052",
+});
+const DATA_API = "https://data-api.polymarket.com";
+const PLAN_TTL_MS = 10 * 60 * 1000;
+
+const REDEEM_ABI = [{
+  type: "function",
+  name: "redeemPositions",
+  stateMutability: "nonpayable",
+  inputs: [
+    { name: "collateralToken", type: "address" },
+    { name: "parentCollectionId", type: "bytes32" },
+    { name: "conditionId", type: "bytes32" },
+    { name: "indexSets", type: "uint256[]" },
+  ],
+  outputs: [],
+}];
+
+const ERC20_BALANCE_ABI = [{
+  type: "function",
+  name: "balanceOf",
+  stateMutability: "view",
+  inputs: [{ name: "account", type: "address" }],
+  outputs: [{ name: "balance", type: "uint256" }],
+}];
+const ERC1155_APPROVAL_ABI = [{
+  type: "function",
+  name: "isApprovedForAll",
+  stateMutability: "view",
+  inputs: [{ name: "account", type: "address" }, { name: "operator", type: "address" }],
+  outputs: [{ name: "approved", type: "bool" }],
+}];
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(canonical(value)).digest("hex");
+}
+
+function normalizeAddress(value, field) {
+  try {
+    return getAddress(value);
+  } catch {
+    throw new Error(`${field} must be a valid EVM address`);
+  }
+}
+
+function buildPlan(positions, context, now = Date.now()) {
+  const account = normalizeAddress(context.account, "account");
+  if (!/^[0-9a-f]{40}$/.test(context.releaseSha)) {
+    throw new Error("releaseSha must be a lowercase 40-character commit SHA");
+  }
+  if (!new Set(["SAFE", "PROXY"]).has(context.walletType)) {
+    throw new Error("walletType must be SAFE or PROXY");
+  }
+
+  const grouped = new Map();
+  for (const position of positions) {
+    if (!position.redeemable || Number(position.size) <= 0) continue;
+    if (normalizeAddress(position.proxyWallet, "position.proxyWallet") !== account) {
+      throw new Error("Data API position wallet does not match the live account");
+    }
+    const conditionId = String(position.conditionId).toLowerCase();
+    if (!/^0x[0-9a-f]{64}$/.test(conditionId)) {
+      throw new Error("conditionId must be bytes32");
+    }
+    const route = position.negativeRisk ? "neg_risk" : "standard";
+    const existing = grouped.get(conditionId);
+    if (existing && existing.route !== route) {
+      throw new Error(`negative-risk disagreement for ${conditionId}`);
+    }
+    const item = existing || { conditionId, route, positions: [] };
+    item.positions.push({
+      asset: String(position.asset),
+      outcome: String(position.outcome),
+      outcomeIndex: Number(position.outcomeIndex),
+      size: String(position.size),
+    });
+    grouped.set(conditionId, item);
+  }
+
+  const items = [...grouped.values()]
+    .sort((a, b) => a.conditionId.localeCompare(b.conditionId))
+    .map((item) => ({
+      ...item,
+      target: item.route === "neg_risk" ? CONTRACTS.negRiskAdapter : CONTRACTS.standardAdapter,
+      operationId: sha256({ chainId: CHAIN_ID, account, conditionId: item.conditionId, route: item.route }),
+    }));
+  const unsigned = {
+    version: 1,
+    chainId: CHAIN_ID,
+    account,
+    walletType: context.walletType,
+    releaseSha: context.releaseSha,
+    generatedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + PLAN_TTL_MS).toISOString(),
+    contracts: CONTRACTS,
+    items,
+  };
+  return { ...unsigned, sha256: sha256(unsigned) };
+}
+
+function validatePlan(plan, context, expectedHash, now = Date.now()) {
+  const { sha256: embeddedHash, ...unsigned } = plan;
+  const actualHash = sha256(unsigned);
+  if (actualHash !== embeddedHash || actualHash !== expectedHash) throw new Error("plan hash mismatch");
+  if (plan.chainId !== CHAIN_ID) throw new Error("plan chain mismatch");
+  if (normalizeAddress(plan.account, "plan.account") !== normalizeAddress(context.account, "account")) {
+    throw new Error("plan account mismatch");
+  }
+  if (plan.releaseSha !== context.releaseSha) throw new Error("plan release mismatch");
+  if (plan.walletType !== context.walletType) throw new Error("plan wallet type mismatch");
+  if (Date.parse(plan.generatedAt) > now + 30_000) throw new Error("plan generated in the future");
+  if (Date.parse(plan.expiresAt) <= now || Date.parse(plan.expiresAt) - Date.parse(plan.generatedAt) > PLAN_TTL_MS) {
+    throw new Error("plan expired or exceeds maximum TTL");
+  }
+  if (canonical(plan.contracts) !== canonical(CONTRACTS)) throw new Error("plan contract manifest mismatch");
+  for (const item of plan.items) {
+    const target = item.route === "neg_risk" ? CONTRACTS.negRiskAdapter : CONTRACTS.standardAdapter;
+    if (normalizeAddress(item.target, "item.target") !== normalizeAddress(target, "expected target")) {
+      throw new Error("redeem adapter mismatch");
+    }
+  }
+  return plan;
+}
+
+function redeemTransaction(item) {
+  return {
+    to: item.target,
+    value: "0",
+    data: encodeFunctionData({
+      abi: REDEEM_ABI,
+      functionName: "redeemPositions",
+      args: [CONTRACTS.pusd, zeroHash, item.conditionId, [1n, 2n]],
+    }),
+  };
+}
+
+async function fetchPositions(account) {
+  const url = new URL("/positions", DATA_API);
+  url.searchParams.set("user", account);
+  url.searchParams.set("limit", "500");
+  url.searchParams.set("sizeThreshold", "0");
+  const response = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+  if (!response.ok) throw new Error(`Data API positions failed: HTTP ${response.status}`);
+  const positions = await response.json();
+  if (!Array.isArray(positions)) throw new Error("Data API positions response is not an array");
+  return positions;
+}
+
+async function verifyPositionRoutes(positions) {
+  for (const position of positions.filter((candidate) => candidate.redeemable && Number(candidate.size) > 0)) {
+    const url = new URL("/neg-risk", "https://clob.polymarket.com");
+    url.searchParams.set("token_id", String(position.asset));
+    const response = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+    if (!response.ok) throw new Error(`CLOB neg-risk check failed: HTTP ${response.status}`);
+    const payload = await response.json();
+    if (Boolean(payload.neg_risk) !== Boolean(position.negativeRisk)) {
+      throw new Error(`Data/CLOB negative-risk disagreement for asset ${position.asset}`);
+    }
+  }
+  return positions;
+}
+
+function ledgerPaths(env = process.env) {
+  const ledger = env.PLOY_REDEEM_LEDGER || "/opt/ploy/data/account-ops/redeem-ledger.jsonl";
+  return { ledger, lock: env.PLOY_REDEEM_LOCK || `${ledger}.lock` };
+}
+
+function appendLedger(ledger, event) {
+  fs.mkdirSync(path.dirname(ledger), { recursive: true, mode: 0o700 });
+  const fd = fs.openSync(ledger, "a", 0o600);
+  try {
+    fs.writeSync(fd, `${JSON.stringify({ at: new Date().toISOString(), ...event })}\n`);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function readLedger(ledger) {
+  if (!fs.existsSync(ledger)) return [];
+  return fs.readFileSync(ledger, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+function requireEnv(name, env = process.env) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function runtimeContext(env = process.env) {
+  return {
+    account: requireEnv("PLOY_LIVE_ACCOUNT_ID", env),
+    releaseSha: requireEnv("PLOY_RELEASE_SHA", env),
+    walletType: requireEnv("POLY_WALLET_TYPE", env).toUpperCase(),
+  };
+}
+
+function makeRelayClient(env = process.env) {
+  const privateKey = requireEnv("POLYMARKET_PRIVATE_KEY", env);
+  const account = privateKeyToAccount(privateKey);
+  const rpcUrl = requireEnv("POLYGON_RPC_URL", env);
+  const wallet = createWalletClient({ account, chain: polygon, transport: http(rpcUrl) });
+  const builderConfig = new BuilderConfig({ localBuilderCreds: {
+    key: requireEnv("POLY_BUILDER_API_KEY", env),
+    secret: requireEnv("POLY_BUILDER_SECRET", env),
+    passphrase: requireEnv("POLY_BUILDER_PASSPHRASE", env),
+  }});
+  const walletType = requireEnv("POLY_WALLET_TYPE", env).toUpperCase();
+  const derived = walletType === "SAFE"
+    ? deriveSafe(account.address, CONTRACTS.safeFactory)
+    : deriveProxyWallet(account.address, CONTRACTS.proxyFactory);
+  if (normalizeAddress(derived, "derived wallet") !== normalizeAddress(requireEnv("PLOY_LIVE_ACCOUNT_ID", env), "live account")) {
+    throw new Error("signer-derived wallet does not match PLOY_LIVE_ACCOUNT_ID");
+  }
+  const txType = walletType === "SAFE" ? RelayerTxType.SAFE : RelayerTxType.PROXY;
+  return {
+    client: new RelayClient(requireEnv("POLYMARKET_RELAYER_URL", env), CHAIN_ID, wallet, builderConfig, txType),
+    publicClient: createPublicClient({ chain: polygon, transport: http(rpcUrl) }),
+  };
+}
+
+async function executePlan(plan, expectedHash, env = process.env) {
+  if (env.PLOY_ACCOUNT_OPS_WRITE_ENABLED !== "true") throw new Error("account-ops writes are disabled");
+  const context = runtimeContext(env);
+  validatePlan(plan, context, expectedHash);
+  const { ledger, lock } = ledgerPaths(env);
+  fs.mkdirSync(lock, { mode: 0o700 });
+  // ponytail: one global lock; switch to per-account locks only if account-ops throughput matters.
+  let submitted = false;
+  try {
+    const history = readLedger(ledger);
+    const { client, publicClient } = makeRelayClient(env);
+    for (const item of plan.items) {
+      const prior = history.filter((event) => event.operationId === item.operationId).at(-1);
+      if (prior && ["submitted", "ambiguous"].includes(prior.state)) {
+        throw new Error(`operation ${item.operationId} requires reconcile`);
+      }
+      if (prior && ["confirmed", "reconciled", "externally_redeemed"].includes(prior.state)) continue;
+
+      const current = await verifyPositionRoutes(await fetchPositions(context.account));
+      const candidates = current.filter((position) => position.redeemable && String(position.conditionId).toLowerCase() === item.conditionId);
+      if (candidates.length === 0) {
+        appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "externally_redeemed" });
+        continue;
+      }
+      if (candidates.some((position) => Boolean(position.negativeRisk) !== (item.route === "neg_risk"))) {
+        throw new Error(`route changed for ${item.conditionId}`);
+      }
+
+      const before = await publicClient.readContract({ address: CONTRACTS.pusd, abi: ERC20_BALANCE_ABI, functionName: "balanceOf", args: [context.account] });
+      const approved = await publicClient.readContract({
+        address: CONTRACTS.conditionalTokens,
+        abi: ERC1155_APPROVAL_ABI,
+        functionName: "isApprovedForAll",
+        args: [context.account, item.target],
+      });
+      if (!approved) throw new Error(`adapter is not approved for condition ${item.conditionId}`);
+      appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "reserved", planSha256: plan.sha256, balanceBefore: before.toString() });
+      const response = await client.execute([redeemTransaction(item)], `ploy redeem ${item.conditionId}`);
+      submitted = true;
+      appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "submitted", transactionId: response.transactionID, transactionHash: response.transactionHash || null });
+      const result = await response.wait();
+      if (!result || !["STATE_MINED", "STATE_CONFIRMED"].includes(result.state)) {
+        appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "ambiguous", transactionId: response.transactionID });
+        throw new Error(`relayer result for ${item.conditionId} is ambiguous`);
+      }
+      const after = await publicClient.readContract({ address: CONTRACTS.pusd, abi: ERC20_BALANCE_ABI, functionName: "balanceOf", args: [context.account] });
+      const remaining = (await fetchPositions(context.account)).some((position) => position.redeemable && String(position.conditionId).toLowerCase() === item.conditionId);
+      appendLedger(ledger, {
+        operationId: item.operationId,
+        conditionId: item.conditionId,
+        state: remaining ? "confirmed" : "reconciled",
+        transactionId: response.transactionID,
+        transactionHash: result.transactionHash || response.transactionHash || null,
+        balanceBefore: before.toString(),
+        balanceAfter: after.toString(),
+      });
+      if (remaining) throw new Error(`confirmed transaction still has a redeemable position for ${item.conditionId}`);
+      submitted = false;
+    }
+    fs.rmdirSync(lock);
+  } catch (error) {
+    if (!submitted && fs.existsSync(lock)) fs.rmdirSync(lock);
+    throw error;
+  }
+}
+
+async function reconcileTransaction(transactionId, env = process.env, dependencies = {}) {
+  if (!transactionId) throw new Error("transaction id is required");
+  const context = runtimeContext(env);
+  const { ledger, lock } = ledgerPaths(env);
+  const history = readLedger(ledger);
+  const submittedEvent = history.findLast((event) =>
+    event.transactionId === transactionId && ["submitted", "ambiguous", "confirmed"].includes(event.state));
+  if (!submittedEvent) throw new Error(`transaction ${transactionId} is not an unresolved ledger operation`);
+  const operationId = submittedEvent.operationId;
+  const latest = history.filter((event) => event.operationId === operationId).at(-1);
+  if (latest && ["reconciled", "externally_redeemed", "failed"].includes(latest.state)) {
+    return { operationId, state: latest.state, transactionId };
+  }
+
+  const relay = dependencies.relay || makeRelayClient(env);
+  const transactions = await relay.client.getTransaction(transactionId);
+  const transaction = Array.isArray(transactions)
+    ? transactions.find((candidate) => candidate.transactionID === transactionId) || transactions.at(-1)
+    : undefined;
+  if (!transaction) throw new Error(`relayer has no record for transaction ${transactionId}`);
+
+  if (["STATE_FAILED", "STATE_INVALID"].includes(transaction.state)) {
+    appendLedger(ledger, {
+      operationId,
+      conditionId: submittedEvent.conditionId,
+      state: "failed",
+      transactionId,
+      transactionHash: transaction.transactionHash || null,
+      relayerState: transaction.state,
+    });
+    if (fs.existsSync(lock)) fs.rmdirSync(lock);
+    return { operationId, state: "failed", transactionId };
+  }
+  if (!["STATE_MINED", "STATE_CONFIRMED"].includes(transaction.state)) {
+    appendLedger(ledger, {
+      operationId,
+      conditionId: submittedEvent.conditionId,
+      state: "ambiguous",
+      transactionId,
+      transactionHash: transaction.transactionHash || null,
+      relayerState: transaction.state,
+    });
+    throw new Error(`transaction ${transactionId} is still ${transaction.state}`);
+  }
+
+  const fetchCurrentPositions = dependencies.fetchPositions || fetchPositions;
+  const verifyCurrentRoutes = dependencies.verifyPositionRoutes || verifyPositionRoutes;
+  const current = await verifyCurrentRoutes(await fetchCurrentPositions(context.account));
+  const remaining = current.some((position) =>
+    position.redeemable && String(position.conditionId).toLowerCase() === submittedEvent.conditionId);
+  const balanceAfter = await relay.publicClient.readContract({
+    address: CONTRACTS.pusd,
+    abi: ERC20_BALANCE_ABI,
+    functionName: "balanceOf",
+    args: [context.account],
+  });
+  const state = remaining ? "confirmed" : "reconciled";
+  appendLedger(ledger, {
+    operationId,
+    conditionId: submittedEvent.conditionId,
+    state,
+    transactionId,
+    transactionHash: transaction.transactionHash || null,
+    relayerState: transaction.state,
+    balanceAfter: balanceAfter.toString(),
+  });
+  if (remaining) throw new Error(`confirmed transaction still has a redeemable position for ${submittedEvent.conditionId}`);
+  if (fs.existsSync(lock)) fs.rmdirSync(lock);
+  return { operationId, state, transactionId };
+}
+
+module.exports = {
+  CHAIN_ID,
+  CONTRACTS,
+  buildPlan,
+  executePlan,
+  fetchPositions,
+  readLedger,
+  reconcileTransaction,
+  redeemTransaction,
+  runtimeContext,
+  sha256,
+  validatePlan,
+  verifyPositionRoutes,
+};

--- a/tools/polymarket-account-ops/account_ops.js
+++ b/tools/polymarket-account-ops/account_ops.js
@@ -276,7 +276,7 @@ function makeRelayClient(env = process.env) {
   };
 }
 
-async function executePlan(plan, expectedHash, env = process.env) {
+async function executePlan(plan, expectedHash, env = process.env, dependencies = {}) {
   if (env.PLOY_ACCOUNT_OPS_WRITE_ENABLED !== "true") throw new Error("account-ops writes are disabled");
   const context = runtimeContext(env);
   validatePlan(plan, context, expectedHash);
@@ -286,15 +286,18 @@ async function executePlan(plan, expectedHash, env = process.env) {
   let submitted = false;
   try {
     const history = readLedger(ledger);
-    const { client, publicClient } = makeRelayClient(env);
+    const relay = dependencies.relay || makeRelayClient(env);
+    const { client, publicClient } = relay;
+    const fetchCurrentPositions = dependencies.fetchPositions || fetchPositions;
+    const verifyCurrentRoutes = dependencies.verifyPositionRoutes || verifyPositionRoutes;
     for (const item of plan.items) {
       const prior = history.filter((event) => event.operationId === item.operationId).at(-1);
-      if (prior && ["submitted", "ambiguous"].includes(prior.state)) {
+      if (prior && ["submitting", "submission_unknown", "submitted", "ambiguous"].includes(prior.state)) {
         throw new Error(`operation ${item.operationId} requires reconcile`);
       }
       if (prior && ["confirmed", "reconciled", "externally_redeemed"].includes(prior.state)) continue;
 
-      const current = await verifyPositionRoutes(await fetchPositions(context.account));
+      const current = await verifyCurrentRoutes(await fetchCurrentPositions(context.account));
       const candidates = current.filter((position) => position.redeemable && String(position.conditionId).toLowerCase() === item.conditionId);
       if (candidates.length === 0) {
         appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "externally_redeemed" });
@@ -313,8 +316,15 @@ async function executePlan(plan, expectedHash, env = process.env) {
       });
       if (!approved) throw new Error(`adapter is not approved for condition ${item.conditionId}`);
       appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "reserved", planSha256: plan.sha256, balanceBefore: before.toString() });
-      const response = await client.execute([redeemTransaction(item)], `ploy redeem ${item.conditionId}`);
       submitted = true;
+      appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "submitting", metadata: `ploy redeem ${item.conditionId}` });
+      let response;
+      try {
+        response = await client.execute([redeemTransaction(item)], `ploy redeem ${item.conditionId}`);
+      } catch (error) {
+        appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "submission_unknown", error: error.message });
+        throw new Error(`relayer submission outcome is unknown for operation ${item.operationId}; reconcile by operation id`);
+      }
       appendLedger(ledger, { operationId: item.operationId, conditionId: item.conditionId, state: "submitted", transactionId: response.transactionID, transactionHash: response.transactionHash || null });
       const result = await response.wait();
       if (!result || !["STATE_MINED", "STATE_CONFIRMED"].includes(result.state)) {
@@ -322,7 +332,7 @@ async function executePlan(plan, expectedHash, env = process.env) {
         throw new Error(`relayer result for ${item.conditionId} is ambiguous`);
       }
       const after = await publicClient.readContract({ address: CONTRACTS.pusd, abi: ERC20_BALANCE_ABI, functionName: "balanceOf", args: [context.account] });
-      const remaining = (await fetchPositions(context.account)).some((position) => position.redeemable && String(position.conditionId).toLowerCase() === item.conditionId);
+      const remaining = (await fetchCurrentPositions(context.account)).some((position) => position.redeemable && String(position.conditionId).toLowerCase() === item.conditionId);
       appendLedger(ledger, {
         operationId: item.operationId,
         conditionId: item.conditionId,
@@ -340,6 +350,42 @@ async function executePlan(plan, expectedHash, env = process.env) {
     if (!submitted && fs.existsSync(lock)) fs.rmdirSync(lock);
     throw error;
   }
+}
+
+async function reconcileOperation(operationId, env = process.env, dependencies = {}) {
+  if (!operationId) throw new Error("operation id is required");
+  const context = runtimeContext(env);
+  const { ledger } = ledgerPaths(env);
+  const history = readLedger(ledger);
+  const events = history.filter((event) => event.operationId === operationId);
+  const latest = events.at(-1);
+  if (!latest || !["submitting", "submission_unknown"].includes(latest.state)) {
+    throw new Error(`operation ${operationId} is not awaiting relayer discovery`);
+  }
+  const submitting = events.findLast((event) => event.state === "submitting");
+  if (!submitting) throw new Error(`operation ${operationId} has no submission evidence`);
+  const relay = dependencies.relay || makeRelayClient(env);
+  const transactions = await relay.client.getTransactions();
+  const earliest = Date.parse(submitting.at) - 60_000;
+  const matches = (Array.isArray(transactions) ? transactions : []).filter((candidate) => {
+    const sameMetadata = candidate.metadata === submitting.metadata;
+    const sameAccount = !candidate.proxyAddress
+      || normalizeAddress(candidate.proxyAddress, "relayer proxyAddress") === normalizeAddress(context.account, "account");
+    return sameMetadata && sameAccount && Date.parse(candidate.createdAt) >= earliest;
+  });
+  if (matches.length !== 1) {
+    throw new Error(`operation ${operationId} matched ${matches.length} relayer transactions; lock retained`);
+  }
+  const transaction = matches[0];
+  appendLedger(ledger, {
+    operationId,
+    conditionId: submitting.conditionId,
+    state: "submitted",
+    transactionId: transaction.transactionID,
+    transactionHash: transaction.transactionHash || null,
+    discoveredByOperation: true,
+  });
+  return reconcileTransaction(transaction.transactionID, env, { ...dependencies, relay });
 }
 
 async function reconcileTransaction(transactionId, env = process.env, dependencies = {}) {
@@ -420,6 +466,7 @@ module.exports = {
   executePlan,
   fetchPositions,
   readLedger,
+  reconcileOperation,
   reconcileTransaction,
   redeemTransaction,
   runtimeContext,

--- a/tools/polymarket-account-ops/account_ops.js
+++ b/tools/polymarket-account-ops/account_ops.js
@@ -367,11 +367,13 @@ async function reconcileOperation(operationId, env = process.env, dependencies =
   const relay = dependencies.relay || makeRelayClient(env);
   const transactions = await relay.client.getTransactions();
   const earliest = Date.parse(submitting.at) - 60_000;
+  const latestCreatedAt = Date.parse(submitting.at) + PLAN_TTL_MS;
   const matches = (Array.isArray(transactions) ? transactions : []).filter((candidate) => {
     const sameMetadata = candidate.metadata === submitting.metadata;
-    const sameAccount = !candidate.proxyAddress
-      || normalizeAddress(candidate.proxyAddress, "relayer proxyAddress") === normalizeAddress(context.account, "account");
-    return sameMetadata && sameAccount && Date.parse(candidate.createdAt) >= earliest;
+    const sameAccount = candidate.proxyAddress
+      && normalizeAddress(candidate.proxyAddress, "relayer proxyAddress") === normalizeAddress(context.account, "account");
+    const createdAt = Date.parse(candidate.createdAt);
+    return sameMetadata && sameAccount && createdAt >= earliest && createdAt <= latestCreatedAt;
   });
   if (matches.length !== 1) {
     throw new Error(`operation ${operationId} matched ${matches.length} relayer transactions; lock retained`);

--- a/tools/polymarket-account-ops/account_ops.js
+++ b/tools/polymarket-account-ops/account_ops.js
@@ -151,11 +151,23 @@ function validatePlan(plan, context, expectedHash, now = Date.now()) {
     throw new Error("plan expired or exceeds maximum TTL");
   }
   if (canonical(plan.contracts) !== canonical(CONTRACTS)) throw new Error("plan contract manifest mismatch");
+  const conditionIds = new Set();
   for (const item of plan.items) {
+    if (!new Set(["standard", "neg_risk"]).has(item.route)) throw new Error("unsupported redeem route");
+    if (!/^0x[0-9a-f]{64}$/.test(item.conditionId)) throw new Error("plan conditionId must be bytes32");
+    if (conditionIds.has(item.conditionId)) throw new Error("plan contains a duplicate conditionId");
+    conditionIds.add(item.conditionId);
     const target = item.route === "neg_risk" ? CONTRACTS.negRiskAdapter : CONTRACTS.standardAdapter;
     if (normalizeAddress(item.target, "item.target") !== normalizeAddress(target, "expected target")) {
       throw new Error("redeem adapter mismatch");
     }
+    const operationId = sha256({
+      chainId: CHAIN_ID,
+      account: normalizeAddress(plan.account, "plan.account"),
+      conditionId: item.conditionId,
+      route: item.route,
+    });
+    if (item.operationId !== operationId) throw new Error("operation id mismatch");
   }
   return plan;
 }
@@ -172,16 +184,23 @@ function redeemTransaction(item) {
   };
 }
 
-async function fetchPositions(account) {
-  const url = new URL("/positions", DATA_API);
-  url.searchParams.set("user", account);
-  url.searchParams.set("limit", "500");
-  url.searchParams.set("sizeThreshold", "0");
-  const response = await fetch(url, { signal: AbortSignal.timeout(20_000) });
-  if (!response.ok) throw new Error(`Data API positions failed: HTTP ${response.status}`);
-  const positions = await response.json();
-  if (!Array.isArray(positions)) throw new Error("Data API positions response is not an array");
-  return positions;
+async function fetchPositions(account, fetchImpl = fetch) {
+  const positions = [];
+  const pageSize = 500;
+  for (let page = 0; page < 20; page += 1) {
+    const url = new URL("/positions", DATA_API);
+    url.searchParams.set("user", account);
+    url.searchParams.set("limit", String(pageSize));
+    url.searchParams.set("offset", String(page * pageSize));
+    url.searchParams.set("sizeThreshold", "0");
+    const response = await fetchImpl(url, { signal: AbortSignal.timeout(20_000) });
+    if (!response.ok) throw new Error(`Data API positions failed: HTTP ${response.status}`);
+    const pagePositions = await response.json();
+    if (!Array.isArray(pagePositions)) throw new Error("Data API positions response is not an array");
+    positions.push(...pagePositions);
+    if (pagePositions.length < pageSize) return positions;
+  }
+  throw new Error("Data API positions exceeded the 10000-position safety limit");
 }
 
 async function verifyPositionRoutes(positions) {

--- a/tools/polymarket-account-ops/account_ops.test.js
+++ b/tools/polymarket-account-ops/account_ops.test.js
@@ -10,9 +10,11 @@ const {
   CONTRACTS,
   buildPlan,
   executePlan,
+  fetchPositions,
   readLedger,
   reconcileTransaction,
   redeemTransaction,
+  sha256,
   validatePlan,
 } = require("./account_ops");
 
@@ -61,11 +63,40 @@ test("validation rejects stale plans and account drift", () => {
 });
 
 test("redeem calldata always routes through the current collateral adapter", () => {
+  assert.equal(CONTRACTS.standardAdapter, "0xAdA100Db00Ca00073811820692005400218FcE1f");
+  assert.equal(CONTRACTS.negRiskAdapter, "0xadA2005600Dec949baf300f4C6120000bDB6eAab");
   const plan = buildPlan([position({ negativeRisk: true })], { account, releaseSha, walletType: "SAFE" }, now);
   const transaction = redeemTransaction(plan.items[0]);
   assert.equal(transaction.to, CONTRACTS.negRiskAdapter);
   assert.equal(transaction.value, "0");
   assert.ok(transaction.data.startsWith("0x"));
+});
+
+test("validation rejects route and operation identity drift even with a recomputed plan hash", () => {
+  const plan = buildPlan([position()], { account, releaseSha, walletType: "SAFE" }, now);
+  plan.items[0].route = "unsupported";
+  const { sha256: _oldHash, ...unsigned } = plan;
+  plan.sha256 = sha256(unsigned);
+  assert.throws(
+    () => validatePlan(plan, { account, releaseSha, walletType: "SAFE" }, plan.sha256, now),
+    /unsupported redeem route/,
+  );
+});
+
+test("position discovery follows Data API offset pagination", async () => {
+  const offsets = [];
+  const positions = await fetchPositions(account, async (url) => {
+    offsets.push(url.searchParams.get("offset"));
+    const offset = Number(url.searchParams.get("offset"));
+    return {
+      ok: true,
+      json: async () => offset === 0
+        ? Array.from({ length: 500 }, (_, index) => ({ asset: String(index) }))
+        : [{ asset: "last" }],
+    };
+  });
+  assert.deepEqual(offsets, ["0", "500"]);
+  assert.equal(positions.length, 501);
 });
 
 test("plan fails closed on wallet and route disagreement", () => {

--- a/tools/polymarket-account-ops/account_ops.test.js
+++ b/tools/polymarket-account-ops/account_ops.test.js
@@ -12,6 +12,7 @@ const {
   executePlan,
   fetchPositions,
   readLedger,
+  reconcileOperation,
   reconcileTransaction,
   redeemTransaction,
   sha256,
@@ -112,6 +113,80 @@ test("plan fails closed on wallet and route disagreement", () => {
 
 test("execute refuses to enter account operations while writes are disabled", async () => {
   await assert.rejects(() => executePlan({}, "ignored", {}), /writes are disabled/);
+});
+
+test("execute retains the lock when the relayer submission response is lost", async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ploy-redeem-submit-unknown-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const ledger = path.join(directory, "redeem-ledger.jsonl");
+  const env = {
+    PLOY_ACCOUNT_OPS_WRITE_ENABLED: "true",
+    PLOY_LIVE_ACCOUNT_ID: account,
+    PLOY_RELEASE_SHA: releaseSha,
+    POLY_WALLET_TYPE: "SAFE",
+    PLOY_REDEEM_LEDGER: ledger,
+    PLOY_REDEEM_LOCK: `${ledger}.lock`,
+  };
+  const plan = buildPlan([position()], { account, releaseSha, walletType: "SAFE" });
+  await assert.rejects(
+    () => executePlan(plan, plan.sha256, env, {
+      relay: {
+        client: { execute: async () => { throw new Error("connection reset"); } },
+        publicClient: {
+          readContract: async ({ functionName }) => functionName === "isApprovedForAll" ? true : 100n,
+        },
+      },
+      fetchPositions: async () => [position()],
+      verifyPositionRoutes: async (positions) => positions,
+    }),
+    /submission outcome is unknown/,
+  );
+  assert.equal(fs.existsSync(`${ledger}.lock`), true);
+  assert.equal(readLedger(ledger).at(-1).state, "submission_unknown");
+});
+
+test("operation reconciliation discovers one exact relayer transaction before reconciling", async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ploy-redeem-operation-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const ledger = path.join(directory, "redeem-ledger.jsonl");
+  const lock = `${ledger}.lock`;
+  fs.mkdirSync(lock);
+  const conditionId = position().conditionId;
+  const operationId = "operation-discovery";
+  const at = new Date().toISOString();
+  fs.writeFileSync(ledger, [
+    { at, operationId, conditionId, state: "submitting", metadata: `ploy redeem ${conditionId}` },
+    { at, operationId, conditionId, state: "submission_unknown" },
+  ].map(JSON.stringify).join("\n") + "\n");
+  const transaction = {
+    transactionID: "relay-discovered",
+    transactionHash: "0xabc",
+    proxyAddress: account,
+    metadata: `ploy redeem ${conditionId}`,
+    createdAt: at,
+    state: "STATE_MINED",
+  };
+  const relay = {
+    client: {
+      getTransactions: async () => [transaction],
+      getTransaction: async () => [transaction],
+    },
+    publicClient: { readContract: async () => 150n },
+  };
+  const result = await reconcileOperation(operationId, {
+    PLOY_LIVE_ACCOUNT_ID: account,
+    PLOY_RELEASE_SHA: releaseSha,
+    POLY_WALLET_TYPE: "SAFE",
+    PLOY_REDEEM_LEDGER: ledger,
+    PLOY_REDEEM_LOCK: lock,
+  }, {
+    relay,
+    fetchPositions: async () => [],
+    verifyPositionRoutes: async (positions) => positions,
+  });
+  assert.equal(result.state, "reconciled");
+  assert.equal(fs.existsSync(lock), false);
+  assert.equal(readLedger(ledger).some((event) => event.discoveredByOperation), true);
 });
 
 test("reconcile clears the lock only after the exact mined transaction disappears from Data API", async (t) => {

--- a/tools/polymarket-account-ops/account_ops.test.js
+++ b/tools/polymarket-account-ops/account_ops.test.js
@@ -1,0 +1,145 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  CHAIN_ID,
+  CONTRACTS,
+  buildPlan,
+  executePlan,
+  readLedger,
+  reconcileTransaction,
+  redeemTransaction,
+  validatePlan,
+} = require("./account_ops");
+
+const account = "0x1111111111111111111111111111111111111111";
+const releaseSha = "a".repeat(40);
+const now = Date.parse("2026-07-12T12:00:00Z");
+
+function position(overrides = {}) {
+  return {
+    proxyWallet: account,
+    asset: "123",
+    conditionId: `0x${"2".repeat(64)}`,
+    size: "10.5",
+    redeemable: true,
+    negativeRisk: false,
+    outcome: "Yes",
+    outcomeIndex: 0,
+    ...overrides,
+  };
+}
+
+test("plan groups a condition and binds account, chain, release, expiry, and hash", () => {
+  const plan = buildPlan(
+    [position(), position({ asset: "456", outcome: "No", outcomeIndex: 1 })],
+    { account, releaseSha, walletType: "SAFE" },
+    now,
+  );
+  assert.equal(plan.chainId, CHAIN_ID);
+  assert.equal(plan.account.toLowerCase(), account);
+  assert.equal(plan.items.length, 1);
+  assert.equal(plan.items[0].target, CONTRACTS.standardAdapter);
+  assert.equal(Date.parse(plan.expiresAt) - Date.parse(plan.generatedAt), 10 * 60 * 1000);
+  assert.equal(validatePlan(plan, { account, releaseSha, walletType: "SAFE" }, plan.sha256, now), plan);
+});
+
+test("validation rejects stale plans and account drift", () => {
+  const plan = buildPlan([position()], { account, releaseSha, walletType: "PROXY" }, now);
+  assert.throws(
+    () => validatePlan(plan, { account, releaseSha, walletType: "PROXY" }, plan.sha256, now + 10 * 60 * 1000),
+    /expired/,
+  );
+  assert.throws(
+    () => validatePlan(plan, { account: "0x3333333333333333333333333333333333333333", releaseSha, walletType: "PROXY" }, plan.sha256, now),
+    /account mismatch/,
+  );
+});
+
+test("redeem calldata always routes through the current collateral adapter", () => {
+  const plan = buildPlan([position({ negativeRisk: true })], { account, releaseSha, walletType: "SAFE" }, now);
+  const transaction = redeemTransaction(plan.items[0]);
+  assert.equal(transaction.to, CONTRACTS.negRiskAdapter);
+  assert.equal(transaction.value, "0");
+  assert.ok(transaction.data.startsWith("0x"));
+});
+
+test("plan fails closed on wallet and route disagreement", () => {
+  assert.throws(
+    () => buildPlan([position({ proxyWallet: "0x3333333333333333333333333333333333333333" })], { account, releaseSha, walletType: "SAFE" }, now),
+    /wallet does not match/,
+  );
+  assert.throws(
+    () => buildPlan([position(), position({ negativeRisk: true })], { account, releaseSha, walletType: "SAFE" }, now),
+    /negative-risk disagreement/,
+  );
+});
+
+test("execute refuses to enter account operations while writes are disabled", async () => {
+  await assert.rejects(() => executePlan({}, "ignored", {}), /writes are disabled/);
+});
+
+test("reconcile clears the lock only after the exact mined transaction disappears from Data API", async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ploy-redeem-reconcile-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const ledger = path.join(directory, "redeem-ledger.jsonl");
+  const lock = `${ledger}.lock`;
+  fs.mkdirSync(lock);
+  fs.writeFileSync(ledger, `${JSON.stringify({
+    operationId: "operation-1",
+    conditionId: position().conditionId,
+    state: "ambiguous",
+    transactionId: "relay-1",
+  })}\n`);
+  const env = {
+    PLOY_LIVE_ACCOUNT_ID: account,
+    PLOY_RELEASE_SHA: releaseSha,
+    POLY_WALLET_TYPE: "SAFE",
+    PLOY_REDEEM_LEDGER: ledger,
+    PLOY_REDEEM_LOCK: lock,
+  };
+  const result = await reconcileTransaction("relay-1", env, {
+    relay: {
+      client: { getTransaction: async () => [{ transactionID: "relay-1", transactionHash: "0xabc", state: "STATE_MINED" }] },
+      publicClient: { readContract: async () => 125n },
+    },
+    fetchPositions: async () => [],
+    verifyPositionRoutes: async (positions) => positions,
+  });
+  assert.equal(result.state, "reconciled");
+  assert.equal(fs.existsSync(lock), false);
+  assert.equal(readLedger(ledger).at(-1).balanceAfter, "125");
+});
+
+test("reconcile retains the lock while the relayer transaction is pending", async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ploy-redeem-pending-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const ledger = path.join(directory, "redeem-ledger.jsonl");
+  const lock = `${ledger}.lock`;
+  fs.mkdirSync(lock);
+  fs.writeFileSync(ledger, `${JSON.stringify({
+    operationId: "operation-2",
+    conditionId: position().conditionId,
+    state: "submitted",
+    transactionId: "relay-2",
+  })}\n`);
+  const env = {
+    PLOY_LIVE_ACCOUNT_ID: account,
+    PLOY_RELEASE_SHA: releaseSha,
+    POLY_WALLET_TYPE: "SAFE",
+    PLOY_REDEEM_LEDGER: ledger,
+    PLOY_REDEEM_LOCK: lock,
+  };
+  await assert.rejects(
+    () => reconcileTransaction("relay-2", env, {
+      relay: { client: { getTransaction: async () => [{ transactionID: "relay-2", state: "STATE_EXECUTED" }] } },
+    }),
+    /still STATE_EXECUTED/,
+  );
+  assert.equal(fs.existsSync(lock), true);
+  assert.equal(readLedger(ledger).at(-1).state, "ambiguous");
+});

--- a/tools/polymarket-account-ops/account_ops.test.js
+++ b/tools/polymarket-account-ops/account_ops.test.js
@@ -168,7 +168,11 @@ test("operation reconciliation discovers one exact relayer transaction before re
   };
   const relay = {
     client: {
-      getTransactions: async () => [transaction],
+      getTransactions: async () => [
+        { ...transaction, transactionID: "missing-account", proxyAddress: undefined },
+        { ...transaction, transactionID: "too-late", createdAt: new Date(Date.parse(at) + 11 * 60 * 1000).toISOString() },
+        transaction,
+      ],
       getTransaction: async () => [transaction],
     },
     publicClient: { readContract: async () => 150n },

--- a/tools/polymarket-account-ops/cli.js
+++ b/tools/polymarket-account-ops/cli.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const {
+  buildPlan,
+  executePlan,
+  fetchPositions,
+  reconcileTransaction,
+  runtimeContext,
+  verifyPositionRoutes,
+} = require("./account_ops");
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const command = process.argv[2] || "check";
+  const context = runtimeContext();
+  if (command === "check") {
+    const positions = await verifyPositionRoutes(await fetchPositions(context.account));
+    const redeemable = positions.filter((position) => position.redeemable && Number(position.size) > 0);
+    process.stdout.write(`${JSON.stringify({ account: context.account, redeemable }, null, 2)}\n`);
+    return;
+  }
+  if (command === "plan") {
+    const output = option("--out");
+    if (!output) throw new Error("plan requires --out <file>");
+    const plan = buildPlan(await verifyPositionRoutes(await fetchPositions(context.account)), context);
+    fs.writeFileSync(output, `${JSON.stringify(plan, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+    process.stdout.write(`${JSON.stringify({ path: output, sha256: plan.sha256, items: plan.items.length })}\n`);
+    return;
+  }
+  if (command === "execute") {
+    const planPath = option("--plan");
+    const expectedHash = option("--sha256");
+    if (!planPath || !expectedHash) throw new Error("execute requires --plan <file> --sha256 <hash>");
+    await executePlan(JSON.parse(fs.readFileSync(planPath, "utf8")), expectedHash);
+    process.stdout.write(`${JSON.stringify({ status: "reconciled" })}\n`);
+    return;
+  }
+  if (command === "reconcile") {
+    const transactionId = option("--transaction-id");
+    if (!transactionId) throw new Error("reconcile requires --transaction-id <id>");
+    const result = await reconcileTransaction(transactionId);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  throw new Error(`unsupported command: ${command}`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tools/polymarket-account-ops/cli.js
+++ b/tools/polymarket-account-ops/cli.js
@@ -6,6 +6,7 @@ const {
   buildPlan,
   executePlan,
   fetchPositions,
+  reconcileOperation,
   reconcileTransaction,
   runtimeContext,
   verifyPositionRoutes,
@@ -43,8 +44,13 @@ async function main() {
   }
   if (command === "reconcile") {
     const transactionId = option("--transaction-id");
-    if (!transactionId) throw new Error("reconcile requires --transaction-id <id>");
-    const result = await reconcileTransaction(transactionId);
+    const operationId = option("--operation-id");
+    if (Boolean(transactionId) === Boolean(operationId)) {
+      throw new Error("reconcile requires exactly one of --transaction-id <id> or --operation-id <id>");
+    }
+    const result = transactionId
+      ? await reconcileTransaction(transactionId)
+      : await reconcileOperation(operationId);
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return;
   }

--- a/tools/polymarket-account-ops/package-lock.json
+++ b/tools/polymarket-account-ops/package-lock.json
@@ -1,0 +1,2052 @@
+{
+  "name": "ploy-polymarket-account-ops",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ploy-polymarket-account-ops",
+      "version": "0.1.0",
+      "dependencies": {
+        "@polymarket/builder-relayer-client": "0.0.10",
+        "@polymarket/builder-signing-sdk": "0.0.8",
+        "viem": "2.55.1"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
+      "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "^5.8.0",
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0",
+        "bech32": "1.1.4",
+        "ws": "8.18.0"
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
+      "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
+      "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/json-wallets": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polymarket/builder-abstract-signer": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polymarket/builder-abstract-signer/-/builder-abstract-signer-0.0.1.tgz",
+      "integrity": "sha512-XuuxQQcXYtqQce8slhqiJQti1lVPr+xXC7M3lbetmNnsc9tlYdYRnojE+tcniCHg7VQ6dokcIu0eLYDtM5vdvQ==",
+      "dependencies": {
+        "ethers": "5.8.0",
+        "ts-node": "^9.1.1",
+        "typescript": "^5.8.3",
+        "viem": "^2.31.4"
+      }
+    },
+    "node_modules/@polymarket/builder-relayer-client": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@polymarket/builder-relayer-client/-/builder-relayer-client-0.0.10.tgz",
+      "integrity": "sha512-TarpcWWHI+wiqz5MYxqL3NawCs2gEPSZNFfLmWZ6EYxXvmi2RYgGNYXObo9AsC97J95dZ9+9RGNF/V2QZ59+Rg==",
+      "dependencies": {
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@polymarket/builder-abstract-signer": "0.0.1",
+        "@polymarket/builder-signing-sdk": "^0.0.8",
+        "axios": "^0.27.2",
+        "browser-or-node": "^3.0.0",
+        "ethers": "5.8.0",
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3",
+        "viem": "^2.31.4"
+      }
+    },
+    "node_modules/@polymarket/builder-signing-sdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@polymarket/builder-signing-sdk/-/builder-signing-sdk-0.0.8.tgz",
+      "integrity": "sha512-rZLCFxEdYahl5FiJmhe22RDXysS1ibFJlWz4NT0s3itJRYq3XJzXXHXEZkAQplU+nIS1IlbbKjA4zDQaeCyYtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.7.18",
+        "axios": "^1.12.2",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "license": "MIT"
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browser-or-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
+      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.8.0",
+        "@ethersproject/abstract-provider": "5.8.0",
+        "@ethersproject/abstract-signer": "5.8.0",
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/base64": "5.8.0",
+        "@ethersproject/basex": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/contracts": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hdnode": "5.8.0",
+        "@ethersproject/json-wallets": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/networks": "5.8.0",
+        "@ethersproject/pbkdf2": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/random": "5.8.0",
+        "@ethersproject/rlp": "5.8.0",
+        "@ethersproject/sha2": "5.8.0",
+        "@ethersproject/signing-key": "5.8.0",
+        "@ethersproject/solidity": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@ethersproject/transactions": "5.8.0",
+        "@ethersproject/units": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@ethersproject/web": "5.8.0",
+        "@ethersproject/wordlists": "5.8.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.55.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.1.tgz",
+      "integrity": "sha512-sajvEmONS3dEDFh0jKXGugTU8ImyGoIV3sEHSWNRhgkH484v/+6DjZAplRhcdeqNV/VBxOs/l3raOG4NaXvX9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.30",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/polymarket-account-ops/package.json
+++ b/tools/polymarket-account-ops/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ploy-polymarket-account-ops",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@polymarket/builder-relayer-client": "0.0.10",
+    "@polymarket/builder-signing-sdk": "0.0.8",
+    "viem": "2.55.1"
+  },
+  "overrides": {
+    "axios": "1.18.1",
+    "ws": "8.21.0"
+  }
+}

--- a/tools/polymarket-account-ops/ploy-account-ops
+++ b/tools/polymarket-account-ops/ploy-account-ops
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_path="$(readlink -f "${BASH_SOURCE[0]}")"
+tool_dir="$(cd "$(dirname "${source_path}")" && pwd -P)"
+exec "${tool_dir}/../../bin/node" "${tool_dir}/cli.js" "$@"


### PR DESCRIPTION
## Summary
- add official Builder Relayer based check/plan/execute/reconcile account operations
- bind plans to chain, account, wallet, release SHA, current adapter manifest, TTL, and content hash
- retain a durable lock across submitted, ambiguous, and response-lost transactions; reconcile exact relayer evidence before any retry
- package a self-contained Node runtime in the immutable paused trade bundle

## Verification
- account-ops Node tests: 11 passed
- deployment/runtime Python tests: 8 passed
- npm audit: 0 moderate/high/critical (16 low transitive advisories)
- shell syntax and diff checks passed

Write operations remain disabled after every deploy. No Redeem was submitted and no live deployment was resumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Polymarket account operations for checking redeemable positions, creating hashed plans, executing approved redemptions, and reconciling transactions.
  - Added a command-line interface for account operations.

- **Bug Fixes**
  - Improved routing validation, wallet and plan verification, transaction tracking, and recovery for uncertain relayer responses.

- **Documentation**
  - Updated claim/redeem procedures, safety requirements, evidence checks, and environment configuration guidance.

- **Chores**
  - Enhanced deployment checks for bundled tools, permissions, configuration, and runtime readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->