### PR TITLE
feat: add Predict.fun market data support

### DIFF
--- a/.github/workflows/deploy-tango-1-1.yml
+++ b/.github/workflows/deploy-tango-1-1.yml
@@ -58,6 +58,7 @@ env:
     047_full_depth_execution_surfaces.sql
     048_official_settlement_coverage_checks.sql
     049_cex_public_market_data.sql
+    050_predict_fun_market_data.sql
 
 jobs:
   build-and-deploy:
@@ -227,6 +228,7 @@ jobs:
           cp deployment/systemd/ploy-deribit-iv-collector.service dist/deployment/systemd/ploy-deribit-iv-collector.service
           cp deployment/systemd/ploy-deribit-greeks-collector.service dist/deployment/systemd/ploy-deribit-greeks-collector.service
           cp deployment/systemd/ploy-cex-public-collector.service dist/deployment/systemd/ploy-cex-public-collector.service
+          cp deployment/systemd/ploy-predict-fun-collector.service dist/deployment/systemd/ploy-predict-fun-collector.service
           cp deployment/systemd/ploy-market-discovery.service dist/deployment/systemd/ploy-market-discovery.service
           cp deployment/systemd/ploy-pm-trade-collector.service dist/deployment/systemd/ploy-pm-trade-collector.service
           cp deployment/systemd/ploy-polymarket-v2-indexer-import.service dist/deployment/systemd/ploy-polymarket-v2-indexer-import.service

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,6 +5121,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
+ "secrecy 0.8.0",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/ploy-market-contracts/src/venue.rs
+++ b/crates/ploy-market-contracts/src/venue.rs
@@ -4,8 +4,24 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum VenueKind {
     Polymarket,
+    PredictFun,
     Kalshi,
     Sportsbook,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VenueKind;
+
+    #[test]
+    fn predict_fun_uses_stable_wire_name() {
+        let encoded = serde_json::to_string(&VenueKind::PredictFun).unwrap();
+        assert_eq!(encoded, "\"predict_fun\"");
+        assert_eq!(
+            serde_json::from_str::<VenueKind>(&encoded).unwrap(),
+            VenueKind::PredictFun
+        );
+    }
 }
 
 impl Default for VenueKind {

--- a/crates/ploy-market-data/Cargo.toml
+++ b/crates/ploy-market-data/Cargo.toml
@@ -14,6 +14,7 @@ live = [
     "dep:futures",
     "dep:polymarket-client-sdk",
     "dep:reqwest",
+    "dep:secrecy",
     "dep:sqlx",
     "dep:tokio-tungstenite",
 ]
@@ -25,6 +26,7 @@ futures = { version = "0.3", optional = true }
 ploy-market-contracts.workspace = true
 polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "data", "gamma", "rtds", "tracing", "ws", "heartbeats"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"], optional = true }
+secrecy = { workspace = true, optional = true }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 serde.workspace = true

--- a/crates/ploy-market-data/src/lib.rs
+++ b/crates/ploy-market-data/src/lib.rs
@@ -17,6 +17,8 @@ mod gamma_keyset;
 #[cfg(feature = "live")]
 pub mod pm_trades;
 #[cfg(feature = "live")]
+pub mod predict_fun;
+#[cfg(feature = "live")]
 pub mod reference_prices;
 #[cfg(feature = "live")]
 pub mod scanner;

--- a/crates/ploy-market-data/src/predict_fun.rs
+++ b/crates/ploy-market-data/src/predict_fun.rs
@@ -1,0 +1,486 @@
+//! Predict.fun REST market-discovery and order-book collector.
+//!
+//! Predict's API is currently beta. Mainnet requires an API key; the official
+//! testnet permits keyless access. This module intentionally contains no order
+//! submission or wallet operations.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use reqwest::Client;
+use rust_decimal::Decimal;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use thiserror::Error;
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+pub const MAINNET_API: &str = "https://api.predict.fun";
+pub const TESTNET_API: &str = "https://api-testnet.predict.fun";
+
+#[derive(Debug, Error)]
+pub enum PredictFunError {
+    #[error("Predict.fun mainnet requires PREDICT_FUN_API_KEY")]
+    MissingMainnetApiKey,
+    #[error("unsupported Predict.fun API origin: {0}")]
+    UnsupportedApiOrigin(String),
+    #[error("Predict.fun API request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Predict.fun API returned success=false for {0}")]
+    Api(String),
+    #[error("Predict.fun persistence failed: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct PredictFunConfig {
+    pub base_url: String,
+    pub api_key: Option<SecretString>,
+    pub refresh_interval_secs: u64,
+    pub per_market_delay_ms: u64,
+    pub once: bool,
+}
+
+impl PredictFunConfig {
+    pub fn from_env(once: bool) -> Result<Self, PredictFunError> {
+        let base_url =
+            std::env::var("PREDICT_FUN_API_URL").unwrap_or_else(|_| MAINNET_API.to_string());
+        let api_key = std::env::var("PREDICT_FUN_API_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(SecretString::from);
+        validate_api_access(
+            &base_url,
+            api_key
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+        )?;
+        Ok(Self {
+            base_url,
+            api_key,
+            refresh_interval_secs: env_positive_u64("PLOY_PREDICT_FUN_REFRESH_SECS", 30),
+            // Predict documents a 240 requests/minute default limit. Keep book
+            // polling below that ceiling and leave room for catalog pages.
+            per_market_delay_ms: env_positive_u64("PLOY_PREDICT_FUN_MARKET_DELAY_MS", 300),
+            once,
+        })
+    }
+}
+
+pub fn validate_api_access(base_url: &str, api_key: Option<&str>) -> Result<(), PredictFunError> {
+    let parsed = reqwest::Url::parse(base_url)
+        .map_err(|_| PredictFunError::UnsupportedApiOrigin(base_url.to_string()))?;
+    let is_origin_only = parsed.scheme() == "https"
+        && parsed.port_or_known_default() == Some(443)
+        && matches!(parsed.path(), "" | "/")
+        && parsed.query().is_none()
+        && parsed.fragment().is_none()
+        && parsed.username().is_empty()
+        && parsed.password().is_none();
+    if !is_origin_only {
+        return Err(PredictFunError::UnsupportedApiOrigin(base_url.to_string()));
+    }
+    match parsed.host_str() {
+        Some("api.predict.fun") if api_key.is_none_or(|key| key.trim().is_empty()) => {
+            Err(PredictFunError::MissingMainnetApiKey)
+        }
+        Some("api.predict.fun" | "api-testnet.predict.fun") => Ok(()),
+        _ => Err(PredictFunError::UnsupportedApiOrigin(base_url.to_string())),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PredictMarket {
+    pub id: i64,
+    pub title: String,
+    pub question: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub condition_id: String,
+    pub decimal_precision: u32,
+    pub trading_status: String,
+    pub status: String,
+    pub is_visible: bool,
+    pub is_neg_risk: bool,
+    #[serde(default)]
+    pub is_yield_bearing: bool,
+    pub fee_rate_bps: i32,
+    #[serde(default)]
+    pub outcomes: Vec<PredictOutcome>,
+    #[serde(default)]
+    pub resolution: Option<serde_json::Value>,
+}
+
+impl PredictMarket {
+    fn is_collectible(&self) -> bool {
+        self.is_visible && self.trading_status.eq_ignore_ascii_case("OPEN")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PredictOutcome {
+    pub name: String,
+    pub index_set: i64,
+    pub on_chain_id: String,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketsResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub cursor: Option<String>,
+    pub data: Vec<PredictMarket>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderBookResponse {
+    pub success: bool,
+    pub data: OrderBook,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderBook {
+    pub market_id: i64,
+    pub update_timestamp_ms: i64,
+    #[serde(default)]
+    pub asks: Vec<[serde_json::Value; 2]>,
+    #[serde(default)]
+    pub bids: Vec<[serde_json::Value; 2]>,
+    #[serde(default)]
+    pub last_order_settled: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComplementedBook {
+    pub yes_bid: Option<Decimal>,
+    pub yes_bid_size: Option<Decimal>,
+    pub yes_ask: Option<Decimal>,
+    pub yes_ask_size: Option<Decimal>,
+    pub no_bid: Option<Decimal>,
+    pub no_bid_size: Option<Decimal>,
+    pub no_ask: Option<Decimal>,
+    pub no_ask_size: Option<Decimal>,
+}
+
+pub fn complement_book(book: &OrderBook, precision: u32) -> ComplementedBook {
+    let yes_bid = book.bids.first().and_then(|level| decimal(&level[0]));
+    let yes_bid_size = book.bids.first().and_then(|level| decimal(&level[1]));
+    let yes_ask = book.asks.first().and_then(|level| decimal(&level[0]));
+    let yes_ask_size = book.asks.first().and_then(|level| decimal(&level[1]));
+
+    ComplementedBook {
+        yes_bid,
+        yes_bid_size,
+        yes_ask,
+        yes_ask_size,
+        no_bid: yes_ask.map(|price| (Decimal::ONE - price).round_dp(precision)),
+        no_bid_size: yes_ask_size,
+        no_ask: yes_bid.map(|price| (Decimal::ONE - price).round_dp(precision)),
+        no_ask_size: yes_bid_size,
+    }
+}
+
+fn decimal(value: &serde_json::Value) -> Option<Decimal> {
+    match value {
+        serde_json::Value::Number(number) => Decimal::from_str(number.as_str()).ok(),
+        serde_json::Value::String(number) => Decimal::from_str(number).ok(),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PredictFunClient {
+    client: Client,
+    base_url: String,
+    api_key: Option<SecretString>,
+}
+
+impl PredictFunClient {
+    pub fn new(base_url: String, api_key: Option<SecretString>) -> Result<Self, PredictFunError> {
+        validate_api_access(
+            &base_url,
+            api_key
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+        )?;
+        Ok(Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(20))
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+        })
+    }
+
+    fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let request = self.client.get(format!("{}{path}", self.base_url));
+        match &self.api_key {
+            Some(key) => request.header("x-api-key", key.expose_secret()),
+            None => request,
+        }
+    }
+
+    pub async fn markets(&self) -> Result<Vec<PredictMarket>, PredictFunError> {
+        let mut all = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let mut request = self.get("/v1/markets").query(&[("first", "100")]);
+            if let Some(after) = cursor.as_deref() {
+                request = request.query(&[("after", after)]);
+            }
+            let response: MarketsResponse =
+                request.send().await?.error_for_status()?.json().await?;
+            if !response.success {
+                return Err(PredictFunError::Api("GET /v1/markets".to_string()));
+            }
+            all.extend(response.data);
+            match response.cursor.filter(|next| Some(next) != cursor.as_ref()) {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        Ok(all)
+    }
+
+    pub async fn orderbook(&self, market_id: i64) -> Result<OrderBook, PredictFunError> {
+        let response: OrderBookResponse = self
+            .get(&format!("/v1/markets/{market_id}/orderbook"))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        if !response.success {
+            return Err(PredictFunError::Api(format!(
+                "GET /v1/markets/{market_id}/orderbook"
+            )));
+        }
+        Ok(response.data)
+    }
+}
+
+pub async fn run_collector(config: PredictFunConfig, pool: PgPool) -> Result<(), PredictFunError> {
+    let client = PredictFunClient::new(config.base_url.clone(), config.api_key.clone())?;
+    loop {
+        if let Err(error) = collect_once(&client, &config, &pool).await {
+            if config.once {
+                return Err(error);
+            }
+            warn!(%error, "Predict.fun collection pass failed");
+        }
+        if config.once {
+            return Ok(());
+        }
+        sleep(Duration::from_secs(config.refresh_interval_secs)).await;
+    }
+}
+
+async fn collect_once(
+    client: &PredictFunClient,
+    config: &PredictFunConfig,
+    pool: &PgPool,
+) -> Result<(), PredictFunError> {
+    let markets = client.markets().await?;
+    let mut books = 0usize;
+    let mut attempted_books = 0usize;
+    for market in &markets {
+        persist_market(pool, market).await?;
+        if !market.is_collectible() {
+            continue;
+        }
+        attempted_books += 1;
+        match client.orderbook(market.id).await {
+            Ok(book) => {
+                persist_book(pool, market, &book).await?;
+                books += 1;
+            }
+            Err(error) => {
+                warn!(market_id = market.id, %error, "Predict.fun orderbook fetch failed")
+            }
+        }
+        sleep(Duration::from_millis(config.per_market_delay_ms)).await;
+    }
+    if attempted_books > 0 && books == 0 {
+        return Err(PredictFunError::Api(
+            "all collectible market orderbook requests failed".to_string(),
+        ));
+    }
+    info!(
+        markets = markets.len(),
+        books, "Predict.fun collection pass complete"
+    );
+    Ok(())
+}
+
+async fn persist_market(pool: &PgPool, market: &PredictMarket) -> Result<(), sqlx::Error> {
+    let outcomes = serde_json::to_value(&market.outcomes).unwrap_or(serde_json::Value::Null);
+    sqlx::query(
+        r#"
+        INSERT INTO predict_fun_markets (
+            market_id, condition_id, title, question, description,
+            decimal_precision, trading_status, status, is_visible, is_neg_risk,
+            is_yield_bearing, fee_rate_bps, outcomes, resolution, observed_at
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW()
+        )
+        ON CONFLICT (market_id) DO UPDATE SET
+            condition_id = EXCLUDED.condition_id,
+            title = EXCLUDED.title,
+            question = EXCLUDED.question,
+            description = EXCLUDED.description,
+            decimal_precision = EXCLUDED.decimal_precision,
+            trading_status = EXCLUDED.trading_status,
+            status = EXCLUDED.status,
+            is_visible = EXCLUDED.is_visible,
+            is_neg_risk = EXCLUDED.is_neg_risk,
+            is_yield_bearing = EXCLUDED.is_yield_bearing,
+            fee_rate_bps = EXCLUDED.fee_rate_bps,
+            outcomes = EXCLUDED.outcomes,
+            resolution = EXCLUDED.resolution,
+            observed_at = NOW()
+        "#,
+    )
+    .bind(market.id)
+    .bind(&market.condition_id)
+    .bind(&market.title)
+    .bind(&market.question)
+    .bind(&market.description)
+    .bind(i32::try_from(market.decimal_precision).unwrap_or(i32::MAX))
+    .bind(&market.trading_status)
+    .bind(&market.status)
+    .bind(market.is_visible)
+    .bind(market.is_neg_risk)
+    .bind(market.is_yield_bearing)
+    .bind(market.fee_rate_bps)
+    .bind(outcomes)
+    .bind(&market.resolution)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn persist_book(
+    pool: &PgPool,
+    market: &PredictMarket,
+    book: &OrderBook,
+) -> Result<(), sqlx::Error> {
+    let normalized = complement_book(book, market.decimal_precision);
+    sqlx::query(
+        r#"
+        INSERT INTO predict_fun_orderbook_ticks (
+            market_id, exchange_timestamp_ms,
+            best_yes_bid, best_yes_bid_size, best_yes_ask, best_yes_ask_size,
+            best_no_bid, best_no_bid_size, best_no_ask, best_no_ask_size,
+            received_at
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW())
+        "#,
+    )
+    .bind(book.market_id)
+    .bind(book.update_timestamp_ms)
+    .bind(normalized.yes_bid)
+    .bind(normalized.yes_bid_size)
+    .bind(normalized.yes_ask)
+    .bind(normalized.yes_ask_size)
+    .bind(normalized.no_bid)
+    .bind(normalized.no_bid_size)
+    .bind(normalized.no_ask)
+    .bind(normalized.no_ask_size)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn env_positive_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{complement_book, validate_api_access, MarketsResponse, OrderBookResponse};
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn parses_official_market_payload() {
+        let response: MarketsResponse = serde_json::from_str(
+            r#"{
+              "success": true,
+              "cursor": "NDc2",
+              "data": [{
+                "id": 476,
+                "title": "<$2,500",
+                "question": "Will Gold close under $2,500?",
+                "description": "Resolution rules",
+                "conditionId": "0xf5cb",
+                "decimalPrecision": 2,
+                "tradingStatus": "OPEN",
+                "status": "REGISTERED",
+                "isVisible": true,
+                "isNegRisk": true,
+                "isYieldBearing": true,
+                "feeRateBps": 200,
+                "outcomes": [
+                  {"name":"Yes","indexSet":1,"onChainId":"11","status":null},
+                  {"name":"No","indexSet":2,"onChainId":"22","status":null}
+                ],
+                "resolution": null
+              }]
+            }"#,
+        )
+        .unwrap();
+        assert!(response.success);
+        assert_eq!(response.cursor.as_deref(), Some("NDc2"));
+        assert_eq!(response.data[0].id, 476);
+        assert_eq!(response.data[0].outcomes[1].on_chain_id, "22");
+    }
+
+    #[test]
+    fn parses_book_and_derives_no_side_at_market_precision() {
+        let response: OrderBookResponse = serde_json::from_str(
+            r#"{
+              "success": true,
+              "data": {
+                "marketId": 476,
+                "updateTimestampMs": 1727910141000,
+                "asks": [[0.492, 30192.26]],
+                "bids": [[0.491, 303518.1]],
+                "lastOrderSettled": null
+              }
+            }"#,
+        )
+        .unwrap();
+        assert!(response.success);
+        let book = complement_book(&response.data, 3);
+        assert_eq!(book.yes_bid, Some(dec!(0.491)));
+        assert_eq!(book.yes_ask, Some(dec!(0.492)));
+        assert_eq!(book.no_bid, Some(dec!(0.508)));
+        assert_eq!(book.no_ask, Some(dec!(0.509)));
+        assert_eq!(book.no_bid_size, Some(dec!(30192.26)));
+        assert_eq!(book.no_ask_size, Some(dec!(303518.1)));
+    }
+
+    #[test]
+    fn mainnet_requires_api_key_but_official_testnet_does_not() {
+        assert!(validate_api_access(MAINNET_API, None).is_err());
+        assert!(validate_api_access("https://api.predict.fun/", Some("key")).is_ok());
+        assert!(validate_api_access("https://api.predict.fun:443", None).is_err());
+        assert!(validate_api_access(TESTNET_API, None).is_ok());
+        assert!(validate_api_access("https://example.com", Some("key")).is_err());
+    }
+
+    use super::{MAINNET_API, TESTNET_API};
+}

--- a/crates/ploy-runner-host/src/lib.rs
+++ b/crates/ploy-runner-host/src/lib.rs
@@ -22,6 +22,8 @@ fn print_usage_for(program: &str) {
     #[cfg(feature = "ops")]
     eprintln!("  collect-pm-trades         Collect public Polymarket trade prints from Data API");
     #[cfg(feature = "ops")]
+    eprintln!("  collect-predict-fun       Collect Predict.fun markets and normalized order books");
+    #[cfg(feature = "ops")]
     eprintln!("  collect-binance-lob       Collect Binance L2 orderbook depth snapshots");
     #[cfg(feature = "ops")]
     eprintln!("  collect-binance-price     Collect Binance spot trade prices");
@@ -95,6 +97,12 @@ pub async fn run_with_args(args: Vec<String>) {
             ops::run_collect_pm_trades(&args).await;
             #[cfg(not(feature = "ops"))]
             eprintln!("The collect-pm-trades command requires the full/ops runner build");
+        }
+        Some("collect-predict-fun") => {
+            #[cfg(feature = "ops")]
+            ops::run_collect_predict_fun(&args).await;
+            #[cfg(not(feature = "ops"))]
+            eprintln!("The collect-predict-fun command requires the full/ops runner build");
         }
         // --- New Binance/Deribit collectors ---
         Some("collect-binance-lob") => {

--- a/crates/ploy-runner-host/src/ops.rs
+++ b/crates/ploy-runner-host/src/ops.rs
@@ -6,6 +6,7 @@ use ploy_market_data::collector::{CollectorConfig, QuoteCollector};
 use ploy_market_data::deribit_collectors::{collect_deribit_greeks, collect_deribit_iv};
 use ploy_market_data::diagnostics::check_database;
 use ploy_market_data::pm_trades::{TradeCollector, TradeCollectorConfig};
+use ploy_market_data::predict_fun::{run_collector as run_predict_fun_collector, PredictFunConfig};
 use ploy_market_data::scanner::{run_market_discovery_collector, MarketDiscoveryCollectorConfig};
 use sqlx::postgres::PgPoolOptions;
 
@@ -72,6 +73,14 @@ pub fn print_usage() {
     eprintln!(
         "  env PLOY_PM_TRADE_COLLECTOR_TAKER_ONLY      true/false Data API takerOnly (default: true)"
     );
+    eprintln!();
+    eprintln!("Options for 'collect-predict-fun':");
+    eprintln!("  --once            Run one discovery/order-book pass and exit");
+    eprintln!("  --db-url <url>    Database URL (or DATABASE_URL/PLOY_DATABASE__URL)");
+    eprintln!("  env PREDICT_FUN_API_URL                    API base URL (default: mainnet)");
+    eprintln!("  env PREDICT_FUN_API_KEY                    Required by Predict.fun mainnet");
+    eprintln!("  env PLOY_PREDICT_FUN_REFRESH_SECS          Poll interval (default: 30)");
+    eprintln!("  env PLOY_PREDICT_FUN_MARKET_DELAY_MS       Per-market delay (default: 300)");
     eprintln!();
     eprintln!("Options for 'collect-binance-lob':");
     eprintln!("  --symbols <list>  Comma-separated symbols (default: BTCUSDT,ETHUSDT,SOLUSDT,XRPUSDT,DOGEUSDT,HYPEUSDT,BNBUSDT)");
@@ -258,6 +267,39 @@ pub async fn run_collect_pm_trades(args: &[String]) {
     let collector = TradeCollector::new(config, pool);
     if let Err(error) = collector.run().await {
         eprintln!("Polymarket trade collector failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+pub async fn run_collect_predict_fun(args: &[String]) {
+    let db_url = match db_url(args) {
+        Ok(db_url) => db_url,
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+    let pool = match PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&db_url)
+        .await
+    {
+        Ok(pool) => pool,
+        Err(error) => {
+            eprintln!("Failed to connect to database: {error}");
+            std::process::exit(1);
+        }
+    };
+    let config = match PredictFunConfig::from_env(args.iter().any(|arg| arg == "--once")) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("Predict.fun configuration failed: {error}");
+            std::process::exit(1);
+        }
+    };
+    if let Err(error) = run_predict_fun_collector(config, pool).await {
+        eprintln!("Predict.fun collector failed: {error}");
         std::process::exit(1);
     }
 }

--- a/deployment/systemd/ploy-predict-fun-collector.service
+++ b/deployment/systemd/ploy-predict-fun-collector.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Ploy Predict.fun Market Data Collector
+After=postgresql.service network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/ploy/predict-fun.env
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ploy
+EnvironmentFile=/etc/ploy/predict-fun.env
+Environment=PLOY_DATABASE__URL=postgresql://postgres:postgres@localhost:5432/ploy
+Environment=PLOY_PREDICT_FUN_REFRESH_SECS=30
+Environment=PLOY_PREDICT_FUN_MARKET_DELAY_MS=300
+ExecStartPre=/bin/sleep 23
+ExecStart=/opt/ploy/bin/ploy-runner collect-predict-fun
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+MemoryHigh=1280M
+MemoryMax=1536M
+CPUQuota=80%
+OOMPolicy=kill
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/COLLECTOR_RUNBOOK.md
+++ b/docs/COLLECTOR_RUNBOOK.md
@@ -34,6 +34,8 @@ systemd units:
 - `ploy-deribit-iv-collector.service`
 - `ploy-deribit-greeks-collector.service`
 - `ploy-cex-public-collector.service`
+- `ploy-predict-fun-collector.service` (enabled only when
+  `/etc/ploy/predict-fun.env` contains `PREDICT_FUN_API_KEY`)
 
 Trigger deploys from `main`:
 
@@ -63,6 +65,8 @@ Examples:
 /opt/ploy/bin/ploy-runner collect-deribit-iv --currencies BTC,ETH,SOL --db-url "$PLOY_DATABASE__URL"
 /opt/ploy/bin/ploy-runner collect-deribit-greeks --currencies BTC,ETH,SOL --db-url "$PLOY_DATABASE__URL"
 /opt/ploy/bin/ploy-runner collect-cex-public --assets BTC,ETH,SOL --poll-secs 5 --sample-ms 1000 --db-url "$PLOY_DATABASE__URL"
+PREDICT_FUN_API_URL=https://api-testnet.predict.fun \
+  /opt/ploy/bin/ploy-runner collect-predict-fun --once --db-url "$PLOY_DATABASE__URL"
 ```
 
 `collect-cex-public` writes one normalized `cex_public_market_ticks` surface:
@@ -71,6 +75,16 @@ plus sampled L2 books from OKX `books5`, Bybit `orderbook.50`, Coinbase Advanced
 Trade `level2`, and Kraken WebSocket v2 `book`. Use the `cex-extended` gap-audit
 profile before consuming these rows in factor research. They are not part of
 the existing PM5D promotion gate by default.
+
+`collect-predict-fun` uses Predict.fun's official beta REST API to persist
+`predict_fun_markets` and normalized `predict_fun_orderbook_ticks`. Predict's
+book is Yes-based; Ploy derives No bids/asks by swapping sides and taking the
+complement at the market's declared decimal precision. Mainnet rejects startup
+without `PREDICT_FUN_API_KEY`; the official testnet permits keyless diagnostics.
+This collector does not submit orders, hold wallet keys, or redeem positions.
+Create `/etc/ploy/predict-fun.env` as a root-owned `0600` file containing only
+`PREDICT_FUN_API_KEY=...`; the default 300 ms book-request spacing stays below
+Predict.fun's documented 240 requests/minute key limit with catalog headroom.
 
 If a diagnostic requires remote secrets or production data, prefer a GitHub
 Actions workflow with environment-scoped secrets over a local command.

--- a/docs/operations/data-jobs-inventory.md
+++ b/docs/operations/data-jobs-inventory.md
@@ -14,6 +14,7 @@ collection behavior.
 | `/opt/ploy/bin/ploy-runner collect-quotes` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Full/ops build only; lean replay/backtest binaries intentionally do not expose it. |
 | `/opt/ploy/bin/ploy-runner collect-pm-trades` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Polls Polymarket Data API trade prints into `clob_trade_ticks`; full/ops build only. |
 | `/opt/ploy/bin/ploy-runner collect-cex-public` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Collects Binance Futures public metrics/liquidations and normalized OKX, Bybit, Coinbase, and Kraken L2 rows. |
+| `/opt/ploy/bin/ploy-runner collect-predict-fun` / `ploy-runner-host::ops` | canonical ops surface | runner ops | Collects Predict.fun market catalog and normalized Yes/No order-book snapshots; mainnet API key required. |
 | `ploy-feed-loaders` | canonical historical DB loader | research/backtest adapters | Owns SQLx historical `MarketUpdate` loading outside strategy-bundles. |
 | `scripts/export_parquet.sh` | canonical export helper | data/export host | Keep as the explicit Parquet export entrypoint until replaced by Rust datactl. |
 | `.github/workflows/backtest.yml` | canonical CI backtest lane | CI/backtest host | Should remain separated from trade-host deploy assumptions. |

--- a/migrations/050_predict_fun_market_data.sql
+++ b/migrations/050_predict_fun_market_data.sql
@@ -1,0 +1,56 @@
+-- Predict.fun market catalog and normalized Yes/No top-of-book history.
+-- Kept separate from Polymarket's pm_* tables so numeric market identifiers
+-- cannot collide across venues.
+
+CREATE TABLE IF NOT EXISTS predict_fun_markets (
+    market_id BIGINT PRIMARY KEY,
+    condition_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    question TEXT NOT NULL,
+    description TEXT,
+    decimal_precision INTEGER NOT NULL CHECK (decimal_precision BETWEEN 0 AND 18),
+    trading_status TEXT NOT NULL,
+    status TEXT NOT NULL,
+    is_visible BOOLEAN NOT NULL,
+    is_neg_risk BOOLEAN NOT NULL,
+    is_yield_bearing BOOLEAN NOT NULL,
+    fee_rate_bps INTEGER NOT NULL,
+    outcomes JSONB NOT NULL,
+    resolution JSONB,
+    observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_predict_fun_markets_trading_status
+    ON predict_fun_markets (trading_status, is_visible);
+CREATE INDEX IF NOT EXISTS idx_predict_fun_markets_observed_at
+    ON predict_fun_markets (observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS predict_fun_orderbook_ticks (
+    id BIGSERIAL PRIMARY KEY,
+    market_id BIGINT NOT NULL REFERENCES predict_fun_markets(market_id),
+    exchange_timestamp_ms BIGINT NOT NULL,
+    best_yes_bid NUMERIC,
+    best_yes_bid_size NUMERIC,
+    best_yes_ask NUMERIC,
+    best_yes_ask_size NUMERIC,
+    best_no_bid NUMERIC,
+    best_no_bid_size NUMERIC,
+    best_no_ask NUMERIC,
+    best_no_ask_size NUMERIC,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_predict_fun_books_market_time
+    ON predict_fun_orderbook_ticks (market_id, received_at DESC);
+CREATE INDEX IF NOT EXISTS idx_predict_fun_books_received_at
+    ON predict_fun_orderbook_ticks (received_at DESC);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ploy') THEN
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE predict_fun_markets TO ploy;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE predict_fun_orderbook_ticks TO ploy;
+        GRANT USAGE, SELECT ON SEQUENCE predict_fun_orderbook_ticks_id_seq TO ploy;
+    END IF;
+END
+$$;

--- a/scripts/ci/deploy_tango_cloud_assist.py
+++ b/scripts/ci/deploy_tango_cloud_assist.py
@@ -82,6 +82,13 @@ service_exists() {{
   systemctl cat "$1" >/dev/null 2>&1
 }}
 
+predict_fun_configured() {{
+  [ -s /etc/ploy/predict-fun.env ] && {{
+    grep -Eq '^PREDICT_FUN_API_KEY=.+$' /etc/ploy/predict-fun.env ||
+    grep -Eq '^PREDICT_FUN_API_URL=https://api-testnet\\.predict\\.fun/?$' /etc/ploy/predict-fun.env
+  }}
+}}
+
 require_research_host_has_no_live() {{
   local deployments
   if grep -Eq '^[[:space:]]*(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=' "${{DEPLOY_ROOT}}/.env"; then
@@ -196,6 +203,7 @@ for unit in \\
   ploy-deribit-iv-collector.service \\
   ploy-deribit-greeks-collector.service \\
   ploy-cex-public-collector.service \\
+  ploy-predict-fun-collector.service \\
   ploy-market-discovery.service \\
   ploy-quote-collector.service \\
   ploy-pm-trade-collector.service; do
@@ -266,6 +274,7 @@ install -m 0644 ./deployment/systemd/ploy-binance-price-collector.service /etc/s
 install -m 0644 ./deployment/systemd/ploy-deribit-iv-collector.service /etc/systemd/system/ploy-deribit-iv-collector.service
 install -m 0644 ./deployment/systemd/ploy-deribit-greeks-collector.service /etc/systemd/system/ploy-deribit-greeks-collector.service
 install -m 0644 ./deployment/systemd/ploy-cex-public-collector.service /etc/systemd/system/ploy-cex-public-collector.service
+install -m 0644 ./deployment/systemd/ploy-predict-fun-collector.service /etc/systemd/system/ploy-predict-fun-collector.service
 install -m 0644 ./deployment/systemd/ploy-market-discovery.service /etc/systemd/system/ploy-market-discovery.service
 install -m 0644 ./deployment/systemd/ploy-pm-trade-collector.service /etc/systemd/system/ploy-pm-trade-collector.service
 install -m 0644 ./deployment/systemd/ploy-polymarket-v2-indexer-import.service /etc/systemd/system/ploy-polymarket-v2-indexer-import.service
@@ -307,6 +316,13 @@ systemctl enable --now ploy-deribit-greeks-collector.service
 systemctl restart ploy-deribit-greeks-collector.service
 systemctl enable --now ploy-cex-public-collector.service
 systemctl restart ploy-cex-public-collector.service
+if predict_fun_configured; then
+  systemctl enable --now ploy-predict-fun-collector.service
+  systemctl restart ploy-predict-fun-collector.service
+else
+  systemctl disable --now ploy-predict-fun-collector.service >/dev/null 2>&1 || true
+  echo "Predict.fun collector installed but disabled: /etc/ploy/predict-fun.env has no API key"
+fi
 systemctl enable --now ploy-market-discovery.service
 systemctl restart ploy-market-discovery.service
 if ! check_recent_rows \\
@@ -360,6 +376,10 @@ systemctl is-active --quiet ploy-deribit-greeks-collector.service
 require_service_guardrails ploy-deribit-greeks-collector.service
 systemctl is-active --quiet ploy-cex-public-collector.service
 require_service_guardrails ploy-cex-public-collector.service
+if predict_fun_configured; then
+  systemctl is-active --quiet ploy-predict-fun-collector.service
+  require_service_guardrails ploy-predict-fun-collector.service
+fi
 systemctl is-active --quiet ploy-market-discovery.service
 require_service_guardrails ploy-market-discovery.service
 if service_exists ployd.service; then
@@ -399,6 +419,17 @@ wait_for_recent_log \\
   "pm trade collector did not complete a healthy poll after deploy" \\
   120 \\
   5
+if predict_fun_configured; then
+  wait_for_recent_rows \\
+    "SELECT EXISTS (SELECT 1 FROM predict_fun_orderbook_ticks WHERE received_at >= NOW() - INTERVAL '10 minutes')" \\
+    "Predict.fun order books are not fresh after deploy"
+  wait_for_recent_log \\
+    "ploy-predict-fun-collector.service" \\
+    "Predict.fun collection pass complete" \\
+    "Predict.fun collector did not complete a healthy pass after deploy" \\
+    120 \\
+    5
+fi
 
 if service_exists ployd.service; then
   assert_no_recent_logs \\

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23075,3 +23075,66 @@ strategy promotion or live-trading gate.
 - Validation: 47 market-data Rust tests, runner full-feature check, 41 focused
   Python workflow/audit tests, and 30 workflow-security tests passed. Binance
   premium-index, open-interest, and basis REST probes also passed live.
+
+# Predict.fun Market Data Support (2026-07-13)
+
+## Goal
+
+Add Predict.fun as a first-class prediction-market venue for market discovery
+and order-book collection on the research host. This slice is collection and
+dry-run/research plumbing only; it must not enable live order submission or
+on-chain redemption without a separate approved execution adapter.
+
+## Evidence stage
+
+Integration/data-coverage evidence. Collected Predict.fun data may feed later
+exploration, but does not by itself satisfy replay, dry-run parity, promotion,
+or live-trading evidence stages from `docs/PROJECT_SEMANTICS.md`.
+
+## TDD seams
+
+- Contract seam: `VenueKind` round-trips `predict_fun` without changing the
+  existing Polymarket default.
+- API seam: official `/v1/markets` and `/v1/markets/{id}/orderbook` payloads
+  deserialize and normalize Yes/No top-of-book prices correctly.
+- Safety seam: mainnet requires an API key; the key is read from the environment
+  and never persisted, while the keyless official testnet remains usable.
+- Operator seam: `ploy-runner collect-predict-fun` persists catalog and book
+  snapshots through a dedicated schema without overloading Polymarket tables.
+
+## Files / Ownership
+
+- `crates/ploy-market-contracts/src/venue.rs`: venue contract.
+- `crates/ploy-market-data/src/predict_fun.rs`: API, normalization, collector.
+- `crates/ploy-runner-host/src/{lib.rs,ops.rs}`: operator command.
+- `migrations/050_predict_fun_market_data.sql`: persistence contract.
+- `docs/COLLECTOR_RUNBOOK.md` and config examples: operator guidance.
+
+## Tasks
+
+- [x] Add failing contract/parser/normalization/safety tests.
+- [x] Implement the smallest API client and collector that make them pass.
+- [x] Wire CLI, migration, configuration, and operator documentation.
+- [x] Run focused and workspace validation; review the diff.
+- [x] Record evidence, commit atomically, push, and open a PR.
+
+## Review
+
+- Added the `predict_fun` venue plus a dedicated official REST collector for
+  paginated market discovery and Yes-based order books. No order, wallet, live,
+  or redeem authority was added.
+- Mainnet fails closed without a zeroizing/redacted API key. Only the two
+  official HTTPS origins are accepted, redirects are disabled, and official
+  keyless testnet remains available for diagnostics.
+- Predict.fun data is isolated in `predict_fun_markets` and
+  `predict_fun_orderbook_ticks`; No-side prices and sizes are derived from the
+  official Yes book at each market's declared decimal precision.
+- The Tango bundle installs a guarded service. It starts only with a mainnet
+  key or explicit official testnet config, uses required systemd limits, and
+  deployment postflight requires both a healthy pass and fresh order-book rows.
+- Validation: 8 market-contract tests, 53 market-data tests, 12 deployment
+  boundary tests, runner ops compilation, rendered remote-shell syntax,
+  actionlint, live official testnet REST probes, and `git diff --check` passed.
+- Independent review found API-key handling, origin validation, zero-book
+  health, testnet enablement, and systemd guardrail gaps; all were corrected
+  before commit.

--- a/tests/test_runtime_market_data_boundary.py
+++ b/tests/test_runtime_market_data_boundary.py
@@ -8,6 +8,29 @@ STRATEGY_DIR = ROOT / "config" / "strategies"
 
 
 class RuntimeMarketDataBoundaryTests(unittest.TestCase):
+    def test_predict_fun_collector_is_deployed_but_requires_host_api_key(self) -> None:
+        runner = (ROOT / "crates/ploy-runner-host/src/lib.rs").read_text()
+        service = (ROOT / "deployment/systemd/ploy-predict-fun-collector.service").read_text()
+        workflow = (ROOT / ".github/workflows/deploy-tango-1-1.yml").read_text()
+        deploy = (ROOT / "scripts/ci/deploy_tango_cloud_assist.py").read_text()
+
+        self.assertIn("collect-predict-fun", runner)
+        self.assertIn("ExecStart=/opt/ploy/bin/ploy-runner collect-predict-fun", service)
+        self.assertIn("EnvironmentFile=/etc/ploy/predict-fun.env", service)
+        self.assertIn("Restart=always", service)
+        self.assertIn("RestartSec=5", service)
+        self.assertIn("MemoryHigh=1280M", service)
+        self.assertIn("MemoryMax=1536M", service)
+        self.assertIn("OOMPolicy=kill", service)
+        self.assertIn("050_predict_fun_market_data.sql", workflow)
+        self.assertIn("ploy-predict-fun-collector.service", workflow)
+        self.assertIn("PREDICT_FUN_API_KEY", deploy)
+        self.assertIn("predict_fun_configured", deploy)
+        self.assertIn("api-testnet\\\\.predict\\\\.fun", deploy)
+        self.assertIn("systemctl disable --now ploy-predict-fun-collector.service", deploy)
+        self.assertIn("Predict.fun collection pass complete", deploy)
+        self.assertIn("predict_fun_orderbook_ticks WHERE received_at", deploy)
+
     def test_public_cex_collector_is_deployed_and_health_gated(self) -> None:
         collector = (ROOT / "crates/ploy-market-data/src/cex_collectors.rs").read_text()
         runner = (ROOT / "crates/ploy-runner-host/src/lib.rs").read_text()


### PR DESCRIPTION
## Summary
- add Predict.fun as a first-class venue with official REST market and order-book collection
- persist isolated Predict.fun catalog and normalized Yes/No top-of-book history
- install a fail-closed Tango collector service with mainnet API-key and deployment freshness gates

## Safety boundary
- no live order submission, wallet custody, or redemption path
- only official Predict.fun mainnet/testnet HTTPS origins are accepted
- mainnet requires a zeroizing/redacted API key; official testnet can run keyless

## Verification
- `cargo test -p ploy-market-contracts` (8 passed)
- `cargo test -p ploy-market-data --features live` (53 passed)
- `cargo check -p ploy-runner-host --features ops`
- `cargo clippy -p ploy-market-data --features live --all-targets`
- `cargo clippy -p ploy-runner-host --features ops --all-targets`
- `python3 -m unittest tests.test_runtime_market_data_boundary tests.test_aliyun_dual_host_workflows` (12 passed)
- rendered Cloud Assistant script `bash -n`, actionlint, live official testnet REST probes, and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Predict.fun market discovery and order-book data collection.
  * Added normalized Yes/No pricing and historical snapshot storage.
  * Added the `collect-predict-fun` operations command with one-time collection support.
  * Added optional system service deployment with automatic restart and configuration safeguards.

* **Documentation**
  * Updated collector runbooks and operations inventory with setup, diagnostics, and data details.

* **Bug Fixes**
  * Added validation to restrict API access to supported secure endpoints and protect mainnet credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->