### PR TITLE
fix: harden Polymarket replay and trade readiness

### DIFF
--- a/.github/scripts/research-issue-labels.js
+++ b/.github/scripts/research-issue-labels.js
@@ -43,6 +43,10 @@ const LABEL_DEFINITIONS = {
     color: "1d76db",
     description: "Issue has diagnostic research evidence; not deployable by itself",
   },
+  "evidence:executable-replay": {
+    color: "1d76db",
+    description: "Issue has executable-price replay evidence; parity gates still apply",
+  },
   "evidence:factor-review": {
     color: "1d76db",
     description: "Issue has factor review workflow evidence",
@@ -82,6 +86,7 @@ const LABEL_DEFINITIONS = {
 };
 
 const MANAGED_STATE_PREFIXES = ["decision:", "parity:", "evidence:missing-"];
+const MANAGED_STATE_LABELS = new Set(["evidence:diagnostic", "evidence:executable-replay"]);
 
 function normalizeLabel(name) {
   return String(name || "").trim();
@@ -137,7 +142,8 @@ async function applyResearchIssueLabels({ github, context, core, issue_number, l
 
   for (const label of current) {
     const name = label.name;
-    const managed = MANAGED_STATE_PREFIXES.some((prefix) => name.startsWith(prefix));
+    const managed = MANAGED_STATE_LABELS.has(name)
+      || MANAGED_STATE_PREFIXES.some((prefix) => name.startsWith(prefix));
     if (!managed || nextSet.has(name)) continue;
     await github.rest.issues.removeLabel({
       owner: context.repo.owner,

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -20,11 +20,11 @@ on:
         required: true
         default: "config/strategies/02-pm5d-threelayer.unified.toml"
       data_dir:
-        description: "Diagnostic Parquet stream dir (leave empty to use DB; not full-depth lake replay)"
+        description: "Parquet replay root (full-depth orderbook_snapshots preferred; leave empty for DB)"
         required: false
         default: ""
       sync_parquet_data:
-        description: "Sync legacy quote-tick Parquet from Tango before running"
+        description: "Sync replay Parquet and the selected full-depth CLOB window from Tango"
         required: false
         default: "false"
       issue_number:
@@ -89,6 +89,8 @@ jobs:
         if: ${{ github.event.inputs.data_dir != '' && github.event.inputs.sync_parquet_data == 'true' }}
         env:
           DATA_DIR: ${{ github.event.inputs.data_dir }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
           TANGO_1_1_KNOWN_HOSTS: ${{ secrets.TANGO_1_1_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
@@ -106,12 +108,46 @@ jobs:
             -e "ssh -i ~/.ssh/tango_key -o HostKeyAlias=tango-1-1 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts" \
             root@172.16.0.204:/opt/ploy/data/parquet/ \
             "${DATA_DIR}/"
+          start_epoch="$(date -u -d "${START_DATE} 00:00:00" +%s)"
+          end_epoch="$(date -u -d "${END_DATE} +1 day 00:00:00" +%s)"
+          current_epoch="$start_epoch"
+          while [ "$current_epoch" -lt "$end_epoch" ]; do
+            day="$(TZ=Asia/Shanghai date -d "@${current_epoch}" +%F)"
+            hour="$(TZ=Asia/Shanghai date -d "@${current_epoch}" +%H)"
+            hour_dir="${DATA_DIR}/orderbook_snapshots/date=${day}/hour=${hour}"
+            mkdir -p "${hour_dir}"
+            rsync -az \
+              -e "ssh -i ~/.ssh/tango_key -o HostKeyAlias=tango-1-1 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts" \
+              "root@172.16.0.204:/opt/ploy/data/lake/orderbook_snapshots/date=${day}/hour=${hour}/" \
+              "${hour_dir}/"
+            HOUR_DIR="${hour_dir}" python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          hour_dir = Path(os.environ["HOUR_DIR"])
+          marker = hour_dir / "_SUCCESS"
+          manifest_path = hour_dir / "manifest.json"
+          parquet_path = hour_dir / "snapshots.parquet"
+          if not marker.is_file() or not manifest_path.is_file() or not parquet_path.is_file():
+              raise SystemExit(f"incomplete full-depth archive hour: {hour_dir}")
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          if manifest.get("full_fidelity") is not True or int(manifest.get("row_count") or 0) <= 0:
+              raise SystemExit(f"invalid full-depth manifest: {manifest_path}")
+          digest = hashlib.sha256(parquet_path.read_bytes()).hexdigest()
+          if digest != manifest.get("sha256"):
+              raise SystemExit(f"full-depth archive checksum mismatch: {parquet_path}")
+          PY
+            current_epoch="$((current_epoch + 3600))"
+          done
 
       - name: Run backtest
         env:
           CONFIG: ${{ github.event.inputs.config }}
           START_DATE: ${{ github.event.inputs.start_date }}
           END_DATE: ${{ github.event.inputs.end_date }}
+          GIT_REF: ${{ github.event.inputs.git_ref }}
           DATA_DIR: ${{ github.event.inputs.data_dir }}
           SYNC_PARQUET_DATA: ${{ github.event.inputs.sync_parquet_data }}
           PLOY_RESEARCH_DATABASE_URL: ${{ secrets.PLOY_RESEARCH_DATABASE_URL || vars.PLOY_RESEARCH_DATABASE_URL }}
@@ -141,23 +177,44 @@ jobs:
             --config "${CONFIG}" \
             --start-date "${START_DATE}" \
             --end-date "${END_DATE}" \
-            --git-ref "${{ github.event.inputs.git_ref }}" \
+            --git-ref "${GIT_REF}" \
             --output-json artifacts/backtest/evaluation.json \
             "${extra_args[@]}"
 
       - name: Publish backtest summary
         if: always()
+        env:
+          CONFIG: ${{ github.event.inputs.config }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+          GIT_REF: ${{ github.event.inputs.git_ref }}
         run: |
+          evidence_stage="diagnostic"
+          promotion_ready="false"
+          promotion_decision="diagnostic_backtest_only"
+          if [ -f artifacts/backtest/evaluation.json ]; then
+            readarray -t evidence < <(python3 - <<'PY'
+          import json
+          data = json.load(open("artifacts/backtest/evaluation.json", encoding="utf-8"))
+          print(data.get("evidence_stage") or "diagnostic")
+          print(str(data.get("promotion_ready") is True).lower())
+          print(data.get("promotion_decision") or "diagnostic_backtest_only")
+          PY
+            )
+            evidence_stage="${evidence[0]}"
+            promotion_ready="${evidence[1]}"
+            promotion_decision="${evidence[2]}"
+          fi
           {
             echo "## Strategy Backtest"
             echo ""
-            echo "Evidence stage: \`diagnostic\`"
-            echo "Promotion ready: \`false\`"
-            echo "Promotion decision: \`diagnostic_backtest_only\`"
+            echo "Evidence stage: \`${evidence_stage}\`"
+            echo "Promotion ready: \`${promotion_ready}\`"
+            echo "Promotion decision: \`${promotion_decision}\`"
             echo ""
-            echo "- Window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}"
-            echo "- Config: \`${{ github.event.inputs.config }}\`"
-            echo "- Git ref: \`${{ github.event.inputs.git_ref }}\`"
+            printf '%s\n' "- Window: ${START_DATE} -> ${END_DATE}"
+            printf '%s\n' "- Config: \`${CONFIG}\`"
+            printf '%s\n' "- Git ref: \`${GIT_REF}\`"
             if [ -f artifacts/backtest/evaluation.json ]; then
               echo "- Artifact: \`backtest-evaluation-${{ github.run_id }}\`"
               echo ""
@@ -167,38 +224,51 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Stage diagnostic evidence contract
+      - name: Stage backtest evidence contract
         if: always()
         run: |
           set -euo pipefail
           mkdir -p artifacts/backtest
-          cat > artifacts/backtest/evidence-stage.json <<EOF
-          {
-            "schema_version": 1,
-            "kind": "research_evidence_stage",
-            "workflow": "backtest.yml",
-            "run_id": "${GITHUB_RUN_ID}",
-            "evidence_stage": "diagnostic",
-            "promotion_ready": false,
-            "promotion_decision": "diagnostic_backtest_only",
-            "allowed_next_stage": "runtime_parity",
-            "blocked_next_stages": ["dry_run_candidate", "live_candidate"],
-            "reason": "Backtest evidence is diagnostic/replay accounting only; promotion requires executable replay, runtime scorer parity, and dry-run parity evidence."
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          evaluation_path = Path("artifacts/backtest/evaluation.json")
+          evaluation = json.loads(evaluation_path.read_text(encoding="utf-8")) if evaluation_path.exists() else {}
+          stage = evaluation.get("evidence_stage") or "diagnostic"
+          decision = evaluation.get("promotion_decision") or "diagnostic_backtest_only"
+          reason = (
+              "Executable replay evidence still requires runtime scorer parity and dry-run parity before promotion."
+              if stage == "executable_replay"
+              else "Backtest evidence is diagnostic/replay accounting only; executable replay and parity evidence are still required."
+          )
+          contract = {
+              "schema_version": 1,
+              "kind": "research_evidence_stage",
+              "workflow": "backtest.yml",
+              "run_id": os.environ["GITHUB_RUN_ID"],
+              "evidence_stage": stage,
+              "promotion_ready": False,
+              "promotion_decision": decision,
+              "allowed_next_stage": "runtime_parity",
+              "blocked_next_stages": ["dry_run_candidate", "live_candidate"],
+              "reason": reason,
           }
-          EOF
-          cat > artifacts/backtest/evidence-stage.md <<EOF
-          # Backtest Evidence Stage
-
-          - Evidence stage: \`diagnostic\`
-          - Promotion ready: \`false\`
-          - Promotion decision: \`diagnostic_backtest_only\`
-          - Allowed next stage: \`runtime_parity\`
-          - Blocked next stages: \`dry_run_candidate\`, \`live_candidate\`
-
-          Backtest evidence is diagnostic/replay accounting only. It is not a
-          dry-run or live promotion input without executable replay, runtime
-          scorer parity, and dry-run parity evidence.
-          EOF
+          Path("artifacts/backtest/evidence-stage.json").write_text(
+              json.dumps(contract, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          Path("artifacts/backtest/evidence-stage.md").write_text(
+              "# Backtest Evidence Stage\n\n"
+              f"- Evidence stage: `{stage}`\n"
+              "- Promotion ready: `false`\n"
+              f"- Promotion decision: `{decision}`\n"
+              "- Allowed next stage: `runtime_parity`\n"
+              "- Blocked next stages: `dry_run_candidate`, `live_candidate`\n\n"
+              f"{reason}\n",
+              encoding="utf-8",
+          )
+          PY
 
       - name: Upload backtest evaluation artifact
         if: always()
@@ -212,11 +282,17 @@ jobs:
       - name: Comment backtest evidence on issue
         if: ${{ always() && github.event.inputs.issue_number != '' }}
         uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          CONFIG: ${{ github.event.inputs.config }}
+          START_DATE: ${{ github.event.inputs.start_date }}
+          END_DATE: ${{ github.event.inputs.end_date }}
+          GIT_REF: ${{ github.event.inputs.git_ref }}
         with:
           script: |
             const fs = require("fs");
             const { applyResearchIssueLabels, labelsForDecision } = require("./.github/scripts/research-issue-labels.js");
-            const issue_number = Number("${{ github.event.inputs.issue_number }}");
+            const issue_number = Number(process.env.ISSUE_NUMBER);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let metrics = null;
             let riskFlags = [];
@@ -228,6 +304,9 @@ jobs:
             if (fs.existsSync("artifacts/backtest/evaluation.json")) {
               const data = JSON.parse(fs.readFileSync("artifacts/backtest/evaluation.json", "utf8"));
               metrics = data.metrics || null;
+              evidenceStage = data.evidence_stage || "diagnostic";
+              promotionReady = data.promotion_ready === true;
+              decision = data.promotion_decision || "diagnostic_backtest_only";
               riskFlags = data.risk_flags || [];
               blockingRiskFlags = data.blocking_risk_flags || [];
               advisoryFlags = data.advisory_flags || [];
@@ -253,9 +332,9 @@ jobs:
               "",
               `- Workflow: ${context.workflow}`,
               `- Run URL: ${runUrl}`,
-              `- Git ref: ${{ github.event.inputs.git_ref }}`,
-              `- Dataset/window: ${{ github.event.inputs.start_date }} -> ${{ github.event.inputs.end_date }}`,
-              `- Config: \`${{ github.event.inputs.config }}\``,
+              `- Git ref: ${process.env.GIT_REF}`,
+              `- Dataset/window: ${process.env.START_DATE} -> ${process.env.END_DATE}`,
+              `- Config: \`${process.env.CONFIG}\``,
               `- Artifact: \`backtest-evaluation-${process.env.GITHUB_RUN_ID}\``,
               `- Evidence stage: \`${evidenceStage}\``,
               `- Promotion ready: \`${promotionReady}\``,
@@ -271,7 +350,10 @@ jobs:
               issue_number,
               body
             });
-            const labels = ["evidence:backtest", "evidence:diagnostic", ...labelsForDecision(decision)];
+            const stageLabel = evidenceStage === "executable_replay"
+              ? "evidence:executable-replay"
+              : "evidence:diagnostic";
+            const labels = ["evidence:backtest", stageLabel, ...labelsForDecision(decision)];
             if (blockingRiskFlags.some((flag) => String(flag).includes("parity"))) {
               labels.push("parity:blocked");
             }

--- a/.github/workflows/deploy-trade.yml
+++ b/.github/workflows/deploy-trade.yml
@@ -356,8 +356,8 @@ jobs:
           upsert_env PLOY_PREDICT_OPS_LEDGER "${root}/data/account-ops/predict-fun-ledger.jsonl"
           upsert_env PLOY_PREDICT_OPS_LOCK "${root}/data/account-ops/predict-fun-ledger.jsonl.lock"
 
-          grep -Eq '^(POLYMARKET_PRIVATE_KEY|PRIVATE_KEY)=[^[:space:]]+' "${root}/.env" || {
-            echo "trade host signing key is missing" >&2
+          grep -Eq '^POLYMARKET_PRIVATE_KEY=[^[:space:]]+' "${root}/.env" || {
+            echo "trade host POLYMARKET_PRIVATE_KEY is missing" >&2
             exit 1
           }
           grep -Eq '^PLOY_LIVE_ACCOUNT_ID=0[xX][0-9a-fA-F]{40}$' "${root}/.env" || {
@@ -370,6 +370,24 @@ jobs:
               exit 1
             }
           done
+          set -a
+          # shellcheck disable=SC1091
+          . "${root}/.env"
+          set +a
+          signature_type="${POLY_SIGNATURE_TYPE:-${POLYMARKET_SIGNATURE_TYPE:-}}"
+          wallet_type="${POLY_WALLET_TYPE^^}"
+          case "${signature_type}:${wallet_type}" in
+            proxy:PROXY|gnosis_safe:SAFE)
+              ;;
+            poly1271:*)
+              echo "POLY_SIGNATURE_TYPE=poly1271 is not supported by the deployed custody/redemption relayer" >&2
+              exit 1
+              ;;
+            *)
+              echo "trade host wallet mapping must be proxy:PROXY or gnosis_safe:SAFE" >&2
+              exit 1
+              ;;
+          esac
 
           ln -sfn "releases/${git_sha}" "${root}/current.next"
           mv -Tf "${root}/current.next" "${root}/current"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",

--- a/apps/ployctl/src/main.rs
+++ b/apps/ployctl/src/main.rs
@@ -8,6 +8,7 @@ enum Command {
     SystemAudit,
     TradingStatus,
     TradingPrincipal,
+    TradingReadiness(rust_decimal::Decimal),
     TradingInspect(String),
     TradingCancel(String, String),
     TradingReplace(
@@ -48,6 +49,14 @@ impl Command {
             }
             [_bin, trading, principal] if trading == "trading" && principal == "principal" => {
                 Ok(Self::TradingPrincipal)
+            }
+            [_bin, trading, readiness, required_pusd]
+                if trading == "trading" && readiness == "readiness" =>
+            {
+                let required_pusd = required_pusd.parse().map_err(|error| {
+                    format!("invalid required pUSD `{required_pusd}`: {error}")
+                })?;
+                Ok(Self::TradingReadiness(required_pusd))
             }
             [_bin, trading, inspect, deployment_id]
                 if trading == "trading" && inspect == "inspect" =>
@@ -132,7 +141,7 @@ impl Command {
             {
                 Ok(Self::DeploymentsArchive(deployment_id.clone()))
             }
-            _ => Err("usage: ployctl system status | ployctl system metrics | ployctl system alerts | ployctl system audit | ployctl trading status | ployctl trading principal | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
+            _ => Err("usage: ployctl system status | ployctl system metrics | ployctl system alerts | ployctl system audit | ployctl trading status | ployctl trading principal | ployctl trading readiness <required-pusd> | ployctl trading inspect <deployment-id> | ployctl trading cancel <deployment-id> <order-id> | ployctl trading replace <deployment-id> <order-id> <quantity> <limit-price|-> | ployctl deployments list | ployctl deployments inspect <deployment-id> | ployctl deployments apply <manifest.json> | ployctl deployments pause <deployment-id> | ployctl deployments resume <deployment-id> | ployctl deployments stop <deployment-id> | ployctl deployments drain <deployment-id> | ployctl deployments enable <deployment-id> | ployctl deployments disable <deployment-id> | ployctl deployments archive <deployment-id>".to_string()),
         }
     }
 }
@@ -160,6 +169,18 @@ fn execute(command: Command, client: &ControlPlaneClient) -> Result<String, Stri
         Command::TradingStatus => trading::render_trading_state(client),
         Command::TradingPrincipal => ploy_connectivity::polymarket_execution_principal_from_env()
             .map_err(|error| error.to_string()),
+        Command::TradingReadiness(required_pusd) => {
+            let readiness = ploy_connectivity::polymarket_account_readiness_from_env(required_pusd)
+                .map_err(|error| error.to_string())?;
+            Ok(format!(
+                "principal: {}\nrequired_pusd: {}\nbalance_pusd: {}\ncountry: {}\nregion: {}\nready: true",
+                readiness.principal,
+                readiness.required_pusd,
+                readiness.balance_pusd,
+                readiness.country,
+                readiness.region,
+            ))
+        }
         Command::TradingInspect(deployment_id) => {
             trading::render_one_trading_state(client, &deployment_id)
         }
@@ -256,6 +277,16 @@ mod tests {
         let command =
             Command::parse(&["ployctl", "system", "alerts"].map(str::to_string)).expect("command");
         assert_eq!(command, Command::SystemAlerts);
+    }
+
+    #[test]
+    fn parses_polymarket_account_readiness_command() {
+        let command = Command::parse(&["ployctl", "trading", "readiness", "5"].map(str::to_string))
+            .expect("command");
+        assert_eq!(
+            command,
+            Command::TradingReadiness(rust_decimal::Decimal::from(5))
+        );
     }
 
     #[test]

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -7,7 +7,9 @@ use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
 use polymarket_client_sdk::clob::types::{Amount, AssetType, OrderType, Side, SignatureType};
 use polymarket_client_sdk::clob::{Client, Config};
 use polymarket_client_sdk::types::{Address, U256};
-use polymarket_client_sdk::{POLYGON, PRIVATE_KEY_VAR};
+use polymarket_client_sdk::{
+    contract_config, derive_proxy_wallet, derive_safe_wallet, POLYGON, PRIVATE_KEY_VAR,
+};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use secrecy::{ExposeSecret, SecretString};
@@ -22,6 +24,7 @@ const TERMINAL_CURSOR: &str = "LTE=";
 const MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS: usize = 10;
 const TRADE_RECONCILE_LOOKBACK_SECS: u64 = 24 * 60 * 60;
 const CONDITIONAL_TOKEN_DECIMALS: u32 = 6;
+const ACCOUNT_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Order execution type for live trading.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -238,6 +241,7 @@ pub enum WalletSignatureType {
     Eoa,
     Proxy,
     GnosisSafe,
+    Poly1271,
 }
 
 impl WalletSignatureType {
@@ -246,6 +250,7 @@ impl WalletSignatureType {
             Self::Eoa => SignatureType::Eoa,
             Self::Proxy => SignatureType::Proxy,
             Self::GnosisSafe => SignatureType::GnosisSafe,
+            Self::Poly1271 => SignatureType::Poly1271,
         }
     }
 }
@@ -264,6 +269,7 @@ impl FromStr for WalletSignatureType {
             "eoa" => Ok(Self::Eoa),
             "proxy" => Ok(Self::Proxy),
             "gnosis_safe" => Ok(Self::GnosisSafe),
+            "poly1271" => Ok(Self::Poly1271),
             other => Err(ExecutionError::Configuration(format!(
                 "unsupported POLY_SIGNATURE_TYPE `{other}`"
             ))),
@@ -282,20 +288,22 @@ pub struct PolymarketExecutionConfig {
 
 impl Default for PolymarketExecutionConfig {
     fn default() -> Self {
-        let funder = polymarket_funder_from_env();
         Self {
             host: DEFAULT_POLY_CLOB_HOST.to_string(),
-            private_key: polymarket_private_key_from_env().map(SecretString::from),
+            private_key: None,
             use_server_time: true,
-            signature_type: polymarket_signature_type_from_env(funder.is_some()),
-            funder,
+            signature_type: WalletSignatureType::Eoa,
+            funder: None,
         }
     }
 }
 
 impl PolymarketExecutionConfig {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self, ExecutionError> {
         let mut config = Self::default();
+        config.private_key = polymarket_private_key_from_env().map(SecretString::from);
+        config.funder = polymarket_funder_from_env();
+        config.signature_type = polymarket_signature_type_from_env(config.funder.is_some())?;
 
         if let Ok(value) = std::env::var("POLY_CLOB_HOST") {
             config.host = value;
@@ -304,43 +312,104 @@ impl PolymarketExecutionConfig {
             config.use_server_time = matches!(value.as_str(), "1" | "true" | "TRUE" | "yes");
         }
 
-        config
+        Ok(config)
     }
 }
 
 pub fn polymarket_execution_principal_from_env() -> Result<String, ExecutionError> {
-    polymarket_execution_principal(&PolymarketExecutionConfig::from_env())
+    polymarket_execution_principal(&PolymarketExecutionConfig::from_env()?)
 }
 
 pub fn polymarket_execution_principal(
     config: &PolymarketExecutionConfig,
 ) -> Result<String, ExecutionError> {
+    let signer = signer_from_config(config)?;
     match config.signature_type {
-        WalletSignatureType::Eoa => {
-            let private_key = config
-                .private_key
-                .as_ref()
-                .map(ExposeSecret::expose_secret)
-                .ok_or_else(|| {
-                    ExecutionError::Configuration(format!("{PRIVATE_KEY_VAR} is not configured"))
-                })?;
-            let signer = PrivateKeySigner::from_str(private_key).map_err(|err| {
-                ExecutionError::Configuration(format!("invalid {PRIVATE_KEY_VAR}: {err}"))
-            })?;
-            Ok(format!("{:#x}", signer.address()))
-        }
-        WalletSignatureType::Proxy | WalletSignatureType::GnosisSafe => {
-            let funder = config.funder.as_deref().ok_or_else(|| {
-                ExecutionError::Configuration(
-                    "POLY_FUNDER is required for proxy or gnosis_safe signatures".to_string(),
-                )
-            })?;
-            let address = Address::from_str(funder).map_err(|err| {
-                ExecutionError::Configuration(format!("invalid POLY_FUNDER: {err}"))
-            })?;
+        WalletSignatureType::Eoa => Ok(format!("{:#x}", signer.address())),
+        WalletSignatureType::Proxy
+        | WalletSignatureType::GnosisSafe
+        | WalletSignatureType::Poly1271 => {
+            let address = validated_funder(config, signer.address())?.expect("non-EOA funder");
             Ok(format!("{address:#x}"))
         }
     }
+}
+
+fn signer_from_config(
+    config: &PolymarketExecutionConfig,
+) -> Result<PrivateKeySigner, ExecutionError> {
+    let private_key = config
+        .private_key
+        .as_ref()
+        .map(ExposeSecret::expose_secret)
+        .ok_or_else(|| {
+            ExecutionError::Configuration(format!("{PRIVATE_KEY_VAR} is not configured"))
+        })?;
+    PrivateKeySigner::from_str(private_key)
+        .map_err(|error| {
+            ExecutionError::Configuration(format!("invalid {PRIVATE_KEY_VAR}: {error}"))
+        })
+        .map(|signer| signer.with_chain_id(Some(POLYGON)))
+}
+
+fn validated_funder(
+    config: &PolymarketExecutionConfig,
+    signer: Address,
+) -> Result<Option<Address>, ExecutionError> {
+    let configured = config
+        .funder
+        .as_deref()
+        .map(Address::from_str)
+        .transpose()
+        .map_err(|error| ExecutionError::Configuration(format!("invalid POLY_FUNDER: {error}")))?;
+    let derived = match config.signature_type {
+        WalletSignatureType::Eoa => {
+            if configured.is_some() {
+                return Err(ExecutionError::Configuration(
+                    "POLY_FUNDER must not be set for eoa signatures".to_string(),
+                ));
+            }
+            return Ok(None);
+        }
+        WalletSignatureType::Proxy => derive_proxy_wallet(signer, POLYGON),
+        WalletSignatureType::GnosisSafe => derive_safe_wallet(signer, POLYGON),
+        WalletSignatureType::Poly1271 => {
+            let funder = configured
+                .filter(|address| *address != Address::ZERO)
+                .ok_or_else(|| {
+                    ExecutionError::Configuration(
+                        "POLY_FUNDER is required for poly1271 signatures".to_string(),
+                    )
+                })?;
+            return Ok(Some(funder));
+        }
+    }
+    .ok_or_else(|| {
+        ExecutionError::Configuration("wallet derivation is unavailable on Polygon".to_string())
+    })?;
+
+    if configured.is_some_and(|configured| configured != derived) {
+        return Err(ExecutionError::Configuration(format!(
+            "POLY_FUNDER does not match the signer-derived {:?} wallet {derived:#x}",
+            config.signature_type
+        )));
+    }
+    Ok(Some(derived))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolymarketAccountReadiness {
+    pub principal: String,
+    pub required_pusd: Decimal,
+    pub balance_pusd: Decimal,
+    pub country: String,
+    pub region: String,
+}
+
+pub fn polymarket_account_readiness_from_env(
+    required_pusd: Decimal,
+) -> Result<PolymarketAccountReadiness, ExecutionError> {
+    PolymarketExecutionGateway::from_env()?.account_readiness(required_pusd)
 }
 
 #[derive(Debug, Clone)]
@@ -352,8 +421,8 @@ pub struct PolymarketExecutionGateway {
 }
 
 impl PolymarketExecutionGateway {
-    pub fn from_env() -> Self {
-        Self::new(PolymarketExecutionConfig::from_env())
+    pub fn from_env() -> Result<Self, ExecutionError> {
+        Ok(Self::new(PolymarketExecutionConfig::from_env()?))
     }
 
     pub fn new(config: PolymarketExecutionConfig) -> Self {
@@ -376,20 +445,7 @@ impl PolymarketExecutionGateway {
             return Ok(signer.clone());
         }
 
-        let private_key = self
-            .config
-            .private_key
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .ok_or_else(|| {
-                ExecutionError::Configuration(format!("{PRIVATE_KEY_VAR} is not configured"))
-            })?;
-
-        let signer = PrivateKeySigner::from_str(private_key)
-            .map_err(|err| {
-                ExecutionError::Configuration(format!("invalid {PRIVATE_KEY_VAR}: {err}"))
-            })?
-            .with_chain_id(Some(POLYGON));
+        let signer = signer_from_config(&self.config)?;
 
         let _ = self.signer.set(signer);
         Ok(self.signer.get().expect("signer set above").clone())
@@ -405,16 +461,23 @@ impl PolymarketExecutionGateway {
             return Ok(client.clone());
         }
 
-        let signer = self.get_or_init_signer()?;
-        let funder = self
-            .config
-            .funder
-            .as_deref()
-            .map(Address::from_str)
-            .transpose()
-            .map_err(|err| ExecutionError::Configuration(format!("invalid POLY_FUNDER: {err}")))?;
+        let client = self.authenticate_client()?;
 
-        let client = self.runtime.block_on(async {
+        let mut guard = self
+            .client
+            .write()
+            .map_err(|_| ExecutionError::Transport("client cache poisoned".to_string()))?;
+        if let Some(existing) = guard.as_ref() {
+            return Ok(existing.clone());
+        }
+        *guard = Some(client.clone());
+        Ok(client)
+    }
+
+    fn authenticate_client(&self) -> Result<Client<Authenticated<Normal>>, ExecutionError> {
+        let signer = self.get_or_init_signer()?;
+        let funder = validated_funder(&self.config, signer.address())?;
+        self.runtime.block_on(async {
             let client = Client::new(
                 &self.config.host,
                 Config::builder()
@@ -432,17 +495,7 @@ impl PolymarketExecutionGateway {
             auth.authenticate()
                 .await
                 .map_err(|err| ExecutionError::Transport(format!("authenticate client: {err}")))
-        })?;
-
-        let mut guard = self
-            .client
-            .write()
-            .map_err(|_| ExecutionError::Transport("client cache poisoned".to_string()))?;
-        if let Some(existing) = guard.as_ref() {
-            return Ok(existing.clone());
-        }
-        *guard = Some(client.clone());
-        Ok(client)
+        })
     }
 
     fn clear_client_cache(&self) {
@@ -455,6 +508,132 @@ impl PolymarketExecutionGateway {
         if is_auth_recovery_error(error) {
             self.clear_client_cache();
         }
+    }
+
+    pub fn account_readiness(
+        &self,
+        required_pusd: Decimal,
+    ) -> Result<PolymarketAccountReadiness, ExecutionError> {
+        let required_raw = pusd_to_raw(required_pusd)?;
+        let principal = polymarket_execution_principal(&self.config)?;
+        let signer = self.get_or_init_signer()?;
+        let funder = validated_funder(&self.config, signer.address())?;
+        let (geoblock, closed_only, balance_allowance) = self.runtime.block_on(async {
+            tokio::time::timeout(ACCOUNT_READINESS_TIMEOUT, async {
+                let client = Client::new(
+                    &self.config.host,
+                    Config::builder()
+                        .use_server_time(self.config.use_server_time)
+                        .heartbeat_interval(Duration::from_secs(60))
+                        .build(),
+                )
+                .map_err(|error| {
+                    ExecutionError::Transport(format!("build readiness client: {error}"))
+                })?;
+                let credentials = client
+                    .derive_api_key(&signer, None)
+                    .await
+                    .map_err(|error| {
+                        ExecutionError::Transport(format!(
+                            "derive existing Polymarket API credentials: {error}"
+                        ))
+                    })?;
+                let mut auth = client
+                    .authentication_builder(&signer)
+                    .credentials(credentials)
+                    .signature_type(self.config.signature_type.into_sdk());
+                if let Some(funder) = funder {
+                    auth = auth.funder(funder);
+                }
+                let mut client = auth.authenticate().await.map_err(|error| {
+                    ExecutionError::Transport(format!("authenticate readiness client: {error}"))
+                })?;
+                client.stop_heartbeats().await.map_err(|error| {
+                    ExecutionError::Transport(format!("stop readiness-client heartbeats: {error}"))
+                })?;
+                if client.heartbeats_active() {
+                    return Err(ExecutionError::Transport(
+                        "readiness client heartbeat task is still active".to_string(),
+                    ));
+                }
+                let version = client.version().await.map_err(|error| {
+                    ExecutionError::Transport(format!("CLOB version probe: {error}"))
+                })?;
+                if version != 2 {
+                    return Err(ExecutionError::Validation(format!(
+                        "Polymarket CLOB API v2 is required; host reported v{version}"
+                    )));
+                }
+                let geoblock = client.check_geoblock().await.map_err(|error| {
+                    ExecutionError::Transport(format!("geoblock probe: {error}"))
+                })?;
+                let closed_only = client.closed_only_mode().await.map_err(|error| {
+                    ExecutionError::Transport(format!("closed-only probe: {error}"))
+                })?;
+                let balance_allowance = client
+                    .balance_allowance(
+                        BalanceAllowanceRequest::builder()
+                            .asset_type(AssetType::Collateral)
+                            .build(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        ExecutionError::Transport(format!(
+                            "collateral balance/allowance probe: {error}"
+                        ))
+                    })?;
+                Ok::<_, ExecutionError>((geoblock, closed_only, balance_allowance))
+            })
+            .await
+            .map_err(|_| {
+                ExecutionError::Transport(format!(
+                    "Polymarket account readiness timed out after {} seconds",
+                    ACCOUNT_READINESS_TIMEOUT.as_secs()
+                ))
+            })?
+        })?;
+
+        let balance_raw = collateral_balance_to_raw(balance_allowance.balance)?;
+        let standard_exchange = contract_config(POLYGON, false)
+            .and_then(|config| config.exchange_v2)
+            .ok_or_else(|| {
+                ExecutionError::Configuration(
+                    "missing Polygon standard V2 exchange contract".to_string(),
+                )
+            })?;
+        let neg_risk_exchange = contract_config(POLYGON, true)
+            .and_then(|config| config.exchange_v2)
+            .ok_or_else(|| {
+                ExecutionError::Configuration(
+                    "missing Polygon neg-risk V2 exchange contract".to_string(),
+                )
+            })?;
+        let standard_allowance = balance_allowance
+            .allowances
+            .get(&standard_exchange)
+            .map(String::as_str)
+            .unwrap_or("0");
+        let neg_risk_allowance = balance_allowance
+            .allowances
+            .get(&neg_risk_exchange)
+            .map(String::as_str)
+            .unwrap_or("0");
+        ensure_account_readiness(
+            geoblock.blocked,
+            closed_only.closed_only,
+            balance_raw,
+            standard_allowance,
+            neg_risk_allowance,
+            required_raw,
+        )?;
+
+        Ok(PolymarketAccountReadiness {
+            principal,
+            required_pusd,
+            balance_pusd: raw_balance_to_pusd(balance_raw)?,
+            country: geoblock.country,
+            region: geoblock.region,
+        })
     }
 }
 
@@ -725,18 +904,27 @@ fn polymarket_funder_from_env() -> Option<String> {
     ])
 }
 
-fn polymarket_signature_type_from_env(has_funder: bool) -> WalletSignatureType {
-    first_env_value(&["POLY_SIGNATURE_TYPE", "POLYMARKET_SIGNATURE_TYPE"])
-        .map(|value| WalletSignatureType::from_str(&value))
+fn wallet_signature_type(
+    value: Option<&str>,
+    has_funder: bool,
+) -> Result<WalletSignatureType, ExecutionError> {
+    value
+        .map(WalletSignatureType::from_str)
         .transpose()
-        .unwrap_or(None)
-        .unwrap_or_else(|| {
-            if has_funder {
+        .map(|value| {
+            value.unwrap_or(if has_funder {
                 WalletSignatureType::Proxy
             } else {
                 WalletSignatureType::Eoa
-            }
+            })
         })
+}
+
+fn polymarket_signature_type_from_env(
+    has_funder: bool,
+) -> Result<WalletSignatureType, ExecutionError> {
+    let value = first_env_value(&["POLY_SIGNATURE_TYPE", "POLYMARKET_SIGNATURE_TYPE"]);
+    wallet_signature_type(value.as_deref(), has_funder)
 }
 
 fn is_auth_recovery_error(error: &ExecutionError) -> bool {
@@ -854,6 +1042,87 @@ fn conditional_token_balance_to_shares(balance: Decimal) -> Decimal {
     }
 }
 
+fn pusd_to_raw(value: Decimal) -> Result<U256, ExecutionError> {
+    if value <= Decimal::ZERO {
+        return Err(ExecutionError::Validation(
+            "required pUSD must be greater than zero".to_string(),
+        ));
+    }
+    let raw = value
+        .checked_mul(Decimal::from(10_u64.pow(CONDITIONAL_TOKEN_DECIMALS)))
+        .ok_or_else(|| ExecutionError::Validation("required pUSD is out of range".to_string()))?;
+    if !raw.fract().is_zero() {
+        return Err(ExecutionError::Validation(
+            "required pUSD supports at most 6 decimal places".to_string(),
+        ));
+    }
+    U256::from_str(&raw.trunc().to_string()).map_err(|error| {
+        ExecutionError::Validation(format!("required pUSD is out of range: {error}"))
+    })
+}
+
+fn collateral_balance_to_raw(balance: Decimal) -> Result<U256, ExecutionError> {
+    if balance < Decimal::ZERO {
+        return Err(ExecutionError::Transport(
+            "venue returned a negative collateral balance".to_string(),
+        ));
+    }
+    if !balance.fract().is_zero() {
+        return Err(ExecutionError::Transport(format!(
+            "venue returned a fractional raw collateral balance: {balance}"
+        )));
+    }
+    U256::from_str(&balance.trunc().to_string()).map_err(|error| {
+        ExecutionError::Transport(format!("invalid raw collateral balance: {error}"))
+    })
+}
+
+fn raw_balance_to_pusd(balance: U256) -> Result<Decimal, ExecutionError> {
+    let raw = Decimal::from_str(&balance.to_string()).map_err(|error| {
+        ExecutionError::Transport(format!("raw collateral balance is out of range: {error}"))
+    })?;
+    Ok(raw / Decimal::from(10_u64.pow(CONDITIONAL_TOKEN_DECIMALS)))
+}
+
+fn ensure_account_readiness(
+    geoblocked: bool,
+    closed_only: bool,
+    balance_raw: U256,
+    standard_allowance: &str,
+    neg_risk_allowance: &str,
+    required_raw: U256,
+) -> Result<(), ExecutionError> {
+    if geoblocked {
+        return Err(ExecutionError::Validation(
+            "Polymarket trading is geoblocked from this host".to_string(),
+        ));
+    }
+    if closed_only {
+        return Err(ExecutionError::Validation(
+            "Polymarket account is in closed-only mode".to_string(),
+        ));
+    }
+    if balance_raw < required_raw {
+        return Err(ExecutionError::Validation(format!(
+            "insufficient pUSD balance: required_raw={required_raw}, available_raw={balance_raw}"
+        )));
+    }
+    for (label, allowance) in [
+        ("standard V2", standard_allowance),
+        ("neg-risk V2", neg_risk_allowance),
+    ] {
+        let allowance = U256::from_str(allowance).map_err(|error| {
+            ExecutionError::Transport(format!("invalid {label} allowance: {error}"))
+        })?;
+        if allowance < required_raw {
+            return Err(ExecutionError::Validation(format!(
+                "insufficient {label} allowance: required_raw={required_raw}, available_raw={allowance}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn normalize_aggressive_price(
     limit_price: Decimal,
     side: TradeSide,
@@ -960,10 +1229,11 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        cap_sell_quantity_to_balance, conditional_token_balance_to_shares,
-        execution_price_override, normalize_aggressive_price, normalize_execution_amount,
-        normalize_market_order_quantity, normalize_order_quantity, polymarket_execution_principal,
-        polymarket_signature_type_from_env, tracked_trade_fill, trade_side, unique_token_ids,
+        cap_sell_quantity_to_balance, collateral_balance_to_raw,
+        conditional_token_balance_to_shares, ensure_account_readiness, execution_price_override,
+        normalize_aggressive_price, normalize_execution_amount, normalize_market_order_quantity,
+        normalize_order_quantity, polymarket_execution_principal, raw_balance_to_pusd,
+        tracked_trade_fill, trade_side, unique_token_ids, wallet_signature_type,
         CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
         ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
         PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
@@ -1014,13 +1284,25 @@ mod tests {
         assert_eq!(eoa, "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
 
         let proxy = polymarket_execution_principal(&PolymarketExecutionConfig {
-            private_key: None,
+            private_key: Some(SecretString::from(
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
+            )),
             signature_type: WalletSignatureType::Proxy,
-            funder: Some("0x1111111111111111111111111111111111111111".to_string()),
+            funder: Some("0x365f0ca36ae1f641e02fe3b7743673da42a13a70".to_string()),
             ..PolymarketExecutionConfig::default()
         })
         .expect("proxy principal");
-        assert_eq!(proxy, "0x1111111111111111111111111111111111111111");
+        assert_eq!(proxy, "0x365f0ca36ae1f641e02fe3b7743673da42a13a70");
+
+        let mismatched_proxy = polymarket_execution_principal(&PolymarketExecutionConfig {
+            private_key: Some(SecretString::from(
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
+            )),
+            signature_type: WalletSignatureType::Proxy,
+            funder: Some("0x1111111111111111111111111111111111111111".to_string()),
+            ..PolymarketExecutionConfig::default()
+        });
+        assert!(mismatched_proxy.is_err());
     }
 
     #[test]
@@ -1127,6 +1409,23 @@ mod tests {
     }
 
     #[test]
+    fn collateral_readiness_balance_is_always_raw_base_units() {
+        assert_eq!(
+            collateral_balance_to_raw(dec!(5000000)).expect("raw balance"),
+            U256::from(5_000_000_u64)
+        );
+        assert_eq!(
+            collateral_balance_to_raw(dec!(5000000.0)).expect("raw balance with scale"),
+            U256::from(5_000_000_u64)
+        );
+        assert!(collateral_balance_to_raw(dec!(5000000.5)).is_err());
+        assert_eq!(
+            raw_balance_to_pusd(U256::from(5_000_000_u64)).expect("display balance"),
+            dec!(5)
+        );
+    }
+
+    #[test]
     fn sell_quantity_rejects_when_conditional_token_balance_is_zero() {
         let error = cap_sell_quantity_to_balance(dec!(5), Decimal::ZERO)
             .expect_err("zero balance should reject");
@@ -1145,12 +1444,62 @@ mod tests {
     #[test]
     fn signature_type_defaults_to_proxy_when_funder_is_present() {
         assert_eq!(
-            polymarket_signature_type_from_env(true),
+            wallet_signature_type(None, true).expect("default"),
             WalletSignatureType::Proxy
         );
         assert_eq!(
-            polymarket_signature_type_from_env(false),
+            wallet_signature_type(None, false).expect("default"),
             WalletSignatureType::Eoa
+        );
+        assert_eq!(
+            wallet_signature_type(Some("poly1271"), true).expect("deposit wallet"),
+            WalletSignatureType::Poly1271
+        );
+        assert!(wallet_signature_type(Some("typo"), false).is_err());
+    }
+
+    #[test]
+    fn account_readiness_fails_closed_on_every_trading_gate() {
+        let required = U256::from(5_000_000_u64);
+        let enough = U256::from(10_000_000_u64);
+        let allowance = "10000000";
+
+        assert!(
+            ensure_account_readiness(false, false, enough, allowance, allowance, required).is_ok()
+        );
+        assert!(
+            ensure_account_readiness(true, false, enough, allowance, allowance, required).is_err()
+        );
+        assert!(
+            ensure_account_readiness(false, true, enough, allowance, allowance, required).is_err()
+        );
+        assert!(
+            ensure_account_readiness(false, false, U256::ZERO, allowance, allowance, required)
+                .is_err()
+        );
+        assert!(ensure_account_readiness(false, false, enough, "0", allowance, required).is_err());
+        assert!(ensure_account_readiness(false, false, enough, allowance, "0", required).is_err());
+    }
+
+    #[test]
+    fn readiness_uses_a_dedicated_client_with_heartbeats_stopped() {
+        let source = include_str!("lib.rs");
+        let readiness = &source[source.find("pub fn account_readiness").unwrap()..];
+        let readiness = &readiness[..readiness.find("impl LiveExecutionGateway").unwrap()];
+
+        assert!(readiness.contains("derive_api_key(&signer, None)"));
+        assert!(readiness.contains(".credentials(credentials)"));
+        assert!(readiness.contains("stop_heartbeats().await"));
+        assert!(readiness.contains("heartbeats_active()"));
+        assert!(!readiness.contains("create_or_derive_api_key"));
+        assert!(!readiness.contains("create_api_key"));
+        assert!(
+            readiness.find("tokio::time::timeout").unwrap()
+                < readiness.find("derive_api_key(&signer, None)").unwrap()
+        );
+        assert!(
+            readiness.find("stop_heartbeats().await").unwrap()
+                < readiness.find("client.version().await").unwrap()
         );
     }
 

--- a/crates/ploy-daemon-host/src/runtime.rs
+++ b/crates/ploy-daemon-host/src/runtime.rs
@@ -97,7 +97,9 @@ pub struct PloyDaemon {
 
 impl PloyDaemon {
     pub fn boot(config: &PlatformConfig) -> io::Result<Self> {
-        Self::boot_with_live_execution(config, Box::new(PolymarketExecutionGateway::from_env()))
+        let gateway = PolymarketExecutionGateway::from_env()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+        Self::boot_with_live_execution(config, Box::new(gateway))
     }
 
     pub fn boot_with_live_execution(

--- a/crates/ploy-feed-loaders/Cargo.toml
+++ b/crates/ploy-feed-loaders/Cargo.toml
@@ -11,9 +11,9 @@ description = "Database-backed market-update loaders for Ploy"
 chrono.workspace = true
 ploy-market-contracts.workspace = true
 rust_decimal.workspace = true
+serde_json.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "chrono", "rust_decimal", "json"] }
 tracing.workspace = true
 
 [dev-dependencies]
 rust_decimal_macros.workspace = true
-serde_json.workspace = true

--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -733,7 +733,7 @@ async fn load_pm_quotes_from_snapshots(
                   AND token_id = ANY($3)
             ) snapshot
             ORDER BY snapshot.token_id, snapshot.bucket, snapshot.received_at DESC
-        ),
+        )
         SELECT received_at, token_id, bids, asks
         FROM sampled
         WHERE jsonb_array_length(bids) > 0 OR jsonb_array_length(asks) > 0
@@ -745,8 +745,7 @@ async fn load_pm_quotes_from_snapshots(
     .bind(&token_ids)
     .bind(sample_secs)
     .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    .await?;
 
     let mut row_count = 0usize;
     for (ts, token_id, bids, asks) in rows {
@@ -1198,6 +1197,22 @@ mod tests {
         assert_eq!(bids.len(), 2);
         assert_eq!(asks[0].price, dec!(0.51));
         assert_eq!(asks[0].size, dec!(7));
+    }
+
+    #[test]
+    fn full_depth_snapshot_query_does_not_separate_cte_with_a_dangling_comma() {
+        let source = include_str!("database.rs");
+        let query = &source[source
+            .find("async fn load_pm_quotes_from_snapshots")
+            .unwrap()..];
+        let query = &query[..query.find("let mut row_count").unwrap()];
+        assert!(!query.contains(
+            "ORDER BY snapshot.token_id, snapshot.bucket, snapshot.received_at DESC\n        ),\n        SELECT received_at, token_id, bids, asks"
+        ));
+        assert!(query.contains(
+            "ORDER BY snapshot.token_id, snapshot.bucket, snapshot.received_at DESC\n        )\n        SELECT received_at, token_id, bids, asks"
+        ));
+        assert!(!query.contains(".fetch_all(pool)\n    .await\n    .unwrap_or_default()"));
     }
 
     #[test]

--- a/crates/ploy-feed-loaders/src/database.rs
+++ b/crates/ploy-feed-loaders/src/database.rs
@@ -25,11 +25,10 @@ use std::sync::Arc;
 use tracing::info;
 
 use ploy_market_contracts::{
-    l2_updates_from_depth_totals, market_update_sort_ts, normalize_token_id, HistoricalLoadOptions,
-    MarketUpdate,
+    l2_updates_from_depth_totals, market_update_sort_ts, normalize_token_id, BookLevel,
+    HistoricalLoadOptions, MarketUpdate,
 };
 
-#[cfg(test)]
 use serde_json::Value;
 
 /// How far before `from` to load spot prices for EWMA volatility warm-up.
@@ -253,39 +252,21 @@ pub async fn load_from_database_with_options(
     )
     .await?;
 
-    // 3. Polymarket quotes — prefer persisted top-of-book rows when they carry
-    // executable size. Older `ploy_runner_live` quote rows are price-only; those
-    // are useful for rough direction studies but must not drive executable PnL.
+    // 3. Polymarket quotes — prefer sampled full-depth snapshots. Top-of-book
+    // quote ticks are a diagnostic fallback only.
     let token_map = load_token_mappings(pool, symbols, from, to).await?;
-    let quote_count_before = updates.len();
-    let quote_stats = load_pm_quotes(pool, &token_map, from, to, &mut updates).await?;
-
-    // If clob_quote_ticks has no executable size, replace those price-only
-    // rows with quotes extracted from full order-book snapshots. This preserves
-    // point-in-time prices while grounding research labels in actual CLOB depth.
-    if quote_stats.rows == 0 || quote_stats.sized_rows == 0 {
-        if quote_stats.rows == 0 {
-            info!("No real quotes in clob_quote_ticks, falling back to orderbook snapshots");
-        } else {
-            info!(
-                rows = quote_stats.rows,
-                "clob_quote_ticks rows are price-only, replacing with orderbook snapshot depth"
-            );
-        }
-        updates.truncate(quote_count_before);
-        let snapshot_stats = load_pm_quotes_from_snapshots(
-            pool,
-            &token_map,
-            from,
-            to,
-            options.lob_sample_secs,
-            &mut updates,
-        )
-        .await?;
-        if snapshot_stats.rows == 0 && quote_stats.rows > 0 {
-            info!("No usable orderbook snapshots found, restoring price-only quote rows");
-            load_pm_quotes(pool, &token_map, from, to, &mut updates).await?;
-        }
+    let snapshot_stats = load_pm_quotes_from_snapshots(
+        pool,
+        &token_map,
+        from,
+        to,
+        options.lob_sample_secs,
+        &mut updates,
+    )
+    .await?;
+    if snapshot_stats.rows == 0 {
+        info!("No usable orderbook snapshots found; using diagnostic top-of-book quotes");
+        load_pm_quotes(pool, &token_map, from, to, &mut updates).await?;
     }
 
     // 4. L2 orderbook from binance_lob_ticks.
@@ -567,7 +548,6 @@ type TokenMap = std::collections::HashMap<String, (String, bool)>;
 #[derive(Debug, Default, Clone, Copy)]
 struct PmQuoteLoadStats {
     rows: usize,
-    sized_rows: usize,
 }
 
 async fn load_token_mappings(
@@ -702,10 +682,7 @@ async fn load_pm_quotes(
         });
     }
 
-    Ok(PmQuoteLoadStats {
-        rows: row_count,
-        sized_rows,
-    })
+    Ok(PmQuoteLoadStats { rows: row_count })
 }
 
 /// Fallback quote loader from `clob_orderbook_snapshots`.
@@ -731,19 +708,9 @@ async fn load_pm_quotes_from_snapshots(
     }
     let sample_secs = sample_secs.max(1) as i64;
 
-    // Extract executable top-of-book directly from JSONB depth. This intentionally
-    // avoids synthetic opposite-side prices: if a snapshot has only bids or only
-    // asks, only that executable side receives size. Downsample in SQL before
-    // expanding JSONB so full-day factor reviews do not materialize every CLOB
-    // snapshot into memory.
-    let rows: Vec<(
-        DateTime<Utc>,
-        String,
-        Option<Decimal>,
-        Option<Decimal>,
-        Option<Decimal>,
-        Option<Decimal>,
-    )> = sqlx::query_as(
+    // Downsample before transferring JSONB so full-day reviews do not load every
+    // snapshot. Preserve every level in each selected book.
+    let rows: Vec<(DateTime<Utc>, String, Value, Value)> = sqlx::query_as(
         r#"
         WITH sampled AS (
             SELECT DISTINCT ON (snapshot.token_id, snapshot.bucket)
@@ -767,38 +734,9 @@ async fn load_pm_quotes_from_snapshots(
             ) snapshot
             ORDER BY snapshot.token_id, snapshot.bucket, snapshot.received_at DESC
         ),
-        extracted AS (
-            SELECT snapshot.received_at,
-                   snapshot.token_id,
-                   best_bid.price AS best_bid,
-                   best_ask.price AS best_ask,
-                   best_bid.size AS bid_size,
-                   best_ask.size AS ask_size
-            FROM sampled snapshot
-            LEFT JOIN LATERAL (
-                SELECT (elem->>'price')::numeric AS price,
-                       (elem->>'size')::numeric AS size
-                FROM jsonb_array_elements(COALESCE(snapshot.bids, '[]'::jsonb)) AS elem
-                WHERE (elem->>'price')::numeric > 0.01
-                  AND (elem->>'price')::numeric < 0.99
-                  AND (elem->>'size')::numeric > 0
-                ORDER BY price DESC
-                LIMIT 1
-            ) best_bid ON true
-            LEFT JOIN LATERAL (
-                SELECT (elem->>'price')::numeric AS price,
-                       (elem->>'size')::numeric AS size
-                FROM jsonb_array_elements(COALESCE(snapshot.asks, '[]'::jsonb)) AS elem
-                WHERE (elem->>'price')::numeric > 0.01
-                  AND (elem->>'price')::numeric < 0.99
-                  AND (elem->>'size')::numeric > 0
-                ORDER BY price ASC
-                LIMIT 1
-            ) best_ask ON true
-        )
-        SELECT received_at, token_id, best_bid, best_ask, bid_size, ask_size
-        FROM extracted
-        WHERE best_bid IS NOT NULL OR best_ask IS NOT NULL
+        SELECT received_at, token_id, bids, asks
+        FROM sampled
+        WHERE jsonb_array_length(bids) > 0 OR jsonb_array_length(asks) > 0
         ORDER BY received_at
         "#,
     )
@@ -810,38 +748,70 @@ async fn load_pm_quotes_from_snapshots(
     .await
     .unwrap_or_default();
 
-    let sized_rows = rows
-        .iter()
-        .filter(|(_, _, _, _, bid_size, ask_size)| {
-            bid_size.is_some_and(|size| size > Decimal::ZERO)
-                || ask_size.is_some_and(|size| size > Decimal::ZERO)
-        })
-        .count();
-
-    info!(
-        count = rows.len(),
-        sized_rows,
-        sample_secs,
-        "Loaded PM quotes from clob_orderbook_snapshots (real bid/ask and size extracted from JSONB depth)"
-    );
-    let row_count = rows.len();
-    for (ts, token_id, bid, ask, bid_size, ask_size) in rows {
+    let mut row_count = 0usize;
+    for (ts, token_id, bids, asks) in rows {
+        let bid_levels = book_levels_from_json(&bids, false);
+        let ask_levels = book_levels_from_json(&asks, true);
+        if bid_levels.is_empty() && ask_levels.is_empty() {
+            continue;
+        }
+        let best_bid = bid_levels.first();
+        let best_ask = ask_levels.first();
         updates.push(MarketUpdate::Quote {
             token_id: Arc::from(token_id),
-            bid,
-            ask,
-            bid_size,
-            ask_size,
-            bid_levels: Vec::new(),
-            ask_levels: Vec::new(),
+            bid: best_bid.map(|level| level.price),
+            ask: best_ask.map(|level| level.price),
+            bid_size: best_bid.map(|level| level.size),
+            ask_size: best_ask.map(|level| level.size),
+            bid_levels,
+            ask_levels,
             ts,
         });
+        row_count += 1;
     }
 
-    Ok(PmQuoteLoadStats {
-        rows: row_count,
-        sized_rows,
-    })
+    info!(
+        count = row_count,
+        sample_secs, "Loaded full-depth PM quotes from clob_orderbook_snapshots"
+    );
+
+    Ok(PmQuoteLoadStats { rows: row_count })
+}
+
+fn book_levels_from_json(value: &Value, ascending: bool) -> Vec<BookLevel> {
+    let mut levels = value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| match item {
+            Value::Array(parts) if parts.len() >= 2 => {
+                Some((decimal_from_json(&parts[0])?, decimal_from_json(&parts[1])?))
+            }
+            Value::Object(parts) => Some((
+                decimal_from_json(parts.get("price")?)?,
+                decimal_from_json(parts.get("size")?)?,
+            )),
+            _ => None,
+        })
+        .filter(|(price, size)| {
+            *price > Decimal::new(1, 2) && *price < Decimal::new(99, 2) && *size > Decimal::ZERO
+        })
+        .map(|(price, size)| BookLevel { price, size })
+        .collect::<Vec<_>>();
+    if ascending {
+        levels.sort_by_key(|level| level.price);
+    } else {
+        levels.sort_by_key(|level| std::cmp::Reverse(level.price));
+    }
+    levels
+}
+
+fn decimal_from_json(value: &Value) -> Option<Decimal> {
+    match value {
+        Value::Number(number) => number.to_string().parse().ok(),
+        Value::String(text) => text.parse().ok(),
+        _ => None,
+    }
 }
 
 // ── L2 Data ──────────────────────────────────────────────
@@ -1030,6 +1000,14 @@ async fn load_events(
 
     let event_ids: Vec<String> = rows.iter().map(|row| row.market_slug.clone()).collect();
     let settlement_prices = load_event_settlement_prices(pool, &event_ids).await?;
+    if require_official_settlement {
+        let (discovered, resolved) = official_settlement_coverage(&rows, &settlement_prices);
+        if resolved != discovered {
+            return Err(sqlx::Error::Protocol(format!(
+                "official settlement coverage is incomplete: resolved={resolved}, discovered={discovered}"
+            )));
+        }
+    }
 
     info!(count = rows.len(), "Loaded events from pm_market_metadata");
     updates.extend(build_event_updates(
@@ -1039,6 +1017,39 @@ async fn load_events(
     ));
 
     Ok(())
+}
+
+fn official_settlement_coverage(
+    rows: &[EventMetadataRow],
+    settlement_prices: &HashMap<(String, String), Decimal>,
+) -> (usize, usize) {
+    let mut discovered = 0usize;
+    let mut resolved = 0usize;
+    for row in rows {
+        let symbol = row.symbol.as_deref().unwrap_or_default();
+        let up_token = normalize_token_id(row.up_token_id.as_deref().unwrap_or_default());
+        let down_token = normalize_token_id(row.down_token_id.as_deref().unwrap_or_default());
+        if symbol.is_empty()
+            || row.start_time.is_none()
+            || row.end_time.is_none()
+            || up_token.is_empty()
+            || down_token.is_empty()
+        {
+            continue;
+        }
+        discovered += 1;
+        if resolve_up_won_from_settlements(
+            settlement_prices,
+            &row.market_slug,
+            &up_token,
+            &down_token,
+        )
+        .is_some()
+        {
+            resolved += 1;
+        }
+    }
+    (discovered, resolved)
 }
 
 fn build_event_updates(
@@ -1165,10 +1176,29 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        build_event_updates, l2_updates_from_book, near_depth, EventMetadataRow, MarketUpdate,
+        book_levels_from_json, build_event_updates, l2_updates_from_book, near_depth,
+        official_settlement_coverage, EventMetadataRow, MarketUpdate,
         BINANCE_AGG_TRADE_SAMPLED_QUERY, BINANCE_LOB_SAMPLED_QUERY, BINANCE_PRICE_SAMPLED_QUERY,
         SYNC_RECORDS_SPOT_SAMPLED_QUERY,
     };
+
+    #[test]
+    fn polymarket_depth_levels_are_decimal_sorted_and_tradeable() {
+        let bids = json!([["0.48", "10"], ["0.49", "5"], ["0.01", "999"]]);
+        let asks = json!([
+            {"price": "0.52", "size": "8"},
+            {"price": "0.51", "size": "7"}
+        ]);
+
+        let bids = book_levels_from_json(&bids, false);
+        let asks = book_levels_from_json(&asks, true);
+
+        assert_eq!(bids[0].price, dec!(0.49));
+        assert_eq!(bids[0].size, dec!(5));
+        assert_eq!(bids.len(), 2);
+        assert_eq!(asks[0].price, dec!(0.51));
+        assert_eq!(asks[0].size, dec!(7));
+    }
 
     #[test]
     fn binance_samplers_use_bucketed_index_lookups() {
@@ -1257,6 +1287,36 @@ mod tests {
             updates.is_empty(),
             "official-only mode should skip unresolved events"
         );
+    }
+
+    #[test]
+    fn official_settlement_coverage_detects_partial_event_windows() {
+        let now = Utc::now();
+        let rows = vec![
+            EventMetadataRow {
+                market_slug: "evt-1".into(),
+                symbol: Some("BTCUSDT".into()),
+                end_time: Some(now + Duration::minutes(5)),
+                start_time: Some(now),
+                up_token_id: Some("up-1".into()),
+                down_token_id: Some("down-1".into()),
+                price_to_beat: Some(dec!(100000)),
+            },
+            EventMetadataRow {
+                market_slug: "evt-2".into(),
+                symbol: Some("ETHUSDT".into()),
+                end_time: Some(now + Duration::minutes(5)),
+                start_time: Some(now),
+                up_token_id: Some("up-2".into()),
+                down_token_id: Some("down-2".into()),
+                price_to_beat: Some(dec!(3000)),
+            },
+        ];
+        let mut prices = HashMap::new();
+        prices.insert(("evt-1".to_string(), "up-1".to_string()), dec!(1));
+        prices.insert(("evt-1".to_string(), "down-1".to_string()), dec!(0));
+
+        assert_eq!(official_settlement_coverage(&rows, &prices), (2, 1));
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/Cargo.toml
+++ b/crates/ploy-strategy-bundles/Cargo.toml
@@ -22,6 +22,7 @@ rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = false }
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 toml.workspace = true

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -376,6 +376,43 @@ mod tests {
             purpose: ploy_trading::IntentPurpose::Entry,
             created_at: started + Duration::seconds(1),
         });
+        snapshot.intents.push(ploy_trading::TradingIntent {
+            intent_id: "orphan-exit".into(),
+            deployment_id: "pm5d-test".into(),
+            market_id: "event-without-entry".into(),
+            token_id: "orphan-token".into(),
+            side: ploy_trading::TradeSide::Sell,
+            quantity: dec!(1),
+            limit_price: Some(dec!(0.75)),
+            purpose: ploy_trading::IntentPurpose::Exit,
+            created_at: started + Duration::seconds(40),
+        });
+        snapshot.orders.push(ploy_trading::OrderRecord {
+            order_id: "orphan-exit-order".into(),
+            intent_id: "orphan-exit".into(),
+            deployment_id: "pm5d-test".into(),
+            token_id: "orphan-token".into(),
+            requested_qty: dec!(1),
+            limit_price: Some(dec!(0.75)),
+            venue_order_id: None,
+            venue_order_history: Vec::new(),
+            revision: 0,
+            idempotency_key: None,
+            state: ploy_trading::OrderState::Filled,
+            filled_qty: dec!(1),
+            rejection_reason: None,
+            last_error: None,
+        });
+        snapshot.fills.push(ploy_trading::FillRecord {
+            fill_id: "orphan-exit-fill".into(),
+            order_id: "orphan-exit-order".into(),
+            token_id: "orphan-token".into(),
+            side: ploy_trading::TradeSide::Sell,
+            quantity: dec!(1),
+            price: dec!(0.75),
+            fee: Decimal::ZERO,
+            timestamp: started + Duration::seconds(40),
+        });
 
         let metrics = backtest_evidence_metrics(&snapshot);
 
@@ -383,6 +420,7 @@ mod tests {
         assert_eq!(metrics.max_event_decisions, 2);
         assert_eq!(metrics.closed_event_count, 3);
         assert_eq!(metrics.open_event_count, 0);
+        assert_eq!(metrics.lifecycle_without_entry_decision_count, 1);
         assert_eq!(metrics.max_drawdown, dec!(-25));
     }
 }
@@ -781,6 +819,7 @@ fn build_backtest_evaluation_artifact(
         && result.full_depth_fills_observed == result.non_settlement_fills_observed;
     let has_event_level_accounting = evidence_metrics.unique_event_count > 0
         && evidence_metrics.missing_event_id_count == 0
+        && evidence_metrics.lifecycle_without_entry_decision_count == 0
         && evidence_metrics.max_event_decisions <= 1
         && evidence_metrics.open_event_count == 0
         && evidence_metrics.closed_event_count == evidence_metrics.unique_event_count;
@@ -797,6 +836,9 @@ fn build_backtest_evaluation_artifact(
     }
     if evidence_metrics.missing_event_id_count > 0 {
         blocking_risk_flags.push("missing_event_ids");
+    }
+    if evidence_metrics.lifecycle_without_entry_decision_count > 0 {
+        blocking_risk_flags.push("lifecycle_without_entry_decision");
     }
     if evidence_metrics.max_event_decisions > 1 {
         blocking_risk_flags.push("multiple_entry_decisions_per_event");
@@ -895,6 +937,7 @@ fn build_backtest_evaluation_artifact(
             "closed_event_count": evidence_metrics.closed_event_count,
             "open_event_count": evidence_metrics.open_event_count,
             "missing_event_id_count": evidence_metrics.missing_event_id_count,
+            "lifecycle_without_entry_decision_count": evidence_metrics.lifecycle_without_entry_decision_count,
             "max_drawdown": evidence_metrics.max_drawdown,
             "realized_pnl": result.pnl.realized_pnl,
             "unrealized_pnl": result.pnl.unrealized_pnl,
@@ -916,6 +959,7 @@ struct BacktestEvidenceMetrics {
     unique_event_count: usize,
     max_event_decisions: usize,
     missing_event_id_count: usize,
+    lifecycle_without_entry_decision_count: usize,
     closed_event_count: usize,
     open_event_count: usize,
     max_drawdown: Decimal,
@@ -992,6 +1036,10 @@ fn backtest_evidence_metrics(
 
     let mut closed = Vec::new();
     let mut open_event_count = 0usize;
+    let lifecycle_without_entry_decision_count = lifecycles
+        .keys()
+        .filter(|event_id| !entry_decisions.contains_key(event_id.as_str()))
+        .count();
     for event_id in entry_decisions.keys() {
         match lifecycles.get(event_id) {
             Some(lifecycle)
@@ -1025,6 +1073,7 @@ fn backtest_evidence_metrics(
         unique_event_count: entry_decisions.len(),
         max_event_decisions: entry_decisions.values().copied().max().unwrap_or(0),
         missing_event_id_count,
+        lifecycle_without_entry_decision_count,
         closed_event_count: closed.len(),
         open_event_count,
         max_drawdown,

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -240,6 +240,7 @@ mod tests {
                 venue_order_id: Some("venue-1".to_string()),
                 venue_order_history: vec![],
                 revision: 0,
+                idempotency_key: None,
                 state: ploy_trading::OrderState::Filled,
                 filled_qty: dec!(10),
                 rejection_reason: None,
@@ -275,6 +276,114 @@ mod tests {
         assert_eq!(evidence["orders"][0]["status"], "FILLED");
         assert_eq!(evidence["fills"][0]["fill_id"], "fill-1");
         assert_eq!(evidence["fills"][0]["fill_side"], "BUY");
+    }
+
+    #[test]
+    fn backtest_evidence_tracks_event_uniqueness_and_closed_drawdown() {
+        let started = Utc::now();
+        let mut snapshot = ploy_trading::TradingRuntimeSnapshot::default();
+        for (index, (event_id, exit_price)) in [
+            ("event-1", dec!(0.60)),
+            ("event-2", dec!(0.25)),
+            ("event-3", dec!(0.55)),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let entry_intent_id = format!("entry-{index}");
+            let exit_intent_id = format!("exit-{index}");
+            let entry_order_id = format!("entry-order-{index}");
+            let exit_order_id = format!("exit-order-{index}");
+            let token_id = format!("token-{index}");
+            let opened_at = started + Duration::seconds(index as i64 * 10);
+            let closed_at = opened_at + Duration::seconds(5);
+            snapshot.intents.extend([
+                ploy_trading::TradingIntent {
+                    intent_id: entry_intent_id.clone(),
+                    deployment_id: "pm5d-test".into(),
+                    market_id: event_id.into(),
+                    token_id: token_id.clone(),
+                    side: ploy_trading::TradeSide::Buy,
+                    quantity: dec!(100),
+                    limit_price: Some(dec!(0.50)),
+                    purpose: ploy_trading::IntentPurpose::Entry,
+                    created_at: opened_at,
+                },
+                ploy_trading::TradingIntent {
+                    intent_id: exit_intent_id.clone(),
+                    deployment_id: "pm5d-test".into(),
+                    market_id: event_id.into(),
+                    token_id: token_id.clone(),
+                    side: ploy_trading::TradeSide::Sell,
+                    quantity: dec!(100),
+                    limit_price: Some(exit_price),
+                    purpose: ploy_trading::IntentPurpose::Exit,
+                    created_at: closed_at,
+                },
+            ]);
+            for (order_id, intent_id) in [
+                (entry_order_id.clone(), entry_intent_id.clone()),
+                (exit_order_id.clone(), exit_intent_id.clone()),
+            ] {
+                snapshot.orders.push(ploy_trading::OrderRecord {
+                    order_id,
+                    intent_id,
+                    deployment_id: "pm5d-test".into(),
+                    token_id: token_id.clone(),
+                    requested_qty: dec!(100),
+                    limit_price: Some(dec!(0.50)),
+                    venue_order_id: None,
+                    venue_order_history: Vec::new(),
+                    revision: 0,
+                    idempotency_key: None,
+                    state: ploy_trading::OrderState::Filled,
+                    filled_qty: dec!(100),
+                    rejection_reason: None,
+                    last_error: None,
+                });
+            }
+            snapshot.fills.extend([
+                ploy_trading::FillRecord {
+                    fill_id: format!("entry-fill-{index}"),
+                    order_id: entry_order_id,
+                    token_id: token_id.clone(),
+                    side: ploy_trading::TradeSide::Buy,
+                    quantity: dec!(100),
+                    price: dec!(0.50),
+                    fee: Decimal::ZERO,
+                    timestamp: opened_at,
+                },
+                ploy_trading::FillRecord {
+                    fill_id: format!("exit-fill-{index}"),
+                    order_id: exit_order_id,
+                    token_id,
+                    side: ploy_trading::TradeSide::Sell,
+                    quantity: dec!(100),
+                    price: exit_price,
+                    fee: Decimal::ZERO,
+                    timestamp: closed_at,
+                },
+            ]);
+        }
+        snapshot.intents.push(ploy_trading::TradingIntent {
+            intent_id: "duplicate-event-1".into(),
+            deployment_id: "pm5d-test".into(),
+            market_id: "event-1".into(),
+            token_id: "token-0".into(),
+            side: ploy_trading::TradeSide::Buy,
+            quantity: dec!(1),
+            limit_price: Some(dec!(0.50)),
+            purpose: ploy_trading::IntentPurpose::Entry,
+            created_at: started + Duration::seconds(1),
+        });
+
+        let metrics = backtest_evidence_metrics(&snapshot);
+
+        assert_eq!(metrics.unique_event_count, 3);
+        assert_eq!(metrics.max_event_decisions, 2);
+        assert_eq!(metrics.closed_event_count, 3);
+        assert_eq!(metrics.open_event_count, 0);
+        assert_eq!(metrics.max_drawdown, dec!(-25));
     }
 }
 
@@ -658,6 +767,7 @@ fn build_backtest_evaluation_artifact(
     snapshot: &ploy_trading::TradingRuntimeSnapshot,
 ) -> serde_json::Value {
     let cashflow = snapshot.fill_cashflow_summary();
+    let evidence_metrics = backtest_evidence_metrics(snapshot);
     let mut artifact_risk_flags = Vec::new();
     if snapshot.orders.is_empty() {
         artifact_risk_flags.push("no_order_level_rows");
@@ -667,7 +777,13 @@ fn build_backtest_evaluation_artifact(
     }
 
     let has_official_settlement_gate = backtest_options.require_official_settlement;
-    let has_full_depth_clob = false;
+    let has_full_depth_clob = result.non_settlement_fills_observed > 0
+        && result.full_depth_fills_observed == result.non_settlement_fills_observed;
+    let has_event_level_accounting = evidence_metrics.unique_event_count > 0
+        && evidence_metrics.missing_event_id_count == 0
+        && evidence_metrics.max_event_decisions <= 1
+        && evidence_metrics.open_event_count == 0
+        && evidence_metrics.closed_event_count == evidence_metrics.unique_event_count;
     let has_replay_dryrun_parity = false;
     let has_runtime_scorer_parity = false;
     let is_synthetic = source_kind == "synthetic";
@@ -678,6 +794,15 @@ fn build_backtest_evaluation_artifact(
     }
     if !has_official_settlement_gate {
         blocking_risk_flags.push("missing_official_settlement_gate");
+    }
+    if evidence_metrics.missing_event_id_count > 0 {
+        blocking_risk_flags.push("missing_event_ids");
+    }
+    if evidence_metrics.max_event_decisions > 1 {
+        blocking_risk_flags.push("multiple_entry_decisions_per_event");
+    }
+    if !has_event_level_accounting {
+        blocking_risk_flags.push("incomplete_event_lifecycle_accounting");
     }
     if !has_replay_dryrun_parity {
         blocking_risk_flags.push("missing_replay_dryrun_parity");
@@ -691,22 +816,33 @@ fn build_backtest_evaluation_artifact(
     blocking_risk_flags.extend(artifact_risk_flags.iter().copied());
 
     let mut advisory_flags = Vec::new();
-    if source_kind == "parquet_stream" {
+    if source_kind == "parquet_stream" && result.depth_quote_updates_observed == 0 {
         advisory_flags.push("parquet_stream_uses_quote_ticks_not_full_clob_lake");
     }
     if source_kind == "db_eager" {
         advisory_flags.push("db_eager_mode_is_debug_or_small_window_only");
     }
 
-    let evidence_stage = if !is_synthetic && has_official_settlement_gate {
+    let evidence_stage = if !is_synthetic
+        && has_official_settlement_gate
+        && has_full_depth_clob
+        && has_event_level_accounting
+    {
         "executable_replay"
     } else {
         "diagnostic"
     };
-    let canonical_result = if artifact_risk_flags.is_empty() {
+    let canonical_result = if !artifact_risk_flags.is_empty() {
+        "fix-workflow-or-data-source"
+    } else if blocking_risk_flags.is_empty() {
         "continue"
     } else {
-        "fix-workflow-or-data-source"
+        "revise"
+    };
+    let full_depth_quote_coverage = if result.quote_updates_observed == 0 {
+        0.0
+    } else {
+        result.depth_quote_updates_observed as f64 / result.quote_updates_observed as f64
     };
 
     json!({
@@ -731,6 +867,7 @@ fn build_backtest_evaluation_artifact(
             "spot_sample_secs": backtest_options.spot_sample_secs,
             "official_settlement_required": has_official_settlement_gate,
             "full_depth_clob_fillability": has_full_depth_clob,
+            "event_level_accounting": has_event_level_accounting,
             "runtime_replay_parity": has_replay_dryrun_parity,
             "runtime_scorer_parity": has_runtime_scorer_parity,
         },
@@ -744,10 +881,21 @@ fn build_backtest_evaluation_artifact(
         },
         "metrics": {
             "updates_processed": result.updates_processed,
+            "quote_updates_observed": result.quote_updates_observed,
+            "depth_quote_updates_observed": result.depth_quote_updates_observed,
+            "full_depth_quote_coverage": full_depth_quote_coverage,
             "intents_submitted": result.intents_submitted,
             "orders": snapshot.orders.len(),
             "fills_recorded": result.fills_recorded,
             "fills": snapshot.fills.len(),
+            "non_settlement_fills_observed": result.non_settlement_fills_observed,
+            "full_depth_fills_observed": result.full_depth_fills_observed,
+            "unique_event_count": evidence_metrics.unique_event_count,
+            "max_event_decisions": evidence_metrics.max_event_decisions,
+            "closed_event_count": evidence_metrics.closed_event_count,
+            "open_event_count": evidence_metrics.open_event_count,
+            "missing_event_id_count": evidence_metrics.missing_event_id_count,
+            "max_drawdown": evidence_metrics.max_drawdown,
             "realized_pnl": result.pnl.realized_pnl,
             "unrealized_pnl": result.pnl.unrealized_pnl,
             "total_fees": result.pnl.total_fees,
@@ -761,6 +909,126 @@ fn build_backtest_evaluation_artifact(
         "advisory_flags": advisory_flags,
         "runtime_evidence": normalized_runtime_evidence(snapshot),
     })
+}
+
+#[derive(Debug, Default)]
+struct BacktestEvidenceMetrics {
+    unique_event_count: usize,
+    max_event_decisions: usize,
+    missing_event_id_count: usize,
+    closed_event_count: usize,
+    open_event_count: usize,
+    max_drawdown: Decimal,
+}
+
+#[derive(Debug, Default)]
+struct EventLifecycle {
+    net_quantity_by_token: BTreeMap<String, Decimal>,
+    net_pnl: Decimal,
+    closed_at: Option<chrono::DateTime<Utc>>,
+    has_fill: bool,
+}
+
+fn backtest_evidence_metrics(
+    snapshot: &ploy_trading::TradingRuntimeSnapshot,
+) -> BacktestEvidenceMetrics {
+    let mut entry_decisions = BTreeMap::<String, usize>::new();
+    let mut missing_event_id_count = 0usize;
+    for intent in snapshot
+        .intents
+        .iter()
+        .filter(|intent| intent.purpose == ploy_trading::IntentPurpose::Entry)
+    {
+        if intent.market_id.trim().is_empty() {
+            missing_event_id_count += 1;
+        } else {
+            *entry_decisions.entry(intent.market_id.clone()).or_default() += 1;
+        }
+    }
+
+    let intents_by_id = snapshot
+        .intents
+        .iter()
+        .map(|intent| (intent.intent_id.as_str(), intent))
+        .collect::<BTreeMap<_, _>>();
+    let orders_by_id = snapshot
+        .orders
+        .iter()
+        .map(|order| (order.order_id.as_str(), order))
+        .collect::<BTreeMap<_, _>>();
+    let mut lifecycles = BTreeMap::<String, EventLifecycle>::new();
+    for fill in &snapshot.fills {
+        let Some(intent) = orders_by_id
+            .get(fill.order_id.as_str())
+            .and_then(|order| intents_by_id.get(order.intent_id.as_str()))
+            .copied()
+        else {
+            continue;
+        };
+        if intent.market_id.trim().is_empty() {
+            continue;
+        }
+        let lifecycle = lifecycles.entry(intent.market_id.clone()).or_default();
+        let signed_quantity = match fill.side {
+            ploy_trading::TradeSide::Buy => fill.quantity,
+            ploy_trading::TradeSide::Sell => -fill.quantity,
+        };
+        *lifecycle
+            .net_quantity_by_token
+            .entry(fill.token_id.clone())
+            .or_default() += signed_quantity;
+        let signed_notional = match fill.side {
+            ploy_trading::TradeSide::Buy => -(fill.quantity * fill.price),
+            ploy_trading::TradeSide::Sell => fill.quantity * fill.price,
+        };
+        lifecycle.net_pnl += signed_notional - fill.fee;
+        lifecycle.closed_at = Some(
+            lifecycle
+                .closed_at
+                .map_or(fill.timestamp, |current| current.max(fill.timestamp)),
+        );
+        lifecycle.has_fill = true;
+    }
+
+    let mut closed = Vec::new();
+    let mut open_event_count = 0usize;
+    for event_id in entry_decisions.keys() {
+        match lifecycles.get(event_id) {
+            Some(lifecycle)
+                if lifecycle.has_fill
+                    && lifecycle
+                        .net_quantity_by_token
+                        .values()
+                        .all(Decimal::is_zero) =>
+            {
+                closed.push((
+                    lifecycle.closed_at.unwrap_or_default(),
+                    event_id.as_str(),
+                    lifecycle.net_pnl,
+                ));
+            }
+            _ => open_event_count += 1,
+        }
+    }
+    closed.sort_by_key(|(closed_at, event_id, _)| (*closed_at, *event_id));
+
+    let mut cumulative = Decimal::ZERO;
+    let mut peak = Decimal::ZERO;
+    let mut max_drawdown = Decimal::ZERO;
+    for (_, _, pnl) in &closed {
+        cumulative += *pnl;
+        peak = peak.max(cumulative);
+        max_drawdown = max_drawdown.min(cumulative - peak);
+    }
+
+    BacktestEvidenceMetrics {
+        unique_event_count: entry_decisions.len(),
+        max_event_decisions: entry_decisions.values().copied().max().unwrap_or(0),
+        missing_event_id_count,
+        closed_event_count: closed.len(),
+        open_event_count,
+        max_drawdown,
+    }
 }
 
 fn normalized_runtime_evidence(

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -102,6 +102,25 @@ fn live_retry_remainder_is_dust(remaining_qty: Decimal, limit_price: Option<Deci
         .unwrap_or(false)
 }
 
+fn observe_fill_evidence(
+    intent: &TradingIntent,
+    price_basis: Option<&str>,
+    non_settlement_fills_observed: &mut u64,
+    full_depth_fills_observed: &mut u64,
+) {
+    let is_settlement = intent.purpose == IntentPurpose::Exit
+        && intent
+            .limit_price
+            .is_some_and(|price| price == dec!(0) || price == dec!(1));
+    if is_settlement || price_basis == Some("settlement") {
+        return;
+    }
+    *non_settlement_fills_observed += 1;
+    if price_basis == Some("full_depth_sweep") {
+        *full_depth_fills_observed += 1;
+    }
+}
+
 /// Unified strategy runtime.
 ///
 /// Generic over:
@@ -352,12 +371,12 @@ where
                     }
                     self.strategy.on_fill(&fill);
                     fills_recorded += 1;
-                    if report.price_basis != Some("settlement") {
-                        non_settlement_fills_observed += 1;
-                        if report.price_basis == Some("full_depth_sweep") {
-                            full_depth_fills_observed += 1;
-                        }
-                    }
+                    observe_fill_evidence(
+                        &intent,
+                        report.price_basis,
+                        &mut non_settlement_fills_observed,
+                        &mut full_depth_fills_observed,
+                    );
                     debug!(
                         order_id = %order_id,
                         token = %fill.token_id,
@@ -453,13 +472,12 @@ where
                         }
                         self.strategy.on_fill(&fill);
                         fills_recorded += 1;
-                        let is_settlement = intent.purpose == IntentPurpose::Exit
-                            && intent
-                                .limit_price
-                                .is_some_and(|price| price == dec!(0) || price == dec!(1));
-                        if !is_settlement {
-                            non_settlement_fills_observed += 1;
-                        }
+                        observe_fill_evidence(
+                            &intent,
+                            report.price_basis,
+                            &mut non_settlement_fills_observed,
+                            &mut full_depth_fills_observed,
+                        );
                         if self
                             .trading
                             .order(&fill.order_id)
@@ -494,6 +512,8 @@ where
                         &mut pending_live_orders,
                         &mut intents_submitted,
                         &mut fills_recorded,
+                        &mut non_settlement_fills_observed,
+                        &mut full_depth_fills_observed,
                     )
                     .await
                 {
@@ -618,6 +638,8 @@ where
         pending_live_orders: &mut BTreeMap<String, PendingLiveOrder>,
         intents_submitted: &mut u64,
         fills_recorded: &mut u64,
+        non_settlement_fills_observed: &mut u64,
+        full_depth_fills_observed: &mut u64,
     ) -> Result<(), String> {
         if self.config.mode != RuntimeMode::Live || pending_live_orders.is_empty() {
             return Ok(());
@@ -781,6 +803,12 @@ where
                         .await?;
                     self.strategy.on_fill(fill);
                     *fills_recorded += 1;
+                    observe_fill_evidence(
+                        &retry_intent,
+                        report.price_basis,
+                        non_settlement_fills_observed,
+                        full_depth_fills_observed,
+                    );
                 }
             } else {
                 pending_live_orders.insert(
@@ -838,8 +866,8 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::{
-        retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig, RuntimeMode,
-        StrategyRuntime,
+        observe_fill_evidence, retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig,
+        RuntimeMode, StrategyRuntime,
     };
     use crate::traits::{
         ExecutionPolicy, ExecutionReport, Executor, Feed, MarketUpdate, NullRecorder, Recorder,
@@ -867,6 +895,33 @@ mod tests {
             "pm5d_BTCUSDT_UP"
         );
         assert_eq!(retry_attempt_from_intent_id("pm5d_BTCUSDT_UP_retry2"), 2);
+    }
+
+    #[test]
+    fn settlement_intent_cannot_count_as_full_depth_fillability() {
+        let mut non_settlement = 0;
+        let mut full_depth = 0;
+        let settlement = TradingIntent {
+            intent_id: "settlement".into(),
+            deployment_id: "test".into(),
+            market_id: "event".into(),
+            token_id: "token".into(),
+            side: TradeSide::Sell,
+            quantity: dec!(1),
+            limit_price: Some(dec!(1)),
+            purpose: IntentPurpose::Exit,
+            created_at: Utc::now(),
+        };
+
+        observe_fill_evidence(
+            &settlement,
+            Some("full_depth_sweep"),
+            &mut non_settlement,
+            &mut full_depth,
+        );
+
+        assert_eq!(non_settlement, 0);
+        assert_eq!(full_depth, 0);
     }
 
     #[async_trait]
@@ -1347,6 +1402,7 @@ mod tests {
     struct AcknowledgingExecutor {
         policy: ExecutionPolicy,
         submissions: Arc<Mutex<Vec<String>>>,
+        fill_on_retry: bool,
     }
 
     impl Default for AcknowledgingExecutor {
@@ -1354,6 +1410,7 @@ mod tests {
             Self {
                 policy: ExecutionPolicy::default(),
                 submissions: Arc::new(Mutex::new(Vec::new())),
+                fill_on_retry: false,
             }
         }
     }
@@ -1364,11 +1421,31 @@ mod tests {
             self.policy
         }
 
-        async fn submit(&mut self, intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
+        async fn submit(&mut self, intent: &TradingIntent, order_id: &str) -> ExecutionReport {
             self.submissions
                 .lock()
                 .unwrap()
                 .push(intent.intent_id.clone());
+            if self.fill_on_retry && intent.intent_id.ends_with("_retry2") {
+                return ExecutionReport {
+                    order_id: order_id.to_string(),
+                    fill: Some(FillRecord {
+                        fill_id: format!("fill-{order_id}"),
+                        order_id: order_id.to_string(),
+                        token_id: intent.token_id.clone(),
+                        side: intent.side,
+                        quantity: intent.quantity,
+                        price: intent.limit_price.expect("retry limit price"),
+                        fee: Decimal::ZERO,
+                        timestamp: intent.created_at,
+                    }),
+                    rejected: false,
+                    rejection_reason: None,
+                    slippage: Some(Decimal::ZERO),
+                    market_impact: Some(Decimal::ZERO),
+                    price_basis: Some("full_depth_sweep"),
+                };
+            }
             ExecutionReport {
                 order_id: "venue-order-1".into(),
                 fill: None,
@@ -2033,6 +2110,7 @@ mod tests {
                 reconcile_cycles_before_retry: 1,
             },
             submissions: submissions.clone(),
+            fill_on_retry: true,
         };
         let recorder = Box::new(CollectingRecorder {
             signals: Arc::new(Mutex::new(Vec::new())),
@@ -2060,7 +2138,7 @@ mod tests {
 
         let mut runtime = StrategyRuntime::new(strategy, feed, executor, recorder, config)
             .with_deployment_id("test.live");
-        let _ = runtime.run().await;
+        let result = runtime.run().await;
         let snapshot = runtime.trading().snapshot(&BTreeMap::new());
 
         assert_eq!(
@@ -2080,11 +2158,13 @@ mod tests {
             snapshot
                 .orders
                 .iter()
-                .filter(|order| order.state == ploy_trading::OrderState::Acknowledged)
+                .filter(|order| order.state == ploy_trading::OrderState::Filled)
                 .count(),
             1
         );
-        assert_eq!(snapshot.fills.len(), 0);
+        assert_eq!(snapshot.fills.len(), 1);
+        assert_eq!(result.non_settlement_fills_observed, 1);
+        assert_eq!(result.full_depth_fills_observed, 1);
     }
 
     #[tokio::test]
@@ -2122,6 +2202,7 @@ mod tests {
                 reconcile_cycles_before_retry: 1,
             },
             submissions: submissions.clone(),
+            fill_on_retry: false,
         };
         let recorder = Box::new(CollectingRecorder {
             signals: Arc::new(Mutex::new(Vec::new())),
@@ -2251,6 +2332,7 @@ mod tests {
                 reconcile_cycles_before_retry: 1,
             },
             submissions: submissions.clone(),
+            fill_on_retry: false,
         };
         let feed = SingleUpdateFeed {
             next: Some(MarketUpdate::SpotPrice {

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -56,8 +56,12 @@ pub struct RuntimeConfig {
 pub struct RuntimeResult {
     pub mode: RuntimeMode,
     pub updates_processed: u64,
+    pub quote_updates_observed: u64,
+    pub depth_quote_updates_observed: u64,
     pub intents_submitted: u64,
     pub fills_recorded: u64,
+    pub non_settlement_fills_observed: u64,
+    pub full_depth_fills_observed: u64,
     pub pnl: PnlSnapshot,
     pub risk: RiskSnapshot,
     pub elapsed_secs: f64,
@@ -176,8 +180,12 @@ where
     pub async fn run(&mut self) -> RuntimeResult {
         let start = std::time::Instant::now();
         let mut updates_processed: u64 = 0;
+        let mut quote_updates_observed: u64 = 0;
+        let mut depth_quote_updates_observed: u64 = 0;
         let mut intents_submitted: u64 = 0;
         let mut fills_recorded: u64 = 0;
+        let mut non_settlement_fills_observed: u64 = 0;
+        let mut full_depth_fills_observed: u64 = 0;
         let mut last_eval_ts: Option<DateTime<Utc>> = None;
         let mut pending_live_orders = self.initial_pending_live_orders();
 
@@ -189,6 +197,17 @@ where
 
         'runtime: while let Some(update) = self.feed.next().await {
             updates_processed += 1;
+            if let MarketUpdate::Quote {
+                bid_levels,
+                ask_levels,
+                ..
+            } = &update
+            {
+                quote_updates_observed += 1;
+                if !bid_levels.is_empty() || !ask_levels.is_empty() {
+                    depth_quote_updates_observed += 1;
+                }
+            }
             self.executor.observe_market_update(&update);
 
             if let MarketUpdate::EventExpired { event_id, .. } = &update {
@@ -333,6 +352,12 @@ where
                     }
                     self.strategy.on_fill(&fill);
                     fills_recorded += 1;
+                    if report.price_basis != Some("settlement") {
+                        non_settlement_fills_observed += 1;
+                        if report.price_basis == Some("full_depth_sweep") {
+                            full_depth_fills_observed += 1;
+                        }
+                    }
                     debug!(
                         order_id = %order_id,
                         token = %fill.token_id,
@@ -428,6 +453,13 @@ where
                         }
                         self.strategy.on_fill(&fill);
                         fills_recorded += 1;
+                        let is_settlement = intent.purpose == IntentPurpose::Exit
+                            && intent
+                                .limit_price
+                                .is_some_and(|price| price == dec!(0) || price == dec!(1));
+                        if !is_settlement {
+                            non_settlement_fills_observed += 1;
+                        }
                         if self
                             .trading
                             .order(&fill.order_id)
@@ -504,8 +536,12 @@ where
         let result = RuntimeResult {
             mode: self.config.mode,
             updates_processed,
+            quote_updates_observed,
+            depth_quote_updates_observed,
             intents_submitted,
             fills_recorded,
+            non_settlement_fills_observed,
+            full_depth_fills_observed,
             pnl: snapshot.pnl,
             risk: snapshot.risk,
             elapsed_secs: elapsed,
@@ -978,8 +1014,14 @@ mod tests {
                     ask: Some(dec!(0.59)),
                     bid_size: Some(dec!(100)),
                     ask_size: Some(dec!(100)),
-                    bid_levels: vec![],
-                    ask_levels: vec![],
+                    bid_levels: vec![ploy_market_contracts::BookLevel {
+                        price: dec!(0.58),
+                        size: dec!(100),
+                    }],
+                    ask_levels: vec![ploy_market_contracts::BookLevel {
+                        price: dec!(0.59),
+                        size: dec!(100),
+                    }],
                     ts: now + Duration::milliseconds(300),
                 },
             ]),
@@ -1009,6 +1051,8 @@ mod tests {
         let result = runtime.run().await;
 
         assert_eq!(result.updates_processed, 4);
+        assert_eq!(result.quote_updates_observed, 2);
+        assert_eq!(result.depth_quote_updates_observed, 1);
         assert_eq!(
             seen_updates.lock().unwrap().as_slice(),
             ["spot", "quote", "quote"]
@@ -1263,7 +1307,7 @@ mod tests {
                 rejection_reason: None,
                 slippage: Some(Decimal::ZERO),
                 market_impact: Some(Decimal::ZERO),
-                price_basis: None,
+                price_basis: Some("full_depth_sweep"),
             }
         }
 
@@ -1569,6 +1613,8 @@ mod tests {
 
         let result = runtime.run().await;
         assert_eq!(result.fills_recorded, 1);
+        assert_eq!(result.non_settlement_fills_observed, 1);
+        assert_eq!(result.full_depth_fills_observed, 0);
         assert_eq!(runtime.trading().positions().net_qty("token-up"), dec!(2));
     }
 
@@ -1671,6 +1717,8 @@ mod tests {
 
         assert_eq!(result.intents_submitted, 1);
         assert_eq!(result.fills_recorded, 1);
+        assert_eq!(result.non_settlement_fills_observed, 1);
+        assert_eq!(result.full_depth_fills_observed, 1);
         assert_eq!(order_store.lock().unwrap().len(), 1);
         assert_eq!(fill_store.lock().unwrap().as_slice(), ["fill-1"]);
     }

--- a/crates/ploy-strategy-bundles/src/feed/parquet.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet.rs
@@ -380,6 +380,8 @@ fn load_pm_quotes(
             ask,
             bid_size,
             ask_size,
+            bid_levels: Vec::new(),
+            ask_levels: Vec::new(),
             ts,
         });
         count += 1;

--- a/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
+++ b/crates/ploy-strategy-bundles/src/feed/parquet_stream.rs
@@ -192,6 +192,11 @@ fn run_background(
     let agg_glob = format!("{data_dir}/binance_agg_trade_ticks/*.parquet");
     let lob_glob = format!("{data_dir}/binance_lob_ticks/*.parquet");
     let quote_glob = format!("{data_dir}/clob_quote_ticks/*.parquet");
+    let orderbook_dir = format!("{data_dir}/orderbook_snapshots");
+    let orderbook_glob = format!("{orderbook_dir}/**/*.parquet");
+    if Path::new(&orderbook_dir).exists() {
+        validate_orderbook_archive_window(Path::new(&orderbook_dir), from, to)?;
+    }
 
     // ── 1. Load events separately (small, ~11K rows) ────────────────────────
     let events = load_events_vec(
@@ -203,6 +208,7 @@ fn run_background(
         require_official_settlement,
     )?;
     info!(count = events.len(), "StreamingParquetFeed: loaded events");
+    let token_filter = event_token_filter_sql(&events);
     let mut evt_idx = 0;
 
     // ── 2. Build UNION ALL query for the big tables ─────────────────────────
@@ -214,7 +220,7 @@ fn run_background(
             "SELECT epoch_us(trade_time)::BIGINT AS ts_us, \
                     {SPOT_SOURCE_RANK} AS source_rank, \
                     'spot' AS typ, \
-                    symbol AS s1, NULL AS s2, \
+                    symbol AS s1, NULL AS s2, NULL AS s3, \
                     CAST(price AS DOUBLE) AS f1, 0.0 AS f2, 0.0 AS f3, 0.0 AS f4, \
                     CAST(0 AS BIGINT) AS i1, false AS b1 \
              FROM read_parquet('{spot_glob}') \
@@ -232,7 +238,7 @@ fn run_background(
             "SELECT epoch_us(trade_time)::BIGINT AS ts_us, \
                     {AGG_SOURCE_RANK} AS source_rank, \
                     'agg' AS typ, \
-                    symbol AS s1, NULL AS s2, \
+                    symbol AS s1, NULL AS s2, NULL AS s3, \
                     CAST(price AS DOUBLE) AS f1, CAST(quantity AS DOUBLE) AS f2, \
                     0.0 AS f3, 0.0 AS f4, \
                     CAST(agg_trade_id AS BIGINT) AS i1, is_buyer_maker AS b1 \
@@ -252,7 +258,7 @@ fn run_background(
             "SELECT epoch_us(event_time)::BIGINT AS ts_us, \
                     {LOB_SOURCE_RANK} AS source_rank, \
                     'lob' AS typ, \
-                    symbol AS s1, NULL AS s2, \
+                    symbol AS s1, NULL AS s2, NULL AS s3, \
                     CAST(COALESCE(obi_5, 0.0) AS DOUBLE) AS f1, \
                     CAST(COALESCE(spread_bps, 0.0) AS DOUBLE) AS f2, \
                     CAST(COALESCE(bid_volume_5, 0.0) AS DOUBLE) AS f3, \
@@ -265,23 +271,40 @@ fn run_background(
         ));
     }
 
-    // PM quotes — align with database.rs: DISTINCT ON per-second per-token, trusted sources only.
-    // Prefer book rows with executable size over later price-only rows in the same second.
-    if Path::new(&format!("{data_dir}/clob_quote_ticks")).exists() {
+    // Prefer the full-fidelity CLOB archive. If it is present, missing rows for
+    // the requested window fail closed instead of silently mixing top-book data.
+    if Path::new(&orderbook_dir).exists() {
         parts.push(format!(
-            "SELECT ts_us, source_rank, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
+            "SELECT EPOCH_US(received_at)::BIGINT AS ts_us, \
+                    {QUOTE_SOURCE_RANK} AS source_rank, \
+                    'quote_depth' AS typ, \
+                    token_id AS s1, CAST(bids AS VARCHAR) AS s2, \
+                    CAST(asks AS VARCHAR) AS s3, \
+                    NULL AS f1, NULL AS f2, NULL AS f3, NULL AS f4, \
+                    CAST(0 AS BIGINT) AS i1, false AS b1 \
+             FROM read_parquet('{orderbook_glob}') \
+             WHERE received_at >= TIMESTAMPTZ '{from_str}' \
+               AND received_at <= TIMESTAMPTZ '{to_str}' \
+               {token_filter}"
+        ));
+    // Legacy PM quote ticks remain useful for diagnostics, but never carry
+    // full-depth evidence.
+    } else if Path::new(&format!("{data_dir}/clob_quote_ticks")).exists() {
+        parts.push(format!(
+            "SELECT ts_us, source_rank, typ, s1, s2, s3, f1, f2, f3, f4, i1, b1 \
              FROM ( \
                  SELECT DISTINCT ON (date_trunc('second', received_at), token_id) \
                         EPOCH_US(received_at)::BIGINT AS ts_us, \
                         {QUOTE_SOURCE_RANK} AS source_rank, \
                         'quote' AS typ, \
-                        token_id AS s1, NULL AS s2, \
+                        token_id AS s1, NULL AS s2, NULL AS s3, \
                         CAST(best_bid AS DOUBLE) AS f1, CAST(best_ask AS DOUBLE) AS f2, \
                         CAST(bid_size AS DOUBLE) AS f3, CAST(ask_size AS DOUBLE) AS f4, \
                         CAST(0 AS BIGINT) AS i1, false AS b1 \
                  FROM read_parquet('{quote_glob}') \
                  WHERE received_at >= TIMESTAMPTZ '{from_str}' \
                    AND received_at <= TIMESTAMPTZ '{to_str}' \
+                   {token_filter} \
                    AND source IN ('polymarket_ws', 'polymarket_ws_collector', 'ploy_runner_live') \
                    AND best_bid IS NOT NULL AND best_ask IS NOT NULL \
                    AND (best_bid > 0.01 AND best_bid < 0.99 OR best_ask > 0.01 AND best_ask < 0.99) \
@@ -318,18 +341,19 @@ fn run_background(
             row.get::<_, String>(1)?,         // typ
             row.get::<_, Option<String>>(2)?, // s1
             row.get::<_, Option<String>>(3)?, // s2
-            row.get::<_, Option<f64>>(4)?,    // f1 (nullable for quotes with NULL bid)
-            row.get::<_, Option<f64>>(5)?,    // f2
-            row.get::<_, Option<f64>>(6)?,    // f3
-            row.get::<_, Option<f64>>(7)?,    // f4
-            row.get::<_, Option<i64>>(8)?,    // i1
-            row.get::<_, Option<bool>>(9)?,   // b1
+            row.get::<_, Option<String>>(4)?, // s3
+            row.get::<_, Option<f64>>(5)?,    // f1 (nullable for quotes with NULL bid)
+            row.get::<_, Option<f64>>(6)?,    // f2
+            row.get::<_, Option<f64>>(7)?,    // f3
+            row.get::<_, Option<f64>>(8)?,    // f4
+            row.get::<_, Option<i64>>(9)?,    // i1
+            row.get::<_, Option<bool>>(10)?,  // b1
         ))
     })?;
 
     let mut total = 0usize;
     for row in rows {
-        let (ts_us, typ, s1, _s2, f1_opt, f2_opt, f3_opt, f4_opt, i1_opt, b1_opt) = row?;
+        let (ts_us, typ, s1, s2, s3, f1_opt, f2_opt, f3_opt, f4_opt, i1_opt, b1_opt) = row?;
 
         // Insert any events that should come before this row
         while evt_idx < events.len() && should_send_event_before_row(events[evt_idx].0, ts_us) {
@@ -343,6 +367,8 @@ fn run_background(
             ts_us,
             typ,
             s1,
+            s2,
+            s3,
             f1: f1_opt,
             f2: f2_opt,
             f3: f3_opt,
@@ -388,6 +414,8 @@ struct StreamRow {
     ts_us: i64,
     typ: String,
     s1: Option<String>,
+    s2: Option<String>,
+    s3: Option<String>,
     f1: Option<f64>,
     f2: Option<f64>,
     f3: Option<f64>,
@@ -459,11 +487,81 @@ fn market_updates_from_row(row: StreamRow) -> Vec<MarketUpdate> {
                     ask,
                     bid_size,
                     ask_size,
+                    bid_levels: Vec::new(),
+                    ask_levels: Vec::new(),
+                    ts,
+                }]
+            }
+        }
+        "quote_depth" => {
+            let token_id: std::sync::Arc<str> = std::sync::Arc::from(row.s1.unwrap_or_default());
+            let bid_levels = book_levels_from_json(row.s2.as_deref(), false);
+            let ask_levels = book_levels_from_json(row.s3.as_deref(), true);
+            if bid_levels.is_empty() && ask_levels.is_empty() {
+                Vec::new()
+            } else {
+                let best_bid = bid_levels.first();
+                let best_ask = ask_levels.first();
+                vec![MarketUpdate::Quote {
+                    token_id,
+                    bid: best_bid.map(|level| level.price),
+                    ask: best_ask.map(|level| level.price),
+                    bid_size: best_bid.map(|level| level.size),
+                    ask_size: best_ask.map(|level| level.size),
+                    bid_levels,
+                    ask_levels,
                     ts,
                 }]
             }
         }
         _ => Vec::new(),
+    }
+}
+
+#[cfg(feature = "parquet-feed")]
+fn book_levels_from_json(
+    value: Option<&str>,
+    ascending: bool,
+) -> Vec<ploy_market_contracts::BookLevel> {
+    use ploy_market_contracts::BookLevel;
+    use rust_decimal_macros::dec;
+
+    let Ok(serde_json::Value::Array(items)) =
+        serde_json::from_str::<serde_json::Value>(value.unwrap_or("[]"))
+    else {
+        return Vec::new();
+    };
+    let mut levels = items
+        .iter()
+        .filter_map(|item| match item {
+            serde_json::Value::Array(parts) if parts.len() >= 2 => {
+                Some((decimal_from_json(&parts[0])?, decimal_from_json(&parts[1])?))
+            }
+            serde_json::Value::Object(parts) => Some((
+                decimal_from_json(parts.get("price")?)?,
+                decimal_from_json(parts.get("size")?)?,
+            )),
+            _ => None,
+        })
+        .filter(|(price, size)| {
+            *price > dec!(0.01) && *price < dec!(0.99) && *size > rust_decimal::Decimal::ZERO
+        })
+        .map(|(price, size)| BookLevel { price, size })
+        .collect::<Vec<_>>();
+    if ascending {
+        levels.sort_by_key(|level| level.price);
+    } else {
+        levels.sort_by_key(|level| std::cmp::Reverse(level.price));
+    }
+    levels
+}
+
+#[cfg(feature = "parquet-feed")]
+fn decimal_from_json(value: &serde_json::Value) -> Option<rust_decimal::Decimal> {
+    match value {
+        serde_json::Value::Number(number) => number.to_string().parse().ok(),
+        serde_json::Value::String(text) => text.parse().ok(),
+        _ => None,
     }
 }
 
@@ -495,7 +593,7 @@ const QUOTE_SOURCE_RANK: u8 = 40;
 #[cfg(feature = "parquet-feed")]
 fn build_union_sql(parts: &[String]) -> String {
     format!(
-        "SELECT ts_us, typ, s1, s2, f1, f2, f3, f4, i1, b1 \
+        "SELECT ts_us, typ, s1, s2, s3, f1, f2, f3, f4, i1, b1 \
          FROM ({}) \
          ORDER BY ts_us, source_rank, s1, i1, f1, f2, f3, f4",
         parts.join(" UNION ALL ")
@@ -627,7 +725,26 @@ fn load_events_vec(
     }
 
     let discovered_event_rows = event_rows.len();
-    let mut resolved_event_rows = 0usize;
+    let resolved_event_rows = event_rows
+        .iter()
+        .filter(|row| {
+            resolve_up_won_from_settlements(
+                &settlement_prices,
+                &row.market_slug,
+                &row.up_token,
+                &row.down_token,
+            )
+            .is_some()
+        })
+        .count();
+    if require_official_settlement && resolved_event_rows != discovered_event_rows {
+        return Err(format!(
+            "official settlement coverage is incomplete \
+             (resolved={resolved_event_rows}, event_rows={discovered_event_rows}, settlement_prices={})",
+            settlement_prices.len()
+        )
+        .into());
+    }
     let mut events = Vec::new();
     for row in event_rows {
         let resolved_up_won = resolve_up_won_from_settlements(
@@ -639,10 +756,6 @@ fn load_events_vec(
         if require_official_settlement && resolved_up_won.is_none() {
             continue;
         }
-        if resolved_up_won.is_some() {
-            resolved_event_rows += 1;
-        }
-
         let up_token: Arc<str> = Arc::from(row.up_token);
         let down_token: Arc<str> = Arc::from(row.down_token);
         if row.symbol.is_empty() || up_token.is_empty() || down_token.is_empty() {
@@ -682,15 +795,6 @@ fn load_events_vec(
                 resolved_up_won,
             },
         ));
-    }
-
-    if require_official_settlement && discovered_event_rows > 0 && resolved_event_rows == 0 {
-        return Err(format!(
-            "official settlement required but no PM event metadata rows matched settlement payouts \
-             (event_rows={discovered_event_rows}, settlement_prices={})",
-            settlement_prices.len()
-        )
-        .into());
     }
 
     events.sort_by(|(left_ts, left), (right_ts, right)| {
@@ -790,6 +894,116 @@ fn symbol_filter_sql(symbols: &[String]) -> String {
     format!("AND symbol IN ({list})")
 }
 
+#[cfg(feature = "parquet-feed")]
+fn event_token_filter_sql(events: &[(i64, MarketUpdate)]) -> String {
+    let mut tokens = events
+        .iter()
+        .filter_map(|(_, update)| match update {
+            MarketUpdate::EventDiscovered {
+                up_token,
+                down_token,
+                ..
+            } => Some([up_token.as_ref(), down_token.as_ref()]),
+            _ => None,
+        })
+        .flatten()
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    tokens.sort();
+    tokens.dedup();
+    if tokens.is_empty() {
+        return "AND 1 = 0".to_string();
+    }
+    let list = tokens
+        .iter()
+        .map(|token| format!("'{}'", token.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("AND token_id IN ({list})")
+}
+
+#[cfg(feature = "parquet-feed")]
+fn validate_orderbook_archive_window(
+    root: &std::path::Path,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use chrono::{FixedOffset, TimeZone};
+
+    if to < from {
+        return Err("full-depth archive window end precedes start".into());
+    }
+    let shanghai = FixedOffset::east_opt(8 * 60 * 60).expect("valid UTC+8 offset");
+    let start_hour = from.timestamp().div_euclid(3600) * 3600;
+    let end_hour = to.timestamp().div_euclid(3600) * 3600;
+    let mut epoch = start_hour;
+    while epoch <= end_hour {
+        let utc = Utc
+            .timestamp_opt(epoch, 0)
+            .single()
+            .ok_or("invalid archive hour")?;
+        let local = utc.with_timezone(&shanghai);
+        let day = local.format("%Y-%m-%d").to_string();
+        let hour = local.format("%H").to_string();
+        let hour_dir = root.join(format!("date={day}/hour={hour}"));
+        let marker = hour_dir.join("_SUCCESS");
+        let manifest_path = hour_dir.join("manifest.json");
+        let parquet_path = hour_dir.join("snapshots.parquet");
+        if !marker.is_file() || !manifest_path.is_file() || !parquet_path.is_file() {
+            return Err(
+                format!("incomplete full-depth archive hour: {}", hour_dir.display()).into(),
+            );
+        }
+        let manifest: serde_json::Value = serde_json::from_slice(&std::fs::read(&manifest_path)?)?;
+        let row_count = manifest
+            .get("row_count")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default();
+        let expected_sha256 = manifest
+            .get("sha256")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if manifest
+            .get("full_fidelity")
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
+            || manifest.get("date").and_then(serde_json::Value::as_str) != Some(day.as_str())
+            || manifest.get("hour").and_then(serde_json::Value::as_str) != Some(hour.as_str())
+            || row_count == 0
+            || std::fs::metadata(&parquet_path)?.len() == 0
+            || expected_sha256.len() != 64
+            || sha256_file(&parquet_path)? != expected_sha256
+        {
+            return Err(format!(
+                "invalid full-depth archive manifest: {}",
+                manifest_path.display()
+            )
+            .into());
+        }
+        epoch += 3600;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "parquet-feed")]
+fn sha256_file(path: &std::path::Path) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
 #[cfg(all(test, feature = "parquet-feed"))]
 mod tests {
     use super::*;
@@ -826,9 +1040,9 @@ mod tests {
 
     #[test]
     fn union_query_orders_same_timestamp_sources_deterministically() {
-        let sql = build_union_sql(&["SELECT 1 AS ts_us, 10 AS source_rank, 'spot' AS typ, 'BTCUSDT' AS s1, NULL AS s2, 1.0 AS f1, 0.0 AS f2, 0.0 AS f3, 0.0 AS f4, 0 AS i1, false AS b1".to_string()]);
+        let sql = build_union_sql(&["SELECT 1 AS ts_us, 10 AS source_rank, 'spot' AS typ, 'BTCUSDT' AS s1, NULL AS s2, NULL AS s3, 1.0 AS f1, 0.0 AS f2, 0.0 AS f3, 0.0 AS f4, 0 AS i1, false AS b1".to_string()]);
 
-        assert!(sql.contains("SELECT ts_us, typ, s1, s2, f1, f2, f3, f4, i1, b1"));
+        assert!(sql.contains("SELECT ts_us, typ, s1, s2, s3, f1, f2, f3, f4, i1, b1"));
         assert!(sql.contains("ORDER BY ts_us, source_rank, s1, i1, f1, f2, f3, f4"));
         assert!(SPOT_SOURCE_RANK < AGG_SOURCE_RANK);
         assert!(AGG_SOURCE_RANK < LOB_SOURCE_RANK);
@@ -836,10 +1050,68 @@ mod tests {
     }
 
     #[test]
+    fn full_depth_archive_requires_every_intersecting_shanghai_hour() {
+        let root =
+            std::env::temp_dir().join(format!("ploy-orderbook-window-{}", uuid::Uuid::new_v4()));
+        let from = Utc.with_ymd_and_hms(2026, 7, 1, 15, 30, 0).unwrap();
+        let to = Utc.with_ymd_and_hms(2026, 7, 1, 16, 30, 0).unwrap();
+        for (day, hour) in [("2026-07-01", "23"), ("2026-07-02", "00")] {
+            let hour_dir = root.join(format!("date={day}/hour={hour}"));
+            std::fs::create_dir_all(&hour_dir).unwrap();
+            std::fs::write(hour_dir.join("_SUCCESS"), "").unwrap();
+            let parquet_path = hour_dir.join("snapshots.parquet");
+            std::fs::write(&parquet_path, "fixture").unwrap();
+            std::fs::write(
+                hour_dir.join("manifest.json"),
+                serde_json::json!({
+                    "date": day,
+                    "hour": hour,
+                    "row_count": 1,
+                    "full_fidelity": true,
+                    "sha256": sha256_file(&parquet_path).unwrap()
+                })
+                .to_string(),
+            )
+            .unwrap();
+        }
+        assert!(validate_orderbook_archive_window(&root, from, to).is_ok());
+        std::fs::remove_file(root.join("date=2026-07-02/hour=00/_SUCCESS")).unwrap();
+        assert!(validate_orderbook_archive_window(&root, from, to)
+            .unwrap_err()
+            .to_string()
+            .contains("incomplete full-depth archive hour"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn events_are_emitted_before_same_timestamp_rows() {
         assert!(should_send_event_before_row(1_000, 1_000));
         assert!(should_send_event_before_row(999, 1_000));
         assert!(!should_send_event_before_row(1_001, 1_000));
+    }
+
+    #[test]
+    fn archive_quotes_are_scoped_to_discovered_event_tokens() {
+        let ts = Utc.timestamp_micros(1_000_000).unwrap();
+        let events = vec![(
+            1_000_000,
+            MarketUpdate::EventDiscovered {
+                event_id: Arc::from("event-a"),
+                symbol: Arc::from("BTCUSDT"),
+                up_token: Arc::from("up-token"),
+                down_token: Arc::from("down-token"),
+                end_time: ts,
+                window_secs: 300,
+                price_to_beat: Some(dec!(50000)),
+                resolved_up_won: None,
+            },
+        )];
+
+        assert_eq!(
+            event_token_filter_sql(&events),
+            "AND token_id IN ('down-token', 'up-token')"
+        );
+        assert_eq!(event_token_filter_sql(&[]), "AND 1 = 0");
     }
 
     #[test]
@@ -883,6 +1155,8 @@ mod tests {
             ts_us: 1_000_000,
             typ: "lob".to_string(),
             s1: Some("BTCUSDT".to_string()),
+            s2: None,
+            s3: None,
             f1: Some(0.25),
             f2: Some(3.0),
             f3: Some(12.5),
@@ -902,6 +1176,8 @@ mod tests {
             ts_us: 1_000_000,
             typ: "agg".to_string(),
             s1: Some("BTCUSDT".to_string()),
+            s2: None,
+            s3: None,
             f1: Some(51000.0),
             f2: Some(0.42),
             f3: None,
@@ -930,6 +1206,8 @@ mod tests {
             ts_us: 1_000_000,
             typ: "quote".to_string(),
             s1: Some("token".to_string()),
+            s2: None,
+            s3: None,
             f1: None,
             f2: None,
             f3: None,
@@ -947,6 +1225,8 @@ mod tests {
             ts_us: 1_000_000,
             typ: "quote".to_string(),
             s1: Some("token".to_string()),
+            s2: None,
+            s3: None,
             f1: Some(0.5),
             f2: Some(0.75),
             f3: Some(12.0),
@@ -962,12 +1242,54 @@ mod tests {
                 ask,
                 bid_size,
                 ask_size,
+                bid_levels,
+                ask_levels,
                 ..
             } => {
                 assert_eq!(*bid, Some(dec!(0.5)));
                 assert_eq!(*ask, Some(dec!(0.75)));
                 assert_eq!(*bid_size, Some(dec!(12)));
                 assert_eq!(*ask_size, Some(dec!(13)));
+                assert!(bid_levels.is_empty());
+                assert!(ask_levels.is_empty());
+            }
+            other => panic!("expected Quote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn orderbook_row_preserves_sorted_executable_depth() {
+        let updates = market_updates_from_row(StreamRow {
+            ts_us: 1_000_000,
+            typ: "quote_depth".to_string(),
+            s1: Some("token".to_string()),
+            s2: Some(r#"[["0.48","10"],["0.49","5"]]"#.to_string()),
+            s3: Some(r#"[{"price":"0.52","size":"8"},{"price":"0.51","size":"7"}]"#.to_string()),
+            f1: None,
+            f2: None,
+            f3: None,
+            f4: None,
+            i1: None,
+            b1: None,
+        });
+
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            MarketUpdate::Quote {
+                bid,
+                ask,
+                bid_size,
+                ask_size,
+                bid_levels,
+                ask_levels,
+                ..
+            } => {
+                assert_eq!(*bid, Some(dec!(0.49)));
+                assert_eq!(*ask, Some(dec!(0.51)));
+                assert_eq!(*bid_size, Some(dec!(5)));
+                assert_eq!(*ask_size, Some(dec!(7)));
+                assert_eq!(bid_levels.len(), 2);
+                assert_eq!(ask_levels.len(), 2);
             }
             other => panic!("expected Quote, got {other:?}"),
         }
@@ -1038,9 +1360,8 @@ mod tests {
         assert!(quote_section.contains("CASE WHEN bid_size IS NOT NULL AND bid_size > 0"));
         assert!(source.contains("pm_token_settlements"));
         assert!(source.contains("if require_official_settlement && resolved_up_won.is_none()"));
-        assert!(
-            source.contains("official settlement required but no PM event metadata rows matched")
-        );
+        assert!(source.contains("official settlement coverage is incomplete"));
+        assert!(source.contains("resolved_event_rows != discovered_event_rows"));
     }
 
     fn section_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {

--- a/docs/runbooks/live-deployment-checklist.md
+++ b/docs/runbooks/live-deployment-checklist.md
@@ -36,8 +36,14 @@ Recommended:
 
 - `PLOY_OPERATOR_TOKEN` for remote `ployctl` mutation without full admin access
 - `PLOY_API_AUTH_COOKIE_SECRET` if browser sessions are used
-- `POLY_SIGNATURE_TYPE`
-- `POLY_FUNDER` when `POLY_SIGNATURE_TYPE=proxy` or `POLY_SIGNATURE_TYPE=gnosis_safe`
+- `POLY_SIGNATURE_TYPE=proxy` with `POLY_WALLET_TYPE=PROXY`, or
+  `POLY_SIGNATURE_TYPE=gnosis_safe` with `POLY_WALLET_TYPE=SAFE`
+- `POLY_FUNDER` matching the signer-derived Proxy/Safe address
+
+`poly1271`/`DEPOSIT` order signing is understood by the Rust adapter, but the
+current custody/redemption relayer does not support that wallet route. The
+deploy and live gates therefore reject it instead of presenting an incomplete
+wallet lifecycle as live-ready.
 
 ## Baseline Service Checks
 
@@ -89,6 +95,7 @@ manually reviewed:
 - `ployctl system metrics`
 - `ployctl system alerts`
 - `ployctl trading status`
+- `ployctl trading readiness 5`
 - the most recent audit log entries
 
 ## PM5D ThreeLayer Live Gate
@@ -99,9 +106,14 @@ For the current PM5D ThreeLayer setup, stage the live deployment in paused mode:
 /opt/ploy/scripts/drills/pm5d_threelayer_live_gate.sh
 ```
 
-This verifies `02-pm5d-threelayer.live.toml` against the dry-run config, applies
-`pm5d.threelayer.live` with `desired_state=paused`, and stops before any live
-orders can be placed.
+This verifies `02-pm5d-threelayer.live.toml` against the dry-run config, checks
+the authenticated Polymarket account for geoblock, closed-only status, pUSD
+balance, and both V2 allowances, applies `pm5d.threelayer.live` with
+`desired_state=paused`, and stops before any live orders can be placed.
+The readiness command derives an already-existing L2 API key with the read-only
+endpoint, never creates one, and stops its temporary SDK heartbeat task before
+the first venue probe. Missing credentials or a 15-second end-to-end timeout
+fails the gate closed.
 
 The staging script cannot resume live. Real live enablement is available only
 through `.github/workflows/approve-live-trade.yml`, which requires successful

--- a/docs/runbooks/strategy-research-cicd.md
+++ b/docs/runbooks/strategy-research-cicd.md
@@ -74,12 +74,15 @@ when the mismatch is understood and tracked as a follow-up issue.
 | Live approval | `.github/workflows/approve-live-trade.yml` | Validate exact-SHA replay/dry-run/parity evidence, then require protected human approval before bounded live resume |
 
 `backtest.yml` emits `strategy_backtest_evaluation` as replay/backtest
-evidence, not as dry-run or live promotion evidence. Its `data_dir` path uses
-the legacy streaming Parquet feed for quote-tick replay; it does not consume the
-full-fidelity CLOB lake under `/opt/ploy/data/lake/orderbook_snapshots` yet.
-Treat profitable backtest metrics as blocked for promotion until the artifact
-also has full-depth CLOB fillability, official settlement, replay/dry-run
-parity, and runtime scorer parity. The machine-readable fields
+evidence, not as dry-run or live promotion evidence. Its `data_dir` path now
+prefers `orderbook_snapshots` from the full-fidelity CLOB lake under
+`/opt/ploy/data/lake/orderbook_snapshots` and falls back to legacy quote ticks
+only when no full-depth directory is present. The artifact reports observed
+depth-quote coverage and only marks full-depth CLOB fillability when every
+non-settlement fill actually used the simulator's `full_depth_sweep`
+price basis. Treat profitable metrics as blocked for promotion until the
+artifact also has official settlement, event-level lifecycle accounting,
+replay/dry-run parity, and runtime scorer parity. The machine-readable fields
 `evidence_stage`, `promotion_ready`, `blocking_risk_flags`, and
 `advisory_flags` are the operator-facing source of truth for that distinction.
 

--- a/scripts/drills/live_dry_run.sh
+++ b/scripts/drills/live_dry_run.sh
@@ -222,21 +222,21 @@ if env_has_any_key \
 else
   warn "operator credential not configured; dry-run will rely on local ployctl access"
 fi
-require_any_env_key "Polymarket private key" "POLYMARKET_PRIVATE_KEY" "PRIVATE_KEY"
+require_env_key "POLYMARKET_PRIVATE_KEY"
 SIGNATURE_TYPE="$(first_env_value "POLY_SIGNATURE_TYPE" "POLYMARKET_SIGNATURE_TYPE" || true)"
-FUNDER_PRESENT=0
-if env_has_any_key "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"; then
-  FUNDER_PRESENT=1
-fi
-if [[ -n "${SIGNATURE_TYPE}" ]]; then
-  if [[ "${SIGNATURE_TYPE}" == "proxy" || "${SIGNATURE_TYPE}" == "gnosis_safe" ]]; then
-    require_any_env_key "proxy funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
-  elif [[ "${SIGNATURE_TYPE}" != "eoa" ]]; then
-    fail "unsupported POLY_SIGNATURE_TYPE: ${SIGNATURE_TYPE}"
-  fi
-elif [[ "${FUNDER_PRESENT}" -eq 1 ]]; then
-  warn "POLY_SIGNATURE_TYPE is not explicit; current SDK defaults to proxy when a funder is present"
-fi
+WALLET_TYPE="$(first_env_value "POLY_WALLET_TYPE" || true)"
+WALLET_TYPE="${WALLET_TYPE^^}"
+case "${SIGNATURE_TYPE}:${WALLET_TYPE}" in
+  proxy:PROXY|gnosis_safe:SAFE)
+    require_any_env_key "non-EOA funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
+    ;;
+  poly1271:*)
+    fail "POLY_SIGNATURE_TYPE=poly1271 is not supported by the current custody/redemption relayer"
+    ;;
+  *)
+    fail "wallet mapping must be proxy:PROXY or gnosis_safe:SAFE; got ${SIGNATURE_TYPE:-unset}:${WALLET_TYPE:-unset}"
+    ;;
+esac
 [[ -f "${STATE_ROOT}/deployments.json" ]] || fail "missing deployments state file: ${STATE_ROOT}/deployments.json"
 [[ -f "${RUNTIME_ROOT}/system-status.json" ]] || fail "missing system status snapshot: ${RUNTIME_ROOT}/system-status.json"
 [[ -f "${RUNTIME_ROOT}/deployments.json" ]] || fail "missing deployment snapshot: ${RUNTIME_ROOT}/deployments.json"

--- a/scripts/drills/pm5d_threelayer_live_gate.sh
+++ b/scripts/drills/pm5d_threelayer_live_gate.sh
@@ -217,27 +217,19 @@ if [[ "$ALERTS_NORMALIZED" != "none" ]]; then
 fi
 
 log_step "credential presence"
-require_any_env_key "Polymarket private key" "POLYMARKET_PRIVATE_KEY" "PRIVATE_KEY"
+require_env_key "POLYMARKET_PRIVATE_KEY"
 SIGNATURE_TYPE="$(first_env_value "POLY_SIGNATURE_TYPE" "POLYMARKET_SIGNATURE_TYPE" || true)"
-FUNDER_PRESENT=0
-if env_has_any_key "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"; then
-  FUNDER_PRESENT=1
-fi
-case "$SIGNATURE_TYPE" in
-  proxy|gnosis_safe)
-    require_any_env_key "proxy funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
+WALLET_TYPE="$(first_env_value "POLY_WALLET_TYPE" || true)"
+WALLET_TYPE="${WALLET_TYPE^^}"
+case "${SIGNATURE_TYPE}:${WALLET_TYPE}" in
+  proxy:PROXY|gnosis_safe:SAFE)
+    require_any_env_key "non-EOA funder" "POLY_FUNDER" "POLYMARKET_FUNDER" "POLYMARKET_FUNDER_ADDRESS"
     ;;
-  eoa)
-    ;;
-  "")
-    if [[ "$FUNDER_PRESENT" -eq 1 ]]; then
-      warn "POLY_SIGNATURE_TYPE is not explicit; current SDK defaults to proxy when a funder is present"
-    else
-      warn "POLY_SIGNATURE_TYPE and funder are absent; current SDK defaults to eoa"
-    fi
+  poly1271:*)
+    fail "POLY_SIGNATURE_TYPE=poly1271 is not supported by the current custody/redemption relayer"
     ;;
   *)
-    fail "unsupported POLY_SIGNATURE_TYPE: $SIGNATURE_TYPE"
+    fail "live wallet mapping must be proxy:PROXY or gnosis_safe:SAFE; got ${SIGNATURE_TYPE:-unset}:${WALLET_TYPE:-unset}"
     ;;
 esac
 
@@ -300,6 +292,13 @@ if dryrun != live:
 
 print("manifest/config gate: paused apply only")
 PY
+
+MAX_GROSS_EXPOSURE="$(extract_manifest_field max_gross_exposure)"
+log_step "Polymarket account trading readiness"
+if ! READINESS_OUTPUT="$(ployctl_capture trading readiness "$MAX_GROSS_EXPOSURE")"; then
+  fail "Polymarket account readiness failed: $READINESS_OUTPUT"
+fi
+printf '%s\n' "$READINESS_OUTPUT"
 
 RENDERED_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/ploy-live-manifest.XXXXXX.json")"
 python3 - "$MANIFEST" "$RENDERED_MANIFEST" "$NORMALIZED_LIVE_ACCOUNT_ID" <<'PY'

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -378,3 +378,15 @@
   Retry the runtime tick while waiting for a spawned fixture under CI load, and
   explicitly stop the final child before the test returns so parallel suites do
   not accumulate orphan workers and starve later spawns.
+
+## 2026-07-13
+
+- Pattern: A generic “exchange trading works” check can accidentally prove the
+  Binance reference-data lane while leaving the requested Polymarket quote,
+  order, settlement, and wallet lifecycle unverified.
+- Rule: For Polymarket readiness, report four separate truths: live quote/data
+  reachability, local order-construction/reconciliation tests, executable-depth
+  replay/backtest evidence, and authenticated account/order evidence. Never use
+  Binance feed health or an unauthenticated quote as proof that a Polymarket
+  order can be accepted; do not place a funded test order without explicit live
+  authorization.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23249,11 +23249,15 @@ does not claim `dry_run_candidate` or `live_candidate` evidence.
   signature-to-wallet mapping used by custody/redeem. Poly1271/DEPOSIT remains
   fail-closed because the deployed relayer does not yet support its redemption
   lifecycle.
-- Verification passes: connectivity 22, feed-loader 7, strategy 202 unit + 6
+- Verification passes: connectivity 22, feed-loader 8, strategy 203 unit + 6
   integration, backtest artifact 3, ployctl 27, account-ops 12, Python contract
   13, shellcheck, YAML parsing, formatting, diff checks, daemon/CLI checks, and
   Parquet-feature test compilation. Feature test execution still requires the
   Linux CI DuckDB shared library; no account, order, chain, cloud, or host write
   occurred locally.
+- PR review follow-up closed four evidence gaps: the full-depth PostgreSQL query
+  is valid and propagates database errors, filled lifecycles without an Entry
+  decision block promotion, settlement intents cannot count as full-depth
+  fillability, and immediate retry fills update both execution counters.
 - Independent final reviews found no remaining P0/P1/P2 in the Polymarket
   readiness or backtest-evidence slices.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23190,3 +23190,70 @@ operator adapters; it does not produce dry-run parity or authorize live trade.
   within ten minutes; the REST remove-only endpoint is intentionally unused.
 - PR #752 passed every required check and merged to `main` as `7c51f821`; no
   deployment was attempted because trusted ECS identity remains blocked by #751.
+
+# Polymarket Quote/Backtest Readiness Repair (2026-07-13)
+
+## Goal
+
+Repair the confirmed Polymarket quote-replay and backtest fixture regressions,
+and make promotion artifacts report conservative depth, drawdown, and
+event-level execution evidence. Keep authenticated trading fail closed: this
+slice may add read-only preflight evidence but cannot submit or resume live.
+
+## Evidence stage
+
+`diagnostic` progressing to `executable_replay` plumbing. A passing local test
+does not claim `dry_run_candidate` or `live_candidate` evidence.
+
+## TDD seams
+
+- Parquet feed seam: serialized quote rows reconstruct `MarketUpdate::Quote`
+  with explicit depth fields and remain compatible with top-of-book datasets.
+- Backtest artifact seam: results expose max drawdown, unique event count,
+  maximum decisions per event, and observed full-depth coverage.
+- Account preflight seam: authenticated readiness is read-only and fails closed
+  unless signer/auth, balance/allowance, and venue health are all proven.
+
+## Files / Ownership
+
+- Main session: implementation and integration across
+  `crates/ploy-feed-loaders`, `crates/ploy-strategy-bundles`, and the smallest
+  existing Polymarket connectivity/preflight surface.
+- Subagents: read-only failure analysis, promotion-contract audit, and final
+  review; they do not edit this worktree.
+
+## Tasks
+
+- [x] Reproduce and fix Parquet quote-depth and `OrderRecord` fixture failures.
+- [x] Add artifact drawdown, event uniqueness, and depth-coverage evidence.
+- [x] Add or tighten the read-only authenticated Polymarket readiness gate.
+- [x] Run focused and relevant package/workflow validation.
+- [x] Review, document evidence, commit atomically, push, and open a PR.
+
+## Review
+
+- Quote replay now carries ordered executable CLOB depth from PostgreSQL or the
+  hourly Parquet archive. Archive replay is scoped to event tokens and fails
+  closed unless every intersecting Shanghai hour has a non-empty full-fidelity
+  manifest and `_SUCCESS`; official settlement coverage must also be complete.
+- Backtest evidence reports actual depth-sweep fills, event-level decisions and
+  lifecycle accounting, closed-event drawdown, and a stage consistent across
+  JSON, workflow summary, issue comment, and labels. Promotion remains false
+  until the separate runtime/dry-run parity gates are satisfied.
+- `ployctl trading readiness` derives an existing L2 key through the GET-only
+  path inside a 15-second total timeout, stops the temporary heartbeat before
+  probing, verifies CLOB v2, geoblock, closed-only, raw pUSD balance, both V2
+  allowances, and signer-derived wallet identity. It neither creates a key nor
+  submits an order.
+- Live staging now requires the same named private key and exact Proxy/Safe
+  signature-to-wallet mapping used by custody/redeem. Poly1271/DEPOSIT remains
+  fail-closed because the deployed relayer does not yet support its redemption
+  lifecycle.
+- Verification passes: connectivity 22, feed-loader 7, strategy 202 unit + 6
+  integration, backtest artifact 3, ployctl 27, account-ops 12, Python contract
+  13, shellcheck, YAML parsing, formatting, diff checks, daemon/CLI checks, and
+  Parquet-feature test compilation. Feature test execution still requires the
+  Linux CI DuckDB shared library; no account, order, chain, cloud, or host write
+  occurred locally.
+- Independent final reviews found no remaining P0/P1/P2 in the Polymarket
+  readiness or backtest-evidence slices.

--- a/tests/test_replay_backtest_evidence_contract.py
+++ b/tests/test_replay_backtest_evidence_contract.py
@@ -21,6 +21,11 @@ class ReplayBacktestEvidenceContractTest(unittest.TestCase):
             '"missing_replay_dryrun_parity"',
             '"missing_runtime_scorer_parity"',
             '"parquet_stream_uses_quote_ticks_not_full_clob_lake"',
+            '"max_drawdown"',
+            '"unique_event_count"',
+            '"max_event_decisions"',
+            '"full_depth_fills_observed"',
+            '"incomplete_event_lifecycle_accounting"',
         ]
         for snippet in required_snippets:
             self.assertIn(snippet, source)
@@ -29,8 +34,8 @@ class ReplayBacktestEvidenceContractTest(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/backtest.yml").read_text()
 
         required_snippets = [
-            "not full-depth lake replay",
-            "legacy quote-tick Parquet",
+            "full-depth orderbook_snapshots preferred",
+            "orderbook_snapshots/date=${day}",
             "evidence_stage",
             "promotion_ready",
             "promotion_decision",
@@ -38,14 +43,26 @@ class ReplayBacktestEvidenceContractTest(unittest.TestCase):
             "Blocking promotion flags",
             "parity:blocked",
             "evidence-stage.json",
-            '"evidence_stage": "diagnostic"',
-            '"promotion_ready": false',
-            '"promotion_decision": "diagnostic_backtest_only"',
+            '"evidence_stage": stage',
+            '"promotion_ready": False',
+            '"promotion_decision": decision',
             "diagnostic_backtest_not_promotion_evidence",
             "evidence:diagnostic",
+            "evidence:executable-replay",
+            "full-depth archive checksum mismatch",
+            "TZ=Asia/Shanghai",
+            "process.env.ISSUE_NUMBER",
+            "process.env.GIT_REF",
         ]
         for snippet in required_snippets:
             self.assertIn(snippet, workflow)
+        self.assertNotIn('--git-ref "${{ github.event.inputs.git_ref }}"', workflow)
+        self.assertNotIn('Number("${{ github.event.inputs.issue_number }}")', workflow)
+
+        parquet_source = (
+            ROOT / "crates/ploy-strategy-bundles/src/feed/parquet_stream.rs"
+        ).read_text()
+        self.assertIn("sha256_file(&parquet_path)? != expected_sha256", parquet_source)
 
     def test_research_runbook_preserves_backtest_caveat(self):
         runbook = (ROOT / "docs/runbooks/strategy-research-cicd.md").read_text()
@@ -54,6 +71,7 @@ class ReplayBacktestEvidenceContractTest(unittest.TestCase):
             "not as dry-run or live promotion evidence",
             "/opt/ploy/data/lake/orderbook_snapshots",
             "full-depth CLOB fillability",
+            "full_depth_sweep",
             "`evidence_stage`, `promotion_ready`, `blocking_risk_flags`, and",
         ]
         for snippet in required_snippets:

--- a/tests/test_replay_backtest_evidence_contract.py
+++ b/tests/test_replay_backtest_evidence_contract.py
@@ -26,6 +26,8 @@ class ReplayBacktestEvidenceContractTest(unittest.TestCase):
             '"max_event_decisions"',
             '"full_depth_fills_observed"',
             '"incomplete_event_lifecycle_accounting"',
+            '"lifecycle_without_entry_decision"',
+            '"lifecycle_without_entry_decision_count"',
         ]
         for snippet in required_snippets:
             self.assertIn(snippet, source)

--- a/tests/test_strategy_config_contracts.py
+++ b/tests/test_strategy_config_contracts.py
@@ -51,12 +51,21 @@ class StrategyConfigContractTests(unittest.TestCase):
         self.assertIn("PLOY_LIVE_ACCOUNT_ID", script)
         self.assertIn("NORMALIZED_LIVE_ACCOUNT_ID", script)
         self.assertIn("trading principal", script)
+        self.assertIn("trading readiness", script)
+        self.assertIn('require_env_key "POLYMARKET_PRIVATE_KEY"', script)
+        self.assertIn("poly1271 is not supported", script)
+        self.assertIn("proxy:PROXY", script)
+        self.assertIn("gnosis_safe:SAFE", script)
         self.assertIn("does not match execution principal", script)
         self.assertIn("mktemp", script)
         self.assertIn('deployments apply "$RENDERED_MANIFEST"', script)
         self.assertIn("Only the protected live-approval workflow may resume", script)
         self.assertNotIn("--go-live", script)
         self.assertNotIn('deployments resume "$DEPLOYMENT_ID"', script)
+        self.assertLess(
+            script.index("trading readiness"),
+            script.index('deployments apply "$RENDERED_MANIFEST"'),
+        )
 
     def test_live_gate_manifest_config_parity_fixture_executes(self) -> None:
         script = (ROOT / "scripts" / "drills" / "pm5d_threelayer_live_gate.sh").read_text()

--- a/tools/polymarket-account-ops/account_ops.js
+++ b/tools/polymarket-account-ops/account_ops.js
@@ -81,6 +81,13 @@ function normalizeAddress(value, field) {
   }
 }
 
+function relayerWalletRoute(walletType) {
+  const normalized = String(walletType || "").toUpperCase();
+  if (normalized === "SAFE") return { walletType: normalized, txType: RelayerTxType.SAFE };
+  if (normalized === "PROXY") return { walletType: normalized, txType: RelayerTxType.PROXY };
+  throw new Error("walletType must be SAFE or PROXY; DEPOSIT/poly1271 custody is not supported");
+}
+
 function buildPlan(positions, context, now = Date.now()) {
   const account = normalizeAddress(context.account, "account");
   if (!/^[0-9a-f]{40}$/.test(context.releaseSha)) {
@@ -262,14 +269,13 @@ function makeRelayClient(env = process.env) {
     secret: requireEnv("POLY_BUILDER_SECRET", env),
     passphrase: requireEnv("POLY_BUILDER_PASSPHRASE", env),
   }});
-  const walletType = requireEnv("POLY_WALLET_TYPE", env).toUpperCase();
+  const { walletType, txType } = relayerWalletRoute(requireEnv("POLY_WALLET_TYPE", env));
   const derived = walletType === "SAFE"
     ? deriveSafe(account.address, CONTRACTS.safeFactory)
     : deriveProxyWallet(account.address, CONTRACTS.proxyFactory);
   if (normalizeAddress(derived, "derived wallet") !== normalizeAddress(requireEnv("PLOY_LIVE_ACCOUNT_ID", env), "live account")) {
     throw new Error("signer-derived wallet does not match PLOY_LIVE_ACCOUNT_ID");
   }
-  const txType = walletType === "SAFE" ? RelayerTxType.SAFE : RelayerTxType.PROXY;
   return {
     client: new RelayClient(requireEnv("POLYMARKET_RELAYER_URL", env), CHAIN_ID, wallet, builderConfig, txType),
     publicClient: createPublicClient({ chain: polygon, transport: http(rpcUrl) }),
@@ -468,6 +474,7 @@ module.exports = {
   executePlan,
   fetchPositions,
   readLedger,
+  relayerWalletRoute,
   reconcileOperation,
   reconcileTransaction,
   redeemTransaction,

--- a/tools/polymarket-account-ops/account_ops.test.js
+++ b/tools/polymarket-account-ops/account_ops.test.js
@@ -12,6 +12,7 @@ const {
   executePlan,
   fetchPositions,
   readLedger,
+  relayerWalletRoute,
   reconcileOperation,
   reconcileTransaction,
   redeemTransaction,
@@ -109,6 +110,11 @@ test("plan fails closed on wallet and route disagreement", () => {
     () => buildPlan([position(), position({ negativeRisk: true })], { account, releaseSha, walletType: "SAFE" }, now),
     /negative-risk disagreement/,
   );
+});
+
+test("custody relayer rejects unsupported deposit/poly1271 wallets", () => {
+  assert.throws(() => relayerWalletRoute("DEPOSIT"), /poly1271 custody is not supported/);
+  assert.throws(() => relayerWalletRoute("unknown"), /walletType must be SAFE or PROXY/);
 });
 
 test("execute refuses to enter account operations while writes are disabled", async () => {


### PR DESCRIPTION
## Summary

- restore quote-depth and order fixture compatibility, and replay full Polymarket CLOB depth from DB/hourly Parquet
- fail closed on incomplete hourly archives, SHA drift, partial official settlements, duplicate event decisions, and incomplete event lifecycle accounting
- add conservative backtest drawdown/depth/stage evidence with consistent workflow artifacts and labels
- add derive-only authenticated Polymarket readiness for signer/funder identity, API v2, geoblock, closed-only, pUSD balance, and both exchange allowances
- align live custody/redeem wallet mapping and reject unsupported Poly1271/DEPOSIT lifecycle before staging

## Verification

- `cargo test -p ploy-connectivity` (22)
- `cargo test -p ploy-feed-loaders` (7)
- `cargo test -p ploy-strategy-bundles` (202 unit + 6 integration)
- `cargo test -p ploy-strategy-bundles --example run_backtest` (3)
- `cargo check -p ploy-strategy-bundles --features parquet-feed --tests`
- `cargo test -p ployctl` (27)
- Polymarket account-ops Node tests (12)
- workflow/config Python contracts (13), shellcheck, YAML parse, fmt, diff checks

## Safety boundary

No account request, order, chain write, host deployment, or live resume was performed. `promotion_ready` remains false until runtime/dry-run parity and protected human approval are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trading-readiness check for validating account access, balances, allowances, and venue connectivity.
  * Backtests now support full-depth order-book replay and produce richer evidence, including drawdown, event lifecycle, fillability, and promotion results.
  * Backtest summaries and issue updates now reflect the evaluated evidence stage and decision.

* **Bug Fixes**
  * Improved settlement coverage validation and quote-depth parsing.
  * Added stricter wallet and custody compatibility checks during live deployment.

* **Documentation**
  * Updated live deployment and research runbooks with readiness requirements and evidence-gating guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->