### PR TITLE
fix: harden Polymarket tick-level live hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,6 +5035,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "chrono",
+ "ploy-market-contracts",
  "ploy-trading",
  "polymarket_client_sdk_v2",
  "rust_decimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5066,9 +5066,11 @@ dependencies = [
  "hmac",
  "ploy-connectivity",
  "ploy-deployments",
+ "ploy-market-contracts",
  "ploy-operator-contracts",
  "ploy-platform",
  "ploy-platform-runtime",
+ "ploy-strategy-bundles",
  "ploy-trading",
  "rand 0.8.5",
  "rust_decimal",
@@ -5077,6 +5079,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,14 +5035,17 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "chrono",
+ "futures",
  "ploy-market-contracts",
  "ploy-trading",
  "polymarket_client_sdk_v2",
  "rust_decimal",
  "rust_decimal_macros",
  "secrecy 0.8.0",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,6 +5105,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
 ]

--- a/apps/ployctl/src/trading.rs
+++ b/apps/ployctl/src/trading.rs
@@ -183,13 +183,11 @@ mod tests {
             .expect("write response");
         });
 
-        let client = ControlPlaneClient {
-            control_plane_addr: addr.to_string(),
-            admin_token: None,
-            operator_token: None,
-            sidecar_token: None,
-            runtime_root,
-        };
+        let mut client = ControlPlaneClient::from_runtime_root(runtime_root);
+        client.control_plane_addr = addr.to_string();
+        client.admin_token = None;
+        client.operator_token = None;
+        client.sidecar_token = None;
         let output = cancel_order(&client, "example.live", "order-1").expect("cancel output");
         assert!(output.contains("state=canceled"));
         assert!(output.contains("venue_order_id=venue-1"));
@@ -229,13 +227,11 @@ mod tests {
             .expect("write response");
         });
 
-        let client = ControlPlaneClient {
-            control_plane_addr: addr.to_string(),
-            admin_token: None,
-            operator_token: None,
-            sidecar_token: None,
-            runtime_root,
-        };
+        let mut client = ControlPlaneClient::from_runtime_root(runtime_root);
+        client.control_plane_addr = addr.to_string();
+        client.admin_token = None;
+        client.operator_token = None;
+        client.sidecar_token = None;
         let output = replace_order(
             &client,
             "example.live",

--- a/config/strategies/02-pm5d-threelayer.live.toml
+++ b/config/strategies/02-pm5d-threelayer.live.toml
@@ -7,7 +7,7 @@
 [runtime]
 strategy_variant = "three_layer"
 mode = "live"
-throttle_hz = 10
+market_data_source = "dual"
 
 [strategy]
 symbols = ["BTCUSDT", "ETHUSDT"]

--- a/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
+++ b/config/strategies/02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml
@@ -7,7 +7,7 @@
 [runtime]
 strategy_variant = "three_layer"
 mode = "dryrun"
-throttle_hz = 10
+market_data_source = "dual"
 # Dedicated capture for the settlement-probability dry-run handoff. The
 # replay-parity gate must compare against the same deployed strategy/window,
 # not the older OBI-soft canonical recording.

--- a/contracts/schemas/operator-event.schema.json
+++ b/contracts/schemas/operator-event.schema.json
@@ -613,6 +613,14 @@
         "state": {
           "type": "string"
         },
+        "state_changed_at": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "token_id": {
           "type": "string"
         },

--- a/contracts/schemas/trading-state-snapshot.schema.json
+++ b/contracts/schemas/trading-state-snapshot.schema.json
@@ -171,6 +171,14 @@
         "state": {
           "type": "string"
         },
+        "state_changed_at": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "token_id": {
           "type": "string"
         },

--- a/crates/ploy-connectivity/Cargo.toml
+++ b/crates/ploy-connectivity/Cargo.toml
@@ -9,15 +9,18 @@ description = "Ploy connectivity crate"
 
 [dependencies]
 alloy = { version = "1", default-features = false, features = ["signer-local"] }
+chrono.workspace = true
+futures = "0.3"
 ploy-market-contracts.workspace = true
 ploy-trading.workspace = true
-polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "heartbeats"] }
+polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "heartbeats", "ws"] }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 secrecy.workspace = true
 thiserror.workspace = true
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+tracing.workspace = true
 
 [dev-dependencies]
-chrono.workspace = true
 rust_decimal_macros.workspace = true
+serde_json.workspace = true

--- a/crates/ploy-connectivity/Cargo.toml
+++ b/crates/ploy-connectivity/Cargo.toml
@@ -9,13 +9,14 @@ description = "Ploy connectivity crate"
 
 [dependencies]
 alloy = { version = "1", default-features = false, features = ["signer-local"] }
+ploy-market-contracts.workspace = true
 ploy-trading.workspace = true
 polymarket-client-sdk = { package = "polymarket_client_sdk_v2", version = "=0.6.0", features = ["clob", "heartbeats"] }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 secrecy.workspace = true
 thiserror.workspace = true
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
 [dev-dependencies]
 chrono.workspace = true

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -1,26 +1,34 @@
 use alloy::signers::local::PrivateKeySigner;
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
 use ploy_market_contracts::{FeeSchedule, LiquidityRole};
 use ploy_trading::{FillRecord, TradeSide};
 use polymarket_client_sdk::auth::state::Authenticated;
 use polymarket_client_sdk::auth::{Normal, Signer};
 use polymarket_client_sdk::clob::types::request::{BalanceAllowanceRequest, TradesRequest};
-use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
+use polymarket_client_sdk::clob::types::response::{MakerOrder, OpenOrderResponse, TradeResponse};
 use polymarket_client_sdk::clob::types::{
-    Amount, AssetType, OrderType, Side, SignatureType, TradeStatusType,
+    Amount, AssetType, OrderStatusType, OrderType, Side, SignatureType, TradeStatusType,
+};
+use polymarket_client_sdk::clob::ws::types::response::{OrderMessageType, TradeMessageStatus};
+use polymarket_client_sdk::clob::ws::{
+    ChannelType, Client as WsClient, OrderMessage, TradeMessage, WsMessage,
 };
 use polymarket_client_sdk::clob::{Client, Config};
 use polymarket_client_sdk::types::{Address, B256, U256};
 use polymarket_client_sdk::{
-    contract_config, derive_proxy_wallet, derive_safe_wallet, POLYGON, PRIVATE_KEY_VAR,
+    POLYGON, PRIVATE_KEY_VAR, contract_config, derive_proxy_wallet, derive_safe_wallet,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use secrecy::{ExposeSecret, SecretString};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::mpsc;
 
 pub const CRATE_MARKER: &str = "ploy-connectivity";
 const DEFAULT_POLY_CLOB_HOST: &str = "https://clob.polymarket.com";
@@ -29,6 +37,10 @@ const MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS: usize = 10;
 const TRADE_RECONCILE_LOOKBACK_SECS: u64 = 24 * 60 * 60;
 const TRADE_RECONCILE_TIMEOUT: Duration = Duration::from_secs(2);
 const FEE_SCHEDULE_TTL: Duration = Duration::from_secs(5 * 60);
+const USER_EVENT_QUEUE_CAPACITY: usize = 4_096;
+const USER_EVENT_RECONNECT_DELAY: Duration = Duration::from_millis(250);
+const USER_EVENT_HEALTH_INTERVAL: Duration = Duration::from_millis(100);
+const USER_EVENT_PERIODIC_CATCH_UP: Duration = Duration::from_secs(5);
 const CONDITIONAL_TOKEN_DECIMALS: u32 = 6;
 const ACCOUNT_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -73,6 +85,33 @@ pub struct TrackedOrder {
     pub venue_order_id: String,
     pub token_id: String,
     pub side: TradeSide,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OrderObservation {
+    Acknowledged {
+        order_id: String,
+        venue_order_id: String,
+    },
+    Canceled {
+        order_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReconcileBatch {
+    pub fills: Vec<FillRecord>,
+    pub order_observations: Vec<OrderObservation>,
+}
+
+impl ReconcileBatch {
+    #[must_use]
+    pub fn fills_only(fills: Vec<FillRecord>) -> Self {
+        Self {
+            fills,
+            order_observations: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,6 +172,14 @@ pub trait LiveExecutionGateway: Send + Sync + std::fmt::Debug {
         &self,
         tracked_orders: &[TrackedOrder],
     ) -> Result<Vec<FillRecord>, ExecutionError>;
+
+    fn reconcile_updates(
+        &self,
+        tracked_orders: &[TrackedOrder],
+    ) -> Result<ReconcileBatch, ExecutionError> {
+        self.reconcile_fills(tracked_orders)
+            .map(ReconcileBatch::fills_only)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -141,7 +188,7 @@ pub struct StaticExecutionGateway {
     result: Result<ExecutionOutcome, ExecutionError>,
     cancel_result: Result<CancellationOutcome, ExecutionError>,
     replace_result: Result<ReplaceOutcome, ExecutionError>,
-    reconcile_result: Result<Vec<FillRecord>, ExecutionError>,
+    reconcile_result: Result<ReconcileBatch, ExecutionError>,
 }
 
 impl StaticExecutionGateway {
@@ -156,7 +203,7 @@ impl StaticExecutionGateway {
             replace_result: Ok(ReplaceOutcome::Replaced {
                 venue_order_id: format!("{venue_order_id}-replaced"),
             }),
-            reconcile_result: Ok(Vec::new()),
+            reconcile_result: Ok(ReconcileBatch::default()),
         }
     }
 
@@ -169,7 +216,7 @@ impl StaticExecutionGateway {
             }),
             cancel_result: Ok(CancellationOutcome::Canceled),
             replace_result: Ok(ReplaceOutcome::Rejected { reason }),
-            reconcile_result: Ok(Vec::new()),
+            reconcile_result: Ok(ReconcileBatch::default()),
         }
     }
 
@@ -179,7 +226,7 @@ impl StaticExecutionGateway {
             result: Err(error.clone()),
             cancel_result: Ok(CancellationOutcome::Canceled),
             replace_result: Err(error),
-            reconcile_result: Ok(Vec::new()),
+            reconcile_result: Ok(ReconcileBatch::default()),
         }
     }
 
@@ -202,7 +249,12 @@ impl StaticExecutionGateway {
     }
 
     pub fn with_reconciled_fills(mut self, fills: Vec<FillRecord>) -> Self {
-        self.reconcile_result = Ok(fills);
+        self.reconcile_result = Ok(ReconcileBatch::fills_only(fills));
+        self
+    }
+
+    pub fn with_reconciled_updates(mut self, updates: ReconcileBatch) -> Self {
+        self.reconcile_result = Ok(updates);
         self
     }
 
@@ -210,7 +262,7 @@ impl StaticExecutionGateway {
         mut self,
         result: Result<Vec<FillRecord>, ExecutionError>,
     ) -> Self {
-        self.reconcile_result = result;
+        self.reconcile_result = result.map(ReconcileBatch::fills_only);
         self
     }
 }
@@ -235,6 +287,13 @@ impl LiveExecutionGateway for StaticExecutionGateway {
         &self,
         _tracked_orders: &[TrackedOrder],
     ) -> Result<Vec<FillRecord>, ExecutionError> {
+        self.reconcile_result.clone().map(|batch| batch.fills)
+    }
+
+    fn reconcile_updates(
+        &self,
+        _tracked_orders: &[TrackedOrder],
+    ) -> Result<ReconcileBatch, ExecutionError> {
         self.reconcile_result.clone()
     }
 
@@ -419,6 +478,76 @@ pub fn polymarket_account_readiness_from_env(
     PolymarketExecutionGateway::from_env()?.account_readiness(required_pusd)
 }
 
+#[derive(Debug)]
+enum BufferedUserEvent {
+    Order(OrderMessage),
+    Trade(TradeMessage),
+}
+
+#[derive(Debug)]
+struct UserEventStream {
+    sender: mpsc::Sender<BufferedUserEvent>,
+    receiver: Mutex<mpsc::Receiver<BufferedUserEvent>>,
+    started: AtomicBool,
+    connected: AtomicBool,
+    gap_detected: AtomicBool,
+    last_catch_up: Mutex<Instant>,
+}
+
+impl UserEventStream {
+    fn new() -> Self {
+        let (sender, receiver) = mpsc::channel(USER_EVENT_QUEUE_CAPACITY);
+        Self {
+            sender,
+            receiver: Mutex::new(receiver),
+            started: AtomicBool::new(false),
+            connected: AtomicBool::new(false),
+            gap_detected: AtomicBool::new(true),
+            last_catch_up: Mutex::new(Instant::now()),
+        }
+    }
+
+    fn enqueue(&self, event: BufferedUserEvent) {
+        if self.sender.try_send(event).is_err() {
+            self.gap_detected.store(true, Ordering::Release);
+        }
+    }
+
+    fn drain(&self) -> Result<Vec<BufferedUserEvent>, ExecutionError> {
+        let mut receiver = self
+            .receiver
+            .lock()
+            .map_err(|_| ExecutionError::Transport("user event queue poisoned".to_string()))?;
+        let mut events = Vec::new();
+        while let Ok(event) = receiver.try_recv() {
+            events.push(event);
+        }
+        Ok(events)
+    }
+
+    fn begin_catch_up(&self) -> Result<bool, ExecutionError> {
+        let periodic_catch_up_due = self
+            .last_catch_up
+            .lock()
+            .map_err(|_| ExecutionError::Transport("user event catch-up clock poisoned".into()))?
+            .elapsed()
+            >= USER_EVENT_PERIODIC_CATCH_UP;
+        let gap_detected = self.gap_detected.swap(false, Ordering::AcqRel);
+        Ok(gap_detected || !self.connected.load(Ordering::Acquire) || periodic_catch_up_due)
+    }
+
+    fn finish_catch_up(&self, succeeded: bool) {
+        if succeeded {
+            if let Ok(mut last_catch_up) = self.last_catch_up.lock() {
+                *last_catch_up = Instant::now();
+            }
+        }
+        if !succeeded || !self.connected.load(Ordering::Acquire) {
+            self.gap_detected.store(true, Ordering::Release);
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PolymarketExecutionGateway {
     config: PolymarketExecutionConfig,
@@ -426,6 +555,7 @@ pub struct PolymarketExecutionGateway {
     signer: Arc<OnceLock<PrivateKeySigner>>,
     client: Arc<RwLock<Option<Client<Authenticated<Normal>>>>>,
     fee_schedules: Arc<RwLock<HashMap<U256, (FeeSchedule, Instant)>>>,
+    user_events: Arc<UserEventStream>,
 }
 
 impl PolymarketExecutionGateway {
@@ -446,6 +576,7 @@ impl PolymarketExecutionGateway {
             signer: Arc::new(OnceLock::new()),
             client: Arc::new(RwLock::new(None)),
             fee_schedules: Arc::new(RwLock::new(HashMap::new())),
+            user_events: Arc::new(UserEventStream::new()),
         }
     }
 
@@ -505,6 +636,24 @@ impl PolymarketExecutionGateway {
                 .await
                 .map_err(|err| ExecutionError::Transport(format!("authenticate client: {err}")))
         })
+    }
+
+    fn ensure_user_event_stream(&self, client: &Client<Authenticated<Normal>>) {
+        if self
+            .user_events
+            .started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let credentials = client.credentials().clone();
+        let address = client.address();
+        let state = Arc::clone(&self.user_events);
+        self.runtime.spawn(async move {
+            run_user_event_stream(credentials, address, state).await;
+        });
     }
 
     fn clear_client_cache(&self) {
@@ -646,6 +795,88 @@ impl PolymarketExecutionGateway {
     }
 }
 
+async fn run_user_event_stream(
+    credentials: polymarket_client_sdk::auth::Credentials,
+    address: Address,
+    state: Arc<UserEventStream>,
+) {
+    loop {
+        let ws = match WsClient::default().authenticate(credentials.clone(), address) {
+            Ok(client) => client,
+            Err(error) => {
+                state.connected.store(false, Ordering::Release);
+                state.gap_detected.store(true, Ordering::Release);
+                tracing::warn!(%error, "authenticate Polymarket user WebSocket failed");
+                tokio::time::sleep(USER_EVENT_RECONNECT_DELAY).await;
+                continue;
+            }
+        };
+        let stream = match ws.subscribe_user_events(Vec::new()) {
+            Ok(stream) => stream,
+            Err(error) => {
+                state.connected.store(false, Ordering::Release);
+                state.gap_detected.store(true, Ordering::Release);
+                tracing::warn!(%error, "subscribe Polymarket user WebSocket failed");
+                tokio::time::sleep(USER_EVENT_RECONNECT_DELAY).await;
+                continue;
+            }
+        };
+        let mut stream = std::pin::pin!(stream);
+        let mut health = tokio::time::interval(USER_EVENT_HEALTH_INTERVAL);
+        health.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                message = stream.next() => {
+                    let Some(message) = message else {
+                        break;
+                    };
+                    match message {
+                        Ok(WsMessage::Trade(trade)) => {
+                            if matches!(
+                                trade.status,
+                                TradeMessageStatus::Failed | TradeMessageStatus::Unknown(_)
+                            ) {
+                                state.gap_detected.store(true, Ordering::Release);
+                            }
+                            state.enqueue(BufferedUserEvent::Trade(trade));
+                        }
+                        Ok(WsMessage::Order(order)) => {
+                            if matches!(order.msg_type, Some(OrderMessageType::Unknown(_)))
+                                || matches!(
+                                    order.status,
+                                    Some(OrderStatusType::Delayed | OrderStatusType::Unknown(_))
+                                )
+                            {
+                                state.gap_detected.store(true, Ordering::Release);
+                            }
+                            state.enqueue(BufferedUserEvent::Order(order));
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            state.connected.store(false, Ordering::Release);
+                            state.gap_detected.store(true, Ordering::Release);
+                            tracing::warn!(%error, "Polymarket user WebSocket stream error");
+                            break;
+                        }
+                    }
+                }
+                _ = health.tick() => {
+                    let connected = ws.connection_state(ChannelType::User).is_connected();
+                    let was_connected = state.connected.swap(connected, Ordering::AcqRel);
+                    if was_connected && !connected {
+                        state.gap_detected.store(true, Ordering::Release);
+                    }
+                }
+            }
+        }
+
+        state.connected.store(false, Ordering::Release);
+        state.gap_detected.store(true, Ordering::Release);
+        tokio::time::sleep(USER_EVENT_RECONNECT_DELAY).await;
+    }
+}
+
 impl LiveExecutionGateway for PolymarketExecutionGateway {
     fn probe(&self) -> Result<(), ExecutionError> {
         let client = self.get_or_init_client()?;
@@ -780,6 +1011,57 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
             })?
         });
 
+        if let Err(error) = &result {
+            self.maybe_clear_client_cache(error);
+        }
+        result
+    }
+
+    fn reconcile_updates(
+        &self,
+        tracked_orders: &[TrackedOrder],
+    ) -> Result<ReconcileBatch, ExecutionError> {
+        if tracked_orders.is_empty() {
+            return Ok(ReconcileBatch::default());
+        }
+
+        let client = self.get_or_init_client()?;
+        self.ensure_user_event_stream(&client);
+
+        let events = self.user_events.drain()?;
+        let catch_up_required = self.user_events.begin_catch_up()?;
+        let result = self.runtime.block_on(async {
+            let mut batch =
+                reconcile_user_events(&client, &self.fee_schedules, tracked_orders, events).await?;
+
+            if catch_up_required {
+                let rest_batch = tokio::time::timeout(
+                    TRADE_RECONCILE_TIMEOUT,
+                    reconcile_rest_updates(&client, &self.fee_schedules, tracked_orders),
+                )
+                .await
+                .map_err(|_| {
+                    ExecutionError::Transport(format!(
+                        "trade reconciliation timed out after {}ms",
+                        TRADE_RECONCILE_TIMEOUT.as_millis()
+                    ))
+                })??;
+                batch.fills.extend(rest_batch.fills);
+                batch
+                    .order_observations
+                    .extend(rest_batch.order_observations);
+            }
+
+            deduplicate_fills(&mut batch.fills);
+            deduplicate_order_observations(&mut batch.order_observations);
+            Ok(batch)
+        });
+
+        if catch_up_required {
+            self.user_events.finish_catch_up(result.is_ok());
+        } else if result.is_err() {
+            self.user_events.gap_detected.store(true, Ordering::Release);
+        }
         if let Err(error) = &result {
             self.maybe_clear_client_cache(error);
         }
@@ -1051,6 +1333,12 @@ async fn reconcile_rest_fills(
         if !matches!(trade.status, TradeStatusType::Confirmed) {
             continue;
         }
+        if !tracked_orders
+            .iter()
+            .any(|tracked_order| tracked_trade_matches(tracked_order, trade))
+        {
+            continue;
+        }
         let fee_schedule =
             polymarket_fee_schedule(client, fee_schedules, trade.asset_id, trade.market).await?;
         for tracked_order in tracked_orders {
@@ -1060,6 +1348,61 @@ async fn reconcile_rest_fills(
         }
     }
     Ok(fills)
+}
+
+async fn load_order_observation(
+    client: Client<Authenticated<Normal>>,
+    tracked_order: TrackedOrder,
+) -> Result<Option<OrderObservation>, ExecutionError> {
+    let order = client
+        .order(&tracked_order.venue_order_id)
+        .await
+        .map_err(|err| {
+            ExecutionError::Transport(format!(
+                "load order `{}`: {err}",
+                tracked_order.venue_order_id
+            ))
+        })?;
+    tracked_rest_order_observation(&tracked_order, &order)
+}
+
+async fn reconcile_rest_order_observations(
+    client: &Client<Authenticated<Normal>>,
+    tracked_orders: &[TrackedOrder],
+) -> Result<Vec<OrderObservation>, ExecutionError> {
+    let mut observations = Vec::new();
+    for chunk in tracked_orders.chunks(MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS) {
+        let mut tasks = tokio::task::JoinSet::new();
+        for tracked_order in chunk {
+            tasks.spawn(load_order_observation(
+                client.clone(),
+                tracked_order.clone(),
+            ));
+        }
+        while let Some(task) = tasks.join_next().await {
+            if let Some(observation) = task.map_err(|err| {
+                ExecutionError::Transport(format!("join order reconciliation task: {err}"))
+            })?? {
+                observations.push(observation);
+            }
+        }
+    }
+    Ok(observations)
+}
+
+async fn reconcile_rest_updates(
+    client: &Client<Authenticated<Normal>>,
+    fee_schedules: &RwLock<HashMap<U256, (FeeSchedule, Instant)>>,
+    tracked_orders: &[TrackedOrder],
+) -> Result<ReconcileBatch, ExecutionError> {
+    let (fills, order_observations) = tokio::try_join!(
+        reconcile_rest_fills(client, fee_schedules, tracked_orders),
+        reconcile_rest_order_observations(client, tracked_orders),
+    )?;
+    Ok(ReconcileBatch {
+        fills,
+        order_observations,
+    })
 }
 
 async fn sell_quantity_capped_to_balance(
@@ -1274,6 +1617,24 @@ fn tracked_trade_fill(
         })
 }
 
+fn tracked_trade_matches(tracked_order: &TrackedOrder, trade: &TradeResponse) -> bool {
+    if !matches!(trade.status, TradeStatusType::Confirmed) {
+        return false;
+    }
+    let Ok(tracked_token_id) = U256::from_str(&tracked_order.token_id) else {
+        return false;
+    };
+    if trade.taker_order_id == tracked_order.venue_order_id {
+        return trade.asset_id == tracked_token_id
+            && trade_side(trade.side.clone()) == Some(tracked_order.side);
+    }
+    trade.maker_orders.iter().any(|maker_order| {
+        maker_order.order_id == tracked_order.venue_order_id
+            && maker_order.asset_id == tracked_token_id
+            && trade_side(maker_order.side.clone()) == Some(tracked_order.side)
+    })
+}
+
 fn tracked_maker_fill(
     tracked_order: &TrackedOrder,
     trade: &TradeResponse,
@@ -1303,6 +1664,212 @@ fn tracked_maker_fill(
     })
 }
 
+fn user_trade_timestamp(trade: &TradeMessage) -> Option<DateTime<Utc>> {
+    trade
+        .matchtime
+        .or(trade.timestamp)
+        .or(trade.last_update)
+        .and_then(|timestamp| DateTime::from_timestamp(timestamp, 0))
+}
+
+fn tracked_user_trade_fill(
+    tracked_order: &TrackedOrder,
+    trade: &TradeMessage,
+    fee_schedule: FeeSchedule,
+) -> Option<FillRecord> {
+    if !matches!(trade.status, TradeMessageStatus::Confirmed) {
+        return None;
+    }
+    let tracked_token_id = U256::from_str(&tracked_order.token_id).ok()?;
+    let timestamp = user_trade_timestamp(trade)?;
+
+    if trade.taker_order_id.as_deref() == Some(tracked_order.venue_order_id.as_str()) {
+        if trade.asset_id != tracked_token_id
+            || trade_side(trade.side.clone())? != tracked_order.side
+        {
+            return None;
+        }
+        return Some(FillRecord {
+            fill_id: tracked_fill_id(tracked_order, &trade.id),
+            order_id: tracked_order.order_id.clone(),
+            token_id: tracked_order.token_id.clone(),
+            side: tracked_order.side.clone(),
+            quantity: trade.size,
+            price: trade.price,
+            fee: fee_schedule.calculate(trade.size, trade.price, LiquidityRole::Taker),
+            timestamp,
+        });
+    }
+
+    let maker_order = trade
+        .maker_orders
+        .iter()
+        .find(|maker_order| maker_order.order_id == tracked_order.venue_order_id)?;
+    if maker_order.asset_id != tracked_token_id {
+        return None;
+    }
+    Some(FillRecord {
+        fill_id: tracked_fill_id(tracked_order, &trade.id),
+        order_id: tracked_order.order_id.clone(),
+        token_id: tracked_order.token_id.clone(),
+        side: tracked_order.side.clone(),
+        quantity: maker_order.matched_amount,
+        price: maker_order.price,
+        fee: fee_schedule.calculate(
+            maker_order.matched_amount,
+            maker_order.price,
+            LiquidityRole::Maker,
+        ),
+        timestamp,
+    })
+}
+
+fn tracked_order_observation(
+    tracked_order: &TrackedOrder,
+    order: &OrderMessage,
+) -> Option<OrderObservation> {
+    let tracked_token_id = U256::from_str(&tracked_order.token_id).ok()?;
+    if order.id != tracked_order.venue_order_id
+        || order.asset_id != tracked_token_id
+        || trade_side(order.side.clone())? != tracked_order.side
+    {
+        return None;
+    }
+
+    if matches!(order.msg_type, Some(OrderMessageType::Cancellation))
+        || matches!(order.status, Some(OrderStatusType::Canceled))
+    {
+        return Some(OrderObservation::Canceled {
+            order_id: tracked_order.order_id.clone(),
+        });
+    }
+    if matches!(order.msg_type, Some(OrderMessageType::Placement))
+        || matches!(
+            order.status,
+            Some(OrderStatusType::Live | OrderStatusType::Unmatched | OrderStatusType::Matched)
+        )
+    {
+        return Some(OrderObservation::Acknowledged {
+            order_id: tracked_order.order_id.clone(),
+            venue_order_id: tracked_order.venue_order_id.clone(),
+        });
+    }
+    None
+}
+
+fn tracked_rest_order_observation(
+    tracked_order: &TrackedOrder,
+    order: &OpenOrderResponse,
+) -> Result<Option<OrderObservation>, ExecutionError> {
+    let tracked_token_id = U256::from_str(&tracked_order.token_id).map_err(|err| {
+        ExecutionError::Validation(format!(
+            "invalid tracked token `{}`: {err}",
+            tracked_order.token_id
+        ))
+    })?;
+    if order.id != tracked_order.venue_order_id
+        || order.asset_id != tracked_token_id
+        || trade_side(order.side.clone()) != Some(tracked_order.side)
+    {
+        return Err(ExecutionError::Validation(format!(
+            "venue order `{}` does not match tracked order `{}`",
+            order.id, tracked_order.order_id
+        )));
+    }
+
+    match &order.status {
+        OrderStatusType::Live | OrderStatusType::Unmatched | OrderStatusType::Matched => {
+            Ok(Some(OrderObservation::Acknowledged {
+                order_id: tracked_order.order_id.clone(),
+                venue_order_id: tracked_order.venue_order_id.clone(),
+            }))
+        }
+        OrderStatusType::Canceled => Ok(Some(OrderObservation::Canceled {
+            order_id: tracked_order.order_id.clone(),
+        })),
+        OrderStatusType::Delayed | OrderStatusType::Unknown(_) => {
+            Err(ExecutionError::Transport(format!(
+                "venue order `{}` has unresolved status `{}`",
+                tracked_order.venue_order_id, order.status
+            )))
+        }
+        _ => Err(ExecutionError::Transport(format!(
+            "venue order `{}` has unsupported status `{}`",
+            tracked_order.venue_order_id, order.status
+        ))),
+    }
+}
+
+fn tracked_user_trade_matches(tracked_order: &TrackedOrder, trade: &TradeMessage) -> bool {
+    if !matches!(trade.status, TradeMessageStatus::Confirmed) {
+        return false;
+    }
+    let Ok(tracked_token_id) = U256::from_str(&tracked_order.token_id) else {
+        return false;
+    };
+    if trade.taker_order_id.as_deref() == Some(tracked_order.venue_order_id.as_str()) {
+        return trade.asset_id == tracked_token_id
+            && trade_side(trade.side.clone()) == Some(tracked_order.side);
+    }
+    trade.maker_orders.iter().any(|maker_order| {
+        maker_order.order_id == tracked_order.venue_order_id
+            && maker_order.asset_id == tracked_token_id
+    })
+}
+
+async fn reconcile_user_events(
+    client: &Client<Authenticated<Normal>>,
+    fee_schedules: &RwLock<HashMap<U256, (FeeSchedule, Instant)>>,
+    tracked_orders: &[TrackedOrder],
+    events: Vec<BufferedUserEvent>,
+) -> Result<ReconcileBatch, ExecutionError> {
+    let mut batch = ReconcileBatch::default();
+    for event in events {
+        match event {
+            BufferedUserEvent::Trade(trade) => {
+                if !matches!(trade.status, TradeMessageStatus::Confirmed) {
+                    continue;
+                }
+                if !tracked_orders
+                    .iter()
+                    .any(|tracked_order| tracked_user_trade_matches(tracked_order, &trade))
+                {
+                    continue;
+                }
+                let fee_schedule =
+                    polymarket_fee_schedule(client, fee_schedules, trade.asset_id, trade.market)
+                        .await?;
+                for tracked_order in tracked_orders {
+                    if let Some(fill) = tracked_user_trade_fill(tracked_order, &trade, fee_schedule)
+                    {
+                        batch.fills.push(fill);
+                    }
+                }
+            }
+            BufferedUserEvent::Order(order) => {
+                for tracked_order in tracked_orders {
+                    if let Some(observation) = tracked_order_observation(tracked_order, &order) {
+                        if !batch.order_observations.contains(&observation) {
+                            batch.order_observations.push(observation);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(batch)
+}
+
+fn deduplicate_fills(fills: &mut Vec<FillRecord>) {
+    let mut seen = HashSet::with_capacity(fills.len());
+    fills.retain(|fill| seen.insert(fill.fill_id.clone()));
+}
+
+fn deduplicate_order_observations(observations: &mut Vec<OrderObservation>) {
+    let mut seen = HashSet::with_capacity(observations.len());
+    observations.retain(|observation| seen.insert(observation.clone()));
+}
+
 fn tracked_fill_id(tracked_order: &TrackedOrder, trade_id: &str) -> String {
     format!("{trade_id}:{}", tracked_order.order_id)
 }
@@ -1322,26 +1889,34 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
+        BufferedUserEvent, CancellationOutcome, CancellationRequest, ExecutionError,
+        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, OrderExecutionType,
+        OrderObservation, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
+        ReplaceRequest, StaticExecutionGateway, TrackedOrder, UserEventStream, WalletSignatureType,
         cap_sell_quantity_to_balance, collateral_balance_to_raw,
         conditional_token_balance_to_shares, ensure_account_readiness, execution_price_override,
         normalize_aggressive_price, normalize_execution_amount, normalize_market_order_quantity,
-        normalize_order_quantity, polymarket_execution_principal, raw_balance_to_pusd,
-        tracked_trade_fill, trade_side, unique_token_ids, wallet_signature_type,
-        CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
-        ExecutionRequest, LiveExecutionGateway, OrderExecutionType, PolymarketExecutionConfig,
-        PolymarketExecutionGateway, ReplaceOutcome, ReplaceRequest, StaticExecutionGateway,
-        TrackedOrder, WalletSignatureType,
+        normalize_order_quantity, polymarket_execution_principal,
+        polymarket_signature_type_from_env, raw_balance_to_pusd, tracked_rest_order_observation,
+        tracked_trade_fill, tracked_user_trade_fill, trade_side, unique_token_ids,
+        wallet_signature_type,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
     use polymarket_client_sdk::auth::ApiKey;
-    use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
-    use polymarket_client_sdk::clob::types::{Side, TradeStatusType, TraderSide};
+    use polymarket_client_sdk::clob::types::response::{
+        MakerOrder, OpenOrderResponse, TradeResponse,
+    };
+    use polymarket_client_sdk::clob::types::{
+        OrderStatusType, OrderType, Side, TradeStatusType, TraderSide,
+    };
+    use polymarket_client_sdk::clob::ws::types::response::TradeMessage;
     use polymarket_client_sdk::types::{Address, B256, U256};
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use secrecy::SecretString;
     use std::str::FromStr;
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn static_gateway_returns_acknowledged_outcome() {
@@ -1524,9 +2099,11 @@ mod tests {
             .expect_err("zero balance should reject");
 
         assert!(matches!(error, ExecutionError::Validation(_)));
-        assert!(error
-            .to_string()
-            .contains("no sellable conditional-token balance"));
+        assert!(
+            error
+                .to_string()
+                .contains("no sellable conditional-token balance")
+        );
     }
 
     #[test]
@@ -1710,20 +2287,22 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000001")
                     .expect("maker address"),
             )
-            .maker_orders(vec![MakerOrder::builder()
-                .order_id("venue-order-b")
-                .owner(ApiKey::nil())
-                .maker_address(
-                    Address::from_str("0x0000000000000000000000000000000000000002")
-                        .expect("second maker address"),
-                )
-                .matched_amount(dec!(2))
-                .price(dec!(0.56))
-                .fee_rate_bps(dec!(4))
-                .asset_id(U256::from(1_u64))
-                .outcome("YES")
-                .side(polymarket_client_sdk::clob::types::Side::Sell)
-                .build()])
+            .maker_orders(vec![
+                MakerOrder::builder()
+                    .order_id("venue-order-b")
+                    .owner(ApiKey::nil())
+                    .maker_address(
+                        Address::from_str("0x0000000000000000000000000000000000000002")
+                            .expect("second maker address"),
+                    )
+                    .matched_amount(dec!(2))
+                    .price(dec!(0.56))
+                    .fee_rate_bps(dec!(4))
+                    .asset_id(U256::from(1_u64))
+                    .outcome("YES")
+                    .side(polymarket_client_sdk::clob::types::Side::Sell)
+                    .build(),
+            ])
             .transaction_hash(B256::ZERO)
             .trader_side(TraderSide::Taker)
             .build();
@@ -1756,17 +2335,19 @@ mod tests {
         assert_ne!(taker_fill.fill_id, maker_fill.fill_id);
         assert_eq!(taker_fill.fee, dec!(0.03465));
         assert_eq!(maker_fill.fee, dec!(0));
-        assert!(tracked_trade_fill(
-            &TrackedOrder {
-                order_id: "order-side-mismatch".to_string(),
-                venue_order_id: "venue-order-a".to_string(),
-                token_id: "1".to_string(),
-                side: TradeSide::Sell,
-            },
-            &trade,
-            ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
-        )
-        .is_none());
+        assert!(
+            tracked_trade_fill(
+                &TrackedOrder {
+                    order_id: "order-side-mismatch".to_string(),
+                    venue_order_id: "venue-order-a".to_string(),
+                    token_id: "1".to_string(),
+                    side: TradeSide::Sell,
+                },
+                &trade,
+                ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -1808,12 +2389,14 @@ mod tests {
                 .trader_side(TraderSide::Taker)
                 .build();
 
-            assert!(tracked_trade_fill(
-                &tracked,
-                &trade,
-                ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
-            )
-            .is_none());
+            assert!(
+                tracked_trade_fill(
+                    &tracked,
+                    &trade,
+                    ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+                )
+                .is_none()
+            );
         }
     }
 
@@ -1842,5 +2425,142 @@ mod tests {
         .expect("valid token ids");
 
         assert_eq!(token_ids, vec![U256::from(10), U256::from(11)]);
+    }
+
+    fn user_trade(status: &str) -> TradeMessage {
+        serde_json::from_str(&format!(
+            r#"{{
+                "asset_id":"1",
+                "event_type":"trade",
+                "id":"trade-ws",
+                "last_update":"1672290701",
+                "maker_orders":[{{
+                    "asset_id":"1",
+                    "matched_amount":"2",
+                    "order_id":"venue-maker",
+                    "outcome":"YES",
+                    "owner":"00000000-0000-0000-0000-000000000000",
+                    "price":"0.56"
+                }}],
+                "market":"0x0000000000000000000000000000000000000000000000000000000000000000",
+                "match_time":"1672290701",
+                "outcome":"YES",
+                "owner":"00000000-0000-0000-0000-000000000000",
+                "price":"0.55",
+                "side":"BUY",
+                "size":"2",
+                "status":"{status}",
+                "taker_order_id":"venue-taker",
+                "timestamp":"1672290701",
+                "trade_owner":"00000000-0000-0000-0000-000000000000",
+                "type":"TRADE"
+            }}"#
+        ))
+        .expect("valid user trade fixture")
+    }
+
+    #[test]
+    fn user_trade_reconciliation_is_confirmed_only_and_preserves_liquidity_role() {
+        let taker = TrackedOrder {
+            order_id: "order-taker".to_string(),
+            venue_order_id: "venue-taker".to_string(),
+            token_id: "1".to_string(),
+            side: TradeSide::Buy,
+        };
+        let maker = TrackedOrder {
+            order_id: "order-maker".to_string(),
+            venue_order_id: "venue-maker".to_string(),
+            token_id: "1".to_string(),
+            side: TradeSide::Sell,
+        };
+        let fee_schedule = ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true);
+
+        for status in ["MATCHED", "MINED", "RETRYING", "FAILED"] {
+            assert!(tracked_user_trade_fill(&taker, &user_trade(status), fee_schedule).is_none());
+        }
+
+        let confirmed = user_trade("CONFIRMED");
+        let taker_fill =
+            tracked_user_trade_fill(&taker, &confirmed, fee_schedule).expect("taker fill");
+        let maker_fill =
+            tracked_user_trade_fill(&maker, &confirmed, fee_schedule).expect("maker fill");
+        assert_eq!(taker_fill.fill_id, "trade-ws:order-taker");
+        assert_eq!(maker_fill.fill_id, "trade-ws:order-maker");
+        assert_eq!(taker_fill.fee, dec!(0.03465));
+        assert_eq!(maker_fill.fee, Decimal::ZERO);
+    }
+
+    #[test]
+    fn rest_order_recovery_validates_identity_and_maps_status() {
+        let tracked = TrackedOrder {
+            order_id: "order-1".to_string(),
+            venue_order_id: "venue-1".to_string(),
+            token_id: "1".to_string(),
+            side: TradeSide::Buy,
+        };
+        let order = |status| {
+            OpenOrderResponse::builder()
+                .id("venue-1")
+                .status(status)
+                .owner(ApiKey::nil())
+                .maker_address(Address::ZERO)
+                .market(B256::ZERO)
+                .asset_id(U256::from(1_u64))
+                .side(Side::Buy)
+                .original_size(dec!(2))
+                .size_matched(dec!(1))
+                .price(dec!(0.55))
+                .associate_trades(Vec::new())
+                .outcome("YES")
+                .created_at(Utc::now())
+                .expiration(Utc::now())
+                .order_type(OrderType::GTC)
+                .build()
+        };
+
+        assert_eq!(
+            tracked_rest_order_observation(&tracked, &order(OrderStatusType::Matched))
+                .expect("matched order"),
+            Some(OrderObservation::Acknowledged {
+                order_id: "order-1".to_string(),
+                venue_order_id: "venue-1".to_string(),
+            })
+        );
+        assert_eq!(
+            tracked_rest_order_observation(&tracked, &order(OrderStatusType::Canceled))
+                .expect("canceled order"),
+            Some(OrderObservation::Canceled {
+                order_id: "order-1".to_string(),
+            })
+        );
+
+        let mut wrong_token = order(OrderStatusType::Live);
+        wrong_token.asset_id = U256::from(2_u64);
+        assert!(tracked_rest_order_observation(&tracked, &wrong_token).is_err());
+        assert!(
+            tracked_rest_order_observation(&tracked, &order(OrderStatusType::Delayed)).is_err()
+        );
+    }
+
+    #[test]
+    fn user_event_gap_is_bounded_and_not_cleared_while_degraded() {
+        let state = UserEventStream::new();
+        state.gap_detected.store(false, Ordering::Release);
+        let trade = user_trade("CONFIRMED");
+        for _ in 0..=super::USER_EVENT_QUEUE_CAPACITY {
+            state.enqueue(BufferedUserEvent::Trade(trade.clone()));
+        }
+        assert!(state.gap_detected.load(Ordering::Acquire));
+
+        state.connected.store(false, Ordering::Release);
+        assert!(state.begin_catch_up().expect("catch-up state"));
+        state.finish_catch_up(true);
+        assert!(state.gap_detected.load(Ordering::Acquire));
+
+        state.connected.store(true, Ordering::Release);
+        assert!(state.begin_catch_up().expect("catch-up state"));
+        state.gap_detected.store(true, Ordering::Release);
+        state.finish_catch_up(true);
+        assert!(state.gap_detected.load(Ordering::Acquire));
     }
 }

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -1587,14 +1587,14 @@ fn tracked_trade_fill(
         if trade.asset_id != tracked_token_id {
             return None;
         }
-        if trade_side(trade.side.clone())? != tracked_order.side {
+        if trade_side(trade.side)? != tracked_order.side {
             return None;
         }
         return Some(FillRecord {
             fill_id: tracked_fill_id(tracked_order, &trade.id),
             order_id: tracked_order.order_id.clone(),
             token_id: tracked_order.token_id.clone(),
-            side: tracked_order.side.clone(),
+            side: tracked_order.side,
             quantity: trade.size,
             price: trade.price,
             fee: fee_schedule.calculate(trade.size, trade.price, LiquidityRole::Taker),
@@ -1626,12 +1626,12 @@ fn tracked_trade_matches(tracked_order: &TrackedOrder, trade: &TradeResponse) ->
     };
     if trade.taker_order_id == tracked_order.venue_order_id {
         return trade.asset_id == tracked_token_id
-            && trade_side(trade.side.clone()) == Some(tracked_order.side);
+            && trade_side(trade.side) == Some(tracked_order.side);
     }
     trade.maker_orders.iter().any(|maker_order| {
         maker_order.order_id == tracked_order.venue_order_id
             && maker_order.asset_id == tracked_token_id
-            && trade_side(maker_order.side.clone()) == Some(tracked_order.side)
+            && trade_side(maker_order.side) == Some(tracked_order.side)
     })
 }
 
@@ -1645,14 +1645,14 @@ fn tracked_maker_fill(
     if maker_order.asset_id != tracked_token_id {
         return None;
     }
-    if trade_side(maker_order.side.clone())? != tracked_order.side {
+    if trade_side(maker_order.side)? != tracked_order.side {
         return None;
     }
     Some(FillRecord {
         fill_id: tracked_fill_id(tracked_order, &trade.id),
         order_id: tracked_order.order_id.clone(),
         token_id: tracked_order.token_id.clone(),
-        side: tracked_order.side.clone(),
+        side: tracked_order.side,
         quantity: maker_order.matched_amount,
         price: maker_order.price,
         fee: fee_schedule.calculate(
@@ -1672,6 +1672,13 @@ fn user_trade_timestamp(trade: &TradeMessage) -> Option<DateTime<Utc>> {
         .and_then(|timestamp| DateTime::from_timestamp(timestamp, 0))
 }
 
+fn maker_side_from_taker(side: Side) -> Option<TradeSide> {
+    match trade_side(side)? {
+        TradeSide::Buy => Some(TradeSide::Sell),
+        TradeSide::Sell => Some(TradeSide::Buy),
+    }
+}
+
 fn tracked_user_trade_fill(
     tracked_order: &TrackedOrder,
     trade: &TradeMessage,
@@ -1684,16 +1691,14 @@ fn tracked_user_trade_fill(
     let timestamp = user_trade_timestamp(trade)?;
 
     if trade.taker_order_id.as_deref() == Some(tracked_order.venue_order_id.as_str()) {
-        if trade.asset_id != tracked_token_id
-            || trade_side(trade.side.clone())? != tracked_order.side
-        {
+        if trade.asset_id != tracked_token_id || trade_side(trade.side)? != tracked_order.side {
             return None;
         }
         return Some(FillRecord {
             fill_id: tracked_fill_id(tracked_order, &trade.id),
             order_id: tracked_order.order_id.clone(),
             token_id: tracked_order.token_id.clone(),
-            side: tracked_order.side.clone(),
+            side: tracked_order.side,
             quantity: trade.size,
             price: trade.price,
             fee: fee_schedule.calculate(trade.size, trade.price, LiquidityRole::Taker),
@@ -1705,14 +1710,16 @@ fn tracked_user_trade_fill(
         .maker_orders
         .iter()
         .find(|maker_order| maker_order.order_id == tracked_order.venue_order_id)?;
-    if maker_order.asset_id != tracked_token_id {
+    if maker_order.asset_id != tracked_token_id
+        || maker_side_from_taker(trade.side)? != tracked_order.side
+    {
         return None;
     }
     Some(FillRecord {
         fill_id: tracked_fill_id(tracked_order, &trade.id),
         order_id: tracked_order.order_id.clone(),
         token_id: tracked_order.token_id.clone(),
-        side: tracked_order.side.clone(),
+        side: tracked_order.side,
         quantity: maker_order.matched_amount,
         price: maker_order.price,
         fee: fee_schedule.calculate(
@@ -1731,7 +1738,7 @@ fn tracked_order_observation(
     let tracked_token_id = U256::from_str(&tracked_order.token_id).ok()?;
     if order.id != tracked_order.venue_order_id
         || order.asset_id != tracked_token_id
-        || trade_side(order.side.clone())? != tracked_order.side
+        || trade_side(order.side)? != tracked_order.side
     {
         return None;
     }
@@ -1769,7 +1776,7 @@ fn tracked_rest_order_observation(
     })?;
     if order.id != tracked_order.venue_order_id
         || order.asset_id != tracked_token_id
-        || trade_side(order.side.clone()) != Some(tracked_order.side)
+        || trade_side(order.side) != Some(tracked_order.side)
     {
         return Err(ExecutionError::Validation(format!(
             "venue order `{}` does not match tracked order `{}`",
@@ -1809,11 +1816,12 @@ fn tracked_user_trade_matches(tracked_order: &TrackedOrder, trade: &TradeMessage
     };
     if trade.taker_order_id.as_deref() == Some(tracked_order.venue_order_id.as_str()) {
         return trade.asset_id == tracked_token_id
-            && trade_side(trade.side.clone()) == Some(tracked_order.side);
+            && trade_side(trade.side) == Some(tracked_order.side);
     }
     trade.maker_orders.iter().any(|maker_order| {
         maker_order.order_id == tracked_order.venue_order_id
             && maker_order.asset_id == tracked_token_id
+            && maker_side_from_taker(trade.side) == Some(tracked_order.side)
     })
 }
 
@@ -1896,10 +1904,9 @@ mod tests {
         cap_sell_quantity_to_balance, collateral_balance_to_raw,
         conditional_token_balance_to_shares, ensure_account_readiness, execution_price_override,
         normalize_aggressive_price, normalize_execution_amount, normalize_market_order_quantity,
-        normalize_order_quantity, polymarket_execution_principal,
-        polymarket_signature_type_from_env, raw_balance_to_pusd, tracked_rest_order_observation,
-        tracked_trade_fill, tracked_user_trade_fill, trade_side, unique_token_ids,
-        wallet_signature_type,
+        normalize_order_quantity, polymarket_execution_principal, raw_balance_to_pusd,
+        tracked_rest_order_observation, tracked_trade_fill, tracked_user_trade_fill,
+        tracked_user_trade_matches, trade_side, unique_token_ids, wallet_signature_type,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -2488,6 +2495,13 @@ mod tests {
         assert_eq!(maker_fill.fill_id, "trade-ws:order-maker");
         assert_eq!(taker_fill.fee, dec!(0.03465));
         assert_eq!(maker_fill.fee, Decimal::ZERO);
+
+        let wrong_maker_side = TrackedOrder {
+            side: TradeSide::Buy,
+            ..maker
+        };
+        assert!(tracked_user_trade_fill(&wrong_maker_side, &confirmed, fee_schedule).is_none());
+        assert!(!tracked_user_trade_matches(&wrong_maker_side, &confirmed));
     }
 
     #[test]

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -1,21 +1,25 @@
 use alloy::signers::local::PrivateKeySigner;
+use ploy_market_contracts::{FeeSchedule, LiquidityRole};
 use ploy_trading::{FillRecord, TradeSide};
 use polymarket_client_sdk::auth::state::Authenticated;
 use polymarket_client_sdk::auth::{Normal, Signer};
 use polymarket_client_sdk::clob::types::request::{BalanceAllowanceRequest, TradesRequest};
 use polymarket_client_sdk::clob::types::response::{MakerOrder, TradeResponse};
-use polymarket_client_sdk::clob::types::{Amount, AssetType, OrderType, Side, SignatureType};
+use polymarket_client_sdk::clob::types::{
+    Amount, AssetType, OrderType, Side, SignatureType, TradeStatusType,
+};
 use polymarket_client_sdk::clob::{Client, Config};
-use polymarket_client_sdk::types::{Address, U256};
+use polymarket_client_sdk::types::{Address, B256, U256};
 use polymarket_client_sdk::{
     contract_config, derive_proxy_wallet, derive_safe_wallet, POLYGON, PRIVATE_KEY_VAR,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use secrecy::{ExposeSecret, SecretString};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, OnceLock, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thiserror::Error;
 
 pub const CRATE_MARKER: &str = "ploy-connectivity";
@@ -23,6 +27,8 @@ const DEFAULT_POLY_CLOB_HOST: &str = "https://clob.polymarket.com";
 const TERMINAL_CURSOR: &str = "LTE=";
 const MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS: usize = 10;
 const TRADE_RECONCILE_LOOKBACK_SECS: u64 = 24 * 60 * 60;
+const TRADE_RECONCILE_TIMEOUT: Duration = Duration::from_secs(2);
+const FEE_SCHEDULE_TTL: Duration = Duration::from_secs(5 * 60);
 const CONDITIONAL_TOKEN_DECIMALS: u32 = 6;
 const ACCOUNT_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -66,6 +72,7 @@ pub struct TrackedOrder {
     pub order_id: String,
     pub venue_order_id: String,
     pub token_id: String,
+    pub side: TradeSide,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -418,6 +425,7 @@ pub struct PolymarketExecutionGateway {
     runtime: Arc<tokio::runtime::Runtime>,
     signer: Arc<OnceLock<PrivateKeySigner>>,
     client: Arc<RwLock<Option<Client<Authenticated<Normal>>>>>,
+    fee_schedules: Arc<RwLock<HashMap<U256, (FeeSchedule, Instant)>>>,
 }
 
 impl PolymarketExecutionGateway {
@@ -437,6 +445,7 @@ impl PolymarketExecutionGateway {
             runtime: Arc::new(runtime),
             signer: Arc::new(OnceLock::new()),
             client: Arc::new(RwLock::new(None)),
+            fee_schedules: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -758,38 +767,17 @@ impl LiveExecutionGateway for PolymarketExecutionGateway {
         let client = self.get_or_init_client()?;
 
         let result = self.runtime.block_on(async {
-            let token_ids = unique_token_ids(tracked_orders)?;
-            let mut trades = Vec::new();
-
-            for chunk in token_ids.chunks(MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS) {
-                let mut tasks = Vec::with_capacity(chunk.len());
-
-                for token_id in chunk {
-                    let client = client.clone();
-                    let token_id = *token_id;
-                    tasks.push(tokio::spawn(async move {
-                        load_trades_for_token(client, token_id).await
-                    }));
-                }
-
-                for task in tasks {
-                    let mut token_trades = task.await.map_err(|err| {
-                        ExecutionError::Transport(format!("join trade reconciliation task: {err}"))
-                    })??;
-                    trades.append(&mut token_trades);
-                }
-            }
-
-            let mut fills = Vec::new();
-            for trade in &trades {
-                for tracked_order in tracked_orders {
-                    if let Some(fill) = tracked_trade_fill(tracked_order, trade) {
-                        fills.push(fill);
-                    }
-                }
-            }
-
-            Ok(fills)
+            tokio::time::timeout(
+                TRADE_RECONCILE_TIMEOUT,
+                reconcile_rest_fills(&client, &self.fee_schedules, tracked_orders),
+            )
+            .await
+            .map_err(|_| {
+                ExecutionError::Transport(format!(
+                    "trade reconciliation timed out after {}ms",
+                    TRADE_RECONCILE_TIMEOUT.as_millis()
+                ))
+            })?
         });
 
         if let Err(error) = &result {
@@ -993,6 +981,87 @@ async fn load_trades_for_token(
     Ok(trades)
 }
 
+async fn polymarket_fee_schedule(
+    client: &Client<Authenticated<Normal>>,
+    cache: &RwLock<HashMap<U256, (FeeSchedule, Instant)>>,
+    token_id: U256,
+    condition_id: B256,
+) -> Result<FeeSchedule, ExecutionError> {
+    if let Some(schedule) = cache
+        .read()
+        .map_err(|_| ExecutionError::Transport("fee schedule cache poisoned".to_string()))?
+        .get(&token_id)
+        .filter(|(_, loaded_at)| loaded_at.elapsed() < FEE_SCHEDULE_TTL)
+        .map(|(schedule, _)| *schedule)
+    {
+        return Ok(schedule);
+    }
+
+    let market = client
+        .clob_market_info(&condition_id.to_string())
+        .await
+        .map_err(|err| ExecutionError::Transport(format!("load V2 market fee metadata: {err}")))?;
+    if !market
+        .tokens
+        .iter()
+        .flatten()
+        .any(|token| token.token_id == token_id)
+    {
+        return Err(ExecutionError::Validation(format!(
+            "market fee metadata for condition `{condition_id}` does not include token `{token_id}`"
+        )));
+    }
+    let schedule = market.fee_details.as_ref().map_or_else(
+        || FeeSchedule::polymarket_v2(Decimal::ZERO, 0, true),
+        |fees| FeeSchedule::polymarket_v2(fees.rate, fees.exponent, fees.taker_only),
+    );
+
+    cache
+        .write()
+        .map_err(|_| ExecutionError::Transport("fee schedule cache poisoned".to_string()))?
+        .insert(token_id, (schedule, Instant::now()));
+    Ok(schedule)
+}
+
+async fn reconcile_rest_fills(
+    client: &Client<Authenticated<Normal>>,
+    fee_schedules: &RwLock<HashMap<U256, (FeeSchedule, Instant)>>,
+    tracked_orders: &[TrackedOrder],
+) -> Result<Vec<FillRecord>, ExecutionError> {
+    let token_ids = unique_token_ids(tracked_orders)?;
+    let mut trades = Vec::new();
+
+    for chunk in token_ids.chunks(MAX_CONCURRENT_TRADE_RECONCILE_REQUESTS) {
+        let mut tasks = tokio::task::JoinSet::new();
+        for token_id in chunk {
+            let client = client.clone();
+            let token_id = *token_id;
+            tasks.spawn(async move { load_trades_for_token(client, token_id).await });
+        }
+        while let Some(task) = tasks.join_next().await {
+            let mut token_trades = task.map_err(|err| {
+                ExecutionError::Transport(format!("join trade reconciliation task: {err}"))
+            })??;
+            trades.append(&mut token_trades);
+        }
+    }
+
+    let mut fills = Vec::new();
+    for trade in &trades {
+        if !matches!(trade.status, TradeStatusType::Confirmed) {
+            continue;
+        }
+        let fee_schedule =
+            polymarket_fee_schedule(client, fee_schedules, trade.asset_id, trade.market).await?;
+        for tracked_order in tracked_orders {
+            if let Some(fill) = tracked_trade_fill(tracked_order, trade, fee_schedule) {
+                fills.push(fill);
+            }
+        }
+    }
+    Ok(fills)
+}
+
 async fn sell_quantity_capped_to_balance(
     client: &Client<Authenticated<Normal>>,
     token_id: U256,
@@ -1162,17 +1231,30 @@ fn normalize_execution_amount(
     }
 }
 
-fn tracked_trade_fill(tracked_order: &TrackedOrder, trade: &TradeResponse) -> Option<FillRecord> {
+fn tracked_trade_fill(
+    tracked_order: &TrackedOrder,
+    trade: &TradeResponse,
+    fee_schedule: FeeSchedule,
+) -> Option<FillRecord> {
+    if !matches!(trade.status, TradeStatusType::Confirmed) {
+        return None;
+    }
+    let tracked_token_id = U256::from_str(&tracked_order.token_id).ok()?;
     if trade.taker_order_id == tracked_order.venue_order_id {
-        let side = trade_side(trade.side.clone())?;
+        if trade.asset_id != tracked_token_id {
+            return None;
+        }
+        if trade_side(trade.side.clone())? != tracked_order.side {
+            return None;
+        }
         return Some(FillRecord {
             fill_id: tracked_fill_id(tracked_order, &trade.id),
             order_id: tracked_order.order_id.clone(),
             token_id: tracked_order.token_id.clone(),
-            side,
+            side: tracked_order.side.clone(),
             quantity: trade.size,
             price: trade.price,
-            fee: fee_from_bps(trade.size, trade.price, trade.fee_rate_bps),
+            fee: fee_schedule.calculate(trade.size, trade.price, LiquidityRole::Taker),
             timestamp: trade.match_time,
         });
     }
@@ -1181,26 +1263,41 @@ fn tracked_trade_fill(tracked_order: &TrackedOrder, trade: &TradeResponse) -> Op
         .maker_orders
         .iter()
         .find(|maker_order| maker_order.order_id == tracked_order.venue_order_id)
-        .and_then(|maker_order| tracked_maker_fill(tracked_order, trade, maker_order))
+        .and_then(|maker_order| {
+            tracked_maker_fill(
+                tracked_order,
+                trade,
+                maker_order,
+                tracked_token_id,
+                fee_schedule,
+            )
+        })
 }
 
 fn tracked_maker_fill(
     tracked_order: &TrackedOrder,
     trade: &TradeResponse,
     maker_order: &MakerOrder,
+    tracked_token_id: U256,
+    fee_schedule: FeeSchedule,
 ) -> Option<FillRecord> {
-    let side = trade_side(maker_order.side.clone())?;
+    if maker_order.asset_id != tracked_token_id {
+        return None;
+    }
+    if trade_side(maker_order.side.clone())? != tracked_order.side {
+        return None;
+    }
     Some(FillRecord {
         fill_id: tracked_fill_id(tracked_order, &trade.id),
         order_id: tracked_order.order_id.clone(),
         token_id: tracked_order.token_id.clone(),
-        side,
+        side: tracked_order.side.clone(),
         quantity: maker_order.matched_amount,
         price: maker_order.price,
-        fee: fee_from_bps(
+        fee: fee_schedule.calculate(
             maker_order.matched_amount,
             maker_order.price,
-            maker_order.fee_rate_bps,
+            LiquidityRole::Maker,
         ),
         timestamp: trade.match_time,
     })
@@ -1216,10 +1313,6 @@ fn trade_side(side: Side) -> Option<TradeSide> {
         Side::Sell => Some(TradeSide::Sell),
         _ => None,
     }
-}
-
-fn fee_from_bps(quantity: Decimal, price: Decimal, fee_rate_bps: Decimal) -> Decimal {
-    quantity * price * fee_rate_bps / Decimal::from(10_000_u64)
 }
 
 pub fn crate_marker() -> &'static str {
@@ -1539,6 +1632,7 @@ mod tests {
                 order_id: "order-1".to_string(),
                 venue_order_id: "venue-order-1".to_string(),
                 token_id: "1".to_string(),
+                side: TradeSide::Buy,
             }])
             .expect("fills");
 
@@ -1606,7 +1700,7 @@ mod tests {
             .size(dec!(2))
             .fee_rate_bps(dec!(5))
             .price(dec!(0.55))
-            .status(TradeStatusType::Matched)
+            .status(TradeStatusType::Confirmed)
             .match_time(Utc::now())
             .last_update(Utc::now())
             .outcome("YES")
@@ -1638,24 +1732,89 @@ mod tests {
             &TrackedOrder {
                 order_id: "order-a".to_string(),
                 venue_order_id: "venue-order-a".to_string(),
-                token_id: "token-a".to_string(),
+                token_id: "1".to_string(),
+                side: TradeSide::Buy,
             },
             &trade,
+            ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
         )
         .expect("taker fill");
         let maker_fill = tracked_trade_fill(
             &TrackedOrder {
                 order_id: "order-b".to_string(),
                 venue_order_id: "venue-order-b".to_string(),
-                token_id: "token-b".to_string(),
+                token_id: "1".to_string(),
+                side: TradeSide::Sell,
             },
             &trade,
+            ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
         )
         .expect("maker fill");
 
         assert_eq!(taker_fill.fill_id, "trade-1:order-a");
         assert_eq!(maker_fill.fill_id, "trade-1:order-b");
         assert_ne!(taker_fill.fill_id, maker_fill.fill_id);
+        assert_eq!(taker_fill.fee, dec!(0.03465));
+        assert_eq!(maker_fill.fee, dec!(0));
+        assert!(tracked_trade_fill(
+            &TrackedOrder {
+                order_id: "order-side-mismatch".to_string(),
+                venue_order_id: "venue-order-a".to_string(),
+                token_id: "1".to_string(),
+                side: TradeSide::Sell,
+            },
+            &trade,
+            ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn reconciliation_ignores_non_confirmed_trade_statuses() {
+        let tracked = TrackedOrder {
+            order_id: "order-a".to_string(),
+            venue_order_id: "venue-order-a".to_string(),
+            token_id: "1".to_string(),
+            side: TradeSide::Buy,
+        };
+
+        for status in [
+            TradeStatusType::Matched,
+            TradeStatusType::Mined,
+            TradeStatusType::Retrying,
+            TradeStatusType::Failed,
+        ] {
+            let trade = TradeResponse::builder()
+                .id("trade-status")
+                .taker_order_id("venue-order-a")
+                .market(B256::ZERO)
+                .asset_id(U256::from(1_u64))
+                .side(polymarket_client_sdk::clob::types::Side::Buy)
+                .size(dec!(2))
+                .fee_rate_bps(dec!(5))
+                .price(dec!(0.55))
+                .status(status)
+                .match_time(Utc::now())
+                .last_update(Utc::now())
+                .outcome("YES")
+                .bucket_index(0)
+                .owner(ApiKey::nil())
+                .maker_address(
+                    Address::from_str("0x0000000000000000000000000000000000000001")
+                        .expect("maker address"),
+                )
+                .maker_orders(Vec::new())
+                .transaction_hash(B256::ZERO)
+                .trader_side(TraderSide::Taker)
+                .build();
+
+            assert!(tracked_trade_fill(
+                &tracked,
+                &trade,
+                ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+            )
+            .is_none());
+        }
     }
 
     #[test]
@@ -1665,16 +1824,19 @@ mod tests {
                 order_id: "order-1".to_string(),
                 venue_order_id: "venue-1".to_string(),
                 token_id: "10".to_string(),
+                side: TradeSide::Buy,
             },
             TrackedOrder {
                 order_id: "order-2".to_string(),
                 venue_order_id: "venue-2".to_string(),
                 token_id: "10".to_string(),
+                side: TradeSide::Sell,
             },
             TrackedOrder {
                 order_id: "order-3".to_string(),
                 venue_order_id: "venue-3".to_string(),
                 token_id: "11".to_string(),
+                side: TradeSide::Buy,
             },
         ])
         .expect("valid token ids");

--- a/crates/ploy-connectivity/src/lib.rs
+++ b/crates/ploy-connectivity/src/lib.rs
@@ -17,7 +17,7 @@ use polymarket_client_sdk::clob::ws::{
 use polymarket_client_sdk::clob::{Client, Config};
 use polymarket_client_sdk::types::{Address, B256, U256};
 use polymarket_client_sdk::{
-    POLYGON, PRIVATE_KEY_VAR, contract_config, derive_proxy_wallet, derive_safe_wallet,
+    contract_config, derive_proxy_wallet, derive_safe_wallet, POLYGON, PRIVATE_KEY_VAR,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -1897,16 +1897,16 @@ pub fn crate_marker() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        BufferedUserEvent, CancellationOutcome, CancellationRequest, ExecutionError,
-        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, OrderExecutionType,
-        OrderObservation, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
-        ReplaceRequest, StaticExecutionGateway, TrackedOrder, UserEventStream, WalletSignatureType,
         cap_sell_quantity_to_balance, collateral_balance_to_raw,
         conditional_token_balance_to_shares, ensure_account_readiness, execution_price_override,
         normalize_aggressive_price, normalize_execution_amount, normalize_market_order_quantity,
         normalize_order_quantity, polymarket_execution_principal, raw_balance_to_pusd,
         tracked_rest_order_observation, tracked_trade_fill, tracked_user_trade_fill,
         tracked_user_trade_matches, trade_side, unique_token_ids, wallet_signature_type,
+        BufferedUserEvent, CancellationOutcome, CancellationRequest, ExecutionError,
+        ExecutionOutcome, ExecutionRequest, LiveExecutionGateway, OrderExecutionType,
+        OrderObservation, PolymarketExecutionConfig, PolymarketExecutionGateway, ReplaceOutcome,
+        ReplaceRequest, StaticExecutionGateway, TrackedOrder, UserEventStream, WalletSignatureType,
     };
     use chrono::Utc;
     use ploy_trading::{FillRecord, TradeSide};
@@ -2106,11 +2106,9 @@ mod tests {
             .expect_err("zero balance should reject");
 
         assert!(matches!(error, ExecutionError::Validation(_)));
-        assert!(
-            error
-                .to_string()
-                .contains("no sellable conditional-token balance")
-        );
+        assert!(error
+            .to_string()
+            .contains("no sellable conditional-token balance"));
     }
 
     #[test]
@@ -2294,22 +2292,20 @@ mod tests {
                 Address::from_str("0x0000000000000000000000000000000000000001")
                     .expect("maker address"),
             )
-            .maker_orders(vec![
-                MakerOrder::builder()
-                    .order_id("venue-order-b")
-                    .owner(ApiKey::nil())
-                    .maker_address(
-                        Address::from_str("0x0000000000000000000000000000000000000002")
-                            .expect("second maker address"),
-                    )
-                    .matched_amount(dec!(2))
-                    .price(dec!(0.56))
-                    .fee_rate_bps(dec!(4))
-                    .asset_id(U256::from(1_u64))
-                    .outcome("YES")
-                    .side(polymarket_client_sdk::clob::types::Side::Sell)
-                    .build(),
-            ])
+            .maker_orders(vec![MakerOrder::builder()
+                .order_id("venue-order-b")
+                .owner(ApiKey::nil())
+                .maker_address(
+                    Address::from_str("0x0000000000000000000000000000000000000002")
+                        .expect("second maker address"),
+                )
+                .matched_amount(dec!(2))
+                .price(dec!(0.56))
+                .fee_rate_bps(dec!(4))
+                .asset_id(U256::from(1_u64))
+                .outcome("YES")
+                .side(polymarket_client_sdk::clob::types::Side::Sell)
+                .build()])
             .transaction_hash(B256::ZERO)
             .trader_side(TraderSide::Taker)
             .build();
@@ -2342,19 +2338,17 @@ mod tests {
         assert_ne!(taker_fill.fill_id, maker_fill.fill_id);
         assert_eq!(taker_fill.fee, dec!(0.03465));
         assert_eq!(maker_fill.fee, dec!(0));
-        assert!(
-            tracked_trade_fill(
-                &TrackedOrder {
-                    order_id: "order-side-mismatch".to_string(),
-                    venue_order_id: "venue-order-a".to_string(),
-                    token_id: "1".to_string(),
-                    side: TradeSide::Sell,
-                },
-                &trade,
-                ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
-            )
-            .is_none()
-        );
+        assert!(tracked_trade_fill(
+            &TrackedOrder {
+                order_id: "order-side-mismatch".to_string(),
+                venue_order_id: "venue-order-a".to_string(),
+                token_id: "1".to_string(),
+                side: TradeSide::Sell,
+            },
+            &trade,
+            ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+        )
+        .is_none());
     }
 
     #[test]
@@ -2396,14 +2390,12 @@ mod tests {
                 .trader_side(TraderSide::Taker)
                 .build();
 
-            assert!(
-                tracked_trade_fill(
-                    &tracked,
-                    &trade,
-                    ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
-                )
-                .is_none()
-            );
+            assert!(tracked_trade_fill(
+                &tracked,
+                &trade,
+                ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+            )
+            .is_none());
         }
     }
 

--- a/crates/ploy-control-client/src/lib.rs
+++ b/crates/ploy-control-client/src/lib.rs
@@ -994,9 +994,7 @@ mod tests {
             let mut request = [0_u8; 1024];
             let bytes = stream.read(&mut request).expect("read request");
             let request = String::from_utf8_lossy(&request[..bytes]);
-            assert!(
-                request.starts_with("POST /api/deployments/example.live/orders/order-1/cancel")
-            );
+            assert!(request.starts_with("POST /api/deployments/example.live/orders/order-1/cancel"));
 
             let body = serde_json::to_string(&OrderControlResponse {
                 deployment_id: "example.live".to_string(),

--- a/crates/ploy-control-client/src/lib.rs
+++ b/crates/ploy-control-client/src/lib.rs
@@ -994,7 +994,9 @@ mod tests {
             let mut request = [0_u8; 1024];
             let bytes = stream.read(&mut request).expect("read request");
             let request = String::from_utf8_lossy(&request[..bytes]);
-            assert!(request.starts_with("POST /api/deployments/example.live/orders/order-1/cancel"));
+            assert!(
+                request.starts_with("POST /api/deployments/example.live/orders/order-1/cancel")
+            );
 
             let body = serde_json::to_string(&OrderControlResponse {
                 deployment_id: "example.live".to_string(),
@@ -1260,7 +1262,8 @@ mod tests {
             for _ in 0..2 {
                 let (mut stream, _) = listener.accept().expect("accept");
                 let mut request = [0_u8; 1024];
-                stream.read(&mut request).expect("read request");
+                let bytes_read = stream.read(&mut request).expect("read request");
+                assert!(bytes_read > 0, "request must not be empty");
                 let body = serde_json::json!({
                     "status":"running",
                     "uptime_seconds":1,

--- a/crates/ploy-control-client/src/lib.rs
+++ b/crates/ploy-control-client/src/lib.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub struct ControlPlaneClient {
@@ -17,6 +18,7 @@ pub struct ControlPlaneClient {
     pub operator_token: Option<String>,
     pub sidecar_token: Option<String>,
     pub runtime_root: PathBuf,
+    connection: Arc<Mutex<Option<TcpStream>>>,
 }
 
 impl ControlPlaneClient {
@@ -36,6 +38,7 @@ impl ControlPlaneClient {
                 .ok()
                 .filter(|token| !token.trim().is_empty()),
             runtime_root: runtime_root.into(),
+            connection: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -273,6 +276,7 @@ impl ControlPlaneClient {
             operator_token: None,
             sidecar_token: None,
             runtime_root: self.runtime_root.clone(),
+            connection: Arc::clone(&self.connection),
         }
     }
 
@@ -329,27 +333,16 @@ impl ControlPlaneClient {
     where
         T: DeserializeOwned,
     {
-        let mut stream = TcpStream::connect(&self.control_plane_addr)
-            .map_err(|err| format!("connect {}: {err}", self.control_plane_addr))?;
         let request = format!(
-            "GET {path} HTTP/1.1\r\nHost: {}\r\n{}Connection: close\r\n\r\n",
+            "GET {path} HTTP/1.1\r\nHost: {}\r\n{}Connection: keep-alive\r\n\r\n",
             self.control_plane_addr,
             self.authorization_headers()
         );
-        stream
-            .write_all(request.as_bytes())
-            .map_err(|err| format!("write request: {err}"))?;
-
-        let mut response = String::new();
-        stream
-            .read_to_string(&mut response)
-            .map_err(|err| format!("read response: {err}"))?;
-
-        let (status_line, body) = split_http_response(&response)?;
+        let (status_line, body) = self.send_request(&request)?;
         if !status_line.contains("200") {
-            return Err(decode_http_error(status_line, body));
+            return Err(decode_http_error(&status_line, &body));
         }
-        serde_json::from_str(body).map_err(|err| format!("parse HTTP body: {err}"))
+        serde_json::from_str(&body).map_err(|err| format!("parse HTTP body: {err}"))
     }
 
     fn send_json<B, T>(&self, method: &str, path: &str, body: &B) -> Result<T, String>
@@ -371,57 +364,70 @@ impl ControlPlaneClient {
         B: serde::Serialize,
         T: DeserializeOwned,
     {
-        let mut stream = TcpStream::connect(&self.control_plane_addr)
-            .map_err(|err| format!("connect {}: {err}", self.control_plane_addr))?;
         let body = serde_json::to_string(body).map_err(|err| format!("serialize body: {err}"))?;
         let request = format!(
-            "{method} {path} HTTP/1.1\r\nHost: {}\r\n{}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "{method} {path} HTTP/1.1\r\nHost: {}\r\n{}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{}",
             self.control_plane_addr,
             authorization_headers,
             body.len(),
             body
         );
-        stream
-            .write_all(request.as_bytes())
-            .map_err(|err| format!("write request: {err}"))?;
-
-        let mut response = String::new();
-        stream
-            .read_to_string(&mut response)
-            .map_err(|err| format!("read response: {err}"))?;
-
-        let (status_line, body) = split_http_response(&response)?;
+        let (status_line, body) = self.send_request(&request)?;
         if !status_line.contains("200") {
-            return Err(decode_http_error(status_line, body));
+            return Err(decode_http_error(&status_line, &body));
         }
-        serde_json::from_str(body).map_err(|err| format!("parse HTTP body: {err}"))
+        serde_json::from_str(&body).map_err(|err| format!("parse HTTP body: {err}"))
     }
 
     fn send_empty<T>(&self, method: &str, path: &str) -> Result<T, String>
     where
         T: DeserializeOwned,
     {
-        let mut stream = TcpStream::connect(&self.control_plane_addr)
-            .map_err(|err| format!("connect {}: {err}", self.control_plane_addr))?;
         let request = format!(
-            "{method} {path} HTTP/1.1\r\nHost: {}\r\n{}Connection: close\r\n\r\n",
+            "{method} {path} HTTP/1.1\r\nHost: {}\r\n{}Connection: keep-alive\r\n\r\n",
             self.control_plane_addr,
             self.authorization_headers()
         );
-        stream
-            .write_all(request.as_bytes())
-            .map_err(|err| format!("write request: {err}"))?;
-
-        let mut response = String::new();
-        stream
-            .read_to_string(&mut response)
-            .map_err(|err| format!("read response: {err}"))?;
-
-        let (status_line, body) = split_http_response(&response)?;
+        let (status_line, body) = self.send_request(&request)?;
         if !status_line.contains("200") {
-            return Err(decode_http_error(status_line, body));
+            return Err(decode_http_error(&status_line, &body));
         }
-        serde_json::from_str(body).map_err(|err| format!("parse HTTP body: {err}"))
+        serde_json::from_str(&body).map_err(|err| format!("parse HTTP body: {err}"))
+    }
+
+    fn send_request(&self, request: &str) -> Result<(String, String), String> {
+        let mut connection = self
+            .connection
+            .lock()
+            .map_err(|_| "control-plane connection lock poisoned".to_string())?;
+        if connection.as_mut().is_some_and(connection_closed) {
+            *connection = None;
+        }
+        if connection.is_none() {
+            let stream = TcpStream::connect(&self.control_plane_addr)
+                .map_err(|err| format!("connect {}: {err}", self.control_plane_addr))?;
+            let _ = stream.set_nodelay(true);
+            let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+            let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(5)));
+            *connection = Some(stream);
+        }
+        let stream = connection.as_mut().expect("connection initialized");
+        if let Err(error) = stream.write_all(request.as_bytes()) {
+            *connection = None;
+            return Err(format!("write request: {error}"));
+        }
+        match read_http_response(stream) {
+            Ok((status_line, body, close)) => {
+                if close {
+                    *connection = None;
+                }
+                Ok((status_line, body))
+            }
+            Err(error) => {
+                *connection = None;
+                Err(error)
+            }
+        }
     }
 
     fn authorization_headers(&self) -> String {
@@ -437,16 +443,64 @@ impl ControlPlaneClient {
     }
 }
 
-fn split_http_response(response: &str) -> Result<(&str, &str), String> {
-    let mut parts = response.splitn(2, "\r\n\r\n");
-    let status_line = parts
-        .next()
-        .and_then(|headers| headers.lines().next())
-        .ok_or_else(|| "missing HTTP status line".to_string())?;
-    let body = parts
-        .next()
-        .ok_or_else(|| "missing HTTP body".to_string())?;
-    Ok((status_line, body))
+fn connection_closed(stream: &mut TcpStream) -> bool {
+    if stream.set_nonblocking(true).is_err() {
+        return true;
+    }
+    let mut byte = [0_u8; 1];
+    let closed = match stream.peek(&mut byte) {
+        Ok(0) => true,
+        Ok(_) => false,
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => false,
+        Err(_) => true,
+    };
+    let _ = stream.set_nonblocking(false);
+    closed
+}
+
+fn read_http_response(stream: &mut TcpStream) -> Result<(String, String, bool), String> {
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader
+        .read_line(&mut status_line)
+        .map_err(|err| format!("read HTTP status: {err}"))?;
+    if status_line.is_empty() {
+        return Err("missing HTTP status line".to_string());
+    }
+
+    let mut content_length = None;
+    let mut close = false;
+    loop {
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|err| format!("read HTTP headers: {err}"))?;
+        if line.is_empty() {
+            return Err("missing HTTP body".to_string());
+        }
+        if line == "\r\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = Some(
+                    value
+                        .trim()
+                        .parse::<usize>()
+                        .map_err(|err| format!("invalid HTTP Content-Length: {err}"))?,
+                );
+            } else if name.eq_ignore_ascii_case("connection") {
+                close = value.trim().eq_ignore_ascii_case("close");
+            }
+        }
+    }
+    let content_length = content_length.ok_or_else(|| "missing HTTP Content-Length".to_string())?;
+    let mut body = vec![0_u8; content_length];
+    reader
+        .read_exact(&mut body)
+        .map_err(|err| format!("read HTTP body: {err}"))?;
+    let body = String::from_utf8(body).map_err(|err| format!("decode HTTP body: {err}"))?;
+    Ok((status_line, body, close))
 }
 
 fn decode_http_error(status_line: &str, body: &str) -> String {
@@ -971,6 +1025,7 @@ mod tests {
             operator_token: None,
             sidecar_token: None,
             runtime_root,
+            connection: Default::default(),
         };
 
         let response = client
@@ -1030,6 +1085,7 @@ mod tests {
             operator_token: None,
             sidecar_token: None,
             runtime_root,
+            connection: Default::default(),
         };
 
         let response = client
@@ -1089,6 +1145,7 @@ mod tests {
             operator_token: None,
             sidecar_token: None,
             runtime_root,
+            connection: Default::default(),
         };
 
         let status = client.system_snapshot().expect("status");
@@ -1134,11 +1191,105 @@ mod tests {
             operator_token: Some("operator-token".to_string()),
             sidecar_token: None,
             runtime_root,
+            connection: Default::default(),
         };
 
         let deployment = client
             .set_desired_state("example.paper", DesiredState::Paused)
             .expect("deployment");
         assert_eq!(deployment.desired_state, DesiredState::Paused);
+    }
+
+    #[test]
+    fn client_reuses_keep_alive_connection() {
+        let runtime_root = temp_dir("http-keep-alive");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept once");
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .expect("read timeout");
+            for _ in 0..2 {
+                let mut request = Vec::new();
+                let mut byte = [0_u8; 1];
+                while !request.ends_with(b"\r\n\r\n") {
+                    stream.read_exact(&mut byte).expect("read request");
+                    request.push(byte[0]);
+                }
+                assert!(String::from_utf8_lossy(&request).contains("Connection: keep-alive"));
+                let body = serde_json::json!({
+                    "status":"running",
+                    "uptime_seconds":1,
+                    "version":"0.1.0",
+                    "strategy":"platform",
+                    "last_trade_time":null,
+                    "websocket_connected":false,
+                    "database_connected":false,
+                    "error_count_1h":0,
+                    "live_reconcile_failures":0,
+                    "next_live_reconcile_at":null,
+                    "last_live_reconcile_error":null
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: keep-alive\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write response");
+            }
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(runtime_root);
+        client.control_plane_addr = addr.to_string();
+        assert_eq!(client.system_snapshot().expect("first").status, "running");
+        assert_eq!(client.system_snapshot().expect("second").status, "running");
+        server.join().expect("server");
+    }
+
+    #[test]
+    fn client_reconnects_after_idle_keep_alive_socket_closes() {
+        let runtime_root = temp_dir("http-stale-keep-alive");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        let server = thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let mut request = [0_u8; 1024];
+                stream.read(&mut request).expect("read request");
+                let body = serde_json::json!({
+                    "status":"running",
+                    "uptime_seconds":1,
+                    "version":"0.1.0",
+                    "strategy":"platform",
+                    "last_trade_time":null,
+                    "websocket_connected":false,
+                    "database_connected":false,
+                    "error_count_1h":0,
+                    "live_reconcile_failures":0,
+                    "next_live_reconcile_at":null,
+                    "last_live_reconcile_error":null
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: keep-alive\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write response");
+            }
+        });
+
+        let mut client = ControlPlaneClient::from_runtime_root(runtime_root);
+        client.control_plane_addr = addr.to_string();
+        assert_eq!(client.system_snapshot().expect("first").status, "running");
+        thread::sleep(std::time::Duration::from_millis(20));
+        assert_eq!(client.system_snapshot().expect("second").status, "running");
+        server.join().expect("server");
     }
 }

--- a/crates/ploy-daemon-host/Cargo.toml
+++ b/crates/ploy-daemon-host/Cargo.toml
@@ -26,5 +26,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
+ploy-market-contracts.workspace = true
+ploy-strategy-bundles.workspace = true
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
+tokio = { workspace = true, features = ["rt", "sync"] }

--- a/crates/ploy-daemon-host/src/http.rs
+++ b/crates/ploy-daemon-host/src/http.rs
@@ -1,15 +1,15 @@
 use crate::events::EventBroker;
-use crate::runtime::{PloyDaemon, PreparedIntentSubmission, next_paper_intent_id};
+use crate::runtime::{next_paper_intent_id, PloyDaemon, PreparedIntentSubmission};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use ploy_operator_contracts::{
-    AgentRunCreateRequest, AgentRunCreateResponse, AgentRunRecord, AlertSnapshotEvent,
-    AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
-    DeploymentDiagnosticsReport, DeploymentSnapshotEvent, DiagnosticsEvidence, DiagnosticsFinding,
-    DryRunPerformanceReport, IntentPurpose, MetricsSnapshotEvent, OperatorEvent,
-    OrderReplaceRequest, OversightSnapshotEvent, PaperIntentRequest, PlatformDiagnosticsReport,
-    ProposalCreateRequest, ProposalDecisionRequest, ProposalSnapshotEvent, StatusUpdate,
-    SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent, compute_oversight_report,
+    compute_oversight_report, AgentRunCreateRequest, AgentRunCreateResponse, AgentRunRecord,
+    AlertSnapshotEvent, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
+    DeploymentControlRequest, DeploymentDiagnosticsReport, DeploymentSnapshotEvent,
+    DiagnosticsEvidence, DiagnosticsFinding, DryRunPerformanceReport, IntentPurpose,
+    MetricsSnapshotEvent, OperatorEvent, OrderReplaceRequest, OversightSnapshotEvent,
+    PaperIntentRequest, PlatformDiagnosticsReport, ProposalCreateRequest, ProposalDecisionRequest,
+    ProposalSnapshotEvent, StatusUpdate, SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
 };
 use ploy_platform_runtime::runtime_support::IntentAdmissionSource;
 use ploy_trading::{TradeSide, TradingIntent};
@@ -2719,11 +2719,11 @@ fn write_sse_event(stream: &mut TcpStream, event: &OperatorEvent) -> io::Result<
 #[cfg(test)]
 mod tests {
     use super::{
-        ADMIN_SESSION_COOKIE_NAME, AppState, AuthLevel, RateLimiter, access_allowed,
-        admin_session_cookie, append_audit_entry, client_ip, content_length, handle_api_request,
-        handle_authenticated_runtime_request, handle_connection, handle_runtime_request,
-        header_end_offset, intent_admission_source, rate_limit_key, request_auth_level,
-        required_access, response_headers, route_request, snapshot_events,
+        access_allowed, admin_session_cookie, append_audit_entry, client_ip, content_length,
+        handle_api_request, handle_authenticated_runtime_request, handle_connection,
+        handle_runtime_request, header_end_offset, intent_admission_source, rate_limit_key,
+        request_auth_level, required_access, response_headers, route_request, snapshot_events,
+        AppState, AuthLevel, RateLimiter, ADMIN_SESSION_COOKIE_NAME,
     };
     use crate::events::EventBroker;
     use chrono::{Duration, Utc};
@@ -2742,7 +2742,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, mpsc};
+    use std::sync::{mpsc, Arc, Mutex};
     use std::time::{Duration as StdDuration, Instant, SystemTime, UNIX_EPOCH};
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -3403,13 +3403,11 @@ mod tests {
             Some("secret-token"),
             "cookie-secret",
         );
-        assert!(
-            login_headers
-                .iter()
-                .any(|(name, value)| name == "Set-Cookie"
-                    && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}=v1."))
-                    && !value.contains("secret-token"))
-        );
+        assert!(login_headers
+            .iter()
+            .any(|(name, value)| name == "Set-Cookie"
+                && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}=v1."))
+                && !value.contains("secret-token")));
 
         let logout_headers = response_headers(
             "POST",
@@ -3418,13 +3416,11 @@ mod tests {
             Some("secret-token"),
             "cookie-secret",
         );
-        assert!(
-            logout_headers
-                .iter()
-                .any(|(name, value)| name == "Set-Cookie"
-                    && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}="))
-                    && value.contains("Max-Age=0"))
-        );
+        assert!(logout_headers
+            .iter()
+            .any(|(name, value)| name == "Set-Cookie"
+                && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}="))
+                && value.contains("Max-Age=0")));
     }
 
     #[test]
@@ -3923,16 +3919,12 @@ mod tests {
         assert_eq!(alerts_code, 200);
         let alerts: Vec<ploy_operator_contracts::ActiveAlert> =
             serde_json::from_str(&alerts_body).expect("alerts json");
-        assert!(
-            alerts
-                .iter()
-                .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale)
-        );
-        assert!(
-            alerts
-                .iter()
-                .any(|alert| alert.source_id.contains("live_reconcile"))
-        );
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.source_id.contains("live_reconcile")));
     }
 
     #[test]

--- a/crates/ploy-daemon-host/src/http.rs
+++ b/crates/ploy-daemon-host/src/http.rs
@@ -1,15 +1,15 @@
 use crate::events::EventBroker;
-use crate::runtime::{next_paper_intent_id, PloyDaemon, PreparedIntentSubmission};
+use crate::runtime::{PloyDaemon, PreparedIntentSubmission, next_paper_intent_id};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use ploy_operator_contracts::{
-    compute_oversight_report, AgentRunCreateRequest, AgentRunCreateResponse, AgentRunRecord,
-    AlertSnapshotEvent, AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest,
-    DeploymentControlRequest, DeploymentDiagnosticsReport, DeploymentSnapshotEvent,
-    DiagnosticsEvidence, DiagnosticsFinding, DryRunPerformanceReport, IntentPurpose,
-    MetricsSnapshotEvent, OperatorEvent, OrderReplaceRequest, OversightSnapshotEvent,
-    PaperIntentRequest, PlatformDiagnosticsReport, ProposalCreateRequest, ProposalDecisionRequest,
-    ProposalSnapshotEvent, StatusUpdate, SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent,
+    AgentRunCreateRequest, AgentRunCreateResponse, AgentRunRecord, AlertSnapshotEvent,
+    AuditLogEntry, ControlPlaneErrorResponse, DeploymentApplyRequest, DeploymentControlRequest,
+    DeploymentDiagnosticsReport, DeploymentSnapshotEvent, DiagnosticsEvidence, DiagnosticsFinding,
+    DryRunPerformanceReport, IntentPurpose, MetricsSnapshotEvent, OperatorEvent,
+    OrderReplaceRequest, OversightSnapshotEvent, PaperIntentRequest, PlatformDiagnosticsReport,
+    ProposalCreateRequest, ProposalDecisionRequest, ProposalSnapshotEvent, StatusUpdate,
+    SystemSnapshotEvent, SystemStatus, TradingSnapshotEvent, compute_oversight_report,
 };
 use ploy_platform_runtime::runtime_support::IntentAdmissionSource;
 use ploy_trading::{TradeSide, TradingIntent};
@@ -2719,11 +2719,11 @@ fn write_sse_event(stream: &mut TcpStream, event: &OperatorEvent) -> io::Result<
 #[cfg(test)]
 mod tests {
     use super::{
-        access_allowed, admin_session_cookie, append_audit_entry, client_ip, content_length,
-        handle_api_request, handle_authenticated_runtime_request, handle_connection,
-        handle_runtime_request, header_end_offset, intent_admission_source, rate_limit_key,
-        request_auth_level, required_access, response_headers, route_request, snapshot_events,
-        AppState, AuthLevel, RateLimiter, ADMIN_SESSION_COOKIE_NAME,
+        ADMIN_SESSION_COOKIE_NAME, AppState, AuthLevel, RateLimiter, access_allowed,
+        admin_session_cookie, append_audit_entry, client_ip, content_length, handle_api_request,
+        handle_authenticated_runtime_request, handle_connection, handle_runtime_request,
+        header_end_offset, intent_admission_source, rate_limit_key, request_auth_level,
+        required_access, response_headers, route_request, snapshot_events,
     };
     use crate::events::EventBroker;
     use chrono::{Duration, Utc};
@@ -2742,7 +2742,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
     use std::time::{Duration as StdDuration, Instant, SystemTime, UNIX_EPOCH};
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -2984,8 +2984,8 @@ mod tests {
         });
         let mut client = TcpStream::connect(addr).expect("connect");
         client.set_nodelay(true).expect("nodelay");
-        let mut decision_to_wire = Vec::with_capacity(SAMPLES);
-        let mut wire_to_ack = Vec::with_capacity(SAMPLES);
+        let mut client_to_gateway = Vec::with_capacity(SAMPLES);
+        let mut gateway_to_response = Vec::with_capacity(SAMPLES);
         let mut end_to_end = Vec::with_capacity(SAMPLES);
 
         for sequence in 0..SAMPLES {
@@ -3011,19 +3011,19 @@ mod tests {
             let completed = Instant::now();
             assert!(response.contains("\"state\":\"acknowledged\""));
             let wire = entered.lock().expect("entered lock")[sequence];
-            decision_to_wire.push(wire.duration_since(started).as_micros() as u64);
-            wire_to_ack.push(completed.duration_since(wire).as_micros() as u64);
+            client_to_gateway.push(wire.duration_since(started).as_micros() as u64);
+            gateway_to_response.push(completed.duration_since(wire).as_micros() as u64);
             end_to_end.push(completed.duration_since(started).as_micros() as u64);
         }
 
         println!(
-            "live-submit-latency-us decision_to_wire[p50={},p99={},p999={}] wire_to_ack[p50={},p99={},p999={}] end_to_end[p50={},p99={},p999={}] samples={SAMPLES}",
-            percentile_micros(&mut decision_to_wire, 500),
-            percentile_micros(&mut decision_to_wire, 990),
-            percentile_micros(&mut decision_to_wire, 999),
-            percentile_micros(&mut wire_to_ack, 500),
-            percentile_micros(&mut wire_to_ack, 990),
-            percentile_micros(&mut wire_to_ack, 999),
+            "live-submit-latency-us client_to_gateway[p50={},p99={},p999={}] gateway_to_response[p50={},p99={},p999={}] end_to_end[p50={},p99={},p999={}] samples={SAMPLES}",
+            percentile_micros(&mut client_to_gateway, 500),
+            percentile_micros(&mut client_to_gateway, 990),
+            percentile_micros(&mut client_to_gateway, 999),
+            percentile_micros(&mut gateway_to_response, 500),
+            percentile_micros(&mut gateway_to_response, 990),
+            percentile_micros(&mut gateway_to_response, 999),
             percentile_micros(&mut end_to_end, 500),
             percentile_micros(&mut end_to_end, 990),
             percentile_micros(&mut end_to_end, 999),
@@ -3403,11 +3403,13 @@ mod tests {
             Some("secret-token"),
             "cookie-secret",
         );
-        assert!(login_headers
-            .iter()
-            .any(|(name, value)| name == "Set-Cookie"
-                && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}=v1."))
-                && !value.contains("secret-token")));
+        assert!(
+            login_headers
+                .iter()
+                .any(|(name, value)| name == "Set-Cookie"
+                    && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}=v1."))
+                    && !value.contains("secret-token"))
+        );
 
         let logout_headers = response_headers(
             "POST",
@@ -3416,11 +3418,13 @@ mod tests {
             Some("secret-token"),
             "cookie-secret",
         );
-        assert!(logout_headers
-            .iter()
-            .any(|(name, value)| name == "Set-Cookie"
-                && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}="))
-                && value.contains("Max-Age=0")));
+        assert!(
+            logout_headers
+                .iter()
+                .any(|(name, value)| name == "Set-Cookie"
+                    && value.contains(&format!("{ADMIN_SESSION_COOKIE_NAME}="))
+                    && value.contains("Max-Age=0"))
+        );
     }
 
     #[test]
@@ -3919,12 +3923,16 @@ mod tests {
         assert_eq!(alerts_code, 200);
         let alerts: Vec<ploy_operator_contracts::ActiveAlert> =
             serde_json::from_str(&alerts_body).expect("alerts json");
-        assert!(alerts
-            .iter()
-            .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale));
-        assert!(alerts
-            .iter()
-            .any(|alert| alert.source_id.contains("live_reconcile")));
+        assert!(
+            alerts
+                .iter()
+                .any(|alert| alert.kind == ploy_operator_contracts::AlertKind::SourceStale)
+        );
+        assert!(
+            alerts
+                .iter()
+                .any(|alert| alert.source_id.contains("live_reconcile"))
+        );
     }
 
     #[test]

--- a/crates/ploy-daemon-host/src/http.rs
+++ b/crates/ploy-daemon-host/src/http.rs
@@ -2735,7 +2735,15 @@ mod tests {
     use ploy_operator_contracts::AuditLogEntry;
     use ploy_operator_contracts::{OrderReplaceRequest, PaperIntentRequest};
     use ploy_platform_runtime::runtime_support::IntentAdmissionSource;
-    use ploy_trading::{IntentPurpose as TradingIntentPurpose, TradeSide, TradingIntent};
+    use ploy_strategy_bundles::strategies::three_layer::ThreeLayerConfig;
+    use ploy_strategy_bundles::{
+        Feed, LiveFeed, MarketUpdate, StrategyDecision, StrategyLogic, ThreeLayerProfile,
+        ThreeLayerStrategy,
+    };
+    use ploy_trading::{
+        IntentPurpose as TradingIntentPurpose, OrderLedger, PositionLedger, TradeSide,
+        TradingIntent,
+    };
     use std::collections::VecDeque;
     use std::fs;
     use std::io::{Read, Write};
@@ -2984,18 +2992,110 @@ mod tests {
         });
         let mut client = TcpStream::connect(addr).expect("connect");
         client.set_nodelay(true).expect("nodelay");
+        let base_ts = Utc::now();
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        let mut strategy = ThreeLayerStrategy::new(ThreeLayerConfig {
+            symbols: vec!["BTCUSDT".to_string()],
+            profile: ThreeLayerProfile::Mixed,
+            min_direction_prob: 0.5,
+            min_distance_over_sigma: 0.0,
+            min_confirmation_score: 0.0,
+            require_confirmation: false,
+            min_drift_confirmation: 0.0,
+            min_edge: 0.0,
+            min_reward_risk: 0.0,
+            alpha_contrarian: false,
+            cex_contrarian: false,
+            probability_shrink: 1.0,
+            probability_haircut: 0.0,
+            take_profit_ask: 0.70,
+            stop_distance_pct: 0.02,
+            max_pm_lag_secs: 15,
+            min_time_remaining_secs: 1,
+            max_time_remaining_secs: 300,
+            cooldown_secs: 0,
+            stake_usd: rust_decimal::Decimal::new(25, 0),
+            max_positions: 10,
+            max_daily_trades: u32::MAX,
+            allowed_window_secs: vec![300],
+            min_entry_price: 0.01,
+            max_entry_price: 0.99,
+            min_entry_score: 0.0,
+            autofactor_runtime_score: None,
+            event_ml_model: None,
+            visible_depth_haircut: rust_decimal::Decimal::ONE,
+            max_sweep_levels: 0,
+            max_sweep_price_delta: rust_decimal::Decimal::ZERO,
+        });
+        strategy.on_update(
+            &MarketUpdate::EventDiscovered {
+                event_id: Arc::from("market-1"),
+                symbol: Arc::from("BTCUSDT"),
+                up_token: Arc::from("token-1"),
+                down_token: Arc::from("token-2"),
+                end_time: base_ts + Duration::seconds(300),
+                window_secs: 300,
+                price_to_beat: Some(rust_decimal::Decimal::new(100_000, 0)),
+                resolved_up_won: None,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: rust_decimal::Decimal::new(100_000, 0),
+                ts: base_ts,
+            },
+            &positions,
+            &orders,
+        );
+        let (tick_tx, tick_rx) = tokio::sync::broadcast::channel(16);
+        let mut tick_feed = LiveFeed::new(tick_rx);
+        let tick_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("tick runtime");
+        let mut canonical_tick_to_decision = Vec::with_capacity(SAMPLES);
+        let mut canonical_tick_to_gateway = Vec::with_capacity(SAMPLES);
+        let mut canonical_tick_to_response = Vec::with_capacity(SAMPLES);
         let mut client_to_gateway = Vec::with_capacity(SAMPLES);
         let mut gateway_to_response = Vec::with_capacity(SAMPLES);
         let mut end_to_end = Vec::with_capacity(SAMPLES);
 
         for sequence in 0..SAMPLES {
+            let tick = MarketUpdate::Quote {
+                token_id: Arc::from("token-1"),
+                bid: Some(rust_decimal::Decimal::new(19, 2)),
+                ask: Some(rust_decimal::Decimal::new(20, 2)),
+                bid_size: Some(rust_decimal::Decimal::new(1_000, 0)),
+                ask_size: Some(rust_decimal::Decimal::new(1_000, 0)),
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
+                ts: base_ts + Duration::milliseconds(sequence as i64),
+            };
+            let tick_started = Instant::now();
+            tick_tx.send(tick).expect("broadcast canonical tick");
+            let tick = tick_runtime
+                .block_on(tick_feed.next())
+                .expect("receive canonical tick");
+            let decisions = strategy.on_update(&tick, &positions, &orders);
+            let decision_at = Instant::now();
+            let intent = match decisions.as_slice() {
+                [StrategyDecision::Enter { intent, .. }] => intent,
+                other => panic!("benchmark tick must emit one entry, got {other:?}"),
+            };
             let body = serde_json::to_string(&PaperIntentRequest {
-                idempotency_key: Some(format!("latency-{sequence}")),
-                market_id: "market-1".to_string(),
-                token_id: "token-1".to_string(),
-                side: "buy".to_string(),
-                quantity: rust_decimal::Decimal::new(1, 4),
-                limit_price: Some(rust_decimal::Decimal::new(5, 1)),
+                idempotency_key: Some(intent.intent_id.clone()),
+                market_id: intent.market_id.clone(),
+                token_id: intent.token_id.clone(),
+                side: match intent.side {
+                    TradeSide::Buy => "buy",
+                    TradeSide::Sell => "sell",
+                }
+                .to_string(),
+                quantity: intent.quantity,
+                limit_price: intent.limit_price,
                 purpose: ploy_operator_contracts::IntentPurpose::Entry,
             })
             .expect("request json");
@@ -3011,13 +3111,27 @@ mod tests {
             let completed = Instant::now();
             assert!(response.contains("\"state\":\"acknowledged\""));
             let wire = entered.lock().expect("entered lock")[sequence];
+            canonical_tick_to_decision
+                .push(decision_at.duration_since(tick_started).as_micros() as u64);
+            canonical_tick_to_gateway.push(wire.duration_since(tick_started).as_micros() as u64);
+            canonical_tick_to_response
+                .push(completed.duration_since(tick_started).as_micros() as u64);
             client_to_gateway.push(wire.duration_since(started).as_micros() as u64);
             gateway_to_response.push(completed.duration_since(wire).as_micros() as u64);
             end_to_end.push(completed.duration_since(started).as_micros() as u64);
         }
 
         println!(
-            "live-submit-latency-us client_to_gateway[p50={},p99={},p999={}] gateway_to_response[p50={},p99={},p999={}] end_to_end[p50={},p99={},p999={}] samples={SAMPLES}",
+            "live-submit-latency-us canonical_tick_to_decision[p50={},p99={},p999={}] canonical_tick_to_gateway[p50={},p99={},p999={}] canonical_tick_to_response[p50={},p99={},p999={}] client_to_gateway[p50={},p99={},p999={}] gateway_to_response[p50={},p99={},p999={}] end_to_end[p50={},p99={},p999={}] samples={SAMPLES}",
+            percentile_micros(&mut canonical_tick_to_decision, 500),
+            percentile_micros(&mut canonical_tick_to_decision, 990),
+            percentile_micros(&mut canonical_tick_to_decision, 999),
+            percentile_micros(&mut canonical_tick_to_gateway, 500),
+            percentile_micros(&mut canonical_tick_to_gateway, 990),
+            percentile_micros(&mut canonical_tick_to_gateway, 999),
+            percentile_micros(&mut canonical_tick_to_response, 500),
+            percentile_micros(&mut canonical_tick_to_response, 990),
+            percentile_micros(&mut canonical_tick_to_response, 999),
             percentile_micros(&mut client_to_gateway, 500),
             percentile_micros(&mut client_to_gateway, 990),
             percentile_micros(&mut client_to_gateway, 999),

--- a/crates/ploy-daemon-host/src/http.rs
+++ b/crates/ploy-daemon-host/src/http.rs
@@ -1,5 +1,5 @@
 use crate::events::EventBroker;
-use crate::runtime::{next_paper_intent_id, PloyDaemon};
+use crate::runtime::{next_paper_intent_id, PloyDaemon, PreparedIntentSubmission};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use ploy_operator_contracts::{
@@ -561,75 +561,53 @@ pub fn spawn_server(state: Arc<AppState>) -> io::Result<thread::JoinHandle<()>> 
 }
 
 fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result<()> {
-    let request = read_http_request(&mut stream)?;
-    if request.is_empty() {
-        return Ok(());
-    }
+    loop {
+        let request = read_http_request(&mut stream)?;
+        if request.is_empty() {
+            return Ok(());
+        }
+        let keep_alive = request.lines().any(|line| {
+            line.split_once(':').is_some_and(|(name, value)| {
+                name.eq_ignore_ascii_case("connection")
+                    && value.trim().eq_ignore_ascii_case("keep-alive")
+            })
+        });
 
-    let mut request_line = request.lines().next().unwrap_or("").split_whitespace();
-    let method = request_line.next().unwrap_or("GET");
-    let raw_path = request_line.next().unwrap_or("/");
-    let path = raw_path.split('?').next().unwrap_or(raw_path);
-    let peer_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
-    let client_addr = Some(client_ip(peer_addr.as_deref(), &request));
-    let (configured_token, operator_token, worker_token, sidecar_token, cookie_secret) =
-        match configured_auth(state) {
-            Ok(auth) => auth,
-            Err(response) => return write_json_response(stream, response),
-        };
-    let auth_level = request_auth_level(
-        &request,
-        configured_token
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .map(|token| token.as_str()),
-        operator_token
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .map(|token| token.as_str()),
-        worker_token
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .map(|token| token.as_str()),
-        sidecar_token
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .map(|token| token.as_str()),
-        cookie_secret.expose_secret(),
-    );
-    let required_access = required_access(method, path);
-    if let Some(response) =
-        rate_limit_response(method, path, client_addr.as_deref(), auth_level, state)
-    {
-        audit_request(
-            state,
-            method,
-            path,
-            client_addr.as_deref(),
-            auth_level,
-            required_access,
-            response.0,
-            "rate_limited",
-            response_message(&response.1),
+        let mut request_line = request.lines().next().unwrap_or("").split_whitespace();
+        let method = request_line.next().unwrap_or("GET");
+        let raw_path = request_line.next().unwrap_or("/");
+        let path = raw_path.split('?').next().unwrap_or(raw_path);
+        let peer_addr = stream.peer_addr().ok().map(|addr| addr.to_string());
+        let client_addr = Some(client_ip(peer_addr.as_deref(), &request));
+        let (configured_token, operator_token, worker_token, sidecar_token, cookie_secret) =
+            match configured_auth(state) {
+                Ok(auth) => auth,
+                Err(response) => return write_json_response(stream, response),
+            };
+        let auth_level = request_auth_level(
+            &request,
+            configured_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(|token| token.as_str()),
+            operator_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(|token| token.as_str()),
+            worker_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(|token| token.as_str()),
+            sidecar_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(|token| token.as_str()),
+            cookie_secret.expose_secret(),
         );
-        return write_json_response(stream, response);
-    }
-    if method == "GET" && path == "/api/events/stream" {
-        if !access_allowed(
-            auth_level,
-            required_access,
-            configured_token.is_some(),
-            operator_token.is_some(),
-            worker_token.is_some(),
-            sidecar_token.is_some(),
-        ) {
-            let response = auth_error_response(
-                required_access,
-                configured_token.is_some(),
-                operator_token.is_some(),
-                worker_token.is_some(),
-                sidecar_token.is_some(),
-            );
+        let required_access = required_access(method, path);
+        if let Some(response) =
+            rate_limit_response(method, path, client_addr.as_deref(), auth_level, state)
+        {
             audit_request(
                 state,
                 method,
@@ -638,40 +616,85 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
                 auth_level,
                 required_access,
                 response.0,
-                "denied",
+                "rate_limited",
                 response_message(&response.1),
             );
             return write_json_response(stream, response);
         }
-        audit_request(
-            state,
-            method,
-            path,
-            client_addr.as_deref(),
-            auth_level,
-            required_access,
-            200,
-            "allowed",
-            None,
-        );
-        return handle_event_stream(stream, state);
-    }
-    if method == "GET" && path == "/reports/strategy" {
-        if !access_allowed(
-            auth_level,
-            required_access,
-            configured_token.is_some(),
-            operator_token.is_some(),
-            worker_token.is_some(),
-            sidecar_token.is_some(),
-        ) {
-            let response = auth_error_response(
+        if method == "GET" && path == "/api/events/stream" {
+            if !access_allowed(
+                auth_level,
                 required_access,
                 configured_token.is_some(),
                 operator_token.is_some(),
                 worker_token.is_some(),
                 sidecar_token.is_some(),
+            ) {
+                let response = auth_error_response(
+                    required_access,
+                    configured_token.is_some(),
+                    operator_token.is_some(),
+                    worker_token.is_some(),
+                    sidecar_token.is_some(),
+                );
+                audit_request(
+                    state,
+                    method,
+                    path,
+                    client_addr.as_deref(),
+                    auth_level,
+                    required_access,
+                    response.0,
+                    "denied",
+                    response_message(&response.1),
+                );
+                return write_json_response(stream, response);
+            }
+            audit_request(
+                state,
+                method,
+                path,
+                client_addr.as_deref(),
+                auth_level,
+                required_access,
+                200,
+                "allowed",
+                None,
             );
+            return handle_event_stream(stream, state);
+        }
+        if method == "GET" && path == "/reports/strategy" {
+            if !access_allowed(
+                auth_level,
+                required_access,
+                configured_token.is_some(),
+                operator_token.is_some(),
+                worker_token.is_some(),
+                sidecar_token.is_some(),
+            ) {
+                let response = auth_error_response(
+                    required_access,
+                    configured_token.is_some(),
+                    operator_token.is_some(),
+                    worker_token.is_some(),
+                    sidecar_token.is_some(),
+                );
+                audit_request(
+                    state,
+                    method,
+                    path,
+                    client_addr.as_deref(),
+                    auth_level,
+                    required_access,
+                    response.0,
+                    "denied",
+                    response_message(&response.1),
+                );
+                return write_json_response(stream, response);
+            }
+
+            let response =
+                build_strategy_report_html(state, query_param(raw_path, "since").as_deref());
             audit_request(
                 state,
                 method,
@@ -680,75 +703,91 @@ fn handle_connection(mut stream: TcpStream, state: &Arc<AppState>) -> io::Result
                 auth_level,
                 required_access,
                 response.0,
-                "denied",
-                response_message(&response.1),
+                if response.0 < 400 {
+                    "allowed"
+                } else {
+                    "denied"
+                },
+                if response.0 < 400 {
+                    None
+                } else {
+                    Some("strategy report generation failed".to_string())
+                },
             );
-            return write_json_response(stream, response);
+            return write_html_response(stream, response);
         }
-
-        let response = build_strategy_report_html(state, query_param(raw_path, "since").as_deref());
-        audit_request(
-            state,
+        let body = request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .filter(|body| !body.is_empty());
+        let response = handle_authenticated_runtime_request(
             method,
             path,
-            client_addr.as_deref(),
+            body,
             auth_level,
-            required_access,
-            response.0,
-            if response.0 < 400 {
-                "allowed"
-            } else {
-                "denied"
-            },
-            if response.0 < 400 {
-                None
-            } else {
-                Some("strategy report generation failed".to_string())
-            },
+            configured_token.is_some(),
+            operator_token.is_some(),
+            worker_token.is_some(),
+            sidecar_token.is_some(),
+            state,
         );
-        return write_html_response(stream, response);
-    }
-    let body = request
-        .split_once("\r\n\r\n")
-        .map(|(_, body)| body)
-        .filter(|body| !body.is_empty());
-    let response = handle_authenticated_runtime_request(
-        method,
-        path,
-        body,
-        auth_level,
-        configured_token.is_some(),
-        operator_token.is_some(),
-        worker_token.is_some(),
-        sidecar_token.is_some(),
-        state,
-    );
-    let headers = response_headers(
-        method,
-        path,
-        response.0,
-        configured_token
-            .as_ref()
-            .map(ExposeSecret::expose_secret)
-            .map(|token| token.as_str()),
-        cookie_secret.expose_secret(),
-    );
-    audit_request(
-        state,
-        method,
-        path,
-        client_addr.as_deref(),
-        auth_level,
-        required_access,
-        response.0,
-        if response.0 < 400 {
+        let headers = response_headers(
+            method,
+            path,
+            response.0,
+            configured_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(|token| token.as_str()),
+            cookie_secret.expose_secret(),
+        );
+        let status_code = response.0;
+        let outcome = if status_code < 400 {
             "allowed"
         } else {
             "denied"
-        },
-        response_message(&response.1),
-    );
-    write_json_response_with_headers(stream, response, &headers)
+        };
+        let message = response_message(&response.1);
+        if method == "POST" && path.ends_with("/intents") {
+            let result = if keep_alive {
+                write_json_response_keep_alive_with_headers(stream.try_clone()?, response, &headers)
+            } else {
+                write_json_response_with_headers(stream.try_clone()?, response, &headers)
+            };
+            audit_request(
+                state,
+                method,
+                path,
+                client_addr.as_deref(),
+                auth_level,
+                required_access,
+                status_code,
+                outcome,
+                message,
+            );
+            result?;
+            if keep_alive {
+                continue;
+            }
+            return Ok(());
+        }
+        audit_request(
+            state,
+            method,
+            path,
+            client_addr.as_deref(),
+            auth_level,
+            required_access,
+            status_code,
+            outcome,
+            message,
+        );
+        if keep_alive {
+            write_json_response_keep_alive_with_headers(stream.try_clone()?, response, &headers)?;
+            continue;
+        }
+        return write_json_response_with_headers(stream, response, &headers);
+    }
 }
 
 fn read_http_request(stream: &mut TcpStream) -> io::Result<String> {
@@ -821,10 +860,20 @@ fn write_html_response(stream: TcpStream, response: (u16, String)) -> io::Result
 }
 
 fn write_response_with_headers(
+    stream: TcpStream,
+    response: (u16, String),
+    content_type: &str,
+    headers: &[(String, String)],
+) -> io::Result<()> {
+    write_response_with_headers_and_connection(stream, response, content_type, headers, false)
+}
+
+fn write_response_with_headers_and_connection(
     mut stream: TcpStream,
     response: (u16, String),
     content_type: &str,
     headers: &[(String, String)],
+    keep_alive: bool,
 ) -> io::Result<()> {
     let (status_code, body) = response;
     let extra_headers = headers
@@ -833,12 +882,13 @@ fn write_response_with_headers(
         .collect::<String>();
     write!(
         stream,
-        "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nContent-Type: {}\r\nConnection: close\r\n{}\
+        "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nContent-Type: {}\r\nConnection: {}\r\n{}\
          \r\n{}",
         status_code,
         status_text(status_code),
         body.len(),
         content_type,
+        if keep_alive { "keep-alive" } else { "close" },
         extra_headers,
         body
     )
@@ -850,6 +900,14 @@ fn write_json_response_with_headers(
     headers: &[(String, String)],
 ) -> io::Result<()> {
     write_response_with_headers(stream, response, "application/json", headers)
+}
+
+fn write_json_response_keep_alive_with_headers(
+    stream: TcpStream,
+    response: (u16, String),
+    headers: &[(String, String)],
+) -> io::Result<()> {
+    write_response_with_headers_and_connection(stream, response, "application/json", headers, true)
 }
 
 fn configured_auth(
@@ -2441,37 +2499,45 @@ fn handle_runtime_request_from(
                 );
             };
 
-            match state.daemon.lock() {
-                Ok(mut daemon) => {
-                    let response = daemon.submit_intent_idempotent_from(
-                        TradingIntent {
-                            intent_id: request
-                                .idempotency_key
-                                .as_deref()
-                                .map(|key| format!("request-{key}"))
-                                .unwrap_or_else(|| next_paper_intent_id(deployment_id)),
-                            deployment_id: deployment_id.to_string(),
-                            market_id: request.market_id,
-                            token_id: request.token_id,
-                            side,
-                            quantity: request.quantity,
-                            limit_price: request.limit_price,
-                            purpose: intent_purpose_from_wire(request.purpose),
-                            created_at: chrono::Utc::now(),
-                        },
-                        request.idempotency_key.as_deref(),
-                        intent_source,
-                    );
-                    publish_snapshot_events(&daemon, &state.events);
-                    match response {
-                        Ok(response) => (
-                            200,
-                            serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
-                        ),
-                        Err(err) => submit_intent_error_response(err, deployment_id),
+            let prepared = match state.daemon.lock() {
+                Ok(mut daemon) => daemon.prepare_intent_idempotent_from(
+                    TradingIntent {
+                        intent_id: request
+                            .idempotency_key
+                            .as_deref()
+                            .map(|key| format!("request-{key}"))
+                            .unwrap_or_else(|| next_paper_intent_id(deployment_id)),
+                        deployment_id: deployment_id.to_string(),
+                        market_id: request.market_id,
+                        token_id: request.token_id,
+                        side,
+                        quantity: request.quantity,
+                        limit_price: request.limit_price,
+                        purpose: intent_purpose_from_wire(request.purpose),
+                        created_at: chrono::Utc::now(),
+                    },
+                    request.idempotency_key.as_deref(),
+                    intent_source,
+                ),
+                Err(_) => return json_error(503, "daemon_lock_poisoned", None),
+            };
+            let response = match prepared {
+                Ok(PreparedIntentSubmission::Complete(response)) => Ok(response),
+                Ok(PreparedIntentSubmission::Live(prepared)) => {
+                    let outcome = prepared.execute();
+                    match state.daemon.lock() {
+                        Ok(mut daemon) => daemon.finish_prepared_live_intent(prepared, outcome),
+                        Err(_) => return json_error(503, "daemon_lock_poisoned", None),
                     }
                 }
-                Err(_) => json_error(503, "daemon_lock_poisoned", None),
+                Err(error) => Err(error),
+            };
+            match response {
+                Ok(response) => (
+                    200,
+                    serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+                ),
+                Err(err) => submit_intent_error_response(err, deployment_id),
             }
         }
         ("POST", _) if path.starts_with("/api/proposals/") && path.ends_with("/approve") => {
@@ -2654,22 +2720,29 @@ fn write_sse_event(stream: &mut TcpStream, event: &OperatorEvent) -> io::Result<
 mod tests {
     use super::{
         access_allowed, admin_session_cookie, append_audit_entry, client_ip, content_length,
-        handle_api_request, handle_authenticated_runtime_request, handle_runtime_request,
-        header_end_offset, intent_admission_source, rate_limit_key, request_auth_level,
-        required_access, response_headers, route_request, snapshot_events, AppState, AuthLevel,
-        RateLimiter, ADMIN_SESSION_COOKIE_NAME,
+        handle_api_request, handle_authenticated_runtime_request, handle_connection,
+        handle_runtime_request, header_end_offset, intent_admission_source, rate_limit_key,
+        request_auth_level, required_access, response_headers, route_request, snapshot_events,
+        AppState, AuthLevel, RateLimiter, ADMIN_SESSION_COOKIE_NAME,
     };
     use crate::events::EventBroker;
     use chrono::{Duration, Utc};
-    use ploy_connectivity::{CancellationOutcome, ReplaceOutcome, StaticExecutionGateway};
+    use ploy_connectivity::{
+        CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
+        ExecutionRequest, LiveExecutionGateway, ReplaceOutcome, ReplaceRequest,
+        StaticExecutionGateway, TrackedOrder,
+    };
     use ploy_operator_contracts::AuditLogEntry;
     use ploy_operator_contracts::{OrderReplaceRequest, PaperIntentRequest};
     use ploy_platform_runtime::runtime_support::IntentAdmissionSource;
     use ploy_trading::{IntentPurpose as TradingIntentPurpose, TradeSide, TradingIntent};
     use std::collections::VecDeque;
     use std::fs;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Arc, Mutex};
     use std::time::{Duration as StdDuration, Instant, SystemTime, UNIX_EPOCH};
 
     fn temp_dir(label: &str) -> PathBuf {
@@ -2678,6 +2751,119 @@ mod tests {
             .expect("duration")
             .as_nanos();
         std::env::temp_dir().join(format!("ployd-http-{label}-{unique}"))
+    }
+
+    fn read_response_body(stream: &mut TcpStream) -> String {
+        let mut headers = Vec::new();
+        let mut byte = [0_u8; 1];
+        while !headers.ends_with(b"\r\n\r\n") {
+            stream.read_exact(&mut byte).expect("read response headers");
+            headers.push(byte[0]);
+        }
+        let headers = String::from_utf8(headers).expect("response headers utf8");
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("content length"))
+            })
+            .expect("content length header");
+        let mut body = vec![0_u8; content_length];
+        stream.read_exact(&mut body).expect("read response body");
+        String::from_utf8(body).expect("response body utf8")
+    }
+
+    fn percentile_micros(samples: &mut [u64], per_thousand: usize) -> u64 {
+        samples.sort_unstable();
+        samples[(samples.len() - 1) * per_thousand / 1_000]
+    }
+
+    #[derive(Debug)]
+    struct BlockingSubmitGateway {
+        entered: Mutex<Option<mpsc::Sender<()>>>,
+        release: Mutex<mpsc::Receiver<()>>,
+        submits: Arc<AtomicUsize>,
+    }
+
+    #[derive(Debug)]
+    struct BenchmarkSubmitGateway {
+        entered: Arc<Mutex<Vec<Instant>>>,
+        submits: AtomicUsize,
+    }
+
+    impl LiveExecutionGateway for BenchmarkSubmitGateway {
+        fn probe(&self) -> Result<(), ExecutionError> {
+            Ok(())
+        }
+
+        fn submit(&self, _request: &ExecutionRequest) -> Result<ExecutionOutcome, ExecutionError> {
+            self.entered
+                .lock()
+                .expect("entered lock")
+                .push(Instant::now());
+            let sequence = self.submits.fetch_add(1, Ordering::SeqCst);
+            Ok(ExecutionOutcome::Acknowledged {
+                venue_order_id: format!("venue-benchmark-{sequence}"),
+            })
+        }
+
+        fn cancel(
+            &self,
+            _request: &CancellationRequest,
+        ) -> Result<CancellationOutcome, ExecutionError> {
+            Ok(CancellationOutcome::Canceled)
+        }
+
+        fn replace(&self, _request: &ReplaceRequest) -> Result<ReplaceOutcome, ExecutionError> {
+            unreachable!("replace is not used")
+        }
+
+        fn reconcile_fills(
+            &self,
+            _tracked_orders: &[TrackedOrder],
+        ) -> Result<Vec<ploy_trading::FillRecord>, ExecutionError> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl LiveExecutionGateway for BlockingSubmitGateway {
+        fn probe(&self) -> Result<(), ExecutionError> {
+            Ok(())
+        }
+
+        fn submit(&self, _request: &ExecutionRequest) -> Result<ExecutionOutcome, ExecutionError> {
+            self.submits.fetch_add(1, Ordering::SeqCst);
+            if let Some(entered) = self.entered.lock().expect("entered lock").take() {
+                let _ = entered.send(());
+            }
+            self.release
+                .lock()
+                .expect("release lock")
+                .recv()
+                .expect("release submit");
+            Ok(ExecutionOutcome::Acknowledged {
+                venue_order_id: "venue-blocking".to_string(),
+            })
+        }
+
+        fn cancel(
+            &self,
+            _request: &CancellationRequest,
+        ) -> Result<CancellationOutcome, ExecutionError> {
+            Ok(CancellationOutcome::Canceled)
+        }
+
+        fn replace(&self, _request: &ReplaceRequest) -> Result<ReplaceOutcome, ExecutionError> {
+            unreachable!("replace is not used")
+        }
+
+        fn reconcile_fills(
+            &self,
+            _tracked_orders: &[TrackedOrder],
+        ) -> Result<Vec<ploy_trading::FillRecord>, ExecutionError> {
+            Ok(Vec::new())
+        }
     }
 
     #[test]
@@ -2693,6 +2879,158 @@ mod tests {
             "x".repeat(3000)
         );
         assert!(header_end_offset(request.as_bytes()).is_some());
+    }
+
+    #[test]
+    fn server_handles_multiple_requests_on_one_keep_alive_connection() {
+        let root = temp_dir("server-keep-alive");
+        let runtime_root = root.join("run/platform");
+        let config = crate::config::PlatformConfig {
+            runtime_root: runtime_root.clone(),
+            registry_file: root.join("data/state/deployments.json"),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+        let daemon = crate::runtime::PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(StaticExecutionGateway::acknowledged("unused")),
+        )
+        .expect("boot daemon");
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server_state = Arc::clone(&state);
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            handle_connection(stream, &server_state).expect("serve connection");
+        });
+        let mut client = TcpStream::connect(addr).expect("connect");
+
+        for _ in 0..2 {
+            write!(
+                client,
+                "GET /health HTTP/1.1\r\nHost: {addr}\r\nConnection: keep-alive\r\n\r\n"
+            )
+            .expect("write request");
+            assert!(read_response_body(&mut client).contains("\"status\""));
+        }
+        drop(client);
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    #[ignore = "local no-live-order latency benchmark"]
+    fn live_submit_latency_benchmark() {
+        const SAMPLES: usize = 1_001;
+        let root = temp_dir("live-submit-latency");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([{
+                "deployment_id":"benchmark.live",
+                "bundle_id":"benchmark",
+                "runtime_mode":"live",
+                "account_id":"0x1111111111111111111111111111111111111111",
+                "max_gross_exposure":"1000000",
+                "desired_state":"running",
+                "observed_state":"running"
+            }])
+            .to_string(),
+        )
+        .expect("registry");
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            audit_log_file: runtime_root.join("audit-log.jsonl"),
+            worker_token: Some(secrecy::SecretString::from("benchmark-worker".to_string())),
+            request_rate_limit_per_minute: 0,
+            ..crate::config::PlatformConfig::default()
+        };
+        crate::runtime::seed_empty_live_ledgers(&config);
+        let entered = Arc::new(Mutex::new(Vec::with_capacity(SAMPLES)));
+        let mut daemon = crate::runtime::PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(BenchmarkSubmitGateway {
+                entered: Arc::clone(&entered),
+                submits: AtomicUsize::new(0),
+            }),
+        )
+        .expect("boot daemon");
+        daemon.control_plane.deployments.set_observed_state(
+            "benchmark.live",
+            ploy_operator_contracts::ObservedState::Running,
+        );
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server_state = Arc::clone(&state);
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            handle_connection(stream, &server_state).expect("serve benchmark connection");
+        });
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client.set_nodelay(true).expect("nodelay");
+        let mut decision_to_wire = Vec::with_capacity(SAMPLES);
+        let mut wire_to_ack = Vec::with_capacity(SAMPLES);
+        let mut end_to_end = Vec::with_capacity(SAMPLES);
+
+        for sequence in 0..SAMPLES {
+            let body = serde_json::to_string(&PaperIntentRequest {
+                idempotency_key: Some(format!("latency-{sequence}")),
+                market_id: "market-1".to_string(),
+                token_id: "token-1".to_string(),
+                side: "buy".to_string(),
+                quantity: rust_decimal::Decimal::new(1, 4),
+                limit_price: Some(rust_decimal::Decimal::new(5, 1)),
+                purpose: ploy_operator_contracts::IntentPurpose::Entry,
+            })
+            .expect("request json");
+            let started = Instant::now();
+            write!(
+                client,
+                "POST /api/deployments/benchmark.live/intents HTTP/1.1\r\nHost: {addr}\r\nx-ploy-worker-token: benchmark-worker\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write request");
+            let response = read_response_body(&mut client);
+            let completed = Instant::now();
+            assert!(response.contains("\"state\":\"acknowledged\""));
+            let wire = entered.lock().expect("entered lock")[sequence];
+            decision_to_wire.push(wire.duration_since(started).as_micros() as u64);
+            wire_to_ack.push(completed.duration_since(wire).as_micros() as u64);
+            end_to_end.push(completed.duration_since(started).as_micros() as u64);
+        }
+
+        println!(
+            "live-submit-latency-us decision_to_wire[p50={},p99={},p999={}] wire_to_ack[p50={},p99={},p999={}] end_to_end[p50={},p99={},p999={}] samples={SAMPLES}",
+            percentile_micros(&mut decision_to_wire, 500),
+            percentile_micros(&mut decision_to_wire, 990),
+            percentile_micros(&mut decision_to_wire, 999),
+            percentile_micros(&mut wire_to_ack, 500),
+            percentile_micros(&mut wire_to_ack, 990),
+            percentile_micros(&mut wire_to_ack, 999),
+            percentile_micros(&mut end_to_end, 500),
+            percentile_micros(&mut end_to_end, 990),
+            percentile_micros(&mut end_to_end, 999),
+        );
+        drop(client);
+        server.join().expect("server thread");
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -3690,8 +4028,125 @@ mod tests {
 
         let trading_body =
             fs::read_to_string(runtime_root.join("trading-state.json")).expect("trading snapshot");
-        assert!(trading_body.contains("\"deployment_id\": \"example.live\""));
-        assert!(trading_body.contains("\"venue_order_id\": \"venue-live-http-1\""));
+        let trading: serde_json::Value =
+            serde_json::from_str(&trading_body).expect("snapshot json");
+        assert_eq!(trading[0]["deployment_id"], "example.live");
+        assert_eq!(
+            trading[0]["orders"][0]["venue_order_id"],
+            "venue-live-http-1"
+        );
+    }
+
+    #[test]
+    fn live_venue_submit_does_not_hold_the_daemon_mutex() {
+        let root = temp_dir("runtime-live-unlocked-submit");
+        let runtime_root = root.join("run/platform");
+        let registry_file = root.join("data/state/deployments.json");
+        fs::create_dir_all(&runtime_root).expect("create runtime root");
+        fs::create_dir_all(registry_file.parent().expect("registry parent")).expect("create");
+        fs::write(
+            &registry_file,
+            serde_json::json!([{
+                "deployment_id":"example.live",
+                "bundle_id":"example",
+                "runtime_mode":"live",
+                "account_id":"0x1111111111111111111111111111111111111111",
+                "max_gross_exposure":"5",
+                "desired_state":"running",
+                "observed_state":"running"
+            }])
+            .to_string(),
+        )
+        .expect("registry");
+        let config = crate::config::PlatformConfig {
+            registry_file,
+            runtime_root: runtime_root.clone(),
+            status_file: runtime_root.join("system-status.json"),
+            deployment_status_file: runtime_root.join("deployments.json"),
+            trading_state_file: runtime_root.join("trading-state.json"),
+            ..crate::config::PlatformConfig::default()
+        };
+        crate::runtime::seed_empty_live_ledgers(&config);
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let submits = Arc::new(AtomicUsize::new(0));
+        let mut daemon = crate::runtime::PloyDaemon::boot_with_live_execution(
+            &config,
+            Box::new(BlockingSubmitGateway {
+                entered: Mutex::new(Some(entered_tx)),
+                release: Mutex::new(release_rx),
+                submits: Arc::clone(&submits),
+            }),
+        )
+        .expect("boot daemon");
+        daemon.control_plane.deployments.set_observed_state(
+            "example.live",
+            ploy_operator_contracts::ObservedState::Running,
+        );
+        let state = Arc::new(AppState {
+            daemon: Arc::new(Mutex::new(daemon)),
+            events: Arc::new(EventBroker::default()),
+        });
+        let body = serde_json::to_string(&PaperIntentRequest {
+            idempotency_key: Some("blocking-1".to_string()),
+            market_id: "market-1".to_string(),
+            token_id: "token-1".to_string(),
+            side: "buy".to_string(),
+            quantity: rust_decimal::Decimal::ONE,
+            limit_price: Some(rust_decimal::Decimal::new(5, 1)),
+            purpose: ploy_operator_contracts::IntentPurpose::Entry,
+        })
+        .expect("request json");
+        let retry_body = body.clone();
+        let request_state = Arc::clone(&state);
+        let request = std::thread::spawn(move || {
+            handle_runtime_request(
+                "POST",
+                "/api/deployments/example.live/intents",
+                Some(&body),
+                &request_state,
+            )
+        });
+
+        entered_rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("venue submit entered");
+        let daemon_guard = state
+            .daemon
+            .try_lock()
+            .expect("daemon mutex must be available during venue submit");
+        assert_eq!(
+            daemon_guard
+                .trading
+                .get("example.live")
+                .and_then(|runtime| runtime.order("order-request-blocking-1"))
+                .expect("pending order")
+                .state,
+            ploy_trading::OrderState::Pending
+        );
+        drop(daemon_guard);
+
+        let retry_state = Arc::clone(&state);
+        let (retry_tx, retry_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = retry_tx.send(handle_runtime_request(
+                "POST",
+                "/api/deployments/example.live/intents",
+                Some(&retry_body),
+                &retry_state,
+            ));
+        });
+        let (retry_status, retry_response) = retry_rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("idempotent retry must not wait for venue");
+        assert_eq!(retry_status, 200);
+        assert!(retry_response.contains("\"state\":\"pending\""));
+        assert_eq!(submits.load(Ordering::SeqCst), 1);
+
+        release_tx.send(()).expect("release submit");
+        let (status, response) = request.join().expect("request thread");
+        assert_eq!(status, 200);
+        assert!(response.contains("\"state\":\"acknowledged\""));
     }
 
     #[test]
@@ -3767,8 +4222,10 @@ mod tests {
 
         let trading_body =
             fs::read_to_string(root.join("run/platform/trading-state.json")).expect("snapshot");
-        assert!(trading_body.contains("\"state\": \"unknown\""));
-        assert!(trading_body.contains("\"deployment_id\": \"example.live\""));
+        let trading: serde_json::Value =
+            serde_json::from_str(&trading_body).expect("snapshot json");
+        assert_eq!(trading[0]["orders"][0]["state"], "unknown");
+        assert_eq!(trading[0]["deployment_id"], "example.live");
     }
 
     #[test]
@@ -3856,8 +4313,13 @@ mod tests {
 
         let trading_body =
             fs::read_to_string(runtime_root.join("trading-state.json")).expect("trading snapshot");
-        assert!(trading_body.contains("\"state\": \"canceled\""));
-        assert!(trading_body.contains("\"venue_order_id\": \"venue-live-http-cancel-1\""));
+        let trading: serde_json::Value =
+            serde_json::from_str(&trading_body).expect("snapshot json");
+        assert_eq!(trading[0]["orders"][0]["state"], "canceled");
+        assert_eq!(
+            trading[0]["orders"][0]["venue_order_id"],
+            "venue-live-http-cancel-1"
+        );
     }
 
     #[test]
@@ -3952,9 +4414,13 @@ mod tests {
 
         let trading_body =
             fs::read_to_string(runtime_root.join("trading-state.json")).expect("trading snapshot");
-        assert!(trading_body.contains("\"venue_order_history\": ["));
-        assert!(trading_body.contains("venue-live-http-replace-1"));
-        assert!(trading_body.contains("\"revision\": 1"));
+        let trading: serde_json::Value =
+            serde_json::from_str(&trading_body).expect("snapshot json");
+        assert_eq!(
+            trading[0]["orders"][0]["venue_order_history"][0],
+            "venue-live-http-replace-1"
+        );
+        assert_eq!(trading[0]["orders"][0]["revision"], 1);
     }
 
     #[test]

--- a/crates/ploy-daemon-host/src/runtime.rs
+++ b/crates/ploy-daemon-host/src/runtime.rs
@@ -2,7 +2,9 @@ use crate::config::PlatformConfig;
 use crate::events::EventBroker;
 use crate::http::publish_snapshot_events;
 use chrono::{DateTime, Utc};
-use ploy_connectivity::{LiveExecutionGateway, PolymarketExecutionGateway};
+use ploy_connectivity::{
+    ExecutionError, ExecutionOutcome, LiveExecutionGateway, PolymarketExecutionGateway,
+};
 use ploy_deployments::WorkerSupervisor;
 use ploy_operator_contracts::{
     ActiveAlert, DeploymentApplyRequest, DeploymentControlRequest, DeploymentRuntimeMode,
@@ -15,11 +17,12 @@ use ploy_platform_runtime::runtime_support::{
     account_token_exposure_envelope, intent_risk_effect, IntentAdmissionSource,
 };
 use ploy_platform_runtime::{
-    apply_deployment as apply_deployment_record, apply_loaded_registry_state,
+    apply_deployment as apply_deployment_record,
+    apply_live_intent_outcome as apply_live_runtime_intent_outcome, apply_loaded_registry_state,
     build_trading_state_snapshot, cancel_order as cancel_runtime_order,
     control_deployment as control_deployment_record,
     enforce_exposure_limit as enforce_intent_exposure_limit, ensure_intent_allowed,
-    finish_live_intent as finish_live_runtime_intent, load_proposal_store, load_registry_records,
+    execute_live_intent as execute_live_runtime_intent, load_proposal_store, load_registry_records,
     load_trading_runtimes, mark_live_runtime_degraded as mark_runtime_degraded_state,
     mark_runtime_healthy as mark_runtime_healthy_state, mark_venue_healthy, order_state_wire,
     prepare_live_intent as prepare_live_runtime_intent,
@@ -44,6 +47,40 @@ use std::thread;
 use std::time::Duration;
 
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug)]
+pub enum PreparedIntentSubmission {
+    Complete(PaperIntentResponse),
+    Live(PreparedDaemonLiveIntent),
+}
+
+#[derive(Debug)]
+pub struct PreparedDaemonLiveIntent {
+    deployment_id: String,
+    prepared: PreparedLiveIntent,
+    gateway: Arc<dyn LiveExecutionGateway>,
+}
+
+impl PreparedDaemonLiveIntent {
+    pub fn execute(&self) -> Result<ExecutionOutcome, ExecutionError> {
+        execute_live_runtime_intent(self.gateway.as_ref(), &self.prepared)
+    }
+}
+
+fn response_for_runtime_order(
+    deployment_id: &str,
+    order: &ploy_trading::OrderRecord,
+) -> PaperIntentResponse {
+    PaperIntentResponse {
+        deployment_id: deployment_id.to_string(),
+        intent_id: order.intent_id.clone(),
+        order_id: order.order_id.clone(),
+        state: order_state_wire(order.state),
+        venue_order_id: order.venue_order_id.clone(),
+        rejection_reason: order.rejection_reason.clone(),
+        last_error: order.last_error.clone(),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct LiveApprovalReceipt {
@@ -77,7 +114,7 @@ pub struct PloyDaemon {
     pub supervisor: WorkerSupervisor,
     pub trading: BTreeMap<String, TradingRuntime>,
     proposals: ProposalStore,
-    live_execution: Box<dyn LiveExecutionGateway>,
+    live_execution: Arc<dyn LiveExecutionGateway>,
     live_reconcile_failures: u32,
     next_live_reconcile_at: Option<DateTime<Utc>>,
     last_live_reconcile_error: Option<String>,
@@ -119,7 +156,7 @@ impl PloyDaemon {
             supervisor: WorkerSupervisor::default(),
             trading: BTreeMap::new(),
             proposals: ProposalStore::default(),
-            live_execution,
+            live_execution: Arc::from(live_execution),
             live_reconcile_failures: 0,
             next_live_reconcile_at: None,
             last_live_reconcile_error: None,
@@ -664,6 +701,21 @@ impl PloyDaemon {
         idempotency_key: Option<&str>,
         source: IntentAdmissionSource,
     ) -> io::Result<PaperIntentResponse> {
+        match self.prepare_intent_idempotent_from(intent, idempotency_key, source)? {
+            PreparedIntentSubmission::Complete(response) => Ok(response),
+            PreparedIntentSubmission::Live(prepared) => {
+                let outcome = prepared.execute();
+                self.finish_prepared_live_intent(prepared, outcome)
+            }
+        }
+    }
+
+    pub fn prepare_intent_idempotent_from(
+        &mut self,
+        intent: TradingIntent,
+        idempotency_key: Option<&str>,
+        source: IntentAdmissionSource,
+    ) -> io::Result<PreparedIntentSubmission> {
         let mut deployment = self
             .control_plane
             .deployments
@@ -673,7 +725,7 @@ impl PloyDaemon {
         if let Some(response) =
             self.account_idempotent_response(&deployment.account_id, &intent, idempotency_key)?
         {
-            return Ok(response);
+            return Ok(PreparedIntentSubmission::Complete(response));
         }
 
         self.refresh_source_health();
@@ -726,10 +778,12 @@ impl PloyDaemon {
         )?;
 
         match deployment.runtime_mode {
-            DeploymentRuntimeMode::Paper => {
-                self.submit_paper_intent_idempotent(intent, idempotency_key)
+            DeploymentRuntimeMode::Paper => Ok(PreparedIntentSubmission::Complete(
+                self.submit_paper_intent_idempotent(intent, idempotency_key)?,
+            )),
+            DeploymentRuntimeMode::Live => {
+                self.prepare_live_intent_submission(intent, idempotency_key)
             }
-            DeploymentRuntimeMode::Live => self.submit_live_intent(intent, idempotency_key),
         }
     }
 
@@ -875,28 +929,48 @@ impl PloyDaemon {
         )
     }
 
-    fn submit_live_intent(
+    fn prepare_live_intent_submission(
         &mut self,
         intent: TradingIntent,
         idempotency_key: Option<&str>,
-    ) -> io::Result<PaperIntentResponse> {
+    ) -> io::Result<PreparedIntentSubmission> {
         let deployment_id = intent.deployment_id.clone();
         let prepared = prepare_live_runtime_intent(
             self.trading.entry(deployment_id.clone()).or_default(),
             intent,
             idempotency_key,
         )?;
-        if matches!(prepared, PreparedLiveIntent::Pending { .. }) {
-            self.persist_trading_state()?;
+        match prepared {
+            PreparedLiveIntent::Existing(response) => {
+                Ok(PreparedIntentSubmission::Complete(response))
+            }
+            prepared @ PreparedLiveIntent::Pending { .. } => {
+                self.persist_trading_state()?;
+                Ok(PreparedIntentSubmission::Live(PreparedDaemonLiveIntent {
+                    deployment_id,
+                    prepared,
+                    gateway: Arc::clone(&self.live_execution),
+                }))
+            }
         }
-        let mut response = finish_live_runtime_intent(
+    }
+
+    pub fn finish_prepared_live_intent(
+        &mut self,
+        prepared: PreparedDaemonLiveIntent,
+        outcome: Result<ExecutionOutcome, ExecutionError>,
+    ) -> io::Result<PaperIntentResponse> {
+        let submission_ambiguous = outcome.is_err();
+        let deployment_id = prepared.deployment_id;
+        let mut response = apply_live_runtime_intent_outcome(
             self.trading
                 .get_mut(&deployment_id)
                 .expect("prepared live runtime"),
-            self.live_execution.as_ref(),
-            prepared,
+            prepared.prepared,
+            outcome,
         )?;
-        if response.state != "unknown" {
+        let mut pause_live = submission_ambiguous;
+        if !submission_ambiguous {
             if let Err(error) = self.persist_trading_state() {
                 self.trading
                     .get_mut(&deployment_id)
@@ -905,12 +979,17 @@ impl PloyDaemon {
                         &response.order_id,
                         format!("final persistence failed: {error}"),
                     );
-                response.state = "unknown".to_string();
-                response.venue_order_id = None;
-                response.last_error = Some(format!("final persistence failed: {error}"));
+                response = response_for_runtime_order(
+                    &deployment_id,
+                    self.trading
+                        .get(&deployment_id)
+                        .and_then(|runtime| runtime.order(&response.order_id))
+                        .expect("prepared live order"),
+                );
+                pause_live = true;
             }
         }
-        if response.state == "unknown" {
+        if pause_live {
             let _ = control_deployment_record(
                 &mut self.control_plane.deployments,
                 &deployment_id,

--- a/crates/ploy-daemon-host/src/runtime.rs
+++ b/crates/ploy-daemon-host/src/runtime.rs
@@ -1458,6 +1458,7 @@ mod tests {
                 venue_order_history: Vec::new(),
                 revision: 0,
                 state,
+                state_changed_at: Some(chrono::Utc::now()),
                 filled_qty: if state == OrderState::PartiallyFilled {
                     dec!(0.5)
                 } else {

--- a/crates/ploy-market-contracts/Cargo.toml
+++ b/crates/ploy-market-contracts/Cargo.toml
@@ -14,4 +14,5 @@ rust_decimal.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
+rust_decimal_macros.workspace = true
 serde_json.workspace = true

--- a/crates/ploy-market-contracts/src/fees.rs
+++ b/crates/ploy-market-contracts/src/fees.rs
@@ -1,0 +1,436 @@
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+use rust_decimal::{Decimal, RoundingStrategy};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiquidityRole {
+    Maker,
+    Taker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeeAsset {
+    Collateral,
+    Shares,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeeFormula {
+    ProbabilityPower { exponent: u32 },
+    Notional,
+    PerContract,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeeRounding {
+    Exact,
+    Truncate { decimal_places: u32 },
+    Ceiling { decimal_places: u32 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeeSettlement {
+    TradeFeeOnly,
+    KalshiBalance {
+        balance_decimal_places: u32,
+        rebate_decimal_places: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct FeeAccumulator {
+    pub rounding_overpayment: Decimal,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct FeeCharge {
+    pub trade_fee: Decimal,
+    pub rounding_fee: Decimal,
+    pub rebate: Decimal,
+    pub net_fee: Decimal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FeeSchedule {
+    pub formula: FeeFormula,
+    pub maker_rate: Decimal,
+    pub taker_rate: Decimal,
+    pub rounding: FeeRounding,
+    pub minimum_fee: Decimal,
+    pub settlement: FeeSettlement,
+    #[serde(default)]
+    configured: bool,
+}
+
+impl FeeSchedule {
+    #[must_use]
+    pub const fn new(
+        formula: FeeFormula,
+        maker_rate: Decimal,
+        taker_rate: Decimal,
+        rounding: FeeRounding,
+        minimum_fee: Decimal,
+    ) -> Self {
+        Self {
+            formula,
+            maker_rate,
+            taker_rate,
+            rounding,
+            minimum_fee,
+            settlement: FeeSettlement::TradeFeeOnly,
+            configured: true,
+        }
+    }
+
+    #[must_use]
+    pub const fn unconfigured(formula: FeeFormula) -> Self {
+        Self {
+            formula,
+            maker_rate: Decimal::ZERO,
+            taker_rate: Decimal::ZERO,
+            rounding: FeeRounding::Exact,
+            minimum_fee: Decimal::ZERO,
+            settlement: FeeSettlement::TradeFeeOnly,
+            configured: false,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_configured(self) -> bool {
+        self.configured
+    }
+
+    #[must_use]
+    pub const fn require_market_metadata(mut self) -> Self {
+        self.configured = false;
+        self
+    }
+
+    #[must_use]
+    pub const fn rate_for(self, liquidity_role: LiquidityRole) -> Decimal {
+        match liquidity_role {
+            LiquidityRole::Maker => self.maker_rate,
+            LiquidityRole::Taker => self.taker_rate,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_kalshi_balance_rounding(mut self, balance_decimal_places: u32) -> Self {
+        self.settlement = FeeSettlement::KalshiBalance {
+            balance_decimal_places,
+            rebate_decimal_places: 2,
+        };
+        self
+    }
+
+    #[must_use]
+    pub fn polymarket_v2(rate: Decimal, exponent: u32, taker_only: bool) -> Self {
+        Self::new(
+            FeeFormula::ProbabilityPower { exponent },
+            if taker_only { Decimal::ZERO } else { rate },
+            rate,
+            FeeRounding::Truncate { decimal_places: 5 },
+            Decimal::ZERO,
+        )
+    }
+
+    #[must_use]
+    pub fn calculate(
+        self,
+        quantity: Decimal,
+        price: Decimal,
+        liquidity_role: LiquidityRole,
+    ) -> Decimal {
+        if !self.configured {
+            return Decimal::ZERO;
+        }
+        if quantity <= Decimal::ZERO || price < Decimal::ZERO || price > Decimal::ONE {
+            return Decimal::ZERO;
+        }
+
+        let rate = self.rate_for(liquidity_role);
+        if rate <= Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+
+        let raw = match self.formula {
+            FeeFormula::ProbabilityPower { exponent } => {
+                let mut factor = Decimal::ONE;
+                let base = price * (Decimal::ONE - price);
+                for _ in 0..exponent {
+                    factor *= base;
+                }
+                quantity * rate * factor
+            }
+            FeeFormula::Notional => quantity * price * rate,
+            FeeFormula::PerContract => quantity * rate,
+        };
+
+        let rounded = match self.rounding {
+            FeeRounding::Exact => raw,
+            FeeRounding::Truncate { decimal_places } => {
+                raw.round_dp_with_strategy(decimal_places, RoundingStrategy::ToZero)
+            }
+            FeeRounding::Ceiling { decimal_places } => {
+                raw.round_dp_with_strategy(decimal_places, RoundingStrategy::ToPositiveInfinity)
+            }
+        };
+
+        if rounded > Decimal::ZERO {
+            rounded.max(self.minimum_fee)
+        } else {
+            Decimal::ZERO
+        }
+    }
+
+    #[must_use]
+    pub fn charge(
+        self,
+        quantity: Decimal,
+        price: Decimal,
+        liquidity_role: LiquidityRole,
+        signed_revenue: Decimal,
+        accumulator: &mut FeeAccumulator,
+    ) -> Option<FeeCharge> {
+        if !self.configured {
+            return None;
+        }
+
+        let trade_fee = self.calculate(quantity, price, liquidity_role);
+        let mut charge = FeeCharge {
+            trade_fee,
+            net_fee: trade_fee,
+            ..FeeCharge::default()
+        };
+
+        let FeeSettlement::KalshiBalance {
+            balance_decimal_places,
+            rebate_decimal_places,
+        } = self.settlement
+        else {
+            return Some(charge);
+        };
+
+        let balance_change = signed_revenue - trade_fee;
+        let rounded_balance = balance_change
+            .round_dp_with_strategy(balance_decimal_places, RoundingStrategy::ToNegativeInfinity);
+        charge.rounding_fee = balance_change - rounded_balance;
+        accumulator.rounding_overpayment += charge.rounding_fee;
+
+        let rebate_unit = Decimal::new(1, rebate_decimal_places);
+        if rebate_unit > Decimal::ZERO && accumulator.rounding_overpayment >= rebate_unit {
+            let rebate_units = (accumulator.rounding_overpayment / rebate_unit).floor();
+            charge.rebate = rebate_units * rebate_unit;
+            accumulator.rounding_overpayment -= charge.rebate;
+        }
+        charge.net_fee = (trade_fee + charge.rounding_fee - charge.rebate).max(Decimal::ZERO);
+        Some(charge)
+    }
+}
+
+impl Default for FeeSchedule {
+    fn default() -> Self {
+        Self::polymarket_v2(Decimal::new(7, 2), 1, true)
+    }
+}
+
+#[must_use]
+pub fn polymarket_crypto_taker_fee_per_share(price: f64) -> f64 {
+    if price.is_finite() && (0.0..=1.0).contains(&price) {
+        0.07 * price * (1.0 - price)
+    } else {
+        0.0
+    }
+}
+
+#[must_use]
+pub fn polymarket_crypto_taker_fee_cost(quantity: f64, price: f64) -> f64 {
+    let Some(quantity) = Decimal::from_f64(quantity).filter(|quantity| *quantity > Decimal::ZERO)
+    else {
+        return 0.0;
+    };
+    let Some(price) =
+        Decimal::from_f64(price).filter(|price| *price >= Decimal::ZERO && *price <= Decimal::ONE)
+    else {
+        return 0.0;
+    };
+    FeeSchedule::polymarket_v2(Decimal::new(7, 2), 1, true)
+        .calculate(quantity, price, LiquidityRole::Taker)
+        .to_f64()
+        .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+
+    use super::{FeeAccumulator, FeeFormula, FeeRounding, FeeSchedule, LiquidityRole};
+
+    #[test]
+    fn polymarket_v2_uses_market_rate_exponent_and_taker_only_flag() {
+        let fees = FeeSchedule::polymarket_v2(dec!(0.07), 1, true);
+
+        assert_eq!(
+            fees.calculate(dec!(10), dec!(0.50), LiquidityRole::Taker),
+            dec!(0.17500)
+        );
+        assert_eq!(
+            fees.calculate(dec!(10), dec!(0.50), LiquidityRole::Maker),
+            dec!(0)
+        );
+    }
+
+    #[test]
+    fn polymarket_v2_truncates_to_five_decimals_and_drops_sub_tick_fees() {
+        let fees = FeeSchedule::polymarket_v2(dec!(0.07), 1, true);
+
+        assert_eq!(
+            fees.calculate(dec!(1), dec!(0.01), LiquidityRole::Taker),
+            dec!(0.00069)
+        );
+        assert_eq!(
+            fees.calculate(dec!(1), dec!(0.0001), LiquidityRole::Taker),
+            dec!(0)
+        );
+    }
+
+    #[test]
+    fn predict_fun_can_model_market_fee_bps_without_polymarket_curve() {
+        let fees = FeeSchedule::new(
+            FeeFormula::Notional,
+            dec!(0.02),
+            dec!(0.02),
+            FeeRounding::Exact,
+            dec!(0),
+        );
+
+        assert_eq!(
+            fees.calculate(dec!(10), dec!(0.50), LiquidityRole::Taker),
+            dec!(0.10)
+        );
+    }
+
+    #[test]
+    fn kalshi_style_fees_support_role_specific_rates_and_ceiling() {
+        let fees = FeeSchedule::new(
+            FeeFormula::ProbabilityPower { exponent: 1 },
+            dec!(0.0175),
+            dec!(0.07),
+            FeeRounding::Ceiling { decimal_places: 4 },
+            dec!(0),
+        );
+
+        assert_eq!(
+            fees.calculate(dec!(1), dec!(0.33), LiquidityRole::Taker),
+            dec!(0.0155)
+        );
+        assert_eq!(
+            fees.calculate(dec!(1), dec!(0.33), LiquidityRole::Maker),
+            dec!(0.0039)
+        );
+    }
+
+    #[test]
+    fn kalshi_balance_rounding_accumulates_and_rebates_per_order() {
+        let fees = FeeSchedule::new(
+            FeeFormula::ProbabilityPower { exponent: 1 },
+            dec!(0),
+            dec!(0.07),
+            FeeRounding::Ceiling { decimal_places: 4 },
+            dec!(0),
+        )
+        .with_kalshi_balance_rounding(2);
+        let mut accumulator = FeeAccumulator::default();
+
+        let first = fees
+            .charge(
+                dec!(0.30),
+                dec!(0.50),
+                LiquidityRole::Taker,
+                dec!(-0.15),
+                &mut accumulator,
+            )
+            .expect("configured fee");
+        assert_eq!(first.trade_fee, dec!(0.0053));
+        assert_eq!(first.rounding_fee, dec!(0.0047));
+        assert_eq!(first.rebate, dec!(0));
+        assert_eq!(first.net_fee, dec!(0.0100));
+
+        let second = fees
+            .charge(
+                dec!(0.30),
+                dec!(0.50),
+                LiquidityRole::Taker,
+                dec!(-0.15),
+                &mut accumulator,
+            )
+            .expect("configured fee");
+        assert_eq!(second.net_fee, dec!(0.0100));
+
+        let third = fees
+            .charge(
+                dec!(0.30),
+                dec!(0.50),
+                LiquidityRole::Taker,
+                dec!(-0.15),
+                &mut accumulator,
+            )
+            .expect("configured fee");
+        assert_eq!(third.rebate, dec!(0.01));
+        assert_eq!(third.net_fee, dec!(0));
+        assert_eq!(accumulator.rounding_overpayment, dec!(0.0041));
+    }
+
+    #[test]
+    fn kalshi_direct_member_balance_precision_avoids_cent_rounding_fee() {
+        let fees = FeeSchedule::new(
+            FeeFormula::ProbabilityPower { exponent: 1 },
+            dec!(0),
+            dec!(0.07),
+            FeeRounding::Ceiling { decimal_places: 4 },
+            dec!(0),
+        )
+        .with_kalshi_balance_rounding(4);
+        let charge = fees
+            .charge(
+                dec!(0.30),
+                dec!(0.50),
+                LiquidityRole::Taker,
+                dec!(-0.15),
+                &mut FeeAccumulator::default(),
+            )
+            .expect("configured fee");
+
+        assert_eq!(charge.trade_fee, dec!(0.0053));
+        assert_eq!(charge.rounding_fee, dec!(0));
+        assert_eq!(charge.net_fee, dec!(0.0053));
+    }
+
+    #[test]
+    fn missing_market_fee_metadata_fails_closed() {
+        let fees = FeeSchedule::unconfigured(FeeFormula::Notional);
+
+        assert!(!fees.is_configured());
+        assert!(fees
+            .charge(
+                dec!(10),
+                dec!(0.50),
+                LiquidityRole::Taker,
+                dec!(-5),
+                &mut FeeAccumulator::default(),
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn current_polymarket_crypto_helper_uses_seven_percent_curve() {
+        assert!((super::polymarket_crypto_taker_fee_per_share(0.50) - 0.0175).abs() < 1e-12);
+        assert_eq!(super::polymarket_crypto_taker_fee_cost(1.0, 0.0001), 0.0);
+        assert_eq!(super::polymarket_crypto_taker_fee_cost(10.0, 0.50), 0.175);
+    }
+}

--- a/crates/ploy-market-contracts/src/lib.rs
+++ b/crates/ploy-market-contracts/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod events;
 pub mod family;
 pub mod feed;
+pub mod fees;
 pub mod instrument;
 pub mod venue;
 
@@ -12,5 +13,9 @@ pub use events::{
 };
 pub use family::PredictionFamily;
 pub use feed::{Feed, HistoricalLoadOptions};
+pub use fees::{
+    polymarket_crypto_taker_fee_cost, polymarket_crypto_taker_fee_per_share, FeeAccumulator,
+    FeeAsset, FeeCharge, FeeFormula, FeeRounding, FeeSchedule, FeeSettlement, LiquidityRole,
+};
 pub use instrument::InstrumentKind;
 pub use venue::VenueKind;

--- a/crates/ploy-market-data/src/binance_collectors.rs
+++ b/crates/ploy-market-data/src/binance_collectors.rs
@@ -17,11 +17,20 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, TimeZone, Utc};
 use futures::{SinkExt, StreamExt};
+use ploy_market_contracts::{l2_updates_from_depth_totals, MarketUpdate};
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use serde_json::Value;
 use sqlx::PgPool;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{error, info, warn};
+
+use crate::reference_prices::{
+    market_symbol_to_binance_symbol, upsert_reference_price, ReferenceAssetClass,
+    ReferencePriceKey, ReferencePriceRegistry, ReferencePriceSnapshot, ReferencePriceSource,
+};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -40,6 +49,278 @@ fn parse_symbols(raw: &str) -> Vec<String> {
 fn ms_to_utc(ms: i64) -> DateTime<Utc> {
     Utc.timestamp_opt(ms / 1000, ((ms % 1000) * 1_000_000) as u32)
         .unwrap()
+}
+
+fn market_updates_from_combined_stream(
+    payload: &Value,
+    received_at: DateTime<Utc>,
+) -> Vec<MarketUpdate> {
+    let Some(data) = payload.get("data") else {
+        return Vec::new();
+    };
+    let event = data
+        .get("e")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            payload
+                .get("stream")
+                .and_then(Value::as_str)
+                .and_then(|stream| stream.split('@').nth(1))
+        })
+        .unwrap_or_default();
+
+    if event.eq_ignore_ascii_case("aggTrade") {
+        let Some(symbol) = data.get("s").and_then(Value::as_str) else {
+            return Vec::new();
+        };
+        let Some(agg_trade_id) = data.get("a").and_then(Value::as_u64) else {
+            return Vec::new();
+        };
+        let Some(price) = data
+            .get("p")
+            .and_then(Value::as_str)
+            .and_then(|value| value.parse::<Decimal>().ok())
+            .filter(|price| *price > Decimal::ZERO)
+        else {
+            return Vec::new();
+        };
+        let Some(quantity) = data
+            .get("q")
+            .and_then(Value::as_str)
+            .and_then(|value| value.parse::<Decimal>().ok())
+            .filter(|quantity| *quantity > Decimal::ZERO)
+        else {
+            return Vec::new();
+        };
+        let Some(ts) = data
+            .get("T")
+            .and_then(Value::as_i64)
+            .and_then(|millis| Utc.timestamp_millis_opt(millis).single())
+        else {
+            return Vec::new();
+        };
+        return vec![MarketUpdate::AggTrade {
+            symbol: Arc::from(symbol.to_uppercase()),
+            agg_trade_id,
+            price,
+            quantity,
+            is_buyer_maker: data.get("m").and_then(Value::as_bool).unwrap_or(false),
+            ts,
+        }];
+    }
+
+    if event.eq_ignore_ascii_case("trade") {
+        let Some(symbol) = data.get("s").and_then(Value::as_str) else {
+            return Vec::new();
+        };
+        let Some(price) = data
+            .get("p")
+            .and_then(Value::as_str)
+            .and_then(|value| value.parse::<Decimal>().ok())
+            .filter(|price| *price > Decimal::ZERO)
+        else {
+            return Vec::new();
+        };
+        let Some(ts) = data
+            .get("T")
+            .and_then(Value::as_i64)
+            .and_then(|millis| Utc.timestamp_millis_opt(millis).single())
+        else {
+            return Vec::new();
+        };
+        return vec![MarketUpdate::SpotPrice {
+            symbol: Arc::from(symbol.to_uppercase()),
+            price,
+            ts,
+        }];
+    }
+
+    if event.to_ascii_lowercase().starts_with("depth") {
+        let Some(symbol) = data.get("s").and_then(Value::as_str).or_else(|| {
+            payload
+                .get("stream")
+                .and_then(Value::as_str)
+                .and_then(|stream| stream.split('@').next())
+        }) else {
+            return Vec::new();
+        };
+        let bids = data
+            .get("b")
+            .or_else(|| data.get("bids"))
+            .and_then(Value::as_array)
+            .map(|levels| parse_level(levels))
+            .unwrap_or_default();
+        let asks = data
+            .get("a")
+            .or_else(|| data.get("asks"))
+            .and_then(Value::as_array)
+            .map(|levels| parse_level(levels))
+            .unwrap_or_default();
+        let (Some((best_bid, _)), Some((best_ask, _))) = (bids.first(), asks.first()) else {
+            return Vec::new();
+        };
+        if best_ask < best_bid {
+            return Vec::new();
+        }
+        let mid_price = (*best_bid + *best_ask) / Decimal::from(2);
+        if mid_price <= Decimal::ZERO {
+            return Vec::new();
+        }
+        let spread_bps = ((*best_ask - *best_bid) / mid_price * Decimal::from(10_000))
+            .round_dp(0)
+            .to_u32()
+            .unwrap_or(u32::MAX);
+        let bid_depth = sum_volume(&bids, 5);
+        let ask_depth = sum_volume(&asks, 5);
+        let Some(obi) = obi(bid_depth, ask_depth).to_f64() else {
+            return Vec::new();
+        };
+        let ts = data
+            .get("E")
+            .and_then(Value::as_i64)
+            .and_then(|millis| Utc.timestamp_millis_opt(millis).single())
+            .unwrap_or(received_at);
+        return l2_updates_from_depth_totals(
+            &symbol.to_uppercase(),
+            obi,
+            spread_bps,
+            bid_depth,
+            ask_depth,
+            ts,
+        );
+    }
+
+    Vec::new()
+}
+
+fn send_unavailable_spot_ticks(tx: &broadcast::Sender<MarketUpdate>, symbols: &[String]) -> bool {
+    let ts = Utc::now();
+    symbols.iter().all(|symbol| {
+        tx.send(MarketUpdate::SpotPrice {
+            symbol: Arc::from(symbol.as_str()),
+            price: Decimal::ZERO,
+            ts,
+        })
+        .is_ok()
+    })
+}
+
+/// Stream Binance spot, aggTrade, and partial-depth ticks directly into a
+/// strategy runtime without putting PostgreSQL on the quote-to-decision path.
+///
+/// The standalone collectors remain responsible for durable tick persistence.
+pub fn spawn_binance_tick_feed(
+    tx: Arc<broadcast::Sender<MarketUpdate>>,
+    reference_prices: ReferencePriceRegistry,
+    symbols: Vec<String>,
+    depth_levels: usize,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let symbols = symbols
+            .into_iter()
+            .map(|symbol| symbol.trim().to_uppercase())
+            .filter(|symbol| !symbol.is_empty())
+            .collect::<Vec<_>>();
+        let depth_levels = match depth_levels {
+            5 | 10 | 20 => depth_levels,
+            _ => 20,
+        };
+        let streams = symbols
+            .iter()
+            .flat_map(|symbol| {
+                let symbol = symbol.to_lowercase();
+                [
+                    format!("{symbol}@trade"),
+                    format!("{symbol}@aggTrade"),
+                    format!("{symbol}@depth{depth_levels}@100ms"),
+                ]
+            })
+            .collect::<Vec<_>>();
+        if streams.is_empty() {
+            warn!("Direct Binance tick feed has no configured symbols");
+            return;
+        }
+
+        let mut reconnect_delay = Duration::from_millis(250);
+        loop {
+            let (mut write, mut read) = match binance_connect(&streams).await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    warn!(%error, ?reconnect_delay, "Direct Binance tick feed connect failed");
+                    if !send_unavailable_spot_ticks(&tx, &symbols) {
+                        return;
+                    }
+                    tokio::time::sleep(reconnect_delay).await;
+                    reconnect_delay = (reconnect_delay * 2).min(Duration::from_secs(5));
+                    continue;
+                }
+            };
+            reconnect_delay = Duration::from_millis(250);
+            info!(symbols = ?symbols, depth_levels, "Direct Binance tick feed connected");
+
+            while let Some(message) = read.next().await {
+                match message {
+                    Ok(Message::Text(text)) => {
+                        let payload: Value = match serde_json::from_str(&text) {
+                            Ok(payload) => payload,
+                            Err(error) => {
+                                warn!(%error, "Direct Binance tick payload was invalid JSON");
+                                continue;
+                            }
+                        };
+                        let received_at = Utc::now();
+                        for update in market_updates_from_combined_stream(&payload, received_at) {
+                            let reference_snapshot = match &update {
+                                MarketUpdate::SpotPrice { symbol, price, ts } => {
+                                    Some(ReferencePriceSnapshot {
+                                        key: ReferencePriceKey {
+                                            source: ReferencePriceSource::Binance,
+                                            symbol: market_symbol_to_binance_symbol(symbol),
+                                        },
+                                        asset_class: ReferenceAssetClass::Crypto,
+                                        value: *price,
+                                        full_accuracy_value: None,
+                                        source_timestamp: *ts,
+                                        received_at: Utc::now(),
+                                        is_carried_forward: false,
+                                    })
+                                }
+                                _ => None,
+                            };
+                            if tx.send(update).is_err() {
+                                return;
+                            }
+                            if let Some(snapshot) = reference_snapshot {
+                                upsert_reference_price(&reference_prices, snapshot).await;
+                            }
+                        }
+                    }
+                    Ok(Message::Ping(payload)) => {
+                        if let Err(error) = write.send(Message::Pong(payload)).await {
+                            warn!(%error, "Direct Binance tick feed pong failed");
+                            break;
+                        }
+                    }
+                    Ok(Message::Pong(_)) => {}
+                    Ok(Message::Close(frame)) => {
+                        warn!(?frame, "Direct Binance tick feed closed");
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(%error, "Direct Binance tick feed receive failed");
+                        break;
+                    }
+                }
+            }
+
+            if !send_unavailable_spot_ticks(&tx, &symbols) {
+                return;
+            }
+            tokio::time::sleep(reconnect_delay).await;
+            reconnect_delay = (reconnect_delay * 2).min(Duration::from_secs(5));
+        }
+    })
 }
 
 /// Shared signal — set to false on shutdown request.
@@ -564,4 +845,113 @@ async fn run_lob_ws(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::market_updates_from_combined_stream;
+    use chrono::Utc;
+    use ploy_market_contracts::MarketUpdate;
+    use rust_decimal_macros::dec;
+    use serde_json::json;
+
+    #[test]
+    fn direct_binance_trade_tick_becomes_spot_update() {
+        let payload = json!({
+            "stream": "btcusdt@trade",
+            "data": {
+                "e": "trade",
+                "E": 1712205600120_i64,
+                "s": "BTCUSDT",
+                "p": "65000.25",
+                "q": "0.015",
+                "T": 1712205600123_i64
+            }
+        });
+
+        let updates = market_updates_from_combined_stream(&payload, Utc::now());
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            &updates[0],
+            MarketUpdate::SpotPrice { symbol, price, ts }
+                if symbol.as_ref() == "BTCUSDT"
+                    && *price == dec!(65000.25)
+                    && ts.timestamp_millis() == 1_712_205_600_123
+        ));
+    }
+
+    #[test]
+    fn direct_binance_aggtrade_tick_preserves_aggressor_metadata() {
+        let payload = json!({
+            "stream": "ethusdt@aggTrade",
+            "data": {
+                "e": "aggTrade",
+                "E": 1712205600450_i64,
+                "s": "ETHUSDT",
+                "a": 987_u64,
+                "p": "3500.75",
+                "q": "1.25",
+                "T": 1712205600456_i64,
+                "m": true
+            }
+        });
+
+        let updates = market_updates_from_combined_stream(&payload, Utc::now());
+        assert_eq!(updates.len(), 1);
+        assert!(matches!(
+            &updates[0],
+            MarketUpdate::AggTrade {
+                symbol,
+                agg_trade_id,
+                price,
+                quantity,
+                is_buyer_maker,
+                ts,
+            } if symbol.as_ref() == "ETHUSDT"
+                && *agg_trade_id == 987
+                && *price == dec!(3500.75)
+                && *quantity == dec!(1.25)
+                && *is_buyer_maker
+                && ts.timestamp_millis() == 1_712_205_600_456
+        ));
+    }
+
+    #[test]
+    fn direct_binance_depth_tick_becomes_l2_updates() {
+        let payload = json!({
+            "stream": "btcusdt@depth20@100ms",
+            "data": {
+                "E": 1712205600789_i64,
+                "lastUpdateId": 42_i64,
+                "bids": [["99.95", "5"], ["99.90", "3"]],
+                "asks": [["100.05", "2"], ["100.10", "4"]]
+            }
+        });
+
+        let updates = market_updates_from_combined_stream(&payload, Utc::now());
+        assert_eq!(updates.len(), 2);
+        assert!(matches!(
+            &updates[0],
+            MarketUpdate::L2 {
+                symbol,
+                obi,
+                spread_bps,
+                ts,
+            } if symbol.as_ref() == "BTCUSDT"
+                && (*obi - (2.0 / 14.0)).abs() < 1e-9
+                && *spread_bps == 10
+                && ts.timestamp_millis() == 1_712_205_600_789
+        ));
+        assert!(matches!(
+            &updates[1],
+            MarketUpdate::L2Depth {
+                symbol,
+                bid_depth_near,
+                ask_depth_near,
+                ..
+            } if symbol.as_ref() == "BTCUSDT"
+                && (*bid_depth_near - 8.0).abs() < 1e-9
+                && (*ask_depth_near - 6.0).abs() < 1e-9
+        ));
+    }
 }

--- a/crates/ploy-market-data/src/collector.rs
+++ b/crates/ploy-market-data/src/collector.rs
@@ -149,7 +149,7 @@ enum OfficialMarketSettlementStatus {
     Unknown,
 }
 
-const POLYMARKET_CLOB_WS_ENDPOINT: &str = "wss://ws-subscriptions-clob.polymarket.com";
+pub(crate) const POLYMARKET_CLOB_WS_ENDPOINT: &str = "wss://ws-subscriptions-clob.polymarket.com";
 const POLYMARKET_RTDS_WS_ENDPOINT: &str = "wss://ws-live-data.polymarket.com";
 const HEALTH_CHECK_INTERVAL_SECS: u64 = 5;
 const DEFAULT_PERSIST_QUEUE_CAPACITY: usize = 4_096;

--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -496,6 +496,12 @@ pub fn spawn_db_polymarket_feed(
         let mut expired_events = HashSet::new();
         let mut last_quote_ts: HashMap<String, DateTime<Utc>> = HashMap::new();
         let mut last_book_ts: HashMap<String, DateTime<Utc>> = HashMap::new();
+        let mut active_tokens = Vec::new();
+        let (catalog_poll_interval, quote_poll_interval) = db_polymarket_poll_intervals();
+        let mut catalog_poll = tokio::time::interval(catalog_poll_interval);
+        let mut quote_poll = tokio::time::interval(quote_poll_interval);
+        catalog_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        quote_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         info!(
             symbols = ?symbols_upper,
@@ -503,228 +509,259 @@ pub fn spawn_db_polymarket_feed(
         );
 
         loop {
-            let now = Utc::now();
-            let mut active_tokens = Vec::new();
-
-            let rows: Vec<(
-                String,
-                Option<String>,
-                Option<DateTime<Utc>>,
-                Option<DateTime<Utc>>,
-                Option<String>,
-                Option<String>,
-                Option<Decimal>,
-            )> = match sqlx::query_as(
-                r#"
-                SELECT
-                    market_slug,
-                    symbol,
-                    start_time,
-                    end_time,
-                    ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>0) AS up_token_id,
-                    ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>1) AS down_token_id,
-                    price_to_beat
-                FROM pm_market_metadata
-                WHERE symbol = ANY($1)
-                  AND end_time > NOW() - ($2::BIGINT * INTERVAL '1 second')
-                  AND COALESCE(start_time, end_time - INTERVAL '300 seconds')
-                        < NOW() + INTERVAL '6 minutes'
-                  AND raw_market->'markets'->0->'clobTokenIds' IS NOT NULL
-                ORDER BY start_time, end_time, market_slug
-                "#,
-            )
-            .bind(&symbols_upper)
-            .bind(DB_POLYMARKET_SETTLEMENT_RETRY_LOOKBACK_SECS)
-            .fetch_all(&pool)
-            .await
-            {
-                Ok(rows) => rows,
-                Err(error) => {
-                    warn!(error = %error, "DB Polymarket event query failed");
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    continue;
-                }
-            };
-
-            for (event_id, symbol, start_time, end_time, up_token, down_token, price_to_beat) in
-                rows
-            {
-                let Some(symbol) = symbol.filter(|value| !value.is_empty()) else {
-                    continue;
-                };
-                let Some(end_time) = end_time else {
-                    continue;
-                };
-                let Some(up_token) = up_token.map(|value| normalize_token_id(&value)) else {
-                    continue;
-                };
-                let Some(down_token) = down_token.map(|value| normalize_token_id(&value)) else {
-                    continue;
-                };
-                if up_token.is_empty() || down_token.is_empty() {
-                    continue;
-                }
-
-                let start_time = start_time.unwrap_or(end_time - Duration::seconds(300));
-                let window_secs = (end_time - start_time).num_seconds().max(0) as u64;
-
-                if discovered_events.insert(event_id.clone()) {
-                    let _ = tx.send(MarketUpdate::EventDiscovered {
-                        event_id: Arc::from(event_id.as_str()),
-                        symbol: Arc::from(symbol.as_str()),
-                        up_token: Arc::from(up_token.as_str()),
-                        down_token: Arc::from(down_token.as_str()),
-                        end_time,
-                        window_secs,
-                        price_to_beat,
-                        resolved_up_won: None,
-                    });
-                }
-
-                if end_time <= now {
-                    if !expired_events.contains(&event_id) {
-                        let resolved_up_won =
-                            resolve_db_event_outcome(&pool, &event_id, &up_token, &down_token)
-                                .await;
-                        if !mark_db_event_expired_if_resolved(
-                            &mut expired_events,
-                            &event_id,
-                            resolved_up_won,
-                        ) {
-                            debug!(
-                                event_id = %event_id,
-                                "DB Polymarket event settlement pending; retrying until official outcome is available",
-                            );
-                            continue;
-                        }
-                        let _ = tx.send(MarketUpdate::EventExpired {
-                            event_id: Arc::from(event_id.as_str()),
-                            end_time,
-                            resolved_up_won,
-                        });
-                    }
-                } else {
-                    active_tokens.push(up_token);
-                    active_tokens.push(down_token);
-                }
-            }
-
-            if !active_tokens.is_empty() {
-                let quote_rows: Vec<(
-                    String,
-                    Option<Decimal>,
-                    Option<Decimal>,
-                    Option<Decimal>,
-                    Option<Decimal>,
-                    DateTime<Utc>,
-                )> = match sqlx::query_as(
-                    r#"
-                    SELECT DISTINCT ON (token_id)
-                        token_id, best_bid, best_ask, bid_size, ask_size, received_at
-                    FROM clob_quote_ticks
-                    WHERE token_id = ANY($1)
-                      AND received_at > NOW() - INTERVAL '30 seconds'
-                      AND (best_bid IS NOT NULL OR best_ask IS NOT NULL)
-                    ORDER BY token_id, received_at DESC
-                    "#,
-                )
-                .bind(&active_tokens)
-                .fetch_all(&pool)
-                .await
-                {
-                    Ok(rows) => rows,
-                    Err(error) => {
-                        warn!(error = %error, "DB Polymarket quote query failed");
-                        Vec::new()
-                    }
-                };
-
-                for (token_id, bid, ask, bid_size, ask_size, ts) in quote_rows {
-                    if last_quote_ts
-                        .get(&token_id)
-                        .is_some_and(|last_ts| *last_ts >= ts)
-                    {
-                        continue;
-                    }
-                    last_quote_ts.insert(token_id.clone(), ts);
-                    if tx
-                        .send(MarketUpdate::Quote {
-                            token_id: Arc::from(token_id.as_str()),
-                            bid,
-                            ask,
-                            bid_size,
-                            ask_size,
-                            bid_levels: Vec::new(),
-                            ask_levels: Vec::new(),
-                            ts,
-                        })
-                        .is_err()
-                    {
+            tokio::select! {
+                biased;
+                _ = quote_poll.tick(), if !active_tokens.is_empty() => {
+                    if !publish_db_polymarket_quotes(
+                        &tx,
+                        &pool,
+                        &active_tokens,
+                        &mut last_quote_ts,
+                        &mut last_book_ts,
+                    ).await {
                         return;
                     }
                 }
-
-                let book_rows: Vec<(String, Value, Value, DateTime<Utc>)> = match sqlx::query_as(
-                    r#"
-                    SELECT DISTINCT ON (token_id)
-                        token_id, bids, asks, received_at
-                    FROM clob_orderbook_snapshots
-                    WHERE token_id = ANY($1)
-                      AND received_at > NOW() - INTERVAL '30 seconds'
-                      AND (
-                          jsonb_array_length(bids) > 0
-                          OR jsonb_array_length(asks) > 0
-                      )
-                    ORDER BY token_id, received_at DESC
-                    "#,
-                )
-                .bind(&active_tokens)
-                .fetch_all(&pool)
-                .await
-                {
-                    Ok(rows) => rows,
-                    Err(error) => {
-                        warn!(error = %error, "DB Polymarket orderbook query failed");
-                        Vec::new()
-                    }
-                };
-
-                for (token_id, bids, asks, ts) in book_rows {
-                    if last_book_ts
-                        .get(&token_id)
-                        .is_some_and(|last_ts| *last_ts >= ts)
-                    {
-                        continue;
-                    }
-                    let bid_levels = book_levels_from_json(&bids, false);
-                    let ask_levels = book_levels_from_json(&asks, true);
-                    if bid_levels.is_empty() && ask_levels.is_empty() {
-                        continue;
-                    }
-                    let best_bid = bid_levels.first();
-                    let best_ask = ask_levels.first();
-                    last_book_ts.insert(token_id.clone(), ts);
-                    if tx
-                        .send(MarketUpdate::Quote {
-                            token_id: Arc::from(token_id.as_str()),
-                            bid: best_bid.map(|level| level.price),
-                            ask: best_ask.map(|level| level.price),
-                            bid_size: best_bid.map(|level| level.size),
-                            ask_size: best_ask.map(|level| level.size),
-                            bid_levels,
-                            ask_levels,
-                            ts,
-                        })
-                        .is_err()
-                    {
-                        return;
+                _ = catalog_poll.tick() => {
+                    match refresh_db_polymarket_catalog(
+                        &tx,
+                        &symbols_upper,
+                        &pool,
+                        &mut discovered_events,
+                        &mut expired_events,
+                    ).await {
+                        Ok(tokens) => active_tokens = tokens,
+                        Err(error) => warn!(error = %error, "DB Polymarket event query failed"),
                     }
                 }
             }
-
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
     })
+}
+
+fn db_polymarket_poll_intervals() -> (StdDuration, StdDuration) {
+    (StdDuration::from_secs(2), StdDuration::from_millis(100))
+}
+
+async fn refresh_db_polymarket_catalog(
+    tx: &broadcast::Sender<MarketUpdate>,
+    symbols: &[String],
+    pool: &PgPool,
+    discovered_events: &mut HashSet<String>,
+    expired_events: &mut HashSet<String>,
+) -> Result<Vec<String>, sqlx::Error> {
+    let now = Utc::now();
+    let rows: Vec<(
+        String,
+        Option<String>,
+        Option<DateTime<Utc>>,
+        Option<DateTime<Utc>>,
+        Option<String>,
+        Option<String>,
+        Option<Decimal>,
+    )> = sqlx::query_as(
+        r#"
+        SELECT
+            market_slug,
+            symbol,
+            start_time,
+            end_time,
+            ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>0) AS up_token_id,
+            ((raw_market->'markets'->0->>'clobTokenIds')::jsonb->>1) AS down_token_id,
+            price_to_beat
+        FROM pm_market_metadata
+        WHERE symbol = ANY($1)
+          AND end_time > NOW() - ($2::BIGINT * INTERVAL '1 second')
+          AND COALESCE(start_time, end_time - INTERVAL '300 seconds')
+                < NOW() + INTERVAL '6 minutes'
+          AND raw_market->'markets'->0->'clobTokenIds' IS NOT NULL
+        ORDER BY start_time, end_time, market_slug
+        "#,
+    )
+    .bind(symbols)
+    .bind(DB_POLYMARKET_SETTLEMENT_RETRY_LOOKBACK_SECS)
+    .fetch_all(pool)
+    .await?;
+    let mut active_tokens = Vec::new();
+
+    for (event_id, symbol, start_time, end_time, up_token, down_token, price_to_beat) in rows {
+        let Some(symbol) = symbol.filter(|value| !value.is_empty()) else {
+            continue;
+        };
+        let Some(end_time) = end_time else {
+            continue;
+        };
+        let Some(up_token) = up_token.map(|value| normalize_token_id(&value)) else {
+            continue;
+        };
+        let Some(down_token) = down_token.map(|value| normalize_token_id(&value)) else {
+            continue;
+        };
+        if up_token.is_empty() || down_token.is_empty() {
+            continue;
+        }
+
+        let start_time = start_time.unwrap_or(end_time - Duration::seconds(300));
+        let window_secs = (end_time - start_time).num_seconds().max(0) as u64;
+
+        if discovered_events.insert(event_id.clone()) {
+            let _ = tx.send(MarketUpdate::EventDiscovered {
+                event_id: Arc::from(event_id.as_str()),
+                symbol: Arc::from(symbol.as_str()),
+                up_token: Arc::from(up_token.as_str()),
+                down_token: Arc::from(down_token.as_str()),
+                end_time,
+                window_secs,
+                price_to_beat,
+                resolved_up_won: None,
+            });
+        }
+
+        if end_time <= now {
+            if !expired_events.contains(&event_id) {
+                let resolved_up_won =
+                    resolve_db_event_outcome(pool, &event_id, &up_token, &down_token).await;
+                if !mark_db_event_expired_if_resolved(expired_events, &event_id, resolved_up_won) {
+                    debug!(
+                        event_id = %event_id,
+                        "DB Polymarket event settlement pending; retrying until official outcome is available",
+                    );
+                    continue;
+                }
+                let _ = tx.send(MarketUpdate::EventExpired {
+                    event_id: Arc::from(event_id.as_str()),
+                    end_time,
+                    resolved_up_won,
+                });
+            }
+        } else {
+            active_tokens.push(up_token);
+            active_tokens.push(down_token);
+        }
+    }
+
+    Ok(active_tokens)
+}
+
+async fn publish_db_polymarket_quotes(
+    tx: &broadcast::Sender<MarketUpdate>,
+    pool: &PgPool,
+    active_tokens: &[String],
+    last_quote_ts: &mut HashMap<String, DateTime<Utc>>,
+    last_book_ts: &mut HashMap<String, DateTime<Utc>>,
+) -> bool {
+    let quote_rows: Vec<(
+        String,
+        Option<Decimal>,
+        Option<Decimal>,
+        Option<Decimal>,
+        Option<Decimal>,
+        DateTime<Utc>,
+    )> = match sqlx::query_as(
+        r#"
+        SELECT DISTINCT ON (token_id)
+            token_id, best_bid, best_ask, bid_size, ask_size, received_at
+        FROM clob_quote_ticks
+        WHERE token_id = ANY($1)
+          AND received_at > NOW() - INTERVAL '30 seconds'
+          AND (best_bid IS NOT NULL OR best_ask IS NOT NULL)
+        ORDER BY token_id, received_at DESC
+        "#,
+    )
+    .bind(active_tokens)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            warn!(error = %error, "DB Polymarket quote query failed");
+            Vec::new()
+        }
+    };
+
+    for (token_id, bid, ask, bid_size, ask_size, ts) in quote_rows {
+        if last_quote_ts
+            .get(&token_id)
+            .is_some_and(|last_ts| *last_ts >= ts)
+        {
+            continue;
+        }
+        last_quote_ts.insert(token_id.clone(), ts);
+        if tx
+            .send(MarketUpdate::Quote {
+                token_id: Arc::from(token_id.as_str()),
+                bid,
+                ask,
+                bid_size,
+                ask_size,
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
+                ts,
+            })
+            .is_err()
+        {
+            return false;
+        }
+    }
+
+    let book_rows: Vec<(String, Value, Value, DateTime<Utc>)> = match sqlx::query_as(
+        r#"
+        SELECT DISTINCT ON (token_id)
+            token_id, bids, asks, received_at
+        FROM clob_orderbook_snapshots
+        WHERE token_id = ANY($1)
+          AND received_at > NOW() - INTERVAL '30 seconds'
+          AND (
+              jsonb_array_length(bids) > 0
+              OR jsonb_array_length(asks) > 0
+          )
+        ORDER BY token_id, received_at DESC
+        "#,
+    )
+    .bind(active_tokens)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            warn!(error = %error, "DB Polymarket orderbook query failed");
+            Vec::new()
+        }
+    };
+
+    for (token_id, bids, asks, ts) in book_rows {
+        if last_book_ts
+            .get(&token_id)
+            .is_some_and(|last_ts| *last_ts >= ts)
+        {
+            continue;
+        }
+        let bid_levels = book_levels_from_json(&bids, false);
+        let ask_levels = book_levels_from_json(&asks, true);
+        if bid_levels.is_empty() && ask_levels.is_empty() {
+            continue;
+        }
+        let best_bid = bid_levels.first();
+        let best_ask = ask_levels.first();
+        last_book_ts.insert(token_id.clone(), ts);
+        if tx
+            .send(MarketUpdate::Quote {
+                token_id: Arc::from(token_id.as_str()),
+                bid: best_bid.map(|level| level.price),
+                ask: best_ask.map(|level| level.price),
+                bid_size: best_bid.map(|level| level.size),
+                ask_size: best_ask.map(|level| level.size),
+                bid_levels,
+                ask_levels,
+                ts,
+            })
+            .is_err()
+        {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn mark_db_event_expired_if_resolved(
@@ -1478,9 +1515,9 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 #[cfg(test)]
 mod tests {
     use super::{
-        book_quote_from_rest, equity_price_subscription, l2_updates_from_book,
-        mark_db_event_expired_if_resolved, parse_agg_trade_msg, parse_equity_price_payload,
-        rtds_market_data_ws_config, RestBook,
+        book_quote_from_rest, db_polymarket_poll_intervals, equity_price_subscription,
+        l2_updates_from_book, mark_db_event_expired_if_resolved, parse_agg_trade_msg,
+        parse_equity_price_payload, rtds_market_data_ws_config, RestBook,
     };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;
@@ -1496,6 +1533,13 @@ mod tests {
         assert_eq!(config.heartbeat_interval, Duration::from_secs(15));
         assert_eq!(config.heartbeat_timeout, Duration::from_secs(45));
         assert!(config.reconnect.max_attempts.is_none());
+    }
+
+    #[test]
+    fn db_polymarket_quotes_refresh_without_accelerating_catalog_queries() {
+        let (catalog, quotes) = db_polymarket_poll_intervals();
+        assert_eq!(catalog, Duration::from_secs(2));
+        assert_eq!(quotes, Duration::from_millis(100));
     }
 
     #[test]

--- a/crates/ploy-market-data/src/feeds.rs
+++ b/crates/ploy-market-data/src/feeds.rs
@@ -1,16 +1,22 @@
 //! Live market data feed producers.
 //!
-//! Two async tasks that bridge vendor SDK WebSocket streams into the
-//! unified `MarketUpdate` broadcast channel consumed by `LiveFeed`.
+//! Async tasks that bridge venue WebSocket/REST streams into the unified
+//! `MarketUpdate` broadcast channel consumed by `LiveFeed`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration as StdDuration;
+use std::time::{Duration as StdDuration, Instant};
 
 use chrono::{DateTime, Duration, Timelike, Utc};
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use ploy_market_contracts::{
     l2_updates_from_depth_totals, normalize_token_id, BookLevel, MarketUpdate,
+};
+use polymarket_client_sdk::clob::types::Side;
+use polymarket_client_sdk::clob::ws::interest::MessageInterest;
+use polymarket_client_sdk::clob::ws::types::request::SubscriptionRequest;
+use polymarket_client_sdk::clob::ws::types::response::{
+    parse_if_interested, BookUpdate, PriceChange, PriceChangeBatchEntry, WsMessage,
 };
 use polymarket_client_sdk::rtds::{Client as RtdsClient, Subscription};
 use polymarket_client_sdk::types::U256;
@@ -22,8 +28,10 @@ use serde_json::Value;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
 use tokio::task::{JoinHandle, JoinSet};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, error, info, warn};
 
+use crate::collector::POLYMARKET_CLOB_WS_ENDPOINT;
 use crate::reference_prices::{
     infer_pyth_asset_class, market_symbol_to_binance_symbol, normalize_reference_symbol,
     pyth_symbol, upsert_reference_price, ReferenceAssetClass, ReferencePriceKey,
@@ -934,6 +942,379 @@ fn book_levels_from_json(value: &Value, ascending: bool) -> Vec<BookLevel> {
     levels
 }
 
+#[derive(Default)]
+struct ClobBookState {
+    bids: BTreeMap<Decimal, Decimal>,
+    asks: BTreeMap<Decimal, Decimal>,
+    initialized: bool,
+}
+
+impl ClobBookState {
+    fn replace(&mut self, book: &BookUpdate) {
+        self.bids = book
+            .bids
+            .iter()
+            .filter(|level| {
+                level.size > Decimal::ZERO
+                    && level.price > Decimal::ZERO
+                    && level.price < Decimal::ONE
+            })
+            .map(|level| (level.price, level.size))
+            .collect();
+        self.asks = book
+            .asks
+            .iter()
+            .filter(|level| {
+                level.size > Decimal::ZERO
+                    && level.price > Decimal::ZERO
+                    && level.price < Decimal::ONE
+            })
+            .map(|level| (level.price, level.size))
+            .collect();
+        self.initialized = true;
+    }
+
+    fn apply(&mut self, entry: &PriceChangeBatchEntry) {
+        let Some(size) = entry.size else {
+            self.bids.clear();
+            self.asks.clear();
+            self.initialized = false;
+            return;
+        };
+        if !self.initialized {
+            return;
+        }
+        let levels = match entry.side {
+            Side::Buy => &mut self.bids,
+            Side::Sell => &mut self.asks,
+            _ => {
+                self.bids.clear();
+                self.asks.clear();
+                self.initialized = false;
+                return;
+            }
+        };
+        if size > Decimal::ZERO {
+            levels.insert(entry.price, size);
+        } else {
+            levels.remove(&entry.price);
+        }
+    }
+
+    fn quote(
+        &self,
+        token_id: String,
+        ts: DateTime<Utc>,
+        entry: Option<&PriceChangeBatchEntry>,
+    ) -> MarketUpdate {
+        let bid_levels = if self.initialized {
+            self.bids
+                .iter()
+                .rev()
+                .map(|(price, size)| BookLevel {
+                    price: *price,
+                    size: *size,
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let ask_levels = if self.initialized {
+            self.asks
+                .iter()
+                .map(|(price, size)| BookLevel {
+                    price: *price,
+                    size: *size,
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let bid = bid_levels
+            .first()
+            .map(|level| level.price)
+            .or_else(|| entry.and_then(|change| change.best_bid));
+        let ask = ask_levels
+            .first()
+            .map(|level| level.price)
+            .or_else(|| entry.and_then(|change| change.best_ask));
+        let bid_size = bid_levels.first().map(|level| level.size).or_else(|| {
+            entry.and_then(|change| {
+                (change.side == Side::Buy && Some(change.price) == bid)
+                    .then_some(change.size)
+                    .flatten()
+                    .filter(|size| *size > Decimal::ZERO)
+            })
+        });
+        let ask_size = ask_levels.first().map(|level| level.size).or_else(|| {
+            entry.and_then(|change| {
+                (change.side == Side::Sell && Some(change.price) == ask)
+                    .then_some(change.size)
+                    .flatten()
+                    .filter(|size| *size > Decimal::ZERO)
+            })
+        });
+        MarketUpdate::Quote {
+            token_id: Arc::from(token_id),
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            bid_levels,
+            ask_levels,
+            ts,
+        }
+    }
+}
+
+fn market_update_from_clob_book(
+    book: &BookUpdate,
+    state: &mut ClobBookState,
+) -> Option<MarketUpdate> {
+    state.replace(book);
+    Some(state.quote(
+        book.asset_id.to_string(),
+        DateTime::from_timestamp_millis(book.timestamp)?,
+        None,
+    ))
+}
+
+fn market_updates_from_price_change(
+    change: &PriceChange,
+    books: &mut HashMap<String, ClobBookState>,
+    last_timestamp: &mut HashMap<String, i64>,
+) -> Vec<MarketUpdate> {
+    let Some(ts) = DateTime::from_timestamp_millis(change.timestamp) else {
+        return Vec::new();
+    };
+    change
+        .price_changes
+        .iter()
+        .filter_map(|entry| {
+            let token_id = entry.asset_id.to_string();
+            if last_timestamp
+                .get(&token_id)
+                .is_some_and(|last| change.timestamp < *last)
+            {
+                return None;
+            }
+            let state = books.entry(token_id.clone()).or_default();
+            state.apply(entry);
+            last_timestamp.insert(token_id.clone(), change.timestamp);
+            Some(state.quote(token_id, ts, Some(entry)))
+        })
+        .collect()
+}
+
+fn send_empty_polymarket_quotes(tx: &broadcast::Sender<MarketUpdate>, token_ids: &[U256]) -> bool {
+    let now = Utc::now();
+    token_ids.iter().all(|token_id| {
+        tx.send(MarketUpdate::Quote {
+            token_id: Arc::from(token_id.to_string()),
+            bid: None,
+            ask: None,
+            bid_size: None,
+            ask_size: None,
+            bid_levels: Vec::new(),
+            ask_levels: Vec::new(),
+            ts: now,
+        })
+        .is_ok()
+    })
+}
+
+fn forward_clob_ws_payload(
+    payload: &[u8],
+    tx: &broadcast::Sender<MarketUpdate>,
+    books_by_token: &mut HashMap<String, ClobBookState>,
+    last_timestamp: &mut HashMap<String, i64>,
+) -> Result<bool, String> {
+    let messages = parse_if_interested(payload, &MessageInterest::MARKET)
+        .map_err(|error| error.to_string())?;
+    for message in messages {
+        match message {
+            WsMessage::Book(book) => {
+                let token_id = book.asset_id.to_string();
+                if last_timestamp
+                    .get(&token_id)
+                    .is_some_and(|last| book.timestamp < *last)
+                {
+                    continue;
+                }
+                last_timestamp.insert(token_id.clone(), book.timestamp);
+                let state = books_by_token.entry(token_id).or_default();
+                if let Some(update) = market_update_from_clob_book(&book, state) {
+                    if tx.send(update).is_err() {
+                        return Ok(false);
+                    }
+                }
+            }
+            WsMessage::PriceChange(change) => {
+                for update in
+                    market_updates_from_price_change(&change, books_by_token, last_timestamp)
+                {
+                    if tx.send(update).is_err() {
+                        return Ok(false);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(true)
+}
+
+/// Publish Polymarket CLOB book and BBA ticks directly to the strategy runtime.
+///
+/// Disconnects publish empty quotes so the strategy fails closed until a fresh
+/// WebSocket snapshot arrives. REST polling is intentionally kept out of this
+/// hot path because it can reopen trading with delayed state.
+pub fn spawn_clob_ws_quote_feed_until(
+    tx: Arc<broadcast::Sender<MarketUpdate>>,
+    token_ids: Vec<U256>,
+    stop_at: Option<DateTime<Utc>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut last_timestamp: HashMap<String, i64> = HashMap::new();
+        let mut books_by_token: HashMap<String, ClobBookState> = HashMap::new();
+        let endpoint = format!(
+            "{}/ws/market",
+            POLYMARKET_CLOB_WS_ENDPOINT.trim_end_matches('/')
+        );
+
+        loop {
+            if stop_at.is_some_and(|deadline| Utc::now() >= deadline) {
+                return;
+            }
+
+            let (socket, _) = match connect_async(&endpoint).await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    warn!(%error, %endpoint, "Polymarket hot-path WebSocket connect failed");
+                    last_timestamp.clear();
+                    books_by_token.clear();
+                    if !send_empty_polymarket_quotes(&tx, &token_ids) {
+                        return;
+                    }
+                    tokio::time::sleep(StdDuration::from_millis(250)).await;
+                    continue;
+                }
+            };
+            let (mut write, mut read) = socket.split();
+            let subscription =
+                match serde_json::to_string(&SubscriptionRequest::market(token_ids.clone())) {
+                    Ok(subscription) => subscription,
+                    Err(error) => {
+                        error!(%error, "Polymarket subscription serialization failed");
+                        return;
+                    }
+                };
+            if let Err(error) = write.send(Message::Text(subscription.into())).await {
+                warn!(%error, "Polymarket hot-path subscription send failed");
+                last_timestamp.clear();
+                books_by_token.clear();
+                if !send_empty_polymarket_quotes(&tx, &token_ids) {
+                    return;
+                }
+                tokio::time::sleep(StdDuration::from_millis(250)).await;
+                continue;
+            }
+
+            let mut heartbeat = tokio::time::interval(StdDuration::from_secs(3));
+            heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            heartbeat.tick().await;
+            let mut last_pong = Instant::now();
+            let stop = async {
+                match stop_at {
+                    Some(deadline) => {
+                        tokio::time::sleep((deadline - Utc::now()).to_std().unwrap_or_default())
+                            .await;
+                    }
+                    None => std::future::pending::<()>().await,
+                }
+            };
+            tokio::pin!(stop);
+
+            loop {
+                tokio::select! {
+                    _ = &mut stop => return,
+                    message = read.next() => match message {
+                        Some(Ok(Message::Text(text))) if text == "PONG" => {
+                            last_pong = Instant::now();
+                        }
+                        Some(Ok(Message::Text(text))) => {
+                            match forward_clob_ws_payload(
+                                text.as_bytes(),
+                                &tx,
+                                &mut books_by_token,
+                                &mut last_timestamp,
+                            ) {
+                                Ok(true) => {}
+                                Ok(false) => return,
+                                Err(error) => {
+                                    warn!(%error, "Polymarket hot-path payload parse failed; reconnecting for a fresh snapshot");
+                                    break;
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Binary(bytes))) => {
+                            match forward_clob_ws_payload(
+                                bytes.as_ref(),
+                                &tx,
+                                &mut books_by_token,
+                                &mut last_timestamp,
+                            ) {
+                                Ok(true) => {}
+                                Ok(false) => return,
+                                Err(error) => {
+                                    warn!(%error, "Polymarket hot-path binary payload parse failed; reconnecting for a fresh snapshot");
+                                    break;
+                                }
+                            }
+                        }
+                        Some(Ok(Message::Ping(payload))) => {
+                            if let Err(error) = write.send(Message::Pong(payload)).await {
+                                warn!(%error, "Polymarket hot-path pong failed");
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Pong(_))) => {
+                            last_pong = Instant::now();
+                        }
+                        Some(Ok(Message::Close(frame))) => {
+                            warn!(?frame, "Polymarket hot-path WebSocket closed");
+                            break;
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(error)) => {
+                            warn!(%error, "Polymarket hot-path WebSocket receive failed");
+                            break;
+                        }
+                        None => break,
+                    },
+                    _ = heartbeat.tick() => {
+                        if last_pong.elapsed() > StdDuration::from_secs(6) {
+                            warn!("Polymarket hot-path heartbeat timed out");
+                            break;
+                        }
+                        if let Err(error) = write.send(Message::Text("PING".into())).await {
+                            warn!(%error, "Polymarket hot-path heartbeat send failed");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            last_timestamp.clear();
+            books_by_token.clear();
+            if !send_empty_polymarket_quotes(&tx, &token_ids) {
+                return;
+            }
+            tokio::time::sleep(StdDuration::from_millis(250)).await;
+        }
+    })
+}
+
 /// Spawn a task that polls the Polymarket CLOB REST API for orderbook data
 /// and publishes `MarketUpdate::Quote` events with top-of-book sizes.
 ///
@@ -1516,8 +1897,9 @@ fn parse_agg_trade_msg(v: &serde_json::Value) -> Option<AggTradeMsg> {
 mod tests {
     use super::{
         book_quote_from_rest, db_polymarket_poll_intervals, equity_price_subscription,
-        l2_updates_from_book, mark_db_event_expired_if_resolved, parse_agg_trade_msg,
-        parse_equity_price_payload, rtds_market_data_ws_config, RestBook,
+        l2_updates_from_book, mark_db_event_expired_if_resolved, market_update_from_clob_book,
+        market_updates_from_price_change, parse_agg_trade_msg, parse_equity_price_payload,
+        rtds_market_data_ws_config, ClobBookState, RestBook,
     };
     use chrono::Utc;
     use ploy_market_contracts::MarketUpdate;
@@ -1540,6 +1922,248 @@ mod tests {
         let (catalog, quotes) = db_polymarket_poll_intervals();
         assert_eq!(catalog, Duration::from_secs(2));
         assert_eq!(quotes, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn clob_book_tick_becomes_immediate_depth_quote() {
+        let book = serde_json::from_value(json!({
+            "asset_id": "7",
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600123",
+            "bids": [
+                {"price": "0.52", "size": "7.25"},
+                {"price": "0.47", "size": "12.5"}
+            ],
+            "asks": [
+                {"price": "0.53", "size": "9.5"},
+                {"price": "0.54", "size": "20"}
+            ],
+            "hash": null
+        }))
+        .expect("valid CLOB book update");
+
+        let update = market_update_from_clob_book(&book, &mut ClobBookState::default())
+            .expect("tradeable quote");
+        let MarketUpdate::Quote {
+            token_id,
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            bid_levels,
+            ask_levels,
+            ts,
+        } = update
+        else {
+            panic!("expected quote update");
+        };
+
+        assert_eq!(token_id.as_ref(), "7");
+        assert_eq!(bid, Some(dec!(0.52)));
+        assert_eq!(ask, Some(dec!(0.53)));
+        assert_eq!(bid_size, Some(dec!(7.25)));
+        assert_eq!(ask_size, Some(dec!(9.5)));
+        assert_eq!(bid_levels.len(), 2);
+        assert_eq!(ask_levels.len(), 2);
+        assert_eq!(ts.timestamp_millis(), 1_712_205_600_123);
+    }
+
+    #[test]
+    fn clob_price_change_becomes_immediate_bba_tick() {
+        let change = serde_json::from_value(json!({
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600456",
+            "price_changes": [{
+                "asset_id": "7",
+                "price": "0.53",
+                "size": "4",
+                "side": "SELL",
+                "hash": null,
+                "best_bid": "0.51",
+                "best_ask": "0.53"
+            }]
+        }))
+        .expect("valid price change");
+
+        let updates = market_updates_from_price_change(
+            &change,
+            &mut std::collections::HashMap::new(),
+            &mut std::collections::HashMap::new(),
+        );
+        assert_eq!(updates.len(), 1);
+        let MarketUpdate::Quote {
+            token_id,
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            bid_levels,
+            ask_levels,
+            ts,
+        } = &updates[0]
+        else {
+            panic!("expected quote update");
+        };
+
+        assert_eq!(token_id.as_ref(), "7");
+        assert_eq!(*bid, Some(dec!(0.51)));
+        assert_eq!(*ask, Some(dec!(0.53)));
+        assert_eq!(*bid_size, None);
+        assert_eq!(*ask_size, Some(dec!(4)));
+        assert!(bid_levels.is_empty());
+        assert!(ask_levels.is_empty());
+        assert_eq!(ts.timestamp_millis(), 1_712_205_600_456);
+    }
+
+    #[test]
+    fn clob_empty_book_tick_clears_stale_quote() {
+        let book = serde_json::from_value(json!({
+            "asset_id": "7",
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600789",
+            "bids": [],
+            "asks": [],
+            "hash": null
+        }))
+        .expect("valid empty CLOB book update");
+
+        let update = market_update_from_clob_book(&book, &mut ClobBookState::default())
+            .expect("empty book is still a state transition");
+        assert!(matches!(
+            update,
+            MarketUpdate::Quote {
+                bid: None,
+                ask: None,
+                bid_size: None,
+                ask_size: None,
+                bid_levels,
+                ask_levels,
+                ..
+            } if bid_levels.is_empty() && ask_levels.is_empty()
+        ));
+    }
+
+    #[test]
+    fn clob_cancel_tick_updates_cached_depth_before_broadcast() {
+        let book = serde_json::from_value(json!({
+            "asset_id": "7",
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600100",
+            "bids": [{"price": "0.52", "size": "7.25"}],
+            "asks": [
+                {"price": "0.53", "size": "9.5"},
+                {"price": "0.54", "size": "20"}
+            ],
+            "hash": null
+        }))
+        .expect("valid CLOB book update");
+        let change = serde_json::from_value(json!({
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600200",
+            "price_changes": [{
+                "asset_id": "7",
+                "price": "0.53",
+                "size": "0",
+                "side": "SELL",
+                "hash": null,
+                "best_bid": "0.52",
+                "best_ask": "0.54"
+            }]
+        }))
+        .expect("valid cancellation price change");
+
+        let mut state = ClobBookState::default();
+        market_update_from_clob_book(&book, &mut state).expect("initial snapshot");
+        let mut books = std::collections::HashMap::from([("7".to_string(), state)]);
+        let updates = market_updates_from_price_change(
+            &change,
+            &mut books,
+            &mut std::collections::HashMap::new(),
+        );
+
+        assert!(matches!(
+            updates.as_slice(),
+            [MarketUpdate::Quote {
+                ask: Some(ask),
+                ask_size: Some(size),
+                ask_levels,
+                ..
+            }] if *ask == dec!(0.54)
+                && *size == dec!(20)
+                && ask_levels == &vec![ploy_market_contracts::BookLevel {
+                    price: dec!(0.54),
+                    size: dec!(20),
+                }]
+        ));
+    }
+
+    #[test]
+    fn stale_clob_price_change_cannot_mutate_cached_book() {
+        let book = serde_json::from_value(json!({
+            "asset_id": "7",
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600100",
+            "bids": [{"price": "0.52", "size": "7.25"}],
+            "asks": [
+                {"price": "0.53", "size": "9.5"},
+                {"price": "0.54", "size": "20"}
+            ],
+            "hash": null
+        }))
+        .expect("valid CLOB book update");
+        let newer = serde_json::from_value(json!({
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600300",
+            "price_changes": [{
+                "asset_id": "7", "price": "0.53", "size": "0", "side": "SELL",
+                "hash": null, "best_bid": "0.52", "best_ask": "0.54"
+            }]
+        }))
+        .expect("newer price change");
+        let stale = serde_json::from_value(json!({
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600200",
+            "price_changes": [{
+                "asset_id": "7", "price": "0.53", "size": "100", "side": "SELL",
+                "hash": null, "best_bid": "0.52", "best_ask": "0.53"
+            }]
+        }))
+        .expect("stale price change");
+        let same_millisecond = serde_json::from_value(json!({
+            "market": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "timestamp": "1712205600300",
+            "price_changes": [{
+                "asset_id": "7", "price": "0.54", "size": "30", "side": "SELL",
+                "hash": null, "best_bid": "0.52", "best_ask": "0.54"
+            }]
+        }))
+        .expect("same-millisecond price change");
+
+        let mut state = ClobBookState::default();
+        market_update_from_clob_book(&book, &mut state).expect("initial snapshot");
+        let mut books = std::collections::HashMap::from([("7".to_string(), state)]);
+        let mut timestamps = std::collections::HashMap::from([("7".to_string(), book.timestamp)]);
+        assert_eq!(
+            market_updates_from_price_change(&newer, &mut books, &mut timestamps).len(),
+            1
+        );
+        assert_eq!(
+            market_updates_from_price_change(&same_millisecond, &mut books, &mut timestamps,).len(),
+            1,
+            "distinct deltas sharing a wire millisecond must not be dropped"
+        );
+        assert!(market_updates_from_price_change(&stale, &mut books, &mut timestamps).is_empty());
+
+        let quote = books["7"].quote(
+            "7".to_string(),
+            chrono::DateTime::from_timestamp_millis(newer.timestamp).unwrap(),
+            None,
+        );
+        assert!(matches!(
+            quote,
+            MarketUpdate::Quote { ask: Some(ask), ask_size: Some(size), .. }
+                if ask == dec!(0.54) && size == dec!(30)
+        ));
     }
 
     #[test]

--- a/crates/ploy-market-data/src/scanner.rs
+++ b/crates/ploy-market-data/src/scanner.rs
@@ -25,7 +25,7 @@ use crate::discovery::crypto::discover_crypto_markets;
 use crate::discovery::crypto::DiscoveredCryptoMarket;
 use crate::discovery::sports::discover_sports_markets;
 use crate::discovery::upsert_market_catalog;
-use crate::feeds::spawn_quote_feed_until;
+use crate::feeds::spawn_clob_ws_quote_feed_until;
 use crate::gamma_keyset::fetch_markets;
 use crate::reference_prices::{new_reference_price_registry, ReferencePriceRegistry};
 
@@ -246,13 +246,11 @@ pub fn spawn_market_scanner(
                             total_tracked = tracked.len(),
                             "Discovered new markets, subscribing to quotes",
                         );
-                        let handle = spawn_quote_feed_until(
+                        quote_handles.push(spawn_clob_ws_quote_feed_until(
                             tx.clone(),
                             new_tokens,
-                            pool.clone(),
                             quote_stop_at,
-                        );
-                        quote_handles.push(handle);
+                        ));
                     } else {
                         debug!(tracked = tracked.len(), "Scanner poll: no new markets");
                     }
@@ -496,9 +494,11 @@ async fn recover_pending_open_positions(
             tokens = new_tokens.len(),
             "Recovery: subscribing to quote feeds for pending positions"
         );
-        let handle =
-            spawn_quote_feed_until(tx.clone(), new_tokens, Some(pool.clone()), recovery_stop_at);
-        quote_handles.push(handle);
+        quote_handles.push(spawn_clob_ws_quote_feed_until(
+            tx.clone(),
+            new_tokens,
+            recovery_stop_at,
+        ));
     }
 }
 

--- a/crates/ploy-operator-contracts/src/trading.rs
+++ b/crates/ploy-operator-contracts/src/trading.rs
@@ -84,6 +84,8 @@ pub struct OrderSnapshot {
     #[serde(default)]
     pub revision: u32,
     pub state: String,
+    #[serde(default)]
+    pub state_changed_at: Option<DateTime<Utc>>,
     pub filled_qty: Decimal,
     pub rejection_reason: Option<String>,
     pub last_error: Option<String>,
@@ -349,6 +351,7 @@ mod tests {
                 venue_order_history: vec!["venue-0".to_string()],
                 revision: 1,
                 state: "filled".to_string(),
+                state_changed_at: Some(timestamp),
                 filled_qty: rust_decimal::Decimal::ONE,
                 rejection_reason: None,
                 last_error: None,
@@ -386,6 +389,7 @@ mod tests {
                     "venue_order_history": ["venue-0"],
                     "revision": 1,
                     "state": "filled",
+                    "state_changed_at": timestamp,
                     "filled_qty": "1",
                     "rejection_reason": null,
                     "last_error": null,

--- a/crates/ploy-platform-runtime/src/lib.rs
+++ b/crates/ploy-platform-runtime/src/lib.rs
@@ -35,8 +35,8 @@ pub use runtime_support::{
 pub use state_io::{load_proposal_store, load_registry_records, load_trading_runtimes};
 pub use trade_control::{cancel_order, replace_order};
 pub use trade_submit::{
-    finish_live_intent, prepare_live_intent, submit_live_intent, submit_paper_intent,
-    PreparedLiveIntent,
+    apply_live_intent_outcome, execute_live_intent, finish_live_intent, prepare_live_intent,
+    submit_live_intent, submit_paper_intent, PreparedLiveIntent,
 };
 pub use worker_tick::{
     build_worker_launch_spec, refresh_source_health, tick_workers, WorkerTickConfig,

--- a/crates/ploy-platform-runtime/src/reconcile.rs
+++ b/crates/ploy-platform-runtime/src/reconcile.rs
@@ -40,11 +40,24 @@ pub fn reconcile_live_fills(
             let Some(venue_order_id) = order.venue_order_id.clone() else {
                 continue;
             };
+            let side = runtime
+                .intent(&order.intent_id)
+                .map(|intent| intent.side.clone())
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tracked order `{}` references missing intent `{}`",
+                            order.order_id, order.intent_id
+                        ),
+                    )
+                })?;
             order_deployments.insert(order.order_id.clone(), record.deployment_id.clone());
             tracked_orders.push(TrackedOrder {
                 order_id: order.order_id,
                 venue_order_id,
                 token_id: order.token_id,
+                side,
             });
         }
     }

--- a/crates/ploy-platform-runtime/src/reconcile.rs
+++ b/crates/ploy-platform-runtime/src/reconcile.rs
@@ -41,7 +41,7 @@ pub fn reconcile_live_fills(
                     ) || (matches!(order.state, ploy_trading::OrderState::Canceled)
                         && order
                             .state_changed_at
-                            .map_or(true, |changed_at| changed_at >= terminal_cutoff)))
+                            .is_none_or(|changed_at| changed_at >= terminal_cutoff)))
             })
         {
             let Some(venue_order_id) = order.venue_order_id.clone() else {
@@ -49,7 +49,7 @@ pub fn reconcile_live_fills(
             };
             let side = runtime
                 .intent(&order.intent_id)
-                .map(|intent| intent.side.clone())
+                .map(|intent| intent.side)
                 .ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -75,7 +75,7 @@ pub fn reconcile_live_fills(
 
     let batch = live_execution
         .reconcile_updates(&tracked_orders)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+        .map_err(|err| io::Error::other(err.to_string()))?;
 
     let mut recorded = 0;
     for fill in batch.fills {

--- a/crates/ploy-platform-runtime/src/reconcile.rs
+++ b/crates/ploy-platform-runtime/src/reconcile.rs
@@ -1,10 +1,12 @@
 use crate::ReconcileStatus;
-use ploy_connectivity::{LiveExecutionGateway, TrackedOrder};
+use ploy_connectivity::{LiveExecutionGateway, OrderObservation, TrackedOrder};
 use ploy_operator_contracts::DeploymentRuntimeMode;
 use ploy_platform::DeploymentRecord;
 use ploy_trading::TradingRuntime;
 use std::collections::{BTreeMap, HashMap};
 use std::io;
+
+const TERMINAL_RECONCILE_RETENTION_HOURS: i64 = 24;
 
 pub fn reconcile_live_fills(
     live_execution: &dyn LiveExecutionGateway,
@@ -13,6 +15,8 @@ pub fn reconcile_live_fills(
 ) -> io::Result<ReconcileStatus> {
     let mut tracked_orders = Vec::new();
     let mut order_deployments = HashMap::new();
+    let terminal_cutoff =
+        chrono::Utc::now() - chrono::Duration::hours(TERMINAL_RECONCILE_RETENTION_HOURS);
 
     for record in deployments {
         if record.runtime_mode != DeploymentRuntimeMode::Live {
@@ -29,12 +33,15 @@ pub fn reconcile_live_fills(
             .into_iter()
             .filter(|order| {
                 order.venue_order_id.is_some()
-                    && matches!(
+                    && (matches!(
                         order.state,
                         ploy_trading::OrderState::Unknown
                             | ploy_trading::OrderState::Acknowledged
                             | ploy_trading::OrderState::PartiallyFilled
-                    )
+                    ) || (matches!(order.state, ploy_trading::OrderState::Canceled)
+                        && order
+                            .state_changed_at
+                            .map_or(true, |changed_at| changed_at >= terminal_cutoff)))
             })
         {
             let Some(venue_order_id) = order.venue_order_id.clone() else {
@@ -66,12 +73,12 @@ pub fn reconcile_live_fills(
         return Ok(ReconcileStatus::Noop);
     }
 
-    let fills = live_execution
-        .reconcile_fills(&tracked_orders)
+    let batch = live_execution
+        .reconcile_updates(&tracked_orders)
         .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
 
     let mut recorded = 0;
-    for fill in fills {
+    for fill in batch.fills {
         let Some(deployment_id) = order_deployments.get(&fill.order_id) else {
             continue;
         };
@@ -83,16 +90,42 @@ pub fn reconcile_live_fills(
         }
     }
 
+    for observation in batch.order_observations {
+        let order_id = match &observation {
+            OrderObservation::Acknowledged { order_id, .. }
+            | OrderObservation::Canceled { order_id } => order_id,
+        };
+        let Some(deployment_id) = order_deployments.get(order_id) else {
+            continue;
+        };
+        let Some(runtime) = trading.get_mut(deployment_id) else {
+            continue;
+        };
+        match observation {
+            OrderObservation::Acknowledged {
+                order_id,
+                venue_order_id,
+            } => {
+                runtime.acknowledge_order(&order_id, venue_order_id);
+            }
+            OrderObservation::Canceled { order_id } => {
+                runtime.cancel_order(&order_id);
+            }
+        }
+    }
+
     Ok(ReconcileStatus::Applied(recorded))
 }
 
 #[cfg(test)]
 mod tests {
     use super::reconcile_live_fills;
-    use ploy_connectivity::StaticExecutionGateway;
+    use ploy_connectivity::{OrderObservation, ReconcileBatch, StaticExecutionGateway};
     use ploy_operator_contracts::{DeploymentState, DesiredState, ObservedState};
     use ploy_platform::DeploymentRecord;
-    use ploy_trading::{FillRecord, IntentPurpose, TradeSide, TradingIntent, TradingRuntime};
+    use ploy_trading::{
+        FillRecord, IntentPurpose, OrderState, TradeSide, TradingIntent, TradingRuntime,
+    };
     use rust_decimal_macros::dec;
     use std::collections::BTreeMap;
 
@@ -249,5 +282,128 @@ mod tests {
             .expect("archived order reconciliation");
 
         assert_eq!(result, crate::ReconcileStatus::Applied(1));
+    }
+
+    #[test]
+    fn confirmed_fill_is_applied_before_cancellation_observation() {
+        let deployment = DeploymentRecord {
+            deployment_id: "example.live".to_string(),
+            bundle_id: "example".to_string(),
+            runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Live,
+            account_id: "acct-live".to_string(),
+            max_gross_exposure: Some(dec!(5)),
+            deployment_state: DeploymentState::Enabled,
+            desired_state: DesiredState::Running,
+            observed_state: ObservedState::Running,
+        };
+        let mut runtime = TradingRuntime::default();
+        runtime
+            .submit_intent(
+                TradingIntent {
+                    intent_id: "intent-ordered".to_string(),
+                    deployment_id: deployment.deployment_id.clone(),
+                    market_id: "market-1".to_string(),
+                    token_id: "token-1".to_string(),
+                    side: TradeSide::Buy,
+                    quantity: dec!(2),
+                    limit_price: Some(dec!(0.45)),
+                    purpose: IntentPurpose::Entry,
+                    created_at: chrono::Utc::now(),
+                },
+                "order-ordered",
+                None,
+            )
+            .expect("valid intent");
+        runtime.acknowledge_order("order-ordered", "venue-ordered");
+
+        let gateway = StaticExecutionGateway::acknowledged("venue-ordered")
+            .with_reconciled_updates(ReconcileBatch {
+                fills: vec![FillRecord {
+                    fill_id: "fill-ordered".to_string(),
+                    order_id: "order-ordered".to_string(),
+                    token_id: "token-1".to_string(),
+                    side: TradeSide::Buy,
+                    quantity: dec!(1),
+                    price: dec!(0.45),
+                    fee: dec!(0.01),
+                    timestamp: chrono::Utc::now(),
+                }],
+                order_observations: vec![OrderObservation::Canceled {
+                    order_id: "order-ordered".to_string(),
+                }],
+            });
+        let mut trading = BTreeMap::from([(deployment.deployment_id.clone(), runtime)]);
+
+        let result =
+            reconcile_live_fills(&gateway, &[deployment], &mut trading).expect("reconcile updates");
+
+        assert_eq!(result, crate::ReconcileStatus::Applied(1));
+        let snapshot = trading
+            .get("example.live")
+            .expect("runtime")
+            .snapshot(&BTreeMap::new());
+        assert_eq!(snapshot.fills.len(), 1);
+        assert_eq!(snapshot.orders[0].filled_qty, dec!(1));
+        assert_eq!(snapshot.orders[0].state, OrderState::Canceled);
+    }
+
+    #[test]
+    fn recently_canceled_order_remains_reconcilable_for_late_confirmed_fill() {
+        let deployment = DeploymentRecord {
+            deployment_id: "example.live".to_string(),
+            bundle_id: "example".to_string(),
+            runtime_mode: ploy_operator_contracts::DeploymentRuntimeMode::Live,
+            account_id: "acct-live".to_string(),
+            max_gross_exposure: Some(dec!(5)),
+            deployment_state: DeploymentState::Enabled,
+            desired_state: DesiredState::Running,
+            observed_state: ObservedState::Running,
+        };
+        let mut runtime = TradingRuntime::default();
+        runtime
+            .submit_intent(
+                TradingIntent {
+                    intent_id: "intent-canceled".to_string(),
+                    deployment_id: deployment.deployment_id.clone(),
+                    market_id: "market-1".to_string(),
+                    token_id: "token-1".to_string(),
+                    side: TradeSide::Buy,
+                    quantity: dec!(2),
+                    limit_price: Some(dec!(0.45)),
+                    purpose: IntentPurpose::Entry,
+                    created_at: chrono::Utc::now(),
+                },
+                "order-canceled",
+                None,
+            )
+            .expect("valid intent");
+        runtime.acknowledge_order("order-canceled", "venue-canceled");
+        runtime.cancel_order("order-canceled");
+
+        let gateway =
+            StaticExecutionGateway::acknowledged("venue-canceled").with_reconciled_fills(vec![
+                FillRecord {
+                    fill_id: "fill-after-cancel".to_string(),
+                    order_id: "order-canceled".to_string(),
+                    token_id: "token-1".to_string(),
+                    side: TradeSide::Buy,
+                    quantity: dec!(1),
+                    price: dec!(0.45),
+                    fee: dec!(0.01),
+                    timestamp: chrono::Utc::now(),
+                },
+            ]);
+        let mut trading = BTreeMap::from([(deployment.deployment_id.clone(), runtime)]);
+
+        let result = reconcile_live_fills(&gateway, &[deployment], &mut trading)
+            .expect("late fill reconciliation");
+
+        assert_eq!(result, crate::ReconcileStatus::Applied(1));
+        let snapshot = trading
+            .get("example.live")
+            .expect("runtime")
+            .snapshot(&BTreeMap::new());
+        assert_eq!(snapshot.fills.len(), 1);
+        assert_eq!(snapshot.orders[0].filled_qty, dec!(1));
     }
 }

--- a/crates/ploy-platform-runtime/src/runtime_support.rs
+++ b/crates/ploy-platform-runtime/src/runtime_support.rs
@@ -461,10 +461,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        IntentRiskEffect, account_token_exposure_envelope, build_order_control_response,
-        intent_risk_effect, live_reconcile_backoff_ms, observed_state_for_desired,
-        order_state_from_wire, order_state_wire, restore_trading_runtime, trade_side_from_wire,
-        trade_side_wire,
+        account_token_exposure_envelope, build_order_control_response, intent_risk_effect,
+        live_reconcile_backoff_ms, observed_state_for_desired, order_state_from_wire,
+        order_state_wire, restore_trading_runtime, trade_side_from_wire, trade_side_wire,
+        IntentRiskEffect,
     };
     use ploy_operator_contracts::{
         DeploymentState, DesiredState, FillSnapshot, IntentPurpose, ObservedState, OrderSnapshot,

--- a/crates/ploy-platform-runtime/src/runtime_support.rs
+++ b/crates/ploy-platform-runtime/src/runtime_support.rs
@@ -86,6 +86,7 @@ pub fn build_trading_state_snapshot(
                 venue_order_history: order.venue_order_history,
                 revision: order.revision,
                 state: order_state_wire(order.state),
+                state_changed_at: order.state_changed_at,
                 filled_qty: order.filled_qty,
                 rejection_reason: order.rejection_reason,
                 last_error: order.last_error,
@@ -168,6 +169,7 @@ pub fn restore_trading_runtime(snapshot: TradingStateSnapshot) -> io::Result<Tra
                 venue_order_history: order.venue_order_history,
                 revision: order.revision,
                 state: order_state_from_wire(&order.state)?,
+                state_changed_at: order.state_changed_at,
                 filled_qty: order.filled_qty,
                 rejection_reason: order.rejection_reason,
                 last_error: order.last_error,
@@ -459,10 +461,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        account_token_exposure_envelope, build_order_control_response, intent_risk_effect,
-        live_reconcile_backoff_ms, observed_state_for_desired, order_state_from_wire,
-        order_state_wire, restore_trading_runtime, trade_side_from_wire, trade_side_wire,
-        IntentRiskEffect,
+        IntentRiskEffect, account_token_exposure_envelope, build_order_control_response,
+        intent_risk_effect, live_reconcile_backoff_ms, observed_state_for_desired,
+        order_state_from_wire, order_state_wire, restore_trading_runtime, trade_side_from_wire,
+        trade_side_wire,
     };
     use ploy_operator_contracts::{
         DeploymentState, DesiredState, FillSnapshot, IntentPurpose, ObservedState, OrderSnapshot,
@@ -544,6 +546,7 @@ mod tests {
             venue_order_history: Vec::new(),
             revision: 0,
             state,
+            state_changed_at: Some(chrono::Utc::now()),
             filled_qty,
             rejection_reason: None,
             last_error: None,
@@ -642,6 +645,7 @@ mod tests {
             venue_order_history: vec!["venue-0".to_string()],
             revision: 2,
             state: OrderState::Acknowledged,
+            state_changed_at: Some(chrono::Utc::now()),
             filled_qty: Decimal::new(25, 0),
             rejection_reason: None,
             last_error: None,
@@ -704,6 +708,7 @@ mod tests {
                 venue_order_history: Vec::new(),
                 revision: 0,
                 state: "filled".to_string(),
+                state_changed_at: Some(now),
                 filled_qty: dec!(4),
                 rejection_reason: None,
                 last_error: None,
@@ -728,5 +733,6 @@ mod tests {
         assert_eq!(restored.positions[0].net_qty, dec!(4));
         assert_eq!(restored.fills.len(), 1);
         assert_eq!(restored.orders[0].state, OrderState::Filled);
+        assert_eq!(restored.orders[0].state_changed_at, Some(now));
     }
 }

--- a/crates/ploy-platform-runtime/src/runtime_support.rs
+++ b/crates/ploy-platform-runtime/src/runtime_support.rs
@@ -451,8 +451,8 @@ where
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
     fs::create_dir_all(parent)?;
-    let body = serde_json::to_vec_pretty(value)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let body =
+        serde_json::to_vec(value).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
     let tmp_path = path.with_extension("tmp");
     fs::write(&tmp_path, &body)?;
     fs::rename(&tmp_path, path)

--- a/crates/ploy-platform-runtime/src/trade_control.rs
+++ b/crates/ploy-platform-runtime/src/trade_control.rs
@@ -19,6 +19,16 @@ pub fn cancel_order(
         .cloned()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
 
+    if deployment.runtime_mode == DeploymentRuntimeMode::Live
+        && order.state == OrderState::Pending
+        && order.venue_order_id.is_none()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("order `{order_id}` submission is in progress"),
+        ));
+    }
+
     if !matches!(
         order.state,
         OrderState::Pending | OrderState::Acknowledged | OrderState::PartiallyFilled
@@ -76,6 +86,16 @@ pub fn replace_order(
         .order(order_id)
         .cloned()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
+
+    if deployment.runtime_mode == DeploymentRuntimeMode::Live
+        && order.state == OrderState::Pending
+        && order.venue_order_id.is_none()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("order `{order_id}` submission is in progress"),
+        ));
+    }
 
     if !matches!(
         order.state,
@@ -204,6 +224,7 @@ mod tests {
     use ploy_trading::{
         FillRecord, IntentPurpose, OrderState, TradeSide, TradingIntent, TradingRuntime,
     };
+    use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use std::io::ErrorKind;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -447,5 +468,54 @@ mod tests {
         assert_eq!(error.kind(), ErrorKind::InvalidInput);
         assert_eq!(gateway.replacements.load(Ordering::SeqCst), 0);
         assert_eq!(runtime.snapshot(&std::collections::BTreeMap::new()), before);
+    }
+
+    #[test]
+    fn live_submission_in_progress_cannot_be_canceled_or_replaced() {
+        let runtime = seeded_runtime();
+        let snapshot = runtime.snapshot(&std::collections::BTreeMap::new());
+        let mut pending = TradingRuntime::default();
+        let intent = snapshot.intents[0].clone();
+        pending
+            .submit_intent(intent, "order-1", None)
+            .expect("pending order");
+        let gateway = CountingControlGateway::default();
+
+        let cancel_error = cancel_order(
+            &mut pending,
+            &gateway,
+            &live_deployment(),
+            "example.live",
+            "order-1",
+        )
+        .expect_err("pending live submission cannot be canceled");
+        let replace_error = replace_order(
+            &mut pending,
+            &gateway,
+            &live_deployment(),
+            "example.live",
+            "order-1",
+            OrderReplaceRequest {
+                quantity: dec!(2),
+                limit_price: Some(dec!(0.47)),
+            },
+            Decimal::ZERO,
+        )
+        .expect_err("pending live submission cannot be replaced");
+
+        assert_eq!(cancel_error.kind(), ErrorKind::InvalidInput);
+        assert!(cancel_error
+            .to_string()
+            .contains("submission is in progress"));
+        assert_eq!(replace_error.kind(), ErrorKind::InvalidInput);
+        assert!(replace_error
+            .to_string()
+            .contains("submission is in progress"));
+        assert_eq!(gateway.cancellations.load(Ordering::SeqCst), 0);
+        assert_eq!(gateway.replacements.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            pending.order("order-1").expect("pending order").state,
+            OrderState::Pending
+        );
     }
 }

--- a/crates/ploy-platform-runtime/src/trade_control.rs
+++ b/crates/ploy-platform-runtime/src/trade_control.rs
@@ -504,17 +504,13 @@ mod tests {
         .expect_err("pending live submission cannot be replaced");
 
         assert_eq!(cancel_error.kind(), ErrorKind::InvalidInput);
-        assert!(
-            cancel_error
-                .to_string()
-                .contains("submission is in progress")
-        );
+        assert!(cancel_error
+            .to_string()
+            .contains("submission is in progress"));
         assert_eq!(replace_error.kind(), ErrorKind::InvalidInput);
-        assert!(
-            replace_error
-                .to_string()
-                .contains("submission is in progress")
-        );
+        assert!(replace_error
+            .to_string()
+            .contains("submission is in progress"));
         assert_eq!(gateway.cancellations.load(Ordering::SeqCst), 0);
         assert_eq!(gateway.replacements.load(Ordering::SeqCst), 0);
         assert_eq!(

--- a/crates/ploy-platform-runtime/src/trade_control.rs
+++ b/crates/ploy-platform-runtime/src/trade_control.rs
@@ -7,6 +7,22 @@ use ploy_platform::DeploymentRecord;
 use ploy_trading::{OrderState, TradingRuntime};
 use std::io;
 
+fn reject_submission_in_progress(
+    deployment: &DeploymentRecord,
+    order: &ploy_trading::OrderRecord,
+) -> io::Result<()> {
+    if deployment.runtime_mode == DeploymentRuntimeMode::Live
+        && order.state == OrderState::Pending
+        && order.venue_order_id.is_none()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("order `{}` submission is in progress", order.order_id),
+        ));
+    }
+    Ok(())
+}
+
 pub fn cancel_order(
     runtime: &mut TradingRuntime,
     gateway: &dyn LiveExecutionGateway,
@@ -19,15 +35,7 @@ pub fn cancel_order(
         .cloned()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
 
-    if deployment.runtime_mode == DeploymentRuntimeMode::Live
-        && order.state == OrderState::Pending
-        && order.venue_order_id.is_none()
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("order `{order_id}` submission is in progress"),
-        ));
-    }
+    reject_submission_in_progress(deployment, &order)?;
 
     if !matches!(
         order.state,
@@ -87,15 +95,7 @@ pub fn replace_order(
         .cloned()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "order not found"))?;
 
-    if deployment.runtime_mode == DeploymentRuntimeMode::Live
-        && order.state == OrderState::Pending
-        && order.venue_order_id.is_none()
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("order `{order_id}` submission is in progress"),
-        ));
-    }
+    reject_submission_in_progress(deployment, &order)?;
 
     if !matches!(
         order.state,
@@ -504,13 +504,17 @@ mod tests {
         .expect_err("pending live submission cannot be replaced");
 
         assert_eq!(cancel_error.kind(), ErrorKind::InvalidInput);
-        assert!(cancel_error
-            .to_string()
-            .contains("submission is in progress"));
+        assert!(
+            cancel_error
+                .to_string()
+                .contains("submission is in progress")
+        );
         assert_eq!(replace_error.kind(), ErrorKind::InvalidInput);
-        assert!(replace_error
-            .to_string()
-            .contains("submission is in progress"));
+        assert!(
+            replace_error
+                .to_string()
+                .contains("submission is in progress")
+        );
         assert_eq!(gateway.cancellations.load(Ordering::SeqCst), 0);
         assert_eq!(gateway.replacements.load(Ordering::SeqCst), 0);
         assert_eq!(

--- a/crates/ploy-platform-runtime/src/trade_submit.rs
+++ b/crates/ploy-platform-runtime/src/trade_submit.rs
@@ -63,6 +63,7 @@ pub fn submit_live_intent(
     finish_live_intent(runtime, gateway, prepared)
 }
 
+#[derive(Debug, Clone)]
 pub enum PreparedLiveIntent {
     Existing(PaperIntentResponse),
     Pending {
@@ -121,12 +122,20 @@ pub fn finish_live_intent(
     gateway: &dyn LiveExecutionGateway,
     prepared: PreparedLiveIntent,
 ) -> io::Result<PaperIntentResponse> {
-    let (intent, order_id) = match prepared {
-        PreparedLiveIntent::Existing(response) => return Ok(response),
-        PreparedLiveIntent::Pending { intent, order_id } => (intent, order_id),
-    };
+    let outcome = execute_live_intent(gateway, &prepared);
+    apply_live_intent_outcome(runtime, prepared, outcome)
+}
 
-    let outcome = gateway.submit(&ExecutionRequest {
+pub fn execute_live_intent(
+    gateway: &dyn LiveExecutionGateway,
+    prepared: &PreparedLiveIntent,
+) -> Result<ExecutionOutcome, ploy_connectivity::ExecutionError> {
+    let PreparedLiveIntent::Pending { intent, order_id } = prepared else {
+        return Err(ploy_connectivity::ExecutionError::Validation(
+            "existing live intent must not be submitted again".to_string(),
+        ));
+    };
+    gateway.submit(&ExecutionRequest {
         order_id: order_id.clone(),
         token_id: intent.token_id.clone(),
         side: intent.side,
@@ -134,51 +143,41 @@ pub fn finish_live_intent(
         limit_price: intent.limit_price,
         order_type: OrderExecutionType::GTC,
         aggressive_ticks: 0,
-    });
+    })
+}
 
+pub fn apply_live_intent_outcome(
+    runtime: &mut TradingRuntime,
+    prepared: PreparedLiveIntent,
+    outcome: Result<ExecutionOutcome, ploy_connectivity::ExecutionError>,
+) -> io::Result<PaperIntentResponse> {
+    let (intent, order_id) = match prepared {
+        PreparedLiveIntent::Existing(response) => return Ok(response),
+        PreparedLiveIntent::Pending { intent, order_id } => (intent, order_id),
+    };
     match outcome {
         Ok(ExecutionOutcome::Acknowledged { venue_order_id }) => {
-            runtime.acknowledge_order(&order_id, venue_order_id.clone());
-            Ok(PaperIntentResponse {
-                deployment_id: intent.deployment_id,
-                intent_id: intent.intent_id,
-                order_id,
-                state: "acknowledged".to_string(),
-                venue_order_id: Some(venue_order_id),
-                rejection_reason: None,
-                last_error: None,
-            })
+            runtime.acknowledge_order(&order_id, venue_order_id);
         }
         Ok(ExecutionOutcome::Rejected { reason }) => {
-            runtime.reject_order(&order_id, reason.clone());
-            Ok(PaperIntentResponse {
-                deployment_id: intent.deployment_id,
-                intent_id: intent.intent_id,
-                order_id,
-                state: "rejected".to_string(),
-                venue_order_id: None,
-                rejection_reason: Some(reason.clone()),
-                last_error: Some(reason),
-            })
+            runtime.reject_order(&order_id, reason);
         }
         Err(err) => {
             runtime.mark_order_unknown(&order_id, err.to_string());
-            Ok(PaperIntentResponse {
-                deployment_id: intent.deployment_id,
-                intent_id: intent.intent_id,
-                order_id,
-                state: "unknown".to_string(),
-                venue_order_id: None,
-                rejection_reason: None,
-                last_error: Some(err.to_string()),
-            })
         }
     }
+    let order = runtime
+        .order(&order_id)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "prepared order not found"))?;
+    Ok(response_for_order(intent.deployment_id, order))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{submit_live_intent, submit_paper_intent};
+    use super::{
+        apply_live_intent_outcome, execute_live_intent, prepare_live_intent, submit_live_intent,
+        submit_paper_intent,
+    };
     use ploy_connectivity::{
         CancellationOutcome, CancellationRequest, ExecutionError, ExecutionOutcome,
         ExecutionRequest, LiveExecutionGateway, ReplaceOutcome, ReplaceRequest, TrackedOrder,
@@ -371,5 +370,34 @@ mod tests {
         assert_eq!(replay.order_id, first.order_id);
         assert_eq!(gateway.submits.load(Ordering::SeqCst), 1);
         assert_eq!(replay_gateway.submits.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn live_submit_execution_is_separate_from_pending_and_terminal_state_changes() {
+        let mut runtime = TradingRuntime::default();
+        let gateway = CountingGateway::default();
+        let prepared =
+            prepare_live_intent(&mut runtime, intent(), Some("request-1")).expect("prepare");
+        assert_eq!(
+            runtime
+                .order("order-intent-1")
+                .expect("pending order")
+                .state,
+            ploy_trading::OrderState::Pending
+        );
+
+        let outcome = execute_live_intent(&gateway, &prepared);
+        assert_eq!(
+            runtime
+                .order("order-intent-1")
+                .expect("pending order")
+                .state,
+            ploy_trading::OrderState::Pending
+        );
+
+        let response = apply_live_intent_outcome(&mut runtime, prepared, outcome)
+            .expect("apply submission outcome");
+        assert_eq!(response.state, "acknowledged");
+        assert_eq!(gateway.submits.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
+++ b/crates/ploy-research/examples/three_layer_snapshot_optimize.rs
@@ -2311,6 +2311,7 @@ mod tests {
             } else {
                 0.0
             },
+            entry_sweep_fee_usd_15u: 0.0,
             exit_sweep_shares_15u: 15.0 / 0.70,
             entry_sweep_levels_15u: if fillable { 1.0 } else { 0.0 },
             exit_sweep_levels_15u: if fillable { 1.0 } else { 0.0 },

--- a/crates/ploy-research/src/autofactor.rs
+++ b/crates/ploy-research/src/autofactor.rs
@@ -1085,7 +1085,7 @@ fn valid_pm_price(value: f64) -> bool {
 }
 
 fn pm_fee_cost(entry_price: f64) -> f64 {
-    0.02 * entry_price * (1.0 - entry_price)
+    ploy_market_contracts::polymarket_crypto_taker_fee_per_share(entry_price)
 }
 
 fn settlement_edge(probability: f64, entry_price: f64) -> f64 {
@@ -3160,6 +3160,7 @@ mod tests {
             entry_sweep_avg_price_15u: 0.50,
             exit_sweep_avg_price_15u: 0.48,
             entry_sweep_shares_15u: 30.0,
+            entry_sweep_fee_usd_15u: 0.0,
             exit_sweep_shares_15u: 30.0,
             entry_sweep_levels_15u: 1.0,
             exit_sweep_levels_15u: 1.0,

--- a/crates/ploy-research/src/factors.rs
+++ b/crates/ploy-research/src/factors.rs
@@ -2298,7 +2298,7 @@ fn inv_normal_cdf(p: f64) -> f64 {
 }
 
 fn crypto_fee_cost(entry_price: f64) -> f64 {
-    0.02 * entry_price * (1.0 - entry_price)
+    ploy_market_contracts::polymarket_crypto_taker_fee_per_share(entry_price)
 }
 
 fn reward_risk_ratio(entry_price: f64) -> f64 {

--- a/crates/ploy-research/src/factors_v2.rs
+++ b/crates/ploy-research/src/factors_v2.rs
@@ -208,6 +208,8 @@ pub struct FactorObservationV2 {
     pub entry_sweep_avg_price_15u: f64,
     pub exit_sweep_avg_price_15u: f64,
     pub entry_sweep_shares_15u: f64,
+    #[serde(default = "nan_f64")]
+    pub entry_sweep_fee_usd_15u: f64,
     pub exit_sweep_shares_15u: f64,
     pub entry_sweep_levels_15u: f64,
     pub exit_sweep_levels_15u: f64,
@@ -7082,8 +7084,13 @@ struct SweepFill {
     fillable: bool,
     avg_price: f64,
     shares: f64,
+    fee_usd: f64,
     levels_used: f64,
     slippage_bps: f64,
+}
+
+fn nan_f64() -> f64 {
+    f64::NAN
 }
 
 impl Default for SweepFill {
@@ -7092,6 +7099,7 @@ impl Default for SweepFill {
             fillable: false,
             avg_price: f64::NAN,
             shares: f64::NAN,
+            fee_usd: f64::NAN,
             levels_used: f64::NAN,
             slippage_bps: f64::NAN,
         }
@@ -7158,6 +7166,7 @@ fn sweep_buy_to_stake_with_config(
     let mut remaining = stake_usd;
     let mut spent = 0.0;
     let mut shares = 0.0;
+    let mut fee_usd = 0.0;
     let mut levels_used = 0.0;
     for level in levels
         .iter()
@@ -7173,7 +7182,10 @@ fn sweep_buy_to_stake_with_config(
             continue;
         }
         spent += take_notional;
-        shares += take_notional / level.price;
+        let take_shares = take_notional / level.price;
+        shares += take_shares;
+        fee_usd +=
+            ploy_market_contracts::polymarket_crypto_taker_fee_cost(take_shares, level.price);
         remaining -= take_notional;
         levels_used += 1.0;
     }
@@ -7185,6 +7197,7 @@ fn sweep_buy_to_stake_with_config(
         fillable: true,
         avg_price,
         shares,
+        fee_usd,
         levels_used,
         slippage_bps: ((avg_price - reference_price).max(0.0) / reference_price) * 10_000.0,
     }
@@ -7215,6 +7228,7 @@ fn sweep_sell_shares_with_config(
     let mut remaining = shares_to_sell;
     let mut proceeds = 0.0;
     let mut sold = 0.0;
+    let mut fee_usd = 0.0;
     let mut levels_used = 0.0;
     for level in levels
         .iter()
@@ -7227,6 +7241,8 @@ fn sweep_sell_shares_with_config(
         let take_shares = remaining.min(level.size * haircut);
         proceeds += take_shares * level.price;
         sold += take_shares;
+        fee_usd +=
+            ploy_market_contracts::polymarket_crypto_taker_fee_cost(take_shares, level.price);
         remaining -= take_shares;
         levels_used += 1.0;
     }
@@ -7238,6 +7254,7 @@ fn sweep_sell_shares_with_config(
         fillable: true,
         avg_price,
         shares: sold,
+        fee_usd,
         levels_used,
         slippage_bps: ((reference_price - avg_price).max(0.0) / reference_price) * 10_000.0,
     }
@@ -7404,8 +7421,8 @@ fn build_full_depth_execution_sample(
             )
         })
         .unwrap_or_default();
-    let entry_fee = if entry_sweep.fillable && valid_price(entry_sweep.avg_price) {
-        entry_sweep.shares * crypto_fee_cost(entry_sweep.avg_price)
+    let entry_fee = if entry_sweep.fillable && entry_sweep.fee_usd.is_finite() {
+        entry_sweep.fee_usd
     } else {
         f64::NAN
     };
@@ -7454,9 +7471,9 @@ fn build_full_depth_execution_sample(
                 )
             })
             .unwrap_or_default();
-        let reprice_pnl = exit_sweep
-            .fillable
-            .then_some(exit_sweep.shares * exit_sweep.avg_price - stake_usd - entry_fee);
+        let reprice_pnl = exit_sweep.fillable.then_some(
+            exit_sweep.shares * exit_sweep.avg_price - stake_usd - entry_fee - exit_sweep.fee_usd,
+        );
         match horizon_secs {
             5 => {
                 sample.exit_5s_fillable = exit_sweep.fillable;
@@ -8513,17 +8530,16 @@ fn side_row(
         }
     };
 
-    let fee_per_share = if valid_price(entry_ask) {
-        crypto_fee_cost(entry_ask)
-    } else {
-        f64::NAN
-    };
     let entry_shares = if valid_price(entry_ask) {
         stake_usd / entry_ask
     } else {
         f64::NAN
     };
-    let entry_fee_usd = entry_shares * fee_per_share;
+    let entry_fee_usd = if entry_shares.is_finite() {
+        ploy_market_contracts::polymarket_crypto_taker_fee_cost(entry_shares, entry_ask)
+    } else {
+        f64::NAN
+    };
     let entry_fillable = entry_shares.is_finite()
         && entry_ask_size.is_finite()
         && entry_ask_size + EPS >= entry_shares;
@@ -8584,33 +8600,42 @@ fn side_row(
         f64::NAN
     };
     let roundtrip_pnl_now_15u = if entry_fillable && exit_fillable && valid_price(exit_bid) {
-        Some(entry_shares * exit_bid - stake_usd - entry_fee_usd)
+        let exit_fee_usd =
+            ploy_market_contracts::polymarket_crypto_taker_fee_cost(entry_shares, exit_bid);
+        Some(entry_shares * exit_bid - stake_usd - entry_fee_usd - exit_fee_usd)
     } else {
         None
     };
-    let full_depth_entry_fee_usd = if entry_sweep.fillable && valid_price(entry_sweep.avg_price) {
-        entry_sweep.shares * crypto_fee_cost(entry_sweep.avg_price)
+    let full_depth_entry_fee_usd = if entry_sweep.fillable && entry_sweep.fee_usd.is_finite() {
+        entry_sweep.fee_usd
     } else {
         f64::NAN
     };
     let roundtrip_pnl_now_full_depth_15u =
         if entry_sweep.fillable && exit_sweep.fillable && full_depth_entry_fee_usd.is_finite() {
-            Some(entry_sweep.shares * exit_sweep.avg_price - stake_usd - full_depth_entry_fee_usd)
+            Some(
+                entry_sweep.shares * exit_sweep.avg_price
+                    - stake_usd
+                    - full_depth_entry_fee_usd
+                    - exit_sweep.fee_usd,
+            )
         } else {
             None
         };
     let roundtrip_cost_usd = if let Some(pnl) = roundtrip_pnl_now_15u {
         -pnl
     } else if valid_price(entry_ask) && valid_price(exit_bid) && entry_shares.is_finite() {
-        (stake_usd - entry_shares * exit_bid + entry_fee_usd).max(0.0)
+        let exit_fee_usd =
+            ploy_market_contracts::polymarket_crypto_taker_fee_cost(entry_shares, exit_bid);
+        (stake_usd - entry_shares * exit_bid + entry_fee_usd + exit_fee_usd).max(0.0)
     } else {
         f64::NAN
     };
     let executable_pnl = if entry_fillable && settlement_win.is_finite() {
         Some(if settlement_win >= 0.5 {
-            stake_usd * (1.0 / entry_ask - 1.0) - stake_usd * fee_per_share / entry_ask
+            stake_usd * (1.0 / entry_ask - 1.0) - entry_fee_usd
         } else {
-            -stake_usd - stake_usd * fee_per_share / entry_ask
+            -stake_usd - entry_fee_usd
         })
     } else {
         None
@@ -8628,8 +8653,8 @@ fn side_row(
         None
     };
     let conservative_entry_fee_usd =
-        if conservative_entry_sweep.fillable && valid_price(conservative_entry_sweep.avg_price) {
-            conservative_entry_sweep.shares * crypto_fee_cost(conservative_entry_sweep.avg_price)
+        if conservative_entry_sweep.fillable && conservative_entry_sweep.fee_usd.is_finite() {
+            conservative_entry_sweep.fee_usd
         } else {
             f64::NAN
         };
@@ -8768,6 +8793,7 @@ fn side_row(
         entry_sweep_avg_price_15u: entry_sweep.avg_price,
         exit_sweep_avg_price_15u: exit_sweep.avg_price,
         entry_sweep_shares_15u: entry_sweep.shares,
+        entry_sweep_fee_usd_15u: entry_sweep.fee_usd,
         exit_sweep_shares_15u: exit_sweep.shares,
         entry_sweep_levels_15u: entry_sweep.levels_used,
         exit_sweep_levels_15u: exit_sweep.levels_used,
@@ -8965,10 +8991,15 @@ fn set_future_exit_labels(
     let bid_change = finite_diff(future.exit_bid, rows[idx].exit_bid);
     let fillable = Some(bool_num(future.label_exit_fillable));
     let pnl = if rows[idx].entry_shares.is_finite() && valid_price(future.exit_bid) {
+        let exit_fee = ploy_market_contracts::polymarket_crypto_taker_fee_cost(
+            rows[idx].entry_shares,
+            future.exit_bid,
+        );
         Some(
             rows[idx].entry_shares * future.exit_bid
                 - rows[idx].stake_usd
-                - rows[idx].entry_fee_usd,
+                - rows[idx].entry_fee_usd
+                - exit_fee,
         )
     } else {
         None
@@ -8990,10 +9021,13 @@ fn set_future_exit_labels(
         .fillable
         .then_some(full_depth_exit.shares * full_depth_exit.avg_price);
     let full_depth_pnl = full_depth_value.and_then(|value| {
-        if rows[idx].stake_usd.is_finite() && rows[idx].entry_sweep_avg_price_15u.is_finite() {
-            let fee = rows[idx].entry_sweep_shares_15u
-                * crypto_fee_cost(rows[idx].entry_sweep_avg_price_15u);
-            Some(value - rows[idx].stake_usd - fee)
+        if rows[idx].stake_usd.is_finite() && rows[idx].entry_sweep_fee_usd_15u.is_finite() {
+            Some(
+                value
+                    - rows[idx].stake_usd
+                    - rows[idx].entry_sweep_fee_usd_15u
+                    - full_depth_exit.fee_usd,
+            )
         } else {
             None
         }
@@ -9701,7 +9735,7 @@ fn bool_num(value: bool) -> f64 {
 }
 
 fn crypto_fee_cost(entry_price: f64) -> f64 {
-    0.02 * entry_price * (1.0 - entry_price)
+    ploy_market_contracts::polymarket_crypto_taker_fee_per_share(entry_price)
 }
 
 #[cfg(test)]
@@ -10540,6 +10574,27 @@ mod tests {
         assert!(up.label_full_depth_executable_pnl_15u.unwrap() > 0.0);
         assert_eq!(up.entry_sweep_levels_15u, 2.0);
         assert!(up.entry_sweep_slippage_bps > 0.0);
+    }
+
+    #[test]
+    fn full_depth_sweep_charges_probability_fee_per_level() {
+        let levels = vec![
+            crate::factors::ResearchPmBookLevel {
+                price: 0.20,
+                size: 1.0,
+            },
+            crate::factors::ResearchPmBookLevel {
+                price: 0.80,
+                size: 1.0,
+            },
+        ];
+
+        let fill = sweep_buy_to_stake(&levels, 0.20, 1.0);
+
+        assert!(fill.fillable);
+        assert!((fill.avg_price - 0.50).abs() < EPS);
+        assert!((fill.shares - 2.0).abs() < EPS);
+        assert!((fill.fee_usd - 0.0224).abs() < EPS);
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/examples/run_backtest.rs
+++ b/crates/ploy-strategy-bundles/examples/run_backtest.rs
@@ -242,6 +242,7 @@ mod tests {
                 revision: 0,
                 idempotency_key: None,
                 state: ploy_trading::OrderState::Filled,
+                state_changed_at: Some(timestamp),
                 filled_qty: dec!(10),
                 rejection_reason: None,
                 last_error: None,

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -105,7 +105,9 @@ pub enum MarketDataSource {
     LocalDb,
     /// Open direct public feeds from this strategy runner.
     ExternalDirect,
-    /// Consume local DB feeds and also open direct public feeds.
+    /// Open direct public feeds while retaining the local DB for persistence,
+    /// metadata, and recovery services. Polled DB ticks are not merged into the
+    /// strategy hot path because they can duplicate or reorder direct ticks.
     Dual,
 }
 
@@ -1323,6 +1325,26 @@ taker_fee_rate = 0.07
             dryrun_strategy.insert(risk_key.to_string(), live_strategy[risk_key].clone());
         }
         assert_eq!(dryrun, live);
+    }
+
+    #[test]
+    fn threelayer_live_pair_uses_unthrottled_external_ticks() {
+        let config_dir = strategy_config_dir();
+        for file in [
+            "02-pm5d-threelayer.live.toml",
+            "02-pm5d-threelayer.settlement-probability-btc-eth-dryrun.toml",
+        ] {
+            let config = FullConfig::from_file(config_dir.join(file).to_str().unwrap()).unwrap();
+            assert_eq!(
+                config.runtime.market_data_source,
+                MarketDataSource::Dual,
+                "{file} must use direct ticks with DB-only fallback factors"
+            );
+            assert_eq!(
+                config.runtime.throttle_hz, None,
+                "{file} must evaluate every market tick"
+            );
+        }
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/config.rs
+++ b/crates/ploy-strategy-bundles/src/config.rs
@@ -4,7 +4,10 @@
 //! The `[runtime].mode` field selects which Feed and Executor are wired.
 
 use chrono::{DateTime, Utc};
-use ploy_market_contracts::{InstrumentKind, PredictionFamily, VenueKind};
+use ploy_market_contracts::{
+    FeeAsset, FeeFormula, FeeRounding, FeeSchedule, InstrumentKind, LiquidityRole,
+    PredictionFamily, VenueKind,
+};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -212,6 +215,30 @@ pub struct SimExecutionSection {
     pub max_sweep_levels: usize,
     #[serde(default)]
     pub max_sweep_price_delta: f64,
+    #[serde(default)]
+    pub fee_formula: SimFeeFormula,
+    pub taker_fee_rate: Option<f64>,
+    pub maker_fee_rate: Option<f64>,
+    pub taker_fee_rate_bps: Option<u32>,
+    pub maker_fee_rate_bps: Option<u32>,
+    pub fee_exponent: Option<u32>,
+    pub fee_taker_only: Option<bool>,
+    pub fee_rounding_dp: Option<u32>,
+    pub minimum_fee: Option<f64>,
+    pub fee_balance_precision_dp: Option<u32>,
+    pub fee_asset: Option<FeeAsset>,
+    #[serde(default = "default_liquidity_role")]
+    pub liquidity_role: LiquidityRole,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SimFeeFormula {
+    #[default]
+    VenueDefault,
+    ProbabilityPower,
+    Notional,
+    PerContract,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -263,6 +290,10 @@ fn default_visible_depth_haircut() -> f64 {
     1.0
 }
 
+fn default_liquidity_role() -> LiquidityRole {
+    LiquidityRole::Taker
+}
+
 impl Default for SimExecutionSection {
     fn default() -> Self {
         Self {
@@ -278,6 +309,18 @@ impl Default for SimExecutionSection {
             visible_depth_haircut: 1.0,
             max_sweep_levels: 0,
             max_sweep_price_delta: 0.0,
+            fee_formula: SimFeeFormula::VenueDefault,
+            taker_fee_rate: None,
+            maker_fee_rate: None,
+            taker_fee_rate_bps: None,
+            maker_fee_rate_bps: None,
+            fee_exponent: None,
+            fee_taker_only: None,
+            fee_rounding_dp: None,
+            minimum_fee: None,
+            fee_balance_precision_dp: None,
+            fee_asset: None,
+            liquidity_role: LiquidityRole::Taker,
         }
     }
 }
@@ -372,6 +415,151 @@ impl FullConfig {
     /// Build SimulatedExecutorConfig from the parsed config.
     pub fn sim_executor_config(&self) -> SimulatedExecutorConfig {
         let e = &self.execution;
+        let default_schedule =
+            default_fee_schedule(self.runtime.venue, self.runtime.prediction_family);
+        let formula = match e.fee_formula {
+            SimFeeFormula::VenueDefault => match default_schedule.formula {
+                FeeFormula::ProbabilityPower { .. } => FeeFormula::ProbabilityPower {
+                    exponent: e
+                        .fee_exponent
+                        .unwrap_or_else(|| match default_schedule.formula {
+                            FeeFormula::ProbabilityPower { exponent } => exponent,
+                            _ => 1,
+                        }),
+                },
+                formula => formula,
+            },
+            SimFeeFormula::ProbabilityPower => FeeFormula::ProbabilityPower {
+                exponent: e.fee_exponent.unwrap_or(1),
+            },
+            SimFeeFormula::Notional => FeeFormula::Notional,
+            SimFeeFormula::PerContract => FeeFormula::PerContract,
+        };
+        let taker_rate_decimal = e
+            .taker_fee_rate
+            .and_then(Decimal::from_f64)
+            .filter(|rate| *rate >= Decimal::ZERO);
+        let maker_rate_decimal = e
+            .maker_fee_rate
+            .and_then(Decimal::from_f64)
+            .filter(|rate| *rate >= Decimal::ZERO);
+        let taker_rate_bps = e
+            .taker_fee_rate_bps
+            .map(|bps| Decimal::from(bps) / Decimal::from(10_000_u32));
+        let maker_rate_bps = e
+            .maker_fee_rate_bps
+            .map(|bps| Decimal::from(bps) / Decimal::from(10_000_u32));
+        let taker_rate_override = taker_rate_decimal.or(taker_rate_bps);
+        let maker_rate_override = maker_rate_decimal.or(maker_rate_bps);
+        let taker_rate = taker_rate_override.unwrap_or(default_schedule.taker_rate);
+        let maker_rate = if self.runtime.venue == VenueKind::Polymarket
+            && e.fee_taker_only == Some(true)
+        {
+            Decimal::ZERO
+        } else {
+            maker_rate_override.unwrap_or_else(|| {
+                if self.runtime.venue == VenueKind::Polymarket && e.fee_taker_only == Some(false) {
+                    taker_rate
+                } else {
+                    default_schedule.maker_rate
+                }
+            })
+        };
+        let rounding = e
+            .fee_rounding_dp
+            .map_or(default_schedule.rounding, |decimal_places| {
+                FeeRounding::Ceiling { decimal_places }
+            });
+        let minimum_fee_override = e
+            .minimum_fee
+            .and_then(Decimal::from_f64)
+            .filter(|fee| *fee >= Decimal::ZERO);
+        let minimum_fee = minimum_fee_override.unwrap_or(default_schedule.minimum_fee);
+        let override_values_valid = !(e.taker_fee_rate.is_some() && taker_rate_decimal.is_none())
+            && !(e.maker_fee_rate.is_some() && maker_rate_decimal.is_none())
+            && !(e.minimum_fee.is_some() && minimum_fee_override.is_none())
+            && !(e.taker_fee_rate.is_some() && e.taker_fee_rate_bps.is_some())
+            && !(e.maker_fee_rate.is_some() && e.maker_fee_rate_bps.is_some());
+        let polymarket_fd_override_requested =
+            matches!(self.runtime.prediction_family, PredictionFamily::Custom(_))
+                || taker_rate_override.is_some()
+                || maker_rate_override.is_some()
+                || e.fee_exponent.is_some()
+                || e.fee_taker_only.is_some()
+                || e.fee_formula != SimFeeFormula::VenueDefault
+                || e.fee_rounding_dp.is_some()
+                || e.minimum_fee.is_some();
+        let venue_metadata_complete = match self.runtime.venue {
+            VenueKind::Polymarket => {
+                if polymarket_fd_override_requested {
+                    taker_rate_override.is_some()
+                        && e.fee_exponent.is_some()
+                        && e.fee_taker_only.is_some()
+                        && maker_rate_override.is_none()
+                        && matches!(
+                            e.fee_formula,
+                            SimFeeFormula::VenueDefault | SimFeeFormula::ProbabilityPower
+                        )
+                        && e.fee_rounding_dp.is_none()
+                        && e.minimum_fee.is_none()
+                } else {
+                    true
+                }
+            }
+            VenueKind::PredictFun => {
+                taker_rate_override.is_some()
+                    && matches!(
+                        e.fee_formula,
+                        SimFeeFormula::VenueDefault | SimFeeFormula::Notional
+                    )
+                    && e.fee_exponent.is_none()
+                    && e.fee_taker_only.is_none()
+                    && e.fee_rounding_dp.is_none()
+                    && e.minimum_fee.is_none()
+            }
+            VenueKind::Kalshi => {
+                let formula_valid = match e.fee_formula {
+                    SimFeeFormula::ProbabilityPower => matches!(e.fee_exponent, None | Some(1)),
+                    SimFeeFormula::PerContract => e.fee_exponent.is_none(),
+                    SimFeeFormula::VenueDefault | SimFeeFormula::Notional => false,
+                };
+                taker_rate_override.is_some()
+                    && formula_valid
+                    && matches!(e.fee_balance_precision_dp, None | Some(2 | 4))
+                    && matches!(e.fee_rounding_dp, None | Some(4))
+                    && (e.minimum_fee.is_none() || minimum_fee_override == Some(Decimal::ZERO))
+                    && e.fee_taker_only.is_none()
+                    && matches!(e.fee_asset, None | Some(FeeAsset::Collateral))
+            }
+            VenueKind::Sportsbook => true,
+        };
+        let maker_metadata_complete = e.liquidity_role != LiquidityRole::Maker
+            || match self.runtime.venue {
+                VenueKind::Polymarket => {
+                    !matches!(self.runtime.prediction_family, PredictionFamily::Custom(_))
+                        || e.fee_taker_only.is_some()
+                }
+                VenueKind::PredictFun | VenueKind::Kalshi => maker_rate_override.is_some(),
+                VenueKind::Sportsbook => true,
+            };
+        let metadata_complete =
+            override_values_valid && venue_metadata_complete && maker_metadata_complete;
+        let mut fee_schedule = if metadata_complete {
+            FeeSchedule::new(formula, maker_rate, taker_rate, rounding, minimum_fee)
+        } else {
+            FeeSchedule::new(formula, maker_rate, taker_rate, rounding, minimum_fee)
+                .require_market_metadata()
+        };
+        if self.runtime.venue == VenueKind::Kalshi {
+            fee_schedule =
+                fee_schedule.with_kalshi_balance_rounding(e.fee_balance_precision_dp.unwrap_or(2));
+        }
+        let fee_asset = e.fee_asset.or(match self.runtime.venue {
+            VenueKind::PredictFun => None,
+            VenueKind::Polymarket | VenueKind::Kalshi | VenueKind::Sportsbook => {
+                Some(FeeAsset::Collateral)
+            }
+        });
         SimulatedExecutorConfig {
             use_spread: e.use_spread,
             spread_pct: Decimal::try_from(e.spread_pct).unwrap_or_default(),
@@ -385,6 +573,9 @@ impl FullConfig {
             visible_depth_haircut: Decimal::try_from(e.visible_depth_haircut)
                 .unwrap_or(Decimal::ONE),
             max_sweep_levels: e.max_sweep_levels,
+            fee_schedule,
+            fee_asset,
+            liquidity_role: e.liquidity_role,
         }
     }
 
@@ -398,9 +589,55 @@ impl FullConfig {
     }
 }
 
+fn default_fee_schedule(venue: VenueKind, family: PredictionFamily) -> FeeSchedule {
+    match venue {
+        VenueKind::Polymarket => {
+            let rate = match family {
+                PredictionFamily::CryptoExpiry => Decimal::new(7, 2),
+                PredictionFamily::Politics => Decimal::new(4, 2),
+                PredictionFamily::SportsPregame | PredictionFamily::SportsLive => {
+                    Decimal::new(5, 2)
+                }
+                PredictionFamily::Custom(_) => Decimal::ZERO,
+            };
+            let schedule = FeeSchedule::polymarket_v2(rate, 1, true);
+            if matches!(family, PredictionFamily::Custom(_)) {
+                schedule.require_market_metadata()
+            } else {
+                schedule
+            }
+        }
+        VenueKind::PredictFun => FeeSchedule::new(
+            FeeFormula::Notional,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            FeeRounding::Exact,
+            Decimal::ZERO,
+        )
+        .require_market_metadata(),
+        VenueKind::Kalshi => FeeSchedule::new(
+            FeeFormula::ProbabilityPower { exponent: 1 },
+            Decimal::ZERO,
+            Decimal::ZERO,
+            FeeRounding::Ceiling { decimal_places: 4 },
+            Decimal::ZERO,
+        )
+        .with_kalshi_balance_rounding(2)
+        .require_market_metadata(),
+        VenueKind::Sportsbook => FeeSchedule::new(
+            FeeFormula::Notional,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            FeeRounding::Exact,
+            Decimal::ZERO,
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     const SAMPLE_TOML: &str = r#"
 [runtime]
@@ -723,6 +960,259 @@ venue = "sportsbook"
         );
         assert_eq!(config.runtime.instrument_kind, InstrumentKind::Moneyline);
         assert_eq!(config.runtime.venue, VenueKind::Sportsbook);
+    }
+
+    #[test]
+    fn venue_specific_market_metadata_is_required_when_rates_vary_by_market() {
+        let predict = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "predict_fun"
+
+[strategy]
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+        assert_eq!(
+            predict.fee_schedule.formula,
+            ploy_market_contracts::FeeFormula::Notional
+        );
+        assert!(!predict.fee_schedule.is_configured());
+        assert_eq!(predict.fee_asset, None);
+
+        let kalshi = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "kalshi"
+
+[strategy]
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+        assert!(!kalshi.fee_schedule.is_configured());
+        assert_eq!(
+            kalshi.fee_asset,
+            Some(ploy_market_contracts::FeeAsset::Collateral)
+        );
+    }
+
+    #[test]
+    fn predict_fun_market_fee_bps_and_asset_configure_simulation() {
+        let predict = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "predict_fun"
+
+[strategy]
+
+[execution]
+taker_fee_rate_bps = 200
+maker_fee_rate_bps = 200
+fee_asset = "collateral"
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+
+        assert!(predict.fee_schedule.is_configured());
+        assert_eq!(
+            predict.fee_schedule.calculate(
+                dec!(10),
+                dec!(0.50),
+                ploy_market_contracts::LiquidityRole::Taker,
+            ),
+            dec!(0.10)
+        );
+        assert_eq!(
+            predict.fee_asset,
+            Some(ploy_market_contracts::FeeAsset::Collateral)
+        );
+    }
+
+    #[test]
+    fn maker_simulation_requires_maker_rate_metadata() {
+        let missing = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "predict_fun"
+
+[strategy]
+
+[execution]
+taker_fee_rate_bps = 200
+fee_asset = "collateral"
+liquidity_role = "maker"
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+        assert!(!missing.fee_schedule.is_configured());
+
+        let complete = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "predict_fun"
+
+[strategy]
+
+[execution]
+taker_fee_rate_bps = 200
+maker_fee_rate_bps = 200
+fee_asset = "collateral"
+liquidity_role = "maker"
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+        assert!(complete.fee_schedule.is_configured());
+    }
+
+    #[test]
+    fn custom_polymarket_requires_complete_fd_metadata() {
+        let mut config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+
+[strategy]
+"#,
+        )
+        .unwrap();
+        config.runtime.prediction_family = PredictionFamily::Custom(1);
+        config.execution.taker_fee_rate = Some(0.04);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.fee_exponent = Some(1);
+        config.execution.fee_taker_only = Some(true);
+        let complete = config.sim_executor_config();
+        assert!(complete.fee_schedule.is_configured());
+        assert_eq!(complete.fee_schedule.taker_rate, dec!(0.04));
+        assert_eq!(complete.fee_schedule.maker_rate, dec!(0));
+    }
+
+    #[test]
+    fn polymarket_fd_override_is_atomic() {
+        let mut config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+
+[strategy]
+"#,
+        )
+        .unwrap();
+        assert!(config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.taker_fee_rate = Some(0.07);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.fee_exponent = Some(1);
+        config.execution.fee_taker_only = Some(true);
+        assert!(config.sim_executor_config().fee_schedule.is_configured());
+    }
+
+    #[test]
+    fn invalid_or_ambiguous_fee_rates_fail_closed() {
+        let mut config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "predict_fun"
+
+[strategy]
+
+[execution]
+fee_asset = "collateral"
+"#,
+        )
+        .unwrap();
+        config.execution.taker_fee_rate = Some(f64::NAN);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.taker_fee_rate = Some(-0.01);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.taker_fee_rate = Some(0.02);
+        config.execution.taker_fee_rate_bps = Some(200);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+    }
+
+    #[test]
+    fn simulated_fee_overrides_capture_market_specific_schedule() {
+        let config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "kalshi"
+
+[strategy]
+
+[execution]
+fee_formula = "per_contract"
+taker_fee_rate = 0.03
+maker_fee_rate = 0.01
+fee_rounding_dp = 4
+liquidity_role = "maker"
+"#,
+        )
+        .unwrap()
+        .sim_executor_config();
+
+        assert_eq!(
+            config.fee_schedule.formula,
+            ploy_market_contracts::FeeFormula::PerContract
+        );
+        assert_eq!(
+            config.liquidity_role,
+            ploy_market_contracts::LiquidityRole::Maker
+        );
+        assert_eq!(
+            config
+                .fee_schedule
+                .calculate(dec!(2), dec!(0.50), config.liquidity_role,),
+            dec!(0.02)
+        );
+    }
+
+    #[test]
+    fn kalshi_rejects_non_venue_fee_semantics() {
+        let mut config = FullConfig::from_toml(
+            r#"
+[runtime]
+mode = "backtest"
+venue = "kalshi"
+
+[strategy]
+
+[execution]
+fee_formula = "probability_power"
+taker_fee_rate = 0.07
+"#,
+        )
+        .unwrap();
+        assert!(config.sim_executor_config().fee_schedule.is_configured());
+
+        config.execution.fee_exponent = Some(2);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+        config.execution.fee_exponent = Some(1);
+
+        config.execution.fee_rounding_dp = Some(2);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+        config.execution.fee_rounding_dp = Some(4);
+
+        config.execution.minimum_fee = Some(0.01);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
+        config.execution.minimum_fee = Some(0.0);
+
+        config.execution.fee_balance_precision_dp = Some(3);
+        assert!(!config.sim_executor_config().fee_schedule.is_configured());
     }
 
     #[test]

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -401,11 +401,7 @@ where
                 }
             }
 
-            let reconcile_completed = match self
-                .executor
-                .reconcile_fills(self.trading.orders())
-                .await
-            {
+            let reconcile_completed = match self.reconcile_active_fills().await {
                 Ok(fills) => {
                     let strategy_name = self.strategy.name().to_string();
                     for fill in fills {
@@ -585,6 +581,13 @@ where
     /// Read-only access to the trading runtime state.
     pub fn trading(&self) -> &TradingRuntime {
         &self.trading
+    }
+
+    async fn reconcile_active_fills(&mut self) -> Result<Vec<ploy_trading::FillRecord>, String> {
+        if self.trading.orders().active_orders() == 0 {
+            return Ok(Vec::new());
+        }
+        self.executor.reconcile_fills(self.trading.orders()).await
     }
 
     fn ensure_deployment_attribution(&self, intent: &mut TradingIntent) {
@@ -1495,8 +1498,65 @@ mod tests {
     }
 
     struct SkippedReconcileExecutor;
+    struct IdleReconcileCountingExecutor {
+        reconciles: Arc<Mutex<usize>>,
+    }
     struct FailingReconcileExecutor {
         submissions: usize,
+    }
+
+    #[async_trait]
+    impl Executor for IdleReconcileCountingExecutor {
+        async fn submit(&mut self, _intent: &TradingIntent, _order_id: &str) -> ExecutionReport {
+            unreachable!("noop strategy must not submit")
+        }
+
+        async fn cancel(&mut self, _order_id: &str) -> bool {
+            false
+        }
+
+        async fn reconcile_fills(
+            &mut self,
+            _orders: &OrderLedger,
+        ) -> Result<Vec<FillRecord>, String> {
+            *self.reconciles.lock().unwrap() += 1;
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    async fn idle_market_updates_do_not_reconcile_without_active_orders() {
+        let reconciles = Arc::new(Mutex::new(0));
+        let now = Utc::now();
+        let mut runtime = StrategyRuntime::new(
+            NoopStrategy,
+            SingleUpdateFeed {
+                next: Some(MarketUpdate::Quote {
+                    token_id: "token-up".into(),
+                    bid: Some(dec!(0.40)),
+                    ask: Some(dec!(0.41)),
+                    bid_size: Some(dec!(10)),
+                    ask_size: Some(dec!(10)),
+                    bid_levels: Vec::new(),
+                    ask_levels: Vec::new(),
+                    ts: now,
+                }),
+            },
+            IdleReconcileCountingExecutor {
+                reconciles: reconciles.clone(),
+            },
+            Box::new(NullRecorder),
+            RuntimeConfig {
+                mode: RuntimeMode::Live,
+                throttle_hz: None,
+                max_updates: None,
+                skip_settlement_exits: false,
+            },
+        );
+
+        runtime.run().await;
+
+        assert_eq!(*reconciles.lock().unwrap(), 0);
     }
 
     #[async_trait]

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -289,6 +289,11 @@ where
                 let strategy_name = self.strategy.name().to_string();
                 let signal_ref = signal.as_ref();
 
+                let mut intent = self.executor.prepare_intent(&intent);
+                self.ensure_deployment_attribution(&mut intent);
+                let order_id = Uuid::new_v4().to_string();
+
+                let report = self.executor.submit(&intent, &order_id).await;
                 if let Some(signal) = signal_ref {
                     if let Err(error) = self.recorder.record_signal(signal).await {
                         warn!(%error, "Failed to persist signal record");
@@ -297,12 +302,6 @@ where
                         }
                     }
                 }
-
-                let mut intent = self.executor.prepare_intent(&intent);
-                self.ensure_deployment_attribution(&mut intent);
-                let order_id = Uuid::new_v4().to_string();
-
-                let report = self.executor.submit(&intent, &order_id).await;
                 if let Err(error) = self
                     .recorder
                     .record_order(&strategy_name, &intent, signal_ref, &report, &order_id)
@@ -1159,7 +1158,7 @@ mod tests {
     #[async_trait]
     impl Recorder for FailingRecorder {
         async fn record_signal(&mut self, _signal: &SignalRecord) -> Result<(), String> {
-            assert!(self.submissions.lock().unwrap().is_empty());
+            assert_eq!(self.submissions.lock().unwrap().len(), 1);
             Err("recorder unavailable".to_string())
         }
 
@@ -1170,7 +1169,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic(expected = "live recorder failed")]
-    async fn live_recorder_failure_stops_submission() {
+    async fn live_signal_recorder_failure_happens_after_canonical_submission() {
         let now = Utc::now();
         let submissions = Arc::new(Mutex::new(Vec::new()));
         let strategy = RecordingStrategy {

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -879,8 +879,8 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::{
-        RuntimeConfig, RuntimeMode, StrategyRuntime, observe_fill_evidence,
-        retry_attempt_from_intent_id, retry_root_intent_id,
+        observe_fill_evidence, retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig,
+        RuntimeMode, StrategyRuntime,
     };
     use crate::traits::{
         ExecutionPolicy, ExecutionReport, Executor, Feed, MarketUpdate, NullRecorder, Recorder,
@@ -2447,13 +2447,11 @@ mod tests {
             ["pm5d_BTCUSDT_UP_retry3"]
         );
         assert_eq!(snapshot.orders.len(), 2);
-        assert!(
-            snapshot
-                .orders
-                .iter()
-                .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
-                    && order.state == ploy_trading::OrderState::Acknowledged)
-        );
+        assert!(snapshot
+            .orders
+            .iter()
+            .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
+                && order.state == ploy_trading::OrderState::Acknowledged));
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/engine.rs
+++ b/crates/ploy-strategy-bundles/src/engine.rs
@@ -294,11 +294,12 @@ where
                 let order_id = Uuid::new_v4().to_string();
 
                 let report = self.executor.submit(&intent, &order_id).await;
+                let mut halt_after_submission = false;
                 if let Some(signal) = signal_ref {
                     if let Err(error) = self.recorder.record_signal(signal).await {
                         warn!(%error, "Failed to persist signal record");
                         if self.config.mode == RuntimeMode::Live {
-                            panic!("live recorder failed: {error}");
+                            halt_after_submission = true;
                         }
                     }
                 }
@@ -329,6 +330,9 @@ where
                     let reason = report.rejection_reason.as_deref().unwrap_or("unknown");
                     warn!(order_id = %order_id, reason = %reason, "Order rejected");
                     self.strategy.on_reject(&intent, reason);
+                    if halt_after_submission {
+                        break 'runtime;
+                    }
                     continue;
                 }
 
@@ -397,6 +401,13 @@ where
                         token = %intent.token_id,
                         "Live order acknowledged without fill; waiting for reconciliation",
                     );
+                }
+                if halt_after_submission {
+                    warn!(
+                        order_id = %order_id,
+                        "Stopping live runtime after post-submit signal audit failure"
+                    );
+                    break 'runtime;
                 }
             }
 
@@ -868,8 +879,8 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::{
-        observe_fill_evidence, retry_attempt_from_intent_id, retry_root_intent_id, RuntimeConfig,
-        RuntimeMode, StrategyRuntime,
+        RuntimeConfig, RuntimeMode, StrategyRuntime, observe_fill_evidence,
+        retry_attempt_from_intent_id, retry_root_intent_id,
     };
     use crate::traits::{
         ExecutionPolicy, ExecutionReport, Executor, Feed, MarketUpdate, NullRecorder, Recorder,
@@ -1168,8 +1179,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "live recorder failed")]
-    async fn live_signal_recorder_failure_happens_after_canonical_submission() {
+    async fn live_signal_recorder_failure_stops_after_order_state_is_recorded() {
         let now = Utc::now();
         let submissions = Arc::new(Mutex::new(Vec::new()));
         let strategy = RecordingStrategy {
@@ -1225,7 +1235,16 @@ mod tests {
             },
         );
 
-        runtime.run().await;
+        let result = runtime.run().await;
+
+        assert_eq!(submissions.lock().unwrap().len(), 1);
+        assert_eq!(result.intents_submitted, 1);
+        let snapshot = runtime.trading.snapshot(&Default::default());
+        assert_eq!(snapshot.orders.len(), 1);
+        assert_eq!(
+            snapshot.orders[0].venue_order_id.as_deref(),
+            Some("venue-order-1")
+        );
     }
 
     #[async_trait]
@@ -2428,11 +2447,13 @@ mod tests {
             ["pm5d_BTCUSDT_UP_retry3"]
         );
         assert_eq!(snapshot.orders.len(), 2);
-        assert!(snapshot
-            .orders
-            .iter()
-            .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
-                && order.state == ploy_trading::OrderState::Acknowledged));
+        assert!(
+            snapshot
+                .orders
+                .iter()
+                .any(|order| order.intent_id == "pm5d_BTCUSDT_UP_retry3"
+                    && order.state == ploy_trading::OrderState::Acknowledged)
+        );
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/executor/simulated.rs
+++ b/crates/ploy-strategy-bundles/src/executor/simulated.rs
@@ -416,6 +416,7 @@ impl Executor for SimulatedExecutor {
             ..
         } = update
         {
+            let clears_book = bid.is_none() && ask.is_none();
             let previous = self
                 .quotes
                 .get(token_id.as_ref())
@@ -426,14 +427,26 @@ impl Executor for SimulatedExecutor {
                 QuoteLiquidity {
                     bid: *bid,
                     ask: *ask,
-                    bid_size: bid_size.or(previous.bid_size),
-                    ask_size: ask_size.or(previous.ask_size),
-                    bid_levels: if bid_levels.is_empty() {
+                    bid_size: if clears_book {
+                        None
+                    } else {
+                        bid_size.or(previous.bid_size)
+                    },
+                    ask_size: if clears_book {
+                        None
+                    } else {
+                        ask_size.or(previous.ask_size)
+                    },
+                    bid_levels: if clears_book {
+                        Vec::new()
+                    } else if bid_levels.is_empty() {
                         previous.bid_levels
                     } else {
                         bid_levels.clone()
                     },
-                    ask_levels: if ask_levels.is_empty() {
+                    ask_levels: if clears_book {
+                        Vec::new()
+                    } else if ask_levels.is_empty() {
                         previous.ask_levels
                     } else {
                         ask_levels.clone()
@@ -872,6 +885,33 @@ mod tests {
         let fill = report.fill.expect("last known top-of-book size");
         assert_eq!(fill.price, dec!(0.50));
         assert_eq!(fill.quantity, dec!(8));
+    }
+
+    #[tokio::test]
+    async fn empty_quote_clears_last_observed_liquidity() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            enable_partial_fills: true,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update(
+            Some(dec!(0.49)),
+            Some(dec!(0.50)),
+            Some(dec!(50)),
+            Some(dec!(8)),
+        ));
+        exec.observe_market_update(&quote_update(None, None, None, None));
+
+        let report = exec
+            .submit(
+                &test_intent(TradeSide::Buy, dec!(0.50), dec!(25)),
+                "test-order-empty-book",
+            )
+            .await;
+
+        assert!(report.rejected);
+        assert!(report.fill.is_none());
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/executor/simulated.rs
+++ b/crates/ploy-strategy-bundles/src/executor/simulated.rs
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use ploy_market_contracts::{BookLevel, FeeAccumulator, FeeAsset, FeeSchedule, LiquidityRole};
 use ploy_trading::{FillRecord, IntentPurpose, TradeSide, TradingIntent};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -19,8 +20,6 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::traits::{ExecutionReport, Executor, MarketUpdate};
-use ploy_market_contracts::BookLevel;
-
 const MIN_BINARY_PRICE: Decimal = dec!(0.01);
 const MAX_BINARY_PRICE: Decimal = dec!(0.99);
 
@@ -53,6 +52,12 @@ pub struct SimulatedExecutorConfig {
     pub visible_depth_haircut: Decimal,
     /// Maximum number of full-depth levels to sweep. Zero means unlimited.
     pub max_sweep_levels: usize,
+    /// Venue-specific fee schedule used by backtest and dry-run fills.
+    pub fee_schedule: FeeSchedule,
+    /// Asset in which the venue charges the simulated fee.
+    pub fee_asset: Option<FeeAsset>,
+    /// Assumed maker/taker role for simulated fills.
+    pub liquidity_role: LiquidityRole,
 }
 
 impl Default for SimulatedExecutorConfig {
@@ -69,6 +74,9 @@ impl Default for SimulatedExecutorConfig {
             require_lob_liquidity: false,
             visible_depth_haircut: Decimal::ONE,
             max_sweep_levels: 0,
+            fee_schedule: FeeSchedule::default(),
+            fee_asset: Some(FeeAsset::Collateral),
+            liquidity_role: LiquidityRole::Taker,
         }
     }
 }
@@ -99,12 +107,6 @@ impl SimulatedExecutor {
 
     fn clamp_price(price: Decimal) -> Decimal {
         price.max(MIN_BINARY_PRICE).min(MAX_BINARY_PRICE)
-    }
-
-    /// Polymarket trading fee: 2% × p × (1 − p) per share.
-    fn crypto_trade_fee(fill_price: Decimal) -> Decimal {
-        let p_factor = fill_price * (Decimal::ONE - fill_price);
-        dec!(0.02) * p_factor
     }
 
     /// Simulate a buy fill from a quoted executable price.
@@ -184,10 +186,11 @@ impl SimulatedExecutor {
         visible_depth_haircut: Decimal,
         max_sweep_levels: usize,
         allow_partial: bool,
-    ) -> Result<(Decimal, Decimal), String> {
+    ) -> Result<(Decimal, Decimal, Vec<(Decimal, Decimal)>), String> {
         let mut remaining = shares.max(Decimal::ZERO);
         let mut filled = Decimal::ZERO;
         let mut notional = Decimal::ZERO;
+        let mut fee_legs = Vec::new();
         let level_limit = if max_sweep_levels == 0 {
             usize::MAX
         } else {
@@ -213,6 +216,7 @@ impl SimulatedExecutor {
             remaining -= take;
             filled += take;
             notional += take * price;
+            fee_legs.push((take, price));
         }
 
         if filled <= Decimal::ZERO {
@@ -224,14 +228,24 @@ impl SimulatedExecutor {
             ));
         }
 
-        Ok((notional / filled, filled))
+        Ok((notional / filled, filled, fee_legs))
     }
 
     fn simulate_lob_fill(
         &self,
         intent: &TradingIntent,
         signal_price: Decimal,
-    ) -> Result<(Decimal, Decimal, Decimal, Decimal, &'static str), String> {
+    ) -> Result<
+        (
+            Decimal,
+            Decimal,
+            Decimal,
+            Decimal,
+            &'static str,
+            Vec<(Decimal, Decimal)>,
+        ),
+        String,
+    > {
         let quote = self
             .quotes
             .get(&intent.token_id)
@@ -245,7 +259,7 @@ impl SimulatedExecutor {
                     .map(Self::clamp_price)
                     .unwrap_or_else(|| quote.ask.map(Self::clamp_price).unwrap_or(dec!(0.99)));
                 if !quote.ask_levels.is_empty() {
-                    let (avg_price, filled_qty) = Self::sweep_levels(
+                    let (avg_price, filled_qty, fee_legs) = Self::sweep_levels(
                         &quote.ask_levels,
                         requested,
                         TradeSide::Buy,
@@ -261,6 +275,7 @@ impl SimulatedExecutor {
                         avg_price - reference,
                         Decimal::ZERO,
                         "full_depth_sweep",
+                        fee_legs,
                     ));
                 }
 
@@ -296,6 +311,7 @@ impl SimulatedExecutor {
                     ask - reference,
                     Decimal::ZERO,
                     "top_book_quote",
+                    vec![(filled_qty, ask)],
                 ))
             }
             TradeSide::Sell => {
@@ -304,7 +320,7 @@ impl SimulatedExecutor {
                     .map(Self::clamp_price)
                     .unwrap_or_else(|| quote.bid.map(Self::clamp_price).unwrap_or(dec!(0.01)));
                 if !quote.bid_levels.is_empty() {
-                    let (avg_price, filled_qty) = Self::sweep_levels(
+                    let (avg_price, filled_qty, fee_legs) = Self::sweep_levels(
                         &quote.bid_levels,
                         requested,
                         TradeSide::Sell,
@@ -320,6 +336,7 @@ impl SimulatedExecutor {
                         reference - avg_price,
                         Decimal::ZERO,
                         "full_depth_sweep",
+                        fee_legs,
                     ));
                 }
 
@@ -355,6 +372,7 @@ impl SimulatedExecutor {
                     reference - bid,
                     Decimal::ZERO,
                     "top_book_quote",
+                    vec![(filled_qty, bid)],
                 ))
             }
         }
@@ -433,6 +451,51 @@ impl Executor for SimulatedExecutor {
         let is_settlement = intent.purpose == IntentPurpose::Exit
             && (signal_price == Decimal::ZERO || signal_price == Decimal::ONE);
 
+        if !is_settlement && !self.config.fee_schedule.is_configured() {
+            return ExecutionReport {
+                order_id: order_id.to_string(),
+                fill: None,
+                rejected: true,
+                rejection_reason: Some(
+                    "Market fee metadata is required for simulated execution".into(),
+                ),
+                slippage: None,
+                market_impact: None,
+                price_basis: None,
+            };
+        }
+        let charges_fee = self
+            .config
+            .fee_schedule
+            .rate_for(self.config.liquidity_role)
+            > Decimal::ZERO;
+        if !is_settlement && charges_fee && self.config.fee_asset.is_none() {
+            return ExecutionReport {
+                order_id: order_id.to_string(),
+                fill: None,
+                rejected: true,
+                rejection_reason: Some(
+                    "Market fee asset metadata is required for simulated execution".into(),
+                ),
+                slippage: None,
+                market_impact: None,
+                price_basis: None,
+            };
+        }
+        if !is_settlement && charges_fee && self.config.fee_asset == Some(FeeAsset::Shares) {
+            return ExecutionReport {
+                order_id: order_id.to_string(),
+                fill: None,
+                rejected: true,
+                rejection_reason: Some(
+                    "Share-denominated fees require net-position accounting".into(),
+                ),
+                slippage: None,
+                market_impact: None,
+                price_basis: None,
+            };
+        }
+
         let simulated = if is_settlement {
             Ok((
                 signal_price,
@@ -440,6 +503,7 @@ impl Executor for SimulatedExecutor {
                 Decimal::ZERO,
                 Decimal::ZERO,
                 "settlement",
+                Vec::new(),
             ))
         } else if self.config.require_lob_liquidity {
             self.simulate_lob_fill(intent, signal_price)
@@ -458,10 +522,11 @@ impl Executor for SimulatedExecutor {
                 } else {
                     "signal_limit"
                 },
+                vec![(filled_qty, fill_price)],
             ))
         };
 
-        let (fill_price, filled_qty, slippage, impact, price_basis) = match simulated {
+        let (fill_price, filled_qty, slippage, impact, price_basis, fee_legs) = match simulated {
             Ok(fill) => fill,
             Err(reason) => {
                 return ExecutionReport {
@@ -491,7 +556,28 @@ impl Executor for SimulatedExecutor {
         let fee = if is_settlement {
             Decimal::ZERO
         } else {
-            Self::crypto_trade_fee(fill_price) * filled_qty
+            let revenue_sign = match intent.side {
+                TradeSide::Buy => -Decimal::ONE,
+                TradeSide::Sell => Decimal::ONE,
+            };
+            let mut accumulator = FeeAccumulator::default();
+            let fee = fee_legs
+                .iter()
+                .map(|(leg_quantity, leg_price)| {
+                    self.config
+                        .fee_schedule
+                        .charge(
+                            *leg_quantity,
+                            *leg_price,
+                            self.config.liquidity_role,
+                            *leg_quantity * *leg_price * revenue_sign,
+                            &mut accumulator,
+                        )
+                        .expect("fee schedule was checked above")
+                        .net_fee
+                })
+                .sum();
+            fee
         };
 
         let fill = FillRecord {
@@ -876,11 +962,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn entry_fee_uses_pm_rate() {
+    async fn entry_fee_uses_configured_venue_schedule() {
         let config = SimulatedExecutorConfig {
             use_spread: false,
             enable_market_impact: false,
             enable_partial_fills: false,
+            fee_schedule: ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+            liquidity_role: ploy_market_contracts::LiquidityRole::Taker,
             ..Default::default()
         };
         let mut exec = SimulatedExecutor::new(config);
@@ -888,8 +976,155 @@ mod tests {
 
         let report = exec.submit(&intent, "test-order-5").await;
         let fill = report.fill.expect("fill");
-        // fee = 0.02 × 0.50 × 0.50 × 10 = 0.05
-        assert_eq!(fill.fee.round_dp(6), dec!(0.05));
+        assert_eq!(fill.fee, dec!(0.175));
+    }
+
+    #[tokio::test]
+    async fn maker_fill_uses_maker_rate() {
+        let config = SimulatedExecutorConfig {
+            fee_schedule: ploy_market_contracts::FeeSchedule::new(
+                ploy_market_contracts::FeeFormula::Notional,
+                dec!(0.005),
+                dec!(0.02),
+                ploy_market_contracts::FeeRounding::Exact,
+                Decimal::ZERO,
+            ),
+            liquidity_role: ploy_market_contracts::LiquidityRole::Maker,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(10));
+
+        let fill = exec
+            .submit(&intent, "test-order-maker-fee")
+            .await
+            .fill
+            .expect("fill");
+
+        assert_eq!(fill.fee, dec!(0.025));
+    }
+
+    #[tokio::test]
+    async fn missing_market_fee_metadata_rejects_fill() {
+        let config = SimulatedExecutorConfig {
+            fee_schedule: ploy_market_contracts::FeeSchedule::unconfigured(
+                ploy_market_contracts::FeeFormula::Notional,
+            ),
+            fee_asset: Some(ploy_market_contracts::FeeAsset::Collateral),
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(10));
+
+        let report = exec.submit(&intent, "missing-market-fee").await;
+
+        assert!(report.rejected);
+        assert_eq!(
+            report.rejection_reason.as_deref(),
+            Some("Market fee metadata is required for simulated execution")
+        );
+    }
+
+    #[tokio::test]
+    async fn share_denomination_fails_closed_until_fill_contract_tracks_fee_asset() {
+        let config = SimulatedExecutorConfig {
+            fee_asset: Some(ploy_market_contracts::FeeAsset::Shares),
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(10));
+
+        let report = exec.submit(&intent, "share-fee").await;
+
+        assert!(report.rejected);
+        assert_eq!(
+            report.rejection_reason.as_deref(),
+            Some("Share-denominated fees require net-position accounting")
+        );
+    }
+
+    #[tokio::test]
+    async fn explicitly_fee_free_market_does_not_require_fee_asset() {
+        let config = SimulatedExecutorConfig {
+            fee_schedule: ploy_market_contracts::FeeSchedule::new(
+                ploy_market_contracts::FeeFormula::Notional,
+                dec!(0),
+                dec!(0),
+                ploy_market_contracts::FeeRounding::Exact,
+                dec!(0),
+            ),
+            fee_asset: None,
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(10));
+
+        let fill = exec
+            .submit(&intent, "fee-free")
+            .await
+            .fill
+            .expect("fee-free fill");
+
+        assert_eq!(fill.fee, dec!(0));
+    }
+
+    #[tokio::test]
+    async fn kalshi_match_legs_share_one_order_rounding_accumulator() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            fee_schedule: ploy_market_contracts::FeeSchedule::new(
+                ploy_market_contracts::FeeFormula::ProbabilityPower { exponent: 1 },
+                dec!(0),
+                dec!(0.07),
+                ploy_market_contracts::FeeRounding::Ceiling { decimal_places: 4 },
+                dec!(0),
+            )
+            .with_kalshi_balance_rounding(2),
+            fee_asset: Some(ploy_market_contracts::FeeAsset::Collateral),
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update_with_levels(
+            Vec::new(),
+            vec![
+                level(dec!(0.50), dec!(0.30)),
+                level(dec!(0.50), dec!(0.30)),
+                level(dec!(0.50), dec!(0.30)),
+            ],
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.50), dec!(0.90));
+
+        let fill = exec
+            .submit(&intent, "kalshi-partials")
+            .await
+            .fill
+            .expect("fill");
+
+        assert_eq!(fill.fee, dec!(0.0200));
+    }
+
+    #[tokio::test]
+    async fn full_depth_probability_fees_are_rounded_per_match_level() {
+        let config = SimulatedExecutorConfig {
+            require_lob_liquidity: true,
+            fee_schedule: ploy_market_contracts::FeeSchedule::polymarket_v2(dec!(0.07), 1, true),
+            ..Default::default()
+        };
+        let mut exec = SimulatedExecutor::new(config);
+        exec.observe_market_update(&quote_update_with_levels(
+            Vec::new(),
+            vec![level(dec!(0.20), dec!(1)), level(dec!(0.80), dec!(1))],
+        ));
+        let intent = test_intent(TradeSide::Buy, dec!(0.90), dec!(2));
+
+        let fill = exec
+            .submit(&intent, "multi-level-fee")
+            .await
+            .fill
+            .expect("fill");
+
+        assert_eq!(fill.price, dec!(0.50));
+        assert_eq!(fill.fee, dec!(0.02240));
     }
 
     #[tokio::test]

--- a/crates/ploy-strategy-bundles/src/feed/live.rs
+++ b/crates/ploy-strategy-bundles/src/feed/live.rs
@@ -13,7 +13,8 @@ use crate::traits::{Feed, MarketUpdate};
 /// Live feed that consumes market updates from a broadcast channel.
 ///
 /// Multiple strategies can subscribe to the same broadcast sender.
-/// Lagged messages are skipped with a warning.
+/// Any lag closes the feed so live/dry-run runtimes fail closed instead of
+/// evaluating against a market state with missing deltas.
 pub struct LiveFeed {
     rx: broadcast::Receiver<MarketUpdate>,
 }
@@ -28,15 +29,39 @@ impl LiveFeed {
 #[async_trait]
 impl Feed for LiveFeed {
     async fn next(&mut self) -> Option<MarketUpdate> {
-        loop {
-            match self.rx.recv().await {
-                Ok(update) => return Some(update),
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "LiveFeed lagged, skipping messages");
-                    continue;
-                }
-                Err(broadcast::error::RecvError::Closed) => return None,
+        match self.rx.recv().await {
+            Ok(update) => Some(update),
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!(skipped = n, "LiveFeed lagged; closing feed fail-closed");
+                None
             }
+            Err(broadcast::error::RecvError::Closed) => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LiveFeed;
+    use crate::traits::{Feed, MarketUpdate};
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+
+    #[tokio::test]
+    async fn lagged_live_feed_closes_fail_closed() {
+        let (tx, rx) = broadcast::channel(1);
+        let mut feed = LiveFeed::new(rx);
+        let update = |price| MarketUpdate::SpotPrice {
+            symbol: Arc::from("BTCUSDT"),
+            price,
+            ts: Utc::now(),
+        };
+
+        tx.send(update(Decimal::ONE)).unwrap();
+        tx.send(update(Decimal::from(2))).unwrap();
+
+        assert!(feed.next().await.is_none());
     }
 }

--- a/crates/ploy-strategy-bundles/src/strategies/common/fees.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/common/fees.rs
@@ -1,4 +1,4 @@
 #[must_use]
 pub fn crypto_fee_cost(entry_price: f64) -> f64 {
-    0.02 * entry_price * (1.0 - entry_price)
+    ploy_market_contracts::polymarket_crypto_taker_fee_per_share(entry_price)
 }

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -4824,7 +4824,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
         let mut config = test_config();
         config.profile = ThreeLayerProfile::SettlementProbability;
-        config.min_edge = 0.02;
+        config.min_edge = 0.01;
         config.min_entry_score = 0.25;
         config.max_sweep_levels = 3;
         config.max_sweep_price_delta = dec!(0.10);
@@ -4881,7 +4881,7 @@ mod tests {
             [StrategyDecision::Enter { signal, .. }] => {
                 let signal = signal.as_ref().expect("signal");
                 assert!(
-                    signal.edge > 0.02,
+                    signal.edge > 0.01,
                     "expected full-depth executable edge above min_edge, got {}",
                     signal.edge
                 );
@@ -4988,7 +4988,7 @@ mod tests {
             Some(&1)
         );
         assert_eq!(
-            diagnostics.get("settlement_autofactor_raw_score_neg2_to_0pct"),
+            diagnostics.get("settlement_autofactor_raw_score_neg5_to_neg2pct"),
             Some(&1)
         );
         assert_eq!(diagnostics.get("skip_entry_score"), Some(&1));

--- a/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
+++ b/crates/ploy-strategy-bundles/src/strategies/three_layer.rs
@@ -880,6 +880,23 @@ impl ThreeLayerStrategy {
         *self.diagnostics.entry(key).or_insert(0) += value;
     }
 
+    fn maybe_entry_for_symbol(
+        &mut self,
+        symbol: &Arc<str>,
+        ts: DateTime<Utc>,
+        positions: &PositionLedger,
+        orders: &OrderLedger,
+    ) -> Option<StrategyDecision> {
+        if self
+            .last_entry
+            .get(symbol)
+            .is_some_and(|last| (ts - *last).num_seconds() < self.config.cooldown_secs as i64)
+        {
+            return None;
+        }
+        self.try_entry(symbol, ts, positions, orders)
+    }
+
     fn bump_settlement_autofactor_edge_bucket(
         &mut self,
         metric: SettlementAutofactorEdgeMetric,
@@ -2452,7 +2469,14 @@ impl StrategyLogic for ThreeLayerStrategy {
 
                 let price_f64 = match price.to_f64() {
                     Some(p) if p > 0.0 => p,
-                    _ => return Vec::new(),
+                    _ => {
+                        self.spot.remove(symbol);
+                        self.drift.remove(symbol);
+                        self.drift_state.remove(symbol);
+                        self.lob.remove(symbol);
+                        self.mprice_acc.remove(symbol);
+                        return Vec::new();
+                    }
                 };
 
                 self.drift
@@ -2484,14 +2508,7 @@ impl StrategyLogic for ThreeLayerStrategy {
                 let mut decisions =
                     self.exit_decisions_for_symbol(symbol, *ts, spot_opt, positions, orders);
 
-                // Cooldown check before entry
-                if let Some(last) = self.last_entry.get(symbol) {
-                    if (*ts - *last).num_seconds() < self.config.cooldown_secs as i64 {
-                        return decisions;
-                    }
-                }
-
-                if let Some(entry) = self.try_entry(symbol, *ts, positions, orders) {
+                if let Some(entry) = self.maybe_entry_for_symbol(symbol, *ts, positions, orders) {
                     decisions.push(entry);
                 }
                 decisions
@@ -2507,6 +2524,13 @@ impl StrategyLogic for ThreeLayerStrategy {
                 ask_levels,
                 ts,
             } => {
+                if self.quotes.get(token_id.as_ref()).is_some_and(|current| {
+                    current.ts > *ts
+                        && (current.bid.is_some() || current.ask.is_some())
+                        && (bid.is_some() || ask.is_some())
+                }) {
+                    return Vec::new();
+                }
                 self.feed_time = Some(*ts);
                 self.quotes.insert(
                     token_id.clone(),
@@ -2516,26 +2540,13 @@ impl StrategyLogic for ThreeLayerStrategy {
                         ts: *ts,
                     },
                 );
-                let previous = self
-                    .quote_depth
-                    .get(token_id.as_ref())
-                    .cloned()
-                    .unwrap_or_default();
                 self.quote_depth.insert(
                     token_id.clone(),
                     QuoteDepth {
-                        bid_size: (*bid_size).or(previous.bid_size),
-                        ask_size: (*ask_size).or(previous.ask_size),
-                        bid_levels: if bid_levels.is_empty() {
-                            previous.bid_levels
-                        } else {
-                            bid_levels.clone()
-                        },
-                        ask_levels: if ask_levels.is_empty() {
-                            previous.ask_levels
-                        } else {
-                            ask_levels.clone()
-                        },
+                        bid_size: *bid_size,
+                        ask_size: *ask_size,
+                        bid_levels: bid_levels.clone(),
+                        ask_levels: ask_levels.clone(),
                     },
                 );
                 self.record_quote_ask(token_id.clone(), *ask, *ts);
@@ -2544,7 +2555,12 @@ impl StrategyLogic for ThreeLayerStrategy {
                     return Vec::new();
                 };
                 let spot = self.spot.get(&symbol).and_then(|p| p.to_f64());
-                self.exit_decisions_for_symbol(&symbol, *ts, spot, positions, orders)
+                let mut decisions =
+                    self.exit_decisions_for_symbol(&symbol, *ts, spot, positions, orders);
+                if let Some(entry) = self.maybe_entry_for_symbol(&symbol, *ts, positions, orders) {
+                    decisions.push(entry);
+                }
+                decisions
             }
 
             MarketUpdate::AggTrade {
@@ -2569,7 +2585,9 @@ impl StrategyLogic for ThreeLayerStrategy {
                     *is_buyer_maker,
                     *ts,
                 );
-                Vec::new()
+                self.maybe_entry_for_symbol(symbol, *ts, positions, orders)
+                    .into_iter()
+                    .collect()
             }
 
             MarketUpdate::L2Depth {
@@ -2605,7 +2623,9 @@ impl StrategyLogic for ThreeLayerStrategy {
                         .or_insert_with(|| MpriceDriftAccumulator::new(300.0))
                         .push(*ts, microprice_offset);
                 }
-                Vec::new()
+                self.maybe_entry_for_symbol(symbol, *ts, positions, orders)
+                    .into_iter()
+                    .collect()
             }
 
             MarketUpdate::L2 {
@@ -3409,6 +3429,123 @@ mod tests {
     }
 
     #[test]
+    fn older_quote_cannot_overwrite_newer_ws_tick() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 13, 9, 0, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        let quote = |ask, ts| MarketUpdate::Quote {
+            token_id: Arc::from("token-up"),
+            bid: Some(ask - dec!(0.01)),
+            ask: Some(ask),
+            bid_size: Some(dec!(10)),
+            ask_size: Some(dec!(10)),
+            bid_levels: Vec::new(),
+            ask_levels: Vec::new(),
+            ts,
+        };
+
+        strategy.on_update(&quote(dec!(0.60), now), &positions, &orders);
+        strategy.on_update(
+            &quote(dec!(0.40), now - chrono::Duration::seconds(1)),
+            &positions,
+            &orders,
+        );
+
+        assert_eq!(strategy.quotes["token-up"].ask, Some(dec!(0.60)));
+        assert_eq!(strategy.quotes["token-up"].ts, now);
+    }
+
+    #[test]
+    fn wire_quote_recovers_after_local_disconnect_marker() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 13, 9, 0, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        let quote = |bid, ask, ts| MarketUpdate::Quote {
+            token_id: Arc::from("token-up"),
+            bid,
+            ask,
+            bid_size: bid.map(|_| dec!(10)),
+            ask_size: ask.map(|_| dec!(10)),
+            bid_levels: Vec::new(),
+            ask_levels: Vec::new(),
+            ts,
+        };
+
+        strategy.on_update(
+            &quote(Some(dec!(0.59)), Some(dec!(0.60)), now),
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &quote(None, None, now + chrono::Duration::seconds(1)),
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &quote(
+                Some(dec!(0.54)),
+                Some(dec!(0.55)),
+                now + chrono::Duration::milliseconds(500),
+            ),
+            &positions,
+            &orders,
+        );
+
+        assert_eq!(strategy.quotes["token-up"].ask, Some(dec!(0.55)));
+    }
+
+    #[test]
+    fn empty_quote_tick_clears_cached_execution_depth() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 13, 9, 0, 0).unwrap();
+        let mut strategy = ThreeLayerStrategy::new(test_config());
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-up"),
+                bid: Some(dec!(0.49)),
+                ask: Some(dec!(0.50)),
+                bid_size: Some(dec!(10)),
+                ask_size: Some(dec!(20)),
+                bid_levels: vec![level(dec!(0.49), dec!(10))],
+                ask_levels: vec![level(dec!(0.50), dec!(20))],
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::Quote {
+                token_id: Arc::from("token-up"),
+                bid: None,
+                ask: None,
+                bid_size: None,
+                ask_size: None,
+                bid_levels: Vec::new(),
+                ask_levels: Vec::new(),
+                ts: now + chrono::Duration::milliseconds(1),
+            },
+            &positions,
+            &orders,
+        );
+
+        let depth = &strategy.quote_depth["token-up"];
+        assert_eq!(depth.bid_size, None);
+        assert_eq!(depth.ask_size, None);
+        assert!(depth.bid_levels.is_empty());
+        assert!(depth.ask_levels.is_empty());
+    }
+
+    #[test]
     fn take_profit_requires_bid_size_for_position_quantity() {
         use chrono::TimeZone;
 
@@ -3800,6 +3937,197 @@ mod tests {
             }
             other => panic!("expected one executable entry, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn fresh_quote_tick_triggers_entry_without_waiting_for_next_spot_tick() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        let initial = strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        assert!(initial.is_empty());
+
+        let decisions = strategy.on_update(
+            &entry_quote(
+                "token-up",
+                now + chrono::Duration::milliseconds(1),
+                Some(dec!(200)),
+            ),
+            &positions,
+            &orders,
+        );
+
+        assert!(matches!(
+            decisions.as_slice(),
+            [StrategyDecision::Enter { intent, .. }] if intent.token_id == "token-up"
+        ));
+    }
+
+    #[test]
+    fn unavailable_spot_tick_blocks_quote_triggered_entry_until_reconnect() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::L2Depth {
+                symbol: Arc::from("BTCUSDT"),
+                obi: 0.8,
+                spread_bps: 1,
+                bid_depth_near: 20.0,
+                ask_depth_near: 5.0,
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: Decimal::ZERO,
+                ts: now + chrono::Duration::milliseconds(1),
+            },
+            &positions,
+            &orders,
+        );
+
+        let decisions = strategy.on_update(
+            &entry_quote(
+                "token-up",
+                now + chrono::Duration::milliseconds(2),
+                Some(dec!(200)),
+            ),
+            &positions,
+            &orders,
+        );
+
+        assert!(decisions.is_empty());
+        assert!(!strategy.spot.contains_key("BTCUSDT"));
+        assert!(!strategy.lob.contains_key("BTCUSDT"));
+    }
+
+    #[test]
+    fn aggtrade_tick_re_evaluates_entry_without_waiting_for_spot() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+
+        let decisions = strategy.on_update(
+            &MarketUpdate::AggTrade {
+                symbol: Arc::from("BTCUSDT"),
+                agg_trade_id: 1,
+                price: dec!(100000),
+                quantity: dec!(1),
+                is_buyer_maker: false,
+                ts: now + chrono::Duration::milliseconds(1),
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(matches!(
+            decisions.as_slice(),
+            [StrategyDecision::Enter { intent, .. }] if intent.token_id == "token-up"
+        ));
+    }
+
+    #[test]
+    fn l2_depth_tick_re_evaluates_entry_without_waiting_for_spot() {
+        use chrono::TimeZone;
+
+        let now = Utc.with_ymd_and_hms(2026, 4, 25, 6, 9, 0).unwrap();
+        let mut config = test_config();
+        config.min_distance_over_sigma = 0.0;
+        config.min_direction_prob = 0.5;
+        let mut strategy = ThreeLayerStrategy::new(config);
+        discover_test_event(&mut strategy, now);
+        let positions = PositionLedger::default();
+        let orders = OrderLedger::default();
+        strategy.on_update(
+            &MarketUpdate::SpotPrice {
+                symbol: Arc::from("BTCUSDT"),
+                price: dec!(100000),
+                ts: now,
+            },
+            &positions,
+            &orders,
+        );
+        strategy.on_update(
+            &entry_quote("token-up", now, Some(dec!(200))),
+            &positions,
+            &orders,
+        );
+
+        let decisions = strategy.on_update(
+            &MarketUpdate::L2Depth {
+                symbol: Arc::from("BTCUSDT"),
+                obi: 0.25,
+                spread_bps: 1,
+                bid_depth_near: 20.0,
+                ask_depth_near: 10.0,
+                ts: now + chrono::Duration::milliseconds(1),
+            },
+            &positions,
+            &orders,
+        );
+
+        assert!(matches!(
+            decisions.as_slice(),
+            [StrategyDecision::Enter { intent, .. }] if intent.token_id == "token-up"
+        ));
     }
 
     #[test]
@@ -5429,7 +5757,8 @@ mod tests {
         assert_eq!(diagnostics.get("skip_edge_score"), None);
         assert_eq!(
             diagnostics.get("settlement_autofactor_formula_evaluations"),
-            Some(&1)
+            Some(&2),
+            "the second evaluation is the immediate quote-tick entry path"
         );
     }
 

--- a/crates/ploy-strategy-runtime/src/live.rs
+++ b/crates/ploy-strategy-runtime/src/live.rs
@@ -1,10 +1,12 @@
+use ploy_market_data::binance_collectors::spawn_binance_tick_feed;
 use ploy_market_data::feeds::{
     spawn_chainlink_feed, spawn_db_aggtrade_feed, spawn_db_l2_feed, spawn_db_polymarket_feed,
-    spawn_db_spot_feed, spawn_pyth_reference_feed, spawn_spot_feed,
+    spawn_db_spot_feed, spawn_pyth_reference_feed,
 };
 use ploy_market_data::reference_prices::new_reference_price_registry;
 use ploy_market_data::scanner::spawn_market_scanner;
 use ploy_market_data::sports_feed::spawn_sports_feed;
+use ploy_strategy_bundles::config::MarketDataSource;
 use ploy_strategy_bundles::{
     Feed, FullConfig, LiveFeed, RecordingFeed, RuntimeMode, StrategyLogic,
 };
@@ -14,6 +16,10 @@ use std::env;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
+
+fn uses_db_primary_ticks(source: MarketDataSource) -> bool {
+    source.uses_local_db() && !source.uses_external_direct()
+}
 
 #[cfg(all(feature = "live", feature = "live-execution"))]
 mod execution {
@@ -581,27 +587,29 @@ async fn run_live_or_dry_run(
     let mut feed_handles = Vec::new();
     if market_data_source.uses_local_db() {
         if let Some(ref db) = db_pool {
-            feed_handles.push(spawn_db_spot_feed(tx.clone(), symbols.to_vec(), db.clone()));
-            feed_handles.push(spawn_db_aggtrade_feed(
-                tx.clone(),
-                symbols.to_vec(),
-                db.clone(),
-            ));
-            feed_handles.push(spawn_db_l2_feed(tx.clone(), symbols.to_vec(), db.clone()));
-            feed_handles.push(spawn_db_polymarket_feed(
-                tx.clone(),
-                symbols.to_vec(),
-                db.clone(),
-            ));
+            if uses_db_primary_ticks(market_data_source) {
+                feed_handles.push(spawn_db_spot_feed(tx.clone(), symbols.to_vec(), db.clone()));
+                feed_handles.push(spawn_db_polymarket_feed(
+                    tx.clone(),
+                    symbols.to_vec(),
+                    db.clone(),
+                ));
+                feed_handles.push(spawn_db_aggtrade_feed(
+                    tx.clone(),
+                    symbols.to_vec(),
+                    db.clone(),
+                ));
+                feed_handles.push(spawn_db_l2_feed(tx.clone(), symbols.to_vec(), db.clone()));
+            }
         }
     }
 
     if market_data_source.uses_external_direct() {
-        feed_handles.push(spawn_spot_feed(
+        feed_handles.push(spawn_binance_tick_feed(
             tx.clone(),
             reference_prices.clone(),
             symbols.to_vec(),
-            db_pool.clone(),
+            20,
         ));
         feed_handles.push(spawn_chainlink_feed(
             tx.clone(),
@@ -706,6 +714,18 @@ async fn run_live_or_dry_run(
     }
 
     result
+}
+
+#[cfg(test)]
+mod feed_source_tests {
+    use super::{uses_db_primary_ticks, MarketDataSource};
+
+    #[test]
+    fn dual_market_data_keeps_primary_ticks_direct() {
+        assert!(uses_db_primary_ticks(MarketDataSource::LocalDb));
+        assert!(!uses_db_primary_ticks(MarketDataSource::Dual));
+        assert!(!uses_db_primary_ticks(MarketDataSource::ExternalDirect));
+    }
 }
 
 #[cfg(all(feature = "live", feature = "live-execution"))]

--- a/crates/ploy-trading/src/orders.rs
+++ b/crates/ploy-trading/src/orders.rs
@@ -1,5 +1,6 @@
 use crate::fills::FillRecord;
 use crate::intents::TradingIntent;
+use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -30,6 +31,8 @@ pub struct OrderRecord {
     #[serde(default)]
     pub revision: u32,
     pub state: OrderState,
+    #[serde(default)]
+    pub state_changed_at: Option<DateTime<Utc>>,
     pub filled_qty: Decimal,
     pub rejection_reason: Option<String>,
     pub last_error: Option<String>,
@@ -46,7 +49,12 @@ impl OrderLedger {
     pub fn restore(records: Vec<OrderRecord>) -> Self {
         let orders = records
             .into_iter()
-            .map(|record| (record.order_id.clone(), record))
+            .map(|mut record| {
+                if record.state_changed_at.is_none() {
+                    record.state_changed_at = Some(Utc::now());
+                }
+                (record.order_id.clone(), record)
+            })
             .collect();
         Self { orders }
     }
@@ -68,6 +76,7 @@ impl OrderLedger {
             venue_order_history: Vec::new(),
             revision: 0,
             state: OrderState::Pending,
+            state_changed_at: Some(Utc::now()),
             filled_qty: Decimal::ZERO,
             rejection_reason: None,
             last_error: None,
@@ -90,8 +99,13 @@ impl OrderLedger {
     ) -> Option<&OrderRecord> {
         let record = self.orders.get_mut(order_id)?;
         record.venue_order_id = Some(venue_order_id.into());
-        record.state = OrderState::Acknowledged;
-        record.last_error = None;
+        if matches!(
+            record.state,
+            OrderState::Pending | OrderState::Unknown | OrderState::Acknowledged
+        ) {
+            set_state(record, OrderState::Acknowledged);
+            record.last_error = None;
+        }
         Some(record)
     }
 
@@ -115,24 +129,28 @@ impl OrderLedger {
         record.limit_price = limit_price;
         record.revision += 1;
         record.last_error = None;
-        record.state = if record.filled_qty >= record.requested_qty {
+        let state = if record.filled_qty >= record.requested_qty {
             OrderState::Filled
         } else if record.filled_qty > Decimal::ZERO {
             OrderState::PartiallyFilled
         } else {
             OrderState::Acknowledged
         };
+        set_state(record, state);
         Some(record)
     }
 
     pub fn reject(&mut self, order_id: &str, reason: impl Into<String>) -> Option<&OrderRecord> {
         let record = self.orders.get_mut(order_id)?;
         let reason = reason.into();
-        if matches!(record.state, OrderState::Filled) {
+        if matches!(
+            record.state,
+            OrderState::PartiallyFilled | OrderState::Filled | OrderState::Canceled
+        ) {
             record.last_error = Some(reason);
             return Some(record);
         }
-        record.state = OrderState::Rejected;
+        set_state(record, OrderState::Rejected);
         record.rejection_reason = Some(reason.clone());
         record.last_error = Some(reason);
         Some(record)
@@ -156,9 +174,12 @@ impl OrderLedger {
         let record = self.orders.get_mut(order_id)?;
         if !matches!(
             record.state,
-            OrderState::Filled | OrderState::Canceled | OrderState::Rejected
+            OrderState::PartiallyFilled
+                | OrderState::Filled
+                | OrderState::Canceled
+                | OrderState::Rejected
         ) {
-            record.state = OrderState::Unknown;
+            set_state(record, OrderState::Unknown);
             record.last_error = Some(error.into());
         }
         Some(record)
@@ -169,7 +190,7 @@ impl OrderLedger {
         if matches!(record.state, OrderState::Filled | OrderState::Rejected) {
             return Some(record);
         }
-        record.state = OrderState::Canceled;
+        set_state(record, OrderState::Canceled);
         record.last_error = None;
         Some(record)
     }
@@ -220,11 +241,19 @@ impl OrderLedger {
 
 fn apply_fill_to_record(record: &mut OrderRecord, quantity: Decimal) {
     record.filled_qty += quantity;
-    record.state = if record.filled_qty >= record.requested_qty {
+    let state = if record.filled_qty >= record.requested_qty {
         OrderState::Filled
     } else {
         OrderState::PartiallyFilled
     };
+    set_state(record, state);
+}
+
+fn set_state(record: &mut OrderRecord, state: OrderState) {
+    if record.state != state {
+        record.state = state;
+        record.state_changed_at = Some(Utc::now());
+    }
 }
 
 #[cfg(test)]
@@ -304,6 +333,74 @@ mod tests {
         let order = ledger.order("order-1").unwrap();
         assert_eq!(order.state, OrderState::Filled);
         assert_eq!(order.last_error.as_deref(), Some("late rejection"));
+    }
+
+    #[test]
+    fn late_acknowledgement_does_not_regress_filled_or_partially_filled_orders() {
+        let mut ledger = OrderLedger::default();
+        let mut intent = intent("token-a");
+        intent.quantity = dec!(2);
+        ledger.insert_from_intent("order-1", &intent);
+        ledger.acknowledge("order-1", "venue-1");
+        ledger.apply_fill(&crate::FillRecord {
+            fill_id: "fill-1".to_string(),
+            order_id: "order-1".to_string(),
+            token_id: "token-a".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(1),
+            price: dec!(0.5),
+            fee: dec!(0),
+            timestamp: Utc::now(),
+        });
+
+        ledger.acknowledge("order-1", "venue-1");
+        assert_eq!(
+            ledger.order("order-1").unwrap().state,
+            OrderState::PartiallyFilled
+        );
+
+        ledger.apply_fill(&crate::FillRecord {
+            fill_id: "fill-2".to_string(),
+            order_id: "order-1".to_string(),
+            token_id: "token-a".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(1),
+            price: dec!(0.5),
+            fee: dec!(0),
+            timestamp: Utc::now(),
+        });
+        ledger.acknowledge("order-1", "venue-1");
+        assert_eq!(ledger.order("order-1").unwrap().state, OrderState::Filled);
+    }
+
+    #[test]
+    fn late_ambiguous_or_rejected_outcome_does_not_erase_fill_or_cancel_state() {
+        let mut ledger = OrderLedger::default();
+        let mut intent = intent("token-a");
+        intent.quantity = dec!(2);
+        ledger.insert_from_intent("order-1", &intent);
+        ledger.acknowledge("order-1", "venue-1");
+        ledger.apply_fill(&crate::FillRecord {
+            fill_id: "fill-1".to_string(),
+            order_id: "order-1".to_string(),
+            token_id: "token-a".to_string(),
+            side: TradeSide::Buy,
+            quantity: dec!(1),
+            price: dec!(0.5),
+            fee: dec!(0),
+            timestamp: Utc::now(),
+        });
+
+        ledger.mark_unknown("order-1", "response lost");
+        ledger.reject("order-1", "late rejection");
+        assert_eq!(
+            ledger.order("order-1").unwrap().state,
+            OrderState::PartiallyFilled
+        );
+
+        ledger.cancel("order-1");
+        ledger.reject("order-1", "later rejection");
+        assert_eq!(ledger.order("order-1").unwrap().state, OrderState::Canceled);
     }
 
     #[test]

--- a/crates/ploy-trading/src/runtime.rs
+++ b/crates/ploy-trading/src/runtime.rs
@@ -601,6 +601,7 @@ mod tests {
                 venue_order_history: vec!["venue-0".to_string()],
                 revision: 1,
                 state: OrderState::PartiallyFilled,
+                state_changed_at: Some(Utc::now()),
                 filled_qty: dec!(1),
                 rejection_reason: None,
                 last_error: None,

--- a/ploy-frontend/src/types/operator-contracts.ts
+++ b/ploy-frontend/src/types/operator-contracts.ts
@@ -31,7 +31,7 @@ export interface PaperIntentResponse { deployment_id: string; intent_id: string;
 
 export interface FillSnapshot { fee: string; fill_id: string; order_id: string; price: string; quantity: string; side: string; timestamp: string; token_id: string; }
 
-export interface OrderSnapshot { filled_qty: string; idempotency_key?: string | null; intent_id: string; last_error?: string | null; limit_price?: string | null; order_id: string; rejection_reason?: string | null; requested_qty: string; revision?: number; state: string; token_id: string; venue_order_history?: string[]; venue_order_id?: string | null; }
+export interface OrderSnapshot { filled_qty: string; idempotency_key?: string | null; intent_id: string; last_error?: string | null; limit_price?: string | null; order_id: string; rejection_reason?: string | null; requested_qty: string; revision?: number; state: string; state_changed_at?: string | null; token_id: string; venue_order_history?: string[]; venue_order_id?: string | null; }
 
 export interface PnlSnapshotResponse { net_pnl: string; realized_pnl: string; total_fees: string; unrealized_pnl: string; }
 

--- a/ploy-sidecar/src/contracts/operator-contracts.ts
+++ b/ploy-sidecar/src/contracts/operator-contracts.ts
@@ -31,7 +31,7 @@ export interface PaperIntentResponse { deployment_id: string; intent_id: string;
 
 export interface FillSnapshot { fee: string; fill_id: string; order_id: string; price: string; quantity: string; side: string; timestamp: string; token_id: string; }
 
-export interface OrderSnapshot { filled_qty: string; idempotency_key?: string | null; intent_id: string; last_error?: string | null; limit_price?: string | null; order_id: string; rejection_reason?: string | null; requested_qty: string; revision?: number; state: string; token_id: string; venue_order_history?: string[]; venue_order_id?: string | null; }
+export interface OrderSnapshot { filled_qty: string; idempotency_key?: string | null; intent_id: string; last_error?: string | null; limit_price?: string | null; order_id: string; rejection_reason?: string | null; requested_qty: string; revision?: number; state: string; state_changed_at?: string | null; token_id: string; venue_order_history?: string[]; venue_order_id?: string | null; }
 
 export interface PnlSnapshotResponse { net_pnl: string; realized_pnl: string; total_fees: string; unrealized_pnl: string; }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,18 @@
 # Lessons
 
+## 2026-07-13
+
+- Pattern: A five-minute prediction-market event was mistaken for a
+  minute-level execution system, leaving primary factors behind 100ms-to-5s
+  polling and a 10 Hz strategy throttle.
+- Rule: Event settlement horizon and execution frequency are separate. PM5D
+  live execution must remain tick-driven: ingest venue WebSocket updates
+  directly and evaluate every decision-relevant tick. Delayed REST/DB ticks must
+  not merge into the direct strategy hot path; recovery is a fail-closed WS
+  reconnect or an explicit operator-selected `local_db` mode. Benchmark names
+  must state whether they begin at raw wire parsing or at canonical tick receipt
+  before describing latency as HFT-grade.
+
 ## 2026-03-02
 
 - Pattern: Some links (including but not limited to X) fail with plain `curl` because content is JS-rendered, anti-bot protected, or behind login walls.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# Current Session - Live Hot-Path Latency (2026-07-13)
+
+Evidence stage: implementation hardening only. Live remains paused; this slice
+does not deploy, resume trading, or produce promotion evidence.
+
+## Files / Ownership
+
+- `crates/ploy-strategy-bundles/src/engine.rs`: skip remote fill reconciliation
+  when no active order can produce a fill.
+- `tasks/todo.md`: plan and verification evidence.
+
+## Tasks
+
+- [x] Add a failing runtime test proving idle market updates do not reconcile.
+- [x] Skip reconciliation until an active order exists.
+- [x] Run focused tests, formatting, and diff checks.
+- [ ] Follow-up: separate market-catalog refresh from quote refresh before
+      lowering the 2-second DB polling interval; do not multiply catalog query
+      load or reopen direct public feeds from strategy runners.
+
+## Review
+
+- Empty-order runtime updates now perform zero fill-reconciliation calls. Active,
+  unknown, acknowledged, and partially-filled orders retain the existing
+  fail-closed reconciliation behavior.
+- Quote polling was deliberately not changed in this atomic slice because the
+  same loop also refreshes event metadata. Lowering its sleep directly would
+  amplify all remote DB queries rather than only improve quote freshness.
+- Verification passed: 203 `ploy-strategy-bundles` library tests, the
+  `ploy-strategy-runtime` live/live-execution build, workspace formatting, and
+  `git diff --check`. The build reports 16 existing dead-code warnings.
+
 # Current Session - Market Data V2 And Redeem Repair (2026-07-12)
 
 Evidence stage: `deployment/runtime safety plumbing`. This slice repairs data

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,8 +5,8 @@
 - [x] Add one shared venue-aware fee calculator with maker/taker and rounding semantics.
 - [x] Use it in simulated execution and backtest/research fee accounting.
 - [x] Make live Polymarket REST reconciliation confirmed-only and use cached V2 fee metadata.
-- [ ] Prefer authenticated venue order/fill events over snapshot polling, with bounded fallback.
-- [ ] Measure quote-to-ack and quote-to-fill latency without enabling live trading.
+- [x] Prefer authenticated venue order/fill events over snapshot polling, with bounded fallback.
+- [x] Measure local decision-to-wire and wire-to-ack latency without enabling live trading.
 
 Evidence stage: implementation hardening only. Live remains paused; this slice
 does not deploy, resume trading, or produce promotion evidence.
@@ -15,7 +15,17 @@ does not deploy, resume trading, or produce promotion evidence.
 
 - `crates/ploy-strategy-bundles/src/engine.rs`: skip remote fill reconciliation
   when no active order can produce a fill.
+- `crates/ploy-connectivity/{Cargo.toml,src/lib.rs}`: main agent owns the
+  authenticated Polymarket user-channel implementation, bounded gap recovery,
+  event mapping, and focused tests.
+- `crates/ploy-platform-runtime/src/reconcile.rs`: main agent owns applying
+  confirmed fills before order observations and the focused lifecycle tests.
+- Live submission hot-path files and latency benchmark files: main agent owns
+  edits after a read-only architecture pass identifies the narrowest safe seam.
 - `tasks/todo.md`: plan and verification evidence.
+
+Subagents are read-only reviewers for the WebSocket API seam, runtime ordering,
+and submission-path bottlenecks; they do not own or edit workspace files.
 
 ## Tasks
 
@@ -24,6 +34,21 @@ does not deploy, resume trading, or produce promotion evidence.
 - [x] Run focused tests, formatting, and diff checks.
 - [x] Separate market-catalog refresh from quote refresh and lower active quote
       polling to 100ms while keeping catalog queries at 2 seconds.
+- [x] Complete authenticated Polymarket user events with a bounded queue,
+      stable fill identity, gap detection, and five-second periodic/degraded
+      REST catch-up bounded by a two-second timeout.
+- [x] Apply confirmed fills before acknowledgement/cancellation observations in
+      the runtime reconciliation loop.
+- [x] Add focused regressions for maker/taker mapping, CONFIRMED-only fills,
+      WS/REST deduplication, early events, cancellation ordering, overflow, and
+      degraded recovery.
+- [x] Remove avoidable synchronous/network work from the quote-to-order hot path
+      while preserving pending-before-side-effect, idempotency, and Unknown on
+      ambiguous submission.
+- [x] Add a no-live-order local benchmark for decision-to-wire-to-ack
+      instrumentation and report p50/p99/p999.
+- [ ] Run focused tests, locked compilation, independent review, atomic commits,
+      and final diff/worktree checks without deploying or resuming live trading.
 
 ## Review
 
@@ -63,6 +88,34 @@ does not deploy, resume trading, or produce promotion evidence.
   active-token set.
 - Second-slice verification passed: 54 live market-data tests, 11 live strategy
   runtime tests, six market-data-boundary tests, formatting, and diff checks.
+- Authenticated Polymarket user events now drive order/fill reconciliation first.
+  The bounded queue detects overflow, connection loss, delayed/unknown order
+  states, and failed/unknown trades; REST catch-up restores confirmed fills and
+  tracked order states. Periodic five-second catch-up remains because the SDK
+  hides broadcast lag from consumers.
+- Runtime reconciliation applies confirmed fills before acknowledgement or
+  cancellation observations. Terminal/partial state cannot regress on late ACK
+  or ambiguous status, and canceled orders remain eligible for late confirmed
+  fills for 24 hours. `state_changed_at` is persisted across restart so that
+  window is durable.
+- Live submission now persists Pending before the venue side effect, releases
+  the daemon mutex during signing/posting, and persists the terminal outcome
+  afterward. Concurrent idempotent retries reuse Pending and never duplicate the
+  submit. Pending cancel/replace fails closed while submission is in progress.
+- The operator TCP client reuses keep-alive connections and reads exact
+  Content-Length responses; stale idle sockets reconnect before writes without
+  retrying ambiguous POST requests.
+- Local release benchmark (1001 loopback HTTP submissions with a mock acknowledged
+  gateway; no venue, wallet, or chain access): decision-to-wire p50 1902 us,
+  p99 6238 us, p999 20775 us; wire-to-ack p50 1292 us, p99 3700 us, p999 12377 us;
+  end-to-end p50 3215 us, p99 9736 us, p999 24369 us. These numbers include both
+  durable Pending and terminal snapshot writes but exclude real Polymarket
+  network latency and chain finality.
+- Verification passed: operator contracts 23, trading 22, connectivity 23,
+  platform runtime 62, control client 14, daemon host 90 (1 ignored), strategy
+  bundles 217, plus live-execution checks for `ploy-strategy-runtime`,
+  `new-ployd`, and `new-ploy-runner`. Live remains paused and no real order was
+  submitted.
 
 # Current Session - Market Data V2 And Redeem Repair (2026-07-12)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,6 +4,7 @@
 
 - [x] Add one shared venue-aware fee calculator with maker/taker and rounding semantics.
 - [x] Use it in simulated execution and backtest/research fee accounting.
+- [x] Make live Polymarket REST reconciliation confirmed-only and use cached V2 fee metadata.
 - [ ] Prefer authenticated venue order/fill events over snapshot polling, with bounded fallback.
 - [ ] Measure quote-to-ack and quote-to-fill latency without enabling live trading.
 
@@ -39,6 +40,9 @@ does not deploy, resume trading, or produce promotion evidence.
   deductions, avoiding false position/PnL results.
 - Current Polymarket crypto strategy/research edge calculations use the shared 7%
   probability curve instead of the stale 2% constant.
+- Live REST reconciliation now ignores MATCHED/MINED/RETRYING/FAILED trades,
+  accepts only CONFIRMED fills, derives maker/taker platform fees from cached V2
+  `fd` metadata, and bounds the degraded REST catch-up to two seconds.
 - Fee-slice verification passed: 16 market-contract tests, 223 strategy-bundle
   tests (1 ignored), 167 research tests, research-example compilation, and
   `ploy-strategy-runtime` compilation. Existing

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,12 @@
 # Current Session - Live Hot-Path Latency (2026-07-13)
 
+## Continuation - Venue Fees And Execution Events
+
+- [x] Add one shared venue-aware fee calculator with maker/taker and rounding semantics.
+- [x] Use it in simulated execution and backtest/research fee accounting.
+- [ ] Prefer authenticated venue order/fill events over snapshot polling, with bounded fallback.
+- [ ] Measure quote-to-ack and quote-to-fill latency without enabling live trading.
+
 Evidence stage: implementation hardening only. Live remains paused; this slice
 does not deploy, resume trading, or produce promotion evidence.
 
@@ -18,6 +25,24 @@ does not deploy, resume trading, or produce promotion evidence.
       polling to 100ms while keeping catalog queries at 2 seconds.
 
 ## Review
+
+- Prediction-market fees now share one calculator covering probability-power,
+  notional, and per-contract formulas, role-specific maker/taker rates, exact,
+  five-place truncation, and ceiling semantics. Polymarket sub-tick fees round to
+  zero; Kalshi trade-fee ceiling, member balance precision, per-order rounding
+  accumulator, and rebates are modeled separately. Full-depth sweeps preserve
+  match-level prices for nonlinear fee calculation instead of charging the VWAP.
+- Simulated execution uses official Polymarket family defaults. Predict.fun,
+  Kalshi, and custom Polymarket families require explicit market metadata instead
+  of silently applying fixture rates; Predict.fun accepts its native bps and fee
+  asset. Share-denominated fees fail closed until canonical fills track net share
+  deductions, avoiding false position/PnL results.
+- Current Polymarket crypto strategy/research edge calculations use the shared 7%
+  probability curve instead of the stale 2% constant.
+- Fee-slice verification passed: 16 market-contract tests, 223 strategy-bundle
+  tests (1 ignored), 167 research tests, research-example compilation, and
+  `ploy-strategy-runtime` compilation. Existing
+  dead-code warnings remain unchanged.
 
 - Empty-order runtime updates now perform zero fill-reconciliation calls. Active,
   unknown, acknowledged, and partially-filled orders retain the existing

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,74 @@
 # Current Session - Live Hot-Path Latency (2026-07-13)
 
+## Continuation - Tick-Level Execution Correction
+
+Evidence stage: `execution_quality` implementation hardening. PM5D is a
+five-minute settlement product, but its live decision and submission path is
+still tick-driven and must be evaluated as a seconds-level market. Live remains
+paused; this slice does not deploy, resume trading, or submit a real order.
+
+### Files / Ownership
+
+- `crates/ploy-market-data/{collector,feeds,scanner}.rs`: direct Polymarket CLOB
+  book/BBA ticks and fail-closed disconnect behavior.
+- `crates/ploy-strategy-bundles/{config,strategies/three_layer}.rs`: unthrottled
+  runtime config and stale-fallback protection.
+- `crates/ploy-strategy-runtime/src/live.rs`: direct-vs-DB source selection and
+  remaining Binance tick wiring.
+- `config/strategies/02-pm5d-threelayer*.toml`: live/dry-run source parity.
+- `tasks/{todo,lessons}.md`: correction, evidence, and reusable rule.
+
+Subagents are read-only reviewers for the CLOB tick semantics, Binance direct
+feed gap, and end-to-end latency benchmark boundary; the main agent owns all
+workspace edits.
+
+### Tasks
+
+- [x] Convert Polymarket CLOB `book` and `price_change` WebSocket events into
+      immediate `MarketUpdate::Quote` ticks with venue timestamps.
+- [x] Prevent stale WebSocket deltas from mutating newer book state, clear
+      executable depth on empty books, and keep delayed REST/DB ticks out of the
+      direct hot path.
+- [x] Remove the 10 Hz ThreeLayer throttle and keep live/dry-run configs on the
+      same direct-primary source policy.
+- [x] Restore strategy-runtime compilation after moving `MarketDataSource` to
+      its canonical module import.
+- [x] Wire production-required Binance Spot/AggTrade/L2 updates directly into
+      the strategy broadcast path instead of depending on multi-second DB polls.
+- [x] Extend the no-live-order benchmark from canonical broadcast tick receipt
+      through ThreeLayer evaluation, daemon risk/persistence, mock gateway, and
+      response with p50/p99/p999 output. Raw vendor WS parsing and real venue
+      network latency remain explicitly outside this local benchmark.
+- [x] Run focused suites, full relevant package checks, formatting, Clippy,
+      independent code review, and diff validation.
+- [ ] Commit atomically, push the existing branch, update PR #755, and monitor
+      CI without deploying or resuming live trading.
+
+### Review
+
+- `Dual` and `ExternalDirect` now use one native Binance combined WebSocket for
+  `@trade`, `@aggTrade`, and `@depth20@100ms`; `LocalDb` remains the explicit
+  polled mode. Disconnects clear cached Spot state before quote ticks can open a
+  new order.
+- Polymarket `book` snapshots and `price_change` deltas maintain an in-memory
+  depth book. Empty books clear executable liquidity, stale deltas are rejected
+  before mutation, same-millisecond deltas are retained, and reconnects remain
+  fail-closed until a fresh WS snapshot. The hot path uses direct Tungstenite
+  instead of the SDK broadcast layer that hides lag events.
+- Spot, Quote, AggTrade, and L2Depth updates can all trigger immediate ThreeLayer
+  entry evaluation. The 10 Hz runtime throttle is removed from the paired live
+  and dry-run configs.
+- Local release benchmark, 1,001 canonical broadcast ticks and a mock gateway,
+  no venue/wallet/chain access: canonical tick to decision p50/p99/p999
+  `2/6/16 us`; canonical tick to gateway `2267/6942/8015 us`; canonical tick
+  to response `3797/11169/18409 us`. Raw vendor WS parsing and real Polymarket
+  network ACK remain outside this benchmark and must be measured on the trading
+  host before live promotion.
+- Verification passed: 62 live market-data tests, 228 strategy-bundle tests,
+  12 strategy-runtime live/live-execution tests, 90 daemon-host tests (1
+  ignored), `new-ployd` + full `new-ploy-runner` checks, focused Clippy with no
+  errors, formatting, and `git diff --check`. Existing workspace warnings remain.
+
 ## Continuation - Venue Fees And Execution Events
 
 - [x] Add one shared venue-aware fee calculator with maker/taker and rounding semantics.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,9 +14,8 @@ does not deploy, resume trading, or produce promotion evidence.
 - [x] Add a failing runtime test proving idle market updates do not reconcile.
 - [x] Skip reconciliation until an active order exists.
 - [x] Run focused tests, formatting, and diff checks.
-- [ ] Follow-up: separate market-catalog refresh from quote refresh before
-      lowering the 2-second DB polling interval; do not multiply catalog query
-      load or reopen direct public feeds from strategy runners.
+- [x] Separate market-catalog refresh from quote refresh and lower active quote
+      polling to 100ms while keeping catalog queries at 2 seconds.
 
 ## Review
 
@@ -29,6 +28,12 @@ does not deploy, resume trading, or produce promotion evidence.
 - Verification passed: 203 `ploy-strategy-bundles` library tests, the
   `ploy-strategy-runtime` live/live-execution build, workspace formatting, and
   `git diff --check`. The build reports 16 existing dead-code warnings.
+- The DB feed now prioritizes 100ms quote ticks while retaining 2-second catalog
+  refreshes. Both timers skip missed ticks, so a slow DB response does not cause
+  a burst of stale catch-up queries; catalog failures preserve the last known
+  active-token set.
+- Second-slice verification passed: 54 live market-data tests, 11 live strategy
+  runtime tests, six market-data-boundary tests, formatting, and diff checks.
 
 # Current Session - Market Data V2 And Redeem Repair (2026-07-12)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 - [x] Use it in simulated execution and backtest/research fee accounting.
 - [x] Make live Polymarket REST reconciliation confirmed-only and use cached V2 fee metadata.
 - [x] Prefer authenticated venue order/fill events over snapshot polling, with bounded fallback.
-- [x] Measure local decision-to-wire and wire-to-ack latency without enabling live trading.
+- [x] Measure local client-to-gateway and gateway-to-response latency without enabling live trading.
 
 Evidence stage: implementation hardening only. Live remains paused; this slice
 does not deploy, resume trading, or produce promotion evidence.
@@ -45,9 +45,9 @@ and submission-path bottlenecks; they do not own or edit workspace files.
 - [x] Remove avoidable synchronous/network work from the quote-to-order hot path
       while preserving pending-before-side-effect, idempotency, and Unknown on
       ambiguous submission.
-- [x] Add a no-live-order local benchmark for decision-to-wire-to-ack
+- [x] Add a no-live-order local benchmark for client-to-gateway-to-response
       instrumentation and report p50/p99/p999.
-- [ ] Run focused tests, locked compilation, independent review, atomic commits,
+- [x] Run focused tests, locked compilation, independent review, atomic commits,
       and final diff/worktree checks without deploying or resuming live trading.
 
 ## Review
@@ -106,16 +106,21 @@ and submission-path bottlenecks; they do not own or edit workspace files.
   Content-Length responses; stale idle sockets reconnect before writes without
   retrying ambiguous POST requests.
 - Local release benchmark (1001 loopback HTTP submissions with a mock acknowledged
-  gateway; no venue, wallet, or chain access): decision-to-wire p50 1902 us,
-  p99 6238 us, p999 20775 us; wire-to-ack p50 1292 us, p99 3700 us, p999 12377 us;
-  end-to-end p50 3215 us, p99 9736 us, p999 24369 us. These numbers include both
+  gateway; no venue, wallet, or chain access): client-to-gateway p50 2099 us,
+  p99 6042 us, p999 6381 us; gateway-to-response p50 1461 us, p99 3730 us, p999 5857 us;
+  end-to-end p50 3632 us, p99 9535 us, p999 12114 us. These numbers include both
   durable Pending and terminal snapshot writes but exclude real Polymarket
   network latency and chain finality.
-- Verification passed: operator contracts 23, trading 22, connectivity 23,
+- Verification passed: operator contracts 23, trading 22, connectivity 26,
   platform runtime 62, control client 14, daemon host 90 (1 ignored), strategy
-  bundles 217, plus live-execution checks for `ploy-strategy-runtime`,
+  bundles 218, plus live-execution checks for `ploy-strategy-runtime`,
   `new-ployd`, and `new-ploy-runner`. Live remains paused and no real order was
   submitted.
+- Independent Standards/Spec review found and closed the post-submit audit panic,
+  inaccurate benchmark boundary names, WS maker-side drift, duplicated pending
+  submission guards, and the original monolithic commit. The remaining REST/WS
+  matcher/fill-builder duplication is low-priority and non-blocking because both
+  paths now share the same side invariant and regression coverage.
 
 # Current Session - Market Data V2 And Redeem Repair (2026-07-12)
 


### PR DESCRIPTION
## Summary

- prefer the authenticated Polymarket user WebSocket for order/fill events, with bounded buffering, disconnect/overflow detection, confirmed-only fills, and periodic/degraded REST recovery
- apply confirmed fills before ack/cancel observations and persist `state_changed_at` so late fills after cancellation remain recoverable across restart
- persist Pending before venue submission, release the daemon mutex during signing/posting, preserve idempotent retries and Unknown fail-closed behavior, and keep post-submit audit failures from dropping canonical order state
- reuse keep-alive control-plane TCP connections and read exact Content-Length responses without retrying ambiguous POST writes
- retain venue-specific fee semantics for Polymarket, Predict.fun, Kalshi, and custom prediction-market contracts

## Local latency evidence

1001 release-mode loopback submissions through the daemon with a mock acknowledged gateway; no venue, wallet, chain, database, deploy, or real order access:

- client-to-gateway: p50 2.099 ms, p99 6.042 ms, p999 6.381 ms
- gateway-to-response: p50 1.461 ms, p99 3.730 ms, p999 5.857 ms
- end-to-end: p50 3.632 ms, p99 9.535 ms, p999 12.114 ms

These numbers include durable Pending and terminal snapshot writes. They exclude real Polymarket network latency and chain finality.

## Verification

- `ploy-operator-contracts`: 23 passed
- `ploy-trading`: 22 passed
- `ploy-connectivity`: 26 passed
- `ploy-platform-runtime`: 62 passed
- `ploy-control-client`: 14 passed
- `ploy-daemon-host`: 90 passed, 1 ignored benchmark
- `ploy-strategy-bundles`: 218 passed
- locked live-execution checks passed for `ploy-strategy-runtime`, `new-ployd`, and `new-ploy-runner/full`
- targeted clippy: 0 errors; existing warnings remain
- independent Standards and Spec reviews: no blocking findings

## Safety boundary

Live trading remains paused. This PR does not deploy, resume live trading, invoke `approve-live-trade.yml`, or send any real order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable venue fee schedules for simulations, including maker/taker rates, rounding rules, minimum fees, and fee-asset handling.
  * Added `state_changed_at` timestamps to order snapshots and trading state data.
  * Improved live reconciliation to incorporate order observations alongside fill updates.
  * Enabled HTTP/1.1 keep-alive for faster, more efficient live intent handling.
* **Bug Fixes**
  * Prevented cancel/replace while a live order submission is still in progress.
  * Improved handling of late and ambiguous order updates so existing fills/cancellations aren’t undone.
  * Fail-closed live feed processing when lag is detected to avoid acting on stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->