### PR TITLE
fix(data): migrate Polymarket collectors to V2 APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,15 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,16 +70,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
- "alloy-contract",
  "alloy-core",
  "alloy-eips",
- "alloy-network",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
- "alloy-transport",
  "alloy-transport-http",
  "alloy-trie",
 ]
@@ -146,38 +134,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-contract"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
-dependencies = [
- "alloy-consensus",
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
- "futures",
- "futures-util",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "alloy-core"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
 dependencies = [
  "alloy-dyn-abi",
- "alloy-json-abi",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-sol-types",
 ]
 
@@ -192,8 +155,6 @@ dependencies = [
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "itoa",
- "serde",
- "serde_json",
  "winnow 0.7.15",
 ]
 
@@ -541,7 +502,6 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
 dependencies = [
- "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
@@ -560,14 +520,12 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
 dependencies = [
- "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
  "macro-string",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -669,18 +627,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -1089,16 +1035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,27 +1044,6 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-object-pool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
-dependencies = [
- "async-lock",
- "event-listener",
 ]
 
 [[package]]
@@ -1210,6 +1125,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "backoff"
@@ -1770,6 +1708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1724,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1806,56 +1761,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
+name = "cmake"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
+ "cc",
 ]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -1875,6 +1787,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1919,7 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2026,6 +1948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,41 +1978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2837,6 +2733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,12 +3112,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3515,6 +3420,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3726,30 +3632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,46 +3731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "httpmock"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
-dependencies = [
- "assert-json-diff",
- "async-object-pool",
- "async-trait",
- "base64",
- "bytes",
- "crossbeam-utils",
- "form_urlencoded",
- "futures-timer",
- "futures-util",
- "headers",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "path-tree",
- "regex",
- "serde",
- "serde_json",
- "serde_regex",
- "similar",
- "stringmetrics",
- "tabwriter",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,7 +3744,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3920,7 +3761,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3945,9 +3785,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4191,6 +4033,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,7 +4118,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4899,12 +4757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,16 +4786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -5008,15 +4850,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-tree"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "pem-rfc7468"
@@ -5179,34 +5012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "ploy"
 version = "0.1.0"
 dependencies = [
@@ -5231,7 +5036,7 @@ dependencies = [
  "alloy",
  "chrono",
  "ploy-trading",
- "polymarket-client-sdk",
+ "polymarket_client_sdk_v2",
  "rust_decimal",
  "rust_decimal_macros",
  "secrecy 0.8.0",
@@ -5311,15 +5116,15 @@ dependencies = [
  "chrono",
  "futures",
  "ploy-market-contracts",
- "polymarket-client-sdk",
- "reqwest 0.12.28",
+ "polymarket_client_sdk_v2",
+ "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
  "serde_json",
  "sqlx",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
 ]
 
@@ -5984,11 +5789,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "polymarket-client-sdk"
-version = "0.4.2"
+name = "polymarket_client_sdk_v2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ed9ca91088808232ee7e6b48f8f4eaa846882f799c40f8190b0a0e3d28ed5e"
 dependencies = [
  "alloy",
- "anyhow",
  "async-stream",
  "async-trait",
  "backoff",
@@ -5996,15 +5802,12 @@ dependencies = [
  "bitflags 2.11.1",
  "bon",
  "chrono",
- "criterion",
  "dashmap",
  "futures",
- "futures-util",
  "hmac",
- "httpmock",
  "phf 0.13.1",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
  "secrecy 0.10.3",
@@ -6015,13 +5818,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_repr",
  "serde_with",
+ "sha1",
  "sha2",
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -6248,6 +6051,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6328,6 +6132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6365,6 +6180,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -6602,7 +6423,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6628,20 +6448,30 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -6869,6 +6699,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6900,11 +6731,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7242,16 +7101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7331,7 +7180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7342,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7412,12 +7261,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -7757,12 +7600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
-name = "stringmetrics"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7815,6 +7652,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7924,12 +7773,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabwriter"
-version = "1.4.1"
+name = "system-configuration"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "unicode-width",
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -8100,16 +7961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8186,7 +8037,23 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -8403,6 +8270,24 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8771,6 +8656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9017,7 +8911,7 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9072,6 +8966,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9090,6 +8995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9097,6 +9011,24 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -9137,6 +9069,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -9168,6 +9115,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -9180,6 +9133,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -9189,6 +9148,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9210,6 +9175,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9219,6 +9190,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9234,6 +9211,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9243,6 +9226,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/ploy-connectivity/Cargo.toml
+++ b/crates/ploy-connectivity/Cargo.toml
@@ -10,7 +10,7 @@ description = "Ploy connectivity crate"
 [dependencies]
 alloy = { version = "1", default-features = false, features = ["signer-local"] }
 ploy-trading.workspace = true
-polymarket-client-sdk = { path = "../../vendor/polymarket-client-sdk", features = ["clob", "heartbeats"] }
+polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "heartbeats"] }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 secrecy.workspace = true

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -885,9 +885,10 @@ fn normalize_execution_amount(
     _limit_price: Decimal,
     side: Side,
 ) -> Result<Amount, polymarket_client_sdk::error::Error> {
+    let shares = normalize_order_quantity(quantity);
     match side {
-        Side::Buy => Amount::shares(normalize_market_order_quantity(quantity)),
-        Side::Sell => Amount::shares(normalize_market_order_quantity(quantity)),
+        Side::Buy => Amount::shares(shares),
+        Side::Sell => Amount::shares(shares),
         _ => unreachable!("invalid Polymarket side"),
     }
 }
@@ -1094,9 +1095,9 @@ mod tests {
             .expect("sell amount");
 
         assert!(buy.is_shares());
-        assert_eq!(buy.as_inner(), dec!(24.4678));
+        assert_eq!(buy.as_inner(), dec!(24.46));
         assert!(sell.is_shares());
-        assert_eq!(sell.as_inner(), dec!(24.4678));
+        assert_eq!(sell.as_inner(), dec!(24.46));
     }
 
     #[test]

--- a/crates/ploy-market-data/Cargo.toml
+++ b/crates/ploy-market-data/Cargo.toml
@@ -21,8 +21,8 @@ live = [
 chrono.workspace = true
 futures = { version = "0.3", optional = true }
 ploy-market-contracts.workspace = true
-polymarket-client-sdk = { path = "../../vendor/polymarket-client-sdk", features = ["clob", "data", "gamma", "rtds", "tracing", "ws", "heartbeats"], optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "data", "gamma", "rtds", "tracing", "ws", "heartbeats"], optional = true }
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"], optional = true }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 serde.workspace = true

--- a/crates/ploy-market-data/src/discovery/sports.rs
+++ b/crates/ploy-market-data/src/discovery/sports.rs
@@ -6,6 +6,7 @@ use polymarket_client_sdk::gamma::Client as GammaClient;
 use serde_json::Value;
 
 use crate::discovery::types::{MarketDescriptor, MarketFamily, MarketSemantics, SettlementSource};
+use crate::gamma_keyset::fetch_markets;
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredSportsMarket {
@@ -29,10 +30,10 @@ pub async fn discover_sports_markets(
 
     let mut request = MarketsRequest::default();
     request.closed = Some(false);
-    request.limit = Some(limit);
+    request.limit = Some(limit.min(100));
     request.sports_market_types = sports_market_types.market_types;
 
-    let markets = client.markets(&request).await?;
+    let markets = fetch_markets(&request, limit.max(1) as usize).await?;
     Ok(normalize_sports_markets(
         &markets, &teams, &sports, &leagues,
     ))

--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -12,7 +12,7 @@ use futures::StreamExt;
 use ploy_market_contracts::{
     l2_updates_from_depth_totals, normalize_token_id, BookLevel, MarketUpdate,
 };
-use polymarket_client_sdk::rtds::{Client as RtdsClient, EquityPriceMessage};
+use polymarket_client_sdk::rtds::{Client as RtdsClient, Subscription};
 use polymarket_client_sdk::types::U256;
 use polymarket_client_sdk::ws::config::{Config as PolymarketWsConfig, ReconnectConfig};
 use rust_decimal::prelude::ToPrimitive;
@@ -1166,132 +1166,7 @@ pub fn spawn_pyth_reference_feed(
             let subscribe_symbol = raw_symbol.clone();
 
             join_set.spawn(async move {
-                let normalized_symbol = pyth_symbol(&subscribe_symbol);
-                let asset_class = infer_pyth_asset_class(&subscribe_symbol);
-                let client =
-                    RtdsClient::new(POLYMARKET_RTDS_WS_ENDPOINT, rtds_market_data_ws_config())
-                        .expect("RTDS market-data config should be valid");
-                let stream =
-                    match client.subscribe_equity_prices(Some(subscribe_symbol.clone()), true) {
-                        Ok(stream) => stream,
-                        Err(error) => {
-                            error!(
-                                symbol = %subscribe_symbol,
-                                error = %error,
-                                "Failed to subscribe to equity_prices"
-                            );
-                            return;
-                        }
-                    };
-
-                let mut stream = Box::pin(stream);
-                let mut message_count = 0_u64;
-
-                while let Some(result) = stream.next().await {
-                    match result {
-                        Ok(EquityPriceMessage::Update(update)) => {
-                            let source_timestamp =
-                                DateTime::from_timestamp_millis(update.timestamp)
-                                    .unwrap_or_else(Utc::now);
-                            let received_at = update
-                                .received_at
-                                .and_then(DateTime::from_timestamp_millis)
-                                .unwrap_or_else(Utc::now);
-
-                            let snapshot = ReferencePriceSnapshot {
-                                key: ReferencePriceKey {
-                                    source: ReferencePriceSource::Pyth,
-                                    symbol: normalize_reference_symbol(&update.symbol),
-                                },
-                                asset_class,
-                                value: update.value,
-                                full_accuracy_value: Some(update.full_accuracy_value.clone()),
-                                source_timestamp,
-                                received_at,
-                                is_carried_forward: update.is_carried_forward,
-                            };
-
-                            upsert_reference_price(&registry, snapshot.clone()).await;
-
-                            if tx.send(reference_price_update(&snapshot)).is_err() {
-                                warn!(
-                                    symbol = %subscribe_symbol,
-                                    "Broadcast channel closed, stopping Pyth reference-price worker"
-                                );
-                                return;
-                            }
-
-                            if let Some(ref db) = pool {
-                                persist_reference_price(db, &snapshot).await;
-                            }
-
-                            message_count += 1;
-                            if message_count == 1 || message_count % 100 == 0 {
-                                info!(
-                                    symbol = %normalized_symbol,
-                                    source = %ReferencePriceSource::Pyth.as_str(),
-                                    asset_class = %asset_class.as_str(),
-                                    carried_forward = snapshot.is_carried_forward,
-                                    count = message_count,
-                                    "Pyth reference prices captured"
-                                );
-                            }
-                        }
-                        Ok(EquityPriceMessage::Snapshot(snapshot)) => {
-                            let snapshot_symbol = normalize_reference_symbol(&snapshot.symbol);
-                            for point in snapshot.data {
-                                let source_timestamp =
-                                    DateTime::from_timestamp_millis(point.timestamp)
-                                        .unwrap_or_else(Utc::now);
-                                let received_at = point
-                                    .received_at
-                                    .and_then(DateTime::from_timestamp_millis)
-                                    .unwrap_or_else(Utc::now);
-                                let snapshot = ReferencePriceSnapshot {
-                                    key: ReferencePriceKey {
-                                        source: ReferencePriceSource::Pyth,
-                                        symbol: snapshot_symbol.clone(),
-                                    },
-                                    asset_class,
-                                    value: point.value,
-                                    full_accuracy_value: point.full_accuracy_value.clone(),
-                                    source_timestamp,
-                                    received_at,
-                                    is_carried_forward: point.is_carried_forward,
-                                };
-
-                                upsert_reference_price(&registry, snapshot.clone()).await;
-
-                                if tx.send(reference_price_update(&snapshot)).is_err() {
-                                    warn!(
-                                        symbol = %subscribe_symbol,
-                                        "Broadcast channel closed, stopping Pyth reference-price worker"
-                                    );
-                                    return;
-                                }
-
-                                if let Some(ref db) = pool {
-                                    persist_reference_price(db, &snapshot).await;
-                                }
-                            }
-                        }
-                        Ok(_) => {
-                            debug!(
-                                symbol = %subscribe_symbol,
-                                "Ignoring unsupported non-exhaustive equity_prices message"
-                            );
-                        }
-                        Err(error) => {
-                            warn!(
-                                symbol = %subscribe_symbol,
-                                error = %error,
-                                "RTDS equity_prices stream error"
-                            );
-                        }
-                    }
-                }
-
-                warn!(symbol = %subscribe_symbol, "RTDS equity_prices stream ended");
+                run_pyth_reference_worker(tx, registry, subscribe_symbol, pool).await;
             });
         }
 
@@ -1301,6 +1176,140 @@ pub fn spawn_pyth_reference_feed(
             }
         }
     })
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct EquityPriceTick {
+    #[serde(default)]
+    symbol: String,
+    value: Decimal,
+    full_accuracy_value: Option<String>,
+    timestamp: i64,
+    received_at: Option<i64>,
+    #[serde(default)]
+    is_carried_forward: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct EquityPriceSnapshotPayload {
+    symbol: String,
+    data: Vec<EquityPriceTick>,
+}
+
+fn parse_equity_price_payload(value: &Value) -> Option<Vec<EquityPriceTick>> {
+    if value.get("topic")?.as_str()? != "equity_prices" {
+        return None;
+    }
+    let message_type = value.get("type")?.as_str()?;
+    let payload = value.get("payload")?.clone();
+    if matches!(message_type, "subscribe" | "snapshot") {
+        let snapshot: EquityPriceSnapshotPayload = serde_json::from_value(payload).ok()?;
+        return Some(
+            snapshot
+                .data
+                .into_iter()
+                .map(|mut point| {
+                    point.symbol.clone_from(&snapshot.symbol);
+                    point
+                })
+                .collect(),
+        );
+    }
+    if message_type == "update" {
+        return serde_json::from_value(payload).ok().map(|tick| vec![tick]);
+    }
+    None
+}
+
+fn equity_price_subscription(symbol: &str) -> Subscription {
+    let inner_filter = serde_json::json!({"symbol": symbol}).to_string();
+    let encoded_filter = serde_json::to_string(&inner_filter)
+        .expect("serializing an equity symbol filter cannot fail");
+    Subscription::builder()
+        .topic("equity_prices".to_owned())
+        .msg_type("*".to_owned())
+        .filters(encoded_filter)
+        .build()
+}
+
+async fn run_pyth_reference_worker(
+    tx: Arc<broadcast::Sender<MarketUpdate>>,
+    registry: ReferencePriceRegistry,
+    subscribe_symbol: String,
+    pool: Option<PgPool>,
+) {
+    let normalized_symbol = pyth_symbol(&subscribe_symbol);
+    let asset_class = infer_pyth_asset_class(&subscribe_symbol);
+    let mut message_count = 0_u64;
+    let client = RtdsClient::new(POLYMARKET_RTDS_WS_ENDPOINT, rtds_market_data_ws_config())
+        .expect("RTDS market-data config should be valid");
+    let subscription = equity_price_subscription(&subscribe_symbol);
+    let stream = match client.subscribe_raw(subscription) {
+        Ok(stream) => stream,
+        Err(error) => {
+            warn!(symbol = %subscribe_symbol, error = %error, "RTDS equity_prices subscribe failed");
+            return;
+        }
+    };
+    let mut stream = Box::pin(stream);
+
+    while let Some(message) = stream.next().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                warn!(symbol = %subscribe_symbol, error = %error, "RTDS equity_prices stream error");
+                continue;
+            }
+        };
+        let envelope = serde_json::json!({
+            "topic": message.topic,
+            "type": message.msg_type,
+            "timestamp": message.timestamp,
+            "payload": message.payload,
+        });
+        let Some(ticks) = parse_equity_price_payload(&envelope) else {
+            continue;
+        };
+        for tick in ticks {
+            let source_timestamp =
+                DateTime::from_timestamp_millis(tick.timestamp).unwrap_or_else(Utc::now);
+            let received_at = tick
+                .received_at
+                .and_then(DateTime::from_timestamp_millis)
+                .unwrap_or_else(Utc::now);
+            let snapshot = ReferencePriceSnapshot {
+                key: ReferencePriceKey {
+                    source: ReferencePriceSource::Pyth,
+                    symbol: normalize_reference_symbol(&tick.symbol),
+                },
+                asset_class,
+                value: tick.value,
+                full_accuracy_value: tick.full_accuracy_value,
+                source_timestamp,
+                received_at,
+                is_carried_forward: tick.is_carried_forward,
+            };
+            upsert_reference_price(&registry, snapshot.clone()).await;
+            if tx.send(reference_price_update(&snapshot)).is_err() {
+                return;
+            }
+            if let Some(ref db) = pool {
+                persist_reference_price(db, &snapshot).await;
+            }
+            message_count += 1;
+            if message_count == 1 || message_count % 100 == 0 {
+                info!(
+                    symbol = %normalized_symbol,
+                    source = %ReferencePriceSource::Pyth.as_str(),
+                    asset_class = %asset_class.as_str(),
+                    carried_forward = snapshot.is_carried_forward,
+                    count = message_count,
+                    "Pyth reference prices captured"
+                );
+            }
+        }
+    }
+    warn!(symbol = %subscribe_symbol, "RTDS equity_prices stream ended");
 }
 
 /// Persist a spot price tick to `binance_price_ticks` for backtest replay.
@@ -1469,8 +1478,9 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 #[cfg(test)]
 mod tests {
     use super::{
-        book_quote_from_rest, l2_updates_from_book, mark_db_event_expired_if_resolved,
-        parse_agg_trade_msg, rtds_market_data_ws_config, RestBook,
+        book_quote_from_rest, equity_price_subscription, l2_updates_from_book,
+        mark_db_event_expired_if_resolved, parse_agg_trade_msg, parse_equity_price_payload,
+        rtds_market_data_ws_config, RestBook,
     };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;
@@ -1486,6 +1496,55 @@ mod tests {
         assert_eq!(config.heartbeat_interval, Duration::from_secs(15));
         assert_eq!(config.heartbeat_timeout, Duration::from_secs(45));
         assert!(config.reconnect.max_attempts.is_none());
+    }
+
+    #[test]
+    fn parses_current_rtds_equity_update_and_snapshot_payloads() {
+        let update = parse_equity_price_payload(&json!({
+            "topic": "equity_prices",
+            "type": "update",
+            "timestamp": 1711382400000_i64,
+            "payload": {
+                "symbol": "aapl",
+                "value": 198.45,
+                "full_accuracy_value": "198.4523",
+                "timestamp": 1711382400000_i64,
+                "received_at": 1711382400005_i64
+            }
+        }))
+        .expect("current update envelope");
+        assert_eq!(update.len(), 1);
+        assert_eq!(update[0].symbol, "aapl");
+        assert_eq!(update[0].full_accuracy_value.as_deref(), Some("198.4523"));
+
+        let snapshot = parse_equity_price_payload(&json!({
+            "topic": "equity_prices",
+            "type": "subscribe",
+            "timestamp": 1711382400000_i64,
+            "payload": {
+                "symbol": "aapl",
+                "data": [{
+                    "value": 198.30,
+                    "full_accuracy_value": "198.3000",
+                    "timestamp": 1711382280000_i64,
+                    "received_at": 1711382280005_i64,
+                    "is_carried_forward": false
+                }]
+            }
+        }))
+        .expect("current snapshot envelope");
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].symbol, "aapl");
+        assert_eq!(snapshot[0].value, dec!(198.30));
+    }
+
+    #[test]
+    fn equity_subscription_preserves_the_server_string_filter_contract() {
+        let serialized = serde_json::to_value(equity_price_subscription("AAPL"))
+            .expect("serialize subscription");
+        assert_eq!(serialized["topic"], "equity_prices");
+        assert_eq!(serialized["type"], "*");
+        assert_eq!(serialized["filters"], r#"{"symbol":"AAPL"}"#);
     }
 
     #[test]

--- a/crates/ploy-market-data/src/gamma_keyset.rs
+++ b/crates/ploy-market-data/src/gamma_keyset.rs
@@ -1,0 +1,58 @@
+use polymarket_client_sdk::gamma::types::request::MarketsRequest;
+use polymarket_client_sdk::gamma::types::response::Market;
+use serde::Deserialize;
+
+const MARKETS_KEYSET_ENDPOINT: &str = "https://gamma-api.polymarket.com/markets/keyset";
+const MAX_PAGE_SIZE: i32 = 100;
+
+#[derive(Debug, Deserialize)]
+struct MarketPage {
+    markets: Vec<Market>,
+    next_cursor: Option<String>,
+}
+
+pub(crate) fn markets_keyset_url() -> &'static str {
+    MARKETS_KEYSET_ENDPOINT
+}
+
+pub(crate) async fn fetch_markets(
+    request: &MarketsRequest,
+    max_items: usize,
+) -> Result<Vec<Market>, reqwest::Error> {
+    let http = reqwest::Client::new();
+    let mut request = request.clone();
+    request.offset = None;
+    request.limit = Some(MAX_PAGE_SIZE.min(max_items.max(1) as i32));
+    let mut cursor: Option<String> = None;
+    let mut markets = Vec::with_capacity(max_items);
+
+    while markets.len() < max_items {
+        let mut call = http.get(markets_keyset_url()).query(&request);
+        if let Some(cursor) = cursor.as_deref() {
+            call = call.query(&[("after_cursor", cursor)]);
+        }
+        let page: MarketPage = call.send().await?.error_for_status()?.json().await?;
+        let page_len = page.markets.len();
+        markets.extend(page.markets.into_iter().take(max_items - markets.len()));
+        cursor = page.next_cursor.filter(|next| !next.is_empty());
+        if page_len < request.limit.unwrap_or(MAX_PAGE_SIZE) as usize || cursor.is_none() {
+            break;
+        }
+    }
+
+    Ok(markets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{markets_keyset_url, MAX_PAGE_SIZE};
+
+    #[test]
+    fn gamma_market_keyset_contract_uses_current_endpoint_and_limit() {
+        assert_eq!(
+            markets_keyset_url(),
+            "https://gamma-api.polymarket.com/markets/keyset"
+        );
+        assert_eq!(MAX_PAGE_SIZE, 100);
+    }
+}

--- a/crates/ploy-market-data/src/lib.rs
+++ b/crates/ploy-market-data/src/lib.rs
@@ -11,6 +11,8 @@ pub mod discovery;
 #[cfg(feature = "live")]
 pub mod feeds;
 #[cfg(feature = "live")]
+mod gamma_keyset;
+#[cfg(feature = "live")]
 pub mod pm_trades;
 #[cfg(feature = "live")]
 pub mod reference_prices;

--- a/crates/ploy-market-data/src/scanner.rs
+++ b/crates/ploy-market-data/src/scanner.rs
@@ -26,15 +26,15 @@ use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
 use crate::feeds::spawn_quote_feed_until;
+use crate::gamma_keyset::{fetch_markets, markets_keyset_url};
 use crate::reference_prices::{new_reference_price_registry, ReferencePriceRegistry};
 
 const SCAN_INTERVAL_SECS: u64 = 30;
 const SPORTS_DISCOVERY_REFRESH_SECS: i64 = 300;
 const SPORTS_DISCOVERY_LIMIT: i32 = 500;
 const DEFAULT_DISCOVERY_LOOKAHEAD_MINUTES: i64 = 20;
-const CRYPTO_MARKET_CATEGORY: &str = "Crypto";
 const CRYPTO_DISCOVERY_PAGE_LIMIT: i32 = 100;
-const CRYPTO_DISCOVERY_MAX_PAGES: i32 = 12;
+const CRYPTO_DISCOVERY_MAX_MARKETS: usize = 1_200;
 const QUOTE_FEED_GRACE_SECS: i64 = 90;
 /// How far back to look for open positions that need recovery on startup.
 const RECOVERY_LOOKBACK_HOURS: i64 = 48;
@@ -167,14 +167,9 @@ pub fn spawn_market_scanner(
 
             expire_tracked_events(&tx, &mut tracked, pool.as_ref(), now).await;
 
-            let mut request = MarketsRequest::default();
-            request.end_date_min = Some(now);
-            request.end_date_max = Some(now + Duration::minutes(6));
-            request.category = Some(CRYPTO_MARKET_CATEGORY.to_string());
-            request.closed = Some(false);
-            request.limit = Some(100);
+            let request = crypto_markets_request(now, 6);
 
-            match client.markets(&request).await {
+            match fetch_markets(&request, CRYPTO_DISCOVERY_MAX_MARKETS).await {
                 Ok(markets) => {
                     let mut new_tokens: Vec<U256> = Vec::new();
                     let mut quote_stop_at: Option<DateTime<Utc>> = None;
@@ -610,55 +605,34 @@ fn should_refresh_sports_catalog(
 }
 
 async fn refresh_crypto_catalog(
-    client: &GammaClient,
+    _client: &GammaClient,
     pool: &PgPool,
     reference_prices: &ReferencePriceRegistry,
     symbols: &[String],
     now: DateTime<Utc>,
     lookahead_minutes: i64,
 ) -> usize {
-    let mut discovered_count = 0;
-
-    for page in 0..CRYPTO_DISCOVERY_MAX_PAGES {
-        let request = crypto_markets_request(now, lookahead_minutes, page);
-
-        match client.markets(&request).await {
-            Ok(markets) => {
-                if markets.is_empty() {
-                    break;
-                }
-
-                let discovered =
-                    discover_crypto_markets(&markets, symbols, reference_prices, now).await;
-                for market in &discovered {
-                    persist_discovered_crypto_market(Some(pool), market).await;
-                }
-                discovered_count += discovered.len();
-
-                if markets.len() < CRYPTO_DISCOVERY_PAGE_LIMIT as usize {
-                    break;
-                }
+    let request = crypto_markets_request(now, lookahead_minutes);
+    match fetch_markets(&request, CRYPTO_DISCOVERY_MAX_MARKETS).await {
+        Ok(markets) => {
+            let discovered =
+                discover_crypto_markets(&markets, symbols, reference_prices, now).await;
+            for market in &discovered {
+                persist_discovered_crypto_market(Some(pool), market).await;
             }
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    page,
-                    "Gamma markets query failed during catalog refresh"
-                );
-                break;
-            }
+            discovered.len()
+        }
+        Err(error) => {
+            warn!(error = %error, "Gamma markets keyset query failed during catalog refresh");
+            0
         }
     }
-
-    discovered_count
 }
 
-fn crypto_markets_request(now: DateTime<Utc>, lookahead_minutes: i64, page: i32) -> MarketsRequest {
+fn crypto_markets_request(now: DateTime<Utc>, lookahead_minutes: i64) -> MarketsRequest {
     let mut request = MarketsRequest::default();
     request.end_date_min = Some(now - Duration::minutes(1));
     request.end_date_max = Some(now + Duration::minutes(lookahead_minutes));
-    request.offset = Some(page * CRYPTO_DISCOVERY_PAGE_LIMIT);
-    request.category = Some(CRYPTO_MARKET_CATEGORY.to_string());
     request.closed = Some(false);
     request.limit = Some(CRYPTO_DISCOVERY_PAGE_LIMIT);
     request
@@ -783,9 +757,8 @@ mod tests {
     use polymarket_client_sdk::ToQueryParams;
 
     use super::{
-        crypto_markets_request, extend_quote_feed_stop_at, parse_token_id, quote_feed_deadline,
-        should_refresh_sports_catalog, MarketDiscoveryCollectorConfig, CRYPTO_DISCOVERY_PAGE_LIMIT,
-        CRYPTO_MARKET_CATEGORY,
+        crypto_markets_request, extend_quote_feed_stop_at, markets_keyset_url, parse_token_id,
+        quote_feed_deadline, should_refresh_sports_catalog, MarketDiscoveryCollectorConfig,
     };
 
     #[test]
@@ -843,15 +816,17 @@ mod tests {
     }
 
     #[test]
-    fn crypto_catalog_request_filters_gamma_to_crypto_category() {
+    fn crypto_catalog_request_uses_gamma_keyset_pagination() {
         let now = Utc.with_ymd_and_hms(2026, 5, 17, 13, 30, 0).unwrap();
-        let request = crypto_markets_request(now, 20, 5);
+        let request = crypto_markets_request(now, 20);
         let query = request.query_params(None);
 
-        assert_eq!(request.category.as_deref(), Some(CRYPTO_MARKET_CATEGORY));
-        assert!(query.contains("category=Crypto"));
-        assert_eq!(request.offset, Some(5 * CRYPTO_DISCOVERY_PAGE_LIMIT));
-        assert!(query.contains("offset=500"));
+        assert_eq!(
+            markets_keyset_url(),
+            "https://gamma-api.polymarket.com/markets/keyset"
+        );
+        assert_eq!(request.offset, None);
+        assert!(!query.contains("offset="));
         assert!(query.contains("closed=false"));
         assert!(query.contains("limit=100"));
     }

--- a/crates/ploy-market-data/src/scanner.rs
+++ b/crates/ploy-market-data/src/scanner.rs
@@ -26,7 +26,7 @@ use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
 use crate::feeds::spawn_quote_feed_until;
-use crate::gamma_keyset::{fetch_markets, markets_keyset_url};
+use crate::gamma_keyset::fetch_markets;
 use crate::reference_prices::{new_reference_price_registry, ReferencePriceRegistry};
 
 const SCAN_INTERVAL_SECS: u64 = 30;
@@ -756,9 +756,11 @@ mod tests {
     use chrono::{Duration, TimeZone, Utc};
     use polymarket_client_sdk::ToQueryParams;
 
+    use crate::gamma_keyset::markets_keyset_url;
+
     use super::{
-        crypto_markets_request, extend_quote_feed_stop_at, markets_keyset_url, parse_token_id,
-        quote_feed_deadline, should_refresh_sports_catalog, MarketDiscoveryCollectorConfig,
+        crypto_markets_request, extend_quote_feed_stop_at, parse_token_id, quote_feed_deadline,
+        should_refresh_sports_catalog, MarketDiscoveryCollectorConfig,
     };
 
     #[test]

--- a/tools/sdk_auth_check/Cargo.toml
+++ b/tools/sdk_auth_check/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 alloy = { version = "1", default-features = false, features = ["signer-local"] }
-polymarket-client-sdk = { version = "0.4", features = ["clob"] }
+polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob"] }


### PR DESCRIPTION
## Summary
- replace active vendored V1 SDK dependency with official `polymarket_client_sdk_v2 = 0.6.0`
- migrate Gamma discovery to `/markets/keyset` cursor pagination
- preserve CLOB/Data feeds and rebuild current RTDS equity subscriptions on the official raw subscription API

## Verification
- `cargo test -p ploy-market-data --features live --lib` (47 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

No host deployment or live trading action is performed by this PR.