### PR TITLE
feat(market-data): collect public CEX signals

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -57,6 +57,7 @@ env:
     046_factor_registry_blockers.sql
     047_full_depth_execution_surfaces.sql
     048_official_settlement_coverage_checks.sql
+    049_cex_public_market_data.sql
 
 jobs:
   build-and-deploy:
@@ -225,6 +226,7 @@ jobs:
           cp deployment/systemd/ploy-binance-price-collector.service dist/deployment/systemd/ploy-binance-price-collector.service
           cp deployment/systemd/ploy-deribit-iv-collector.service dist/deployment/systemd/ploy-deribit-iv-collector.service
           cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
+          cp deployment/systemd/ploy-cex-public-collector.service dist/deployment/systemd/ploy-cex-public-collector.service
           cp deployment/systemd/ploy-market-discovery.service dist/deployment/systemd/ploy-market-discovery.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
           cp deployment/systemd/ploy-polymarket-v2-indexer-import.service dist/deployment/systemd/ploy-polymarket-v2-indexer-import.service
@@ -405,7 +407,7 @@ jobs:
             echo "- Target: \`${{ secrets.TANGO_1_1_HOST }}\`"
             echo "- Transport: \`GitHub Actions -> OSS -> SSH, fallback Cloud Assistant\`"
             echo "- OSS object: \`${{ steps.upload_bundle_to_oss.outputs.bundle_object }}\`"
-            echo "- Services: \`ployd\` (if installed), \`ploy-binance-aggtrade-collector\`, \`ploy-binance-price-collector\`, \`ploy-binance-lob-collector\`, \`ploy-deribit-iv-collector\`, \`ploy-market-discovery\`, \`ploy-quote-collector\`, \`ploy-pm-trade-collector\`"
+            echo "- Services: \`ployd\` (if installed), existing collectors, and \`ploy-cex-public-collector\`"
             echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
             echo "- Migrations: \`${DEPLOY_MIGRATIONS}\`"
             echo "- Postgres pre/postflight: required"

--- a/.github/workflows/healthcheck-tango-1-1.yml
+++ b/.github/workflows/healthcheck-tango-1-1.yml
@@ -158,6 +158,11 @@ jobs:
               echo "Binance futures public data has not advanced within the last 5 minutes" >&2
               exit 1
             fi
+            if [ "$(PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
+              "SELECT NOT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE kind = 'derivatives_snapshot' AND received_at < NOW() - INTERVAL '30 minutes') OR EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE kind = 'liquidation' AND event_time >= NOW() - INTERVAL '24 hours')")" != "t" ]; then
+              echo "Binance force-order stream has produced no liquidation data after its startup grace period" >&2
+              exit 1
+            fi
             for cex in okx bybit coinbase kraken; do
               if [ "$(PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
                 "SELECT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE exchange = '${cex}' AND kind = 'lob' AND event_time >= NOW() - INTERVAL '5 minutes')")" != "t" ]; then

--- a/.github/workflows/healthcheck-tango-1-1.yml
+++ b/.github/workflows/healthcheck-tango-1-1.yml
@@ -107,6 +107,7 @@ jobs:
             systemctl is-active --quiet ploy-binance-lob-collector.service
             systemctl is-active --quiet ploy-deribit-iv-collector.service
             systemctl is-active --quiet ploy-deribit-greeks-collector.service
+            systemctl is-active --quiet ploy-cex-public-collector.service
             systemctl is-active --quiet ployd.service
             systemctl is-active --quiet ploy-quote-collector.service
             if service_exists ploy-pm-trade-collector.service; then
@@ -114,6 +115,7 @@ jobs:
             fi
             require_service_guardrails ploy-binance-lob-collector.service
             require_service_guardrails ploy-deribit-greeks-collector.service
+            require_service_guardrails ploy-cex-public-collector.service
             require_service_guardrails ployd.service
             require_service_guardrails ploy-quote-collector.service
             if service_exists ploy-pm-trade-collector.service; then
@@ -151,6 +153,18 @@ jobs:
               echo "deribit_atm_greeks_ticks has not advanced within the last 15 minutes" >&2
               exit 1
             fi
+            if [ "$(PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
+              "SELECT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE kind = 'derivatives_snapshot' AND event_time >= NOW() - INTERVAL '5 minutes')")" != "t" ]; then
+              echo "Binance futures public data has not advanced within the last 5 minutes" >&2
+              exit 1
+            fi
+            for cex in okx bybit coinbase kraken; do
+              if [ "$(PGPASSWORD=postgres psql -h localhost -U postgres -d ploy -Atqc \
+                "SELECT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE exchange = '${cex}' AND kind = 'lob' AND event_time >= NOW() - INTERVAL '5 minutes')")" != "t" ]; then
+                echo "${cex} L2 public data has not advanced within the last 5 minutes" >&2
+                exit 1
+              fi
+            done
             if journalctl -u ploy-binance-price-collector.service --since '15 minutes ago' --no-pager \
               | grep -qE "uq_binance_price_ticks_symbol_second|duplicate key value"; then
               echo "binance price collector still reports duplicate-write churn" >&2
@@ -212,6 +226,7 @@ jobs:
             echo "lob=$(systemctl show -P ActiveState ploy-binance-lob-collector.service)"
             echo "deribit=$(systemctl show -P ActiveState ploy-deribit-iv-collector.service)"
             echo "deribit_greeks=$(systemctl show -P ActiveState ploy-deribit-greeks-collector.service)"
+            echo "cex_public=$(systemctl show -P ActiveState ploy-cex-public-collector.service)"
             echo "ployd=$(systemctl show -P ActiveState ployd.service)"
             echo "collector=$(systemctl show -P ActiveState ploy-quote-collector.service)"
             if service_exists ploy-pm-trade-collector.service; then
@@ -230,12 +245,13 @@ jobs:
           {
             echo "## tango-1-1 healthcheck"
             echo "- PostgreSQL must be active and queryable"
-            echo "- ployd, ploy-binance-aggtrade-collector, ploy-binance-price-collector, ploy-binance-lob-collector, ploy-deribit-iv-collector, ploy-quote-collector, and installed pm trade collector services must be active"
+            echo "- ployd, existing collectors, and ploy-cex-public-collector must be active"
             echo "- systemd guardrails must remain configured on all checked services"
             echo "- binance_agg_trade_ticks must advance within the last 10 minutes"
             echo "- binance_price_ticks must advance within the last 10 minutes"
             echo "- binance_lob_ticks must advance within the last 15 minutes"
             echo "- deribit_iv_ticks must advance within the last 15 minutes"
             echo "- deribit_atm_greeks_ticks must advance within the last 15 minutes"
+            echo "- Binance Futures and OKX/Bybit/Coinbase/Kraken public rows must advance within the last 5 minutes"
             echo "- ployd must not log degraded persistence messages in the last 15 minutes"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,6 +5319,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5309,6 +5309,7 @@ name = "ploy-market-data"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "crc32fast",
  "futures",
  "ploy-market-contracts",
  "polymarket-client-sdk",

--- a/crates/ploy-market-data/Cargo.toml
+++ b/crates/ploy-market-data/Cargo.toml
@@ -10,6 +10,7 @@ description = "Market-data collection, discovery, and scanning infrastructure fo
 [features]
 default = []
 live = [
+    "dep:crc32fast",
     "dep:futures",
     "dep:polymarket-client-sdk",
     "dep:reqwest",
@@ -19,6 +20,7 @@ live = [
 
 [dependencies]
 chrono.workspace = true
+crc32fast = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
 ploy-market-contracts.workspace = true
 polymarket-client-sdk = { path = "../../vendor/polymarket-client-sdk", features = ["clob", "data", "gamma", "rtds", "tracing", "ws", "heartbeats"], optional = true }
@@ -26,7 +28,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "chrono", "rust_decimal", "json"], optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-native-roots"], optional = true }

--- a/crates/ploy-market-data/Cargo.toml
+++ b/crates/ploy-market-data/Cargo.toml
@@ -33,6 +33,7 @@ sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "chro
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-native-roots"], optional = true }
 tracing.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true

--- a/crates/ploy-market-data/src/cex_collectors.rs
+++ b/crates/ploy-market-data/src/cex_collectors.rs
@@ -20,6 +20,26 @@ const BYBIT_WS: &str = "wss://stream.bybit.com/v5/public/spot";
 const COINBASE_WS: &str = "wss://advanced-trade-ws.coinbase.com";
 const KRAKEN_WS: &str = "wss://ws.kraken.com/v2";
 
+#[derive(Debug, thiserror::Error)]
+pub enum CexCollectorError {
+    #[error("invalid CEX payload: {0}")]
+    InvalidPayload(String),
+    #[error("CEX HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("CEX WebSocket failed: {0}")]
+    WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+    #[error("CEX JSON payload failed: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("CEX database write failed: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+type Result<T> = std::result::Result<T, CexCollectorError>;
+
+fn invalid(message: impl Into<String>) -> CexCollectorError {
+    CexCollectorError::InvalidPayload(message.into())
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct NormalizedTick {
     pub exchange: String,
@@ -60,10 +80,10 @@ pub fn normalize_binance_futures(
     premium: &Value,
     open_interest: &Value,
     basis: Option<&Value>,
-) -> Result<NormalizedTick, String> {
+) -> Result<NormalizedTick> {
     let symbol = required_str(premium, "symbol")?.to_uppercase();
     if open_interest["symbol"].as_str() != Some(symbol.as_str()) {
-        return Err("Binance futures symbol mismatch".to_string());
+        return Err(invalid("Binance futures symbol mismatch"));
     }
     let event_ms = required_i64(premium, "time")?;
     let basis_row = basis
@@ -108,16 +128,16 @@ pub fn normalize_binance_futures(
     })
 }
 
-pub fn normalize_binance_liquidation(message: &Value) -> Result<NormalizedTick, String> {
+pub fn normalize_binance_liquidation(message: &Value) -> Result<NormalizedTick> {
     let data = message.get("data").unwrap_or(message);
     let order = data
         .get("o")
-        .ok_or_else(|| "Binance liquidation missing order".to_string())?;
+        .ok_or_else(|| invalid("Binance liquidation missing order"))?;
     let symbol = required_str(order, "s")?.to_uppercase();
     let event_ms = order["T"]
         .as_i64()
         .or_else(|| data["E"].as_i64())
-        .ok_or_else(|| "Binance liquidation missing event time".to_string())?;
+        .ok_or_else(|| invalid("Binance liquidation missing event time"))?;
     let side = required_str(order, "S")?.to_uppercase();
     let price = decimal_field(order, "ap").or_else(|| decimal_field(order, "p"));
     let quantity = decimal_field(order, "z").or_else(|| decimal_field(order, "q"));
@@ -161,17 +181,17 @@ pub fn normalize_binance_liquidation(message: &Value) -> Result<NormalizedTick, 
     })
 }
 
-fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
     value[field]
         .as_str()
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| format!("missing {field}"))
+        .ok_or_else(|| invalid(format!("missing {field}")))
 }
 
-fn required_i64(value: &Value, field: &str) -> Result<i64, String> {
+fn required_i64(value: &Value, field: &str) -> Result<i64> {
     value[field]
         .as_i64()
-        .ok_or_else(|| format!("missing {field}"))
+        .ok_or_else(|| invalid(format!("missing {field}")))
 }
 
 fn decimal(value: &Value) -> Option<Decimal> {
@@ -187,13 +207,13 @@ fn decimal_field(value: &Value, field: &str) -> Option<Decimal> {
     decimal(&value[field])
 }
 
-fn ms_to_utc(ms: i64) -> Result<DateTime<Utc>, String> {
+fn ms_to_utc(ms: i64) -> Result<DateTime<Utc>> {
     Utc.timestamp_millis_opt(ms)
         .single()
-        .ok_or_else(|| format!("invalid millisecond timestamp {ms}"))
+        .ok_or_else(|| invalid(format!("invalid millisecond timestamp {ms}")))
 }
 
-fn parse_time(value: &Value) -> Result<DateTime<Utc>, String> {
+fn parse_time(value: &Value) -> Result<DateTime<Utc>> {
     if let Some(ms) = value.as_i64() {
         return ms_to_utc(ms);
     }
@@ -203,9 +223,9 @@ fn parse_time(value: &Value) -> Result<DateTime<Utc>, String> {
         }
         return DateTime::parse_from_rfc3339(raw)
             .map(|value| value.with_timezone(&Utc))
-            .map_err(|error| error.to_string());
+            .map_err(|error| invalid(error.to_string()));
     }
-    Err("missing event timestamp".to_string())
+    Err(invalid("missing event timestamp"))
 }
 
 #[derive(Debug)]
@@ -230,13 +250,13 @@ impl CexBook {
         }
     }
 
-    pub fn apply_message(&mut self, _message: &Value) -> Result<Option<NormalizedTick>, String> {
+    pub fn apply_message(&mut self, _message: &Value) -> Result<Option<NormalizedTick>> {
         let update = match self.exchange.as_str() {
             "okx" => parse_okx(_message)?,
             "bybit" => parse_bybit(_message)?,
             "coinbase" => parse_coinbase(_message, &self.exchange_symbol)?,
             "kraken" => parse_kraken(_message)?,
-            other => return Err(format!("unsupported CEX book exchange {other}")),
+            other => return Err(invalid(format!("unsupported CEX book exchange {other}"))),
         };
         let Some(update) = update else {
             return Ok(None);
@@ -265,9 +285,9 @@ impl CexBook {
                 if actual != expected {
                     self.bids.clear();
                     self.asks.clear();
-                    return Err(format!(
+                    return Err(invalid(format!(
                         "Kraken L2 checksum mismatch: expected={expected} actual={actual}"
-                    ));
+                    )));
                 }
             }
         }
@@ -404,7 +424,7 @@ fn truncate_book(
     }
 }
 
-fn parse_okx(message: &Value) -> Result<Option<BookUpdate>, String> {
+fn parse_okx(message: &Value) -> Result<Option<BookUpdate>> {
     let Some(data) = message["data"].as_array().and_then(|rows| rows.first()) else {
         return Ok(None);
     };
@@ -421,7 +441,7 @@ fn parse_okx(message: &Value) -> Result<Option<BookUpdate>, String> {
     }))
 }
 
-fn parse_bybit(message: &Value) -> Result<Option<BookUpdate>, String> {
+fn parse_bybit(message: &Value) -> Result<Option<BookUpdate>> {
     if message["data"].is_null() {
         return Ok(None);
     }
@@ -439,7 +459,7 @@ fn parse_bybit(message: &Value) -> Result<Option<BookUpdate>, String> {
     }))
 }
 
-fn parse_coinbase(message: &Value, exchange_symbol: &str) -> Result<Option<BookUpdate>, String> {
+fn parse_coinbase(message: &Value, exchange_symbol: &str) -> Result<Option<BookUpdate>> {
     if message["channel"].as_str() != Some("l2_data") {
         return Ok(None);
     }
@@ -475,7 +495,7 @@ fn parse_coinbase(message: &Value, exchange_symbol: &str) -> Result<Option<BookU
     }))
 }
 
-fn parse_kraken(message: &Value) -> Result<Option<BookUpdate>, String> {
+fn parse_kraken(message: &Value) -> Result<Option<BookUpdate>> {
     if message["channel"].as_str() != Some("book") {
         return Ok(None);
     }
@@ -607,27 +627,18 @@ async fn run_binance_futures(
     }
 }
 
-async fn fetch_binance_futures(
-    client: &reqwest::Client,
-    symbol: &str,
-) -> Result<NormalizedTick, String> {
-    async fn get(
-        client: &reqwest::Client,
-        path: &str,
-        query: &[(&str, &str)],
-    ) -> Result<Value, String> {
+async fn fetch_binance_futures(client: &reqwest::Client, symbol: &str) -> Result<NormalizedTick> {
+    async fn get(client: &reqwest::Client, path: &str, query: &[(&str, &str)]) -> Result<Value> {
         client
             .get(format!("{BINANCE_FUTURES_REST}{path}"))
             .query(query)
             .timeout(Duration::from_secs(15))
             .send()
-            .await
-            .map_err(|error| error.to_string())?
-            .error_for_status()
-            .map_err(|error| error.to_string())?
+            .await?
+            .error_for_status()?
             .json()
             .await
-            .map_err(|error| error.to_string())
+            .map_err(CexCollectorError::from)
     }
     let premium = get(client, "/fapi/v1/premiumIndex", &[("symbol", symbol)]).await?;
     let open_interest = get(client, "/fapi/v1/openInterest", &[("symbol", symbol)]).await?;
@@ -652,37 +663,28 @@ async fn run_binance_liquidations(pool: PgPool, assets: Vec<String>, running: Ar
         .collect();
     while running.load(Ordering::SeqCst) {
         let result = async {
-            let (socket, _) = connect_async(BINANCE_FUTURES_WS)
-                .await
-                .map_err(|error| error.to_string())?;
+            let stream_url = format!("{BINANCE_FUTURES_WS}?streams={}", streams.join("/"));
+            let (socket, _) = connect_async(stream_url).await?;
             let (mut write, mut read) = socket.split();
-            write
-                .send(Message::Text(
-                    serde_json::json!({"method":"SUBSCRIBE","params":streams,"id":1})
-                        .to_string()
-                        .into(),
-                ))
-                .await
-                .map_err(|error| error.to_string())?;
             while running.load(Ordering::SeqCst) {
                 let Some(message) = read.next().await else {
                     break;
                 };
-                match message.map_err(|error| error.to_string())? {
+                match message? {
                     Message::Text(text) => {
-                        let raw: Value =
-                            serde_json::from_str(&text).map_err(|error| error.to_string())?;
+                        let raw: Value = serde_json::from_str(&text)?;
                         if raw.get("result").is_some() {
                             continue;
                         }
                         let tick = normalize_binance_liquidation(&raw)?;
                         persist_tick(&pool, &tick).await?;
                     }
+                    Message::Ping(payload) => write.send(Message::Pong(payload)).await?,
                     Message::Close(_) => break,
                     _ => {}
                 }
             }
-            Ok::<(), String>(())
+            Ok::<(), CexCollectorError>(())
         }
         .await;
         if let Err(error) = result {
@@ -732,27 +734,24 @@ async fn run_book_connection(
     assets: &[String],
     sample_ms: u64,
     running: &Arc<AtomicBool>,
-) -> Result<(), String> {
+) -> Result<()> {
     let url = match exchange {
         "okx" => OKX_WS,
         "bybit" => BYBIT_WS,
         "coinbase" => COINBASE_WS,
         "kraken" => KRAKEN_WS,
-        _ => return Err(format!("unsupported exchange {exchange}")),
+        _ => return Err(invalid(format!("unsupported exchange {exchange}"))),
     };
     let exchange_symbols: Vec<String> = assets
         .iter()
         .map(|asset| exchange_symbol(exchange, asset))
         .collect();
-    let (socket, _) = connect_async(url)
-        .await
-        .map_err(|error| error.to_string())?;
+    let (socket, _) = connect_async(url).await?;
     let (mut write, mut read) = socket.split();
     for subscription in subscriptions(exchange, &exchange_symbols) {
         write
             .send(Message::Text(subscription.to_string().into()))
-            .await
-            .map_err(|error| error.to_string())?;
+            .await?;
     }
     let mut books: HashMap<String, CexBook> = assets
         .iter()
@@ -775,15 +774,15 @@ async fn run_book_connection(
         tokio::select! {
             _ = heartbeat.tick() => {
                 if let Some(ping) = heartbeat_message(exchange) {
-                    write.send(ping).await.map_err(|error| error.to_string())?;
+                    write.send(ping).await?;
                 }
             }
             message = read.next() => {
                 let Some(message) = message else { break };
-                match message.map_err(|error| error.to_string())? {
+                match message? {
                     Message::Text(text) => {
                         if text.as_str() == "pong" { continue }
-                        let raw: Value = serde_json::from_str(&text).map_err(|error| error.to_string())?;
+                        let raw: Value = serde_json::from_str(&text)?;
                         for (symbol, book) in &mut books {
                             if let Some(tick) = book.apply_message(&raw)? {
                                 let due = last_persisted.get(symbol)
@@ -796,7 +795,7 @@ async fn run_book_connection(
                             }
                         }
                     }
-                    Message::Ping(payload) => write.send(Message::Pong(payload)).await.map_err(|error| error.to_string())?,
+                    Message::Ping(payload) => write.send(Message::Pong(payload)).await?,
                     Message::Close(_) => break,
                     _ => {}
                 }
@@ -838,7 +837,7 @@ fn heartbeat_message(exchange: &str) -> Option<Message> {
     }
 }
 
-async fn persist_tick(pool: &PgPool, tick: &NormalizedTick) -> Result<(), String> {
+async fn persist_tick(pool: &PgPool, tick: &NormalizedTick) -> Result<()> {
     sqlx::query(
         r#"INSERT INTO cex_public_market_ticks (
             exchange, market_type, symbol, exchange_symbol, kind, event_time,
@@ -885,8 +884,7 @@ async fn persist_tick(pool: &PgPool, tick: &NormalizedTick) -> Result<(), String
     .bind(&tick.dedupe_key)
     .bind(&tick.raw)
     .execute(pool)
-    .await
-    .map_err(|error| error.to_string())?;
+    .await?;
     Ok(())
 }
 

--- a/crates/ploy-market-data/src/cex_collectors.rs
+++ b/crates/ploy-market-data/src/cex_collectors.rs
@@ -1,0 +1,977 @@
+//! Public CEX market-data normalization and collection.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, TimeZone, Utc};
+use futures::{SinkExt, StreamExt};
+use rust_decimal::Decimal;
+use serde_json::Value;
+use sqlx::PgPool;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{error, info, warn};
+
+const BINANCE_FUTURES_REST: &str = "https://fapi.binance.com";
+const BINANCE_FUTURES_WS: &str = "wss://fstream.binance.com/stream";
+const OKX_WS: &str = "wss://ws.okx.com:8443/ws/v5/public";
+const BYBIT_WS: &str = "wss://stream.bybit.com/v5/public/spot";
+const COINBASE_WS: &str = "wss://advanced-trade-ws.coinbase.com";
+const KRAKEN_WS: &str = "wss://ws.kraken.com/v2";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NormalizedTick {
+    pub exchange: String,
+    pub market_type: String,
+    pub symbol: String,
+    pub exchange_symbol: String,
+    pub kind: String,
+    pub event_time: DateTime<Utc>,
+    pub update_id: Option<i64>,
+    pub sequence_id: Option<i64>,
+    pub mark_price: Option<Decimal>,
+    pub index_price: Option<Decimal>,
+    pub funding_rate: Option<Decimal>,
+    pub open_interest: Option<Decimal>,
+    pub basis: Option<Decimal>,
+    pub basis_rate: Option<Decimal>,
+    pub annualized_basis_rate: Option<Decimal>,
+    pub next_funding_time: Option<DateTime<Utc>>,
+    pub side: Option<String>,
+    pub price: Option<Decimal>,
+    pub quantity: Option<Decimal>,
+    pub best_bid: Option<Decimal>,
+    pub best_ask: Option<Decimal>,
+    pub mid_price: Option<Decimal>,
+    pub spread_bps: Option<Decimal>,
+    pub obi_5: Option<Decimal>,
+    pub obi_10: Option<Decimal>,
+    pub bid_volume_5: Option<Decimal>,
+    pub ask_volume_5: Option<Decimal>,
+    pub bids: Option<Value>,
+    pub asks: Option<Value>,
+    pub source: String,
+    pub dedupe_key: String,
+    pub raw: Value,
+}
+
+pub fn normalize_binance_futures(
+    premium: &Value,
+    open_interest: &Value,
+    basis: Option<&Value>,
+) -> Result<NormalizedTick, String> {
+    let symbol = required_str(premium, "symbol")?.to_uppercase();
+    if open_interest["symbol"].as_str() != Some(symbol.as_str()) {
+        return Err("Binance futures symbol mismatch".to_string());
+    }
+    let event_ms = required_i64(premium, "time")?;
+    let basis_row = basis
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first());
+    Ok(NormalizedTick {
+        exchange: "binance".to_string(),
+        market_type: "perpetual".to_string(),
+        symbol: symbol.clone(),
+        exchange_symbol: symbol,
+        kind: "derivatives_snapshot".to_string(),
+        event_time: ms_to_utc(event_ms)?,
+        update_id: None,
+        sequence_id: None,
+        mark_price: decimal_field(premium, "markPrice"),
+        index_price: decimal_field(premium, "indexPrice"),
+        funding_rate: decimal_field(premium, "lastFundingRate"),
+        open_interest: decimal_field(open_interest, "openInterest"),
+        basis: basis_row.and_then(|row| decimal_field(row, "basis")),
+        basis_rate: basis_row.and_then(|row| decimal_field(row, "basisRate")),
+        annualized_basis_rate: basis_row.and_then(|row| decimal_field(row, "annualizedBasisRate")),
+        next_funding_time: premium["nextFundingTime"]
+            .as_i64()
+            .map(ms_to_utc)
+            .transpose()?,
+        side: None,
+        price: None,
+        quantity: None,
+        best_bid: None,
+        best_ask: None,
+        mid_price: None,
+        spread_bps: None,
+        obi_5: None,
+        obi_10: None,
+        bid_volume_5: None,
+        ask_volume_5: None,
+        bids: None,
+        asks: None,
+        source: "binance_futures_rest".to_string(),
+        dedupe_key: event_ms.to_string(),
+        raw: serde_json::json!({"premium": premium, "open_interest": open_interest, "basis": basis_row}),
+    })
+}
+
+pub fn normalize_binance_liquidation(message: &Value) -> Result<NormalizedTick, String> {
+    let data = message.get("data").unwrap_or(message);
+    let order = data
+        .get("o")
+        .ok_or_else(|| "Binance liquidation missing order".to_string())?;
+    let symbol = required_str(order, "s")?.to_uppercase();
+    let event_ms = order["T"]
+        .as_i64()
+        .or_else(|| data["E"].as_i64())
+        .ok_or_else(|| "Binance liquidation missing event time".to_string())?;
+    let side = required_str(order, "S")?.to_uppercase();
+    let price = decimal_field(order, "ap").or_else(|| decimal_field(order, "p"));
+    let quantity = decimal_field(order, "z").or_else(|| decimal_field(order, "q"));
+    Ok(NormalizedTick {
+        exchange: "binance".to_string(),
+        market_type: "perpetual".to_string(),
+        symbol: symbol.clone(),
+        exchange_symbol: symbol.clone(),
+        kind: "liquidation".to_string(),
+        event_time: ms_to_utc(event_ms)?,
+        update_id: None,
+        sequence_id: None,
+        mark_price: None,
+        index_price: None,
+        funding_rate: None,
+        open_interest: None,
+        basis: None,
+        basis_rate: None,
+        annualized_basis_rate: None,
+        next_funding_time: None,
+        side: Some(side.clone()),
+        price,
+        quantity,
+        best_bid: None,
+        best_ask: None,
+        mid_price: None,
+        spread_bps: None,
+        obi_5: None,
+        obi_10: None,
+        bid_volume_5: None,
+        ask_volume_5: None,
+        bids: None,
+        asks: None,
+        source: "binance_force_order_ws".to_string(),
+        dedupe_key: format!(
+            "{symbol}:{event_ms}:{side}:{}:{}",
+            price.unwrap_or_default(),
+            quantity.unwrap_or_default()
+        ),
+        raw: message.clone(),
+    })
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
+    value[field]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("missing {field}"))
+}
+
+fn required_i64(value: &Value, field: &str) -> Result<i64, String> {
+    value[field]
+        .as_i64()
+        .ok_or_else(|| format!("missing {field}"))
+}
+
+fn decimal(value: &Value) -> Option<Decimal> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| value.as_number().map(ToString::to_string))?
+        .parse()
+        .ok()
+}
+
+fn decimal_field(value: &Value, field: &str) -> Option<Decimal> {
+    decimal(&value[field])
+}
+
+fn ms_to_utc(ms: i64) -> Result<DateTime<Utc>, String> {
+    Utc.timestamp_millis_opt(ms)
+        .single()
+        .ok_or_else(|| format!("invalid millisecond timestamp {ms}"))
+}
+
+fn parse_time(value: &Value) -> Result<DateTime<Utc>, String> {
+    if let Some(ms) = value.as_i64() {
+        return ms_to_utc(ms);
+    }
+    if let Some(raw) = value.as_str() {
+        if let Ok(ms) = raw.parse::<i64>() {
+            return ms_to_utc(ms);
+        }
+        return DateTime::parse_from_rfc3339(raw)
+            .map(|value| value.with_timezone(&Utc))
+            .map_err(|error| error.to_string());
+    }
+    Err("missing event timestamp".to_string())
+}
+
+#[derive(Debug)]
+pub struct CexBook {
+    exchange: String,
+    market_type: String,
+    symbol: String,
+    exchange_symbol: String,
+    bids: BTreeMap<Decimal, Decimal>,
+    asks: BTreeMap<Decimal, Decimal>,
+}
+
+impl CexBook {
+    pub fn new(exchange: &str, market_type: &str, symbol: &str, exchange_symbol: &str) -> Self {
+        Self {
+            exchange: exchange.to_string(),
+            market_type: market_type.to_string(),
+            symbol: symbol.to_string(),
+            exchange_symbol: exchange_symbol.to_string(),
+            bids: BTreeMap::new(),
+            asks: BTreeMap::new(),
+        }
+    }
+
+    pub fn apply_message(&mut self, _message: &Value) -> Result<Option<NormalizedTick>, String> {
+        let update = match self.exchange.as_str() {
+            "okx" => parse_okx(_message)?,
+            "bybit" => parse_bybit(_message)?,
+            "coinbase" => parse_coinbase(_message, &self.exchange_symbol)?,
+            "kraken" => parse_kraken(_message)?,
+            other => return Err(format!("unsupported CEX book exchange {other}")),
+        };
+        let Some(update) = update else {
+            return Ok(None);
+        };
+        if update.exchange_symbol != self.exchange_symbol {
+            return Ok(None);
+        }
+        if update.snapshot {
+            self.bids.clear();
+            self.asks.clear();
+        }
+        apply_levels(&mut self.bids, &update.bids);
+        apply_levels(&mut self.asks, &update.asks);
+        match self.exchange.as_str() {
+            "okx" => truncate_book(&mut self.bids, &mut self.asks, 5),
+            "bybit" => truncate_book(&mut self.bids, &mut self.asks, 50),
+            "kraken" => truncate_book(&mut self.bids, &mut self.asks, 10),
+            _ => {}
+        }
+        if self.bids.is_empty() || self.asks.is_empty() {
+            return Ok(None);
+        }
+        if self.exchange == "kraken" {
+            if let Some(expected) = update.update_id {
+                let actual = kraken_checksum(&self.bids, &self.asks) as i64;
+                if actual != expected {
+                    self.bids.clear();
+                    self.asks.clear();
+                    return Err(format!(
+                        "Kraken L2 checksum mismatch: expected={expected} actual={actual}"
+                    ));
+                }
+            }
+        }
+        Ok(Some(self.snapshot(update)))
+    }
+
+    fn snapshot(&self, update: BookUpdate) -> NormalizedTick {
+        let bids: Vec<(Decimal, Decimal)> = self
+            .bids
+            .iter()
+            .rev()
+            .take(50)
+            .map(|(price, quantity)| (*price, *quantity))
+            .collect();
+        let asks: Vec<(Decimal, Decimal)> = self
+            .asks
+            .iter()
+            .take(50)
+            .map(|(price, quantity)| (*price, *quantity))
+            .collect();
+        let best_bid = bids[0].0;
+        let best_ask = asks[0].0;
+        let mid = (best_bid + best_ask) / Decimal::from(2);
+        let bid_5 = volume(&bids, 5);
+        let ask_5 = volume(&asks, 5);
+        let bid_10 = volume(&bids, 10);
+        let ask_10 = volume(&asks, 10);
+        let update_key = update
+            .update_id
+            .or(update.sequence_id)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| update.event_time.timestamp_millis().to_string());
+        NormalizedTick {
+            exchange: self.exchange.clone(),
+            market_type: self.market_type.clone(),
+            symbol: self.symbol.clone(),
+            exchange_symbol: self.exchange_symbol.clone(),
+            kind: "lob".to_string(),
+            event_time: update.event_time,
+            update_id: update.update_id,
+            sequence_id: update.sequence_id,
+            mark_price: None,
+            index_price: None,
+            funding_rate: None,
+            open_interest: None,
+            basis: None,
+            basis_rate: None,
+            annualized_basis_rate: None,
+            next_funding_time: None,
+            side: None,
+            price: None,
+            quantity: None,
+            best_bid: Some(best_bid),
+            best_ask: Some(best_ask),
+            mid_price: Some(mid),
+            spread_bps: Some((best_ask - best_bid) / mid * Decimal::from(10_000)),
+            obi_5: Some(imbalance(bid_5, ask_5)),
+            obi_10: (bids.len() >= 10 && asks.len() >= 10).then(|| imbalance(bid_10, ask_10)),
+            bid_volume_5: Some(bid_5),
+            ask_volume_5: Some(ask_5),
+            bids: Some(levels_json(&bids)),
+            asks: Some(levels_json(&asks)),
+            source: format!("{}_public_ws", self.exchange),
+            dedupe_key: update_key,
+            raw: update.raw,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BookUpdate {
+    exchange_symbol: String,
+    event_time: DateTime<Utc>,
+    update_id: Option<i64>,
+    sequence_id: Option<i64>,
+    snapshot: bool,
+    bids: Vec<(Decimal, Decimal)>,
+    asks: Vec<(Decimal, Decimal)>,
+    raw: Value,
+}
+
+fn array_levels(value: &Value) -> Vec<(Decimal, Decimal)> {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|level| {
+            let fields = level.as_array()?;
+            Some((decimal(fields.first()?)?, decimal(fields.get(1)?)?))
+        })
+        .collect()
+}
+
+fn object_levels(value: &Value) -> Vec<(Decimal, Decimal)> {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|level| Some((decimal(&level["price"])?, decimal(&level["qty"])?)))
+        .collect()
+}
+
+fn apply_levels(book: &mut BTreeMap<Decimal, Decimal>, levels: &[(Decimal, Decimal)]) {
+    for (price, quantity) in levels {
+        if *quantity <= Decimal::ZERO {
+            book.remove(price);
+        } else if *price > Decimal::ZERO {
+            book.insert(*price, *quantity);
+        }
+    }
+}
+
+fn truncate_book(
+    bids: &mut BTreeMap<Decimal, Decimal>,
+    asks: &mut BTreeMap<Decimal, Decimal>,
+    depth: usize,
+) {
+    let bid_keys: Vec<Decimal> = bids
+        .keys()
+        .take(bids.len().saturating_sub(depth))
+        .copied()
+        .collect();
+    let ask_keys: Vec<Decimal> = asks
+        .keys()
+        .rev()
+        .take(asks.len().saturating_sub(depth))
+        .copied()
+        .collect();
+    for key in bid_keys {
+        bids.remove(&key);
+    }
+    for key in ask_keys {
+        asks.remove(&key);
+    }
+}
+
+fn parse_okx(message: &Value) -> Result<Option<BookUpdate>, String> {
+    let Some(data) = message["data"].as_array().and_then(|rows| rows.first()) else {
+        return Ok(None);
+    };
+    let exchange_symbol = required_str(&message["arg"], "instId")?.to_string();
+    Ok(Some(BookUpdate {
+        exchange_symbol,
+        event_time: parse_time(&data["ts"])?,
+        update_id: data["seqId"].as_i64(),
+        sequence_id: data["seqId"].as_i64(),
+        snapshot: true,
+        bids: array_levels(&data["bids"]),
+        asks: array_levels(&data["asks"]),
+        raw: message.clone(),
+    }))
+}
+
+fn parse_bybit(message: &Value) -> Result<Option<BookUpdate>, String> {
+    if message["data"].is_null() {
+        return Ok(None);
+    }
+    let data = &message["data"];
+    let update_id = data["u"].as_i64();
+    Ok(Some(BookUpdate {
+        exchange_symbol: required_str(data, "s")?.to_string(),
+        event_time: parse_time(&message["ts"])?,
+        update_id,
+        sequence_id: data["seq"].as_i64(),
+        snapshot: message["type"].as_str() == Some("snapshot") || update_id == Some(1),
+        bids: array_levels(&data["b"]),
+        asks: array_levels(&data["a"]),
+        raw: message.clone(),
+    }))
+}
+
+fn parse_coinbase(message: &Value, exchange_symbol: &str) -> Result<Option<BookUpdate>, String> {
+    if message["channel"].as_str() != Some("l2_data") {
+        return Ok(None);
+    }
+    let event = message["events"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|event| event["product_id"].as_str() == Some(exchange_symbol));
+    let Some(event) = event else { return Ok(None) };
+    let mut bids = Vec::new();
+    let mut asks = Vec::new();
+    for update in event["updates"].as_array().into_iter().flatten() {
+        let Some(level) =
+            decimal_field(update, "price_level").zip(decimal_field(update, "new_quantity"))
+        else {
+            continue;
+        };
+        match update["side"].as_str() {
+            Some("bid") => bids.push(level),
+            Some("offer") => asks.push(level),
+            _ => {}
+        }
+    }
+    Ok(Some(BookUpdate {
+        exchange_symbol: exchange_symbol.to_string(),
+        event_time: parse_time(&message["timestamp"])?,
+        update_id: None,
+        sequence_id: message["sequence_num"].as_i64(),
+        snapshot: event["type"].as_str() == Some("snapshot"),
+        bids,
+        asks,
+        raw: message.clone(),
+    }))
+}
+
+fn parse_kraken(message: &Value) -> Result<Option<BookUpdate>, String> {
+    if message["channel"].as_str() != Some("book") {
+        return Ok(None);
+    }
+    let Some(data) = message["data"].as_array().and_then(|rows| rows.first()) else {
+        return Ok(None);
+    };
+    let checksum = data["checksum"].as_i64();
+    Ok(Some(BookUpdate {
+        exchange_symbol: required_str(data, "symbol")?.to_string(),
+        event_time: parse_time(&data["timestamp"])?,
+        update_id: checksum,
+        sequence_id: None,
+        snapshot: message["type"].as_str() == Some("snapshot"),
+        bids: object_levels(&data["bids"]),
+        asks: object_levels(&data["asks"]),
+        raw: message.clone(),
+    }))
+}
+
+fn volume(levels: &[(Decimal, Decimal)], depth: usize) -> Decimal {
+    levels
+        .iter()
+        .take(depth)
+        .map(|(_, quantity)| *quantity)
+        .sum()
+}
+
+fn imbalance(bids: Decimal, asks: Decimal) -> Decimal {
+    let total = bids + asks;
+    if total.is_zero() {
+        Decimal::ZERO
+    } else {
+        (bids - asks) / total
+    }
+}
+
+fn levels_json(levels: &[(Decimal, Decimal)]) -> Value {
+    Value::Array(levels.iter().map(|(price, quantity)| {
+        serde_json::json!({"price": price.to_string(), "size": quantity.to_string()})
+    }).collect())
+}
+
+fn kraken_checksum(bids: &BTreeMap<Decimal, Decimal>, asks: &BTreeMap<Decimal, Decimal>) -> u32 {
+    fn component(value: Decimal) -> String {
+        let compact = value.to_string().replace('.', "");
+        let trimmed = compact.trim_start_matches('0');
+        if trimmed.is_empty() {
+            "0".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+    let mut payload = String::new();
+    for (price, quantity) in asks.iter().take(10) {
+        payload.push_str(&component(*price));
+        payload.push_str(&component(*quantity));
+    }
+    for (price, quantity) in bids.iter().rev().take(10) {
+        payload.push_str(&component(*price));
+        payload.push_str(&component(*quantity));
+    }
+    crc32fast::hash(payload.as_bytes())
+}
+
+/// Run the complete public CEX collector until Ctrl-C.
+pub async fn collect_cex_public(pool: PgPool, assets_raw: &str, poll_secs: u64, sample_ms: u64) {
+    let assets: Vec<String> = assets_raw
+        .split(',')
+        .map(str::trim)
+        .filter(|asset| !asset.is_empty())
+        .map(str::to_uppercase)
+        .collect();
+    let running = Arc::new(AtomicBool::new(true));
+    let signal = running.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        signal.store(false, Ordering::SeqCst);
+    });
+
+    info!(assets = ?assets, poll_secs, sample_ms, "starting public CEX collector");
+    tokio::join!(
+        run_binance_futures(pool.clone(), assets.clone(), poll_secs, running.clone()),
+        run_binance_liquidations(pool.clone(), assets.clone(), running.clone()),
+        run_book_collector(
+            pool.clone(),
+            "okx",
+            assets.clone(),
+            sample_ms,
+            running.clone()
+        ),
+        run_book_collector(
+            pool.clone(),
+            "bybit",
+            assets.clone(),
+            sample_ms,
+            running.clone()
+        ),
+        run_book_collector(
+            pool.clone(),
+            "coinbase",
+            assets.clone(),
+            sample_ms,
+            running.clone()
+        ),
+        run_book_collector(pool, "kraken", assets, sample_ms, running),
+    );
+}
+
+async fn run_binance_futures(
+    pool: PgPool,
+    assets: Vec<String>,
+    poll_secs: u64,
+    running: Arc<AtomicBool>,
+) {
+    let client = reqwest::Client::new();
+    while running.load(Ordering::SeqCst) {
+        for asset in &assets {
+            let symbol = format!("{asset}USDT");
+            match fetch_binance_futures(&client, &symbol).await {
+                Ok(tick) => {
+                    if let Err(error) = persist_tick(&pool, &tick).await {
+                        error!(%symbol, %error, "failed to persist Binance futures snapshot");
+                    }
+                }
+                Err(error) => warn!(%symbol, %error, "failed to fetch Binance futures snapshot"),
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(poll_secs.max(1))).await;
+    }
+}
+
+async fn fetch_binance_futures(
+    client: &reqwest::Client,
+    symbol: &str,
+) -> Result<NormalizedTick, String> {
+    async fn get(
+        client: &reqwest::Client,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<Value, String> {
+        client
+            .get(format!("{BINANCE_FUTURES_REST}{path}"))
+            .query(query)
+            .timeout(Duration::from_secs(15))
+            .send()
+            .await
+            .map_err(|error| error.to_string())?
+            .error_for_status()
+            .map_err(|error| error.to_string())?
+            .json()
+            .await
+            .map_err(|error| error.to_string())
+    }
+    let premium = get(client, "/fapi/v1/premiumIndex", &[("symbol", symbol)]).await?;
+    let open_interest = get(client, "/fapi/v1/openInterest", &[("symbol", symbol)]).await?;
+    let basis = get(
+        client,
+        "/futures/data/basis",
+        &[
+            ("pair", symbol),
+            ("contractType", "PERPETUAL"),
+            ("period", "5m"),
+            ("limit", "1"),
+        ],
+    )
+    .await?;
+    normalize_binance_futures(&premium, &open_interest, Some(&basis))
+}
+
+async fn run_binance_liquidations(pool: PgPool, assets: Vec<String>, running: Arc<AtomicBool>) {
+    let streams: Vec<String> = assets
+        .iter()
+        .map(|asset| format!("{}usdt@forceOrder", asset.to_lowercase()))
+        .collect();
+    while running.load(Ordering::SeqCst) {
+        let result = async {
+            let (socket, _) = connect_async(BINANCE_FUTURES_WS)
+                .await
+                .map_err(|error| error.to_string())?;
+            let (mut write, mut read) = socket.split();
+            write
+                .send(Message::Text(
+                    serde_json::json!({"method":"SUBSCRIBE","params":streams,"id":1})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .map_err(|error| error.to_string())?;
+            while running.load(Ordering::SeqCst) {
+                let Some(message) = read.next().await else {
+                    break;
+                };
+                match message.map_err(|error| error.to_string())? {
+                    Message::Text(text) => {
+                        let raw: Value =
+                            serde_json::from_str(&text).map_err(|error| error.to_string())?;
+                        if raw.get("result").is_some() {
+                            continue;
+                        }
+                        let tick = normalize_binance_liquidation(&raw)?;
+                        persist_tick(&pool, &tick).await?;
+                    }
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+        if let Err(error) = result {
+            warn!(%error, "Binance liquidation stream disconnected");
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn run_book_collector(
+    pool: PgPool,
+    exchange: &'static str,
+    assets: Vec<String>,
+    sample_ms: u64,
+    running: Arc<AtomicBool>,
+) {
+    while running.load(Ordering::SeqCst) {
+        if let Err(error) = run_book_connection(&pool, exchange, &assets, sample_ms, &running).await
+        {
+            warn!(exchange, %error, "CEX L2 stream disconnected");
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+fn exchange_symbol(exchange: &str, asset: &str) -> String {
+    match exchange {
+        "okx" => format!("{asset}-USDT"),
+        "bybit" => format!("{asset}USDT"),
+        "coinbase" => format!("{asset}-USD"),
+        "kraken" => format!("{asset}/USD"),
+        _ => asset.to_string(),
+    }
+}
+
+fn normalized_symbol(exchange: &str, asset: &str) -> String {
+    if matches!(exchange, "coinbase" | "kraken") {
+        format!("{asset}USD")
+    } else {
+        format!("{asset}USDT")
+    }
+}
+
+async fn run_book_connection(
+    pool: &PgPool,
+    exchange: &str,
+    assets: &[String],
+    sample_ms: u64,
+    running: &Arc<AtomicBool>,
+) -> Result<(), String> {
+    let url = match exchange {
+        "okx" => OKX_WS,
+        "bybit" => BYBIT_WS,
+        "coinbase" => COINBASE_WS,
+        "kraken" => KRAKEN_WS,
+        _ => return Err(format!("unsupported exchange {exchange}")),
+    };
+    let exchange_symbols: Vec<String> = assets
+        .iter()
+        .map(|asset| exchange_symbol(exchange, asset))
+        .collect();
+    let (socket, _) = connect_async(url)
+        .await
+        .map_err(|error| error.to_string())?;
+    let (mut write, mut read) = socket.split();
+    for subscription in subscriptions(exchange, &exchange_symbols) {
+        write
+            .send(Message::Text(subscription.to_string().into()))
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    let mut books: HashMap<String, CexBook> = assets
+        .iter()
+        .map(|asset| {
+            let venue_symbol = exchange_symbol(exchange, asset);
+            (
+                venue_symbol.clone(),
+                CexBook::new(
+                    exchange,
+                    "spot",
+                    &normalized_symbol(exchange, asset),
+                    &venue_symbol,
+                ),
+            )
+        })
+        .collect();
+    let mut last_persisted: HashMap<String, Instant> = HashMap::new();
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(20));
+    while running.load(Ordering::SeqCst) {
+        tokio::select! {
+            _ = heartbeat.tick() => {
+                if let Some(ping) = heartbeat_message(exchange) {
+                    write.send(ping).await.map_err(|error| error.to_string())?;
+                }
+            }
+            message = read.next() => {
+                let Some(message) = message else { break };
+                match message.map_err(|error| error.to_string())? {
+                    Message::Text(text) => {
+                        if text.as_str() == "pong" { continue }
+                        let raw: Value = serde_json::from_str(&text).map_err(|error| error.to_string())?;
+                        for (symbol, book) in &mut books {
+                            if let Some(tick) = book.apply_message(&raw)? {
+                                let due = last_persisted.get(symbol)
+                                    .map(|last| last.elapsed() >= Duration::from_millis(sample_ms))
+                                    .unwrap_or(true);
+                                if due {
+                                    persist_tick(pool, &tick).await?;
+                                    last_persisted.insert(symbol.clone(), Instant::now());
+                                }
+                            }
+                        }
+                    }
+                    Message::Ping(payload) => write.send(Message::Pong(payload)).await.map_err(|error| error.to_string())?,
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn subscriptions(exchange: &str, symbols: &[String]) -> Vec<Value> {
+    match exchange {
+        "okx" => vec![
+            serde_json::json!({"op":"subscribe","args":symbols.iter().map(|symbol| serde_json::json!({"channel":"books5","instId":symbol})).collect::<Vec<_>>()}),
+        ],
+        "bybit" => vec![
+            serde_json::json!({"op":"subscribe","args":symbols.iter().map(|symbol| format!("orderbook.50.{symbol}")).collect::<Vec<_>>()}),
+        ],
+        "coinbase" => vec![
+            serde_json::json!({"type":"subscribe","channel":"level2","product_ids":symbols}),
+            serde_json::json!({"type":"subscribe","channel":"heartbeats"}),
+        ],
+        "kraken" => vec![
+            serde_json::json!({"method":"subscribe","params":{"channel":"book","symbol":symbols,"depth":10,"snapshot":true},"req_id":1}),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+fn heartbeat_message(exchange: &str) -> Option<Message> {
+    match exchange {
+        "okx" => Some(Message::Text("ping".into())),
+        "bybit" => Some(Message::Text(
+            serde_json::json!({"op":"ping"}).to_string().into(),
+        )),
+        "kraken" => Some(Message::Text(
+            serde_json::json!({"method":"ping"}).to_string().into(),
+        )),
+        _ => None,
+    }
+}
+
+async fn persist_tick(pool: &PgPool, tick: &NormalizedTick) -> Result<(), String> {
+    sqlx::query(
+        r#"INSERT INTO cex_public_market_ticks (
+            exchange, market_type, symbol, exchange_symbol, kind, event_time,
+            update_id, sequence_id, mark_price, index_price, funding_rate,
+            open_interest, basis, basis_rate, annualized_basis_rate,
+            next_funding_time, side, price, quantity, best_bid, best_ask,
+            mid_price, spread_bps, obi_5, obi_10, bid_volume_5, ask_volume_5,
+            bids, asks, source, dedupe_key, raw
+        ) VALUES (
+            $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,
+            $17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32
+        ) ON CONFLICT (exchange, kind, exchange_symbol, dedupe_key) DO NOTHING"#,
+    )
+    .bind(&tick.exchange)
+    .bind(&tick.market_type)
+    .bind(&tick.symbol)
+    .bind(&tick.exchange_symbol)
+    .bind(&tick.kind)
+    .bind(tick.event_time)
+    .bind(tick.update_id)
+    .bind(tick.sequence_id)
+    .bind(tick.mark_price)
+    .bind(tick.index_price)
+    .bind(tick.funding_rate)
+    .bind(tick.open_interest)
+    .bind(tick.basis)
+    .bind(tick.basis_rate)
+    .bind(tick.annualized_basis_rate)
+    .bind(tick.next_funding_time)
+    .bind(&tick.side)
+    .bind(tick.price)
+    .bind(tick.quantity)
+    .bind(tick.best_bid)
+    .bind(tick.best_ask)
+    .bind(tick.mid_price)
+    .bind(tick.spread_bps)
+    .bind(tick.obi_5)
+    .bind(tick.obi_10)
+    .bind(tick.bid_volume_5)
+    .bind(tick.ask_volume_5)
+    .bind(&tick.bids)
+    .bind(&tick.asks)
+    .bind(&tick.source)
+    .bind(&tick.dedupe_key)
+    .bind(&tick.raw)
+    .execute(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn normalizes_binance_futures_and_liquidation_payloads() {
+        let premium = json!({
+            "symbol":"BTCUSDT","markPrice":"11793.63104562","indexPrice":"11781.80495970",
+            "lastFundingRate":"0.00038246","nextFundingTime":1597392000000_i64,
+            "time":1597370495002_i64
+        });
+        let oi = json!({"openInterest":"10659.509","symbol":"BTCUSDT","time":1597370495002_i64});
+        let basis = json!([{"pair":"BTCUSDT","basis":"13.94054945","basisRate":"0.0004",
+            "annualizedBasisRate":"0.035","timestamp":1597370400000_i64}]);
+        let tick = normalize_binance_futures(&premium, &oi, Some(&basis)).unwrap();
+        assert_eq!(tick.mark_price, Some(dec!(11793.63104562)));
+        assert_eq!(tick.open_interest, Some(dec!(10659.509)));
+        assert_eq!(tick.basis_rate, Some(dec!(0.0004)));
+
+        let liquidation = json!({"stream":"btcusdt@forceOrder","data":{"E":1568014460893_i64,"o":{
+            "s":"BTCUSDT","S":"SELL","q":"0.014","p":"9910","ap":"9910","z":"0.014","T":1568014460893_i64
+        }}});
+        let tick = normalize_binance_liquidation(&liquidation).unwrap();
+        assert_eq!(tick.kind, "liquidation");
+        assert_eq!(tick.side.as_deref(), Some("SELL"));
+        assert_eq!(tick.quantity, Some(dec!(0.014)));
+    }
+
+    #[test]
+    fn normalizes_okx_and_bybit_books_with_delta_reset() {
+        let mut okx = CexBook::new("okx", "spot", "BTCUSDT", "BTC-USDT");
+        let tick = okx.apply_message(&json!({"arg":{"channel":"books5","instId":"BTC-USDT"},"data":[{
+            "asks":[["101","2","0","1"]],"bids":[["99","3","0","1"]],"ts":"1597026383085","seqId":123
+        }]})).unwrap().unwrap();
+        assert_eq!(tick.best_bid, Some(dec!(99)));
+        assert_eq!(tick.obi_5, Some(dec!(0.2)));
+
+        let mut bybit = CexBook::new("bybit", "spot", "BTCUSDT", "BTCUSDT");
+        bybit
+            .apply_message(
+                &json!({"topic":"orderbook.50.BTCUSDT","type":"snapshot","ts":1672304484978_i64,
+            "data":{"s":"BTCUSDT","b":[["100","2"],["99","1"]],"a":[["101","2"]],"u":10,"seq":20}}),
+            )
+            .unwrap();
+        let tick = bybit
+            .apply_message(
+                &json!({"topic":"orderbook.50.BTCUSDT","type":"delta","ts":1672304485078_i64,
+            "data":{"s":"BTCUSDT","b":[["100","0"],["98","4"]],"a":[],"u":11,"seq":21}}),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(tick.best_bid, Some(dec!(99)));
+        assert_eq!(tick.bid_volume_5, Some(dec!(5)));
+        let tick = bybit
+            .apply_message(
+                &json!({"topic":"orderbook.50.BTCUSDT","type":"snapshot","ts":1672304485178_i64,
+            "data":{"s":"BTCUSDT","b":[["97","1"]],"a":[["98","1"]],"u":1,"seq":22}}),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(tick.best_bid, Some(dec!(97)));
+    }
+
+    #[test]
+    fn normalizes_coinbase_and_kraken_books() {
+        let mut coinbase = CexBook::new("coinbase", "spot", "BTCUSD", "BTC-USD");
+        let tick = coinbase.apply_message(&json!({"channel":"l2_data","timestamp":"2023-02-09T20:32:50.714964855Z","sequence_num":1,
+            "events":[{"type":"snapshot","product_id":"BTC-USD","updates":[
+                {"side":"bid","event_time":"2023-02-09T20:32:50Z","price_level":"99","new_quantity":"3"},
+                {"side":"offer","event_time":"2023-02-09T20:32:50Z","price_level":"101","new_quantity":"2"}
+            ]}]})).unwrap().unwrap();
+        assert_eq!(tick.spread_bps, Some(dec!(200)));
+
+        let mut kraken = CexBook::new("kraken", "spot", "BTCUSD", "BTC/USD");
+        let tick = kraken.apply_message(&json!({"channel":"book","type":"snapshot","data":[{
+            "symbol":"BTC/USD","bids":[{"price":"99.00","qty":"3.000"}],"asks":[{"price":"101.00","qty":"2.000"}],
+            "checksum":4104258857_u32,"timestamp":"2023-10-06T17:35:55.440295Z"
+        }]})).unwrap().unwrap();
+        assert_eq!(tick.best_ask, Some(dec!(101.0)));
+        assert_eq!(tick.update_id, Some(4104258857));
+    }
+}

--- a/crates/ploy-market-data/src/lib.rs
+++ b/crates/ploy-market-data/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "live")]
 pub mod binance_collectors;
 #[cfg(feature = "live")]
+pub mod cex_collectors;
+#[cfg(feature = "live")]
 pub mod collector;
 #[cfg(feature = "live")]
 pub mod deribit_collectors;

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -31,6 +31,10 @@ fn print_usage_for(program: &str) {
     eprintln!("  collect-deribit-iv        Collect Deribit option IV ticks (HTTP poll)");
     #[cfg(feature = "ops")]
     eprintln!("  collect-deribit-greeks    Collect Deribit ATM option greeks (HTTP poll)");
+    #[cfg(feature = "ops")]
+    eprintln!(
+        "  collect-cex-public        Collect Binance Futures and OKX/Bybit/Coinbase/Kraken L2"
+    );
     eprintln!();
     eprintln!("Options for 'run':");
     eprintln!("  --config <path>          Unified TOML config file (required)");
@@ -122,6 +126,12 @@ pub async fn run_with_args(args: Vec<String>) {
             ops::run_collect_deribit_greeks(&args).await;
             #[cfg(not(feature = "ops"))]
             eprintln!("The collect-deribit-greeks command requires the full/ops runner build");
+        }
+        Some("collect-cex-public") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_cex_public(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-cex-public command requires the full/ops runner build");
         }
         // --- End new collectors ---
         Some("run") | None => {

--- a/crates/ploy-runner-host/src/ops.rs
+++ b/crates/ploy-runner-host/src/ops.rs
@@ -1,6 +1,7 @@
 use ploy_market_data::binance_collectors::{
     collect_binance_aggtrade, collect_binance_lob, collect_binance_price,
 };
+use ploy_market_data::cex_collectors::collect_cex_public;
 use ploy_market_data::collector::{CollectorConfig, QuoteCollector};
 use ploy_market_data::deribit_collectors::{collect_deribit_greeks, collect_deribit_iv};
 use ploy_market_data::diagnostics::check_database;
@@ -96,6 +97,12 @@ pub fn print_usage() {
     eprintln!("Options for 'collect-deribit-greeks':");
     eprintln!("  --currencies <l>  Comma-separated currencies (default: BTC,ETH,SOL)");
     eprintln!("  --poll-secs <n>   Poll interval in seconds (default: 30)");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!();
+    eprintln!("Options for 'collect-cex-public':");
+    eprintln!("  --assets <list>   Comma-separated bases (default: BTC,ETH,SOL)");
+    eprintln!("  --poll-secs <n>   Binance Futures REST interval (default: 5)");
+    eprintln!("  --sample-ms <n>   Per-venue L2 persistence interval (default: 1000)");
     eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
 }
 
@@ -481,4 +488,38 @@ pub async fn run_collect_deribit_greeks(args: &[String]) {
         }
     };
     collect_deribit_greeks(pool, currencies, poll_secs).await;
+}
+
+pub async fn run_collect_cex_public(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let assets = arg_value(args, "--assets")
+        .map(String::as_str)
+        .unwrap_or("BTC,ETH,SOL");
+    let poll_secs = arg_value(args, "--poll-secs")
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(5);
+    let sample_ms = arg_value(args, "--sample-ms")
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(1_000);
+    let pool = match PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&db_url)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(error) => {
+            eprintln!("DB connection failed: {error}");
+            std::process::exit(1);
+        }
+    };
+    collect_cex_public(pool, assets, poll_secs, sample_ms).await;
 }

--- a/deployment/systemd/ploy-cex-public-collector.service
+++ b/deployment/systemd/ploy-cex-public-collector.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Ploy Public CEX Market Data Collector
+After=postgresql.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ploy
+Environment=PLOY_CEX_ASSETS=BTC,ETH,SOL
+Environment=PLOY_CEX_FUTURES_POLL_SECS=5
+Environment=PLOY_CEX_LOB_SAMPLE_MS=1000
+Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
+ExecStartPre=/bin/sleep 19
+ExecStart=/opt/ploy/bin/ploy-runner collect-cex-public \
+    --assets ${PLOY_CEX_ASSETS} \
+    --poll-secs ${PLOY_CEX_FUTURES_POLL_SECS} \
+    --sample-ms ${PLOY_CEX_LOB_SAMPLE_MS}
+Restart=always
+RestartSec=11
+StandardOutput=journal
+StandardError=journal
+MemoryHigh=512M
+MemoryMax=1024M
+CPUQuota=80%
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/COLLECTOR_RUNBOOK.md
+++ b/docs/COLLECTOR_RUNBOOK.md
@@ -33,6 +33,7 @@ systemd units:
 - `ploy-binance-lob-collector.service`
 - `ploy-deribit-iv-collector.service`
 - `ploy-deribit-greeks-collector.service`
+- `ploy-cex-public-collector.service`
 
 Trigger deploys from `main`:
 
@@ -61,7 +62,15 @@ Examples:
 /opt/ploy/bin/ploy-runner collect-binance-aggtrade --symbols BTCUSDT,ETHUSDT,SOLUSDT --db-url "$PLOY_DATABASE__URL"
 /opt/ploy/bin/ploy-runner collect-deribit-iv --currencies BTC,ETH,SOL --db-url "$PLOY_DATABASE__URL"
 /opt/ploy/bin/ploy-runner collect-deribit-greeks --currencies BTC,ETH,SOL --db-url "$PLOY_DATABASE__URL"
+/opt/ploy/bin/ploy-runner collect-cex-public --assets BTC,ETH,SOL --poll-secs 5 --sample-ms 1000 --db-url "$PLOY_DATABASE__URL"
 ```
+
+`collect-cex-public` writes one normalized `cex_public_market_ticks` surface:
+Binance USD-M mark/index price, funding, open interest, basis and liquidation;
+plus sampled L2 books from OKX `books5`, Bybit `orderbook.50`, Coinbase Advanced
+Trade `level2`, and Kraken WebSocket v2 `book`. Use the `cex-extended` gap-audit
+profile before consuming these rows in factor research. They are not part of
+the existing PM5D promotion gate by default.
 
 If a diagnostic requires remote secrets or production data, prefer a GitHub
 Actions workflow with environment-scoped secrets over a local command.

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -13,6 +13,7 @@ collection behavior.
 | `crates/ploy-market-data` | canonical | Rust data plane | Owns live feed/scanner/discovery code used by runner/runtime surfaces. |
 | `/opt/ploy/bin/ploy-runner collect-quotes` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Full/ops build only; lean replay/backtest binaries intentionally do not expose it. |
 | `/opt/ploy/bin/ploy-runner collect-pm-trades` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Polls Polymarket Data API trade prints into `clob_trade_ticks`; full/ops build only. |
+| `/opt/ploy/bin/ploy-runner collect-cex-public` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Collects Binance Futures public metrics/liquidations and normalized OKX, Bybit, Coinbase, and Kraken L2 rows. |
 | `ploy-feed-loaders` | canonical historical DB loader | research/backtest adapters | Owns SQLx historical `MarketUpdate` loading outside strategy-bundles. |
 | `scripts/export_parquet.sh` | canonical export helper | data/export host | Keep as the explicit Parquet export entrypoint until replaced by Rust datactl. |
 | `.github/workflows/backtest.yml` | canonical CI backtest lane | CI/backtest host | Should remain separated from trade-host deploy assumptions. |

--- a/migrations/049_cex_public_market_data.sql
+++ b/migrations/049_cex_public_market_data.sql
@@ -1,0 +1,55 @@
+-- Normalized public market data from Binance Futures and external CEX L2 feeds.
+
+CREATE TABLE IF NOT EXISTS cex_public_market_ticks (
+    id BIGSERIAL PRIMARY KEY,
+    exchange TEXT NOT NULL CHECK (exchange IN ('binance','okx','bybit','coinbase','kraken')),
+    market_type TEXT NOT NULL CHECK (market_type IN ('spot','perpetual')),
+    symbol TEXT NOT NULL,
+    exchange_symbol TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('derivatives_snapshot','liquidation','lob')),
+    source_key TEXT GENERATED ALWAYS AS (exchange || '/' || kind) STORED,
+    event_time TIMESTAMPTZ NOT NULL,
+    update_id BIGINT,
+    sequence_id BIGINT,
+    mark_price NUMERIC(30,12),
+    index_price NUMERIC(30,12),
+    funding_rate NUMERIC(20,12),
+    open_interest NUMERIC(30,12),
+    basis NUMERIC(30,12),
+    basis_rate NUMERIC(20,12),
+    annualized_basis_rate NUMERIC(20,12),
+    next_funding_time TIMESTAMPTZ,
+    side TEXT,
+    price NUMERIC(30,12),
+    quantity NUMERIC(30,12),
+    best_bid NUMERIC(30,12),
+    best_ask NUMERIC(30,12),
+    mid_price NUMERIC(30,12),
+    spread_bps NUMERIC(20,8),
+    obi_5 NUMERIC(20,12),
+    obi_10 NUMERIC(20,12),
+    bid_volume_5 NUMERIC(30,12),
+    ask_volume_5 NUMERIC(30,12),
+    bids JSONB,
+    asks JSONB,
+    source TEXT NOT NULL,
+    dedupe_key TEXT NOT NULL,
+    raw JSONB NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (exchange, kind, exchange_symbol, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cex_public_ticks_exchange_symbol_time
+    ON cex_public_market_ticks(exchange, symbol, event_time DESC);
+CREATE INDEX IF NOT EXISTS idx_cex_public_ticks_kind_time
+    ON cex_public_market_ticks(kind, event_time DESC);
+CREATE INDEX IF NOT EXISTS idx_cex_public_ticks_source_key_time
+    ON cex_public_market_ticks(source_key, event_time DESC);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ploy') THEN
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.cex_public_market_ticks TO ploy';
+        EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE public.cex_public_market_ticks_id_seq TO ploy';
+    END IF;
+END $$;

--- a/scripts/audit_market_data_gaps.py
+++ b/scripts/audit_market_data_gaps.py
@@ -61,6 +61,13 @@ SOURCE_PROFILES = {
         "binance_lob",
     ],
     "research-windows": ["research_valid_windows"],
+    "cex-extended": [
+        "binance_futures",
+        "okx_lob",
+        "bybit_lob",
+        "coinbase_lob",
+        "kraken_lob",
+    ],
 }
 
 
@@ -841,6 +848,46 @@ def gap_targets(symbols: Iterable[str]) -> list[GapTarget]:
         ),
         GapTarget("deribit_iv", "deribit_iv_ticks", "fetched_at", 900),
         GapTarget("deribit_atm_greeks", "deribit_atm_greeks_ticks", "fetched_at", 900),
+        GapTarget(
+            "binance_futures",
+            "cex_public_market_ticks",
+            "event_time",
+            300,
+            filter_column="source_key",
+            filter_value="binance/derivatives_snapshot",
+        ),
+        GapTarget(
+            "okx_lob",
+            "cex_public_market_ticks",
+            "event_time",
+            300,
+            filter_column="source_key",
+            filter_value="okx/lob",
+        ),
+        GapTarget(
+            "bybit_lob",
+            "cex_public_market_ticks",
+            "event_time",
+            300,
+            filter_column="source_key",
+            filter_value="bybit/lob",
+        ),
+        GapTarget(
+            "coinbase_lob",
+            "cex_public_market_ticks",
+            "event_time",
+            300,
+            filter_column="source_key",
+            filter_value="coinbase/lob",
+        ),
+        GapTarget(
+            "kraken_lob",
+            "cex_public_market_ticks",
+            "event_time",
+            300,
+            filter_column="source_key",
+            filter_value="kraken/lob",
+        ),
     ]
     for symbol in symbols:
         targets.extend(

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -195,6 +195,7 @@ for unit in \\
   ploy-binance-price-collector.service \\
   ploy-deribit-iv-collector.service \\
   ploy-deribit-greeks-collector.service \\
+  ploy-cex-public-collector.service \\
   ploy-market-discovery.service \\
   ploy-quote-collector.service \\
   ploy-pm-trade-collector.service; do
@@ -264,6 +265,7 @@ install -m 0644 ./deployment/systemd/ploy-binance-lob-collector.service /etc/sys
 install -m 0644 ./deployment/systemd/ploy-binance-price-collector.service /etc/systemd/system/ploy-binance-price-collector.service
 install -m 0644 ./deployment/systemd/ploy-deribit-iv-collector.service /etc/systemd/system/ploy-deribit-iv-collector.service
 install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
+install -m 0644 ./deployment/systemd/ploy-cex-public-collector.service /etc/systemd/system/ploy-cex-public-collector.service
 install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
 install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
 install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.service /etc/systemd/system/ploy-polymarket-v2-indexer-import.service
@@ -303,6 +305,8 @@ systemctl enable --now ploy-deribit-iv-collector.service
 systemctl restart ploy-deribit-iv-collector.service
 systemctl enable --now ploy-deribit-greeks-collector.service
 systemctl restart ploy-deribit-greeks-collector.service
+systemctl enable --now ploy-cex-public-collector.service
+systemctl restart ploy-cex-public-collector.service
 systemctl enable --now ploy-market-discovery.service
 systemctl restart ploy-market-discovery.service
 if ! check_recent_rows \\
@@ -354,6 +358,8 @@ systemctl is-active --quiet ploy-deribit-iv-collector.service
 require_service_guardrails ploy-deribit-iv-collector.service
 systemctl is-active --quiet ploy-deribit-greeks-collector.service
 require_service_guardrails ploy-deribit-greeks-collector.service
+systemctl is-active --quiet ploy-cex-public-collector.service
+require_service_guardrails ploy-cex-public-collector.service
 systemctl is-active --quiet ploy-market-discovery.service
 require_service_guardrails ploy-market-discovery.service
 if service_exists ployd.service; then
@@ -367,6 +373,14 @@ fi
 wait_for_recent_rows \\
   "SELECT EXISTS (SELECT 1 FROM binance_agg_trade_ticks WHERE trade_time >= NOW() - INTERVAL '10 minutes')" \\
   "binance_agg_trade_ticks is not fresh after deploy"
+wait_for_recent_rows \\
+  "SELECT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE kind = 'derivatives_snapshot' AND event_time >= NOW() - INTERVAL '5 minutes')" \\
+  "Binance futures public data is not fresh after deploy"
+for cex in okx bybit coinbase kraken; do
+  wait_for_recent_rows \\
+    "SELECT EXISTS (SELECT 1 FROM cex_public_market_ticks WHERE exchange = '${{cex}}' AND kind = 'lob' AND event_time >= NOW() - INTERVAL '5 minutes')" \\
+    "${{cex}} L2 public data is not fresh after deploy"
+done
 wait_for_recent_rows \\
   "SELECT EXISTS (SELECT 1 FROM binance_lob_ticks WHERE event_time >= NOW() - INTERVAL '10 minutes')" \\
   "binance_lob_ticks is not fresh after deploy"

--- a/scripts/ploy_maintenance.sh
+++ b/scripts/ploy_maintenance.sh
@@ -25,6 +25,7 @@ RETENTION_BINANCE_TICKS_DAYS="${PLOY_RETENTION_BINANCE_TICKS_DAYS:-7}"
 RETENTION_BINANCE_AGGTRADE_DAYS="${PLOY_RETENTION_BINANCE_AGGTRADE_DAYS:-7}"
 RETENTION_BINANCE_LOB_DAYS="${PLOY_RETENTION_BINANCE_LOB_DAYS:-7}"
 RETENTION_DERIBIT_IV_DAYS="${PLOY_RETENTION_DERIBIT_IV_DAYS:-7}"
+RETENTION_CEX_PUBLIC_DAYS="${PLOY_RETENTION_CEX_PUBLIC_DAYS:-30}"
 RETENTION_NBA_OBS_DAYS="${PLOY_RETENTION_NBA_OBS_DAYS:-7}"
 RETENTION_ORDER_EXEC_DAYS="${PLOY_RETENTION_ORDER_EXEC_DAYS:-7}"
 RETENTION_LOG_DAYS="${PLOY_RETENTION_LOG_DAYS:-7}"
@@ -83,6 +84,10 @@ if ! is_uint "$RETENTION_BINANCE_LOB_DAYS"; then
 fi
 if ! is_uint "$RETENTION_DERIBIT_IV_DAYS"; then
   echo "invalid PLOY_RETENTION_DERIBIT_IV_DAYS: $RETENTION_DERIBIT_IV_DAYS" >&2
+  exit 2
+fi
+if ! is_uint "$RETENTION_CEX_PUBLIC_DAYS"; then
+  echo "invalid PLOY_RETENTION_CEX_PUBLIC_DAYS: $RETENTION_CEX_PUBLIC_DAYS" >&2
   exit 2
 fi
 if ! is_uint "$RETENTION_NBA_OBS_DAYS"; then
@@ -146,7 +151,7 @@ if ! is_uint "$DERIBIT_PARTITION_LOOKAHEAD_DAYS"; then
   exit 2
 fi
 
-echo "ploy_maintenance: db=${DB_NAME} log_dir=${LOG_DIR} data_dir=${DATA_DIR} tmp_dir=${TMP_DIR} extra_log_dirs=${EXTRA_LOG_DIRS} clob_book_archive_dir=${CLOB_BOOK_ARCHIVE_DIR} clob_book_require_archive=${REQUIRE_CLOB_BOOK_ARCHIVE} clob_ticks_days=${RETENTION_CLOB_TICKS_DAYS} clob_book_days=${RETENTION_CLOB_BOOK_DAYS} clob_obh_days=${RETENTION_CLOB_ORDERBOOK_HISTORY_DAYS} clob_trades_days=${RETENTION_CLOB_TRADES_DAYS} clob_alerts_days=${RETENTION_CLOB_ALERTS_DAYS} binance_ticks_days=${RETENTION_BINANCE_TICKS_DAYS} binance_aggtrade_days=${RETENTION_BINANCE_AGGTRADE_DAYS} binance_lob_days=${RETENTION_BINANCE_LOB_DAYS} deribit_iv_days=${RETENTION_DERIBIT_IV_DAYS} nba_obs_days=${RETENTION_NBA_OBS_DAYS} order_exec_days=${RETENTION_ORDER_EXEC_DAYS} log_days=${RETENTION_LOG_DAYS} tmp_days=${RETENTION_TMP_DAYS} recording_days=${RETENTION_RECORDING_DAYS} parquet_days=${RETENTION_PARQUET_DAYS} log_max_file_mb=${RETENTION_LOG_MAX_FILE_MB} log_max_dir_mb=${RETENTION_LOG_MAX_DIR_MB} tmp_max_dir_mb=${RETENTION_TMP_MAX_DIR_MB} recording_max_dir_mb=${RETENTION_RECORDING_MAX_DIR_MB} parquet_max_dir_mb=${RETENTION_PARQUET_MAX_DIR_MB} clob_book_delete_batch_size=${CLOB_BOOK_DELETE_BATCH_SIZE} clob_book_delete_max_batches=${CLOB_BOOK_DELETE_MAX_BATCHES} deribit_partition_lookback_days=${DERIBIT_PARTITION_LOOKBACK_DAYS} deribit_partition_lookahead_days=${DERIBIT_PARTITION_LOOKAHEAD_DAYS} refresh_research_windows=${REFRESH_RESEARCH_WINDOWS} logs_only=${LOGS_ONLY}"
+echo "ploy_maintenance: db=${DB_NAME} log_dir=${LOG_DIR} data_dir=${DATA_DIR} tmp_dir=${TMP_DIR} extra_log_dirs=${EXTRA_LOG_DIRS} clob_book_archive_dir=${CLOB_BOOK_ARCHIVE_DIR} clob_book_require_archive=${REQUIRE_CLOB_BOOK_ARCHIVE} clob_ticks_days=${RETENTION_CLOB_TICKS_DAYS} clob_book_days=${RETENTION_CLOB_BOOK_DAYS} clob_obh_days=${RETENTION_CLOB_ORDERBOOK_HISTORY_DAYS} clob_trades_days=${RETENTION_CLOB_TRADES_DAYS} clob_alerts_days=${RETENTION_CLOB_ALERTS_DAYS} binance_ticks_days=${RETENTION_BINANCE_TICKS_DAYS} binance_aggtrade_days=${RETENTION_BINANCE_AGGTRADE_DAYS} binance_lob_days=${RETENTION_BINANCE_LOB_DAYS} deribit_iv_days=${RETENTION_DERIBIT_IV_DAYS} cex_public_days=${RETENTION_CEX_PUBLIC_DAYS} nba_obs_days=${RETENTION_NBA_OBS_DAYS} order_exec_days=${RETENTION_ORDER_EXEC_DAYS} log_days=${RETENTION_LOG_DAYS} tmp_days=${RETENTION_TMP_DAYS} recording_days=${RETENTION_RECORDING_DAYS} parquet_days=${RETENTION_PARQUET_DAYS} log_max_file_mb=${RETENTION_LOG_MAX_FILE_MB} log_max_dir_mb=${RETENTION_LOG_MAX_DIR_MB} tmp_max_dir_mb=${RETENTION_TMP_MAX_DIR_MB} recording_max_dir_mb=${RETENTION_RECORDING_MAX_DIR_MB} parquet_max_dir_mb=${RETENTION_PARQUET_MAX_DIR_MB} clob_book_delete_batch_size=${CLOB_BOOK_DELETE_BATCH_SIZE} clob_book_delete_max_batches=${CLOB_BOOK_DELETE_MAX_BATCHES} deribit_partition_lookback_days=${DERIBIT_PARTITION_LOOKBACK_DAYS} deribit_partition_lookahead_days=${DERIBIT_PARTITION_LOOKAHEAD_DAYS} refresh_research_windows=${REFRESH_RESEARCH_WINDOWS} logs_only=${LOGS_ONLY}"
 
 archived_clob_book_dates_select() {
   local marker day
@@ -449,6 +454,33 @@ BEGIN
 END
 \$\$;
 
+-- Sampled public CEX rows are intentionally bounded independently of raw
+-- Polymarket archives.
+DO \$\$
+DECLARE
+  batch_no integer := 0;
+  deleted_rows integer := 0;
+BEGIN
+  IF to_regclass('public.cex_public_market_ticks') IS NOT NULL THEN
+    LOOP
+      WITH doomed AS (
+        SELECT id
+        FROM cex_public_market_ticks
+        WHERE event_time < NOW() - INTERVAL '${RETENTION_CEX_PUBLIC_DAYS} days'
+        ORDER BY event_time
+        LIMIT ${CLOB_BOOK_DELETE_BATCH_SIZE}
+      )
+      DELETE FROM cex_public_market_ticks t
+      USING doomed
+      WHERE t.id = doomed.id;
+      GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+      batch_no := batch_no + 1;
+      EXIT WHEN deleted_rows = 0 OR batch_no >= ${CLOB_BOOK_DELETE_MAX_BATCHES};
+    END LOOP;
+  END IF;
+END
+\$\$;
+
 -- CLOB orderbook-history L2 ticks (optional; table may not exist on all hosts)
 SELECT format(
   'DELETE FROM clob_orderbook_history_ticks WHERE book_ts < NOW() - INTERVAL ''%s days'';',
@@ -479,6 +511,7 @@ SELECT 'VACUUM (ANALYZE) clob_trade_alerts;' WHERE to_regclass('public.clob_trad
 SELECT 'ANALYZE binance_price_ticks;' WHERE to_regclass('public.binance_price_ticks') IS NOT NULL \\gexec
 SELECT 'ANALYZE binance_agg_trade_ticks;' WHERE to_regclass('public.binance_agg_trade_ticks') IS NOT NULL \\gexec
 SELECT 'ANALYZE binance_lob_ticks;' WHERE to_regclass('public.binance_lob_ticks') IS NOT NULL \\gexec
+SELECT 'ANALYZE cex_public_market_ticks;' WHERE to_regclass('public.cex_public_market_ticks') IS NOT NULL \\gexec
 VACUUM (ANALYZE) nba_live_observations;
 SELECT 'VACUUM (ANALYZE) agent_order_executions;' WHERE to_regclass('public.agent_order_executions') IS NOT NULL \\gexec
 SQL

--- a/scripts/report_market_data_health.py
+++ b/scripts/report_market_data_health.py
@@ -58,14 +58,16 @@ def source_snapshot(
     stale_after_seconds: int,
     scan_table: Optional[str] = None,
     latest_method: str = "order",
+    where_sql: str = "TRUE",
 ):
     scan_table = scan_table or table
     if latest_method == "max":
-        latest_sql = f"SELECT max({timestamp_column}) AS latest_at FROM {scan_table}"
+        latest_sql = f"SELECT max({timestamp_column}) AS latest_at FROM {scan_table} WHERE {where_sql}"
     else:
         latest_sql = f"""
   SELECT {timestamp_column} AS latest_at
   FROM {scan_table}
+  WHERE {where_sql}
   ORDER BY {timestamp_column} DESC
   LIMIT 1
 """
@@ -163,6 +165,41 @@ def main() -> int:
                 "deribit_atm_greeks_ticks",
                 "fetched_at",
                 300,
+            ),
+            source_snapshot(
+                "binance_futures",
+                "cex_public_market_ticks",
+                "event_time",
+                300,
+                where_sql="source_key = 'binance/derivatives_snapshot'",
+            ),
+            source_snapshot(
+                "okx_lob",
+                "cex_public_market_ticks",
+                "event_time",
+                300,
+                where_sql="source_key = 'okx/lob'",
+            ),
+            source_snapshot(
+                "bybit_lob",
+                "cex_public_market_ticks",
+                "event_time",
+                300,
+                where_sql="source_key = 'bybit/lob'",
+            ),
+            source_snapshot(
+                "coinbase_lob",
+                "cex_public_market_ticks",
+                "event_time",
+                300,
+                where_sql="source_key = 'coinbase/lob'",
+            ),
+            source_snapshot(
+                "kraken_lob",
+                "cex_public_market_ticks",
+                "event_time",
+                300,
+                where_sql="source_key = 'kraken/lob'",
             ),
         ]
         payload = {

--- a/scripts/report_market_data_health.py
+++ b/scripts/report_market_data_health.py
@@ -174,6 +174,13 @@ def main() -> int:
                 where_sql="source_key = 'binance/derivatives_snapshot'",
             ),
             source_snapshot(
+                "binance_liquidations",
+                "cex_public_market_ticks",
+                "event_time",
+                86400,
+                where_sql="source_key = 'binance/liquidation'",
+            ),
+            source_snapshot(
                 "okx_lob",
                 "cex_public_market_ticks",
                 "event_time",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22976,3 +22976,45 @@ resume live trading.
   the latest replay had one losing trade and `promotion_ready=false`. This
   slice therefore changes safety plumbing only and does not deploy or resume
   live trading.
+
+# CEX Public Market Data (2026-07-12)
+
+## Goal
+
+Collect current public Binance Futures metrics/liquidations and normalized L2
+books from OKX, Bybit, Coinbase Advanced Trade, and Kraken v2 on the Tango
+research host. This is data-collection plumbing only; it does not change any
+strategy promotion or live-trading gate.
+
+## TDD seams
+
+- Public parser/state seam: official exchange payloads produce normalized
+  futures snapshots, liquidation events, and L2 book snapshots.
+- Operator seam: `ploy-runner` exposes one collector command and the Tango
+  deployment installs, starts, and verifies its systemd service.
+
+## Files / Ownership
+
+- `crates/ploy-market-data/` and `crates/ploy-runner-host/`: collector and CLI.
+- `migrations/049_cex_public_market_data.sql`: normalized persistence contract.
+- `deployment/systemd/`, Tango workflows/scripts, and health/audit scripts:
+  deploy and runtime evidence.
+- `docs/COLLECTOR_RUNBOOK.md`: operator contract.
+
+## Tasks
+
+- [x] Add failing parser/state tests for futures, liquidations, and four L2 feeds.
+- [x] Implement the minimum collector and schema that make those tests pass.
+- [x] Wire the CLI, systemd service, Tango bundle/deploy/health checks, and audits.
+- [x] Update docs and run focused Rust/Python/workflow validation.
+- [x] Review the diff, record evidence here, and commit atomically.
+
+## Review
+
+- Added one normalized table, collector command, and systemd unit for Binance
+  Futures plus OKX, Bybit, Coinbase, and Kraken public L2 data.
+- Kraken validates the official CRC32 top-ten checksum without discarding
+  decimal scale; Bybit delta/reset and all venue payloads have focused tests.
+- Validation: 47 market-data Rust tests, runner full-feature check, 41 focused
+  Python workflow/audit tests, and 30 workflow-security tests passed. Binance
+  premium-index, open-interest, and basis REST probes also passed live.

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -38,6 +38,9 @@ class RuntimeMarketDataBoundaryTests(unittest.TestCase):
             for exchange in ("okx", "bybit", "coinbase", "kraken"):
                 self.assertIn(exchange, text)
         self.assertIn('"cex-extended"', audit)
+        self.assertIn("kind = 'liquidation'", health)
+        self.assertIn('"binance_liquidations"', (ROOT / "scripts/report_market_data_health.py").read_text())
+        self.assertIn('?streams={}', collector)
 
     def test_pm5d_runtime_configs_default_to_local_market_data(self) -> None:
         configs = sorted(STRATEGY_DIR.glob("02-pm5d*.toml"))

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -8,6 +8,37 @@ STRATEGY_DIR = ROOT / "config" / "strategies"
 
 
 class RuntimeMarketDataBoundaryTests(unittest.TestCase):
+    def test_public_cex_collector_is_deployed_and_health_gated(self) -> None:
+        collector = (ROOT / "crates/ploy-market-data/src/cex_collectors.rs").read_text()
+        runner = (ROOT / "crates/ploy-runner-host/src/lib.rs").read_text()
+        service = (ROOT / "deployment/systemd/ploy-cex-public-collector.service").read_text()
+        workflow = (ROOT / ".github/workflows/deploy-tango-1-1.yml").read_text()
+        deploy = (ROOT / "scripts/ci/deploy_tango_cloud_assist.py").read_text()
+        health = (ROOT / ".github/workflows/healthcheck-tango-1-1.yml").read_text()
+        audit = (ROOT / "scripts/audit_market_data_gaps.py").read_text()
+
+        for endpoint in (
+            "https://fapi.binance.com",
+            "wss://fstream.binance.com/stream",
+            "wss://ws.okx.com:8443/ws/v5/public",
+            "wss://stream.bybit.com/v5/public/spot",
+            "wss://advanced-trade-ws.coinbase.com",
+            "wss://ws.kraken.com/v2",
+        ):
+            self.assertIn(endpoint, collector)
+        self.assertIn("collect-cex-public", runner)
+        self.assertIn("ExecStart=/opt/ploy/bin/ploy-runner collect-cex-public", service)
+        self.assertIn("Restart=always", service)
+        self.assertIn("OOMPolicy=kill", service)
+        self.assertIn("049_cex_public_market_data.sql", workflow)
+        self.assertIn("ploy-cex-public-collector.service", workflow)
+        for text in (deploy, health):
+            self.assertIn("ploy-cex-public-collector.service", text)
+            self.assertIn("cex_public_market_ticks", text)
+            for exchange in ("okx", "bybit", "coinbase", "kraken"):
+                self.assertIn(exchange, text)
+        self.assertIn('"cex-extended"', audit)
+
     def test_pm5d_runtime_configs_default_to_local_market_data(self) -> None:
         configs = sorted(STRATEGY_DIR.glob("02-pm5d*.toml"))
         self.assertGreaterEqual(len(configs), 1)


### PR DESCRIPTION
## Summary
- add normalized public collection for Binance futures/force orders, OKX, Bybit, Coinbase, and Kraken
- persist one governed `cex_public_market_ticks` contract with L2/futures/liquidation evidence
- package the collector service on the research host and add freshness/health/retention checks

## Verification
- `cargo test -p ploy-market-data --features live --lib` (47 passed on this branch)
- `cargo check -p ploy-runner-host --features full`
- `python3 -m unittest tests.test_runtime_market_data_boundary` (5 passed)
- combined review suite: workflow-security 30 passed, full Python 374 passed

Research-host only; no credentials or trading authority are added.